### PR TITLE
WinUI measure fixes

### DIFF
--- a/src/Compatibility/Core/src/Windows/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/Windows/RendererToHandlerShim.cs
@@ -109,6 +109,9 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
+			if (widthConstraint < 0 || heightConstraint < 0)
+				return Size.Zero;
+
 			return VisualElementRenderer.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 
@@ -119,6 +122,14 @@ namespace Microsoft.Maui.Controls.Compatibility
 			{
 				SetFrame(VisualElementRenderer.Element.Bounds);
 			}
+		}
+
+		public override void SetFrame(Rectangle rect)
+		{
+			if ((rect.Height >= 0 || rect.Width >= 0) && VisualElementRenderer is UIElement fe)
+				fe.Measure(new Windows.Foundation.Size(rect.Size.Width, rect.Size.Height));
+
+			base.SetFrame(rect);
 		}
 	}
 }

--- a/src/Compatibility/Core/src/Windows/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/Windows/RendererToHandlerShim.cs
@@ -123,13 +123,5 @@ namespace Microsoft.Maui.Controls.Compatibility
 				SetFrame(VisualElementRenderer.Element.Bounds);
 			}
 		}
-
-		public override void SetFrame(Rectangle rect)
-		{
-			if ((rect.Height >= 0 || rect.Width >= 0) && VisualElementRenderer is UIElement fe)
-				fe.Measure(new Windows.Foundation.Size(rect.Size.Width, rect.Size.Height));
-
-			base.SetFrame(rect);
-		}
 	}
 }

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -888,6 +888,7 @@ namespace Microsoft.Maui.Controls
 			InvalidateMeasureInternal(trigger);
 		}
 
+		bool _stopTheRecursion;
 		internal virtual void InvalidateMeasureInternal(InvalidationTrigger trigger)
 		{
 			_measureCache.Clear();
@@ -897,8 +898,13 @@ namespace Microsoft.Maui.Controls
 			// This is a bit awkward because we could have invalidations coming from old bits
 			// to here first and new bits going to IFrameworkElement.InvalidateMeasure
 			// first and each one needs to call the other so this short circuits the ping pong
-			if (IsMeasureValid)
+
+			if (IsMeasureValid && !_stopTheRecursion)
+			{
+				_stopTheRecursion = true;
 				((IFrameworkElement)this).InvalidateMeasure();
+				_stopTheRecursion = false;
+			}
 		}
 
 		void IVisualElementController.InvalidateMeasure(InvalidationTrigger trigger) => InvalidateMeasureInternal(trigger);

--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override TextBlock CreateNativeView() => new TextBlock();
 
-		public static void MapText(IViewHandler handler, ILabel label) { }
+		public static void MapText(IViewHandler handler, ILabel label) =>
+			(handler as LabelHandler)?.TypedNativeView?.UpdateText(label);
+
 		public static void MapTextColor(IViewHandler handler, ILabel label) { }
 		public static void MapCharacterSpacing(IViewHandler handler, ILabel label) { }
 		public static void MapFont(LabelHandler handler, ILabel label) { }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -62,6 +62,13 @@ namespace Microsoft.Maui.Handlers
 					{
 						element.Handler?.SetFrame(element.Frame);
 					}
+				},
+				CrossPlatformInvalidateChildrenMeasure = () =>
+				{
+					foreach (var element in VirtualView.Children)
+					{
+						element.InvalidateMeasure();
+					}
 				}
 			};
 

--- a/src/Core/src/Handlers/View/AbstractViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/AbstractViewHandler.Windows.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class AbstractViewHandler<TVirtualView, TNativeView> : INativeViewHandler
 	{
-		public void SetFrame(Rectangle rect)
+		public virtual void SetFrame(Rectangle rect)
 		{
 			var nativeView = View;
 
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Handlers
 			if (nativeView == null)
 				return Size.Zero;
 
-			if (widthConstraint <= 0 || heightConstraint <= 0)
+			if (widthConstraint < 0 || heightConstraint < 0)
 				return Size.Zero;
 
 			var constraint = new Windows.Foundation.Size(widthConstraint, heightConstraint);

--- a/src/Core/src/Handlers/View/AbstractViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/AbstractViewHandler.Windows.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class AbstractViewHandler<TVirtualView, TNativeView> : INativeViewHandler
 	{
-		public virtual void SetFrame(Rectangle rect)
+		public void SetFrame(Rectangle rect)
 		{
 			var nativeView = View;
 
@@ -13,6 +13,9 @@ namespace Microsoft.Maui.Handlers
 
 			if (rect.Width < 0 || rect.Height < 0)
 				return;
+
+			if ((rect.Height >= 0 || rect.Width >= 0))
+				nativeView.Measure(new Windows.Foundation.Size(rect.Size.Width, rect.Size.Height));
 
 			nativeView.Arrange(new Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height));
 		}

--- a/src/Core/src/Handlers/View/AbstractViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/AbstractViewHandler.Windows.cs
@@ -14,9 +14,7 @@ namespace Microsoft.Maui.Handlers
 			if (rect.Width < 0 || rect.Height < 0)
 				return;
 
-			if ((rect.Height >= 0 || rect.Width >= 0))
-				nativeView.Measure(new Windows.Foundation.Size(rect.Size.Width, rect.Size.Height));
-
+			nativeView.Measure(new Windows.Foundation.Size(rect.Size.Width, rect.Size.Height));
 			nativeView.Arrange(new Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height));
 		}
 

--- a/src/Core/src/Handlers/View/AbstractViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/AbstractViewHandler.Windows.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Maui.Handlers
 			if (nativeView == null)
 				return Size.Zero;
 
+			if (widthConstraint <= 0 || heightConstraint <= 0)
+				return Size.Zero;
+
 			var constraint = new Windows.Foundation.Size(widthConstraint, heightConstraint);
 
 			nativeView.Measure(constraint);

--- a/src/Core/src/Platform/Windows/LayoutView.cs
+++ b/src/Core/src/Platform/Windows/LayoutView.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
 		internal Action<Rectangle>? CrossPlatformArrange { get; set; }
 		internal Action? CrossPlatformArrangeChildren { get; set; }
+		public Action? CrossPlatformInvalidateChildrenMeasure { get; internal set; }
 
 		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
 		{
@@ -22,8 +23,16 @@ namespace Microsoft.Maui
 			var width = availableSize.Width;
 			var height = availableSize.Height;
 
+			// AFAICT you have to call measure on every child every single time
+			// WinUI calls MeasureOverride
+			CrossPlatformInvalidateChildrenMeasure?.Invoke();
 			var crossPlatformSize = CrossPlatformMeasure(width, height);
-			return new Windows.Foundation.Size(crossPlatformSize.Width, crossPlatformSize.Height);
+
+			width = crossPlatformSize.Width;
+			height = crossPlatformSize.Height;
+
+
+			return new Windows.Foundation.Size(width, height);
 		}
 
 		protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
@@ -38,6 +47,10 @@ namespace Microsoft.Maui
 
 			var size = CrossPlatformMeasure.Invoke(width, height);
 			CrossPlatformArrange?.Invoke(new Rectangle(0, 0, width, height));
+
+
+			// AFAICT you have to call arrange on every child every single time
+			// WinUI calls ArrangeOverride
 			CrossPlatformArrangeChildren?.Invoke();
 
 			return new Windows.Foundation.Size(size.Width, size.Height);

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -11,5 +11,10 @@ namespace Microsoft.Maui
 			nativeControl.FontStyle = font.FontAttributes.ToFontStyle();
 			nativeControl.FontWeight = font.FontAttributes.ToFontWeight();
 		}
+
+		public static void UpdateText(this TextBlock nativeControl, IText text)
+		{
+			nativeControl.Text = text.Text;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

- In the "MeasureOverride" call force a measure call on all the winui elements. AFAICT this is required by the UWP measuring system otherwise elements just won't show up. I think this causes the "DesiredSize" to get set
- In SetFrame do a measure call on the nativeView to ensure the nativeView has been measured to the Frame
