### PR TITLE
Implement ReturnType property in EntryHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/Extensions/EntryRendererExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Extensions/EntryRendererExtensions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
 	internal static class EntryRendererExtensions
 	{
-
+		[PortHandler]
 		internal static ImeAction ToAndroidImeAction(this ReturnType returnType)
 		{
 			switch (returnType)

--- a/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
@@ -397,6 +397,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			}
 		}
 
+		[PortHandler]
 		void UpdateReturnType()
 		{
 			if (Control == null || Element == null)

--- a/src/Compatibility/Core/src/iOS/Extensions/Extensions.cs
+++ b/src/Compatibility/Core/src/iOS/Extensions/Extensions.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			}
 		}
 
+		[PortHandler]
 		internal static UIReturnKeyType ToUIReturnKeyType(this ReturnType returnType)
 		{
 			switch (returnType)

--- a/src/Compatibility/Core/src/iOS/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/EntryRenderer.cs
@@ -402,6 +402,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			return newLength <= Element?.MaxLength;
 		}
 
+		[PortHandler]
 		void UpdateReturnType()
 		{
 			if (Control == null || Element == null)

--- a/src/Core/src/Core/IEntry.cs
+++ b/src/Core/src/Core/IEntry.cs
@@ -14,5 +14,10 @@
 		/// Gets a value that controls whether text prediction and automatic text correction is on or off.
 		/// </summary>
 		bool IsTextPredictionEnabled { get; }
+
+		/// <summary>
+		/// Gets an enumeration value that controls the appearance of the return button.
+		/// </summary>
+		ReturnType ReturnType { get; }
 	}
 }

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateIsReadOnly(entry);
 		}
 
+		public static void MapReturnType(EntryHandler handler, IEntry entry)
+		{
+			handler.TypedNativeView?.UpdateReturnType(entry);
+		}
+
 		void OnTextChanged(string? text)
 		{
 			if (VirtualView == null || TypedNativeView == null)

--- a/src/Core/src/Handlers/Entry/EntryHandler.Standard.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Standard.cs
@@ -14,5 +14,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapPlaceholder(IViewHandler handler, IEntry entry) { }
 		public static void MapIsReadOnly(IViewHandler handler, IEntry entry) { }
 		public static void MapFont(IViewHandler handler, IEntry entry) { }
+		public static void MapReturnType(IViewHandler handler, IEntry entry) { }
 	}
 }

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -11,7 +11,8 @@
 			[nameof(IEntry.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled,
 			[nameof(IEntry.Placeholder)] = MapPlaceholder,
 			[nameof(IEntry.IsReadOnly)] = MapIsReadOnly,
-			[nameof(IEntry.Font)] = MapFont
+			[nameof(IEntry.Font)] = MapFont,
+			[nameof(IEntry.ReturnType)] = MapReturnType
 		};
 
 		public EntryHandler() : base(EntryMapper)

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -77,6 +77,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateIsReadOnly(entry);
 		}
 
+		public static void MapReturnType(EntryHandler handler, IEntry entry)
+		{
+			handler.TypedNativeView?.UpdateReturnType(entry);
+		}
+
 		void OnEditingChanged(object? sender, EventArgs e) => OnTextChanged();
 
 		void OnEditingEnded(object? sender, EventArgs e) => OnTextChanged();

--- a/src/Core/src/Platform/Android/EntryExtensions.cs
+++ b/src/Core/src/Platform/Android/EntryExtensions.cs
@@ -102,5 +102,10 @@ namespace Microsoft.Maui
 			if (entry.IsReadOnly)
 				editText.InputType = InputTypes.Null;
 		}
+		
+		public static void UpdateReturnType(this AppCompatEditText editText, IEntry entry)
+		{
+			editText.ImeOptions = entry.ReturnType.ToNative();
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/ImeActionExtensions.cs
+++ b/src/Core/src/Platform/Android/ImeActionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Android.Views.InputMethods;
+
+namespace Microsoft.Maui
+{
+	public static class ImeActionExtensions
+	{
+		public static ImeAction ToNative(this ReturnType returnType)
+		{
+			switch (returnType)
+			{
+				case ReturnType.Go:
+					return ImeAction.Go;
+				case ReturnType.Next:
+					return ImeAction.Next;
+				case ReturnType.Send:
+					return ImeAction.Send;
+				case ReturnType.Search:
+					return ImeAction.Search;
+				case ReturnType.Done:
+					return ImeAction.Done;
+				case ReturnType.Default:
+					return ImeAction.Done;
+				default:
+					throw new NotImplementedException($"ReturnType {returnType} not supported");
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/EntryExtensions.cs
+++ b/src/Core/src/Platform/iOS/EntryExtensions.cs
@@ -69,5 +69,10 @@ namespace Microsoft.Maui
 			var uiFont = fontManager.GetFont(entry.Font);
 			textField.Font = uiFont;
 		}
+
+		public static void UpdateReturnType(this UITextField textField, IEntry entry)
+		{
+			textField.ReturnKeyType = entry.ReturnType.ToNative();
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ReturnKeyTypeExtensions.cs
+++ b/src/Core/src/Platform/iOS/ReturnKeyTypeExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using UIKit;
+
+namespace Microsoft.Maui
+{
+	public static class ReturnKeyTypeExtensions
+	{
+		public static UIReturnKeyType ToNative(this ReturnType returnType)
+		{
+			switch (returnType)
+			{
+				case ReturnType.Go:
+					return UIReturnKeyType.Go;
+				case ReturnType.Next:
+					return UIReturnKeyType.Next;
+				case ReturnType.Send:
+					return UIReturnKeyType.Send;
+				case ReturnType.Search:
+					return UIReturnKeyType.Search;
+				case ReturnType.Done:
+					return UIReturnKeyType.Done;
+				case ReturnType.Default:
+					return UIReturnKeyType.Default;
+				default:
+					throw new NotImplementedException($"ReturnType {returnType} not supported");
+			}
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -1,11 +1,12 @@
 ﻿using System.Threading.Tasks;
 using Android.Text;
+using Android.Views.InputMethods;
 using AndroidX.AppCompat.Widget;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Xunit;
-using AColor = global::Android.Graphics.Color;
+using AColor = Android.Graphics.Color;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -36,6 +37,31 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(fontManager.DefaultTypeface, nativeEntry.Typeface);
 			else
 				Assert.NotEqual(fontManager.DefaultTypeface, nativeEntry.Typeface);
+		}
+
+		[Fact(DisplayName = "ReturnType Initializes Correctly")]
+		public async Task ReturnTypeInitializesCorrectly()
+		{
+			var xplatReturnType = ReturnType.Next;
+			var entry = new EntryStub()
+			{
+				Text = "Test",
+				ReturnType = xplatReturnType
+			};
+
+			ImeAction expectedValue = ImeAction.Next;
+
+			var values = await GetValueAsync(entry, (handler) =>
+			{
+				return new
+				{
+					ViewValue = entry.ReturnType,
+					NativeViewValue = GetNativeReturnType(handler)
+				};
+			});
+
+			Assert.Equal(xplatReturnType, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue);
 		}
 
 		[Fact(DisplayName = "Horizontal TextAlignment Initializes Correctly")]
@@ -113,5 +139,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		Android.Views.TextAlignment GetNativeTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;
+			
+		ImeAction GetNativeReturnType(EntryHandler entryHandler) =>
+			GetNativeEntry(entryHandler).ImeOptions;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -59,6 +59,32 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatHorizontalTextAlignment, values.ViewValue);
 			values.NativeViewValue.AssertHasFlag(expectedValue);
 		}
+		
+		[Fact(DisplayName = "ReturnType Initializes Correctly")]
+		public async Task ReturnTypeInitializesCorrectly()
+		{
+			var xplatReturnType = ReturnType.Next;
+			var entry = new EntryStub()
+			{
+				Text = "Test",
+				ReturnType = xplatReturnType
+			};
+
+			UIReturnKeyType expectedValue = UIReturnKeyType.Next;
+
+			var values = await GetValueAsync(entry, (handler) =>
+			{
+				return new
+				{
+					ViewValue = entry.ReturnType,
+					NativeViewValue = GetNativeReturnType(handler)
+				};
+			});
+
+			Assert.Equal(xplatReturnType, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue);
+		}
+
 
 		UITextField GetNativeEntry(EntryHandler entryHandler) =>
 			(UITextField)entryHandler.View;
@@ -95,5 +121,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		UITextAlignment GetNativeTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;
+			
+		UIReturnKeyType GetNativeReturnType(EntryHandler entryHandler) =>
+			GetNativeEntry(entryHandler).ReturnKeyType;
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/EntryStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/EntryStub.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public TextAlignment HorizontalTextAlignment { get; set; }
 
+		public ReturnType ReturnType { get; set; }
+
 		public event EventHandler<StubPropertyChangedEventArgs<string>> TextChanged;
 
 		void OnTextChanged(string oldValue, string newValue) =>


### PR DESCRIPTION
### Description of Change ###

Implement `ReturnType` property in EntryHandlers.

Related with https://github.com/dotnet/maui/pull/376

### Platforms Affected ### 

- Core
- iOS
- Android

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests