### PR TITLE
Fix WithLineHeight to copy the NSParagraphStyle before applying

### DIFF
--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -63,10 +63,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapLineHeight(LabelHandler handler, ILabel label)
 		{
 			handler.NativeView?.UpdateLineHeight(label);
-
-			// Setting line height may have removed text alignment settings,
-			// so we need to make sure those are applied, again
-			handler.NativeView?.UpdateHorizontalTextAlignment(label);
 		}
 
 		public static void MapFormatting(LabelHandler handler, ILabel label)

--- a/src/Core/src/Platform/iOS/AttributedStringExtensions.cs
+++ b/src/Core/src/Platform/iOS/AttributedStringExtensions.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Maui
 				return null;
 
 			var mutableParagraphStyle = new NSMutableParagraphStyle();
+			if (attribute != null)
+				mutableParagraphStyle.SetParagraphStyle(attribute);
+
 			mutableParagraphStyle.LineHeightMultiple = new nfloat(lineHeight >= 0 ? lineHeight : -1);
 
 			var mutableAttributedString = new NSMutableAttributedString(attributedString);


### PR DESCRIPTION
### Description of Change ###

PR https://github.com/dotnet/maui/pull/684 was actually working around another bug.

The previous implementation always made a new copy of NSParagraphStyle and thus always lot the properties. This PR first makes a copy, then sets the new value and then adds it on the NSAttributedString

### Additions made ###
None.

