### PR TITLE
Handle nested files and throw on missing files

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -143,7 +143,8 @@
     <Target Name="GetSharedItems" Outputs="@(ExportedSharedItem)">
 
         <ItemGroup>
-            <SharedItem Include="@(SharedImage)" ItemGroupName="SharedImage" />
+            <SharedItem Include="@(SharedImage)" ItemGroupName="SharedImage" Condition="'%(SharedImage.ForegroundFile)' == ''" />
+            <SharedItem Include="@(SharedImage)" ItemGroupName="SharedImage" Condition="'%(SharedImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(SharedImage.ForegroundFile)'))" />
         </ItemGroup>
 
         <ItemGroup>

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -77,7 +77,10 @@ namespace Microsoft.Maui.Resizetizer
 						throw new Svg2AndroidDrawableConversionException(fgConvertErr, foregroundFile);
 				}
 				else
+				{
+					Logger.Log("Foreground was not found: " + foregroundFile);
 					File.WriteAllText(foregroundDestination, EmptyVectorDrawable);
+				}
 
 				var adaptiveIconXmlStr = AdaptiveIconDrawableXml.Replace("{name}", AppIconName);
 

--- a/src/SingleProject/Resizetizer/src/DetectInvalidResourceOutputFilenamesTask.cs
+++ b/src/SingleProject/Resizetizer/src/DetectInvalidResourceOutputFilenamesTask.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Resizetizer
 						{
 							var filename = item.ItemSpec;
 
-							if (!Utils.IsValidResourceFilename(filename) || !File.Exists(filename))
+							if (!Utils.IsValidResourceFilename(filename))
 								invalidFilenames.Add(filename);
 						});
 					}

--- a/src/SingleProject/Resizetizer/src/ResizetizeSharedImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeSharedImages.cs
@@ -232,6 +232,8 @@ namespace Microsoft.Maui.Resizetizer
 				var info = new SharedImageInfo();
 
 				var fileInfo = new FileInfo(image.GetMetadata("FullPath"));
+				if (!fileInfo.Exists)
+					throw new FileNotFoundException("Unable to find background file: " + fileInfo.FullName, fileInfo.FullName);
 
 				info.Filename = fileInfo.FullName;
 
@@ -253,17 +255,11 @@ namespace Microsoft.Maui.Resizetizer
 				var fgFile = image.GetMetadata("ForegroundFile");
 				if (!string.IsNullOrEmpty(fgFile))
 				{
-					var bgFileInfo = new FileInfo(info.Filename);
+					var fgFileInfo = new FileInfo(fgFile);
+					if (!fgFileInfo.Exists)
+						throw new FileNotFoundException("Unable to find foreground file: " + fgFileInfo.FullName, fgFileInfo.FullName);
 
-					if (!Path.IsPathRooted(fgFile))
-						fgFile = Path.Combine(bgFileInfo.Directory.FullName, fgFile);
-					else
-						fgFile = Path.GetFullPath(fgFile);
-
-					Logger.Log($"AppIcon Foreground: " + fgFile);
-
-					if (File.Exists(fgFile))
-						info.ForegroundFilename = fgFile;
+					info.ForegroundFilename = fgFileInfo.FullName;
 				}
 
 				// TODO:


### PR DESCRIPTION
Some fixes for nested files where path resolution was a bit dodgy.

Also throw on task startup if the files do not exist. No need to get half way and silently die/