### PR TITLE
Try build ControlGallery Android on CI

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -19,7 +19,7 @@ PowerShell:
 // ADDINS
 //////////////////////////////////////////////////////////////////////
 #addin "nuget:?package=Cake.Android.SdkManager&version=3.0.2"
-#addin "nuget:?package=Cake.Boots&version=1.0.3.556"
+#addin "nuget:?package=Cake.Boots&version=1.0.4.600-preview1"
 #addin "nuget:?package=Cake.AppleSimulator&version=0.2.0"
 #addin "nuget:?package=Cake.FileHelpers&version=3.2.1"
 

--- a/eng/ControlGallery.Build.props
+++ b/eng/ControlGallery.Build.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-</Project>

--- a/eng/pipelines/common/controlgallery-android.yml
+++ b/eng/pipelines/common/controlgallery-android.yml
@@ -45,11 +45,11 @@ steps:
     displayName: 'Copy Android Files for UITest'
     inputs:
       Contents: |
-        **/Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
-        **/Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/nunit.*
-        **/Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/NUnit3.*
-        **/Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Plugin.*
-        **/Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
+        **/Android.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
+        **/Android.UITests/bin/$(BuildConfiguration)/nunit.*
+        **/Android.UITests/bin/$(BuildConfiguration)/NUnit3.*
+        **/Android.UITests/bin/$(BuildConfiguration)/Plugin.*
+        **/Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
       TargetFolder: '$(build.artifactstagingdirectory)/android'
       CleanTargetFolder: true
       flattenFolders: true
@@ -57,7 +57,7 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy $(renderers)'
     inputs:
-      SourceFolder: src/ControlGallery/src/Xamarin.Forms.ControlGallery.Android/bin/$(BuildConfiguration)/
+      SourceFolder: src/Compatibility/ControlGallery/src/Android/bin/$(BuildConfiguration)/
       Contents: '**/*.apk'
       TargetFolder: '$(build.artifactstagingdirectory)/androidApp'
       CleanTargetFolder: true

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -150,6 +150,27 @@ stages:
         steps:
           - template: common/controlgallery-ios.yml
 
+  - stage: build_android
+    displayName: Android
+    dependsOn: []
+    jobs:
+      - job: android
+        workspace:
+          clean: all
+        displayName: Build ControlGallery Android
+        timeoutInMinutes: 120
+        pool:
+          name:  $(macOSXVmPool)
+          vmImage: $(macOSXVmImage)
+        variables:
+          renderers: 'FAST'
+          outputfolder: 'newRenderers'
+          provisionator.xcode : '$(System.DefaultWorkingDirectory)/eng/provisioning/xcode.csx'
+          provisionator.path : '$(System.DefaultWorkingDirectory)/eng/provisioning/provisioning.csx'
+          provisionator.extraArguments : '--v'
+        steps:
+          - template: common/controlgallery-android.yml
+
   - stage: pack_net6
     displayName: Pack .NET 6
     dependsOn: []

--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\..\..\..\..\eng\Environment.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="../../../../../eng/ControlGallery.Build.props" />
-  <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\..\..\..\..\eng\Environment.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -31,7 +31,7 @@
     <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'LEGACY'">$(DefineConstants);LEGACY_RENDERERS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DefineConstants>$(DefineConstants);HAVE_OPENTK</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAVE_OPENTK;ENABLE_TEST_CLOUD</DefineConstants>
     <AndroidKeyStore>True</AndroidKeyStore>
     <AndroidSigningKeyStore>$(MSBuildThisFileDirectory)../../../../../eng/debug.keystore</AndroidSigningKeyStore>
     <AndroidSigningStorePass>android</AndroidSigningStorePass>

--- a/src/Compatibility/ControlGallery/src/Android/FormsAppCompatActivity.cs
+++ b/src/Compatibility/ControlGallery/src/Android/FormsAppCompatActivity.cs
@@ -55,12 +55,14 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Android
 			Microsoft.Maui.Controls.Compatibility.Forms.Init(this, bundle);
 			FormsMaps.Init(this, bundle);
 
+#if ENABLE_TEST_CLOUD
 			Handlers.ViewHandler
 				.ViewMapper[nameof(IView.AutomationId)] = (h, v) =>
 				{
 					(h.NativeView as global::Android.Views.View).ContentDescription =
 						v.AutomationId;
 				};
+#endif
 
 			//FormsMaterial.Init(this, bundle);
 			AndroidAppLinks.Init(this);

--- a/src/Compatibility/ControlGallery/src/Android/LinkDescription.xml
+++ b/src/Compatibility/ControlGallery/src/Android/LinkDescription.xml
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <linker>
-  <assembly fullname="Microsoft.Maui.Controls.ControlGallery.Android">
-    <namespace fullname="Microsoft.Maui.Controls.ControlGallery.Android.Tests" />
-    <namespace fullname="Xamarin.Forms.Controls.Issues" />
+  <assembly fullname="Microsoft.Maui.Controls.Compatibility.ControlGallery.Android">
+    <namespace fullname="Microsoft.Maui.Controls.Compatibility.ControlGallery.Android.Tests" />
+    <namespace fullname="Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues" />
     <type fullname="*Renderer" />
   </assembly>
-  <assembly fullname="Xamarin.Forms.Controls">
-    <namespace fullname="Xamarin.Forms.Controls.Tests" />
+   <assembly fullname="Microsoft.Maui.Controls.Compatibility.ControlGallery">
+    <namespace fullname="Maui.Controls.Tests" />
+    <namespace fullname="Maui.Controls.Compatibility.Tests" />
   </assembly>
   <assembly fullname="nunit.framework"/>
   <assembly fullname="mscorlib">
@@ -14,6 +15,6 @@
     <type fullname="System.Runtime.CompilerServices.INotifyCompletion" />
     <type fullname="System.Runtime.CompilerServices.TaskAwaiter" />
   </assembly>
-  <assembly fullname="Xamarin.Forms.Platform.Android.UnitTests" />
-  <assembly fullname="Xamarin.Platform" />
+  <assembly fullname="Microsoft.Maui.Controls.Compatibility.Android.UnitTests" />
+  <assembly fullname="Microsoft.Maui" />
 </linker>

--- a/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
+++ b/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\..\eng\ControlGallery.Build.props" />
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\..\..\..\..\eng\Environment.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
### Description of Change ###

Build Android ControlGallery

Implements #

### Additions made ###
<!-- List all the additions made here, example:

 - Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for Android and iOS
- Adds extension methods to apply Padding on Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on iOS and Android

 -->

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests