### PR TITLE
Update Resizetizer Dependencies and Support Different Cultures

### DIFF
--- a/eng/pipelines/common/build-windows.yml
+++ b/eng/pipelines/common/build-windows.yml
@@ -16,7 +16,7 @@ steps:
       provisioning_script: $(provisionator.path)
       provisioning_extra_args: $(provisionator.extraArguments)
 
-  - pwsh: |
+  - powershell: |
       $(System.DefaultWorkingDirectory)/build.ps1 --target provision --TeamProject="$(System.TeamProject)"
     displayName: 'Cake Provision'
     condition: eq(variables['provisioningCake'], 'true')

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -111,7 +111,8 @@
 
 	<Target Name="_CopyToNuspecDir" AfterTargets="Build">
 		<ItemGroup>
-			<_CopyItems Include="$(TargetDir)*.dll" />
+			<_CopyItems Include="$(TargetDir)*.dll" Exclude="$(TargetDir)System.*.dll" />
+			<_CopyItems Include="$(TargetDir)System.CodeDom.dll" />
 		</ItemGroup>
 		<Copy SourceFiles="@(_CopyItems)" DestinationFolder="..\..\..\..\.nuspec\" ContinueOnError="true" Retries="0" />
 	</Target>

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Maui
 {
 	public class MauiUIApplicationDelegate<TApplication> : UIApplicationDelegate, IUIApplicationDelegate where TApplication : MauiApp
 	{
+		public override UIWindow? Window
+		{
+			get;
+			set;
+		}
+
 		public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 		{
 			if (!(Activator.CreateInstance(typeof(TApplication)) is TApplication app))
@@ -32,7 +38,7 @@ namespace Microsoft.Maui
 
 			var content = (window.Page as IView) ?? window.Page.View;
 
-			var uiWindow = new UIWindow
+			Window = new UIWindow
 			{
 				RootViewController = new UIViewController
 				{
@@ -40,7 +46,7 @@ namespace Microsoft.Maui
 				}
 			};
 
-			uiWindow.MakeKeyAndVisible();
+			Window.MakeKeyAndVisible();
 
 			return true;
 		}

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -59,9 +59,7 @@ namespace Microsoft.Maui.Resizetizer
 					fileInfo.Directory.Create();
 
 				Logger.Log("Converting Background SVG to Android Drawable Vector: " + backgroundFile);
-				var bgConvertErr = Svg2VectorDrawable.Svg2Vector.Convert(backgroundFile, backgroundDestination);
-				if (!string.IsNullOrEmpty(bgConvertErr))
-					throw new Svg2AndroidDrawableConversionException(bgConvertErr, backgroundFile);
+				Svg2VectorDrawable.Svg2Vector.Convert(backgroundFile, backgroundDestination);
 
 				var foregroundDestination = Path.Combine(fullIntermediateOutputPath.FullName, "drawable", AppIconName + "_foreground.xml");
 				fileInfo = new FileInfo(foregroundDestination);
@@ -72,9 +70,7 @@ namespace Microsoft.Maui.Resizetizer
 				if (foregroundExists)
 				{
 					Logger.Log("Converting Foreground SVG to Android Drawable Vector: " + foregroundFile);
-					var fgConvertErr = Svg2VectorDrawable.Svg2Vector.Convert(foregroundFile, foregroundDestination);
-					if (!string.IsNullOrEmpty(fgConvertErr))
-						throw new Svg2AndroidDrawableConversionException(fgConvertErr, foregroundFile);
+					Svg2VectorDrawable.Svg2Vector.Convert(foregroundFile, foregroundDestination);
 				}
 				else
 				{

--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 
 namespace Microsoft.Maui.Resizetizer
@@ -48,10 +49,14 @@ namespace Microsoft.Maui.Resizetizer
 			{
 				foreach (var idiom in dpi.Idioms)
 				{
+					var w = dpi.Size.Value.Width.ToString("0.#", CultureInfo.InvariantCulture);
+					var h = dpi.Size.Value.Height.ToString("0.#", CultureInfo.InvariantCulture);
+					var s = dpi.Scale.ToString("0", CultureInfo.InvariantCulture);
+
 					appIconImagesJson.Add(new JObject(
 						new JProperty("idiom", idiom),
-						new JProperty("size", $"{dpi.Size.Value.Width}x{dpi.Size.Value.Height}"),
-						new JProperty("scale", dpi.Scale.ToString("0") + "x"),
+						new JProperty("size", $"{w}x{h}"),
+						new JProperty("scale", $"{s}x"),
 						new JProperty("filename", AppIconName + dpi.FileSuffix + ".png")));
 				}
 			}

--- a/src/SingleProject/Resizetizer/src/Resizer.cs
+++ b/src/SingleProject/Resizetizer/src/Resizer.cs
@@ -55,9 +55,7 @@ namespace Microsoft.Maui.Resizetizer
 				Logger.Log("Converting SVG to Android Drawable Vector: " + Info.Filename);
 
 				// Transform into an android vector drawable
-				var convertErr = Svg2VectorDrawable.Svg2Vector.Convert(Info.Filename, destination);
-				if (!string.IsNullOrEmpty(convertErr))
-					throw new Svg2AndroidDrawableConversionException(convertErr, Info.Filename);
+				Svg2VectorDrawable.Svg2Vector.Convert(Info.Filename, destination);
 			}
 			else
 			{

--- a/src/SingleProject/Resizetizer/src/ResizetizeSharedImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeSharedImages.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Maui.Resizetizer
 				}
 				catch (Exception ex)
 				{
-					Log.LogErrorFromException(ex);
+					Log.LogWarningFromException(ex, true);
 
 					throw;
 				}

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -63,12 +63,12 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="Svg2VectorDrawable.Net" Version="0.1.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Svg2VectorDrawable.Net" Version="0.3.0" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="_CopyToNuspecDir" AfterTargets="Build">
     <ItemGroup>
-      <_CopyItems Include="$(TargetDir)**\*.dll" />
+      <_CopyItems Include="$(TargetDir)**\*.dll" Exclude="$(TargetDir)System.*.dll" />
       <_CopyItems Include="$(TargetDir)**\*.dylib" />
     </ItemGroup>
     <Copy SourceFiles="@(_CopyItems)" DestinationFolder="..\..\..\..\.nuspec\%(RecursiveDir)" ContinueOnError="true" Retries="0" />

--- a/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
@@ -6,16 +6,6 @@ using System.Drawing;
 
 namespace Microsoft.Maui.Resizetizer
 {
-	public class Svg2AndroidDrawableConversionException : Exception
-	{
-		public Svg2AndroidDrawableConversionException(string message, string file) : base ("Failed to Convert SVG to Android Drawable: " + message + " in [" + file + "]")
-		{
-			Filename = file;
-		}
-
-		public string Filename { get; }
-	}
-	
 	internal class SkiaSharpSvgTools : SkiaSharpTools, IDisposable
 	{
 		SKSvg svg;


### PR DESCRIPTION
### Description of Change ###

Update resizetizer dependencies to handle different culture/language/region setting.

### Additions made ###

* updates Svg2VectorDrawable.Net
* use invariant calture

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests