### PR TITLE
Set SkipImportNetSdk to false so VS can open the application package project

### DIFF
--- a/.nuspec/Microsoft.Maui.Core.props
+++ b/.nuspec/Microsoft.Maui.Core.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="$(MSBuildProjectFile.EndsWith('.wapproj')) == true ">
-    <ILLinkTasksAssembly>ARBITRARY_VALUE_SO_THAT_NET6_DOESNT_CAUSE_VS_TO_FAIL_OPENING_THIS_PROJECT</ILLinkTasksAssembly>
-  </PropertyGroup>
+    <SkipImportNetSdk>true</SkipImportNetSdk>
+  </PropertyGroup>  
 </Project>

--- a/.nuspec/Microsoft.Maui.Core.props
+++ b/.nuspec/Microsoft.Maui.Core.props
@@ -1,2 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="$(MSBuildProjectFile.EndsWith('.wapproj')) == true ">
+    <ILLinkTasksAssembly>ARBITRARY_VALUE_SO_THAT_NET6_DOESNT_CAUSE_VS_TO_FAIL_OPENING_THIS_PROJECT</ILLinkTasksAssembly>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

Visual Studio 16.10 Preview can't currently open a WinUI3 package project with NET6. This works around that limitation

### Testing

Pull down the nugets and test against the HelloMaui Samples in the develop branch

