### PR TITLE
Use netstandard2.0 for build tasks

### DIFF
--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
@@ -23,7 +23,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.3" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="System.CodeDom" Version="4.4.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.CodeDom" Version="4.7.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" GeneratePathProperty="true" />
 		<PackageReference Include="System.CodeDom" Version="6.0.0-preview.2.21110.7" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
 		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
@@ -55,6 +55,7 @@
 		<None Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.Mdb.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 		<None Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.Pdb.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 		<None Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.Rocks.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
+    <None Include="$(PkgSystem_CodeDom)\lib\netstandard2.0\System.CodeDom.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 
 		<None Include="..\Core\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 		<None Include="..\Core\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.Controls.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
@@ -10,7 +10,7 @@
 		<AssemblyName>Microsoft.Maui.Controls.Build.Tasks</AssemblyName>
 		<RootNamespace>Microsoft.Maui.Controls.Build.Tasks</RootNamespace>
 		<Description>Microsoft MAUI Build Task</Description>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<!-- <SignAssembly Condition=" '$(_DisableStrongNamer)' != 'True' ">True</SignAssembly>
 		<DisableStrongNamer Condition=" '$(_DisableStrongNamer)' == 'True' ">True</DisableStrongNamer>
@@ -55,9 +55,9 @@
 		<None Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.Pdb.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 		<None Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.Rocks.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 
-		<None Include="..\Core\bin\$(Configuration)\net6.0\Microsoft.Maui.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
-		<None Include="..\Core\bin\$(Configuration)\net6.0\Microsoft.Maui.Controls.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
-		<None Include="..\Xaml\bin\$(Configuration)\net6.0\Microsoft.Maui.Controls.Xaml.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
+		<None Include="..\Core\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
+		<None Include="..\Core\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.Controls.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
+		<None Include="..\Xaml\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.Controls.Xaml.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
@@ -23,7 +23,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.3" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="System.CodeDom" Version="6.0.0-preview.2.21110.7" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="System.CodeDom" Version="4.4.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+		<PackageReference Include="System.CodeDom" Version="6.0.0-preview.2.21110.7" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
 		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />

--- a/src/Controls/src/Core/Controls.Core-net6.csproj
+++ b/src/Controls/src/Core/Controls.Core-net6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT'">$(TargetFrameworks);net6.0-maccatalyst</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Controls</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls</AssemblyName>

--- a/src/Controls/src/Xaml.Design/Controls.Xaml.Design-net6.csproj
+++ b/src/Controls/src/Xaml.Design/Controls.Xaml.Design-net6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 		<AssemblyName>Microsoft.Maui.Controls.Xaml.Design</AssemblyName>
 		<EnableDefaultCompileItems>False</EnableDefaultCompileItems>
 	</PropertyGroup>

--- a/src/Controls/src/Xaml/Controls.Xaml-net6.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml-net6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT'">$(TargetFrameworks);net6.0-maccatalyst</TargetFrameworks>
 		<AssemblyName>Microsoft.Maui.Controls.Xaml</AssemblyName>
 		<RootNamespace>Microsoft.Maui.Controls.Xaml</RootNamespace>


### PR DESCRIPTION
It seems that Visual Studio's MSBuild doesn't always resolve net6.0 references correctly, so the build tasks built for net6.0 are not working reliably.  There's no reason these cannot be netstandard2.0, so switching them back to build on that TFM for now which should produce working build tasks in IDE's

