### PR TITLE
[GH-473] Port Font to Editor

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
@@ -210,6 +210,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				ElementController.SendCompleted();
 		}
 
+		[PortHandler]
 		protected virtual void UpdateFont()
 		{
 			EditText.Typeface = Element.ToTypeface();

--- a/src/Compatibility/Core/src/iOS/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/EditorRenderer.cs
@@ -300,6 +300,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				TextView.InputAccessoryView.Hidden = !Element.IsEnabled;
 		}
 
+		[PortHandler]
 		protected internal virtual void UpdateFont()
 		{
 			var font = Element.ToUIFont();

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -90,6 +90,7 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new Editor { Text = "Editor" });
 			verticalStack.Add(new Editor { Text = "Lorem ipsum dolor sit amet", MaxLength = 10 });
 			verticalStack.Add(new Editor { Text = "Predictive Text Off", IsTextPredictionEnabled = false });
+			verticalStack.Add(new Editor { Text = "Lorem ipsum dolor sit amet", FontSize = 10, FontFamily = "dokdo_regular"});
 
 			var entry = new Entry();
 			entry.TextChanged += (sender, e) =>

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Handlers
 		
 		public static void MapFont(EditorHandler handler, IEditor editor)
 		{
-			var services = App.Current?.Services
+			var services = handler.Services
 				   ?? throw new InvalidOperationException($"Unable to find service provider, the App.Current.Services was null.");
 			var fontManager = services.GetRequiredService<IFontManager>();
 

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFont(EditorHandler handler, IEditor editor)
 		{
 			var services = handler.Services
-				   ?? throw new InvalidOperationException($"Unable to find service provider, the App.Current.Services was null.");
+				   ?? throw new InvalidOperationException($"Unable to find service provider, the handler.Services was null.");
 			var fontManager = services.GetRequiredService<IFontManager>();
 
 			handler.TypedNativeView?.UpdateFont(editor, fontManager);

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -1,6 +1,8 @@
-﻿using Android.Views;
+﻿using System;
+using Android.Views;
 using Android.Views.InputMethods;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -39,6 +41,15 @@ namespace Microsoft.Maui.Handlers
 		public static void MapIsTextPredictionEnabled(EditorHandler handler, IEditor editor)
 		{
 			handler.TypedNativeView?.UpdateIsTextPredictionEnabled(editor);
+		}
+		
+		public static void MapFont(EditorHandler handler, IEditor editor)
+		{
+			var services = App.Current?.Services
+				   ?? throw new InvalidOperationException($"Unable to find service provider, the App.Current.Services was null.");
+			var fontManager = services.GetRequiredService<IFontManager>();
+
+			handler.TypedNativeView?.UpdateFont(editor, fontManager);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Editor/EditorHandler.Standard.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Standard.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapCharacterSpacing(IViewHandler handler, IEditor editor) { }
 		public static void MapMaxLength(IViewHandler handler, IEditor editor) { }
 		public static void MapIsTextPredictionEnabled(EditorHandler handler, IEditor editor) { }
+		public static void MapFont(IViewHandler handler, IEditor editor) { }
 	}
 }

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -8,6 +8,7 @@
 			[nameof(IEditor.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEditor.MaxLength)] = MapMaxLength,
 			[nameof(IEditor.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled
+			[nameof(ILabel.Font)] = MapFont
 		};
 
 		public EditorHandler() : base(EditorMapper)

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -8,7 +8,7 @@
 			[nameof(IEditor.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEditor.MaxLength)] = MapMaxLength,
 			[nameof(IEditor.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled
-			[nameof(ILabel.Font)] = MapFont
+			[nameof(IEditor.Font)] = MapFont
 		};
 
 		public EditorHandler() : base(EditorMapper)

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -7,7 +7,7 @@
 			[nameof(IEditor.Text)] = MapText,
 			[nameof(IEditor.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEditor.MaxLength)] = MapMaxLength,
-			[nameof(IEditor.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled
+			[nameof(IEditor.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled,
 			[nameof(IEditor.Font)] = MapFont
 		};
 

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapFont(EditorHandler handler, IEditor editor)
 		{
-			var services = App.Current?.Services ??
+			var services = handler.Services ??
 				throw new InvalidOperationException($"Unable to find service provider, the App.Current.Services was null.");
 			var fontManager = services.GetRequiredService<IFontManager>();
 

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFont(EditorHandler handler, IEditor editor)
 		{
 			var services = handler.Services ??
-				throw new InvalidOperationException($"Unable to find service provider, the App.Current.Services was null.");
+				throw new InvalidOperationException($"Unable to find service provider, the handler.Services was null.");
 			var fontManager = services.GetRequiredService<IFontManager>();
 
 			handler.TypedNativeView?.UpdateFont(editor, fontManager);

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -1,5 +1,7 @@
-﻿using CoreGraphics;
+using CoreGraphics;
 using Foundation;
+using System;
+using Microsoft.Extensions.DependencyInjection;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers
@@ -74,6 +76,15 @@ namespace Microsoft.Maui.Handlers
 			var newLength = currLength + addLength - remLength;
 
 			return newLength <= VirtualView.MaxLength;
+		}
+
+		public static void MapFont(EditorHandler handler, IEditor editor)
+		{
+			var services = App.Current?.Services ??
+				throw new InvalidOperationException($"Unable to find service provider, the App.Current.Services was null.");
+			var fontManager = services.GetRequiredService<IFontManager>();
+
+			handler.TypedNativeView?.UpdateFont(editor, fontManager);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -121,6 +121,17 @@ namespace Microsoft.Maui
 			editText.ImeOptions = entry.ReturnType.ToNative();
 		}
 
+		public static void UpdateFont(this AppCompatEditText editText, IEditor editor, IFontManager fontManager)
+		{
+			var font = editor.Font;
+
+			var tf = fontManager.GetTypeface(font);
+			editText.Typeface = tf;
+
+			var sp = fontManager.GetScaledPixel(font);
+			editText.SetTextSize(Android.Util.ComplexUnitType.Sp, sp);
+		}
+
 		internal static void SetInputType(this AppCompatEditText editText, IEntry entry)
 		{
 			editText.InputType = InputTypes.ClassText;

--- a/src/Core/src/Platform/iOS/TextViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextViewExtensions.cs
@@ -37,5 +37,11 @@ namespace Microsoft.Maui
 			textView.AutocorrectionType = editor.IsTextPredictionEnabled
 				? UITextAutocorrectionType.Yes : UITextAutocorrectionType.No;
 		}
+
+		public static void UpdateFont(this UITextView textView, IEditor editor, IFontManager fontManager)
+		{
+			var uiFont = fontManager.GetFont(editor.Font);
+			textView.Font = uiFont;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.DeviceTests
 			var handler = await CreateHandlerAsync(editor);
 			var nativeEditor = GetNativeEditor(handler);
 
-			var fontManager = App.Services.GetRequiredService<IFontManager>();
+			var fontManager = handler.Services.GetRequiredService<IFontManager>();
 
 			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
 

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.ViewValue);
 			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
 		}
-	
+		
 		[Theory(DisplayName = "Font Family Initializes Correctly")]
 		[InlineData(null)]
 		[InlineData("monospace")]

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Android.Text;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Xunit;
@@ -34,6 +35,33 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.ViewValue);
 			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
 		}
+	
+		[Theory(DisplayName = "Font Family Initializes Correctly")]
+		[InlineData(null)]
+		[InlineData("monospace")]
+		[InlineData("Dokdo")]
+		public async Task FontFamilyInitializesCorrectly(string family)
+		{
+			var label = new EditorStub()
+			{
+				Text = "Test",
+				Font = Font.OfSize(family, 10)
+			};
+
+			var handler = await CreateHandlerAsync(label);
+			var nativeEditor = GetNativeEditor(handler);
+
+			var fontManager = App.Services.GetRequiredService<IFontManager>();
+
+			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
+
+			Assert.Equal(nativeFont, nativeEditor.Typeface);
+
+			if (string.IsNullOrEmpty(family))
+				Assert.Equal(fontManager.DefaultTypeface, nativeEditor.Typeface);
+			else
+				Assert.NotEqual(fontManager.DefaultTypeface, nativeEditor.Typeface);
+		}
 
 		AppCompatEditText GetNativeEditor(EditorHandler editorHandler) =>
 			(AppCompatEditText)editorHandler.View;
@@ -55,5 +83,6 @@ namespace Microsoft.Maui.DeviceTests
 
 			return -1;
 		}
+		
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -84,5 +84,10 @@ namespace Microsoft.Maui.DeviceTests
 			return -1;
 		}
 		
+		double GetNativeUnscaledFontSize(EditorHandler editorHandler)
+		{
+			var textView = GetNativeEditor(editorHandler);
+			return textView.TextSize / textView.Resources.DisplayMetrics.Density;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -42,13 +42,13 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData("Dokdo")]
 		public async Task FontFamilyInitializesCorrectly(string family)
 		{
-			var label = new EditorStub()
+			var editor = new EditorStub()
 			{
 				Text = "Test",
 				Font = Font.OfSize(family, 10)
 			};
 
-			var handler = await CreateHandlerAsync(label);
+			var handler = await CreateHandlerAsync(editor);
 			var nativeEditor = GetNativeEditor(handler);
 
 			var fontManager = App.Services.GetRequiredService<IFontManager>();

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -121,5 +121,21 @@ namespace Microsoft.Maui.DeviceTests
 				setValue,
 				unsetValue);
 		}
+		
+		[Theory(DisplayName = "Font Size Initializes Correctly")]
+		[InlineData(1)]
+		[InlineData(10)]
+		[InlineData(20)]
+		[InlineData(100)]
+		public async Task FontSizeInitializesCorrectly(int fontSize)
+		{
+			var editor = new EditorStub()
+			{
+				Text = "Test",
+				Font = Font.OfSize("Arial", fontSize)
+			};
+
+			await ValidatePropertyInitValue(editor, () => editor.Font.FontSize, GetNativeUnscaledFontSize, editor.Font.FontSize);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using UIKit;
@@ -31,6 +32,31 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(xplatCharacterSpacing, values.ViewValue);
 			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
+		}
+
+		[Theory(DisplayName = "Font Family Initializes Correctly")]
+		[InlineData(null)]
+		[InlineData("Times New Roman")]
+		[InlineData("Dokdo")]
+		public async Task FontFamilyInitializesCorrectly(string family)
+		{
+			var editor = new EditorStub()
+			{
+				Text = "Test",
+				Font = Font.OfSize(family, 10)
+			};
+
+			var nativeFont = await GetValueAsync(editor, handler => GetNativeEditor(handler).Font);
+
+			var fontManager = App.Services.GetRequiredService<IFontManager>();
+
+			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
+
+			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
+			if (string.IsNullOrEmpty(family))
+				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
+			else
+				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
 		}
 
 		UITextView GetNativeEditor(EditorHandler editorHandler) =>

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -73,5 +73,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsTextPredictionEnabled(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).AutocorrectionType == UITextAutocorrectionType.Yes;
+			
+		double GetNativeUnscaledFontSize(EditorHandler editorHandler) =>
+			GetNativeEditor(editorHandler).Font.PointSize;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -46,9 +46,10 @@ namespace Microsoft.Maui.DeviceTests
 				Font = Font.OfSize(family, 10)
 			};
 
+			var handler = await CreateHandlerAsync(editor);
 			var nativeFont = await GetValueAsync(editor, handler => GetNativeEditor(handler).Font);
 
-			var fontManager = App.Services.GetRequiredService<IFontManager>();
+			var fontManager = handler.Services.GetRequiredService<IFontManager>();
 
 			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
 


### PR DESCRIPTION
### Description of Change ###

Implements #473

### Additions made ###

- Adds Font property map to EditorHandler
- Adds Font mapping methods to EditorHandlerfor Android and iOS
- Adds extension methods to apply Font on Android/iOS
- Adds DeviceTests for initial Font values on iOS and Android


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests