### PR TITLE
Fixed a crash in the Entry

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -100,6 +100,9 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null || NativeView == null)
 				return false;
 
+			if(VirtualView.MaxLength < 0)
+				return true;
+
 			var addLength = replacementString?.Length ?? 0;
 			var remLength = range.Length;
 

--- a/src/Core/src/Platform/iOS/TextFieldExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextFieldExtensions.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Maui
 
 		public static void UpdateMaxLength(this UITextField textField, IEntry entry)
 		{
+			if (entry.MaxLength < 0)
+				return;
+				
 			var currentControlText = textField.Text;
 
 			if (currentControlText?.Length > entry.MaxLength)

--- a/src/Core/src/Platform/iOS/TextViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextViewExtensions.cs
@@ -26,6 +26,9 @@ namespace Microsoft.Maui
 
 		public static void UpdateMaxLength(this UITextView textView, IEditor editor)
 		{
+			if (editor.MaxLength < 0)
+				return;
+				
 			var currentControlText = textView.Text;
 
 			if (currentControlText?.Length > editor.MaxLength)


### PR DESCRIPTION
When you pass -1 into the Max Length, the iOS extension would try substring. Added a check to return if the value is < 0.