### PR TITLE
Implement Color property in CheckBoxHandlers

### DIFF
--- a/src/Controls/src/Core/ColorElement.cs
+++ b/src/Controls/src/Core/ColorElement.cs
@@ -5,6 +5,16 @@ namespace Microsoft.Maui.Controls
 	static class ColorElement
 	{
 		public static readonly BindableProperty ColorProperty =
-			BindableProperty.Create(nameof(IColorElement.Color), typeof(Color), typeof(IColorElement), null);
+			BindableProperty.Create(nameof(IColorElement.Color), typeof(Color), typeof(IColorElement), null, propertyChanged: OnColorPropertyChanged);
+
+		static void OnColorPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			// IColorElement doesn't provide handling for property changes directly (the way ITextElement does);
+			// instead we check to see if the BindableObject implements IMapColorPropertyToPaint and use that to update relevant core property
+			if (bindable is IMapColorPropertyToPaint mapper)
+			{
+				mapper.MapColorPropertyToPaint((Color)newValue);
+			}
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/CheckBox.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/CheckBox.Impl.cs
@@ -1,7 +1,14 @@
-﻿namespace Microsoft.Maui.Controls
-{
-	public partial class CheckBox : ICheckBox
-	{
+﻿using Microsoft.Maui.Graphics;
 
+namespace Microsoft.Maui.Controls
+{
+	public partial class CheckBox : ICheckBox, IMapColorPropertyToPaint
+	{
+		public Paint Foreground { get; private set; }
+
+		void IMapColorPropertyToPaint.MapColorPropertyToPaint(Color color)
+		{
+			Foreground = color?.AsPaint();
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/IMapColorPropertyToPaint.cs
+++ b/src/Controls/src/Core/HandlerImpl/IMapColorPropertyToPaint.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls
+{
+	// Provides a way for controls which implement IColorElement to update core properties
+	// when updating legacy Color property values
+	internal interface IMapColorPropertyToPaint 
+	{
+		void MapColorPropertyToPaint(Color color);
+	}
+}

--- a/src/Core/src/Core/ICheckBox.cs
+++ b/src/Core/src/Core/ICheckBox.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
 {
 	/// <summary>
 	/// Represents a View which allows the user to select a binary choice.
@@ -11,8 +13,8 @@
 		bool IsChecked { get; set; }
 
 		/// <summary>
-		/// Gets the CheckBox Color.
+		/// Gets the CheckBox Foreground Paint.
 		/// </summary>
-		Color Color { get; }
+		Paint? Foreground { get; }
 	}
 }

--- a/src/Core/src/Core/ICheckBox.cs
+++ b/src/Core/src/Core/ICheckBox.cs
@@ -9,5 +9,10 @@
 		/// Gets a value that indicates whether the CheckBox is checked.
 		/// </summary>
 		bool IsChecked { get; set; }
+
+		/// <summary>
+		/// Gets the CheckBox Color.
+		/// </summary>
+		Color Color { get; }
 	}
 }

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Android.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Android.cs
@@ -42,6 +42,11 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateIsChecked(check);
 		}
 
+		public static void MapForeground(CheckBoxHandler handler, ICheckBox check)
+		{
+			handler.NativeView?.UpdateForeground(check);
+		}
+
 		void OnCheckedChanged(bool isChecked)
 		{
 			if (VirtualView != null)

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Standard.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Standard.cs
@@ -7,5 +7,7 @@ namespace Microsoft.Maui.Handlers
 		protected override object CreateNativeView() => throw new NotImplementedException();
 
 		public static void MapIsChecked(CheckBoxHandler handler, ICheckBox check) { }
+
+		public static void MapForeground(CheckBoxHandler handler, ICheckBox check) { }
 	}
 }

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Windows.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Windows.cs
@@ -3,11 +3,11 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class CheckBoxHandler : ViewHandler<ICheckBox, CheckBox>
+	public partial class CheckBoxHandler : ViewHandler<ICheckBox, MauiCheckBox>
 	{
-		protected override CheckBox CreateNativeView() => new CheckBox();
+		protected override MauiCheckBox CreateNativeView() => new MauiCheckBox();
 
-		protected override void ConnectHandler(CheckBox nativeView)
+		protected override void ConnectHandler(MauiCheckBox nativeView)
 		{
 			base.ConnectHandler(nativeView);
 
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.Unchecked += OnChecked;
 		}
 
-		protected override void DisconnectHandler(CheckBox nativeView)
+		protected override void DisconnectHandler(MauiCheckBox nativeView)
 		{
 			base.DisconnectHandler(nativeView);
 
@@ -26,6 +26,11 @@ namespace Microsoft.Maui.Handlers
 		public static void MapIsChecked(CheckBoxHandler handler, ICheckBox check)
 		{
 			handler.NativeView?.UpdateIsChecked(check);
+		}
+
+		public static void MapForeground(CheckBoxHandler handler, ICheckBox check)
+		{
+			handler.NativeView?.UpdateForeground(check);
 		}
 
 		void OnChecked(object sender, RoutedEventArgs e)

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
@@ -8,6 +8,7 @@
 			[nameof(ICheckBox.Background)] = MapBackground,
 #endif
 			[nameof(ICheckBox.IsChecked)] = MapIsChecked,
+			[nameof(ICheckBox.Color)] = MapColor,
 		};
 
 		public CheckBoxHandler() : base(CheckBoxMapper)
@@ -18,6 +19,11 @@
 		public CheckBoxHandler(PropertyMapper mapper) : base(mapper ?? CheckBoxMapper)
 		{
 
+		}
+
+		public static void MapColor(CheckBoxHandler handler, ICheckBox check)
+		{
+			handler.TypedNativeView?.UpdateColor(check);
 		}
 	}
 }

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
@@ -8,7 +8,7 @@
 			[nameof(ICheckBox.Background)] = MapBackground,
 #endif
 			[nameof(ICheckBox.IsChecked)] = MapIsChecked,
-			[nameof(ICheckBox.Color)] = MapColor,
+			[nameof(ICheckBox.Foreground)] = MapForeground,
 		};
 
 		public CheckBoxHandler() : base(CheckBoxMapper)
@@ -19,11 +19,6 @@
 		public CheckBoxHandler(PropertyMapper mapper) : base(mapper ?? CheckBoxMapper)
 		{
 
-		}
-
-		public static void MapColor(CheckBoxHandler handler, ICheckBox check)
-		{
-			handler.TypedNativeView?.UpdateColor(check);
 		}
 	}
 }

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.iOS.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.iOS.cs
@@ -34,6 +34,11 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateIsChecked(check);
 		}
 
+		public static void MapForeground(CheckBoxHandler handler, ICheckBox check)
+		{
+			handler.NativeView?.UpdateForeground(check);
+		}
+
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			var size = base.GetDesiredSize(widthConstraint, heightConstraint);

--- a/src/Core/src/Platform/Android/CheckBoxExtensions.cs
+++ b/src/Core/src/Platform/Android/CheckBoxExtensions.cs
@@ -20,5 +20,28 @@ namespace Microsoft.Maui
 		{
 			nativeCheckBox.Checked = check.IsChecked;
 		}
+
+		public static void UpdateColor(this AppCompatCheckBox nativeCheckBox, ICheckBox check)
+		{
+			// TODO: Delete when implementing the logic to set the system accent color. 
+			XColor accent = XColor.FromHex("#ff33b5e5");
+
+			var tintColor = check.Color == XColor.Default ? accent.ToNative() : check.Color.ToNative();
+
+			var tintList = new ColorStateList(
+				CheckedStates,
+				new int[]
+				{
+ 					tintColor,
+ 					tintColor,
+ 					tintColor,
+ 					tintColor
+				});
+
+			var tintMode = PorterDuff.Mode.SrcIn;
+
+			CompoundButtonCompat.SetButtonTintList(nativeCheckBox, tintList);
+			CompoundButtonCompat.SetButtonTintMode(nativeCheckBox, tintMode);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/CheckBoxExtensions.cs
+++ b/src/Core/src/Platform/Android/CheckBoxExtensions.cs
@@ -1,11 +1,23 @@
-﻿using AndroidX.AppCompat.Widget;
+﻿using Android.Content.Res;
+using Android.Graphics;
+using AndroidX.AppCompat.Widget;
+using AndroidX.Core.Widget;
 using Microsoft.Maui.Graphics;
+using static Android.Resource;
 using AColor = Android.Graphics.Color;
 
 namespace Microsoft.Maui
 {
 	public static class CheckBoxExtensions
 	{
+		static readonly int[][] CheckedStates = new int[][]
+		{
+			new int[] { Attribute.StateEnabled, Attribute.StateChecked },
+			new int[] { Attribute.StateEnabled, -Attribute.StateChecked },
+			new int[] { -Attribute.StateEnabled, Attribute.StateChecked },
+			new int[] { -Attribute.StateEnabled, -Attribute.StatePressed },
+		};
+
 		public static void UpdateBackground(this AppCompatCheckBox nativeCheckBox, ICheckBox check)
 		{
 			var paint = check.Background;
@@ -21,12 +33,20 @@ namespace Microsoft.Maui
 			nativeCheckBox.Checked = check.IsChecked;
 		}
 
-		public static void UpdateColor(this AppCompatCheckBox nativeCheckBox, ICheckBox check)
+		public static void UpdateForeground(this AppCompatCheckBox nativeCheckBox, ICheckBox check)
 		{
 			// TODO: Delete when implementing the logic to set the system accent color. 
-			XColor accent = XColor.FromHex("#ff33b5e5");
+			Graphics.Color accent = Graphics.Color.FromArgb("#ff33b5e5");
 
-			var tintColor = check.Color == XColor.Default ? accent.ToNative() : check.Color.ToNative();
+			var targetColor = accent;
+
+			// For the moment, we're only supporting solid color Paint for the Android Checkbox
+			if (check.Foreground is SolidPaint solid)
+			{
+				targetColor = solid.Color;
+			}
+
+			var tintColor = targetColor.ToNative();
 
 			var tintList = new ColorStateList(
 				CheckedStates,

--- a/src/Core/src/Platform/Windows/CheckBoxExtensions.cs
+++ b/src/Core/src/Platform/Windows/CheckBoxExtensions.cs
@@ -9,5 +9,7 @@ namespace Microsoft.Maui
 		{
 			nativeCheckBox.IsChecked = check.IsChecked;
 		}
+
+		public static void UpdateColor(this CheckBox nativeCheckBox, ICheckBox check) { }
 	}
 }

--- a/src/Core/src/Platform/Windows/CheckBoxExtensions.cs
+++ b/src/Core/src/Platform/Windows/CheckBoxExtensions.cs
@@ -1,15 +1,26 @@
-﻿using Microsoft.UI.Xaml.Controls;
-using XColor = Microsoft.Maui.Graphics.Color;
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui
 {
 	public static class CheckBoxExtensions
 	{
-		public static void UpdateIsChecked(this CheckBox nativeCheckBox, ICheckBox check)
+		public static void UpdateIsChecked(this MauiCheckBox nativeCheckBox, ICheckBox check)
 		{
 			nativeCheckBox.IsChecked = check.IsChecked;
 		}
 
-		public static void UpdateColor(this CheckBox nativeCheckBox, ICheckBox check) { }
+		public static void UpdateForeground(this MauiCheckBox nativeCheckBox, ICheckBox check) 
+		{
+			var tintBrush = check.Foreground?.ToNative();
+
+			if (tintBrush == null)
+			{
+				nativeCheckBox.TintBrush = new SolidColorBrush(UI.Colors.Black);
+				return;
+			}
+
+			nativeCheckBox.TintBrush = tintBrush;
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiCheckBox.cs
+++ b/src/Core/src/Platform/Windows/MauiCheckBox.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WBrush = Microsoft.UI.Xaml.Media.Brush;
+
+namespace Microsoft.Maui
+{
+	public class MauiCheckBox : CheckBox
+	{
+		public static readonly DependencyProperty TintBrushProperty =
+			DependencyProperty.Register(nameof(TintBrush), typeof(WBrush), typeof(MauiCheckBox),
+				new PropertyMetadata(default(WBrush), OnTintBrushPropertyChanged));
+
+		static void OnTintBrushPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var checkBox = (MauiCheckBox)d;
+
+			if (checkBox.IsChecked == false)
+			{
+				checkBox.DefaultFillBrush = new UI.Xaml.Media.SolidColorBrush(UI.Colors.Transparent);
+			}
+			else
+			{
+				checkBox.DefaultFillBrush = (WBrush)e.NewValue;
+			}
+		}
+
+		public static readonly DependencyProperty DefaultFillBrushProperty =
+			DependencyProperty.Register(nameof(DefaultFillBrush), typeof(WBrush), typeof(MauiCheckBox),
+				new PropertyMetadata(default(WBrush)));
+
+		public WBrush TintBrush
+		{
+			get { return (WBrush)GetValue(TintBrushProperty); }
+			set { SetValue(TintBrushProperty, value); }
+		}
+
+		public WBrush DefaultFillBrush
+		{
+			get { return (WBrush)GetValue(DefaultFillBrushProperty); }
+			set { SetValue(DefaultFillBrushProperty, value); }
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/Styles/MauiCheckBoxStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/MauiCheckBoxStyle.xaml
@@ -1,0 +1,232 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:win="using:Microsoft.Maui">
+
+    <Style TargetType="win:MauiCheckBox">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="Padding" Value="8,5,0,0"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="VerticalContentAlignment" Value="Top"/>
+        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
+        <Setter Property="MinWidth" Value="32"/>
+        <Setter Property="MinHeight" Value="32"/>
+        <Setter Property="UseSystemFocusVisuals" Value="True"/>
+        <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CheckBox">
+                    <Grid x:Name="RootGrid" 
+                          VerticalAlignment="Center"
+                          Background="{TemplateBinding Background}" 
+                          BorderThickness="{TemplateBinding BorderThickness}" 
+                          BorderBrush="{TemplateBinding BorderBrush}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="20"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CombinedStates">
+                                <VisualState x:Name="UncheckedNormal">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Transparent"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUnchecked}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="UncheckedPointerOver">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Transparent"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedPointerOver}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPressed">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Transparent"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundCheckedPressed}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Opacity" To="1"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="UncheckedPressed">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedPressed}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="StrokeThickness" To="{ThemeResource CheckBoxCheckedStrokeThickness}"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="UncheckedDisabled">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Transparent"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedDisabled}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="CheckedNormal">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundChecked}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="StrokeThickness" To="{ThemeResource CheckBoxCheckedStrokeThickness}"/>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Opacity" To="1"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="CheckedPointerOver">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundCheckedPointerOver}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Opacity" To="1"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="CheckedDisabled">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="White"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Opacity" To="1"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="IndeterminateNormal">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminate}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Glyph">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="&#xE73C;"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Opacity" To="1"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="IndeterminatePointerOver">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminatePointerOver}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Glyph">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="&#xE73C;"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Opacity" To="1"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="IndeterminatePressed">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminatePressed}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Glyph">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="&#xE73C;"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Opacity" To="1"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="IndeterminateDisabled">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Stroke">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminateDisabled}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Glyph">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="&#xE73C;"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Duration="0" Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Opacity" To="1"/>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid Height="32" VerticalAlignment="Top">
+                            <Rectangle x:Name="NormalRectangle" 
+                                       Fill="{Binding DefaultFillBrush, RelativeSource={RelativeSource TemplatedParent}}" 
+                                       Height="20" 
+                                       StrokeThickness="{ThemeResource CheckBoxBorderThemeThickness}" 
+                                       Stroke="{Binding TintBrush, RelativeSource={RelativeSource TemplatedParent}}" 
+                                       UseLayoutRounding="False" 
+                                       Width="20"/>
+                            <FontIcon x:Name="CheckGlyph" FontFamily="{ThemeResource SymbolThemeFontFamily}" Foreground="{ThemeResource CheckBoxCheckGlyphForegroundUnchecked}" FontSize="20" Glyph="&#xE001;" Opacity="0"/>
+                        </Grid>
+                        <ContentPresenter x:Name="ContentPresenter" AutomationProperties.AccessibilityView="Raw" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" Grid.Column="1" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" TextWrapping="Wrap" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/Core/src/Platform/Windows/Styles/Resources.xaml
+++ b/src/Core/src/Platform/Windows/Styles/Resources.xaml
@@ -10,6 +10,7 @@
         <ResourceDictionary Source="MauiComboBoxStyle.xaml" />
         <ResourceDictionary Source="MauiStepperStyle.xaml" />
         <ResourceDictionary Source="MauiTextBoxStyle.xaml" />
+        <ResourceDictionary Source="MauiCheckBoxStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
      
     <uwp:ColorConverter x:Key="ColorConverter" />

--- a/src/Core/src/Platform/iOS/CheckBoxExtensions.cs
+++ b/src/Core/src/Platform/iOS/CheckBoxExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
 {
 	public static class CheckBoxExtensions
 	{
@@ -7,9 +9,13 @@
 			nativeCheckBox.IsChecked = check.IsChecked;
 		}
 
-		public static void UpdateColor(this MauiCheckBox nativeCheckBox, ICheckBox check)
+		public static void UpdateForeground(this MauiCheckBox nativeCheckBox, ICheckBox check)
 		{
-			nativeCheckBox.CheckBoxTintColor = check.Color;
+			// For the moment, we're only supporting solid color Paint for the iOS Checkbox
+			if (check.Foreground is SolidPaint solid)
+			{
+				nativeCheckBox.CheckBoxTintColor = solid.Color;
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/CheckBoxExtensions.cs
+++ b/src/Core/src/Platform/iOS/CheckBoxExtensions.cs
@@ -6,5 +6,10 @@
 		{
 			nativeCheckBox.IsChecked = check.IsChecked;
 		}
+
+		public static void UpdateColor(this MauiCheckBox nativeCheckBox, ICheckBox check)
+		{
+			nativeCheckBox.CheckBoxTintColor = check.Color;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.Android.cs
@@ -1,4 +1,6 @@
-﻿using AndroidX.AppCompat.Widget;
+﻿using System;
+using System.Threading.Tasks;
+using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.DeviceTests
@@ -10,5 +12,18 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsChecked(CheckBoxHandler checkBoxHandler) =>
 			GetNativeCheckBox(checkBoxHandler).Checked;
-	}
+
+        Task ValidateColor(ICheckBox checkBoxStub, Color color, Action action = null) =>
+            ValidateHasColor(checkBoxStub, color, action);
+
+        Task ValidateHasColor(ICheckBox checkBoxStub, Color color, Action action = null)
+        {
+            return InvokeOnMainThreadAsync(() =>
+            {
+                var nativeSwitch = GetNativeCheckBox(CreateHandler(checkBoxStub));
+                action?.Invoke();
+                nativeSwitch.AssertContainsColor(color);
+            });
+        }
+    }
 }

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.DeviceTests

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Xunit;
 
@@ -21,16 +22,16 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(checkBoxStub, () => checkBoxStub.IsChecked, GetNativeIsChecked, checkBoxStub.IsChecked);
 		}
 
-		[Fact(DisplayName = "Color Updates Correctly")]
-		public async Task ColorUpdatesCorrectly()
+		[Fact(DisplayName = "Foreground Updates Correctly")]
+		public async Task ForegroundUpdatesCorrectly()
 		{
 			var checkBoxStub = new CheckBoxStub()
 			{
-				Color = Color.Red,
+				Foreground = new SolidPaint(Colors.Red),
 				IsChecked = true
 			};
 
-			await ValidateColor(checkBoxStub, Color.Red, () => checkBoxStub.Color = Color.Red);
+			await ValidateColor(checkBoxStub, Colors.Red);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.cs
@@ -20,5 +20,17 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidatePropertyInitValue(checkBoxStub, () => checkBoxStub.IsChecked, GetNativeIsChecked, checkBoxStub.IsChecked);
 		}
+
+		[Fact(DisplayName = "Color Updates Correctly")]
+		public async Task ColorUpdatesCorrectly()
+		{
+			var checkBoxStub = new CheckBoxStub()
+			{
+				Color = Color.Red,
+				IsChecked = true
+			};
+
+			await ValidateColor(checkBoxStub, Color.Red, () => checkBoxStub.Color = Color.Red);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Xunit;
 

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Maui.Handlers;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -9,5 +12,16 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsChecked(CheckBoxHandler checkBoxHandler) =>
 			GetNativeCheckBox(checkBoxHandler).IsChecked;
-	}
+
+        async Task ValidateColor(ICheckBox checkBoxStub, Color color, Action action = null)
+        {
+            var expected = await GetValueAsync(checkBoxStub, handler =>
+            {
+                var native = GetNativeCheckBox(handler);
+                action?.Invoke();
+                return native.CheckBoxTintColor;
+            });
+            Assert.Equal(expected, color);
+        }
+    }
 }

--- a/src/Core/tests/DeviceTests/Stubs/CheckBoxStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/CheckBoxStub.cs
@@ -3,5 +3,6 @@
 	public partial class CheckBoxStub : StubBase, ICheckBox
 	{
 		public bool IsChecked { get; set; }
+		public Color Color { get; set; }
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/CheckBoxStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/CheckBoxStub.cs
@@ -1,8 +1,10 @@
-﻿namespace Microsoft.Maui.DeviceTests.Stubs
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public partial class CheckBoxStub : StubBase, ICheckBox
 	{
 		public bool IsChecked { get; set; }
-		public Color Color { get; set; }
+		public Paint Foreground { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `Color` property in CheckBoxHandlers.

### Platforms Affected ### 

- Core
- iOS
- Android

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests