### PR TITLE
iOS Max Length now works with a -1 value

### DIFF
--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -154,6 +154,9 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null || TypedNativeView == null)
 				return false;
 
+			if (VirtualView.MaxLength < 0)
+				return true;
+
 			var addLength = replacementString?.Length ?? 0;
 			var remLength = range.Length;
 


### PR DESCRIPTION
For Max Length, a value of -1 should mean unlimited. This fixes it for iOS.
