### PR TITLE
Implement Placeholder property in SearchBarHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
@@ -243,6 +243,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			_editText.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
+		[PortHandler]
 		void UpdatePlaceholder()
 		{
 			Control.SetQueryHint(Element.Placeholder);

--- a/src/Compatibility/Core/src/iOS/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/SearchBarRenderer.cs
@@ -304,6 +304,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			Control.UserInteractionEnabled = Element.IsEnabled;
 		}
 
+		[PortHandler("Partially ported")]
 		void UpdatePlaceholder()
 		{
 			if (_textField == null)

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -27,10 +27,6 @@ namespace Maui.Controls.Sample.Pages
 			var verticalStack = new VerticalStackLayout() { Spacing = 5, BackgroundColor = Color.AntiqueWhite };
 			var horizontalStack = new HorizontalStackLayout() { Spacing = 2, BackgroundColor = Color.CornflowerBlue };
 
-			var searchBar = new SearchBar();
-			searchBar.Text = "A search query";
-			verticalStack.Add(searchBar);
-
 			var label = new Label { Text = "This will disappear in ~5 seconds", BackgroundColor = Color.Fuchsia };
 			label.Margin = new Thickness(15, 10, 20, 15);
 
@@ -66,6 +62,7 @@ namespace Maui.Controls.Sample.Pages
 			{
 				System.Console.WriteLine($"Text Changed from '{e.OldTextValue}' to '{e.NewTextValue}'");
 			};
+
 			verticalStack.Add(entry);
 			verticalStack.Add(new Entry { Text = "Entry", TextColor = Color.DarkRed });
 			verticalStack.Add(new Entry { IsPassword = true, TextColor = Color.Black });
@@ -77,14 +74,25 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new ProgressBar { Progress = 0.5, BackgroundColor = Color.LightCoral });
 			verticalStack.Add(new ProgressBar { Progress = 0.5, ProgressColor = Color.Purple });
 
+			var searchBar = new SearchBar();
+			searchBar.Text = "A search query";
+			verticalStack.Add(searchBar);
+
+			var placeholderSearchBar = new SearchBar();
+			placeholderSearchBar.Placeholder = "Placeholder";
+			verticalStack.Add(placeholderSearchBar);
+
 			verticalStack.Add(new Slider());
 
 			verticalStack.Add(new Switch());
 			verticalStack.Add(new Switch() { OnColor = Color.Green });
 			verticalStack.Add(new Switch() { ThumbColor = Color.Yellow });
 			verticalStack.Add(new Switch() { OnColor = Color.Green, ThumbColor = Color.Yellow });
+
 			verticalStack.Add(new DatePicker());
+
 			verticalStack.Add(new TimePicker());
+
 			verticalStack.Add(new Image() { Source = "dotnet_bot.png" });
 
 			Content = verticalStack;

--- a/src/Core/src/Core/IPlaceholder.cs
+++ b/src/Core/src/Core/IPlaceholder.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Maui
+{
+	/// <summary>
+	/// Provides functionality to be able to use a Placeholder.
+	/// </summary>
+	public interface IPlaceholder : IView
+	{
+		/// <summary>
+		/// Gets the placeholder or hint text.
+		/// </summary>
+		string Placeholder { get; }
+	}
+}

--- a/src/Core/src/Core/ISearchBar.cs
+++ b/src/Core/src/Core/ISearchBar.cs
@@ -1,7 +1,13 @@
 ﻿namespace Microsoft.Maui
 {
-	public interface ISearchBar : IView
+	/// <summary>
+	/// Represents a View used to initiating a search.
+	/// </summary>
+	public interface ISearchBar : IView, IPlaceholder
 	{
+		/// <summary>
+		/// Gets a string containing the query text in the SearchBar.
+		/// </summary>
 		string Text { get; }
 	}
 }

--- a/src/Core/src/Core/ITextInput.cs
+++ b/src/Core/src/Core/ITextInput.cs
@@ -3,17 +3,12 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Represents a View which can take keyboard input.
 	/// </summary>
-	public interface ITextInput : IText
+	public interface ITextInput : IText, IPlaceholder
 	{
 		/// <summary>
 		/// Gets or sets the text.
 		/// </summary>
 		new string Text { get; set; }
-
-		/// <summary>
-		/// Gets the placeholder or hint text.
-		/// </summary>
-		string Placeholder { get; }
 
 		/// <summary>
 		/// Gets a value indicating whether or not the view is read-only.

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -13,5 +13,10 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.TypedNativeView?.UpdateText(searchBar);
 		}
+
+		public static void MapPlaceholder(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.TypedNativeView?.UpdatePlaceholder(searchBar);
+		}
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Standard.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Standard.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Maui.Handlers
 		protected override object CreateNativeView() => throw new NotImplementedException();
 
 		public static void MapText(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapPlaceholder(IViewHandler handler, ISearchBar searchBar) { }
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
@@ -4,7 +4,8 @@
 	{
 		public static PropertyMapper<ISearchBar, SearchBarHandler> SearchBarMapper = new PropertyMapper<ISearchBar, SearchBarHandler>(ViewHandler.ViewMapper)
 		{
-			[nameof(ISearchBar.Text)] = MapText
+			[nameof(ISearchBar.Text)] = MapText,
+			[nameof(ISearchBar.Placeholder)] = MapPlaceholder
 		};
 
 		public SearchBarHandler() : base(SearchBarMapper)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -11,5 +11,10 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.TypedNativeView?.UpdateText(searchBar);
 		}
+
+		public static void MapPlaceholder(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.TypedNativeView?.UpdatePlaceholder(searchBar);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/Android/SearchBarExtensions.cs
@@ -8,5 +8,10 @@ namespace Microsoft.Maui
 		{
 			searchView.SetQuery(searchBar.Text, false);
 		}
+
+		public static void UpdatePlaceholder(this SearchView searchView, ISearchBar searchBar)
+		{
+			searchView.QueryHint = searchBar.Placeholder;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -11,12 +11,7 @@ namespace Microsoft.Maui
 
 		public static void UpdatePlaceholder(this UISearchBar uiSearchBar, ISearchBar searchBar)
 		{
-			var textField = uiSearchBar.FindDescendantView<UITextField>();
-
-			if (textField == null)
-				return;
-
-			textField.Text = searchBar.Placeholder;
+			uiSearchBar.Placeholder = searchBar.Placeholder;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -8,5 +8,15 @@ namespace Microsoft.Maui
 		{
 			uiSearchBar.Text = searchBar.Text;
 		}
+
+		public static void UpdatePlaceholder(this UISearchBar uiSearchBar, ISearchBar searchBar)
+		{
+			var textField = uiSearchBar.FindDescendantView<UITextField>();
+
+			if (textField == null)
+				return;
+
+			textField.Text = searchBar.Placeholder;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UIKit;
 
 namespace Microsoft.Maui
@@ -24,6 +25,25 @@ namespace Microsoft.Maui
 
 			if (!color.IsDefault)
 				nativeView.BackgroundColor = color.ToNative();
+		}
+
+		public static T? FindDescendantView<T>(this UIView view) where T : UIView
+		{
+			var queue = new Queue<UIView>();
+			queue.Enqueue(view);
+
+			while (queue.Count > 0)
+			{
+				var descendantView = queue.Dequeue();
+
+				if (descendantView is T result)
+					return result;
+
+				for (var i = 0; i < descendantView.Subviews?.Length; i++)
+					queue.Enqueue(descendantView.Subviews[i]);
+			}
+
+			return null;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -1,5 +1,4 @@
-﻿using Android.Widget;
-using Microsoft.Maui.Handlers;
+﻿using Microsoft.Maui.Handlers;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
 
 namespace Microsoft.Maui.DeviceTests
@@ -11,5 +10,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		string GetNativeText(SearchBarHandler searchBarHandler) =>
 			GetNativeSearchBar(searchBarHandler).Query;
+
+		string GetNativePlaceholder(SearchBarHandler searchBarHandler) =>
+			GetNativeSearchBar(searchBarHandler).QueryHint;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -39,11 +39,22 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					var n = GetNativeText(h);
 					if (string.IsNullOrEmpty(n))
-						n = null; // native platforms may not support null text
+						n = null; // Native platforms may not support null text
 					return n;
 				},
 				setValue,
 				unsetValue);
+		}
+
+		[Fact(DisplayName = "Placeholder Initializes Correctly")]
+		public async Task PlaceholderInitializesCorrectly()
+		{
+			var searchBar = new SearchBarStub
+			{
+				Placeholder = "Placeholder"
+			};
+
+			await ValidatePropertyInitValue(searchBar, () => searchBar.Placeholder, GetNativePlaceholder, searchBar.Placeholder);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -10,5 +10,16 @@ namespace Microsoft.Maui.DeviceTests
 
 		string GetNativeText(SearchBarHandler searchBarHandler) =>
 			GetNativeEntry(searchBarHandler).Text;
+
+		string GetNativePlaceholder(SearchBarHandler searchBarHandler)
+		{
+			var searchBar = GetNativeEntry(searchBarHandler);
+			var textField = searchBar.FindDescendantView<UITextField>();
+
+			if (textField == null)
+				return string.Empty;
+
+			return searchBar.Placeholder;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -11,15 +11,7 @@ namespace Microsoft.Maui.DeviceTests
 		string GetNativeText(SearchBarHandler searchBarHandler) =>
 			GetNativeEntry(searchBarHandler).Text;
 
-		string GetNativePlaceholder(SearchBarHandler searchBarHandler)
-		{
-			var searchBar = GetNativeEntry(searchBarHandler);
-			var textField = searchBar.FindDescendantView<UITextField>();
-
-			if (textField == null)
-				return string.Empty;
-
-			return searchBar.Placeholder;
-		}
+		string GetNativePlaceholder(SearchBarHandler searchBarHandler) =>
+			GetNativeEntry(searchBarHandler).Placeholder;
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/SearchBarStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/SearchBarStub.cs
@@ -2,8 +2,10 @@
 {
 	public partial class SearchBarStub : StubBase, ISearchBar
 	{
-		private string _text;
+		string _text;
 
 		public string Text { get => _text; set => SetProperty(ref _text, value); }
+
+		public string Placeholder { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `Placeholder` property in SearchBarHandlers.

Related with https://github.com/dotnet/maui/pull/457

### Platforms Affected ### 

- Core
- iOS
- Android

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests