### PR TITLE
Fix Android infinite height bug

### DIFF
--- a/src/Core/src/Handlers/View/AbstractViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/AbstractViewHandler.Android.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			var mode = MeasureSpecMode.AtMost;
 
-			if (explicitSize > -1)
+			if (explicitSize >= 0)
 			{
 				// We have a set value (i.e., a Width or Height)
 				mode = MeasureSpecMode.Exactly;

--- a/src/Core/src/Handlers/View/AbstractViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/AbstractViewHandler.Android.cs
@@ -46,25 +46,42 @@ namespace Microsoft.Maui.Handlers
 
 		public virtual Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			if (TypedNativeView == null)
+			if (TypedNativeView == null || VirtualView == null || Context == null)
 			{
 				return Size.Zero;
 			}
 
-			if (Context == null)
-			{
-				return new Size(widthConstraint, heightConstraint);
-			}
-
-			var deviceWidthConstraint = Context.ToPixels(widthConstraint);
-			var deviceHeightConstraint = Context.ToPixels(heightConstraint);
-
-			var widthSpec = MeasureSpecMode.AtMost.MakeMeasureSpec((int)deviceWidthConstraint);
-			var heightSpec = MeasureSpecMode.AtMost.MakeMeasureSpec((int)deviceHeightConstraint);
+			// Create a spec to handle the native measure
+			var widthSpec = CreateMeasureSpec(widthConstraint, VirtualView.Width);
+			var heightSpec = CreateMeasureSpec(heightConstraint, VirtualView.Height);
 
 			TypedNativeView.Measure(widthSpec, heightSpec);
 
+			// Convert back to xplat sizes for the return value
 			return Context.FromPixels(TypedNativeView.MeasuredWidth, TypedNativeView.MeasuredHeight);
+		}
+
+		int CreateMeasureSpec(double constraint, double explicitSize)
+		{
+			var mode = MeasureSpecMode.AtMost;
+
+			if (explicitSize > -1)
+			{
+				// We have a set value (i.e., a Width or Height)
+				mode = MeasureSpecMode.Exactly;
+				constraint = explicitSize;
+			}
+			else if (double.IsInfinity(constraint))
+			{
+				// We've got infinite space; we'll leave the size up to the native control
+				mode = MeasureSpecMode.Unspecified;
+				constraint = 0;
+			}
+
+			// Convert to a native size to create the spec for measuring
+			var deviceConstraint = (int)Context!.ToPixels(constraint);
+
+			return mode.MakeMeasureSpec(deviceConstraint);
 		}
 
 		void SetupContainer()


### PR DESCRIPTION
Fixes issue where using `Context.ToPixels()` conversion on infinite sizes causes infinite-height control measurements on some architectures. 