### PR TITLE
More template fixes

### DIFF
--- a/src/Controls/src/Templates/maui-mobile/.template.config/template.json
+++ b/src/Controls/src/Templates/maui-mobile/.template.config/template.json
@@ -5,7 +5,7 @@
     "identity": "Microsoft.Maui.SingleProject",
     "name": ".NET Maui Mobile Application",
     "description": "A project for creating a .NET MAUI application for iOS and Android",
-    "shortName": "maui-mobile",
+    "shortName": "maui",
     "tags": {
       "language": "C#",
       "type": "project"

--- a/src/Controls/src/Templates/maui-mobile/Application.cs
+++ b/src/Controls/src/Templates/maui-mobile/Application.cs
@@ -6,7 +6,7 @@ namespace MauiApp1
 {
 	public class Application : MauiApp
 	{
-		public override IAppHostBuilder CreateBuilder() => 
+		public override IAppHostBuilder CreateBuilder() =>
 			base.CreateBuilder().ConfigureServices((ctx, services) =>
 				{
 					services.AddTransient<MainPage>();

--- a/src/Controls/src/Templates/maui-mobile/MacCatalyst/AppDelegate.cs
+++ b/src/Controls/src/Templates/maui-mobile/MacCatalyst/AppDelegate.cs
@@ -1,0 +1,10 @@
+﻿using Foundation;
+using Microsoft.Maui;
+
+namespace MauiApp1
+{
+	[Register("AppDelegate")]
+	public class AppDelegate : MauiUIApplicationDelegate<Application>
+	{
+	}
+}

--- a/src/Controls/src/Templates/maui-mobile/MacCatalyst/Entitlements.plist
+++ b/src/Controls/src/Templates/maui-mobile/MacCatalyst/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+    </dict>
+</plist>

--- a/src/Controls/src/Templates/maui-mobile/MacCatalyst/Info.plist
+++ b/src/Controls/src/Templates/maui-mobile/MacCatalyst/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.15</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/appicon.appiconset</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/src/Controls/src/Templates/maui-mobile/MacCatalyst/LaunchScreen.storyboard
+++ b/src/Controls/src/Templates/maui-mobile/MacCatalyst/LaunchScreen.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.29803922770000002" green="0.1764705926" blue="0.80392158030000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/src/Controls/src/Templates/maui-mobile/MacCatalyst/Program.cs
+++ b/src/Controls/src/Templates/maui-mobile/MacCatalyst/Program.cs
@@ -1,0 +1,15 @@
+﻿using UIKit;
+
+namespace MauiApp1
+{
+	public class Program
+	{
+		// This is the main entry point of the application.
+		static void Main(string[] args)
+		{
+			// if you want to use a different Application Delegate class from "AppDelegate"
+			// you can specify it here.
+			UIApplication.Main(args, null, "AppDelegate");
+		}
+	}
+}

--- a/src/Controls/src/Templates/maui-mobile/MauiApp1.in.csproj
+++ b/src/Controls/src/Templates/maui-mobile/MauiApp1.in.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0-android;net6.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net6.0-maccatalyst</TargetFrameworks>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MauiApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <SingleProject>true</SingleProject>
@@ -9,6 +10,8 @@
     <ApplicationId>com.companyname.MauiApp1</ApplicationId>
     <ApplicationVersion>1.0</ApplicationVersion>
     <AndroidVersionCode>1</AndroidVersionCode>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">ios-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

* For now make the template `dotnet new maui`. We can change it back
  to `maui-mobile` when desktop templates are added.
* Added Catalyst to the template to match what we have in
  dotnet/net6-mobile-samples.
* Define a default `$(RuntimeIdentifier)` for Apple platforms.
* Ran `dotnet format` on the templates that fixed a small thing.

### Additions made ###

`dotnet new maui-mobile` -> `dotnet new maui`

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests