### PR TITLE
Added more tests and fixed a bug

### DIFF
--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -63,6 +63,10 @@ namespace Microsoft.Maui.Handlers
 		public static void MapLineHeight(LabelHandler handler, ILabel label)
 		{
 			handler.NativeView?.UpdateLineHeight(label);
+
+			// Setting line height may have removed text alignment settings,
+			// so we need to make sure those are applied, again
+			handler.NativeView?.UpdateHorizontalTextAlignment(label);
 		}
 
 		public static void MapFormatting(LabelHandler handler, ILabel label)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.DeviceTests
 				return new
 				{
 					ViewValue = entry.HorizontalTextAlignment,
-					NativeViewValue = GetNativeTextAlignment(handler)
+					NativeViewValue = GetNativeHorizontalTextAlignment(handler)
 				};
 			});
 
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.DeviceTests
 		bool GetNativeIsItalic(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).Typeface.IsItalic;
 
-		Android.Views.TextAlignment GetNativeTextAlignment(EntryHandler entryHandler) =>
+		Android.Views.TextAlignment GetNativeHorizontalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;
 
 		ImeAction GetNativeReturnType(EntryHandler entryHandler) =>

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -320,5 +320,117 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedText, nativeText);
 			Assert.Equal(expectedText, entry.Text);
 		}
+
+		[Theory(DisplayName = "Updating Font Does Not Affect CharacterSpacing")]
+		[InlineData(10, 20)]
+		[InlineData(20, 10)]
+		public async Task FontDoesNotAffectCharacterSpacing(double initialSize, double newSize)
+		{
+			var entry = new EntryStub
+			{
+				Text = "This is TEXT!",
+				CharacterSpacing = 5,
+				Font = Font.SystemFontOfSize(initialSize)
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				entry,
+				GetNativeCharacterSpacing,
+				nameof(IEntry.Font),
+				() => entry.Font = Font.SystemFontOfSize(newSize));
+		}
+
+		[Theory(DisplayName = "Updating Text Does Not Affect CharacterSpacing")]
+		[InlineData("Short", "Longer Text")]
+		[InlineData("Long thext here", "Short")]
+		public async Task TextDoesNotAffectCharacterSpacing(string initialText, string newText)
+		{
+			var entry = new EntryStub
+			{
+				Text = initialText,
+				CharacterSpacing = 5,
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				entry,
+				GetNativeCharacterSpacing,
+				nameof(IEntry.Text),
+				() => entry.Text = newText);
+		}
+
+		[Theory(DisplayName = "Updating Font Does Not Affect HorizontalTextAlignment")]
+		[InlineData(10, 20)]
+		[InlineData(20, 10)]
+		public async Task FontDoesNotAffectHorizontalTextAlignment(double initialSize, double newSize)
+		{
+			var entry = new EntryStub
+			{
+				Text = "This is TEXT!",
+				HorizontalTextAlignment = TextAlignment.Center,
+				Font = Font.SystemFontOfSize(initialSize),
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				entry,
+				GetNativeHorizontalTextAlignment,
+				nameof(IEntry.Font),
+				() => entry.Font = Font.SystemFontOfSize(newSize));
+		}
+
+		[Theory(DisplayName = "Updating Text Does Not Affect HorizontalTextAlignment")]
+		[InlineData("Short", "Longer Text")]
+		[InlineData("Long thext here", "Short")]
+		public async Task TextDoesNotAffectHorizontalTextAlignment(string initialText, string newText)
+		{
+			var entry = new EntryStub
+			{
+				Text = initialText,
+				HorizontalTextAlignment = TextAlignment.Center,
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				entry,
+				GetNativeHorizontalTextAlignment,
+				nameof(IEntry.Text),
+				() => entry.Text = newText);
+		}
+
+		[Theory(DisplayName = "Updating MaxLength Does Not Affect HorizontalTextAlignment")]
+		[InlineData(5, 20)]
+		[InlineData(20, 5)]
+		public async Task MaxLengthDoesNotAffectHorizontalTextAlignment(int initialSize, int newSize)
+		{
+			var entry = new EntryStub
+			{
+				Text = "This is TEXT!",
+				HorizontalTextAlignment = TextAlignment.Center,
+				MaxLength = initialSize,
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				entry,
+				GetNativeHorizontalTextAlignment,
+				nameof(IEntry.MaxLength),
+				() => entry.MaxLength = newSize);
+		}
+
+		[Theory(DisplayName = "Updating CharacterSpacing Does Not Affect HorizontalTextAlignment")]
+		[InlineData(1, 5)]
+		[InlineData(5, 1)]
+		public async Task CharacterSpacingDoesNotAffectHorizontalTextAlignment(int initialSize, int newSize)
+		{
+			var entry = new EntryStub
+			{
+				Text = "This is TEXT!",
+				HorizontalTextAlignment = TextAlignment.Center,
+				CharacterSpacing = initialSize,
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				entry,
+				GetNativeHorizontalTextAlignment,
+				nameof(IEntry.CharacterSpacing),
+				() => entry.CharacterSpacing = newSize);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.DeviceTests
 				return new
 				{
 					ViewValue = entry.HorizontalTextAlignment,
-					NativeViewValue = GetNativeTextAlignment(handler)
+					NativeViewValue = GetNativeHorizontalTextAlignment(handler)
 				};
 			});
 
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.DeviceTests
 		bool GetNativeClearButtonVisibility(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ClearButtonMode == UITextFieldViewMode.WhileEditing;
 
-		UITextAlignment GetNativeTextAlignment(EntryHandler entryHandler) =>
+		UITextAlignment GetNativeHorizontalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;
 
 		UIReturnKeyType GetNativeReturnType(EntryHandler entryHandler) =>

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.DeviceTests
 				return new
 				{
 					ViewValue = labelStub.HorizontalTextAlignment,
-					NativeViewValue = GetNativeTextAlignment(handler)
+					NativeViewValue = GetNativeHorizontalTextAlignment(handler)
 				};
 			});
 
@@ -70,21 +70,6 @@ namespace Microsoft.Maui.DeviceTests
 			var expectedValue = ATextAlignemnt.ViewEnd;
 
 			Assert.Equal(expectedValue, textAlignment);
-		}
-
-		[Fact(DisplayName = "Negative MaxLines value with wrap is correct")]
-		public async Task NegativeMaxValueWithWrapIsCorrect()
-		{
-			var label = new LabelStub()
-			{
-				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-				MaxLines = -1,
-				LineBreakMode = LineBreakMode.WordWrap
-			};
-
-			var nativeValue = await GetValueAsync(label, GetNativeMaxLines);
-
-			Assert.Equal(int.MaxValue, nativeValue);
 		}
 
 		[Fact(DisplayName = "Padding Initializes Correctly")]
@@ -112,7 +97,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedBottom, bottom);
 		}
 
-		[Fact(DisplayName = "[LabelHandler] TextDecorations Initializes Correctly")]
+		[Fact(DisplayName = "TextDecorations Initializes Correctly")]
 		public async Task TextDecorationsInitializesCorrectly()
 		{
 			var xplatTextDecorations = TextDecorations.Underline;
@@ -137,31 +122,6 @@ namespace Microsoft.Maui.DeviceTests
 			values.NativeViewValue.AssertHasFlag(expectedValue);
 		}
 
-		[Fact(DisplayName = "LineHeight Initializes Correctly")]
-		public async Task LineHeightInitializesCorrectly()
-		{
-			var xplatLineHeight = 1.5d;
-
-			var labelHandler = new LabelStub()
-			{
-				LineHeight = xplatLineHeight
-			};
-
-			var values = await GetValueAsync(labelHandler, (handler) =>
-			{
-				return new
-				{
-					ViewValue = labelHandler.LineHeight,
-					NativeViewValue = GetNativeLineHeight(handler)
-				};
-			});
-
-			float expectedValue = 1.5f;
-
-			Assert.Equal(xplatLineHeight, values.ViewValue);
-			Assert.Equal(expectedValue, values.NativeViewValue);
-		}
-
 		TextView GetNativeLabel(LabelHandler labelHandler) =>
 			(TextView)labelHandler.NativeView;
 
@@ -183,7 +143,7 @@ namespace Microsoft.Maui.DeviceTests
 		bool GetNativeIsItalic(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).Typeface.IsItalic;
 
-		(GravityFlags gravity, ATextAlignemnt alignment) GetNativeTextAlignment(LabelHandler labelHandler)
+		(GravityFlags gravity, ATextAlignemnt alignment) GetNativeHorizontalTextAlignment(LabelHandler labelHandler)
 		{
 			var textView = GetNativeLabel(labelHandler);
 			return (textView.Gravity, textView.TextAlignment);

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
@@ -111,21 +111,23 @@ namespace Microsoft.Maui.DeviceTests
 				unsetValue);
 		}
 
-		[Fact(DisplayName = "Updating Font Does Not Affect CharacterSpacing")]
-		public async Task FontDoesNotAffectCharacterSpacing()
+		[Theory(DisplayName = "Updating Font Does Not Affect CharacterSpacing")]
+		[InlineData(10, 20)]
+		[InlineData(20, 10)]
+		public async Task FontDoesNotAffectCharacterSpacing(double initialSize, double newSize)
 		{
 			var label = new LabelStub
 			{
 				Text = "This is TEXT!",
 				CharacterSpacing = 5,
-				Font = Font.SystemFontOfSize(20)
+				Font = Font.SystemFontOfSize(initialSize)
 			};
 
 			await ValidateUnrelatedPropertyUnaffected(
 				label,
 				GetNativeCharacterSpacing,
 				nameof(ILabel.Font),
-				() => label.Font = Font.SystemFontOfSize(15));
+				() => label.Font = Font.SystemFontOfSize(newSize));
 		}
 
 		[Theory(DisplayName = "Updating Text Does Not Affect CharacterSpacing")]
@@ -144,6 +146,82 @@ namespace Microsoft.Maui.DeviceTests
 				GetNativeCharacterSpacing,
 				nameof(ILabel.Text),
 				() => label.Text = newText);
+		}
+
+		[Theory(DisplayName = "Updating Font Does Not Affect HorizontalTextAlignment")]
+		[InlineData(10, 20)]
+		[InlineData(20, 10)]
+		public async Task FontDoesNotAffectHorizontalTextAlignment(double initialSize, double newSize)
+		{
+			var label = new LabelStub
+			{
+				Text = "This is TEXT!",
+				HorizontalTextAlignment = TextAlignment.Center,
+				Font = Font.SystemFontOfSize(initialSize),
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				label,
+				GetNativeHorizontalTextAlignment,
+				nameof(ILabel.Font),
+				() => label.Font = Font.SystemFontOfSize(newSize));
+		}
+
+		[Theory(DisplayName = "Updating Text Does Not Affect HorizontalTextAlignment")]
+		[InlineData("Short", "Longer Text")]
+		[InlineData("Long thext here", "Short")]
+		public async Task TextDoesNotAffectHorizontalTextAlignment(string initialText, string newText)
+		{
+			var label = new LabelStub
+			{
+				Text = initialText,
+				HorizontalTextAlignment = TextAlignment.Center,
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				label,
+				GetNativeHorizontalTextAlignment,
+				nameof(ILabel.Text),
+				() => label.Text = newText);
+		}
+
+		[Theory(DisplayName = "Updating LineHeight Does Not Affect HorizontalTextAlignment")]
+		[InlineData(1, 2)]
+		[InlineData(2, 1)]
+		public async Task LineHeightDoesNotAffectHorizontalTextAlignment(double initialSize, double newSize)
+		{
+			var label = new LabelStub
+			{
+				Text = "This is TEXT!",
+				HorizontalTextAlignment = TextAlignment.Center,
+				LineHeight = initialSize,
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				label,
+				GetNativeHorizontalTextAlignment,
+				nameof(ILabel.LineHeight),
+				() => label.LineHeight = newSize);
+		}
+
+		[Theory(DisplayName = "Updating TextDecorations Does Not Affect HorizontalTextAlignment")]
+		[InlineData(TextDecorations.None, TextDecorations.Underline)]
+		[InlineData(TextDecorations.Underline, TextDecorations.Strikethrough)]
+		[InlineData(TextDecorations.Underline, TextDecorations.None)]
+		public async Task TextDecorationsDoesNotAffectHorizontalTextAlignment(TextDecorations initialDecorations, TextDecorations newDecorations)
+		{
+			var label = new LabelStub
+			{
+				Text = "This is TEXT!",
+				HorizontalTextAlignment = TextAlignment.Center,
+				TextDecorations = initialDecorations,
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				label,
+				GetNativeHorizontalTextAlignment,
+				nameof(ILabel.TextDecorations),
+				() => label.TextDecorations = newDecorations);
 		}
 
 		[Fact(DisplayName = "LineBreakMode Initializes Correctly")]
@@ -267,6 +345,113 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await ValidatePropertyInitValue(label, () => label.MaxLines, GetNativeMaxLines, label.MaxLines);
+		}
+
+		[Fact]
+		[Category(TestCategory.TextFormatting)]
+		public async Task LineHeightAppliedWhenTextAdded()
+		{
+			double xplatLineHeight = 2;
+			var expectedLineHeight = xplatLineHeight;
+
+			var label = new LabelStub() { LineHeight = xplatLineHeight }; // No text set
+
+			var handler = await CreateHandlerAsync(label);
+
+			label.Text = "Now we have text";
+			await InvokeOnMainThreadAsync(() => handler.UpdateValue(nameof(label.Text)));
+
+			var actualLineHeight = await InvokeOnMainThreadAsync(() => GetNativeLineHeight(handler));
+
+			Assert.Equal(expectedLineHeight, actualLineHeight);
+		}
+
+		[Fact]
+		[Category(TestCategory.TextFormatting)]
+		public async Task CharacterSpacingAppliedWhenTextAdded()
+		{
+			double xplatCharacterSpacing = 1.5;
+			var expectedCharacterSpacing = xplatCharacterSpacing;
+
+			var label = new LabelStub() { CharacterSpacing = xplatCharacterSpacing }; // No text set
+
+			var handler = await CreateHandlerAsync(label);
+
+			label.Text = "Now we have text";
+			await InvokeOnMainThreadAsync(() => handler.UpdateValue(nameof(label.Text)));
+
+			var actualCharacterSpacing = await InvokeOnMainThreadAsync(() => GetNativeCharacterSpacing(handler));
+
+			Assert.Equal(expectedCharacterSpacing, actualCharacterSpacing);
+		}
+
+		[Fact]
+		[Category(TestCategory.TextFormatting)]
+		public async Task LineHeightSurvivesCharacterSpacing()
+		{
+			double xplatCharacterSpacing = 1.5;
+			var expectedCharacterSpacing = xplatCharacterSpacing;
+			double xplatLineHeight = 2;
+			var expectedLineHeight = xplatLineHeight;
+
+			var label = new LabelStub() { Text = "test", LineHeight = xplatLineHeight };
+
+			var handler = await CreateHandlerAsync(label);
+
+			label.CharacterSpacing = xplatCharacterSpacing;
+			await InvokeOnMainThreadAsync(() => handler.UpdateValue(nameof(label.CharacterSpacing)));
+
+			var actualLineHeight = await InvokeOnMainThreadAsync(() => GetNativeLineHeight(handler));
+			var actualCharacterSpacing = await InvokeOnMainThreadAsync(() => GetNativeCharacterSpacing(handler));
+
+			Assert.Equal(expectedLineHeight, actualLineHeight);
+			Assert.Equal(expectedCharacterSpacing, actualCharacterSpacing);
+		}
+
+		[Theory(DisplayName = "Negative MaxLines value with wrap is correct")]
+#if __IOS__
+		[InlineData(0)]
+#elif __ANDROID__
+		[InlineData(int.MaxValue)]
+#endif
+		public async Task NegativeMaxValueWithWrapIsCorrect(int expectedLines)
+		{
+			var label = new LabelStub()
+			{
+				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+				MaxLines = -1,
+				LineBreakMode = LineBreakMode.WordWrap
+			};
+
+			var nativeValue = await GetValueAsync(label, GetNativeMaxLines);
+
+			Assert.Equal(expectedLines, nativeValue);
+		}
+
+		[Fact(DisplayName = "LineHeight Initializes Correctly")]
+		public async Task LineHeightInitializesCorrectly()
+		{
+			var xplatLineHeight = 1.5d;
+
+			var labelHandler = new LabelStub()
+			{
+				Text = "test",
+				LineHeight = xplatLineHeight
+			};
+
+			var values = await GetValueAsync(labelHandler, (handler) =>
+			{
+				return new
+				{
+					ViewValue = labelHandler.LineHeight,
+					NativeViewValue = GetNativeLineHeight(handler)
+				};
+			});
+
+			float expectedValue = 1.5f;
+
+			Assert.Equal(xplatLineHeight, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
@@ -55,27 +55,12 @@ namespace Microsoft.Maui.DeviceTests
 				return new
 				{
 					ViewValue = labelStub.HorizontalTextAlignment,
-					NativeViewValue = GetNativeTextAlignment(handler)
+					NativeViewValue = GetNativeHorizontalTextAlignment(handler)
 				};
 			});
 
 			Assert.Equal(xplatHorizontalTextAlignment, values.ViewValue);
 			values.NativeViewValue.AssertHasFlag(expectedValue);
-		}
-
-		[Fact(DisplayName = "Negative MaxLines value with wrap is correct")]
-		public async Task NegativeMaxValueWithWrapIsCorrect()
-		{
-			var label = new LabelStub()
-			{
-				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-				MaxLines = -1,
-				LineBreakMode = LineBreakMode.WordWrap,
-			};
-
-			var nativeValue = await GetValueAsync(label, GetNativeMaxLines);
-
-			Assert.Equal(0, nativeValue);
 		}
 
 		[Fact(DisplayName = "Padding Initializes Correctly")]
@@ -120,31 +105,6 @@ namespace Microsoft.Maui.DeviceTests
 			values.AttributedText.AssertHasUnderline();
 		}
 
-		[Fact(DisplayName = "LineHeight Initializes Correctly")]
-		public async Task LineHeightInitializesCorrectly()
-		{
-			var xplatLineHeight = 1.5d;
-
-			var labelHandler = new LabelStub()
-			{
-				Text = "test",
-				LineHeight = xplatLineHeight
-			};
-
-			var values = await GetValueAsync(labelHandler, (handler) =>
-			{
-				return new
-				{
-					ViewValue = labelHandler.LineHeight,
-					NativeViewValue = GetNativeLineHeight(handler)
-				};
-			});
-
-			nfloat expectedValue = new nfloat(1.5f);
-			Assert.Equal(xplatLineHeight, values.ViewValue);
-			Assert.Equal(expectedValue, values.NativeViewValue);
-		}
-
 		[Fact]
 		[Category(TestCategory.TextFormatting)]
 		public async Task CanSetAlignmentAndLineHeight()
@@ -166,49 +126,11 @@ namespace Microsoft.Maui.DeviceTests
 			var expectedLineHeight = xplatLineHeight;
 
 			var handler = await CreateHandlerAsync(label);
-			var actualAlignment = await InvokeOnMainThreadAsync(() => GetNativeTextAlignment(handler));
+			var actualAlignment = await InvokeOnMainThreadAsync(() => GetNativeHorizontalTextAlignment(handler));
 			var actualLineHeight = await InvokeOnMainThreadAsync(() => GetNativeLineHeight(handler));
 
 			Assert.Equal(expectedLineHeight, actualLineHeight);
 			Assert.Equal(expectedAlignment, actualAlignment);
-		}
-
-		[Fact]
-		[Category(TestCategory.TextFormatting)]
-		public async Task LineHeightAppliedWhenTextAdded()
-		{
-			double xplatLineHeight = 2;
-			var expectedLineHeight = xplatLineHeight;
-
-			var label = new LabelStub() { LineHeight = xplatLineHeight }; // No text set
-
-			var handler = await CreateHandlerAsync(label);
-
-			label.Text = "Now we have text";
-			await InvokeOnMainThreadAsync(() => handler.UpdateValue(nameof(label.Text)));
-
-			var actualLineHeight = await InvokeOnMainThreadAsync(() => GetNativeLineHeight(handler));
-
-			Assert.Equal(expectedLineHeight, actualLineHeight);
-		}
-
-		[Fact]
-		[Category(TestCategory.TextFormatting)]
-		public async Task CharacterSpacingAppliedWhenTextAdded()
-		{
-			double xplatCharacterSpacing = 1.5;
-			var expectedCharacterSpacing = xplatCharacterSpacing;
-
-			var label = new LabelStub() { CharacterSpacing = xplatCharacterSpacing }; // No text set
-
-			var handler = await CreateHandlerAsync(label);
-
-			label.Text = "Now we have text";
-			await InvokeOnMainThreadAsync(() => handler.UpdateValue(nameof(label.Text)));
-
-			var actualCharacterSpacing = await InvokeOnMainThreadAsync(() => GetNativeCharacterSpacing(handler));
-
-			Assert.Equal(expectedCharacterSpacing, actualCharacterSpacing);
 		}
 
 		[Fact]
@@ -251,29 +173,6 @@ namespace Microsoft.Maui.DeviceTests
 			attributedText.AssertHasUnderline();
 		}
 
-		[Fact]
-		[Category(TestCategory.TextFormatting)]
-		public async Task LineHeightSurvivesCharacterSpacing()
-		{
-			double xplatCharacterSpacing = 1.5;
-			var expectedCharacterSpacing = xplatCharacterSpacing;
-			double xplatLineHeight = 2;
-			var expectedLineHeight = xplatLineHeight;
-
-			var label = new LabelStub() { Text = "test", LineHeight = xplatLineHeight };
-
-			var handler = await CreateHandlerAsync(label);
-
-			label.CharacterSpacing = xplatCharacterSpacing;
-			await InvokeOnMainThreadAsync(() => handler.UpdateValue(nameof(label.CharacterSpacing)));
-
-			var actualLineHeight = await InvokeOnMainThreadAsync(() => GetNativeLineHeight(handler));
-			var actualCharacterSpacing = await InvokeOnMainThreadAsync(() => GetNativeCharacterSpacing(handler));
-
-			Assert.Equal(expectedLineHeight, actualLineHeight);
-			Assert.Equal(expectedCharacterSpacing, actualCharacterSpacing);
-		}
-
 		UILabel GetNativeLabel(LabelHandler labelHandler) =>
 			(UILabel)labelHandler.NativeView;
 
@@ -311,7 +210,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		UITextAlignment GetNativeTextAlignment(LabelHandler labelHandler) =>
+		UITextAlignment GetNativeHorizontalTextAlignment(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).TextAlignment;
 
 		Task ValidateNativeBackgroundColor(ILabel label, Color color)
@@ -325,7 +224,7 @@ namespace Microsoft.Maui.DeviceTests
 		UILineBreakMode GetNativeLineBreakMode(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).LineBreakMode;
 
-		nfloat GetNativeLineHeight(LabelHandler labelHandler)
+		double GetNativeLineHeight(LabelHandler labelHandler)
 		{
 			var attrText = GetNativeLabel(labelHandler).AttributedText;
 


### PR DESCRIPTION
### Description of Change ###

This PR adds a bunch of tests to make sure setting font styles does not break "related" properties. For example on iOS, setting `Text` resets all formatting. And it also resets the TextAlignment when setting LineHeight.

Android, on the other hand, is just perfect. No issues every found there.

### Additions made ###

* Adds tests?

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arragement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR then the PR will need to provide testing to demonstrate that accessibility still works. 
