### PR TITLE
[android] remove EmbedAssembliesIntoApk from .NET 6 projects

### DIFF
--- a/src/Compatibility/Core/src/Compatibility-net6.csproj
+++ b/src/Compatibility/Core/src/Compatibility-net6.csproj
@@ -65,12 +65,6 @@
     <Compile Include="AppHostBuilderExtensions.cs" />
     
   </ItemGroup>
-
-  <PropertyGroup>
-    <!-- TODO: disable Fast Deployment temporarily -->
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/Core/src/Core-net6.csproj
+++ b/src/Core/src/Core-net6.csproj
@@ -12,12 +12,6 @@
     <PackageId>Microsoft.Maui.Core</PackageId>
   </PropertyGroup>
   <Import Project="..\..\..\.nuspec\Microsoft.Maui.Controls.MultiTargeting.targets" />
-
-  <PropertyGroup>
-    <!-- TODO: disable Fast Deployment temporarily -->
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />


### PR DESCRIPTION
### Description of Change ###

This was a workaround for a problem in .NET 6 Preview 1, it should be fixed in .NET 6 Preview 2 (and newer).

This setting also only applies to Android "app" projects, so I'm not sure if these were actually doing anything.

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests