### PR TITLE
Fix CA1416 because we didn't set a min version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,8 +4,9 @@
     <BuildForWinUI Condition="'$(SolutionFileName)' == 'Microsoft.Maui.WinUI.sln'">true</BuildForWinUI>
     <BuildForNet6 Condition="'$(SolutionFileName)' == 'Microsoft.Maui-net6.sln' or '$(BuildForWinUI)' == 'true'">true</BuildForNet6>
     <MauiPlatforms>net6.0-ios;net6.0-maccatalyst;net6.0-android</MauiPlatforms>
-    <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);net6.0-windows10.0.18362.0</MauiPlatforms>
-    <MauiPlatforms Condition="'$(BuildForWinUI)' == 'true'">net6.0-windows10.0.18362.0</MauiPlatforms>
+    <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362.0</WindowsTargetFramework>
+    <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);$(WindowsTargetFramework)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(BuildForWinUI)' == 'true'">$(WindowsTargetFramework)</MauiPlatforms>
     <_MauiBuildTasksLocation>$(_MauiBuildTasksLocation)</_MauiBuildTasksLocation>
     <_MauiBuildTasksLocation Condition="'$(_MauiBuildTasksLocation)' == ''">$(MSBuildThisFileDirectory).nuspec\</_MauiBuildTasksLocation>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,8 +4,8 @@
     <BuildForWinUI Condition="'$(SolutionFileName)' == 'Microsoft.Maui.WinUI.sln'">true</BuildForWinUI>
     <BuildForNet6 Condition="'$(SolutionFileName)' == 'Microsoft.Maui-net6.sln' or '$(BuildForWinUI)' == 'true'">true</BuildForNet6>
     <MauiPlatforms>net6.0-ios;net6.0-maccatalyst;net6.0-android</MauiPlatforms>
-    <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);net6.0-windows10.0.19041.0</MauiPlatforms>
-    <MauiPlatforms Condition="'$(BuildForWinUI)' == 'true'">net6.0-windows10.0.19041.0</MauiPlatforms>
+    <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);net6.0-windows10.0.18362.0</MauiPlatforms>
+    <MauiPlatforms Condition="'$(BuildForWinUI)' == 'true'">net6.0-windows10.0.18362.0</MauiPlatforms>
     <_MauiBuildTasksLocation>$(_MauiBuildTasksLocation)</_MauiBuildTasksLocation>
     <_MauiBuildTasksLocation Condition="'$(_MauiBuildTasksLocation)' == ''">$(MSBuildThisFileDirectory).nuspec\</_MauiBuildTasksLocation>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -17,6 +17,7 @@
     <Company>Microsoft</Company>
     <Product>Microsoft MAUI</Product>
     <ProduceReferenceAssembly Condition="'$(UsingMicrosoftNETSdk)' == 'True' AND '$(Configuration)' == 'Debug'">True</ProduceReferenceAssembly>
+    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == '' and $(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup>
     <GitDefaultBranch>main</GitDefaultBranch>
@@ -38,8 +39,7 @@
   <Target Name="GitInfo" />
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="$(MSBuildThisFileDirectory)eng\Environment.Build.props" />
   <Import Condition="'$(SampleProject)' != 'True' and '$(CI)' == 'true'" Project="$(MSBuildThisFileDirectory)eng\SourceLink.Build.props" />
-  
   <ItemGroup Condition="'$(MSBuildVersion)' != '' AND '$(MSBuildVersion)' &lt; '16.7.0'  ">
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0" PrivateAssets="all" />
   </ItemGroup>
-  </Project>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <BuildForWinUI Condition="'$(SolutionFileName)' == 'Microsoft.Maui.WinUI.sln'">true</BuildForWinUI>
     <BuildForNet6 Condition="'$(SolutionFileName)' == 'Microsoft.Maui-net6.sln' or '$(BuildForWinUI)' == 'true'">true</BuildForNet6>
     <MauiPlatforms>net6.0-ios;net6.0-maccatalyst;net6.0-android</MauiPlatforms>
-    <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362.0</WindowsTargetFramework>
+    <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362</WindowsTargetFramework>
     <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);$(WindowsTargetFramework)</MauiPlatforms>
     <MauiPlatforms Condition="'$(BuildForWinUI)' == 'true'">$(WindowsTargetFramework)</MauiPlatforms>
     <_MauiBuildTasksLocation>$(_MauiBuildTasksLocation)</_MauiBuildTasksLocation>

--- a/src/Compatibility/Core/src/Compatibility-net6.csproj
+++ b/src/Compatibility/Core/src/Compatibility-net6.csproj
@@ -95,7 +95,7 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />
-    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\%(RecursiveDir)\%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui.Controls.Compatibility\%(RecursiveDir)\%(FileName)%(Extension)" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\%(RecursiveDir)%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui.Controls.Compatibility\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 </Project>
 

