### PR TITLE
Implemented LineHeight on Label

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/LabelRenderer.cs
@@ -248,6 +248,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			}
 		}
 
+		[PortHandler]
 		void UpdateLineHeight()
 		{
 			_lastSizeRequest = null;

--- a/src/Compatibility/Core/src/iOS/Renderers/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/LabelRenderer.cs
@@ -431,6 +431,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			_perfectSizeValid = false;
 		}
 
+		[PortHandler("Partially. Mapped LineHeight")]
 		void UpdateText()
 		{
 			if (IsElementOrControlEmpty)

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -50,6 +50,7 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new Label { Text = loremIpsum, MaxLines = 2 });
 			verticalStack.Add(new Label { Text = loremIpsum, LineBreakMode = LineBreakMode.TailTruncation });
 			verticalStack.Add(new Label { Text = loremIpsum, MaxLines = 2, LineBreakMode = LineBreakMode.TailTruncation });
+			verticalStack.Add(new Label { Text = "This should have five times the line height!", LineHeight = 5});
 
 
 			var paddingButton = new Button

--- a/src/Core/src/Core/ILabel.cs
+++ b/src/Core/src/Core/ILabel.cs
@@ -17,8 +17,13 @@ namespace Microsoft.Maui
 
 		/// <summary>
 		/// Gets the text decoration applied to the Label.
-		/// Underline and strikethrough text decorations can be applied.
+		/// Underline and strike-through text decorations can be applied.
 		/// </summary>
 		TextDecorations TextDecorations { get; }
+		/// <summary>
+		/// Gets the line height applied to the Label.
+		/// Underline and strike-through text decorations can be applied.
+		/// </summary>
+		double LineHeight { get; }
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Maui.Handlers
 	public partial class LabelHandler : AbstractViewHandler<ILabel, TextView>
 	{
 		static Color DefaultTextColor { get; set; }
+		static float LineSpacingAddDefault { get; set; }
+		static float LineSpacingMultDefault { get; set; }
 
 		protected override TextView CreateNativeView() => new TextView(Context);
 
@@ -20,6 +22,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				DefaultTextColor = Color.FromUint((uint)nativeView.TextColors.DefaultColor);
 			}
+			LineSpacingAddDefault = nativeView.LineSpacingExtra;
+			LineSpacingMultDefault = nativeView.LineSpacingMultiplier;
 		}
 
 		public static void MapText(LabelHandler handler, ILabel label)
@@ -69,6 +73,10 @@ namespace Microsoft.Maui.Handlers
 			var fontManager = services.GetRequiredService<IFontManager>();
 
 			handler.TypedNativeView?.UpdateFont(label, fontManager);
+		}
+		public static void MapLineHeight(LabelHandler handler, ILabel label)
+		{
+			handler.TypedNativeView?.UpdateLineHeight(label, LineSpacingAddDefault, LineSpacingMultDefault);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
@@ -15,5 +15,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextDecorations(LabelHandler handler, ILabel label) { }
 		public static void MapMaxLines(IViewHandler handler, ILabel label) { }
 		public static void MapPadding(LabelHandler handler, ILabel label) { }
+		public static void MapLineHeight(LabelHandler handler, ILabel label) { }
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ILabel.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
 			[nameof(ILabel.LineBreakMode)] = MapLineBreakMode,
 			[nameof(ILabel.Padding)] = MapPadding,
-			[nameof(ILabel.TextDecorations)] = MapTextDecorations
+			[nameof(ILabel.TextDecorations)] = MapTextDecorations,
+			[nameof(ILabel.LineHeight)] = MapLineHeight
 		};
 
 		public LabelHandler() : base(LabelMapper)

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -56,5 +56,10 @@ namespace Microsoft.Maui.Handlers
 
 			handler.TypedNativeView?.UpdateFont(label, fontManager);
 		}
+
+ 		public static void MapLineHeight(LabelHandler handler, ILabel label)
+		{
+			handler.TypedNativeView?.UpdateLineHeight(label);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -143,5 +143,13 @@ namespace Microsoft.Maui
 			textView.SetSingleLine(singleLine);
 			textView.SetMaxLines(maxLines);
 		}
+
+		internal static void UpdateLineHeight(this TextView textView, ILabel label, float lineSpacingAddDefault, float lineSpacingMultDefault)
+		{
+			if (label.LineHeight == - 1)
+				textView.SetLineSpacing(lineSpacingAddDefault, lineSpacingMultDefault);
+			else if (label.LineHeight >= 0)
+				textView.SetLineSpacing(0, (float)label.LineHeight);
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -79,32 +79,6 @@ namespace Microsoft.Maui
 				(float)label.Padding.Right);
 		}
 
-		public static void UpdateTextDecorations(this UILabel nativeLabel, ILabel label)
-		{
-			if (nativeLabel.AttributedText != null && !(nativeLabel.AttributedText?.Length > 0))
-				return;
-
-			var textDecorations = label?.TextDecorations;
-
-			var newAttributedText = nativeLabel.AttributedText != null ? new NSMutableAttributedString(nativeLabel.AttributedText) : new NSMutableAttributedString(label?.Text ?? string.Empty);
-			var strikeThroughStyleKey = UIStringAttributeKey.StrikethroughStyle;
-			var underlineStyleKey = UIStringAttributeKey.UnderlineStyle;
-
-			var range = new NSRange(0, newAttributedText.Length);
-
-			if ((textDecorations & TextDecorations.Strikethrough) == 0)
-				newAttributedText.RemoveAttribute(strikeThroughStyleKey, range);
-			else
-				newAttributedText.AddAttribute(strikeThroughStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
-
-			if ((textDecorations & TextDecorations.Underline) == 0)
-				newAttributedText.RemoveAttribute(underlineStyleKey, range);
-			else
-				newAttributedText.AddAttribute(underlineStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
-
-			nativeLabel.AttributedText = newAttributedText;
-		}
-
 		internal static void SetLineBreakMode(this UILabel nativeLabel, ILabel label)
 		{
 			int maxLines = label.MaxLines;

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -139,5 +139,39 @@ namespace Microsoft.Maui
 
 			nativeLabel.Lines = maxLines;
 		}
+
+		public static void UpdateTextDecorations(this UILabel nativeLabel, ILabel label)
+		{
+			if (nativeLabel.AttributedText != null && !(nativeLabel.AttributedText?.Length > 0))
+				return;
+
+			var textDecorations = label?.TextDecorations;
+
+			var newAttributedText = nativeLabel.AttributedText != null ? new NSMutableAttributedString(nativeLabel.AttributedText) : new NSMutableAttributedString(label?.Text ?? string.Empty);
+			var strikeThroughStyleKey = UIStringAttributeKey.StrikethroughStyle;
+			var underlineStyleKey = UIStringAttributeKey.UnderlineStyle;
+
+			var range = new NSRange(0, newAttributedText.Length);
+
+			if ((textDecorations & TextDecorations.Strikethrough) == 0)
+				newAttributedText.RemoveAttribute(strikeThroughStyleKey, range);
+			else
+				newAttributedText.AddAttribute(strikeThroughStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
+
+			if ((textDecorations & TextDecorations.Underline) == 0)
+				newAttributedText.RemoveAttribute(underlineStyleKey, range);
+			else
+				newAttributedText.AddAttribute(underlineStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
+
+			nativeLabel.AttributedText = newAttributedText;
+		}
+
+		internal static void UpdateLineHeight(this UILabel nativeLabel, ILabel label)
+		{
+			var modAttrText = nativeLabel.AttributedText?.WithLineHeight(label.LineHeight);
+
+			if (modAttrText != null)
+				nativeLabel.AttributedText = modAttrText;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/NSAttributedStringExtensions.cs
+++ b/src/Core/src/Platform/iOS/NSAttributedStringExtensions.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Maui
 			if (lineHeight == -1 && attribute == null)
 				return null;
 
-			var mutableParagraphStyle = new NSMutableParagraphStyle(attribute);
-			mutableParagraphStyle.LineHeightMultiple = new nfloat(lineHeight >= 0 ? lineHeight : -1);
+			var mutableParagraphStyle = new NSMutableParagraphStyle();
+			mutableParagraphStyle.LineHeightMultiple = new System.nfloat(lineHeight >= 0 ? lineHeight : -1);
 
 			var mutableAttributedString = new NSMutableAttributedString(attributedString);
 			mutableAttributedString.AddAttribute
@@ -47,6 +47,7 @@ namespace Microsoft.Maui
 				mutableParagraphStyle ,
 				new NSRange(0, mutableAttributedString.Length)
 			);
+
 			return mutableAttributedString;
 		}
 	}

--- a/src/Core/src/Platform/iOS/NSAttributedStringExtensions.cs
+++ b/src/Core/src/Platform/iOS/NSAttributedStringExtensions.cs
@@ -25,5 +25,29 @@ namespace Microsoft.Maui
 			);
 			return mutableAttributedString;
 		}
+
+		public static NSMutableAttributedString? WithLineHeight(this NSAttributedString attributedString, double lineHeight)
+		{
+			if (attributedString == null || attributedString.Length == 0)
+				return null;
+
+			var attribute = (NSParagraphStyle) attributedString.GetAttribute(UIStringAttributeKey.ParagraphStyle, 0, out _);
+
+			// if we need to un-set the line height but there is no attribute to modify then we do nothing
+			if (lineHeight == -1 && attribute == null)
+				return null;
+
+			var mutableParagraphStyle = new NSMutableParagraphStyle(attribute);
+			mutableParagraphStyle.LineHeightMultiple = new nfloat(lineHeight >= 0 ? lineHeight : -1);
+
+			var mutableAttributedString = new NSMutableAttributedString(attributedString);
+			mutableAttributedString.AddAttribute
+			(
+				UIStringAttributeKey.ParagraphStyle,
+				mutableParagraphStyle ,
+				new NSRange(0, mutableAttributedString.Length)
+			);
+			return mutableAttributedString;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
@@ -137,6 +137,31 @@ namespace Microsoft.Maui.DeviceTests
 			values.NativeViewValue.AssertHasFlag(expectedValue);
 		}
 
+		[Fact(DisplayName = "LineHeight Initializes Correctly")]
+		public async Task LineHeightInitializesCorrectly()
+		{
+			var xplatLineHeight = 1.5d;
+
+			var labelHandler = new LabelStub()
+			{
+				LineHeight = xplatLineHeight
+			};
+
+			var values = await GetValueAsync(labelHandler, (handler) =>
+			{
+				return new
+				{
+					ViewValue = labelHandler.LineHeight,
+					NativeViewValue = GetNativeLineHeight(handler)
+				};
+			});
+
+			float expectedValue = 1.5f;
+
+			Assert.Equal(xplatLineHeight, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue);
+		}
+
 		TextView GetNativeLabel(LabelHandler labelHandler) =>
 			(TextView)labelHandler.View;
 
@@ -188,5 +213,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		PaintFlags GetNativeTextDecorations(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).PaintFlags;
+
+		float GetNativeLineHeight(LabelHandler labelHandler) =>
+			GetNativeLabel(labelHandler).LineSpacingMultiplier;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
@@ -118,6 +118,30 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.NotNull(values.NativeViewValue);
 		}
 
+		[Fact(DisplayName = "LineHeight Initializes Correctly")]
+		public async Task LineHeightInitializesCorrectly()
+		{
+			var xplatLineHeight = 1.5d;
+
+			var labelHandler = new LabelStub()
+			{
+				LineHeight = xplatLineHeight
+			};
+
+			var values = await GetValueAsync(labelHandler, (handler) =>
+			{
+				return new
+				{
+					ViewValue = labelHandler.LineHeight,
+					NativeViewValue = GetNativeLineHeight(handler)
+				};
+			});
+
+			nfloat expectedValue = new nfloat(1.5f);
+			Assert.Equal(xplatLineHeight, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue);
+		}
+
 		UILabel GetNativeLabel(LabelHandler labelHandler) =>
 			(UILabel)labelHandler.View;
 
@@ -162,5 +186,20 @@ namespace Microsoft.Maui.DeviceTests
 
 		NSAttributedString GetNativeTextDecorations(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).AttributedText;
+
+		nfloat GetNativeLineHeight(LabelHandler labelHandler)
+		{
+			var attrText = GetNativeLabel(labelHandler).AttributedText;
+
+			if(attrText == null)
+				return new nfloat(-1.0f);
+
+			var paragraphStyle = (NSParagraphStyle)attrText.GetAttribute(UIStringAttributeKey.ParagraphStyle, 0, out _);
+
+			if(paragraphStyle == null)
+				return new nfloat(-1.0f);
+
+			return paragraphStyle.LineHeightMultiple;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
@@ -125,6 +126,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			var labelHandler = new LabelStub()
 			{
+				Text = "test",
 				LineHeight = xplatLineHeight
 			};
 

--- a/src/Core/tests/DeviceTests/Stubs/LabelStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LabelStub.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public TextDecorations TextDecorations { get; set; }
 
 		public int MaxLines { get; set; } = -1;
+
+		public double LineHeight { get; set; } = -1;
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Implements #368 (Re-do of #511)
### Additions made ###
- Adds `double LineHeight { get; }` to the `ILabel` interface
- Adds LineHeight property map to LabelHandler
- Adds LineHeight mapping methods to LabelHandler for Android and iOS
- Adds extension methods to apply LineHeight on Android/iOS
- Adds DeviceTests for initial LineHeight values on iOS and Android
### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests