### PR TITLE
Maui renderer refactor spike

### DIFF
--- a/System.Maui.Core/Entry.cs
+++ b/System.Maui.Core/Entry.cs
@@ -7,7 +7,7 @@ using System.Maui.Platform;
 namespace System.Maui
 {
 	[RenderWith(typeof(_EntryRenderer))]
-	public class Entry : InputView, IFontElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>
+	public partial class Entry : InputView, IFontElement, ITextAlignmentElement, IEntryController, IElementConfiguration<Entry>
 	{
 		public static readonly BindableProperty ReturnTypeProperty = BindableProperty.Create(nameof(ReturnType), typeof(ReturnType), typeof(Entry), ReturnType.Default);
 

--- a/System.Maui.Core/Label.cs
+++ b/System.Maui.Core/Label.cs
@@ -12,7 +12,7 @@ namespace System.Maui
 {
 	[ContentProperty("Text")]
 	[RenderWith(typeof(_LabelRenderer))]
-	public class Label : View, IFontElement, ITextElement, ITextAlignmentElement, ILineHeightElement, IElementConfiguration<Label>, IDecorableTextElement, IPaddingElement
+	public partial class Label : View, IFontElement, ITextElement, ITextAlignmentElement, ILineHeightElement, IElementConfiguration<Label>, IDecorableTextElement, IPaddingElement
 	{
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 

--- a/System.Maui.Core/Maui/IEntry.cs
+++ b/System.Maui.Core/Maui/IEntry.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Maui
+{
+	public partial class Entry : ITextInput
+	{
+		TextType IText.TextType => TextType.Text;
+
+		Color IText.Color => TextColor;
+	}
+}

--- a/System.Maui.Core/Maui/IFrameworkElement.cs
+++ b/System.Maui.Core/Maui/IFrameworkElement.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Maui
+{
+	public interface IFrameworkElement
+	{
+		//bool IsEnabled { get; }
+		//Color BackgroundColor { get; }
+		//Rectangle Frame { get; }
+		//IViewRenderer Renderer { get; set; }
+		//IFrameworkElement Parent { get; }
+
+		//void Arrange(Rectangle bounds);
+		//SizeRequest Measure(double widthConstraint, double heightConstraint);
+
+		//SizeRequest DesiredSize { get; }
+		//bool IsMeasureValid { get; }
+		//bool IsArrangeValid { get; }
+
+		//void InvalidateMeasure();
+		//void InvalidateArrange();
+	}
+}

--- a/System.Maui.Core/Maui/ILabel.cs
+++ b/System.Maui.Core/Maui/ILabel.cs
@@ -1,0 +1,13 @@
+﻿namespace System.Maui
+{
+	public interface ILabel : IText
+	{
+		double LineHeight { get; }
+		FormattedString FormattedText { get; }
+		Font Font { get; }
+		Color TextColor { get; }
+		TextTransform TextTransform { get; }
+
+		string UpdateFormsText(string text, TextTransform textTransform);
+	}
+}

--- a/System.Maui.Core/Maui/IText.cs
+++ b/System.Maui.Core/Maui/IText.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Maui
+{
+	public interface IText : IView
+	{
+		string Text { get; }
+
+		TextType TextType { get; }
+		//TODO: Add fonts and Colors
+		Color Color { get; }
+	}
+}

--- a/System.Maui.Core/Maui/ITextInput.cs
+++ b/System.Maui.Core/Maui/ITextInput.cs
@@ -1,0 +1,14 @@
+﻿namespace System.Maui
+{
+	public interface ITextInput : IText
+	{
+		int MaxLength { get; }
+		string Placeholder { get; }
+		Color PlaceholderColor { get; }
+		new string Text { get; set; }
+		TextTransform TextTransform { get; }
+
+		string UpdateFormsText(string text, TextTransform textTransform);
+		//string IText.Text => Text;
+	}
+}

--- a/System.Maui.Core/Maui/IView.cs
+++ b/System.Maui.Core/Maui/IView.cs
@@ -1,0 +1,11 @@
+﻿namespace System.Maui
+{
+	public interface IView : IFrameworkElement
+	{
+
+		//Alignment GetVerticalAlignment(ILayout layout) => Alignment.Fill;
+		//Alignment GetHorizontalAlignment(ILayout layout) => Alignment.Fill;
+		bool IsEnabled { get; }
+		Color BackgroundColor { get; }
+	}
+}

--- a/System.Maui.Core/Maui/IViewRenderer.cs
+++ b/System.Maui.Core/Maui/IViewRenderer.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Maui.Core;
+
+namespace System.Maui {
+	public interface IMauiRenderer
+	{
+		//void SetView (IFrameworkElement view);
+		//void UpdateValue (string property);
+		//void Remove (IFrameworkElement view);
+		object NativeView { get; }
+		//bool HasContainer { get; set; } 
+		//SizeRequest GetDesiredSize (double widthConstraint, double heightConstraint);
+		//void SetFrame (Rectangle frame);
+	}
+}

--- a/System.Maui.Core/Maui/Label.cs
+++ b/System.Maui.Core/Maui/Label.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Maui
+{
+	public partial class Label : ILabel
+	{
+		Color IText.Color => TextColor;
+	}
+}

--- a/System.Maui.Core/Properties/AssemblyInfo.cs
+++ b/System.Maui.Core/Properties/AssemblyInfo.cs
@@ -34,6 +34,8 @@ using System.Maui.StyleSheets;
 [assembly: InternalsVisibleTo("System.Maui.CarouselView")]
 [assembly: InternalsVisibleTo("System.Maui.DualScreen")]
 [assembly: InternalsVisibleTo("System.Maui.DualScreen.UnitTests")]
+
+
 [assembly: Preserve]
 
 [assembly: XmlnsDefinition("http://xamarin.com/schemas/2014/forms", "System.Maui")]

--- a/System.Maui.Core/System.Maui.Core.csproj
+++ b/System.Maui.Core/System.Maui.Core.csproj
@@ -1,11 +1,23 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
-	</PropertyGroup>
+    <MauiBuild>true</MauiBuild>
+    <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
+    <!--<TargetFrameworks Condition=" '$(MauiBuild)' == 'true' ">netstandard2.1</TargetFrameworks>-->
+  </PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
 	</PropertyGroup>
+  <PropertyGroup Condition="'$(MauiBuild)' == 'true'">
+    <LangVersion>8.0</LangVersion>
+    <DefineConstants>$(DefineConstants);__MAUI__</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup Condition="$(MauiBuild) != true ">
+    <Compile Remove="Maui\**\*.cs" />
+    <None Include="Maui\**\*.Ios.cs" />
+  </ItemGroup>
+  
+  
 	<ItemGroup>
 		<ProjectReference Include="..\System.Maui.Platform\System.Maui.Platform.csproj" />
 	</ItemGroup>
@@ -14,6 +26,8 @@
 		<EmbeddedResource Remove="Internals\Legacy\**" />
 		<None Remove="Internals\Legacy\**" />
 	</ItemGroup>
+
+  
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
 		<Compile Include="Internals\Legacy\**" />
 		<PackageReference Include="System.ComponentModel" Version="4.3.0" />

--- a/System.Maui.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/System.Maui.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -18,7 +18,7 @@ using AView = Android.Views.View;
 
 namespace System.Maui.Platform.Android.FastRenderers
 {
-	public class ButtonRenderer : AppCompatButton,
+	public partial class ButtonRenderer : AppCompatButton,
 		IBorderVisualElementRenderer, IButtonLayoutRenderer, IVisualElementRenderer, IViewRenderer, ITabStop,
 		AView.IOnAttachStateChangeListener, AView.IOnFocusChangeListener, AView.IOnClickListener, AView.IOnTouchListener
 	{

--- a/System.Maui.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/System.Maui.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -13,6 +13,9 @@ using Android.Util;
 using Android.Views;
 using Android.Widget;
 using AView = Android.Views.View;
+#if !__MAUI__
+using ILabel = global::System.Maui.Label;
+#endif
 
 namespace System.Maui.Platform.Android.FastRenderers
 {

--- a/System.Maui.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/System.Maui.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -16,7 +16,7 @@ using AView = Android.Views.View;
 
 namespace System.Maui.Platform.Android.FastRenderers
 {
-	public class LabelRenderer : FormsTextView, IVisualElementRenderer, IViewRenderer, ITabStop
+	public partial class LabelRenderer : FormsTextView, IVisualElementRenderer, IViewRenderer, ITabStop
 	{
 		int? _defaultLabelFor;
 		bool _disposed;
@@ -390,45 +390,51 @@ namespace System.Maui.Platform.Android.FastRenderers
 
 		void UpdateText()
 		{
+			UpdateText(Element, this);
+		}
+
+		internal static void UpdateText(ILabel Element, FormsTextView formsTextView)
+		{
+			var renderer = (LabelRenderer)formsTextView;
 			if (Element.FormattedText != null)
 			{
 				FormattedString formattedText = Element.FormattedText ?? Element.Text;
 #pragma warning disable 618 // We will need to update this when .Font goes away
-				TextFormatted = _spannableString = formattedText.ToAttributed(Element.Font, Element.TextColor, this);
+				formsTextView.TextFormatted = renderer._spannableString = formattedText.ToAttributed(Element.Font, Element.TextColor, renderer);
 #pragma warning restore 618
-				_wasFormatted = true;
+				renderer._wasFormatted = true;
 			}
 			else
 			{
-				if (_wasFormatted)
+				if (renderer._wasFormatted)
 				{
-					SetTextColor(_labelTextColorDefault);
-					_lastUpdateColor = Color.Default;
+					renderer.SetTextColor(renderer._labelTextColorDefault);
+					renderer._lastUpdateColor = Color.Default;
 				}
 
 				switch (Element.TextType)
 				{
 					case TextType.Html:
 						if (System.Maui.Maui.IsNougatOrNewer)
-							Control.SetText(Html.FromHtml(Element.Text ?? string.Empty, FromHtmlOptions.ModeCompact), BufferType.Spannable);
+							renderer.SetText(Html.FromHtml(Element.Text ?? string.Empty, FromHtmlOptions.ModeCompact), BufferType.Spannable);
 						else
 #pragma warning disable CS0618 // Type or member is obsolete
-							Control.SetText(Html.FromHtml(Element.Text ?? string.Empty), BufferType.Spannable);
+							renderer.SetText(Html.FromHtml(Element.Text ?? string.Empty), BufferType.Spannable);
 #pragma warning restore CS0618 // Type or member is obsolete
 						break;
 
 					default:
-							Text = Element.UpdateFormsText(Element.Text, Element.TextTransform);
+						renderer.Text = Element.UpdateFormsText(Element.Text, Element.TextTransform);
 						break;
 				}
-				
-				UpdateColor();
-				UpdateFont();
 
-				_wasFormatted = false;
+				renderer.UpdateColor();
+				renderer.UpdateFont();
+
+				renderer._wasFormatted = false;
 			}
 
-			_lastSizeRequest = null;
+			renderer._lastSizeRequest = null;
 		}
 
 		void UpdateLineHeight()

--- a/System.Maui.Platform.Android/Maui/AbstractViewRenderer.Android.cs
+++ b/System.Maui.Platform.Android/Maui/AbstractViewRenderer.Android.cs
@@ -1,0 +1,75 @@
+﻿using System.ComponentModel;
+using System.Maui.Platform.Android;
+using System.Runtime.Versioning;
+using Android.Content;
+using Android.Views;
+
+namespace System.Maui.Platform
+{
+	public partial class AbstractViewRenderer<TVirtualView, TNativeView> : IAndroidViewRenderer
+	{
+		public void SetContext (Context context) => Context = context;
+		public Context Context { get; private set; }
+
+		//public void SetFrame(Rectangle frame)
+		//{	
+		//	var nativeView = View;
+		//	if (nativeView == null)
+		//		return;
+
+		//	if (frame.Width < 0 || frame.Height < 0)
+		//	{
+		//		// This is just some initial Forms value nonsense, nothing is actually laying out yet
+		//		return;
+		//	}
+
+		//	var left = Context.ToPixels(frame.Left);
+		//	var top = Context.ToPixels(frame.Top);
+		//	var bottom = Context.ToPixels(frame.Bottom);
+		//	var right = Context.ToPixels(frame.Right);
+		//	var width = Context.ToPixels(frame.Width);
+		//	var height = Context.ToPixels(frame.Height);
+			
+		//	if (nativeView.LayoutParameters == null)
+		//	{
+		//		nativeView.LayoutParameters = new ViewGroup.LayoutParams((int)width, (int)height);
+		//	}
+		//	else
+		//	{
+		//		nativeView.LayoutParameters.Width = (int)width;
+		//		nativeView.LayoutParameters.Height = (int)height;
+		//	}
+
+		//	nativeView.Layout((int)left, (int)top, (int)right, (int)bottom);
+		//}
+
+		//public virtual SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		//{
+		//	if (TypedNativeView == null)
+		//	{
+		//		return new SizeRequest(Size.Zero);
+		//	}
+
+		//	var deviceWidthConstraint = Context.ToPixels(widthConstraint);
+		//	var deviceHeightConstraint = Context.ToPixels(heightConstraint);
+
+		//	var widthSpec = MeasureSpecMode.AtMost.MakeMeasureSpec((int)deviceWidthConstraint);
+		//	var heightSpec = MeasureSpecMode.AtMost.MakeMeasureSpec((int)deviceHeightConstraint);
+
+		//	TypedNativeView.Measure(widthSpec, heightSpec);
+
+		//	var deviceIndependentSize = Context.FromPixels(TypedNativeView.MeasuredWidth, TypedNativeView.MeasuredHeight);
+
+		//	return new SizeRequest(deviceIndependentSize);
+		//}
+
+		//void SetupContainer () {
+		//	ContainerView = new Core.Controls.ContainerView (this.Context) {
+		//		MainView = this.TypedNativeView,
+		//	};
+		//}
+		
+		//void RemoveContainer () {
+		//}
+	}
+}

--- a/System.Maui.Platform.Android/Maui/AbstractViewRenderer.cs
+++ b/System.Maui.Platform.Android/Maui/AbstractViewRenderer.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Maui.Core;
+#if __IOS__
+using NativeView = UIKit.UIView;
+#elif __MACOS__
+using NativeView = AppKit.NSView;
+#elif MONOANDROID
+using NativeView = Android.Views.View;
+#elif NETCOREAPP
+using NativeView = System.Windows.FrameworkElement;
+#elif NETSTANDARD
+using NativeView = System.Object;
+#endif
+
+namespace System.Maui.Platform
+{
+	public abstract partial class AbstractViewRenderer<TVirtualView, TNativeView> : IMauiRenderer
+		where TVirtualView : class, IFrameworkElement
+#if !NETSTANDARD
+		where TNativeView : NativeView
+#endif
+	{
+
+		protected AbstractViewRenderer (PropertyMapper mapper)
+		{
+			this.defaultMapper = mapper;
+		}
+
+		protected readonly PropertyMapper defaultMapper;
+		protected PropertyMapper mapper;
+
+		protected abstract TNativeView CreateView();
+
+		public NativeView View =>
+			TypedNativeView;
+		//HasContainer ? (NativeView)ContainerView: TypedNativeView;
+
+		public TNativeView TypedNativeView { get; private set; }
+		protected TVirtualView VirtualView { get; private set; }
+		public object NativeView => TypedNativeView;
+		static bool hasSetDefaults;
+		public virtual void SetView(IFrameworkElement view)
+		{
+			VirtualView = view as TVirtualView;
+			TypedNativeView ??= CreateView();
+			if(!hasSetDefaults)
+			{
+				SetupDefaults();
+				hasSetDefaults = true;
+			}
+			mapper = defaultMapper;
+			if (VirtualView is IPropertyMapperView imv)
+			{
+				var map = imv.GetPropertyMapperOverrides();
+				var instancePropertyMapper = map as PropertyMapper<TVirtualView>;
+				if(map != null && instancePropertyMapper == null)
+				{
+				}
+				if (instancePropertyMapper != null)
+				{
+					instancePropertyMapper.Chained = defaultMapper;
+					mapper = instancePropertyMapper;
+				}
+			}
+			
+			mapper?.UpdateProperties(this, VirtualView);
+		}
+
+		public virtual void Remove(IFrameworkElement view)
+		{
+			VirtualView = null;
+		}
+
+		protected virtual void DisposeView(TNativeView nativeView)
+		{
+
+		}
+
+		public virtual void UpdateValue(string property)
+			=> mapper?.UpdateProperty(this, VirtualView, property);
+
+		protected virtual void SetupDefaults() { }
+
+		//public ContainerView ContainerView { get; private set; }
+
+		bool _hasContainer;
+		public bool HasContainer {
+			get => _hasContainer;
+			set {
+				if (_hasContainer == value)
+					return;
+				_hasContainer = value;
+				//if (value) {
+				//	SetupContainer ();
+				//	_hasContainer = ContainerView != null;
+				//} else
+				//	RemoveContainer ();
+			}
+				
+		}
+
+		static protected Color CleanseColor(Color color, Color defaultColor) => color.IsDefault ? defaultColor : color;
+		
+	}
+}

--- a/System.Maui.Platform.Android/Maui/EntryRenderer.Android.cs
+++ b/System.Maui.Platform.Android/Maui/EntryRenderer.Android.cs
@@ -1,0 +1,39 @@
+﻿using Android.Content;
+using Android.Graphics;
+using Android.Util;
+using Android.Views;
+
+#if __ANDROID_29__
+using AndroidX.Core.View;
+using AndroidX.AppCompat.Widget;
+#else
+using Android.Support.V4.View;
+using Android.Support.V7.Widget;
+#endif
+
+using AColor = Android.Graphics.Color;
+using AView = Android.Views.View;
+using System.Maui.Platform;
+using System.Maui.Platform.Android;
+using Android.Widget;
+
+namespace System.Maui.Platform
+{
+	public partial class EntryRenderer : AbstractViewRenderer<ITextInput, AppCompatEditText>
+	{
+		public EntryRenderer(PropertyMapper mapper) : base(mapper)
+		{
+		}
+
+		protected override AppCompatEditText CreateView()
+		{
+			return new AppCompatEditText(Context);
+		}
+
+		static void MapPropertyText(IMauiRenderer arg1, ITextInput arg2)
+		{
+			System.Maui.Platform.Android.EntryRenderer
+				.UpdateText(arg2, arg1.NativeView as EditText);
+		}
+	}
+}

--- a/System.Maui.Platform.Android/Maui/EntryRenderer.cs
+++ b/System.Maui.Platform.Android/Maui/EntryRenderer.cs
@@ -1,0 +1,21 @@
+﻿
+using System.Maui.Platform;
+
+namespace System.Maui.Platform
+{
+	public partial class EntryRenderer
+	{
+		public static PropertyMapper<ITextInput> EntryMapper = new PropertyMapper<ITextInput>(MauiRenderer.ViewMapper)
+		{
+			[nameof(IText.Text)] = MapPropertyText,
+
+			//[nameof(ITextInput.Placeholder)] = MapPropertyPlaceholder,
+			//[nameof(ITextInput.PlaceholderColor)] = MapPropertyPlaceholderColor,
+		};
+
+		public EntryRenderer() : base(EntryMapper)
+		{
+
+		}
+	}
+}

--- a/System.Maui.Platform.Android/Maui/IPropertyMapperView.cs
+++ b/System.Maui.Platform.Android/Maui/IPropertyMapperView.cs
@@ -1,0 +1,5 @@
+﻿namespace System.Maui {
+	public interface IPropertyMapperView {
+		PropertyMapper GetPropertyMapperOverrides ();
+	}
+}

--- a/System.Maui.Platform.Android/Maui/IViewRenderer.Android.cs
+++ b/System.Maui.Platform.Android/Maui/IViewRenderer.Android.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using AView = Android.Views.View;
+using Android.Content;
+
+namespace System.Maui {
+	public interface IAndroidViewRenderer : IMauiRenderer
+	{
+		void SetContext(Context context);
+
+		AView View { get; }
+	}
+}

--- a/System.Maui.Platform.Android/Maui/LabelRenderer.Android.cs
+++ b/System.Maui.Platform.Android/Maui/LabelRenderer.Android.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Android.Content;
+using System.ComponentModel;
+using Android.Content.Res;
+using Android.Graphics;
+#if __ANDROID_29__
+using AndroidX.Core.View;
+#else
+using Android.Support.V4.View;
+#endif
+using Android.Text;
+using Android.Views;
+using Android.Widget;
+using System.Maui.Platform;
+using System.Maui.Platform.Android;
+
+namespace System.Maui.Platform
+{
+	public partial class LabelRenderer : AbstractViewRenderer<ILabel, TextView>
+	{
+		public LabelRenderer(PropertyMapper mapper) : base(mapper)
+		{
+		}
+
+		public static void MapPropertyText(IMauiRenderer renderer, ILabel view)
+		{
+			var control =
+				renderer.NativeView as Platform.Android.FastRenderers.LabelRenderer;
+
+			Platform.Android.FastRenderers.LabelRenderer.UpdateText(view, control);
+		}
+
+		protected override TextView CreateView()
+		{
+			return new
+				System.Maui.Platform.Android.FastRenderers.LabelRenderer(Context);
+		}
+	}
+}

--- a/System.Maui.Platform.Android/Maui/LabelRenderer.cs
+++ b/System.Maui.Platform.Android/Maui/LabelRenderer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Maui.Platform;
+
+namespace System.Maui.Platform
+{
+	// THIS CLASS WILL BE ADDED AS A LINKED FILE ACROSS PLATFORMS
+	// THEN ONCE MULTI TARGETING IS BETTER IT WON'T BE :-)
+	public partial class LabelRenderer 
+	{
+		//public static PropertyMapper<IText> ITextMapper = new PropertyMapper<IText>(ViewRenderer.ViewMapper)
+		//{
+		//	[nameof(ILabel.Text)] = MapPropertyText,
+		//	//[nameof(ILabel.Color)] = MapPropertyColor,
+		//};
+
+		public static PropertyMapper<ILabel> Mapper = new PropertyMapper<ILabel>(MauiRenderer.ViewMapper)
+		{
+			[nameof(ILabel.Text)] = MapPropertyText,
+			//[nameof(ILabel.Color)] = MapPropertyColor,
+			//[nameof(ILabel.LineHeight)] = MapPropertyLineHeight,
+		};
+
+	}
+}

--- a/System.Maui.Platform.Android/Maui/MauiRenderer.Android.cs
+++ b/System.Maui.Platform.Android/Maui/MauiRenderer.Android.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using AView = Android.Views.View;
+using Android.Graphics.Drawables;
+using System.Maui.Platform.Android;
+
+namespace System.Maui.Platform {
+	public partial class MauiRenderer {
+		public static void MapPropertyIsEnabled (IMauiRenderer renderer, IView view)
+		{
+			var nativeView = renderer.NativeView as AView;
+			if (nativeView != null)
+				nativeView.Enabled = view.IsEnabled;
+		}
+
+		public static void MapBackgroundColor (IMauiRenderer renderer, IView view)
+		{
+			var aview = renderer.NativeView as AView;
+			Color backgroundColor = view.BackgroundColor;
+			if (backgroundColor.IsDefault)
+				aview.Background = null;
+			else
+				aview.Background = new ColorDrawable { Color = backgroundColor.ToAndroid() };
+		}
+	}
+}

--- a/System.Maui.Platform.Android/Maui/MauiRenderer.cs
+++ b/System.Maui.Platform.Android/Maui/MauiRenderer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+
+namespace System.Maui.Platform {
+	public partial class MauiRenderer
+	{
+		public static PropertyMapper<IView> ViewMapper = new PropertyMapper<IView> {
+			[nameof(IView.IsEnabled)] = MapPropertyIsEnabled,
+			[nameof(IView.BackgroundColor)] = MapBackgroundColor,
+			//[nameof(IView.Frame)] = MapPropertyFrame,
+			//[nameof(IClipShapeView.ClipShape)] = MapPropertyClipShape
+		};
+
+		//public static void MapPropertyFrame(IMauiRenderer renderer, IView view)
+		//	=> renderer?.SetFrame(view.Frame);
+
+
+		//public static void MapPropertyClipShape(IMauiRenderer renderer, IView view)
+		//{
+		//	if (!(view is IClipShapeView clipShape))
+		//		return;
+		//	//If we are ever going to set HasContainer = false,
+		//	//we need to add a method to verify if anything else requires it
+		//	if (clipShape.ClipShape != null)
+		//		renderer.HasContainer = true;
+		//	if (renderer.ContainerView != null)
+		//		renderer.ContainerView.ClipShape = clipShape.ClipShape;
+		//}
+	}
+}

--- a/System.Maui.Platform.Android/Maui/PropertyMapper.cs
+++ b/System.Maui.Platform.Android/Maui/PropertyMapper.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace System.Maui
+{
+	public class PropertyMapper {
+		internal Dictionary<string, (Action<IMauiRenderer, IFrameworkElement> Action, bool RunOnUpdateAll)> genericMap = new Dictionary<string, (Action<IMauiRenderer, IFrameworkElement> action, bool runOnUpdateAll)> ();
+		protected virtual void UpdateProperty (string key, IMauiRenderer viewRenderer, IFrameworkElement virtualView)
+		{
+			if (genericMap.TryGetValue(key, out var action))
+			{
+				action.Action?.Invoke(viewRenderer, virtualView);
+			}
+		}
+		public void UpdateProperty (IMauiRenderer viewRenderer, IFrameworkElement virtualView, string property)
+		{
+			if (virtualView == null)
+				return;
+			UpdateProperty (property, viewRenderer, virtualView);
+		}
+		public void UpdateProperties (IMauiRenderer viewRenderer, IFrameworkElement virtualView)
+		{
+			if (virtualView == null)
+				return;
+			foreach (var key in Keys) {
+				UpdateProperty (key, viewRenderer, virtualView);
+			}
+		}
+		public virtual ICollection<string> Keys => genericMap.Keys;
+	}
+
+	public class PropertyMapper<TVirtualView> : PropertyMapper, IEnumerable
+		where TVirtualView : IFrameworkElement {
+		private PropertyMapper chained;
+		public PropertyMapper Chained {
+			get => chained;
+			set {
+				chained = value;
+				cachedKeys = null;
+			}
+		}
+
+		ICollection<string> cachedKeys;
+		public override ICollection<string> Keys => cachedKeys ??= (Chained?.Keys.Union (keysForStartup) as ICollection<string> ?? genericMap.Keys);
+		ICollection<string> keysForStartup => genericMap.Where(x => x.Value.RunOnUpdateAll).Select(x => x.Key).ToList();
+
+		public int Count => Keys.Count;
+
+		public bool IsReadOnly => false;
+
+		public Action<IMauiRenderer, TVirtualView> this [string key] {
+			set => genericMap [key] = ((r, v) => value?.Invoke (r, (TVirtualView)v),true);
+		}
+
+		public PropertyMapper ()
+		{
+		}
+
+		public PropertyMapper (PropertyMapper chained)
+		{
+			Chained = chained;
+		}
+		ActionMapper<TVirtualView> actions;
+		public ActionMapper<TVirtualView> Actions {
+			get => actions ??= new ActionMapper<TVirtualView>(this);
+		}
+
+		
+
+		protected override void UpdateProperty (string key, IMauiRenderer viewRenderer, IFrameworkElement virtualView)
+		{
+			if (genericMap.TryGetValue (key, out var action))
+				action.Action?.Invoke (viewRenderer, virtualView);
+			else
+				Chained?.UpdateProperty (viewRenderer, virtualView, key);
+		}
+
+		public void Add (string key, Action<IMauiRenderer, TVirtualView> action)
+			=> this [key] = action;
+
+		public void Add(string key, Action<IMauiRenderer, TVirtualView> action, bool ignoreOnStartup)
+			=>genericMap[key] = ((r, v) => action?.Invoke(r, (TVirtualView)v), ignoreOnStartup);
+
+		
+		
+
+		IEnumerator IEnumerable.GetEnumerator () => genericMap.GetEnumerator ();
+
+		public class ActionMapper<TView>
+			where TView : TVirtualView, IFrameworkElement
+		{
+			public ActionMapper(PropertyMapper<TView> propertyMapper)
+			{
+				PropertyMapper = propertyMapper;
+			}
+
+			public PropertyMapper<TView> PropertyMapper { get; }
+
+			public Action<IMauiRenderer, TView> this[string key]
+			{
+				set => PropertyMapper.genericMap[key] = ((r, v) => value?.Invoke(r, (TView)v), false);
+			}
+		}
+
+	}
+
+}

--- a/System.Maui.Platform.Android/Renderers/EntryRenderer.cs
+++ b/System.Maui.Platform.Android/Renderers/EntryRenderer.cs
@@ -19,7 +19,7 @@ using System.Maui.PlatformConfiguration.AndroidSpecific;
 
 namespace System.Maui.Platform.Android
 {
-	public class EntryRenderer : EntryRendererBase<FormsEditText>
+	public partial class EntryRenderer : EntryRendererBase<FormsEditText>
 	{
 		TextColorSwitcher _hintColorSwitcher;
 		TextColorSwitcher _textColorSwitcher;
@@ -179,7 +179,7 @@ namespace System.Maui.Platform.Android
 			_selectionLengthChangePending = Element.IsSet(Entry.SelectionLengthProperty);
 
 			UpdatePlaceHolderText();
-			UpdateText();
+			UpdateText(Element, EditText);
 			UpdateInputType();
 			UpdateColor();
 			UpdateCharacterSpacing();
@@ -245,7 +245,7 @@ namespace System.Maui.Platform.Android
 			else if (e.PropertyName == Entry.IsPasswordProperty.PropertyName)
 				UpdateInputType();
 			else if (e.IsOneOf(Entry.TextProperty, Entry.TextTransformProperty))
-				UpdateText();
+				UpdateText(Element, EditText);
 			else if (e.PropertyName == Entry.TextColorProperty.PropertyName)
 				UpdateColor();
 			else if (e.PropertyName == InputView.KeyboardProperty.PropertyName)
@@ -532,7 +532,7 @@ namespace System.Maui.Platform.Android
 			EditText.Focusable = isReadOnly;
 		}
 
-		void UpdateText()
+		internal static void UpdateText(ITextInput Element, EditText EditText)
 		{
 			var text = Element.UpdateFormsText(Element.Text, Element.TextTransform);
 			

--- a/System.Maui.Platform.Android/Renderers/EntryRenderer.cs
+++ b/System.Maui.Platform.Android/Renderers/EntryRenderer.cs
@@ -17,6 +17,10 @@ using Android.Widget;
 using Java.Lang;
 using System.Maui.PlatformConfiguration.AndroidSpecific;
 
+#if !__MAUI__
+using ITextInput = global::System.Maui.Entry;
+#endif
+
 namespace System.Maui.Platform.Android
 {
 	public partial class EntryRenderer : EntryRendererBase<FormsEditText>

--- a/System.Maui.Platform.Android/System.Maui.Platform.Android.csproj
+++ b/System.Maui.Platform.Android/System.Maui.Platform.Android.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <Description>Android Backend for System.Maui</Description>
     <AssemblyName>System.Maui.Platform.Android</AssemblyName>
@@ -7,6 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <RootNamespace>System.Maui.Platform.Android</RootNamespace>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <MauiBuild>true</MauiBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -15,6 +16,16 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(MauiBuild)' == 'true'">
+    <DefineConstants>$(DefineConstants);__MAUI__</DefineConstants>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup Condition="$(MauiBuild) != true ">
+    <Compile Remove="Maui\**\*.cs" />
+    <None Include="Maui\**\*.Ios.cs" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Compile Remove="AppCompat\Resource.cs" />
   </ItemGroup>


### PR DESCRIPTION
Spike refactoring renderers towards slim renderers

- Create MAUI folders that can get removed/added based on if you're building for MAUI
  - Maui folder contains the abstract rendererer
  - It also contains the mappers that call out to the static methods
- Move operation like `updatetext` to static methods on the old renderers
  - Call into these static methods from the mappers
  - This ensures we don't regress the old renderers because we are just changing the methods to static

In this version the new renderers aren't using the old renderers at all outside of the static methods for acting against the native component. This lets the maui renderers evolve as slim/fast renderers which should let Comet, etc... develop in parallel

This also gets us thinking about and shaping the interfaces really early in the cycle. Currently the interfaces on here have some extra methods that will probably go away once we actually invert the depedency.

This also sets up the old renderers to work against interfaces so once we do invert the dependency it should "just work"
