### PR TITLE
Clean up duplicate code around IText

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
-  "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "3.0.23",
-    "Microsoft.Build.NoTargets": "2.0.1"
-  }
+    "msbuild-sdks":  {
+                         "MSBuild.Sdk.Extras":  "3.0.23",
+                         "Microsoft.Build.NoTargets":  "2.0.1"
+                     },
+    "sdk":  {
+                "version":  "6.0.100-preview.3.21202.5"
+            }
 }

--- a/global.json
+++ b/global.json
@@ -1,9 +1,6 @@
 {
-    "msbuild-sdks":  {
-                         "MSBuild.Sdk.Extras":  "3.0.23",
-                         "Microsoft.Build.NoTargets":  "2.0.1"
-                     },
-    "sdk":  {
-                "version":  "6.0.100-preview.3.21202.5"
-            }
+    "msbuild-sdks": {
+        "MSBuild.Sdk.Extras": "3.0.23",
+        "Microsoft.Build.NoTargets": "2.0.1"
+    }
 }

--- a/src/Controls/src/Core/HandlerImpl/DatePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/DatePicker.Impl.cs
@@ -4,6 +4,8 @@
 	{
 		Font? _font;
 
-		Font IDatePicker.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font IText.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+
+		string IText.Text => this.Date.ToFormattedString(this.Format);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
@@ -4,6 +4,8 @@
 	{
 		Font? _font;
 
-		Font ITimePicker.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font IText.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+
+		string IText.Text => this.Time.ToFormattedString(this.Format);
 	}
 }

--- a/src/Core/src/Core/IDatePicker.cs
+++ b/src/Core/src/Core/IDatePicker.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Represents a View that allows the user to select a date.
 	/// </summary>
-	public interface IDatePicker : IView
+	public interface IDatePicker : IView, IText
 	{
 		/// <summary>
 		/// Gets the format of the date to display to the user. 
@@ -26,15 +26,5 @@ namespace Microsoft.Maui
 		/// Gets the maximum DateTime selectable.
 		/// </summary>
 		DateTime MaximumDate { get; }
-
-		/// <summary>
-		/// Gets the spacing between characters of the text.
-		/// </summary>
-		double CharacterSpacing { get; }
-
-		/// <summary>
-		/// Gets the font family, style and size of the font.
-		/// </summary>
-		Font Font { get; }
 	}
 }

--- a/src/Core/src/Core/ITimePicker.cs
+++ b/src/Core/src/Core/ITimePicker.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Represents a View that allows the user to select a time.
 	/// </summary>
-	public interface ITimePicker : IView
+	public interface ITimePicker : IView, IText
 	{
 		/// <summary>
 		/// The format of the time to display to the user.
@@ -16,15 +16,5 @@ namespace Microsoft.Maui
 		/// Gets the displayed time.
 		/// </summary>
 		TimeSpan Time { get; set; }
-
-		/// <summary>
-		/// Gets the spacing between characters of the text.
-		/// </summary>
-		double CharacterSpacing { get; }
-
-		/// <summary>
-		/// Gets the font family, style and size of the font.
-		/// </summary>
-		Font Font { get; }
 	}
 }

--- a/src/Core/src/Platform/Android/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ButtonExtensions.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Maui
 		public static void UpdateTextColor(this AppCompatButton appCompatButton, IButton button, XColor defaultColor) =>
 			appCompatButton.SetTextColor(button.TextColor.Cleanse(defaultColor).ToNative());
 
-		public static void UpdateCharacterSpacing(this AppCompatButton appCompatButton, IButton button) =>
-			appCompatButton.LetterSpacing = button.CharacterSpacing.ToEm();
 
 		public static void UpdateFont(this AppCompatButton appCompatButton, IButton button, IFontManager fontManager)
 		{

--- a/src/Core/src/Platform/Android/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/DatePickerExtensions.cs
@@ -42,25 +42,9 @@ namespace Microsoft.Maui
 			}
 		}
 
-		public static void UpdateCharacterSpacing(this MauiDatePicker nativeDatePicker, IDatePicker datePicker)
-		{
-			nativeDatePicker.LetterSpacing = datePicker.CharacterSpacing.ToEm();
-		}
-
-		public static void UpdateFont(this MauiDatePicker nativeDatePicker, IDatePicker datePicker, IFontManager fontManager)
-		{
-			var font = datePicker.Font;
-
-			var tf = fontManager.GetTypeface(font);
-			nativeDatePicker.Typeface = tf;
-
-			var sp = fontManager.GetScaledPixel(font);
-			nativeDatePicker.SetTextSize(ComplexUnitType.Sp, sp);
-		}
-
 		internal static void SetText(this MauiDatePicker nativeDatePicker, IDatePicker datePicker)
 		{
-			nativeDatePicker.Text = datePicker.Date.ToString(datePicker.Format);
+			nativeDatePicker.Text = datePicker.ToFormattedString();
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -33,23 +33,14 @@ namespace Microsoft.Maui
 			}
 		}
 
-		public static void UpdateCharacterSpacing(this TextView textView, IEntry entry) =>
-			UpdateCharacterSpacing(textView, entry.CharacterSpacing);
-
-		public static void UpdateCharacterSpacing(this TextView textView, IEditor editor) =>
-			UpdateCharacterSpacing(textView, editor.CharacterSpacing);
-
-		public static void UpdateCharacterSpacing(this TextView textView, ILabel label) =>
-			UpdateCharacterSpacing(textView, label.CharacterSpacing);
-
-		public static void UpdateCharacterSpacing(this TextView textView, ISearchBar searchBar) =>
-			UpdateCharacterSpacing(textView, searchBar.CharacterSpacing);
+		public static void UpdateCharacterSpacing(this TextView nativeDatePicker, IText text) =>
+			UpdateCharacterSpacing(nativeDatePicker, text.CharacterSpacing);
 
 		public static void UpdateCharacterSpacing(this TextView textView, double characterSpacing) =>
 			textView.LetterSpacing = characterSpacing.ToEm();
 
-		public static void UpdateFont(this TextView textView, ILabel label, IFontManager fontManager) =>
-			UpdateFont(textView, label.Font, fontManager);
+		public static void UpdateFont(this TextView textView, IText text, IFontManager fontManager) =>
+			UpdateFont(textView, text.Font, fontManager);
 
 		public static void UpdateFont(this TextView textView, Font font, IFontManager fontManager)
 		{

--- a/src/Core/src/Platform/Android/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/TimePickerExtensions.cs
@@ -12,14 +12,6 @@
 			mauiTimePicker.SetTime(timePicker);
 		}
 
-		public static void UpdateCharacterSpacing(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
-		{
-			mauiTimePicker.LetterSpacing = timePicker.CharacterSpacing.ToEm();
-		}
-
-		public static void UpdateFont(this MauiTimePicker mauiTimePicker, ITimePicker timePicker, IFontManager fontManager) =>
-			mauiTimePicker.UpdateFont(timePicker.Font, fontManager);
-
 		internal static void SetTime(this MauiTimePicker mauiTimePicker, ITimePicker timePicker)
 		{
 			var time = timePicker.Time;

--- a/src/Core/src/Platform/DateExtensions.cs
+++ b/src/Core/src/Platform/DateExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.Maui
+{
+	public static partial class DateExtensions
+	{
+		public static string ToFormattedString(this IDatePicker datePicker)
+		{
+			var date = datePicker.Date;
+			var format = datePicker.Format;
+
+			return date.ToFormattedString(format);
+		}
+
+		public static string ToFormattedString(this DateTime dateTime, string format, CultureInfo? cultureInfo = null)
+		{
+			cultureInfo ??= CultureInfo.CurrentCulture;
+
+			if (string.IsNullOrEmpty(format))
+			{
+				format = cultureInfo.DateTimeFormat.ShortTimePattern;
+			}
+
+			return dateTime.ToString(format);
+		}
+	}
+}

--- a/src/Core/src/Platform/MaciOS/DateExtensions.cs
+++ b/src/Core/src/Platform/MaciOS/DateExtensions.cs
@@ -3,7 +3,7 @@ using Foundation;
 
 namespace Microsoft.Maui
 {
-	public static class DateExtensions
+	public static partial class DateExtensions
 	{
 		internal static DateTime ReferenceDate = new DateTime(2001, 1, 1, 0, 0, 0);
 


### PR DESCRIPTION
### Description of Change ###

- Add IText to IDatePicker and ITimePicker
- Remove all of the characterspacing extensions that can just be taken care of by IText
- Remove all of the Font extensions that can just be taken care of by IText


### Additions made ###
* Added IText to IDatePicker
* Added IText to ITimePicker

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arragement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR then the PR will need to provide testing to demonstrate that accessibility still works. 
