### PR TITLE
[resizetizer] rename @(SharedImage) to @(MauiImage)

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -143,19 +143,19 @@
 
     <!-- Finds absolute paths to any MauiImage in this project -->
     <!-- App head projects will invoke this target on their project references to collect images -->
-    <Target Name="GetSharedItems" Outputs="@(ExportedSharedItem)">
+    <Target Name="GetMauiItems" Outputs="@(ExportedMauiItem)">
 
         <ItemGroup>
-            <SharedItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' == ''" />
-            <SharedItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(MauiImage.ForegroundFile)'))" />
+            <MauiItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' == ''" />
+            <MauiItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(MauiImage.ForegroundFile)'))" />
         </ItemGroup>
 
         <ItemGroup>
-            <SharedItem Include="@(MauiFont)" ItemGroupName="MauiFont" />
+            <MauiItem Include="@(MauiFont)" ItemGroupName="MauiFont" />
         </ItemGroup>
 
-        <ConvertToAbsolutePath Paths="@(SharedItem)">
-            <Output TaskParameter="AbsolutePaths" ItemName="ExportedSharedItem" />
+        <ConvertToAbsolutePath Paths="@(MauiItem)">
+            <Output TaskParameter="AbsolutePaths" ItemName="ExportedMauiItem" />
         </ConvertToAbsolutePath>
 
     </Target>
@@ -167,35 +167,35 @@
         BeforeTargets="$(ResizetizeCollectItemsBeforeTargets)"
         AfterTargets="$(ResizetizeCollectItemsAfterTargets)">
 
-        <CallTarget Targets="GetSharedItems" Condition="'$(ResizetizerIncludeSelfProject)' == 'True'">
+        <CallTarget Targets="GetMauiItems" Condition="'$(ResizetizerIncludeSelfProject)' == 'True'">
             <Output
                 TaskParameter="TargetOutputs"
-                ItemName="ImportedSharedItem" />
+                ItemName="ImportedMauiItem" />
         </CallTarget>
 
-        <!-- Invoke the GetSharedItems target on all project references -->
+        <!-- Invoke the GetMauiItems target on all project references -->
         <!-- This will accumulate images into our MauiImage group -->
-        <!--<MSBuild Targets="GetSharedItems" Projects="@(_MSBuildProjectReferenceExistent)">-->
+        <!--<MSBuild Targets="GetMauiItems" Projects="@(_MSBuildProjectReferenceExistent)">-->
         <MSBuild
-            Targets="GetSharedItems"
+            Targets="GetMauiItems"
             Projects="@(ProjectReference)"
             SkipNonexistentProjects="true"
             SkipNonexistentTargets="true">
             <Output
                 TaskParameter="TargetOutputs"
-                ItemName="ImportedSharedItem" />
+                ItemName="ImportedMauiItem" />
         </MSBuild>
 
         <ItemGroup>
             <MauiImage
-                Include="@(ImportedSharedItem)"
-                Condition="'%(ImportedSharedItem.ItemGroupName)' == 'MauiImage'" />
+                Include="@(ImportedMauiItem)"
+                Condition="'%(ImportedMauiItem.ItemGroupName)' == 'MauiImage'" />
         </ItemGroup>
 
         <ItemGroup>
             <MauiFont
-                Include="@(ImportedSharedItem)"
-                Condition="'%(ImportedSharedItem.ItemGroupName)' == 'MauiFont'" />
+                Include="@(ImportedMauiItem)"
+                Condition="'%(ImportedMauiItem.ItemGroupName)' == 'MauiFont'" />
         </ItemGroup>
 
 

--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -2,8 +2,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <ItemGroup>
-        <AvailableItemName Include="SharedImage" />
-        <AvailableItemName Include="SharedFont" />
+        <AvailableItemName Include="MauiImage" />
+        <AvailableItemName Include="MauiFont" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -12,7 +12,7 @@
 
     <UsingTask
         AssemblyFile="$(_ResizetizerTaskAssemblyName)"
-        TaskName="Microsoft.Maui.Resizetizer.ResizetizeSharedImages" />
+        TaskName="Microsoft.Maui.Resizetizer.ResizetizeImages" />
 
     <UsingTask
         AssemblyFile="$(_ResizetizerTaskAssemblyName)"
@@ -30,8 +30,8 @@
 
         <_ResizetizerInputsFile>$(IntermediateOutputPath)resizetizer.inputs</_ResizetizerInputsFile>
         <_ResizetizerStampFile>$(IntermediateOutputPath)resizetizer.stamp</_ResizetizerStampFile>
-        <_SharedFontInputsFile>$(IntermediateOutputPath)sharedfont.inputs</_SharedFontInputsFile>
-        <_SharedFontStampFile>$(IntermediateOutputPath)sharedfont.stamp</_SharedFontStampFile>
+        <_MauiFontInputsFile>$(IntermediateOutputPath)mauifont.inputs</_MauiFontInputsFile>
+        <_MauiFontStampFile>$(IntermediateOutputPath)mauifont.stamp</_MauiFontStampFile>
 
         <ResizetizerIncludeSelfProject Condition="'$(ResizetizerIncludeSelfProject)' == ''">False</ResizetizerIncludeSelfProject>
 
@@ -65,10 +65,10 @@
             $(ResizetizeDependsOnTargets);
             ResizetizeCollectItems;
         </ResizetizeDependsOnTargets>
-        <ProcessSharedFontsDependsOnTargets>
-            $(ProcessSharedFontsDependsOnTargets);
+        <ProcessMauiFontsDependsOnTargets>
+            $(ProcessMauiFontsDependsOnTargets);
             ResizetizeCollectItems;
-        </ProcessSharedFontsDependsOnTargets>
+        </ProcessMauiFontsDependsOnTargets>
     </PropertyGroup>
 
     <!-- iOS -->
@@ -85,10 +85,10 @@
             ResizetizeCollectItems;
         </ResizetizeAfterTargets>
 
-        <ProcessSharedFontsAfterTargets>
-            $(ProcessSharedFontsAfterTargets);
+        <ProcessMauiFontsAfterTargets>
+            $(ProcessMauiFontsAfterTargets);
             _CompileCoreMLModels;
-        </ProcessSharedFontsAfterTargets>
+        </ProcessMauiFontsAfterTargets>
     </PropertyGroup>
 
     <!-- Android -->
@@ -105,10 +105,10 @@
             ResizetizeCollectItems;
         </ResizetizeAfterTargets>
 
-        <ProcessSharedFontsAfterTargets>
-            $(ProcessSharedFontsAfterTargets);
+        <ProcessMauiFontsAfterTargets>
+            $(ProcessMauiFontsAfterTargets);
             ResizetizeCollectItems;
-        </ProcessSharedFontsAfterTargets>
+        </ProcessMauiFontsAfterTargets>
     </PropertyGroup>
 
     <!-- UWP / WinUI -->
@@ -120,10 +120,10 @@
             AssignTargetPaths;
         </ResizetizeBeforeTargets>
 
-        <ProcessSharedFontsBeforeTargets>
-            $(ProcessSharedFontsBeforeTargets);
+        <ProcessMauiFontsBeforeTargets>
+            $(ProcessMauiFontsBeforeTargets);
             AssignTargetPaths;
-        </ProcessSharedFontsBeforeTargets>
+        </ProcessMauiFontsBeforeTargets>
     </PropertyGroup>
 
     <!-- WPF -->
@@ -135,23 +135,23 @@
             FileClassification;
         </ResizetizeBeforeTargets>
 
-        <ProcessSharedFontsBeforeTargets>
-            $(ProcessSharedFontsBeforeTargets);
+        <ProcessMauiFontsBeforeTargets>
+            $(ProcessMauiFontsBeforeTargets);
             FileClassification;
-        </ProcessSharedFontsBeforeTargets>
+        </ProcessMauiFontsBeforeTargets>
     </PropertyGroup>
 
-    <!-- Finds absolute paths to any SharedImage in this project -->
+    <!-- Finds absolute paths to any MauiImage in this project -->
     <!-- App head projects will invoke this target on their project references to collect images -->
     <Target Name="GetSharedItems" Outputs="@(ExportedSharedItem)">
 
         <ItemGroup>
-            <SharedItem Include="@(SharedImage)" ItemGroupName="SharedImage" Condition="'%(SharedImage.ForegroundFile)' == ''" />
-            <SharedItem Include="@(SharedImage)" ItemGroupName="SharedImage" Condition="'%(SharedImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(SharedImage.ForegroundFile)'))" />
+            <SharedItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' == ''" />
+            <SharedItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(MauiImage.ForegroundFile)'))" />
         </ItemGroup>
 
         <ItemGroup>
-            <SharedItem Include="@(SharedFont)" ItemGroupName="SharedFont" />
+            <SharedItem Include="@(MauiFont)" ItemGroupName="MauiFont" />
         </ItemGroup>
 
         <ConvertToAbsolutePath Paths="@(SharedItem)">
@@ -174,7 +174,7 @@
         </CallTarget>
 
         <!-- Invoke the GetSharedItems target on all project references -->
-        <!-- This will accumulate images into our SharedImage group -->
+        <!-- This will accumulate images into our MauiImage group -->
         <!--<MSBuild Targets="GetSharedItems" Projects="@(_MSBuildProjectReferenceExistent)">-->
         <MSBuild
             Targets="GetSharedItems"
@@ -187,15 +187,15 @@
         </MSBuild>
 
         <ItemGroup>
-            <SharedImage
+            <MauiImage
                 Include="@(ImportedSharedItem)"
-                Condition="'%(ImportedSharedItem.ItemGroupName)' == 'SharedImage'" />
+                Condition="'%(ImportedSharedItem.ItemGroupName)' == 'MauiImage'" />
         </ItemGroup>
 
         <ItemGroup>
-            <SharedFont
+            <MauiFont
                 Include="@(ImportedSharedItem)"
-                Condition="'%(ImportedSharedItem.ItemGroupName)' == 'SharedFont'" />
+                Condition="'%(ImportedSharedItem.ItemGroupName)' == 'MauiFont'" />
         </ItemGroup>
 
 
@@ -203,70 +203,70 @@
         <!-- This allows us to invalidate the build based on not just input image files changing but project item metadata as well -->
         <WriteLinesToFile
             File="$(_ResizetizerInputsFile)"
-            Lines="@(SharedImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile)')"
+            Lines="@(MauiImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
 
         <WriteLinesToFile
-            File="$(_SharedFontInputsFile)"
-            Lines="@(SharedFont->'File=%(Identity);Link=%(Link);Alias=%(Alias)')"
+            File="$(_MauiFontInputsFile)"
+            Lines="@(MauiFont->'File=%(Identity);Link=%(Link);Alias=%(Alias)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
 
     </Target>
 
-    <Target Name="ProcessSharedFonts"
-        Inputs="@(SharedFont);$(_SharedFontInputsFile)"
-        Outputs="$(_SharedFontStampFile)"
-        AfterTargets="$(ProcessSharedFontsAfterTargets)"
-        BeforeTargets="$(ProcessSharedFontsBeforeTargets)"
-        DependsOnTargets="$(ProcessSharedFontsDependsOnTargets)">
+    <Target Name="ProcessMauiFonts"
+        Inputs="@(MauiFont);$(_MauiFontInputsFile)"
+        Outputs="$(_MauiFontStampFile)"
+        AfterTargets="$(ProcessMauiFontsAfterTargets)"
+        BeforeTargets="$(ProcessMauiFontsBeforeTargets)"
+        DependsOnTargets="$(ProcessMauiFontsDependsOnTargets)">
 
         <!-- Copy font files over -->
         <Copy
-            SourceFiles="@(SharedFont)"
+            SourceFiles="@(MauiFont)"
             DestinationFolder="$(IntermediateOutputPath)sp\fonts\"
             SkipUnchangedFiles="true" />
 
         <ItemGroup>
-            <_SharedFontCopied Include="$(IntermediateOutputPath)sp\fonts\*" />
+            <_MauiFontCopied Include="$(IntermediateOutputPath)sp\fonts\*" />
         </ItemGroup>
 
-        <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True' And '@(_SharedFontCopied)' != ''">
+        <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True' And '@(_MauiFontCopied)' != ''">
 
             <!-- iOS Expects fonts to be in this group -->
-            <_SharedFontBundleResource Include="@(_SharedFontCopied)">
-                <LogicalName>$([System.IO.Path]::GetFileName(%(_SharedFontCopied.Identity)))</LogicalName>
-                <TargetPath>$([System.IO.Path]::GetFileName(%(_SharedFontCopied.Identity)))</TargetPath>
-            </_SharedFontBundleResource>
+            <_MauiFontBundleResource Include="@(_MauiFontCopied)">
+                <LogicalName>$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</LogicalName>
+                <TargetPath>$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</TargetPath>
+            </_MauiFontBundleResource>
 
-            <BundleResource Include="@(_SharedFontBundleResource)" />
+            <BundleResource Include="@(_MauiFontBundleResource)" />
 
         </ItemGroup>
 
         <!-- Create a partial info.plist for iOS -->
         <CreatePartialInfoPlistTask
-            Condition="'$(_ResizetizerIsiOSApp)' == 'True' And '@(_SharedFontCopied)' != ''"
+            Condition="'$(_ResizetizerIsiOSApp)' == 'True' And '@(_MauiFontCopied)' != ''"
             IntermediateOutputPath="$(IntermediateOutputPath)sp\"
             PlistName="FontInfo.plist"
-            CustomFonts="@(_SharedFontCopied)">
+            CustomFonts="@(_MauiFontCopied)">
             <Output
                 TaskParameter="PListFiles"
-                ItemName="_SharedFontPListFiles" />
+                ItemName="_MauiFontPListFiles" />
 
         </CreatePartialInfoPlistTask>
 
         <!-- iOS - Partial Info.plist for font registration  -->
         <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True' ">
-            <_PartialAppManifest Include="@(_SharedFontPListFiles)" Condition="'@(_SharedFontPListFiles)' != ''" />
-            <FileWrites Include="@(_SharedFontPListFiles)" Condition="'@(_SharedFontPListFiles)' != ''" />
+            <_PartialAppManifest Include="@(_MauiFontPListFiles)" Condition="'@(_MauiFontPListFiles)' != ''" />
+            <FileWrites Include="@(_MauiFontPListFiles)" Condition="'@(_MauiFontPListFiles)' != ''" />
         </ItemGroup>
 
         <!-- Android -->
         <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">
 
-            <AndroidAsset Include="@(_SharedFontCopied)" Condition="'@(_SharedFontCopied)' != ''">
-                <Link>$([System.IO.Path]::GetFileName(%(_SharedFontCopied.Identity)))</Link>
+            <AndroidAsset Include="@(_MauiFontCopied)" Condition="'@(_MauiFontCopied)' != ''">
+                <Link>$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</Link>
             </AndroidAsset>
 
         </ItemGroup>
@@ -274,8 +274,8 @@
         <!-- UWP / WinUI -->
         <ItemGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWinUIApp)' == 'True'">
 
-            <ContentWithTargetPath Include="@(_SharedFontCopied)" Condition="'@(_SharedFontCopied)' != ''">
-                <TargetPath>Assets\$([System.IO.Path]::GetFileName(%(_SharedFontCopied.Identity)))</TargetPath>
+            <ContentWithTargetPath Include="@(_MauiFontCopied)" Condition="'@(_MauiFontCopied)' != ''">
+                <TargetPath>Assets\$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</TargetPath>
             </ContentWithTargetPath>
 
         </ItemGroup>
@@ -283,9 +283,9 @@
         <!-- WPF -->
         <ItemGroup Condition="'$(_ResizetizerIsWPFApp)' == 'True'">
 
-            <Resource Include="@(_SharedFontCopied)" Condition="'@(_SharedFontCopied)' != ''">
-                <LogicalName>$([System.IO.Path]::GetFileName(%(_SharedFontCopied.Identity)))</LogicalName>
-                <Link>$([System.IO.Path]::GetFileName(%(_SharedFontCopied.Identity)))</Link>
+            <Resource Include="@(_MauiFontCopied)" Condition="'@(_MauiFontCopied)' != ''">
+                <LogicalName>$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</LogicalName>
+                <Link>$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</Link>
             </Resource>
 
         </ItemGroup>
@@ -293,34 +293,34 @@
         <!-- iOS Only -->
         <!-- If on Windows, using build host, copy the files over to build server host too -->
         <ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
-            <_SharedFontsToCopyToBuildServer Include="@(_SharedFontBundleResource);@(_SharedFontPListFiles)">
+            <_MauiFontsToCopyToBuildServer Include="@(_MauiFontBundleResource);@(_MauiFontPListFiles)">
                 <TargetPath>%(Identity)</TargetPath>
-            </_SharedFontsToCopyToBuildServer>
+            </_MauiFontsToCopyToBuildServer>
         </ItemGroup>
         <CopyFilesToBuildServer
             Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
             SessionId="$(BuildSessionId)"
-            Files="@(_SharedFontsToCopyToBuildServer)" />
+            Files="@(_MauiFontsToCopyToBuildServer)" />
 
         <!-- Touch/create our stamp file for outputs -->
-        <Touch Files="$(_SharedFontStampFile)" AlwaysCreate="True" />
+        <Touch Files="$(_MauiFontStampFile)" AlwaysCreate="True" />
 
         <!-- Include our fonts and stamp file as filewrites so they don't get rm'd -->
         <ItemGroup>
-            <FileWrites Include="$(_SharedFontStampFile)" />
-            <FileWrites Include="@(_SharedFontCopied)" />
+            <FileWrites Include="$(_MauiFontStampFile)" />
+            <FileWrites Include="@(_MauiFontCopied)" />
         </ItemGroup>
     </Target>
 
     <Target Name="ResizetizeImages"
-        Inputs="@(SharedImage);$(_ResizetizerInputsFile)"
+        Inputs="@(MauiImage);$(_ResizetizerInputsFile)"
         Outputs="$(_ResizetizerStampFile)"
         AfterTargets="$(ResizetizeAfterTargets)"
         BeforeTargets="$(ResizetizeBeforeTargets)"
         DependsOnTargets="$(ResizetizeDependsOnTargets)">
 
         <DetectInvalidResourceOutputFilenamesTask
-            Items="@(SharedImage)"
+            Items="@(MauiImage)"
             ErrorMessage="$(_ResizetizerDefaultInvalidFilenamesErrorMessage)">
         </DetectInvalidResourceOutputFilenamesTask>
 
@@ -330,12 +330,12 @@
         </PropertyGroup>
 
         <!-- Resize the images -->
-        <ResizetizeSharedImages
+        <ResizetizeImages
             PlatformType="$(ResizetizerPlatformType)"
             IntermediateOutputPath="$(ResizetizerIntermediateOutputPath)"
             InputsFile="$(_ResizetizerInputsFile)"
-            SharedImages="@(SharedImage)">
-        </ResizetizeSharedImages>
+            Images="@(MauiImage)">
+        </ResizetizeImages>
 
         <ItemGroup>
             <!-- Get Images that were generated -->
@@ -369,14 +369,14 @@
         <!-- iOS Only -->
         <!-- If on Windows, using build host, copy the files over to build server host too -->
         <ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
-            <_SharedImagesToCopyToBuildServer Include="@(_ResizetizerCollectedBundleResourceImages)">
+            <_MauiImagesToCopyToBuildServer Include="@(_ResizetizerCollectedBundleResourceImages)">
                 <TargetPath>%(Identity)</TargetPath>
-            </_SharedImagesToCopyToBuildServer>
+            </_MauiImagesToCopyToBuildServer>
         </ItemGroup>
         <CopyFilesToBuildServer
             Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
             SessionId="$(BuildSessionId)"
-            Files="@(_SharedImagesToCopyToBuildServer)" />
+            Files="@(_MauiImagesToCopyToBuildServer)" />
 
         <!-- Android -->
         <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">

--- a/src/Controls/samples/Controls.Sample/Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Controls.Sample.csproj
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SharedImage Include="Resources\Images\*" />
-    <SharedImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
-    <SharedFont Include="Resources\Fonts\*" />
+    <MauiImage Include="Resources\Images\*" />
+    <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
+    <MauiFont Include="Resources\Fonts\*" />
   </ItemGroup>
 
 </Project>

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SharedImage Include="Resources\Images\*" />
-    <SharedImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
-    <SharedFont Include="Resources\Fonts\*" />
+    <MauiImage Include="Resources\Images\*" />
+    <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
+    <MauiFont Include="Resources\Fonts\*" />
   </ItemGroup>
 
   <Target Name="Net6WinUIWorkaround" BeforeTargets="_GetSdkToolsPathsFromSdk" Condition="$(TargetFramework.Contains('-windows')) == true ">

--- a/src/Controls/src/Templates/maui-mobile/MauiApp1.in.csproj
+++ b/src/Controls/src/Templates/maui-mobile/MauiApp1.in.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SharedImage Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" IsAppIcon="true" />
+    <MauiImage Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" IsAppIcon="true" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\..\Essentials\src\Essentials.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <SharedFont Include="Fonts\*" />
+    <MauiFont Include="Fonts\*" />
   </ItemGroup>
   <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Resizetizer.targets" />
 </Project>

--- a/src/SingleProject/Resizetizer/samples/SampleApp/Resizetizer.SampleApp.csproj
+++ b/src/SingleProject/Resizetizer/samples/SampleApp/Resizetizer.SampleApp.csproj
@@ -20,15 +20,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SharedImage Include="camera.svg" BaseSize="44" />
-    <SharedImage Include="camera2.svg" BaseSize="44" TintColor="#FF00FF00" />
-    <SharedImage Include="loginbg.png" BaseSize="123,105" />
-    <SharedImage Include="loginbg.png" BaseSize="123,105" Link="changed_name.png" />
+    <MauiImage Include="camera.svg" BaseSize="44" />
+    <MauiImage Include="camera2.svg" BaseSize="44" TintColor="#FF00FF00" />
+    <MauiImage Include="loginbg.png" BaseSize="123,105" />
+    <MauiImage Include="loginbg.png" BaseSize="123,105" Link="changed_name.png" />
 
-    <SharedImage Include="appicon.svg" IsAppIcon="true" ForegroundFile="appiconfg.svg" ForegroundScale="0.65" />
-    <SharedImage Include="camera.svg" IsAppIcon="true" ForegroundFile="appiconfg.svg" ForegroundScale="0.65" Link="new_name" />
+    <MauiImage Include="appicon.svg" IsAppIcon="true" ForegroundFile="appiconfg.svg" ForegroundScale="0.65" />
+    <MauiImage Include="camera.svg" IsAppIcon="true" ForegroundFile="appiconfg.svg" ForegroundScale="0.65" Link="new_name" />
 
-    <SharedFont Include="feather.ttf" Alias="Feather" />
+    <MauiFont Include="feather.ttf" Alias="Feather" />
   </ItemGroup>
 
   <Import Project="..\..\..\..\..\.nuspec\Microsoft.Maui.Resizetizer.targets" />

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Resizetizer
 {
 	internal class AndroidAdaptiveIconGenerator
 	{
-		public AndroidAdaptiveIconGenerator(SharedImageInfo info, string appIconName, string intermediateOutputPath, ILogger logger)
+		public AndroidAdaptiveIconGenerator(ResizeImageInfo info, string appIconName, string intermediateOutputPath, ILogger logger)
 		{
 			Info = info;
 			Logger = logger;
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Resizetizer
 			AppIconName = appIconName;
 		}
 
-		public SharedImageInfo Info { get; private set; }
+		public ResizeImageInfo Info { get; private set; }
 		public string IntermediateOutputPath { get; private set; }
 		public ILogger Logger { get; private set; }
 

--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Resizetizer
 {
 	internal class AppleIconAssetsGenerator
 	{
-		public AppleIconAssetsGenerator(SharedImageInfo info, string appIconName, string intermediateOutputPath, DpiPath[] dpis, ILogger logger)
+		public AppleIconAssetsGenerator(ResizeImageInfo info, string appIconName, string intermediateOutputPath, DpiPath[] dpis, ILogger logger)
 		{
 			Info = info;
 			Logger = logger;
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		public DpiPath[] Dpis { get; }
 
-		public SharedImageInfo Info { get; private set; }
+		public ResizeImageInfo Info { get; private set; }
 		public string IntermediateOutputPath { get; private set; }
 		public ILogger Logger { get; private set; }
 

--- a/src/SingleProject/Resizetizer/src/ImageType.cs
+++ b/src/SingleProject/Resizetizer/src/ImageType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.Maui.Resizetizer
 {
-	public enum SharedImageType
+	public enum ImageType
 	{
 		Vector,
 		Bitmap

--- a/src/SingleProject/Resizetizer/src/ResizeImageInfo.cs
+++ b/src/SingleProject/Resizetizer/src/ResizeImageInfo.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Maui.Resizetizer
 {
-	internal class SharedImageInfo
+	internal class ResizeImageInfo
 	{
 		public string Alias { get; set; }
 

--- a/src/SingleProject/Resizetizer/src/Resizer.cs
+++ b/src/SingleProject/Resizetizer/src/Resizer.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Resizetizer
 {
 	internal class Resizer
 	{
-		public Resizer(SharedImageInfo info, string intermediateOutputPath, ILogger logger)
+		public Resizer(ResizeImageInfo info, string intermediateOutputPath, ILogger logger)
 		{
 			Info = info;
 			Logger = logger;
@@ -15,14 +15,14 @@ namespace Microsoft.Maui.Resizetizer
 
 		public string IntermediateOutputPath { get; private set; }
 
-		public SharedImageInfo Info { get; private set; }
+		public ResizeImageInfo Info { get; private set; }
 
 		SkiaSharpTools tools;
 
 		public string GetFileDestination(DpiPath dpi)
 			=> GetFileDestination(Info, dpi, IntermediateOutputPath);
 
-		public static string GetFileDestination(SharedImageInfo info, DpiPath dpi, string intermediateOutputPath)
+		public static string GetFileDestination(ResizeImageInfo info, DpiPath dpi, string intermediateOutputPath)
 		{
 			var fullIntermediateOutputPath = new DirectoryInfo(intermediateOutputPath);
 

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.Maui.Resizetizer
 {
-	public class ResizetizeSharedImages : AsyncTask, ILogger
+	public class ResizetizeImages : AsyncTask, ILogger
 	{
 		[Required]
 		public string PlatformType { get; set; } = "android";
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		public string InputsFile { get; set; }
 
-		public ITaskItem[] SharedImages { get; set; }
+		public ITaskItem[] Images { get; set; }
 
 		[Output]
 		public ITaskItem[] CopiedResources { get; set; }
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Resizetizer
 		{
 			Svg.SvgDocument.SkipGdiPlusCapabilityCheck = true;
 
-			var images = ParseImageTaskItems(SharedImages);
+			var images = ParseImageTaskItems(Images);
 
 			var dpis = DpiPath.GetDpis(PlatformType);
 
@@ -135,7 +135,7 @@ namespace Microsoft.Maui.Resizetizer
 			return System.Threading.Tasks.Task.CompletedTask;
 		}
 
-		void ProcessAppIcon(SharedImageInfo img, ConcurrentBag<ResizedImageInfo> resizedImages)
+		void ProcessAppIcon(ResizeImageInfo img, ConcurrentBag<ResizedImageInfo> resizedImages)
 		{
 			var appIconName = img.OutputName;
 
@@ -188,7 +188,7 @@ namespace Microsoft.Maui.Resizetizer
 			}
 		}
 
-		void ProcessImageResize(SharedImageInfo img, DpiPath[] dpis, ConcurrentBag<ResizedImageInfo> resizedImages)
+		void ProcessImageResize(ResizeImageInfo img, DpiPath[] dpis, ConcurrentBag<ResizedImageInfo> resizedImages)
 		{
 			var resizer = new Resizer(img, IntermediateOutputPath, this);
 
@@ -203,7 +203,7 @@ namespace Microsoft.Maui.Resizetizer
 			}
 		}
 
-		void ProcessImageCopy(SharedImageInfo img, DpiPath originalScaleDpi, ConcurrentBag<ResizedImageInfo> resizedImages)
+		void ProcessImageCopy(ResizeImageInfo img, DpiPath originalScaleDpi, ConcurrentBag<ResizedImageInfo> resizedImages)
 		{
 			var resizer = new Resizer(img, IntermediateOutputPath, this);
 
@@ -220,16 +220,16 @@ namespace Microsoft.Maui.Resizetizer
 			Log?.LogMessage(message);
 		}
 
-		List<SharedImageInfo> ParseImageTaskItems(ITaskItem[] images)
+		List<ResizeImageInfo> ParseImageTaskItems(ITaskItem[] images)
 		{
-			var r = new List<SharedImageInfo>();
+			var r = new List<ResizeImageInfo>();
 
 			if (images == null)
 				return r;
 
 			foreach (var image in images)
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 
 				var fileInfo = new FileInfo(image.GetMetadata("FullPath"));
 				if (!fileInfo.Exists)

--- a/src/SingleProject/Resizetizer/src/SkiaSharpAppIconTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpAppIconTools.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Resizetizer
 {
 	internal class SkiaSharpAppIconTools
 	{
-		public SkiaSharpAppIconTools(SharedImageInfo info, ILogger logger)
+		public SkiaSharpAppIconTools(ResizeImageInfo info, ILogger logger)
 		{
 			Info = info;
 			Logger = logger;
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Resizetizer
 		SKSize foregroundOriginalSize;
 		SKSize backgroundOriginalSize;
 
-		public SharedImageInfo Info { get; }
+		public ResizeImageInfo Info { get; }
 		public ILogger Logger { get; }
 
 		public string AppIconName { get; }

--- a/src/SingleProject/Resizetizer/src/SkiaSharpBitmapTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpBitmapTools.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Resizetizer
 	{
 		SKBitmap bmp;
 
-		public SkiaSharpBitmapTools(SharedImageInfo info, ILogger logger)
+		public SkiaSharpBitmapTools(ResizeImageInfo info, ILogger logger)
 			: this(info.Filename, info.BaseSize, info.TintColor, logger)
 		{
 		}

--- a/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Resizetizer
 	{
 		SKSvg svg;
 
-		public SkiaSharpSvgTools(SharedImageInfo info, ILogger logger)
+		public SkiaSharpSvgTools(ResizeImageInfo info, ILogger logger)
 			: this(info.Filename, info.BaseSize, info.TintColor, logger)
 		{
 		}

--- a/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Resizetizer
 				? new SkiaSharpSvgTools(filename, baseSize, tintColor, logger) as SkiaSharpTools
 				: new SkiaSharpBitmapTools(filename, baseSize, tintColor, logger);
 
-		public SkiaSharpTools(SharedImageInfo info, ILogger logger)
+		public SkiaSharpTools(ResizeImageInfo info, ILogger logger)
 			: this(info.Filename, info.BaseSize, info.TintColor, logger)
 		{
 		}

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizeImageInfoTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizeImageInfoTests.cs
@@ -2,7 +2,7 @@ using Xunit;
 
 namespace Microsoft.Maui.Resizetizer.Tests
 {
-	public class SharedImageInfoTests
+	public class ResizeImageInfoTests
 	{
 		public class IsVector
 		{
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[InlineData("IMAGE.PNG", false)]
 			public void ReturnsCorrectFolder(string filename, bool isVector)
 			{
-				var info = new SharedImageInfo
+				var info = new ResizeImageInfo
 				{
 					Filename = filename
 				};
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[InlineData("IMAGE")]
 			public void SupportsNoExtension(string filename)
 			{
-				var info = new SharedImageInfo
+				var info = new ResizeImageInfo
 				{
 					Filename = filename
 				};
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[InlineData(null)]
 			public void DoesNotCrashOnNullOrEmpty(string filename)
 			{
-				var info = new SharedImageInfo
+				var info = new ResizeImageInfo
 				{
 					Filename = filename
 				};

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -10,26 +10,26 @@ using Xunit;
 
 namespace Microsoft.Maui.Resizetizer.Tests
 {
-	public class ResizetizeSharedImagesTests
+	public class ResizetizeImagesTests
 	{
-		public abstract class ExecuteForApp : MSBuildTaskTestFixture<ResizetizeSharedImages>
+		public abstract class ExecuteForApp : MSBuildTaskTestFixture<ResizetizeImages>
 		{
 			public ExecuteForApp(string type)
-				: base(Path.Combine(Path.GetTempPath(), "ResizetizeSharedImagesTests", type, Path.GetRandomFileName()))
+				: base(Path.Combine(Path.GetTempPath(), "ResizetizeImagesTests", type, Path.GetRandomFileName()))
 			{
 			}
 
-			protected ResizetizeSharedImages GetNewTask(string type, params ITaskItem[] items) =>
-				new ResizetizeSharedImages
+			protected ResizetizeImages GetNewTask(string type, params ITaskItem[] items) =>
+				new ResizetizeImages
 				{
 					PlatformType = type,
 					IntermediateOutputPath = DestinationDirectory,
 					InputsFile = "resizetizer.inputs",
-					SharedImages = items,
+					Images = items,
 					BuildEngine = this,
 				};
 
-			protected ITaskItem GetCopiedResource(ResizetizeSharedImages task, string path) =>
+			protected ITaskItem GetCopiedResource(ResizetizeImages task, string path) =>
 				task.CopiedResources.Single(c => c.ItemSpec.Replace("\\", "/").EndsWith(path));
 
 			protected void AssertFileSize(string file, int width, int height)
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 			}
 
-			ResizetizeSharedImages GetNewTask(params ITaskItem[] items) =>
+			ResizetizeImages GetNewTask(params ITaskItem[] items) =>
 				GetNewTask("android", items);
 
 			[Fact]
@@ -406,7 +406,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 			}
 
-			ResizetizeSharedImages GetNewTask(params ITaskItem[] items) =>
+			ResizetizeImages GetNewTask(params ITaskItem[] items) =>
 				GetNewTask("ios", items);
 
 			[Fact]

--- a/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpAppIconToolsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpAppIconToolsTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[InlineData(0.3, 2, "appicon.svg", "appiconfg-red-512.svg")]
 			public void BasicTest(double dpi, double fgScale, string bg, string fg)
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/" + bg;
 				info.ForegroundFilename = "images/" + fg;
 				info.ForegroundScale = fgScale;

--- a/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpBitmapToolsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpBitmapToolsTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void BasicNoScaleNoResizeReturnsOriginalSize()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
 				info.Resize = false;
 				var tools = new SkiaSharpBitmapTools(info, Logger);
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void BasicNoScaleReturnsOriginalSize()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void BasicWithDownScaleReturnsDownScaledSize()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 0.5m);
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void BasicWithColorsKeepsColors()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void WithBaseSizeResizes()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
 				info.BaseSize = new Size(512, 512);
 				var tools = new SkiaSharpBitmapTools(info, Logger);
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void WithBaseSizeAndScaleResizes()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
 				info.BaseSize = new Size(512, 512);
 				var tools = new SkiaSharpBitmapTools(info, Logger);
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedReturnsColored()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
 				info.TintColor = Color.Red;
 				var tools = new SkiaSharpBitmapTools(info, Logger);
@@ -172,7 +172,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedWithAlphaReturnsColored()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
 				info.TintColor = Color.FromArgb(127, Color.Red);
 				var tools = new SkiaSharpBitmapTools(info, Logger);
@@ -192,7 +192,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedWithNamedReturnsColored()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
 				info.TintColor = Color.FromName("Red");
 				var tools = new SkiaSharpBitmapTools(info, Logger);
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedWithColorsReplacesColors()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
 				info.TintColor = Color.Red;
 				var tools = new SkiaSharpBitmapTools(info, Logger);
@@ -234,7 +234,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedWithAlphaWithColorsReplacesColors()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
 				info.TintColor = Color.FromArgb(127, Color.Red);
 				var tools = new SkiaSharpBitmapTools(info, Logger);

--- a/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpSvgToolsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpSvgToolsTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void BasicNoScaleReturnsOriginalSize()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void BasicNoScaleNoResizeReturnsOriginalSize()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
 				info.Resize = false;
 				var tools = new SkiaSharpSvgTools(info, Logger);
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void BasicWithDownScaleReturnsDownScaledSize()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 0.5m);
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void BasicWithColorsKeepsColors()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void WithBaseSizeResizes()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
 				info.BaseSize = new Size(512, 512);
 				var tools = new SkiaSharpSvgTools(info, Logger);
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void WithBaseSizeAndScaleResizes()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
 				info.BaseSize = new Size(512, 512);
 				var tools = new SkiaSharpSvgTools(info, Logger);
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedReturnsColored()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
 				info.TintColor = Color.Red;
 				var tools = new SkiaSharpSvgTools(info, Logger);
@@ -172,7 +172,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedWithAlphaReturnsColored()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
 				info.TintColor = Color.FromArgb(127, Color.Red);
 				var tools = new SkiaSharpSvgTools(info, Logger);
@@ -192,7 +192,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedWithNamedReturnsColored()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
 				info.TintColor = Color.FromName("Red");
 				var tools = new SkiaSharpSvgTools(info, Logger);
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedWithColorsReplacesColors()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
 				info.TintColor = Color.Red;
 				var tools = new SkiaSharpSvgTools(info, Logger);
@@ -234,7 +234,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Fact]
 			public void ColorizedWithAlphaWithColorsReplacesColors()
 			{
-				var info = new SharedImageInfo();
+				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
 				info.TintColor = Color.FromArgb(127, Color.Red);
 				var tools = new SkiaSharpSvgTools(info, Logger);


### PR DESCRIPTION
### Description of Change ###

This updates any public facing names for:

* `@(SharedImage)` -> `@(MauiImage)`
* `@(SharedFont)` -> `@(MauiFont)`

And a few private names:

* `<ResizetizeSharedImages/>` MSBuild task to `<ResizetizeImages/>`
* `SharedImageInfo` -> `ResizeImageInfo`
* `SharedImageType` -> `ImageType`.

I didn't change any logic here, only did Find/Replace in VS Code or
refactor/rename in Visual Studio.

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?

No