### PR TITLE
Implement VerticalTextAlignment to EntryHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
@@ -304,6 +304,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			EditText.UpdateTextAlignment(Element.HorizontalTextAlignment, Element.VerticalTextAlignment);
 		}
 
+		[PortHandler]
 		void UpdateVerticalTextAlignment()
 		{
 			EditText.UpdateTextAlignment(Element.HorizontalTextAlignment, Element.VerticalTextAlignment);

--- a/src/Compatibility/Core/src/iOS/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/EntryRenderer.cs
@@ -263,6 +263,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			Control.TextAlignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);
 		}
 
+		[PortHandler]
 		void UpdateVerticalTextAlignment()
 		{
 			Control.VerticalAlignment = Element.VerticalTextAlignment.ToNativeTextAlignment();

--- a/src/Core/src/Core/ITextAlignment.cs
+++ b/src/Core/src/Core/ITextAlignment.cs
@@ -9,5 +9,10 @@ namespace Microsoft.Maui
 		/// Gets the horizontal text alignment.
 		/// </summary>
 		TextAlignment HorizontalTextAlignment { get; }
+
+		/// <summary>
+		/// Gets the vertical text alignment.
+		/// </summary>
+		TextAlignment VerticalTextAlignment { get; }
 	}
 }

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -78,6 +78,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateHorizontalTextAlignment(entry);
 		}
 
+		public static void MapVerticalTextAlignment(EntryHandler handler, IEntry entry)
+		{
+			handler.TypedNativeView?.UpdateVerticalTextAlignment(entry);
+		}
+
 		public static void MapIsTextPredictionEnabled(EntryHandler handler, IEntry entry)
 		{
 			handler.TypedNativeView?.UpdateIsTextPredictionEnabled(entry);

--- a/src/Core/src/Handlers/Entry/EntryHandler.Standard.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Standard.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextColor(IViewHandler handler, IEntry entry) { }
 		public static void MapIsPassword(IViewHandler handler, IEntry entry) { }
 		public static void MapHorizontalTextAlignment(IViewHandler handler, IEntry entry) { }
+		public static void MapVerticalTextAlignment(IViewHandler handler, IEntry entry) { }
 		public static void MapIsTextPredictionEnabled(IViewHandler handler, IEntry entry) { }
 		public static void MapMaxLength(IViewHandler handler, IEntry entry) { }
 		public static void MapPlaceholder(IViewHandler handler, IEntry entry) { }

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextColor(IViewHandler handler, IEntry entry) { }
 		public static void MapIsPassword(IViewHandler handler, IEntry entry) { }
 		public static void MapHorizontalTextAlignment(IViewHandler handler, IEntry entry) { }
+		public static void MapVerticalTextAlignment(IViewHandler handler, IEntry entry) { }
 		public static void MapIsTextPredictionEnabled(IViewHandler handler, IEntry entry) { }
 		public static void MapMaxLength(IViewHandler handler, IEntry entry) { }
 		public static void MapPlaceholder(IViewHandler handler, IEntry entry) { }

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -8,6 +8,7 @@
 			[nameof(IEntry.TextColor)] = MapTextColor,
 			[nameof(IEntry.IsPassword)] = MapIsPassword,
 			[nameof(IEntry.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
+			[nameof(IEntry.VerticalTextAlignment)] = MapVerticalTextAlignment,
 			[nameof(IEntry.IsTextPredictionEnabled)] = MapIsTextPredictionEnabled,
 			[nameof(IEntry.MaxLength)] = MapMaxLength,
 			[nameof(IEntry.Placeholder)] = MapPlaceholder,

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateHorizontalTextAlignment(entry);
 		}
 
+		public static void MapVerticalTextAlignment(EntryHandler handler, IEntry entry)
+		{
+			handler.TypedNativeView?.UpdateVerticalTextAlignment(entry);
+		}
+
 		public static void MapIsTextPredictionEnabled(EntryHandler handler, IEntry entry)
 		{
 			handler.TypedNativeView?.UpdateIsTextPredictionEnabled(entry);

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -55,7 +55,12 @@ namespace Microsoft.Maui
 
 		public static void UpdateHorizontalTextAlignment(this AppCompatEditText editText, IEntry entry)
 		{
-			editText.UpdateHorizontalAlignment(entry.HorizontalTextAlignment, editText.Context != null && editText.Context.HasRtlSupport());
+			editText.UpdateTextAlignment(entry);
+		}
+
+		public static void UpdateVerticalTextAlignment(this AppCompatEditText editText, IEntry entry)
+		{
+			editText.UpdateTextAlignment(entry);
 		}
 
 		public static void UpdateIsTextPredictionEnabled(this AppCompatEditText editText, IEntry entry)
@@ -231,5 +236,10 @@ namespace Microsoft.Maui
 			currentText?.Length > maxLength
 				? currentText.Substring(0, maxLength)
 				: currentText;
+
+		internal static void UpdateTextAlignment(this AppCompatEditText editText, IEntry entry)
+		{
+			editText.UpdateTextAlignment(entry.HorizontalTextAlignment, entry.VerticalTextAlignment);
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Maui
 			textField.TextAlignment = textAlignment.HorizontalTextAlignment.ToNative(true);
 		}
 
+		public static void UpdateVerticalTextAlignment(this UITextField textField, IEntry entry)
+		{
+			textField.VerticalAlignment = entry.VerticalTextAlignment.ToNative();
+		}
+
 		public static void UpdateIsTextPredictionEnabled(this UITextField textField, IEntry entry)
 		{
 			if (entry.IsTextPredictionEnabled)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Views.InputMethods;
 using AndroidX.AppCompat.Widget;
@@ -84,11 +83,37 @@ namespace Microsoft.Maui.DeviceTests
 				return new
 				{
 					ViewValue = entry.HorizontalTextAlignment,
-					NativeViewValue = GetNativeTextAlignment(handler)
+					NativeViewValue = GetNativeHorizontalTextAlignment(handler)
 				};
 			});
 
 			Assert.Equal(xplatHorizontalTextAlignment, values.ViewValue);
+			values.NativeViewValue.AssertHasFlag(expectedValue);
+		}
+
+		[Fact(DisplayName = "Vertical TextAlignment Initializes Correctly")]
+		public async Task VerticalTextAlignmentInitializesCorrectly()
+		{
+			var xplatVerticalTextAlignment = TextAlignment.End;
+
+			var entry = new EntryStub()
+			{
+				Text = "Test",
+				VerticalTextAlignment = xplatVerticalTextAlignment
+			};
+
+			Android.Views.GravityFlags expectedValue = Android.Views.GravityFlags.Bottom;
+
+			var values = await GetValueAsync(entry, (handler) =>
+			{
+				return new
+				{
+					ViewValue = entry.VerticalTextAlignment,
+					NativeViewValue = GetGravityFlags(handler)
+				};
+			});
+
+			Assert.Equal(xplatVerticalTextAlignment, values.ViewValue);
 			values.NativeViewValue.AssertHasFlag(expectedValue);
 		}
 
@@ -139,8 +164,11 @@ namespace Microsoft.Maui.DeviceTests
 		bool GetNativeIsItalic(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).Typeface.IsItalic;
 
-		Android.Views.TextAlignment GetNativeTextAlignment(EntryHandler entryHandler) =>
+		Android.Views.TextAlignment GetNativeHorizontalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;
+
+		Android.Views.GravityFlags GetGravityFlags(EntryHandler entryHandler) =>
+			GetNativeEntry(entryHandler).Gravity;
 
 		ImeAction GetNativeReturnType(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ImeOptions;

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -52,11 +52,37 @@ namespace Microsoft.Maui.DeviceTests
 				return new
 				{
 					ViewValue = entry.HorizontalTextAlignment,
-					NativeViewValue = GetNativeTextAlignment(handler)
+					NativeViewValue = GetNativeHorizontalTextAlignment(handler)
 				};
 			});
 
 			Assert.Equal(xplatHorizontalTextAlignment, values.ViewValue);
+			values.NativeViewValue.AssertHasFlag(expectedValue);
+		}
+
+		[Fact(DisplayName = "Vertical TextAlignment Initializes Correctly")]
+		public async Task VerticalTextAlignmentInitializesCorrectly()
+		{
+			var xplatVerticalTextAlignment = TextAlignment.End;
+
+			var entry = new EntryStub()
+			{
+				Text = "Test",
+				VerticalTextAlignment = xplatVerticalTextAlignment
+			};
+
+			UIControlContentVerticalAlignment expectedValue = UIControlContentVerticalAlignment.Bottom;
+
+			var values = await GetValueAsync(entry, (handler) =>
+			{
+				return new
+				{
+					ViewValue = entry.VerticalTextAlignment,
+					NativeViewValue = GetNativeVerticalTextAlignment(handler)
+				};
+			});
+
+			Assert.Equal(xplatVerticalTextAlignment, values.ViewValue);
 			values.NativeViewValue.AssertHasFlag(expectedValue);
 		}
 
@@ -152,8 +178,11 @@ namespace Microsoft.Maui.DeviceTests
 		bool GetNativeClearButtonVisibility(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ClearButtonMode == UITextFieldViewMode.WhileEditing;
 
-		UITextAlignment GetNativeTextAlignment(EntryHandler entryHandler) =>
+		UITextAlignment GetNativeHorizontalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;
+
+		UIControlContentVerticalAlignment GetNativeVerticalTextAlignment(EntryHandler entryHandler) =>
+			GetNativeEntry(entryHandler).VerticalAlignment;
 
 		UIReturnKeyType GetNativeReturnType(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ReturnKeyType;

--- a/src/Core/tests/DeviceTests/Stubs/EntryStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/EntryStub.cs
@@ -30,7 +30,10 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public TextAlignment HorizontalTextAlignment { get; set; }
 
+		public TextAlignment VerticalTextAlignment { get; set; }
+
 		public ReturnType ReturnType { get; set; }
+
 		public ClearButtonVisibility ClearButtonVisibility { get; set; }
 
 		public event EventHandler<StubPropertyChangedEventArgs<string>> TextChanged;

--- a/src/Core/tests/DeviceTests/Stubs/LabelStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LabelStub.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public TextAlignment HorizontalTextAlignment { get; set; }
 
+		public TextAlignment VerticalTextAlignment { get; set; }
+
 		public LineBreakMode LineBreakMode { get; set; } = LineBreakMode.WordWrap;
 
 		public TextDecorations TextDecorations { get; set; }

--- a/src/Core/tests/DeviceTests/Stubs/SearchBarStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/SearchBarStub.cs
@@ -15,5 +15,7 @@
 		public Font Font { get; set; }
 
 		public TextAlignment HorizontalTextAlignment { get; set; }
+
+		public TextAlignment VerticalTextAlignment { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `VerticalTextAlignment` property in EntryHandlers.

### Platforms Affected ### 

- Core
- iOS
- Android

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests