### PR TITLE
Moved asterisk to right place

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Active development is happening today to build Android and iOS SDKs against .NET
 |Android     |API 19+        |API 21+        |
 |iOS     |9-15         |10+         |
 |Linux     |Community         |Community         |
-|macOS     |Community         |Microsoft<sup>*</sup>         |
+|macOS     |Community         |Microsoft         |
 |Tizen     |Samsung           |Samsung           |
-|Windows     |UWP Microsoft<br/>WPF Community         |Microsoft         |
+|Windows     |UWP Microsoft<br/>WPF Community         |Microsoft<sup>*</sup>         |
 |**Features**     |         |         |
 |Renderers     |Tightly coupled to BindableObject         |Loosely coupled, no Xamarin.Forms dependencies         |
 |App Models     |MVVM<br/>RxUI         |MVVM</br>RxUI</br>MVU <sup>**</sup></br>Blazor <sup>**</sup>         |


### PR DESCRIPTION
### Description of Change ###

Moved asterisk to right place.

I think the asterisk belongs to the windows implementation not the MacOS implementation.


### API Changes ###
 
None


### Platforms Affected ### 

None


### Behavioral/Visual Changes ###

None


### Before/After Screenshots ### 

Not applicable


### Testing Procedure ###

Not applicable


### PR Checklist ###

Not applicable

- [ ] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
