### PR TITLE
Add a way to reset padding using NaN

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -95,14 +95,14 @@ namespace Maui.Controls.Sample.Pages
 
 			verticalStack.Add(horizontalStack);
 
-			var paddingButton = new Button
+			verticalStack.Add(new Button { Text = "Default" });
+			verticalStack.Add(new Button { Text = "0 Padding", Padding = 0 });
+			verticalStack.Add(new Button
 			{
 				Padding = new Thickness(40),
-				Text = "This button has a padding!!",
+				Text = "This button has a padding of 40!!",
 				BackgroundColor = Color.Purple,
-			};
-
-			verticalStack.Add(paddingButton);
+			});
 			verticalStack.Add(new Button { Text = "CharacterSpacing" });
 			verticalStack.Add(new Button { CharacterSpacing = 8, Text = "CharacterSpacing" });
 

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -97,6 +97,8 @@ namespace Maui.Controls.Sample.Pages
 
 			verticalStack.Add(new Button { Text = "Default" });
 			verticalStack.Add(new Button { Text = "0 Padding", Padding = 0 });
+			verticalStack.Add(new Button { Text = "NaN Padding", Padding = double.NaN });
+			verticalStack.Add(new Button { Text = "NaN,0,0,0 Padding", Padding = new Thickness(double.NaN, 0, 0, 0) });
 			verticalStack.Add(new Button
 			{
 				Padding = new Thickness(40),

--- a/src/Controls/src/Core/HandlerImpl/Button.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button.Impl.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		Font IText.Font => Font;
+
+		Thickness IPadding.Padding => IsSet(PaddingProperty) ? Padding : new Thickness(double.NaN);
 	}
 }

--- a/src/Core/src/Platform/Android/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ButtonExtensions.cs
@@ -44,14 +44,7 @@ namespace Microsoft.Maui
 			if (context == null)
 				return;
 
-			// TODO: have a way to use default padding
-			//       Windows keeps the default as a base but this is also wrong.
-			// var padding = defaultPadding ?? new Thickness();
-			var padding = new Thickness();
-			padding.Left += context.ToPixels(button.Padding.Left);
-			padding.Top += context.ToPixels(button.Padding.Top);
-			padding.Right += context.ToPixels(button.Padding.Right);
-			padding.Bottom += context.ToPixels(button.Padding.Bottom);
+			var padding = context.GetThickness(button.Padding, defaultPadding);
 
 			appCompatButton.SetPadding(
 				(int)padding.Left,

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -191,5 +191,19 @@ namespace Microsoft.Maui
 
 			return null;
 		}
+
+		public static Thickness GetThickness(this Context context, Thickness thickness, Thickness? defaultThickness = null)
+		{
+			return new Thickness(
+				Get(thickness.Left, defaultThickness?.Left ?? 0.0),
+				Get(thickness.Top, defaultThickness?.Top ?? 0.0),
+				Get(thickness.Right, defaultThickness?.Right ?? 0.0),
+				Get(thickness.Bottom, defaultThickness?.Bottom ?? 0.0));
+
+			double Get(double side, double def) =>
+				double.IsNaN(side)
+					? def
+					: context.ToPixels(side);
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/ControlExtensions.cs
+++ b/src/Core/src/Platform/Windows/ControlExtensions.cs
@@ -21,18 +21,7 @@ namespace Microsoft.Maui
 		public static void UpdateBackgroundColor(this Control nativeControl, Color color, UI.Xaml.Media.Brush? defaultBrush = null) =>
 			nativeControl.Background = color.IsDefault && defaultBrush != null ? defaultBrush : color.ToNative();
 
-		public static void UpdatePadding(this Control nativeControl, Thickness padding, UI.Xaml.Thickness? defaultThickness = null)
-		{
-			// TODO: have a way to reset the padding
-			//       This is used for button, but this also means there can never be a 0 padding button
-			var newPadding = defaultThickness ?? new UI.Xaml.Thickness();
-
-			newPadding.Left += padding.Left;
-			newPadding.Top += padding.Top;
-			newPadding.Right += padding.Right;
-			newPadding.Bottom += padding.Bottom;
-
-			nativeControl.Padding = newPadding;
-		}
+		public static void UpdatePadding(this Control nativeControl, Thickness padding, UI.Xaml.Thickness? defaultThickness = null) =>
+			nativeControl.Padding = padding.ToNative(defaultThickness);
 	}
 }

--- a/src/Core/src/Platform/Windows/PrimitiveExtensions.cs
+++ b/src/Core/src/Platform/Windows/PrimitiveExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.Maui
+{
+	public static class PrimitiveExtensions
+	{
+		public static UI.Xaml.Thickness ToNative(this Thickness thickness, UI.Xaml.Thickness? defaultThickness = null)
+		{
+			return new UI.Xaml.Thickness(
+				Get(thickness.Left, defaultThickness?.Left ?? 0.0),
+				Get(thickness.Top, defaultThickness?.Top ?? 0.0),
+				Get(thickness.Right, defaultThickness?.Right ?? 0.0),
+				Get(thickness.Bottom, defaultThickness?.Bottom ?? 0.0));
+
+			static double Get(double side, double def) => double.IsNaN(side) ? def : side;
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -49,11 +49,7 @@ namespace Microsoft.Maui
 
 		public static void UpdatePadding(this UIButton nativeButton, IButton button)
 		{
-			nativeButton.ContentEdgeInsets = new UIEdgeInsets(
-				(float)button.Padding.Top,
-				(float)button.Padding.Left,
-				(float)button.Padding.Bottom,
-				(float)button.Padding.Right);
+			nativeButton.ContentEdgeInsets = button.Padding.ToNative();
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/PrimitiveExtensions.cs
+++ b/src/Core/src/Platform/iOS/PrimitiveExtensions.cs
@@ -1,0 +1,18 @@
+﻿using UIKit;
+
+namespace Microsoft.Maui
+{
+	public static class PrimitiveExtensions
+	{
+		public static UIEdgeInsets ToNative(this Thickness thickness, UIEdgeInsets? defaultEdgeInsets = null)
+		{
+			return new UIEdgeInsets(
+				(float)Get(thickness.Left, defaultEdgeInsets?.Left ?? 0.0),
+				(float)Get(thickness.Top, defaultEdgeInsets?.Top ?? 0.0),
+				(float)Get(thickness.Right, defaultEdgeInsets?.Right ?? 0.0),
+				(float)Get(thickness.Bottom, defaultEdgeInsets?.Bottom ?? 0.0));
+
+			static double Get(double side, double def) => double.IsNaN(side) ? def : side;
+		}
+	}
+}

--- a/src/Core/src/Primitives/Thickness.cs
+++ b/src/Core/src/Primitives/Thickness.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Maui
 			get { return Left == 0 && Top == 0 && Right == 0 && Bottom == 0; }
 		}
 
+		public bool IsNaN => Left == double.NaN && Top == double.NaN && Right == double.NaN && Bottom == double.NaN;
+
 		public Thickness(double uniformSize) : this(uniformSize, uniformSize, uniformSize, uniformSize)
 		{
 		}
@@ -97,5 +99,7 @@ namespace Microsoft.Maui
 		}
 
 		public static Thickness Zero = new Thickness(0);
+
+		public static Thickness NaN = new Thickness(double.NaN);
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Related to #657 

Currently the padding for Button is inconsistent, Android, iOS and Windows each do a different thing. This PR makes them follow the simple rules:

1. `IButton.Padding` now returns this: `IsSet(PaddingProperty) ? Padding : Thicknes.NaN`
2. If a padding side is `NaN`, then use default value
3. Use padding value
There are some interesting things with bindable property that actually do still exist. The very act of accessing the `Padding` property will cause the default init to run, thus setting the property. So in the debugger, if you see the padding, then it is set and can no longer use the default. This is an existing bug and is nicely documented in the ButtonManager for Android.

We could potentially make the default actually return `NaN` and then the property getter on `Button.Padding` actually do a `IsNaN ? 0 : value`, bugt this might be a breaking change and also doesn't quite feel bindable. Nice thing is, Comet or new things will not have this issue. This is just for compat and already exists.

We could extend the `BindableProperty` to determine if the value was set by the outside or the default init logic.

### Additions made ###
None.

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arragement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR then the PR will need to provide testing to demonstrate that accessibility still works. 
