### PR TITLE
Fix UIWindow GC on iOS

### DIFF
--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Maui
 {
 	public class MauiUIApplicationDelegate<TApplication> : UIApplicationDelegate, IUIApplicationDelegate where TApplication : MauiApp
 	{
+		public override UIWindow? Window
+		{
+			get;
+			set;
+		}
+
 		public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 		{
 			if (!(Activator.CreateInstance(typeof(TApplication)) is TApplication app))
@@ -32,7 +38,7 @@ namespace Microsoft.Maui
 
 			var content = (window.Page as IView) ?? window.Page.View;
 
-			var uiWindow = new UIWindow
+			Window = new UIWindow
 			{
 				RootViewController = new UIViewController
 				{
@@ -40,7 +46,7 @@ namespace Microsoft.Maui
 				}
 			};
 
-			uiWindow.MakeKeyAndVisible();
+			Window.MakeKeyAndVisible();
 
 			return true;
 		}


### PR DESCRIPTION
### Description of Change ###

Override and store UIWindow to local variable so that it doesn't get collected or swapped out by the operating system.
