### PR TITLE
Fix cake VS-WINUI Target

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
+++ b/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
@@ -37,6 +37,8 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <!-- Windows -->
+    <WindowsProjectFolder>Platform\Windows\</WindowsProjectFolder>
     <!-- Android -->
     <AndroidProjectFolder>Platform\Android\</AndroidProjectFolder>
     <MonoAndroidResourcePrefix>$(AndroidProjectFolder)Resources</MonoAndroidResourcePrefix>
@@ -75,6 +77,7 @@
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <DefineConstants>WINDOWS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-windows')) == true ">
     <PackageReference Include="Microsoft.ProjectReunion" />

--- a/build.cake
+++ b/build.cake
@@ -241,8 +241,8 @@ Task("Clean")
     .Description("Deletes all the obj/bin directories")
     .Does(() =>
 {
-    CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.StartsWith("tools"));
-    CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.StartsWith("tools"));
+    CleanDirectories("./**/obj", (fsi)=> !fsi.Path.FullPath.StartsWith("tools") && !fsi.Path.FullPath.StartsWith("bin"));
+    CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.StartsWith("tools") && !fsi.Path.FullPath.StartsWith("bin"));
 });
 
 Task("provision-macsdk")
@@ -896,17 +896,19 @@ Task("VS-NET6")
 
 
 Task("VS-WINUI")
+    .IsDependentOn("Clean")
     .Does(() =>
     {
         DotNetCoreBuild("./src/DotNet/Dotnet.csproj");
         var ext = IsRunningOnWindows() ? ".exe" : "";
+        
+        StartProcess("powershell", $"./eng/dogfood.ps1 -JustCreateGlobalJSON");
         DotNetCoreBuild("./Microsoft.Maui.BuildTasks-net6.sln", new DotNetCoreBuildSettings { ToolPath = $"./bin/dotnet/dotnet{ext}" });
         
-        MSBuild("Microsoft.Maui.WinUI.sln", 
-            GetMSBuildSettings()
-            .WithRestore()
-            .WithProperty("MauiPlatforms", "net6.0-windows10.0.19041.0")
-            );
+
+        MSBuild("Microsoft.Maui.WinUI.sln",
+                GetMSBuildSettings(includePrerelease:true).
+                WithRestore());
 
         StartVisualStudioForDotNet6("./Microsoft.Maui.WinUI.sln");
     });
@@ -1241,13 +1243,27 @@ void StartVisualStudioForDotNet6(string sln = "./Microsoft.Maui-net6.sln")
     StartProcess("powershell", $"./eng/dogfood.ps1 -vs '{devenv}' -sln '{sln}'");
 }
 
-MSBuildSettings GetMSBuildSettings(PlatformTarget? platformTarget = PlatformTarget.MSIL, string buildConfiguration = null)
+MSBuildSettings GetMSBuildSettings(
+    PlatformTarget? platformTarget = PlatformTarget.MSIL, 
+    string buildConfiguration = null,
+    bool includePrerelease = false)
 {
     var buildSettings =  new MSBuildSettings {
         PlatformTarget = platformTarget,
         MSBuildPlatform = Cake.Common.Tools.MSBuild.MSBuildPlatform.x86,
         Configuration = buildConfiguration ?? configuration,
     };
+
+    var vsInstallation =
+        VSWhereLatest(new VSWhereLatestSettings { Requires = "Microsoft.Component.MSBuild", IncludePrerelease = includePrerelease })
+        ?? VSWhereLatest(new VSWhereLatestSettings { Requires = "Microsoft.Component.MSBuild" });
+
+    if (vsInstallation != null)
+    {
+        buildSettings.ToolPath = vsInstallation.CombineWithFilePath(@"MSBuild\Current\Bin\MSBuild.exe");
+        if (!FileExists(buildSettings.ToolPath))
+            buildSettings.ToolPath = vsInstallation.CombineWithFilePath(@"MSBuild\15.0\Bin\MSBuild.exe");
+    }
 
     buildSettings = buildSettings.WithProperty("ANDROID_RENDERERS", $"{ANDROID_RENDERERS}");
     if(!String.IsNullOrWhiteSpace(XamarinFormsVersion))

--- a/eng/dogfood.ps1
+++ b/eng/dogfood.ps1
@@ -37,7 +37,8 @@
 param(
   [string]$vs = "Enterprise",
   [string]$sln,
-  [switch]$modify
+  [switch]$modify,
+  [switch]$JustCreateGlobalJSON
 )
 
 if ($vs.Contains("\") -Or $vs.Contains("/")) {
@@ -97,8 +98,11 @@ try {
     # Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
     $env:PATH=($env:DOTNET_ROOT + ";" + $env:PATH)
 
-    # Launch VS
-    & "$realVS" "$sln"
+    if(-Not $JustCreateGlobalJSON)
+    {
+        # Launch VS
+        & "$realVS" "$sln"
+    }
 } finally {
     if (-Not $modify) {
         $env:DOTNET_INSTALL_DIR = $oldDOTNET_INSTALL_DIR


### PR DESCRIPTION
### Description of Change ###

This fixes the VS-WINUI target:
- ignore the dotnet/bin folders because a lot of times these are still running and will cause an access violation. Building of the dotnet.csproj should take care of making sure these folders are up to date
- fix the dogfood script so it can be used to generate the global.json and not start Visual Studio. This is helpful for creating the global.json file and then running additional msbuild tasks


### How to use this and be successful 
- Install a preview version of 16.10
- When Visual Studio starts up change the platform to x64. If you leave it on `Any CPU` then you might get error messages about "Xaml" 
- dotnet tool restore
- dotnet cake --target=VS-WINUI