### PR TITLE
Use the correct paths when copying to the build server

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -296,10 +296,15 @@
 
         <!-- iOS Only -->
         <!-- If on Windows, using build host, copy the files over to build server host too -->
+        <ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
+            <_SharedFontsToCopyToBuildServer Include="@(_SharedFontBundleResource);@(_SharedFontPListFiles)">
+                <TargetPath>%(Identity)</TargetPath>
+            </_SharedFontsToCopyToBuildServer>
+        </ItemGroup>
         <CopyFilesToBuildServer
             Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
             SessionId="$(BuildSessionId)"
-            Files="@(_SharedFontBundleResource);@(_SharedFontPListFiles)" />
+            Files="@(_SharedFontsToCopyToBuildServer)" />
 
         <!-- Touch/create our stamp file for outputs -->
         <Touch Files="$(_SharedFontStampFile)" AlwaysCreate="True" />
@@ -367,10 +372,15 @@
 
         <!-- iOS Only -->
         <!-- If on Windows, using build host, copy the files over to build server host too -->
+        <ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
+            <_SharedImagesToCopyToBuildServer Include="@(_ResizetizerCollectedBundleResourceImages)">
+                <TargetPath>%(Identity)</TargetPath>
+            </_SharedImagesToCopyToBuildServer>
+        </ItemGroup>
         <CopyFilesToBuildServer
             Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
             SessionId="$(BuildSessionId)"
-            Files="@(_ResizetizerCollectedBundleResourceImages)" />
+            Files="@(_SharedImagesToCopyToBuildServer)" />
 
         <!-- Android -->
         <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">

--- a/Microsoft.Maui.sln
+++ b/Microsoft.Maui.sln
@@ -25,7 +25,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuspec", ".nuspec", "{7E12
 		.nuspec\Microsoft.Maui.Controls.MultiTargeting.targets = .nuspec\Microsoft.Maui.Controls.MultiTargeting.targets
 		.nuspec\Microsoft.Maui.Controls.nuspec = .nuspec\Microsoft.Maui.Controls.nuspec
 		.nuspec\Microsoft.Maui.Controls.props = .nuspec\Microsoft.Maui.Controls.props
+		.nuspec\Microsoft.Maui.Controls.SingleProject.props = .nuspec\Microsoft.Maui.Controls.SingleProject.props
+		.nuspec\Microsoft.Maui.Controls.SingleProject.targets = .nuspec\Microsoft.Maui.Controls.SingleProject.targets
 		.nuspec\Microsoft.Maui.Controls.targets = .nuspec\Microsoft.Maui.Controls.targets
+		.nuspec\Microsoft.Maui.Resizetizer.targets = .nuspec\Microsoft.Maui.Resizetizer.targets
+		.nuspec\package.ps1 = .nuspec\package.ps1
 		.nuspec\proguard.cfg = .nuspec\proguard.cfg
 	EndProjectSection
 EndProject


### PR DESCRIPTION
### Description of Change ###

Resizetizer sometimes did not pass the final path when copying to the build server and as a result it tried to copy the files to the root without a filename, which is both wrong and impossible as you can't have a blank filename.

