### PR TITLE
[UITests] Make sure to push Xamarin.UITests dll

### DIFF
--- a/eng/pipelines/common/controlgallery-android.yml
+++ b/eng/pipelines/common/controlgallery-android.yml
@@ -51,6 +51,7 @@ steps:
         **/Android.UITests/bin/$(BuildConfiguration)/Plugin.*
         **/Android.UITests/bin/$(BuildConfiguration)/Microsoft.Maui.*
         **/Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
+        **/Android.UITests/bin/$(BuildConfiguration)/Controls.*
       TargetFolder: '$(build.artifactstagingdirectory)/android'
       CleanTargetFolder: true
       flattenFolders: true

--- a/eng/pipelines/common/controlgallery-android.yml
+++ b/eng/pipelines/common/controlgallery-android.yml
@@ -50,6 +50,7 @@ steps:
         **/Android.UITests/bin/$(BuildConfiguration)/NUnit3.*
         **/Android.UITests/bin/$(BuildConfiguration)/Plugin.*
         **/Android.UITests/bin/$(BuildConfiguration)/Microsoft.Maui.*
+        **/Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
       TargetFolder: '$(build.artifactstagingdirectory)/android'
       CleanTargetFolder: true
       flattenFolders: true

--- a/eng/pipelines/common/controlgallery-ios.yml
+++ b/eng/pipelines/common/controlgallery-ios.yml
@@ -72,7 +72,7 @@ steps:
         **/iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
         **/iOS.UITests/bin/$(BuildConfiguration)/Microsoft.Maui.*
         **/iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
-        **/Android.UITests/bin/$(BuildConfiguration)/Controls.*
+        **/iOS.UITests/bin/$(BuildConfiguration)/Controls.*
       TargetFolder: '$(build.artifactstagingdirectory)/ios'
       flattenFolders: true
 

--- a/eng/pipelines/common/controlgallery-ios.yml
+++ b/eng/pipelines/common/controlgallery-ios.yml
@@ -71,6 +71,7 @@ steps:
         **/iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
         **/iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
         **/iOS.UITests/bin/$(BuildConfiguration)/Microsoft.Maui.*
+        **/iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
       TargetFolder: '$(build.artifactstagingdirectory)/ios'
       flattenFolders: true
 

--- a/eng/pipelines/common/controlgallery-ios.yml
+++ b/eng/pipelines/common/controlgallery-ios.yml
@@ -72,6 +72,7 @@ steps:
         **/iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
         **/iOS.UITests/bin/$(BuildConfiguration)/Microsoft.Maui.*
         **/iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
+        **/Android.UITests/bin/$(BuildConfiguration)/Controls.*
       TargetFolder: '$(build.artifactstagingdirectory)/ios'
       flattenFolders: true
 

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -224,8 +224,8 @@ stages:
               displayName: 'Copy SignList.xml Files'
               inputs:
                 Contents: |
-                  **/*.nupkg
-                  **/*.snupkg
+                  **/Microsoft.Maui.*.nupkg
+                  **/Microsoft.Maui.*.snupkg
                   **/SignList.xml
                 TargetFolder: $(build.artifactstagingdirectory)
                 flattenFolders: true

--- a/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
@@ -66,10 +66,6 @@
       <Project>{57b8b73d-c3b5-4c42-869e-7b2f17d354ac}</Project>
       <Name>Controls.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\Controls\src\Xaml\Controls.Xaml.csproj">
-      <Project>{bb98a559-62c4-4c98-90a0-9e4d8df1ca27}</Project>
-      <Name>Controls.Xaml</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\..\Controls\tests\CustomAttributes\Controls.CustomAttributes.csproj">
       <Project>{d816b818-f58f-4738-93ae-924efab7a07f}</Project>
       <Name>Controls.CustomAttributes</Name>

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -66,10 +66,6 @@
       <Project>{57b8b73d-c3b5-4c42-869e-7b2f17d354ac}</Project>
       <Name>Controls.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\Controls\src\Xaml\Controls.Xaml.csproj">
-      <Project>{bb98a559-62c4-4c98-90a0-9e4d8df1ca27}</Project>
-      <Name>Controls.Xaml</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\..\Controls\tests\CustomAttributes\Controls.CustomAttributes.csproj">
       <Project>{d816b818-f58f-4738-93ae-924efab7a07f}</Project>
       <Name>Controls.CustomAttributes</Name>
@@ -77,12 +73,6 @@
     <ProjectReference Include="..\..\..\..\Core\src\Core.csproj">
       <Project>{29913989-0f70-48d8-8ede-b1dd217f21d1}</Project>
       <Name>Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\iOS\Compatibility.ControlGallery.iOS.csproj">
-      <Project>{C7131F14-274F-4B55-ACA9-E81731AD012F}</Project>
-      <Name>Compatibility.ControlGallery.iOS</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -78,6 +78,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ProjectReference Include="..\..\src\iOS\Compatibility.ControlGallery.iOS.csproj">
+    <Project>{C7131F14-274F-4B55-ACA9-E81731AD012F}</Project>
+    <Name>Compatibility.ControlGallery.iOS</Name>
+    <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    <Private>False</Private>
+  </ProjectReference>
   <Import Project="..\..\src\Issues.Shared\Compatibility.ControlGallery.Issues.Shared.projitems" Label="Shared" />
   <Import Project="..\..\src\UITests.Shared\Compatibility.UITests.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -74,16 +74,16 @@
       <Project>{29913989-0f70-48d8-8ede-b1dd217f21d1}</Project>
       <Name>Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\iOS\Compatibility.ControlGallery.iOS.csproj">
+      <Project>{C7131F14-274F-4B55-ACA9-E81731AD012F}</Project>
+      <Name>Compatibility.ControlGallery.iOS</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ProjectReference Include="..\..\src\iOS\Compatibility.ControlGallery.iOS.csproj">
-    <Project>{C7131F14-274F-4B55-ACA9-E81731AD012F}</Project>
-    <Name>Compatibility.ControlGallery.iOS</Name>
-    <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    <Private>False</Private>
-  </ProjectReference>
   <Import Project="..\..\src\Issues.Shared\Compatibility.ControlGallery.Issues.Shared.projitems" Label="Shared" />
   <Import Project="..\..\src\UITests.Shared\Compatibility.UITests.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Copy Xamarin.UItest.dll 

### Additions made ###

None

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests