### PR TITLE
Remove invalid XAML files based on OutputType

### DIFF
--- a/.nuspec/Microsoft.Maui.Core.props
+++ b/.nuspec/Microsoft.Maui.Core.props
@@ -1,13 +1,2 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true AND OutputType == 'WinExe'">
-    <!-- This tells Maui.Controls to not process the WinUI Xaml files -->
-    <EnableDefaultXamlItems>false</EnableDefaultXamlItems>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true AND OutputType != 'WinExe'">
-    <!-- This tells Reunion to not process our xaml files -->
-    <EnableDefaultPageItems>false</EnableDefaultPageItems>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">10.0.17763.0</TargetPlatformMinVersion>
-  </PropertyGroup>
 </Project>

--- a/.nuspec/Microsoft.Maui.Core.targets
+++ b/.nuspec/Microsoft.Maui.Core.targets
@@ -7,9 +7,6 @@
     </PropertyGroup>
   </Target>
   <Target Name="_RemoveIncompatibleXamlFiles" BeforeTargets="BeforeBuild" Condition="$(TargetFramework.Contains('-windows')) == true ">
-    <PropertyGroup>
-      <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">10.0.17763.0</TargetPlatformMinVersion>
-    </PropertyGroup>
     <ItemGroup Condition="$(OutputType) != 'WinExe'">
       <Page Remove="**/*.xaml">
       </Page>

--- a/.nuspec/Microsoft.Maui.Core.targets
+++ b/.nuspec/Microsoft.Maui.Core.targets
@@ -6,4 +6,17 @@
       <TargetPlatformIdentifierAdjusted>UAP</TargetPlatformIdentifierAdjusted>
     </PropertyGroup>
   </Target>
+  <Target Name="_RemoveIncompatibleXamlFiles" BeforeTargets="BeforeBuild" Condition="$(TargetFramework.Contains('-windows')) == true ">
+    <PropertyGroup>
+      <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">10.0.17763.0</TargetPlatformMinVersion>
+    </PropertyGroup>
+    <ItemGroup Condition="$(OutputType) != 'WinExe'">
+      <Page Remove="**/*.xaml">
+      </Page>
+    </ItemGroup>
+    <ItemGroup Condition="$(OutputType) == 'WinExe'">
+      <EmbeddedResource Remove="**\*.xaml"></EmbeddedResource>
+      <Compile Remove="**\*.xaml"></Compile>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Controls/samples/Controls.Sample.WinUI/Maui.Controls.Sample.WinUI.csproj
+++ b/src/Controls/samples/Controls.Sample.WinUI/Maui.Controls.Sample.WinUI.csproj
@@ -7,7 +7,6 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <EnableDefaultXamlItems>false</EnableDefaultXamlItems>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ProjectReunion" Version="0.5.0-prerelease" />

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Maui.Controls.Sample</RootNamespace>
     <AssemblyName>Maui.Controls.Sample</AssemblyName>
     <IsPackable>false</IsPackable>
+    <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows')) == true ">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">


### PR DESCRIPTION
### Description of Change ###

WinUI adds Xaml Pages as Default Page Items and Maui adds them as our own Maui Embedded Resources.

This PR adds a target that `BeforeBuild` will remove the XAML files based on the OutputLibrary type. 

AFAICT we can't key into setting `EnableDefaultItems`because we don't know the Target or OutputType at the point in time that we'd need to toggle `EnableDefaultItems` off