### PR TITLE
Update build.cake to support pre-release VS

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1225,7 +1225,7 @@ void StartVisualStudioForDotNet6(string sln = "./Microsoft.Maui-net6.sln")
         Information("This target is only supported on Windows.");
         return;
     }
-    var vsLatest = VSWhereLatest();
+    var vsLatest = VSWhereLatest(new VSWhereLatestSettings { IncludePrerelease = true, });
     if (vsLatest == null)
         throw new Exception("Unable to find Visual Studio!");
     var devenv = vsLatest.CombineWithFilePath("./Common7/IDE/devenv.exe");


### PR DESCRIPTION
I only run VS pre-release builds because... that's what I do. There's an API in cake to support detecting those:

https://cakebuild.net/api/Cake.Common.Tools.VSWhere.Latest/VSWhereLatestSettings/

With this change, I can run `dotnet cake --target=VS-NET6` and open in VS pre-rel.