### PR TITLE
Implement MaxLines property in LabelHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/Extensions/TextViewExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Extensions/TextViewExtensions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
 	internal static class TextViewExtensions
 	{
+		[PortHandler("Partially ported")]
 		public static void SetMaxLines(this TextView textView, Label label)
 		{
 			var maxLines = label.MaxLines;

--- a/src/Compatibility/Core/src/Android/FastRenderers/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/LabelRenderer.cs
@@ -371,6 +371,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 			_lastSizeRequest = null;
 		}
 
+		[PortHandler]
 		void UpdateMaxLines()
 		{
 			this.SetMaxLines(Element);

--- a/src/Compatibility/Core/src/iOS/Renderers/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/LabelRenderer.cs
@@ -603,6 +603,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 #endif
 		}
 
+		[PortHandler("Partially ported")]
 		void UpdateMaxLines()
 		{
 			if (Element.MaxLines >= 0)

--- a/src/Core/src/Core/ILabel.cs
+++ b/src/Core/src/Core/ILabel.cs
@@ -6,6 +6,11 @@ namespace Microsoft.Maui
 	public interface ILabel : IView, IText
 	{
 		/// <summary>
+		/// Gets the maximum number of lines allowed in the Label.
+		/// </summary>
+		int MaxLines { get; }
+
+		/// <summary>
 		/// Gets the space between the text of the Label and it's border.
 		/// </summary>
 		Thickness Padding { get; }

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -37,6 +37,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateCharacterSpacing(label);
 		}
 
+		public static void MapMaxLines(LabelHandler handler, ILabel label)
+		{
+			handler.TypedNativeView?.UpdateMaxLines(label);
+		}
+
 		public static void MapPadding(LabelHandler handler, ILabel label)
 		{
 			handler.TypedNativeView?.UpdatePadding(label);

--- a/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextColor(IViewHandler handler, ILabel label) { }
 		public static void MapCharacterSpacing(IViewHandler handler, ILabel label) { }
 		public static void MapFont(LabelHandler handler, ILabel label) { }
-		public static void MapPadding(LabelHandler handler, ILabel label) { }
 		public static void MapTextDecorations(LabelHandler handler, ILabel label) { }
+		public static void MapMaxLines(IViewHandler handler, ILabel label) { }
+		public static void MapPadding(LabelHandler handler, ILabel label) {	}
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ILabel.TextColor)] = MapTextColor,
 			[nameof(ILabel.Text)] = MapText,
 			[nameof(ILabel.CharacterSpacing)] = MapCharacterSpacing,
+			[nameof(ILabel.MaxLines)] = MapMaxLines,
 			[nameof(ILabel.Font)] = MapFont,
 			[nameof(ILabel.Padding)] = MapPadding,
 			[nameof(ILabel.TextDecorations)] = MapTextDecorations

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateCharacterSpacing(label);
 		}
 
+		public static void MapMaxLines(LabelHandler handler, ILabel label)
+		{
+			handler.TypedNativeView?.UpdateMaxLines(label);
+		}
+
 		public static void MapPadding(LabelHandler handler, ILabel label)
 		{
 			handler.TypedNativeView?.UpdatePadding(label);

--- a/src/Core/src/Platform/Android/LabelExtensions.cs
+++ b/src/Core/src/Platform/Android/LabelExtensions.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Maui
 			textView.SetTextSize(ComplexUnitType.Sp, sp);
 		}
 
+		public static void UpdateMaxLines(this TextView textView, ILabel label)
+		{
+			textView.SetMaxLines(label.MaxLines);
+		}
+
 		public static void UpdatePadding(this TextView textView, ILabel label)
 		{
 			var context = textView.Context;

--- a/src/Core/src/Platform/Android/LabelExtensions.cs
+++ b/src/Core/src/Platform/Android/LabelExtensions.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Maui
 
 		public static void UpdateMaxLines(this TextView textView, ILabel label)
 		{
-			textView.SetMaxLines(label.MaxLines);
+			int maxLinex = label.MaxLines;
+
+			textView.SetMaxLines(maxLinex);
 		}
 
 		public static void UpdatePadding(this TextView textView, ILabel label)

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -47,6 +47,11 @@ namespace Microsoft.Maui
 			nativeLabel.UpdateCharacterSpacing(label);
 		}
 
+		public static void UpdateMaxLines(this UILabel nativeLabel, ILabel label)
+		{
+			nativeLabel.Lines = label.MaxLines;
+		}
+
 		public static void UpdatePadding(this MauiLabel nativeLabel, ILabel label)
 		{
 			nativeLabel.TextInsets = new UIEdgeInsets(

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -49,7 +49,12 @@ namespace Microsoft.Maui
 
 		public static void UpdateMaxLines(this UILabel nativeLabel, ILabel label)
 		{
-			nativeLabel.Lines = label.MaxLines;
+			int maxLines = label.MaxLines;
+
+			if (maxLines >= 0)
+			{
+				nativeLabel.Lines = maxLines;
+			}
 		}
 
 		public static void UpdatePadding(this MauiLabel nativeLabel, ILabel label)

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.NotEqual(fontManager.DefaultTypeface, nativeLabel.Typeface);
 		}
 
-		[Fact]
+		[Fact(DisplayName = "Padding Initializes Correctly")]
 		public async Task PaddingInitializesCorrectly()
 		{
 			var label = new LabelStub()

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
@@ -109,6 +109,9 @@ namespace Microsoft.Maui.DeviceTests
 		bool GetNativeIsItalic(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).Typeface.IsItalic;
 
+		int GetNativeMaxLines(LabelHandler labelHandler) =>
+			GetNativeLabel(labelHandler).MaxLines;
+
 		Task ValidateNativeBackgroundColor(ILabel label, Color color)
 		{
 			return InvokeOnMainThreadAsync(() =>

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
@@ -148,5 +148,17 @@ namespace Microsoft.Maui.DeviceTests
 				nameof(ILabel.Text),
 				() => label.Text = newText);
 		}
+
+		[Fact(DisplayName = "MaxLines Initializes Correctly")]
+		public async Task MaxLinesInitializesCorrectly()
+		{
+			var label = new LabelStub()
+			{
+				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+				MaxLines = 2
+			};
+
+			await ValidatePropertyInitValue(label, () => label.MaxLines, GetNativeMaxLines, label.MaxLines);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
@@ -95,6 +95,9 @@ namespace Microsoft.Maui.DeviceTests
 		bool GetNativeIsItalic(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
 
+		int GetNativeMaxLines(LabelHandler labelHandler) =>
+ 			(int)GetNativeLabel(labelHandler).Lines;
+
 		double GetNativeCharacterSpacing(LabelHandler labelHandler)
 		{
 			var nativeLabel = GetNativeLabel(labelHandler);

--- a/src/Core/tests/DeviceTests/Stubs/LabelStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LabelStub.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public Font Font { get; set; }
 
 		public TextDecorations TextDecorations { get; set; }
+
+		public int MaxLines { get; set; } = -1;
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `MaxLines` property in LabelHandlers

Related with https://github.com/dotnet/maui/pull/458

### Platforms Affected ### 

- Core
- iOS
- Android

### PR Checklist ###

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests