### PR TITLE
Implement Font properties in TimePickerHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/TimePickerRenderer.cs
@@ -172,6 +172,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			Element.InvalidateMeasureNonVirtual(Internals.InvalidationTrigger.MeasureChanged);
 		}
 
+		[PortHandler]
 		void UpdateFont()
 		{
 			EditText.Typeface = Element.ToTypeface();

--- a/src/Compatibility/Core/src/iOS/Renderers/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/TimePickerRenderer.cs
@@ -176,6 +176,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			(Control as UITextField).UpdateTextAlignment(Element);
 		}
 
+		[PortHandler]
 		protected internal virtual void UpdateFont()
 		{
 			Control.Font = Element.ToUIFont();

--- a/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
@@ -2,6 +2,8 @@
 {
 	public partial class TimePicker : ITimePicker
 	{
+		Font? _font;
 
+		Font ITimePicker.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
 	}
 }

--- a/src/Core/src/Core/ITimePicker.cs
+++ b/src/Core/src/Core/ITimePicker.cs
@@ -21,5 +21,10 @@ namespace Microsoft.Maui
 		/// Gets the spacing between characters of the text.
 		/// </summary>
 		double CharacterSpacing { get; }
+
+		/// <summary>
+		/// Gets the font family, style and size of the font.
+		/// </summary>
+		Font Font { get; }
 	}
 }

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Android.App;
 using Android.Text.Format;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -57,6 +58,15 @@ namespace Microsoft.Maui.Handlers
 		public static void MapCharacterSpacing(TimePickerHandler handler, ITimePicker timePicker)
 		{
 			handler.TypedNativeView?.UpdateCharacterSpacing(timePicker);
+		}
+
+		public static void MapFont(TimePickerHandler handler, ITimePicker timePicker)
+		{
+			_ = handler.Services ?? throw new InvalidOperationException($"{nameof(Services)} should have been set by base class.");
+
+			var fontManager = handler.Services.GetRequiredService<IFontManager>();
+
+			handler.TypedNativeView?.UpdateFont(timePicker, fontManager);
 		}
 
 		void ShowPickerDialog()

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Standard.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Standard.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFormat(TimePickerHandler handler, ITimePicker view) { }
 		public static void MapTime(TimePickerHandler handler, ITimePicker view) { }
 		public static void MapCharacterSpacing(TimePickerHandler handler, ITimePicker view) { }
+		public static void MapFont(TimePickerHandler handler, ITimePicker view) { }
 	}
 }

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
@@ -6,7 +6,8 @@
 		{
 			[nameof(ITimePicker.Format)] = MapFormat,
 			[nameof(ITimePicker.Time)] = MapTime,
-			[nameof(ITimePicker.CharacterSpacing)] = MapCharacterSpacing
+			[nameof(ITimePicker.CharacterSpacing)] = MapCharacterSpacing,
+			[nameof(ITimePicker.Font)] = MapFont
 		};
 
 		public TimePickerHandler() : base(TimePickerMapper)

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -42,6 +43,15 @@ namespace Microsoft.Maui.Handlers
 		public static void MapCharacterSpacing(TimePickerHandler handler, ITimePicker timePicker)
 		{
 			handler.TypedNativeView?.UpdateCharacterSpacing(timePicker);
+		}
+
+		public static void MapFont(TimePickerHandler handler, ITimePicker timePicker)
+		{
+			_ = handler.Services ?? throw new InvalidOperationException($"{nameof(Services)} should have been set by base class.");
+
+			var fontManager = handler.Services.GetRequiredService<IFontManager>();
+
+			handler.TypedNativeView?.UpdateFont(timePicker, fontManager);
 		}
 
 		void OnValueChanged(object? sender, EventArgs e)

--- a/src/Core/src/Platform/Android/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/TimePickerExtensions.cs
@@ -17,6 +17,9 @@
 			mauiTimePicker.LetterSpacing = timePicker.CharacterSpacing.ToEm();
 		}
 
+		public static void UpdateFont(this MauiTimePicker mauiTimePicker, ITimePicker timePicker, IFontManager fontManager) =>
+			mauiTimePicker.UpdateFont(timePicker.Font, fontManager);
+
 		internal static void SetTime(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
 		{
 			var time = timePicker.Time;

--- a/src/Core/src/Platform/iOS/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/TimePickerExtensions.cs
@@ -7,19 +7,19 @@ namespace Microsoft.Maui
 {
 	public static class TimePickerExtensions
 	{
-		public static void UpdateFormat(this MauiTimePicker mauiTimePicker, ITimePicker view)
+		public static void UpdateFormat(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
 		{
-			mauiTimePicker.UpdateTime(view, null);
+			mauiTimePicker.UpdateTime(timePicker, null);
 		}
 
-		public static void UpdateFormat(this MauiTimePicker mauiTimePicker, ITimePicker view, UIDatePicker? picker)
+		public static void UpdateFormat(this MauiTimePicker mauiTimePicker, ITimePicker timePicker, UIDatePicker? picker)
 		{
-			mauiTimePicker.UpdateTime(view, picker);
+			mauiTimePicker.UpdateTime(timePicker, picker);
 		}
 
-		public static void UpdateTime(this MauiTimePicker mauiTimePicker, ITimePicker view)
+		public static void UpdateTime(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
 		{
-			mauiTimePicker.UpdateTime(view, null);
+			mauiTimePicker.UpdateTime(timePicker, null);
 		}
 
 		public static void UpdateTime(this MauiTimePicker mauiTimePicker, ITimePicker timePicker, UIDatePicker? picker)
@@ -62,12 +62,18 @@ namespace Microsoft.Maui
 			mauiTimePicker.UpdateCharacterSpacing(timePicker);
 		}
 
-		public static void UpdateCharacterSpacing(this MauiTimePicker mauiTimePicker, ITimePicker view)
+		public static void UpdateCharacterSpacing(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
 		{
-			var textAttr = mauiTimePicker.AttributedText?.WithCharacterSpacing(view.CharacterSpacing);
+			var textAttr = mauiTimePicker.AttributedText?.WithCharacterSpacing(timePicker.CharacterSpacing);
 
 			if (textAttr != null)
 				mauiTimePicker.AttributedText = textAttr;
+		}
+
+		public static void UpdateFont(this MauiTimePicker mauiTimePicker, ITimePicker timePicker, IFontManager fontManager)
+		{
+			var uiFont = fontManager.GetFont(timePicker.Font);
+			mauiTimePicker.Font = uiFont;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.Android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Xunit;
@@ -34,6 +35,33 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
 		}
 
+		[Theory(DisplayName = "Font Family Initializes Correctly")]
+		[InlineData(null)]
+		[InlineData("monospace")]
+		[InlineData("Dokdo")]
+		public async Task FontFamilyInitializesCorrectly(string family)
+		{
+			var timePicker = new TimePickerStub()
+			{
+				Time = TimeSpan.FromHours(7),
+				Font = Font.OfSize(family, 10)
+			};
+
+			var handler = await CreateHandlerAsync(timePicker);
+			var nativeEntry = GetNativeTimePicker(handler);
+
+			var fontManager = handler.Services.GetRequiredService<IFontManager>();
+
+			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
+
+			Assert.Equal(nativeFont, nativeEntry.Typeface);
+
+			if (string.IsNullOrEmpty(family))
+				Assert.Equal(fontManager.DefaultTypeface, nativeEntry.Typeface);
+			else
+				Assert.NotEqual(fontManager.DefaultTypeface, nativeEntry.Typeface);
+		}
+
 		MauiTimePicker GetNativeTimePicker(TimePickerHandler timePickerHandler) =>
 			(MauiTimePicker)timePickerHandler.View;
 
@@ -62,5 +90,17 @@ namespace Microsoft.Maui.DeviceTests
 
 			return -1;
 		}
+
+		double GetNativeUnscaledFontSize(TimePickerHandler timePickerHandler)
+		{
+			var mauiTimePicker = GetNativeTimePicker(timePickerHandler);
+			return mauiTimePicker.TextSize / mauiTimePicker.Resources.DisplayMetrics.Density;
+		}
+
+		bool GetNativeIsBold(TimePickerHandler timePickerHandler) =>
+			GetNativeTimePicker(timePickerHandler).Typeface.IsBold;
+
+		bool GetNativeIsItalic(TimePickerHandler timePickerHandler) =>
+			GetNativeTimePicker(timePickerHandler).Typeface.IsItalic;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -11,11 +12,44 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Time Initializes Correctly")]
 		public async Task IsToggledInitializesCorrectly()
 		{
-			var timePickerStub = new TimePickerStub();
+			var timePicker = new TimePickerStub();
 
 			var time = new TimeSpan(17, 0, 0);
 
-			await ValidateTime(timePickerStub, () => timePickerStub.Time = time);
+			await ValidateTime(timePicker, () => timePicker.Time = time);
+		}
+
+		[Theory(DisplayName = "Font Size Initializes Correctly")]
+		[InlineData(1)]
+		[InlineData(10)]
+		[InlineData(20)]
+		[InlineData(100)]
+		public async Task FontSizeInitializesCorrectly(int fontSize)
+		{
+			var timePicker = new TimePickerStub()
+			{
+				Time = new TimeSpan(17, 0, 0),
+				Font = Font.OfSize("Arial", fontSize)
+			};
+
+			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.FontSize, GetNativeUnscaledFontSize, timePicker.Font.FontSize);
+		}
+
+		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
+		[InlineData(FontAttributes.None, false, false)]
+		[InlineData(FontAttributes.Bold, true, false)]
+		[InlineData(FontAttributes.Italic, false, true)]
+		[InlineData(FontAttributes.Bold | FontAttributes.Italic, true, true)]
+		public async Task FontAttributesInitializeCorrectly(FontAttributes attributes, bool isBold, bool isItalic)
+		{
+			var timePicker = new TimePickerStub()
+			{
+				Time = new TimeSpan(17, 0, 0),
+				Font = Font.OfSize("Arial", 10).WithAttributes(attributes)
+			};
+
+			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.FontAttributes.HasFlag(FontAttributes.Bold), GetNativeIsBold, isBold);
+			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.FontAttributes.HasFlag(FontAttributes.Italic), GetNativeIsItalic, isItalic);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
+using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -32,6 +34,31 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
 		}
 
+		[Theory(DisplayName = "Font Family Initializes Correctly")]
+		[InlineData(null)]
+		[InlineData("Times New Roman")]
+		[InlineData("Dokdo")]
+		public async Task FontFamilyInitializesCorrectly(string family)
+		{
+			var timePicker = new TimePickerStub
+			{
+				Time = TimeSpan.FromHours(8),
+				Font = Font.OfSize(family, 10)
+			};
+
+			var (services, nativeFont) = await GetValueAsync(timePicker, handler => (handler.Services, GetNativeTimePicker(handler).Font));
+
+			var fontManager = services.GetRequiredService<IFontManager>();
+
+			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
+
+			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
+			if (string.IsNullOrEmpty(family))
+				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
+			else
+				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
+		}
+
 		MauiTimePicker GetNativeTimePicker(TimePickerHandler timePickerHandler) =>
 			(MauiTimePicker)timePickerHandler.View;
 
@@ -55,5 +82,14 @@ namespace Microsoft.Maui.DeviceTests
 			var mauiTimePicker = GetNativeTimePicker(timePickerHandler);
 			return mauiTimePicker.AttributedText.GetCharacterSpacing();
 		}
+
+		double GetNativeUnscaledFontSize(TimePickerHandler timePickerHandler) =>
+			GetNativeTimePicker(timePickerHandler).Font.PointSize;
+
+		bool GetNativeIsBold(TimePickerHandler timePickerHandler) =>
+			GetNativeTimePicker(timePickerHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Bold);
+
+		bool GetNativeIsItalic(TimePickerHandler timePickerHandler) =>
+			GetNativeTimePicker(timePickerHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/TimePickerStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/TimePickerStub.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		}
 
 		public double CharacterSpacing { get; set; }
+
+		public Font Font { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `Font` property in TimePickerHandlers.

Related issue https://github.com/dotnet/maui/issues/478

### Platforms Affected ### 

- Core
- iOS
- Android

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests