### PR TITLE
Bump to .NET 6.0.100-preview.3.21168.18

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,12 @@
     <Company>Microsoft</Company>
     <Product>Microsoft MAUI</Product>
     <ProduceReferenceAssembly Condition="'$(UsingMicrosoftNETSdk)' == 'True' AND '$(Configuration)' == 'Debug'">True</ProduceReferenceAssembly>
+    <!--
+      Workaround for:
+      https://github.com/xamarin/xamarin-macios/issues/10887
+      https://github.com/xamarin/xamarin-android/issues/5751
+    -->
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
   <PropertyGroup>
     <GitDefaultBranch>main</GitDefaultBranch>

--- a/eng/Version.props
+++ b/eng/Version.props
@@ -1,9 +1,9 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETSdkPackageVersion>6.0.100-preview.2.21155.3</MicrosoftNETSdkPackageVersion>
-    <MicrosoftAndroidSdkPackageVersion>11.0.200-ci.main.148</MicrosoftAndroidSdkPackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>14.3.100-ci.main.337</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>14.4.100-ci.main.1192</MicrosoftiOSSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-preview.3.21168.18</MicrosoftNETSdkPackageVersion>
+    <MicrosoftAndroidSdkPackageVersion>11.0.200-ci.main.175</MicrosoftAndroidSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>14.3.100-ci.main.416</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>14.4.100-ci.main.1271</MicrosoftiOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj
+++ b/src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj
@@ -15,22 +15,4 @@
     <PackageReference Include="Xamarin.AndroidX.Browser" />
   </ItemGroup>
 
-  <!--
-    The linker resolves some assembly references too eagerly, and
-    fails when it can't find them, so work around this by referencing
-    the missing assemblies.
-    See: https://github.com/mono/linker/issues/1139
-  -->
-  <PropertyGroup>
-    <_DotNetPackageVersion>5.0.0</_DotNetPackageVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.CodeDom"                        Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.Diagnostics.EventLog"           Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.IO.Ports"                       Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.Security.Permissions"           Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.Threading.AccessControl"        Version="$(_DotNetPackageVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
+++ b/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
@@ -17,21 +17,4 @@
     <ProjectReference Include="..\..\..\Core\src\Core-net6.csproj" />
     <ProjectReference Include="..\..\src\Core\Controls.Core-net6.csproj" />
   </ItemGroup>
-  <!--
-    The linker resolves some assembly references too eagerly, and
-    fails when it can't find them, so work around this by referencing
-    the missing assemblies.
-    See: https://github.com/mono/linker/issues/1139
-  -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0-android' ">
-    <_DotNetPackageVersion>5.0.0</_DotNetPackageVersion>
-  </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-android' ">
-    <PackageReference Include="System.CodeDom"                        Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.Diagnostics.EventLog"           Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.IO.Ports"                       Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.Security.Permissions"           Version="$(_DotNetPackageVersion)" />
-    <PackageReference Include="System.Threading.AccessControl"        Version="$(_DotNetPackageVersion)" />
-  </ItemGroup>
 </Project>

--- a/src/DotNet/Dependencies/Packs.csproj
+++ b/src/DotNet/Dependencies/Packs.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageDownload Include="Microsoft.Android.Ref"            Version="[$(MicrosoftAndroidSdkPackageVersion)]" />
-    <PackageDownload Include="Microsoft.Android.Sdk.win-x64"    Version="[$(MicrosoftAndroidSdkPackageVersion)]" Condition="$([MSBuild]::IsOSPlatform('windows'))" />
-    <PackageDownload Include="Microsoft.Android.Sdk.osx-x64"    Version="[$(MicrosoftAndroidSdkPackageVersion)]" Condition="$([MSBuild]::IsOSPlatform('osx'))" />
+    <PackageDownload Include="Microsoft.Android.Sdk.Windows"    Version="[$(MicrosoftAndroidSdkPackageVersion)]" Condition="$([MSBuild]::IsOSPlatform('windows'))" />
+    <PackageDownload Include="Microsoft.Android.Sdk.Darwin"     Version="[$(MicrosoftAndroidSdkPackageVersion)]" Condition="$([MSBuild]::IsOSPlatform('osx'))" />
     <PackageDownload Include="Microsoft.Android.Sdk.BundleTool" Version="[$(MicrosoftAndroidSdkPackageVersion)]" />
     <PackageDownload Include="Microsoft.MacCatalyst.Ref"        Version="[$(MicrosoftMacCatalystSdkPackageVersion)]" />
     <PackageDownload Include="Microsoft.MacCatalyst.Sdk"        Version="[$(MicrosoftMacCatalystSdkPackageVersion)]" />


### PR DESCRIPTION
### Description of Change ###

* Android 11.0.200-ci.main.175
* iOS 14.4.100-ci.main.1271
* MacCatalyst 14.3.100-ci.main.416

Other changes:

* Some Android SDK packs were renamed.
* We no longer need various packages to appease ILLink, such as:
  System.CodeDom, System.IO.Ports, etc.
* Temporarily set `$(SuppressTrimAnalysisWarnings)` in
  `Directory.Build.props`.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?

No