### PR TITLE
[Housekeeping] Remove CodesignEntitlements from Core DeviceTests Debug

### DIFF
--- a/src/Core/tests/DeviceTests.iOS/Core.DeviceTests.iOS.csproj
+++ b/src/Core/tests/DeviceTests.iOS/Core.DeviceTests.iOS.csproj
@@ -24,7 +24,6 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
### Description of Change ###

Remove CodesignEntitlements from Core DeviceTests using Simulator in Debug mode

We used this for CI? If it is the case, this PR can be closed.

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 