### PR TITLE
Implement IsTextPredictionEnabled property on Editor

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
@@ -216,6 +216,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			EditText.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
+		[PortHandler("Partially Ported")]
 		void UpdateInputType()
 		{
 			Editor model = Element;

--- a/src/Compatibility/Core/src/iOS/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/EditorRenderer.cs
@@ -306,6 +306,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			TextView.Font = font;
 		}
 
+		[PortHandler("Partially Ported")]
 		void UpdateKeyboard()
 		{
 			var keyboard = Element.Keyboard;

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -85,6 +85,7 @@ namespace Maui.Controls.Sample.Pages
       
 			verticalStack.Add(new Editor());
 			verticalStack.Add(new Editor { Text = "Editor" });
+			verticalStack.Add(new Editor { Text = "Predictive Text Off", IsTextPredictionEnabled = false });
 
 			var entry = new Entry();
 			entry.TextChanged += (sender, e) =>

--- a/src/Core/src/Core/IEditor.cs
+++ b/src/Core/src/Core/IEditor.cs
@@ -5,6 +5,9 @@
 	/// </summary>
 	public interface IEditor : IView, IText
 	{
-
+		/// <summary>
+		/// Gets a value that controls whether text prediction and automatic text correction is on or off.
+		/// </summary>
+		bool IsTextPredictionEnabled { get; }
 	}
 }

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -30,5 +30,10 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.TypedNativeView?.UpdateCharacterSpacing(editor);
 		}
+			
+		public static void MapPredictiveText(EditorHandler handler, IEditor editor)
+		{
+			handler.TypedNativeView?.UpdatePredictiveText(editor);
+		}
 	}
 }

--- a/src/Core/src/Handlers/Editor/EditorHandler.Standard.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Standard.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Maui.Handlers
 		protected override object CreateNativeView() => throw new NotImplementedException();
 
 		public static void MapText(IViewHandler handler, IEditor editor) { }
+
 		public static void MapCharacterSpacing(IViewHandler handler, IEditor editor) { }
+		
+		public static void MapPredictiveText(EditorHandler handler, IEditor editor) { }
 	}
 }

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -5,7 +5,8 @@
 		public static PropertyMapper<IEditor, EditorHandler> EditorMapper = new PropertyMapper<IEditor, EditorHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(IEditor.Text)] = MapText,
-			[nameof(IEditor.CharacterSpacing)] = MapCharacterSpacing
+			[nameof(IEditor.CharacterSpacing)] = MapCharacterSpacing,
+			[nameof(IEditor.IsTextPredictionEnabled)] = MapPredictiveText
 		};
 
 		public EditorHandler() : base(EditorMapper)

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -1,4 +1,5 @@
-﻿using CoreGraphics;
+﻿using System;
+using CoreGraphics;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers
@@ -23,6 +24,11 @@ namespace Microsoft.Maui.Handlers
 		public static void MapCharacterSpacing(EditorHandler handler, IEditor editor)
 		{
 			handler.TypedNativeView?.UpdateCharacterSpacing(editor);
+		}
+			
+		public static void MapPredictiveText(EditorHandler handler, IEditor editor)
+		{
+			handler.TypedNativeView?.UpdatePredictiveText(editor);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/EditorExtensions.cs
+++ b/src/Core/src/Platform/Android/EditorExtensions.cs
@@ -1,4 +1,5 @@
-﻿using AndroidX.AppCompat.Widget;
+﻿using Android.Text;
+using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui
 {
@@ -22,6 +23,14 @@ namespace Microsoft.Maui
 		public static void UpdateCharacterSpacing(this AppCompatEditText editText, IEditor editor)
 		{
 			editText.LetterSpacing = editor.CharacterSpacing.ToEm();
+		}
+			
+		public static void UpdatePredictiveText(this AppCompatEditText editText, IEditor editor)
+		{
+			if(editor.IsTextPredictionEnabled)
+				return;
+			
+			editText.InputType |= InputTypes.TextFlagNoSuggestions;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/EditorExtensions.cs
+++ b/src/Core/src/Platform/iOS/EditorExtensions.cs
@@ -23,5 +23,13 @@ namespace Microsoft.Maui
 
 			// TODO: Include AttributedText to Label Placeholder
 		}
+		
+		public static void UpdatePredictiveText(this UITextView textView, IEditor editor)
+		{
+			if(editor.IsTextPredictionEnabled)
+				return;
+			
+			textView.AutocorrectionType = UITextAutocorrectionType.No;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/EditorExtensions.cs
+++ b/src/Core/src/Platform/iOS/EditorExtensions.cs
@@ -26,10 +26,8 @@ namespace Microsoft.Maui
 		
 		public static void UpdatePredictiveText(this UITextView textView, IEditor editor)
 		{
-			if(editor.IsTextPredictionEnabled)
-				return;
-			
-			textView.AutocorrectionType = UITextAutocorrectionType.No;
+			textView.AutocorrectionType = editor.IsTextPredictionEnabled 
+				? UITextAutocorrectionType.Yes : UITextAutocorrectionType.No;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -1,10 +1,8 @@
 ﻿using Android.Text;
 using AndroidX.AppCompat.Widget;
-using Microsoft.Maui.Handlers;
-using System.Threading.Tasks;
-using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using Android.Text;
+using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Handlers;
+using System.Threading.Tasks;
 using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
@@ -39,6 +42,9 @@ namespace Microsoft.Maui.DeviceTests
 
 		string GetNativeText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).Text;
+		
+		bool GetNativeIsTextPredictionEnabled(EditorHandler editorHandler) =>
+			!GetNativeEditor(editorHandler).InputType.HasFlag(InputTypes.TextFlagNoSuggestions);
 
         double GetNativeCharacterSpacing(EditorHandler editorHandler)
         {

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -46,5 +46,18 @@ namespace Microsoft.Maui.DeviceTests
 				setValue,
 				unsetValue);
 		}
+		
+		[Theory(DisplayName = "Is Text Prediction Enabled")]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task IsTextPredictionEnabledCorrectly(bool isEnabled)
+		{
+			var editor = new EditorStub()
+			{
+				IsTextPredictionEnabled = isEnabled
+			};
+
+			await ValidatePropertyInitValue(editor, () => editor.IsTextPredictionEnabled, GetNativeIsTextPredictionEnabled, isEnabled);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -44,5 +44,8 @@ namespace Microsoft.Maui.DeviceTests
             var editor = GetNativeEditor(editorHandler);
             return editor.AttributedText.GetCharacterSpacing();
         }
-    }
+		
+		bool GetNativeIsTextPredictionEnabled(EditorHandler editorHandler) =>
+			GetNativeEditor(editorHandler).AutocorrectionType == UITextAutocorrectionType.Yes;
+	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
@@ -10,6 +10,6 @@
 
 		public double CharacterSpacing { get; set; }
 
-		public bool IsTextPredictionEnabled { get; }
+		public bool IsTextPredictionEnabled { get; set; }
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
@@ -9,5 +9,7 @@
 		public Font Font { get; set; }
 
 		public double CharacterSpacing { get; set; }
+
+		public bool IsTextPredictionEnabled { get; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implements #385

### Additions made ###

- Adds `bool IsTextPredictionEnabled { get; }` to the `IEditor` interface
- Adds IsTextPredictionEnabled property map to EditorHandler
- Adds PredictiveText mapping methods to LabelHandler for Android and iOS
- Adds extension methods to handle Predictive Text on Android/iOS
- Adds DeviceTests for testing IsTextPredictionEnabled values on iOS and Android

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests