### PR TITLE
Switch Entry and Editor from EditText to AppCompatEditText

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -1,14 +1,14 @@
 ﻿using Android.Views;
 using Android.Views.InputMethods;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class EditorHandler : AbstractViewHandler<IEditor, EditText>
+	public partial class EditorHandler : AbstractViewHandler<IEditor, AppCompatEditText>
 	{
-		protected override EditText CreateNativeView()
+		protected override AppCompatEditText CreateNativeView()
 		{
-			var editText = new EditText(Context)
+			var editText = new AppCompatEditText(Context)
 			{
 				ImeOptions = ImeAction.Done
 			};

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -1,33 +1,33 @@
 ﻿using Android.Content.Res;
 using Android.Text;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class EntryHandler : AbstractViewHandler<IEntry, EditText>
+	public partial class EntryHandler : AbstractViewHandler<IEntry, AppCompatEditText>
 	{
 		TextWatcher Watcher { get; } = new TextWatcher();
 
 		static ColorStateList? DefaultTextColors { get; set; }
 
-		protected override EditText CreateNativeView()
+		protected override AppCompatEditText CreateNativeView()
 		{
-			return new EditText(Context);
+			return new AppCompatEditText(Context);
 		}
 
-		protected override void ConnectHandler(EditText nativeView)
+		protected override void ConnectHandler(AppCompatEditText nativeView)
 		{
 			Watcher.Handler = this;
 			nativeView.AddTextChangedListener(Watcher);
 		}
 
-		protected override void DisconnectHandler(EditText nativeView)
+		protected override void DisconnectHandler(AppCompatEditText nativeView)
 		{
 			nativeView.RemoveTextChangedListener(Watcher);
 			Watcher.Handler = null;
 		}
 
-		protected override void SetupDefaults(EditText nativeView)
+		protected override void SetupDefaults(AppCompatEditText nativeView)
 		{
 			base.SetupDefaults(nativeView);
 			DefaultTextColors = nativeView.TextColors;

--- a/src/Core/src/Platform/Android/EditorExtensions.cs
+++ b/src/Core/src/Platform/Android/EditorExtensions.cs
@@ -1,10 +1,10 @@
-﻿using Android.Widget;
+﻿using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui
 {
 	public static class EditorExtensions
 	{
-		public static void UpdateText(this EditText editText, IEditor editor)
+		public static void UpdateText(this AppCompatEditText editText, IEditor editor)
 		{
 			string text = editor.Text;
 

--- a/src/Core/src/Platform/Android/EntryExtensions.cs
+++ b/src/Core/src/Platform/Android/EntryExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Android.Content.Res;
 using Android.Text;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui
 {
@@ -11,7 +11,7 @@ namespace Microsoft.Maui
 			new[] { -global::Android.Resource.Attribute.StateEnabled }
 		};
 
-		public static void UpdateText(this EditText editText, IEntry entry)
+		public static void UpdateText(this AppCompatEditText editText, IEntry entry)
 		{
 			var newText = entry.Text ?? string.Empty;
 			var oldText = editText.Text ?? string.Empty;
@@ -20,7 +20,7 @@ namespace Microsoft.Maui
 				editText.Text = newText;
 		}
 
-		public static void UpdateTextColor(this EditText editText, IEntry entry, ColorStateList? defaultColor)
+		public static void UpdateTextColor(this AppCompatEditText editText, IEntry entry, ColorStateList? defaultColor)
 		{
 			var textColor = entry.TextColor;
 			if (textColor.IsDefault)
@@ -39,12 +39,12 @@ namespace Microsoft.Maui
 			}
 		}
 
-		public static void UpdateIsPassword(this EditText editText, IEntry entry)
+		public static void UpdateIsPassword(this AppCompatEditText editText, IEntry entry)
 		{
 			editText.SetInputType(entry);
 		}
 
-		internal static void SetInputType(this EditText editText, IEntry entry)
+		internal static void SetInputType(this AppCompatEditText editText, IEntry entry)
 		{
 			editText.InputType = InputTypes.ClassText;
 			editText.InputType |= InputTypes.TextFlagMultiLine;
@@ -62,12 +62,12 @@ namespace Microsoft.Maui
 				editText.InputType = InputTypes.Null;
 		}
 
-		public static void UpdateIsTextPredictionEnabled(this EditText editText, IEntry entry)
+		public static void UpdateIsTextPredictionEnabled(this AppCompatEditText editText, IEntry entry)
 		{
 			editText.SetInputType(entry);
 		}
 
-		public static void UpdatePlaceholder(this EditText editText, IEntry entry)
+		public static void UpdatePlaceholder(this AppCompatEditText editText, IEntry entry)
 		{
 			if (editText.Hint == entry.Placeholder)
 				return;
@@ -75,7 +75,7 @@ namespace Microsoft.Maui
 			editText.Hint = entry.Placeholder;
 		}
 
-		public static void UpdateIsReadOnly(this EditText editText, IEntry entry)
+		public static void UpdateIsReadOnly(this AppCompatEditText editText, IEntry entry)
 		{
 			bool isEditable = !entry.IsReadOnly;
 

--- a/src/Core/src/Platform/iOS/EntryExtensions.cs
+++ b/src/Core/src/Platform/iOS/EntryExtensions.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Maui
 				textField.AutocorrectionType = UITextAutocorrectionType.No;
 		}
 
-		public static void UpdatePlaceholder(this UITextField editText, IEntry entry)
+		public static void UpdatePlaceholder(this UITextField textField, IEntry entry)
 		{
-			editText.Placeholder = entry.Placeholder;
+			textField.Placeholder = entry.Placeholder;
 		}
 
 		public static void UpdateIsReadOnly(this UITextField textField, IEntry entry)

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -1,13 +1,12 @@
-﻿using Android.Text;
-using Android.Widget;
+﻿using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EditorHandlerTests
 	{
-		EditText GetNativeEditor(EditorHandler editorHandler) =>
-			(EditText)editorHandler.View;
+		AppCompatEditText GetNativeEditor(EditorHandler editorHandler) =>
+			(AppCompatEditText)editorHandler.View;
 
 		string GetNativeText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).Text;

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -1,5 +1,5 @@
 ﻿using Android.Text;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Handlers;
 using AColor = global::Android.Graphics.Color;
 
@@ -7,8 +7,8 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EntryHandlerTests
 	{
-		EditText GetNativeEntry(EntryHandler entryHandler) =>
-			(EditText)entryHandler.View;
+		AppCompatEditText GetNativeEntry(EntryHandler entryHandler) =>
+			(AppCompatEditText)entryHandler.View;
 
 		string GetNativeText(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).Text;


### PR DESCRIPTION
### Description of Change ###
Switches Android handlers for Entry and Editor from EditText to AppCompatEditText. Fixes #466. 

Also, a small inconsistent parameter name in iOS was changed ("editText" -> "textField"). 

### Additions made ###
- Switch Android native view for Entry from EditText to AppCompatEditText
- Switch Android native view for Editor from EditText to AppCompatEditText
- Switch EntryExtensions from EditText to AppCompatEditText

### PR Checklist ###
- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
