### PR TITLE
[GH-413] Picker Horizontal TextAligment

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,8 +2,5 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.23",
     "Microsoft.Build.NoTargets": "2.0.1"
-  },
-  "sdk": {
-    "version": "6.0.100-preview.3.21202.5"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.23",
     "Microsoft.Build.NoTargets": "2.0.1"
+  },
+  "sdk": {
+    "version": "6.0.100-preview.3.21202.5"
   }
 }

--- a/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
@@ -223,6 +223,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 			EditText.Hint = Element.Title;
 		}
 
+		[PortHandler("Partially ported, still missing VerticalTextAligment.")]
 		protected override void UpdateGravity()
 		{
 			EditText.Gravity = Element.HorizontalTextAlignment.ToHorizontalGravityFlags() | Element.VerticalTextAlignment.ToVerticalGravityFlags();

--- a/src/Compatibility/Core/src/iOS/Renderers/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/PickerRenderer.cs
@@ -283,6 +283,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			_picker.Select(Math.Max(formsIndex, 0), 0, true);
 		}
 
+		[PortHandler("Partially ported, still missing FlowDirection part.")]
 		void UpdateHorizontalTextAlignment()
 		{
 			Control.TextAlignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -173,7 +173,7 @@ namespace Maui.Controls.Sample.Pages
 				"Japanese Macaque"
 			};
 
-			var picker = new Picker { Title = "Select a monkey", FontFamily = "Dokdo" };
+			var picker = new Picker { Title = "Select a monkey", FontFamily = "Dokdo",  HorizontalTextAlignment = TextAlignment.Center};
 
 			picker.ItemsSource = monkeyList;
 			verticalStack.Add(picker);

--- a/src/Core/src/Core/IPicker.cs
+++ b/src/Core/src/Core/IPicker.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Represents a View for selecting a text item from a list of data.
 	/// </summary>
-	public interface IPicker : IView, ITextStyle
+	public interface IPicker : IView, ITextStyle, ITextAlignment
 	{
 		/// <summary>
 		/// Gets the title for the Picker.

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -2,7 +2,6 @@
 using System.Collections.Specialized;
 using System.Linq;
 using Android.App;
-using Microsoft.Extensions.DependencyInjection;
 using AResource = Android.Resource;
 
 namespace Microsoft.Maui.Handlers
@@ -55,6 +54,14 @@ namespace Microsoft.Maui.Handlers
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
 			handler.NativeView?.UpdateFont(picker, fontManager);
+		}
+
+
+		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker picker)
+		{
+			var nativePicker = handler.NativeView;
+			var hasRtlSupport = nativePicker?.Context!.HasRtlSupport() ?? false;
+			nativePicker?.UpdateHorizontalAlignment(picker.HorizontalTextAlignment, hasRtlSupport);
 		}
 
 		[MissingMapper]

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateFont(picker, fontManager);
 		}
 
-
 		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker picker)
 		{
 			var nativePicker = handler.NativeView;

--- a/src/Core/src/Handlers/Picker/PickerHandler.Standard.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Standard.cs
@@ -11,5 +11,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapCharacterSpacing(PickerHandler handler, IPicker view) { }
 		public static void MapFont(PickerHandler handler, IPicker view) { }
 		public static void MapTextColor(PickerHandler handler, IPicker view) { }
+		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker view) { }
 	}
 }

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -21,5 +21,8 @@ namespace Microsoft.Maui.Handlers
 
 		[MissingMapper]
 		public static void MapTextColor(PickerHandler handler, IPicker view) { }
+
+		[MissingMapper]
+		public static void MapHorizontalTextAlignment(EntryHandler handler, IEntry entry) { }
 	}
 }

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -9,6 +9,7 @@
 			[nameof(IPicker.SelectedIndex)] = MapSelectedIndex,
 			[nameof(IPicker.TextColor)] = MapTextColor,
 			[nameof(IPicker.Title)] = MapTitle,
+			[nameof(IPicker.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
 		};
 
 		public PickerHandler() : base(PickerMapper)

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -114,6 +114,11 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateFont(picker, fontManager);
 		}
 
+		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker picker)
+		{
+			handler.NativeView?.UpdateHorizontalTextAlignment(picker);
+		}
+
 		[MissingMapper]
 		public static void MapTextColor(PickerHandler handler, IPicker view) { }
 

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
@@ -84,5 +84,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsItalic(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).Typeface.IsItalic;
+
+		Android.Views.TextAlignment GetNativeHorizontalTextAlignment(PickerHandler pickerHandler) =>
+			GetNativePicker(pickerHandler).TextAlignment;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Xunit;
+using ATextAlignment = Android.Views.TextAlignment;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -85,7 +86,7 @@ namespace Microsoft.Maui.DeviceTests
 		bool GetNativeIsItalic(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).Typeface.IsItalic;
 
-		Android.Views.TextAlignment GetNativeHorizontalTextAlignment(PickerHandler pickerHandler) =>
+		ATextAlignment GetNativeHorizontalTextAlignment(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).TextAlignment;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.cs
@@ -61,5 +61,42 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(picker, () => picker.Font.FontAttributes.HasFlag(FontAttributes.Bold), GetNativeIsBold, isBold);
 			await ValidatePropertyInitValue(picker, () => picker.Font.FontAttributes.HasFlag(FontAttributes.Italic), GetNativeIsItalic, isItalic);
 		}
+
+		[Theory(DisplayName = "Updating Font Does Not Affect HorizontalTextAlignment")]
+		[InlineData(10, 20)]
+		[InlineData(20, 10)]
+		public async Task FontDoesNotAffectHorizontalTextAlignment(double initialSize, double newSize)
+		{
+			var picker = new PickerStub
+			{
+				Title = "This is TEXT!",
+				HorizontalTextAlignment = TextAlignment.Center,
+				Font = Font.SystemFontOfSize(initialSize),
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				picker,
+				GetNativeHorizontalTextAlignment,
+				nameof(IPicker.Font),
+				() => picker.Font = Font.SystemFontOfSize(newSize));
+		}
+
+		[Theory(DisplayName = "Updating Text Does Not Affect HorizontalTextAlignment")]
+		[InlineData("Short", "Longer Text")]
+		[InlineData("Long thext here", "Short")]
+		public async Task TextDoesNotAffectHorizontalTextAlignment(string initialText, string newText)
+		{
+			var picker = new PickerStub
+			{
+				Title = initialText,
+				HorizontalTextAlignment = TextAlignment.Center,
+			};
+
+			await ValidateUnrelatedPropertyUnaffected(
+				picker,
+				GetNativeHorizontalTextAlignment,
+				nameof(IPicker.Title),
+				() => picker.Title = newText);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Theory(DisplayName = "Updating Text Does Not Affect HorizontalTextAlignment")]
-		[InlineData("Short", "Longer Text")]
-		[InlineData("Long thext here", "Short")]
+		[InlineData("Short", "Long text here")]
+		[InlineData("Long text here", "Short")]
 		public async Task TextDoesNotAffectHorizontalTextAlignment(string initialText, string newText)
 		{
 			var picker = new PickerStub

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -46,5 +46,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsItalic(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
+		UITextAlignment GetNativeHorizontalTextAlignment(PickerHandler pickerHandler) =>
+			GetNativePicker(pickerHandler).TextAlignment;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsItalic(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
+		
 		UITextAlignment GetNativeHorizontalTextAlignment(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).TextAlignment;
 	}

--- a/src/Core/tests/DeviceTests/Stubs/PickerStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/PickerStub.cs
@@ -20,5 +20,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public Color TextColor { get; set; }
 
 		public Font Font { get; set; }
+
+		public TextAlignment HorizontalTextAlignment { get; set; }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implements #413

### Additions made ###

* Adds 

 - Adds `ITextAligment` to the `IPicker` interface
- Adds HorizontalTextAlignment property map to PickerHandler
- Adds HorizontalTextAlignment methods map to PickerHandlerfor Android and iOS
- Adds DeviceTests for initial Padding values on iOS and Android


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arragement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR then the PR will need to provide testing to demonstrate that accessibility still works. 