--- a/src/Compatibility/Core/src/Compatibility-net6.csproj
+++ b/src/Compatibility/Core/src/Compatibility-net6.csproj
@@ -94,8 +94,8 @@
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core-net6.csproj" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
-    <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui.Controls.Compatibility.pri" Visible="False" Pack="True" PackagePath="runtimes\$(TargetFramework)\native" />  
-    <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(TargetFramework)\Microsoft.Maui.Controls.Compatibility;runtimes\$(TargetFramework)\native\Microsoft.Maui.Controls.Compatibility" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />  
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility;runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 </Project>
 

--- a/src/Compatibility/Core/src/Compatibility-net6.csproj
+++ b/src/Compatibility/Core/src/Compatibility-net6.csproj
@@ -94,8 +94,8 @@
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core-net6.csproj" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
-    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />  
-    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility;runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui.Controls.Compatibility" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\%(RecursiveDir)\%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui.Controls.Compatibility\%(RecursiveDir)\%(FileName)%(Extension)" />
   </ItemGroup>
 </Project>
 

--- a/src/Compatibility/Core/src/Compatibility-net6.csproj
+++ b/src/Compatibility/Core/src/Compatibility-net6.csproj
@@ -16,7 +16,6 @@
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">
     <NoWarn>$(NoWarn);CA1416;CS8305</NoWarn>
     <DefineConstants>$(DefineConstants);WINDOWS_UWP;WINDOWS</DefineConstants>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   
@@ -95,8 +94,8 @@
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core-net6.csproj" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
-    <None Include="bin\$(Configuration)\net6.0-windows10.0.19041.0\Microsoft.Maui.Controls.Compatibility.pri" Visible="False" Pack="True" PackagePath="runtimes\net6.0-windows10.0.19041.0\native" />  
-    <None Include="bin\$(Configuration)\net6.0-windows10.0.19041.0\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\net6.0-windows10.0.19041\Microsoft.Maui.Controls.Compatibility;runtimes\net6.0-windows10.0.19041.0\native\Microsoft.Maui.Controls.Compatibility" />
+    <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui.Controls.Compatibility.pri" Visible="False" Pack="True" PackagePath="runtimes\$(TargetFramework)\native" />  
+    <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(TargetFramework)\Microsoft.Maui.Controls.Compatibility;runtimes\$(TargetFramework)\native\Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 </Project>
 

--- a/src/Core/src/Core-net6.csproj
+++ b/src/Core/src/Core-net6.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
-    <None Include="bin\$(Configuration)\net6.0-windows10.0.19041.0\Microsoft.Maui.pri" Visible="False" Pack="True" PackagePath="runtimes\net6.0-windows10.0.19041.0\native" />
+    <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui.pri" Visible="False" Pack="True" PackagePath="runtimes\$(TargetFramework)\native" />
   </ItemGroup>
 </Project>
 

--- a/src/Core/src/Core-net6.csproj
+++ b/src/Core/src/Core-net6.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui.pri" Visible="False" Pack="True" PackagePath="runtimes\$(TargetFramework)\native" />
+    <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(TargetFramework)\Microsoft.Maui;runtimes\$(TargetFramework)\native\Microsoft.Maui" />
   </ItemGroup>
 </Project>
 

--- a/src/Core/src/Core-net6.csproj
+++ b/src/Core/src/Core-net6.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />
-    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui\%(RecursiveDir)\%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui\%(RecursiveDir)\%(FileName)%(Extension)" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui\%(RecursiveDir)%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 </Project>
 

--- a/src/Core/src/Core-net6.csproj
+++ b/src/Core/src/Core-net6.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
-    <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui.pri" Visible="False" Pack="True" PackagePath="runtimes\$(TargetFramework)\native" />
-    <None Include="bin\$(Configuration)\$(TargetFramework)\Microsoft.Maui\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(TargetFramework)\Microsoft.Maui;runtimes\$(TargetFramework)\native\Microsoft.Maui" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui;runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui" />
   </ItemGroup>
 </Project>
 

--- a/src/Core/src/Core-net6.csproj
+++ b/src/Core/src/Core-net6.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />
-    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui;runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui\%(RecursiveDir)\%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui\%(RecursiveDir)\%(FileName)%(Extension)" />
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION

### Description of Change ###

CA1416 - This call site is reachable on: 'Windows' 10.0.17763.0 and later. 'XXX' is only supported on: 'Windows' 10.0.18362.0 and later.