### PR TITLE
Update maui-mobile template: Sets the msbuild property _KeepLaunchProfiles to true and adds the MauiSingleProject project capability

### DIFF
--- a/src/Controls/src/Templates/maui-mobile/Directory.Build.targets
+++ b/src/Controls/src/Templates/maui-mobile/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project>
+  <!-- NOTE: we can eventually remove these settings when MAUI is a .NET workload -->
+  <PropertyGroup>
+    <_KeepLaunchProfiles>true</_KeepLaunchProfiles>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectCapability Include="MauiSingleProject" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### Description of Change ###

To enable the switch between target frameworks on VisualStudio the LaunchProfiles capability need to be enabled.

By default, it is enabled but this capability is removed by our SDKs because the HEAD projects (Android and iOS) does not use this IDE feature to display devices on the start button.

The _KeepLaunchProfiles property avoids that removal in order to have LaunchProfiles enabled on VisualStudio.

The MauiSingleProject project capability is required to identify single projects and when VisualStudio loads a project with this capability the initialization required for Android and iOS is executed, starting the services for both platforms.
The Android and iOS project capabilities cannot be used to do that because only one set of these capabilities (related to the current TargetFramework) is available at this moment.

These values need to be available when the project is loaded and if we set them on the targets for the MAUI NuGet package the first time after creating the project there are not recognized because we need a Nuget restore.