### PR TITLE
Bump to .NET 6.0.100-preview.3.21201.23

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,12 +17,6 @@
     <Company>Microsoft</Company>
     <Product>Microsoft MAUI</Product>
     <ProduceReferenceAssembly Condition="'$(UsingMicrosoftNETSdk)' == 'True' AND '$(Configuration)' == 'Debug'">True</ProduceReferenceAssembly>
-    <!--
-      Workaround for:
-      https://github.com/xamarin/xamarin-macios/issues/10887
-      https://github.com/xamarin/xamarin-android/issues/5751
-    -->
-    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
   <PropertyGroup>
     <GitDefaultBranch>main</GitDefaultBranch>

--- a/eng/Version.props
+++ b/eng/Version.props
@@ -1,9 +1,9 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETSdkPackageVersion>6.0.100-preview.3.21174.8</MicrosoftNETSdkPackageVersion>
-    <MicrosoftAndroidSdkPackageVersion>11.0.200-preview.3.189</MicrosoftAndroidSdkPackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>14.3.100-ci.main.438</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftiOSSdkPackageVersion>14.4.100-ci.main.1293</MicrosoftiOSSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-preview.3.21201.23</MicrosoftNETSdkPackageVersion>
+    <MicrosoftAndroidSdkPackageVersion>11.0.200-preview.3.195</MicrosoftAndroidSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>14.3.100-ci.main.465</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>14.4.100-ci.main.1320</MicrosoftiOSSdkPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Controls/samples/Controls.Sample.MacCatalyst/Maui.Controls.Sample.MacCatalyst-net6.csproj
+++ b/src/Controls/samples/Controls.Sample.MacCatalyst/Maui.Controls.Sample.MacCatalyst-net6.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0-maccatalyst</TargetFramework>
     <RuntimeIdentifier>maccatalyst-x64</RuntimeIdentifier>
-    <TargetFramework Condition=" '$(OS)' == 'Windows_NT' ">net6.0-ios</TargetFramework>
-    <RuntimeIdentifier Condition=" '$(OS)' == 'Windows_NT' ">ios-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>Maui.Controls.Sample.MacCatalyst</RootNamespace>
     <AssemblyName>Maui.Controls.Sample.MacCatalyst</AssemblyName>

--- a/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
+++ b/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-ios;net6.0-maccatalyst;net6.0-android</TargetFrameworks>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">ios-x64</RuntimeIdentifier>
+    <TargetFrameworks>net6.0-android;net6.0-maccatalyst;net6.0-ios</TargetFrameworks>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">iossimulator-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <SingleProject>true</SingleProject>

--- a/src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj
+++ b/src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-ios</TargetFramework>
-    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>Maui.Controls.Sample.iOS</RootNamespace>
     <AssemblyName>Maui.Controls.Sample.iOS</AssemblyName>

--- a/src/Templates/src/maui-mobile/MauiApp1.in.csproj
+++ b/src/Templates/src/maui-mobile/MauiApp1.in.csproj
@@ -9,7 +9,7 @@
     <ApplicationId>com.companyname.MauiApp1</ApplicationId>
     <ApplicationVersion>1.0</ApplicationVersion>
     <AndroidVersionCode>1</AndroidVersionCode>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">ios-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">iossimulator-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description of Change ###

* Android 11.0.200-preview.3.195
* Catalyst: 14.3.100-ci.main.465
* iOS: 14.4.100-ci.main.1320

Other changes:
* We should be able to remove the `$(SuppressTrimAnalysisWarnings)` workaround.
* We need to use `iossimulator-x64` everywhere, as the RID has been changed to differentiate iOS simulators between M1 Macs and Intel Macs.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests
