### PR TITLE
Add missing lock in IStyle.Apply

### DIFF
--- a/src/Controls/src/Core/Style.cs
+++ b/src/Controls/src/Core/Style.cs
@@ -85,7 +85,11 @@ namespace Microsoft.Maui.Controls
 
 		void IStyle.Apply(BindableObject bindable)
 		{
-			_targets.Add(new WeakReference<BindableObject>(bindable));
+			lock (_targets)
+			{
+				_targets.Add(new WeakReference<BindableObject>(bindable));
+			}
+
 			if (BaseResourceKey != null)
 				bindable.SetDynamicResource(_basedOnResourceProperty, BaseResourceKey);
 			ApplyCore(bindable, BasedOn ?? GetBasedOnResource(bindable));


### PR DESCRIPTION
I some circumstances it's possible for Styles being applied off the main thread to cause an IndexOutOfRangeException in the Apply method; this should fix that. 