### PR TITLE
Implement CharacterSpacing property in EntryHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
@@ -390,6 +390,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				EditText.Text = currentControlText.Substring(0, Element.MaxLength);
 		}
 
+		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
 			if (Forms.IsLollipopOrNewer)

--- a/src/Compatibility/Core/src/iOS/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/EntryRenderer.cs
@@ -375,6 +375,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				Control.Text = text;
 		}
 
+		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
 			var textAttr = Control.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);

--- a/src/Compatibility/Core/src/iOS/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/EntryRenderer.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				Control.Text = text;
 		}
 
-		[PortHandler]
+		[PortHandler ("Partially ported ...")]
 		void UpdateCharacterSpacing()
 		{
 			var textAttr = Control.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -101,6 +101,7 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new Entry { Placeholder = "This should be placeholder text" });
 			verticalStack.Add(new Entry { Text = "This should be read only property", IsReadOnly = true });
 			verticalStack.Add(new Entry { MaxLength = 5, Placeholder = "MaxLength text" });
+			verticalStack.Add(new Entry { Text = "This should be text with character spacing", CharacterSpacing = 10 });
 
 			verticalStack.Add(new ProgressBar { Progress = 0.5 });
 			verticalStack.Add(new ProgressBar { Progress = 0.5, BackgroundColor = Color.LightCoral });

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -89,6 +89,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateReturnType(entry);
 		}
 
+		public static void MapCharacterSpacing(EntryHandler handler, IEntry entry)
+		{
+			handler.TypedNativeView?.UpdateCharacterSpacing(entry);
+		}
+
 		void OnTextChanged(string? text)
 		{
 			if (VirtualView == null || TypedNativeView == null)

--- a/src/Core/src/Handlers/Entry/EntryHandler.Standard.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Standard.cs
@@ -16,5 +16,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapIsReadOnly(IViewHandler handler, IEntry entry) { }
 		public static void MapFont(IViewHandler handler, IEntry entry) { }
 		public static void MapReturnType(IViewHandler handler, IEntry entry) { }
+		public static void MapCharacterSpacing(IViewHandler handler, IEntry entry) { }
 	}
 }

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -13,7 +13,8 @@
 			[nameof(IEntry.Placeholder)] = MapPlaceholder,
 			[nameof(IEntry.IsReadOnly)] = MapIsReadOnly,
 			[nameof(IEntry.Font)] = MapFont,
-			[nameof(IEntry.ReturnType)] = MapReturnType
+			[nameof(IEntry.ReturnType)] = MapReturnType,
+			[nameof(IEntry.CharacterSpacing)] = MapCharacterSpacing
 		};
 
 		public EntryHandler() : base(EntryMapper)

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -114,6 +114,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateHorizontalTextAlignment(entry);
 		}
 
+		public static void MapCharacterSpacing(EntryHandler handler, IEntry entry)
+		{
+			handler.TypedNativeView?.UpdateCharacterSpacing(entry);
+		}
+
 		void OnEditingChanged(object? sender, EventArgs e) => OnTextChanged();
 
 		void OnEditingEnded(object? sender, EventArgs e) => OnTextChanged();

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -139,6 +139,11 @@ namespace Microsoft.Maui
 			editText.LetterSpacing = editor.CharacterSpacing.ToEm();
 		}
 
+		public static void UpdateCharacterSpacing(this AppCompatEditText editText, IEntry editor)
+		{
+			editText.LetterSpacing = editor.CharacterSpacing.ToEm();
+		}
+
 		internal static void SetInputType(this AppCompatEditText editText, IEntry entry)
 		{
 			editText.InputType = InputTypes.ClassText;

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -91,6 +91,14 @@ namespace Microsoft.Maui
 				textField.AttributedText = textAttr;
 		}
 
+		public static void UpdateCharacterSpacing(this UITextField textField, IEntry textView)
+		{
+			var textAttr = textField.AttributedText?.WithCharacterSpacing(textView.CharacterSpacing);
+
+			if (textAttr != null)
+				textField.AttributedText = textAttr;
+		}
+
 		public static void UpdateFont(this UITextField textField, IText textView, IFontManager fontManager)
 		{
 			var uiFont = fontManager.GetFont(textView.Font);

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -142,5 +142,43 @@ namespace Microsoft.Maui.DeviceTests
 
 		ImeAction GetNativeReturnType(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ImeOptions;
+
+		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
+		public async Task CharacterSpacingInitializesCorrectly()
+		{
+			var xplatCharacterSpacing = 4;
+
+			var entry = new EntryStub()
+			{
+				CharacterSpacing = xplatCharacterSpacing,
+				Text = "Some Test Text"
+			};
+
+			float expectedValue = entry.CharacterSpacing.ToEm();
+
+			var values = await GetValueAsync(entry, (handler) =>
+			{
+				return new
+				{
+					ViewValue = entry.CharacterSpacing,
+					NativeViewValue = GetNativeCharacterSpacing(handler)
+				};
+			});
+
+			Assert.Equal(xplatCharacterSpacing, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
+		}
+
+		double GetNativeCharacterSpacing(EntryHandler entryHandler)
+		{
+			var editText = GetNativeEntry(entryHandler);
+
+			if (editText != null)
+			{
+				return editText.LetterSpacing;
+			}
+
+			return -1;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -85,6 +85,37 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.NativeViewValue);
 		}
 
+		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
+		public async Task CharacterSpacingInitializesCorrectly()
+		{
+			string originalText = "Some Test Text";
+			var xplatCharacterSpacing = 4;
+
+			var entry = new EntryStub()
+			{
+				CharacterSpacing = xplatCharacterSpacing,
+				Text = originalText
+			};
+
+			var values = await GetValueAsync(entry, (handler) =>
+			{
+				return new
+				{
+					ViewValue = entry.CharacterSpacing,
+					NativeViewValue = GetNativeCharacterSpacing(handler)
+				};
+			});
+
+			Assert.Equal(xplatCharacterSpacing, values.ViewValue);
+			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
+		}
+
+		double GetNativeCharacterSpacing(EntryHandler entryHandler)
+		{
+			var entry = GetNativeEntry(entryHandler);
+			return entry.AttributedText.GetCharacterSpacing();
+		}
+
 		UITextField GetNativeEntry(EntryHandler entryHandler) =>
 			(UITextField)entryHandler.View;
 


### PR DESCRIPTION

<!-- 

We are currently only accepting Pull Requests for .NET MAUI issues in our [Handler Property Backlog](https://github.com/dotnet/maui/projects/4). We will continue to update this repository over the next couple of months as we begin to accept more types of PRs.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
          - If the issue you're working on has a milestone, target the corresponding branch.
          - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
               See [Contributing](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md) for more tips!

```
 PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
```
 -->
### Description of Change ###

<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implement `CharacterSpacing` property in EntryHandlers.

Related issue #382 

Platforms Affected

- Core
- iOS
- Android

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests