### PR TITLE
Implement CharacterSpacing property in PickerHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
@@ -161,6 +161,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 			EditText.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
+		[PortHandler]
 		protected void UpdateCharacterSpacing()
 		{
 			if (Forms.IsLollipopOrNewer)

--- a/src/Compatibility/Core/src/iOS/Renderers/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/PickerRenderer.cs
@@ -186,6 +186,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			UpdatePicker();
 		}
 
+		[PortHandler("The code related to Placeholder remains to be ported")]
 		protected void UpdateCharacterSpacing()
 		{
 			if (Control == null)

--- a/src/Core/src/Core/IPicker.cs
+++ b/src/Core/src/Core/IPicker.cs
@@ -3,12 +3,39 @@ using System.Collections.Generic;
 
 namespace Microsoft.Maui
 {
+	/// <summary>
+	/// Represents a View for selecting a text item from a list of data.
+	/// </summary>
 	public interface IPicker : IView
 	{
+		/// <summary>
+		/// Gets the title for the Picker.
+		/// </summary>
 		string Title { get; }
+
+		/// <summary>
+		/// Gets or sets the internal list of items to template and display.
+		/// </summary>
 		IList<string> Items { get; }
+
+		/// <summary>
+		/// Gets or sets the source list of items to template and display.
+		/// </summary>
 		IList ItemsSource { get; }
+
+		/// <summary>
+		/// Gets the index of the selected item of the picker.
+		/// </summary>
 		int SelectedIndex { get; set; }
+
+		/// <summary>
+		/// Gets the selected item.
+		/// </summary>
 		object? SelectedItem { get; set; }
+
+		/// <summary>
+		/// Gets the character spacing.
+		/// </summary>
+		int CharacterSpacing { get; set; }
 	}
 }

--- a/src/Core/src/Core/IPicker.cs
+++ b/src/Core/src/Core/IPicker.cs
@@ -36,6 +36,6 @@ namespace Microsoft.Maui
 		/// <summary>
 		/// Gets the character spacing.
 		/// </summary>
-		int CharacterSpacing { get; set; }
+		double CharacterSpacing { get; set; }
 	}
 }

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -44,6 +44,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateSelectedIndex(picker);
 		}
 
+		public static void MapCharacterSpacing(PickerHandler handler, IPicker picker)
+		{
+			handler.TypedNativeView?.UpdateCharacterSpacing(picker);
+		}
+
 		void OnFocusChange(object? sender, global::Android.Views.View.FocusChangeEventArgs e)
 		{
 			if (TypedNativeView == null)

--- a/src/Core/src/Handlers/Picker/PickerHandler.Standard.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Standard.cs
@@ -8,5 +8,6 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapTitle(PickerHandler handler, IPicker view) { }
 		public static void MapSelectedIndex(PickerHandler handler, IPicker view) { }
+		public static void MapCharacterSpacing(PickerHandler handler, IPicker view) { }
 	}
 }

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -5,7 +5,8 @@
 		public static PropertyMapper<IPicker, PickerHandler> PickerMapper = new PropertyMapper<IPicker, PickerHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(IPicker.Title)] = MapTitle,
-			[nameof(IPicker.SelectedIndex)] = MapSelectedIndex
+			[nameof(IPicker.SelectedIndex)] = MapSelectedIndex,
+			[nameof(IPicker.CharacterSpacing)] = MapCharacterSpacing
 		};
 
 		public PickerHandler() : base(PickerMapper)

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -101,6 +101,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateSelectedIndex(picker);
 		}
 
+		public static void MapCharacterSpacing(PickerHandler handler, IPicker picker)
+		{
+			handler.TypedNativeView?.UpdateCharacterSpacing(picker);
+		}
+
 		void OnCollectionChanged(object? sender, EventArgs e)
 		{
 			if (VirtualView == null || TypedNativeView == null)

--- a/src/Core/src/Platform/Android/PickerExtensions.cs
+++ b/src/Core/src/Platform/Android/PickerExtensions.cs
@@ -8,6 +8,11 @@
 		public static void UpdateSelectedIndex(this MauiPicker nativePicker, IPicker picker) =>
 			UpdatePicker(nativePicker, picker);
 
+		public static void UpdateCharacterSpacing(this MauiPicker nativePicker, IPicker picker)
+		{
+			nativePicker.LetterSpacing = picker.CharacterSpacing.ToEm();
+		}
+
 		internal static void UpdatePicker(this MauiPicker nativePicker, IPicker picker)
 		{
 			nativePicker.Hint = picker.Title;

--- a/src/Core/src/Platform/iOS/PickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/PickerExtensions.cs
@@ -30,6 +30,14 @@ namespace Microsoft.Maui
 			nativePicker.SetSelectedItem(picker);
 		}
 
+		public static void UpdateCharacterSpacing(this MauiPicker nativePicker, IPicker picker)
+		{
+			var textAttr = nativePicker.AttributedText?.WithCharacterSpacing(picker.CharacterSpacing);
+
+			if (textAttr != null)
+				nativePicker.AttributedText = textAttr;
+		}
+
 		internal static void SetSelectedIndex(this MauiPicker nativePicker, IPicker picker, int selectedIndex = 0)
 		{
 			picker.SelectedIndex = selectedIndex;

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -17,10 +19,58 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(picker, () => picker.Title, GetNativeTitle, picker.Title);
 		}
 
+		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
+		public async Task CharacterSpacingInitializesCorrectly()
+		{
+			var xplatCharacterSpacing = 4;
+
+			var items = new List<string>
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3"
+			};
+
+			var picker = new PickerStub()
+			{
+				Title = "Select an Item",
+				CharacterSpacing = xplatCharacterSpacing
+			};
+
+			picker.ItemsSource = items;
+			picker.SelectedIndex = 0;
+
+			float expectedValue = picker.CharacterSpacing.ToEm();
+
+			var values = await GetValueAsync(picker, (handler) =>
+			{
+				return new
+				{
+					ViewValue = picker.CharacterSpacing,
+					NativeViewValue = GetNativeCharacterSpacing(handler)
+				};
+			});
+
+			Assert.Equal(xplatCharacterSpacing, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
+		}
+
 		MauiPicker GetNativePicker(PickerHandler pickerHandler) =>
 			(MauiPicker)pickerHandler.View;
 
 		string GetNativeTitle(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).Hint;
+
+		double GetNativeCharacterSpacing(PickerHandler pickerHandler)
+		{
+			var mauiPicker = GetNativePicker(pickerHandler);
+		
+			if (mauiPicker != null)
+			{
+				return mauiPicker.LetterSpacing;
+			}
+
+			return -1;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/PickerStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/PickerStub.cs
@@ -14,5 +14,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public int SelectedIndex { get; set; } = -1;
 
 		public object SelectedItem { get; set; }
+
+		public double CharacterSpacing { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `CharacterSpacing` property in PickerHandlers.

Related issue https://github.com/dotnet/maui/issues/407

### Platforms Affected ### 

- Core
- iOS
- Android

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests