### PR TITLE
Implement IsReadOnly property in EditorHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
@@ -319,6 +319,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			return currentText.Substring(0, Element.MaxLength);
 		}
 
+		[PortHandler]
 		void UpdateIsReadOnly()
 		{
 			bool isReadOnly = !Element.IsReadOnly;

--- a/src/Compatibility/Core/src/iOS/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/EditorRenderer.cs
@@ -383,6 +383,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			return newLength <= Element.MaxLength;
 		}
 
+		[PortHandler]
 		void UpdateReadOnly()
 		{
 			TextView.UserInteractionEnabled = !Element.IsReadOnly;

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -98,6 +98,8 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new Editor { Text = "Lorem ipsum dolor sit amet", MaxLength = 10 });
 			verticalStack.Add(new Editor { Text = "Predictive Text Off", IsTextPredictionEnabled = false });
 			verticalStack.Add(new Editor { Text = "Lorem ipsum dolor sit amet", FontSize = 10, FontFamily = "dokdo_regular"});
+			verticalStack.Add(new Editor { Text = "ReadOnly Editor", IsReadOnly = true });
+
 
 			var entry = new Entry();
 			entry.TextChanged += (sender, e) =>

--- a/src/Core/src/Core/IEditor.cs
+++ b/src/Core/src/Core/IEditor.cs
@@ -10,6 +10,10 @@
 		/// </summary>
 		Color PlaceholderColor { get; set; }
 		
+		/// Gets a value that indicate if can modify the text.
+		/// </summary>
+		bool IsReadOnly { get; set; }
+
 		/// <summary>
 		/// Gets a value that controls whether text prediction and automatic text correction is on or off.
 		/// </summary>

--- a/src/Core/src/Core/IEditor.cs
+++ b/src/Core/src/Core/IEditor.cs
@@ -10,10 +10,6 @@
 		/// </summary>
 		Color PlaceholderColor { get; set; }
 		
-		/// Gets a value that indicate if can modify the text.
-		/// </summary>
-		bool IsReadOnly { get; set; }
-
 		/// <summary>
 		/// Gets a value that controls whether text prediction and automatic text correction is on or off.
 		/// </summary>

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -56,6 +56,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.TypedNativeView?.UpdateMaxLength(editor);
 		}
+		
+		public static void MapIsReadOnly(EditorHandler handler, IEditor editor)
+		{
+			handler.TypedNativeView?.UpdateIsReadOnly(editor);
+		}
 
 		public static void MapIsTextPredictionEnabled(EditorHandler handler, IEditor editor)
 		{

--- a/src/Core/src/Handlers/Editor/EditorHandler.Standard.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Standard.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapMaxLength(IViewHandler handler, IEditor editor) { }
 		public static void MapIsTextPredictionEnabled(EditorHandler handler, IEditor editor) { }
 		public static void MapFont(IViewHandler handler, IEditor editor) { }
+		public static void MapIsReadOnly(IViewHandler handler, IEditor editor) { }
 	}
 }

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -10,8 +10,8 @@
 			[nameof(IEditor.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(IEditor.MaxLength)] = MapMaxLength,
 			[nameof(IEditor.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled,
-			[nameof(IEditor.Font)] = MapFont
-			[nameof(IEditor.IsReadOnly)] = MapIsReadOnly,
+			[nameof(IEditor.Font)] = MapFont,
+			[nameof(IEditor.IsReadOnly)] = MapIsReadOnly
 		};
 
 		public EditorHandler() : base(EditorMapper)

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -11,6 +11,7 @@
 			[nameof(IEditor.MaxLength)] = MapMaxLength,
 			[nameof(IEditor.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled,
 			[nameof(IEditor.Font)] = MapFont
+			[nameof(IEditor.IsReadOnly)] = MapIsReadOnly,
 		};
 
 		public EditorHandler() : base(EditorMapper)

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.TypedNativeView?.UpdateMaxLength(editor);
 		}
+		
+		public static void MapIsReadOnly(EditorHandler handler, IEditor editor)
+		{
+			handler.TypedNativeView?.UpdateIsReadOnly(editor);
+		}
 
 		public static void MapIsTextPredictionEnabled(EditorHandler handler, IEditor editor)
 		{

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -134,6 +134,15 @@ namespace Microsoft.Maui
 			editText.Focusable = isEditable;
 		}
 
+		public static void UpdateIsReadOnly(this AppCompatEditText editText, IEditor editor)
+		{
+			bool isReadOnly = !editor.IsReadOnly;
+
+			editText.FocusableInTouchMode = isReadOnly;
+			editText.Focusable = isReadOnly;
+			editText.SetCursorVisible(isReadOnly);
+		}
+
 		public static void UpdateFont(this AppCompatEditText editText, IEntry entry, IFontManager fontManager)
 		{
 			var font = entry.Font;

--- a/src/Core/src/Platform/iOS/TextViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextViewExtensions.cs
@@ -43,5 +43,10 @@ namespace Microsoft.Maui
 			var uiFont = fontManager.GetFont(editor.Font);
 			textView.Font = uiFont;
 		}
+		
+		public static void UpdateIsReadOnly(this UITextView textView, IEditor editor)
+		{
+			textView.UserInteractionEnabled = !editor.IsReadOnly;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -75,7 +75,11 @@ namespace Microsoft.Maui.DeviceTests
 		Color GetNativePlaceholderColor(EditorHandler editorHandler) =>
 			((uint)GetNativeEditor(editorHandler).CurrentHintTextColor).ToColor();
 			
-		bool GetNativeIsTextPredictionEnabled(EditorHandler editorHandler) =>
+
+        bool GetNativeIsReadOnly(EditorHandler editorHandler) =>
+            !GetNativeEditor(editorHandler).Focusable;
+
+        bool GetNativeIsTextPredictionEnabled(EditorHandler editorHandler) =>
 			!GetNativeEditor(editorHandler).InputType.HasFlag(InputTypes.TextFlagNoSuggestions);
 
 		double GetNativeCharacterSpacing(EditorHandler editorHandler)

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -80,10 +80,21 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var editor = new EditorStub()
 			{
+				IsReadOnly = isReadOnly,
 				Text = "Test"
 			};
 
-			await ValidatePropertyInitValue(editor, () => editor.Placeholder, GetNativePlaceholderText, editor.Placeholder);
+		}
+		
+		public async Task IsReadOnlyInitializesCorrectly(bool isReadOnly)
+		{
+			var editor = new EditorStub()
+			{
+				IsReadOnly = isReadOnly,
+				Text = "Test"
+			};
+
+			await ValidatePropertyInitValue(editor, () => editor.IsReadOnly, GetNativeIsReadOnly, editor.IsReadOnly);
 		}
 
 		[Theory(DisplayName = "PlaceholderText Updates Correctly")]

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -80,12 +80,15 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var editor = new EditorStub()
 			{
-				IsReadOnly = isReadOnly,
 				Text = "Test"
 			};
 
+			await ValidatePropertyInitValue(editor, () => editor.Placeholder, GetNativePlaceholderText, editor.Placeholder);
 		}
 		
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
 		public async Task IsReadOnlyInitializesCorrectly(bool isReadOnly)
 		{
 			var editor = new EditorStub()

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -79,10 +79,16 @@ namespace Microsoft.Maui.DeviceTests
 			return editor.AttributedText.GetCharacterSpacing();
 		}
 
-		bool GetNativeIsTextPredictionEnabled(EditorHandler editorHandler) =>
-			GetNativeEditor(editorHandler).AutocorrectionType == UITextAutocorrectionType.Yes;
 			
 		double GetNativeUnscaledFontSize(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).Font.PointSize;
+			
+       
+
+        bool GetNativeIsReadOnly(EditorHandler editorHandler) =>
+            !GetNativeEditor(editorHandler).UserInteractionEnabled;
+
+        bool GetNativeIsTextPredictionEnabled(EditorHandler editorHandler) =>
+			GetNativeEditor(editorHandler).AutocorrectionType == UITextAutocorrectionType.Yes;
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public double CharacterSpacing { get; set; }
 
-		public bool IsReadOnly { get;set; }
+		public bool IsReadOnly { get; set; }
 
-		public string Placeholder { get;set; }
+		public string Placeholder { get; set; }
 
 		public Color PlaceholderColor { get; set; }
 
@@ -32,5 +32,6 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		void OnTextChanged(string oldValue, string newValue) =>
 			TextChanged?.Invoke(this, new StubPropertyChangedEventArgs<string>(oldValue, newValue));
+
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `IsReadOnly` property in EditorHandlers.

### Platforms Affected ### 

- Core
- iOS
- Android

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests