### PR TITLE
[Build] Fix GitInfo usage to calculate version

### DIFF
--- a/eng/Git.Build.targets
+++ b/eng/Git.Build.targets
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.0.26" PrivateAssets="All" />
-    <PackageReference Include="MSBuilder.GenerateAssemblyInfo" Version="0.2.1" PrivateAssets="All" />
+    <PackageReference Include="GitInfo" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="MSBuilder.GenerateAssemblyInfo" Version="0.2.2" PrivateAssets="All" />
 	</ItemGroup>
  </Project>

--- a/eng/Version.targets
+++ b/eng/Version.targets
@@ -1,7 +1,7 @@
 <Project>
  <PropertyGroup>
     <NightlyTag>nightly</NightlyTag>
-    <RegexTag>-[a-z]+\.[0-9]</RegexTag>
+    <RegexTag>[a-z]+\.[0-9]</RegexTag>
  </PropertyGroup>
  <PropertyGroup>
     <GitBranch Condition="'$(SYSTEM_PULLREQUEST_TARGETBRANCH)' != ''">$(SYSTEM_PULLREQUEST_TARGETBRANCH)</GitBranch>

--- a/eng/Version.targets
+++ b/eng/Version.targets
@@ -43,7 +43,7 @@
     <PropertyGroup>
       <GitDefaultBranch>main</GitDefaultBranch>
       <GitIgnoreBranchVersion>true</GitIgnoreBranchVersion>
-      <GitIgnoreTagVersion>true</GitIgnoreBranchVersion>
+      <GitIgnoreTagVersion>true</GitIgnoreTagVersion>
     </PropertyGroup>
   </Target>
   <Target Name="SetVersions" BeforeTargets="$(SetVersionsBefore)" DependsOnTargets="$(SetVersionsDependsOn)" Returns="$(Version)">
@@ -51,7 +51,7 @@
       <SemVerLabel>$([System.Text.RegularExpressions.Regex]::Match($(GitTag), $(RegexTag)))</SemVerLabel>
       <GitDefaultBranch>main</GitDefaultBranch>
       <GitIgnoreBranchVersion>true</GitIgnoreBranchVersion>
-      <GitIgnoreTagVersion>true</GitIgnoreBranchVersion>
+      <GitIgnoreTagVersion>true</GitIgnoreTagVersion>
       <GitSemVerLabel Condition=" '$(GitTag)' != '' and $([System.Text.RegularExpressions.Regex]::IsMatch('$(GitTag)', $(RegexTag))) ">$(SemVerLabel)</GitSemVerLabel> 
       <GitSemVerLabel  Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'">$(NightlyTag)</GitSemVerLabel>
       <GitSemVerDashLabel Condition="'$(GitSemVerLabel)' != ''" >-$(GitSemVerLabel)</GitSemVerDashLabel>

--- a/eng/Version.targets
+++ b/eng/Version.targets
@@ -38,7 +38,7 @@
   <Target Name="SetVersions" BeforeTargets="$(SetVersionsBefore)" DependsOnTargets="$(SetVersionsDependsOn)" Returns="$(Version)">
     <PropertyGroup>
       <SemVerLabel>$([System.Text.RegularExpressions.Regex]::Match($(GitTag), $(RegexTag)))</SemVerLabel>
-      <GitSemVerLabel Condition=" '$(GitTag)' != '' and '$(GitTag)' == '$(GitBranch)' and $([System.Text.RegularExpressions.Regex]::IsMatch('$(GitTag)', $(RegexTag))) ">$(SemVerLabel)</GitSemVerLabel> 
+      <GitSemVerLabel Condition=" '$(GitTag)' != '' and $([System.Text.RegularExpressions.Regex]::IsMatch('$(GitTag)', $(RegexTag))) ">$(SemVerLabel)</GitSemVerLabel> 
       <GitSemVerLabel  Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'">$(NightlyTag)</GitSemVerLabel>
       <GitSemVerDashLabel Condition="'$(GitSemVerLabel)' != ''" >-$(GitSemVerLabel)</GitSemVerDashLabel>
     </PropertyGroup>

--- a/eng/Version.targets
+++ b/eng/Version.targets
@@ -39,7 +39,7 @@
     <PropertyGroup>
       <SemVerLabel>$([System.Text.RegularExpressions.Regex]::Match($(GitTag), $(RegexTag)))</SemVerLabel>
       <GitDefaultBranch>main</GitDefaultBranch>
-      <GitIgnoreBranchVersion>main</GitIgnoreBranchVersion>
+      <GitIgnoreBranchVersion>true</GitIgnoreBranchVersion>
       <GitSemVerLabel Condition=" '$(GitTag)' != '' and $([System.Text.RegularExpressions.Regex]::IsMatch('$(GitTag)', $(RegexTag))) ">$(SemVerLabel)</GitSemVerLabel> 
       <GitSemVerLabel  Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'">$(NightlyTag)</GitSemVerLabel>
       <GitSemVerDashLabel Condition="'$(GitSemVerLabel)' != ''" >-$(GitSemVerLabel)</GitSemVerDashLabel>

--- a/eng/Version.targets
+++ b/eng/Version.targets
@@ -38,6 +38,8 @@
   <Target Name="SetVersions" BeforeTargets="$(SetVersionsBefore)" DependsOnTargets="$(SetVersionsDependsOn)" Returns="$(Version)">
     <PropertyGroup>
       <SemVerLabel>$([System.Text.RegularExpressions.Regex]::Match($(GitTag), $(RegexTag)))</SemVerLabel>
+      <GitDefaultBranch>main</GitDefaultBranch>
+      <GitIgnoreBranchVersion>main</GitIgnoreBranchVersion>
       <GitSemVerLabel Condition=" '$(GitTag)' != '' and $([System.Text.RegularExpressions.Regex]::IsMatch('$(GitTag)', $(RegexTag))) ">$(SemVerLabel)</GitSemVerLabel> 
       <GitSemVerLabel  Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'">$(NightlyTag)</GitSemVerLabel>
       <GitSemVerDashLabel Condition="'$(GitSemVerLabel)' != ''" >-$(GitSemVerLabel)</GitSemVerDashLabel>

--- a/eng/Version.targets
+++ b/eng/Version.targets
@@ -33,13 +33,25 @@
       GitVersion;
       $(SetVersionsDependsOn);
     </SetVersionsDependsOn>
+    <SetGitInfoPropsBefore>
+      GitInfo;
+      GitVersion;
+    </SetGitInfoPropsBefore>
   </PropertyGroup>
 
+  <Target Name="SetGitInfoProps" BeforeTargets="$(SetGitInfoPropsBefore)">
+    <PropertyGroup>
+      <GitDefaultBranch>main</GitDefaultBranch>
+      <GitIgnoreBranchVersion>true</GitIgnoreBranchVersion>
+      <GitIgnoreTagVersion>true</GitIgnoreBranchVersion>
+    </PropertyGroup>
+  </Target>
   <Target Name="SetVersions" BeforeTargets="$(SetVersionsBefore)" DependsOnTargets="$(SetVersionsDependsOn)" Returns="$(Version)">
     <PropertyGroup>
       <SemVerLabel>$([System.Text.RegularExpressions.Regex]::Match($(GitTag), $(RegexTag)))</SemVerLabel>
       <GitDefaultBranch>main</GitDefaultBranch>
       <GitIgnoreBranchVersion>true</GitIgnoreBranchVersion>
+      <GitIgnoreTagVersion>true</GitIgnoreBranchVersion>
       <GitSemVerLabel Condition=" '$(GitTag)' != '' and $([System.Text.RegularExpressions.Regex]::IsMatch('$(GitTag)', $(RegexTag))) ">$(SemVerLabel)</GitSemVerLabel> 
       <GitSemVerLabel  Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'">$(NightlyTag)</GitSemVerLabel>
       <GitSemVerDashLabel Condition="'$(GitSemVerLabel)' != ''" >-$(GitSemVerLabel)</GitSemVerDashLabel>

--- a/eng/Version.targets
+++ b/eng/Version.targets
@@ -1,7 +1,7 @@
 <Project>
  <PropertyGroup>
     <NightlyTag>nightly</NightlyTag>
-    <RegexPre>pre\d</RegexPre>
+    <RegexTag>-[a-z]+\.[0-9]</RegexTag>
  </PropertyGroup>
  <PropertyGroup>
     <GitBranch Condition="'$(SYSTEM_PULLREQUEST_TARGETBRANCH)' != ''">$(SYSTEM_PULLREQUEST_TARGETBRANCH)</GitBranch>
@@ -37,6 +37,8 @@
 
   <Target Name="SetVersions" BeforeTargets="$(SetVersionsBefore)" DependsOnTargets="$(SetVersionsDependsOn)" Returns="$(Version)">
     <PropertyGroup>
+      <SemVerLabel>$([System.Text.RegularExpressions.Regex]::Match($(GitTag), $(RegexTag)))</SemVerLabel>
+      <GitSemVerLabel Condition=" '$(GitTag)' != '' and '$(GitTag)' == '$(GitBranch)' and $([System.Text.RegularExpressions.Regex]::IsMatch('$(GitTag)', $(RegexTag))) ">$(SemVerLabel)</GitSemVerLabel> 
       <GitSemVerLabel  Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'">$(NightlyTag)</GitSemVerLabel>
       <GitSemVerDashLabel Condition="'$(GitSemVerLabel)' != ''" >-$(GitSemVerLabel)</GitSemVerDashLabel>
     </PropertyGroup>


### PR DESCRIPTION
### Description of Change ###

Fix GitInfo so it doesn't use the branch/tag to calculate the version.


### Additions made ###
<!-- List all the additions made here, example:

 - Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for Android and iOS
- Adds extension methods to apply Padding on Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on iOS and Android

 -->

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests