### PR TITLE
Clean up iOS simulators

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.21124.1",
+      "version": "1.0.0-prerelease.21165.2",
       "commands": [
         "xharness"
       ]

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -41,7 +41,7 @@ void Cleanup()
 	var sims = ListAppleSimulators();
 	var xharness = sims.Where(s => s.Name.Contains("XHarness")).ToArray();
 	foreach (var sim in xharness) {
-		Information("Deleting XHarness simulator {0}...", sim.Name);
+		Information("Deleting XHarness simulator {0} ({1})...", sim.Name, sim.UDID);
 		StartProcess("xcrun", "simctl shutdown " + sim.UDID);
 		var retries = 3;
 		while (retries > 0) {

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -14,11 +14,48 @@ var TEST_RESULTS = Argument("results", EnvironmentVariable("IOS_TEST_RESULTS") ?
 // other
 string PLATFORM = TEST_DEVICE.ToLower().Contains("simulator") ? "iPhoneSimulator" : "iPhone";
 string CONFIGURATION = "Release";
+bool DEVICE_CLEANUP = Argument("cleanup", true);
 
 Information("Project File: {0}", PROJECT);
 Information("Build Binary Log (binlog): {0}", BINLOG);
 Information("Build Platform: {0}", PLATFORM);
 Information("Build Configuration: {0}", CONFIGURATION);
+
+Setup(context =>
+{
+	Cleanup();
+});
+
+Teardown(context =>
+{
+	Cleanup();
+});
+
+void Cleanup()
+{
+	if (!DEVICE_CLEANUP)
+		return;
+
+	// delete the XHarness simulators first, if it exists
+	Information("Deleting XHarness simulator if exists...");
+	var sims = ListAppleSimulators();
+	var xharness = sims.Where(s => s.Name.Contains("XHarness")).ToArray();
+	foreach (var sim in xharness) {
+		StartProcess("xcrun", "simctl shutdown " + sim.UDID);
+		var retries = 3;
+		while (retries > 0) {
+			var exitCode = StartProcess("xcrun", "simctl delete " + sim.UDID);
+			if (exitCode == 0) {
+				retries = 0;
+			} else {
+				retries--;
+				System.Threading.Thread.Sleep(1000);
+			}
+		}
+	}
+}
+
+Task("Cleanup");
 
 Task("Build")
 	.WithCriteria(!string.IsNullOrEmpty(PROJECT.FullPath))

--- a/eng/devices/ios.cake
+++ b/eng/devices/ios.cake
@@ -41,6 +41,7 @@ void Cleanup()
 	var sims = ListAppleSimulators();
 	var xharness = sims.Where(s => s.Name.Contains("XHarness")).ToArray();
 	foreach (var sim in xharness) {
+		Information("Deleting XHarness simulator {0}...", sim.Name);
 		StartProcess("xcrun", "simctl shutdown " + sim.UDID);
 		var retries = 3;
 		while (retries > 0) {


### PR DESCRIPTION
### Description of Change ###

Sometimes the iOS simulators get into a bad state. This PR makes sure to clean up before running, and then delete the simulators created during the testing.