### PR TITLE
Implement IsToggled property in WinUI SwitchHandler

### DIFF
--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -15,18 +15,16 @@ namespace Microsoft.Maui.Controls.Compatibility
 			typeof(Label),
 			typeof(CheckBox),
 			typeof(Entry),
-#if !WINDOWS
+			typeof(Switch),
+			typeof(Editor),
 			typeof(ActivityIndicator),
 			typeof(DatePicker),
-			typeof(Editor),
 			typeof(Picker),
 			typeof(ProgressBar),
 			typeof(SearchBar),
 			typeof(Slider),
 			typeof(Stepper),
-			typeof(Switch),
 			typeof(TimePicker),
-#endif
 		};
 
 		public static IAppHostBuilder UseFormsCompatibility(this IAppHostBuilder builder, bool registerRenderers = true)

--- a/src/Controls/src/Core/HandlerImpl/Switch.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Switch.Impl.cs
@@ -14,5 +14,11 @@ namespace Microsoft.Maui.Controls
 				return null;
 			}
 		}
+
+		bool ISwitch.IsOn
+		{
+			get => IsToggled;
+			set => IsToggled = value;
+		}
 	}
 }

--- a/src/Core/src/Core/ISwitch.cs
+++ b/src/Core/src/Core/ISwitch.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui
 		/// <summary>
 		/// Gets or sets a Boolean value that indicates whether this Switch is toggled.
 		/// </summary>
-		bool IsToggled { get; set; }
+		bool IsOn { get; set; }
 
 		/// <summary>
 		/// Gets the Switch Track Color.

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
@@ -68,12 +68,12 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateThumbColor(view, DefaultThumbColorStateList);
 		}
 
-		void OnCheckedChanged(bool isToggled)
+		void OnCheckedChanged(bool isOn)
 		{
 			if (VirtualView == null)
 				return;
 
-			VirtualView.IsToggled = isToggled;
+			VirtualView.IsOn = isOn;
 		}
 
 		class CheckedChangeListener : Java.Lang.Object, CompoundButton.IOnCheckedChangeListener

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Handlers
 			return size;
 		}
 
-		public static void MapIsToggled(SwitchHandler handler, ISwitch view)
+		public static void MapIsOn(SwitchHandler handler, ISwitch view)
 		{
 			handler.NativeView?.UpdateIsToggled(view);
 		}

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapIsOn(SwitchHandler handler, ISwitch view)
 		{
-			handler.NativeView?.UpdateIsToggled(view);
+			handler.NativeView?.UpdateIsOn(view);
 		}
 
 		public static void MapTrackColor(SwitchHandler handler, ISwitch view)

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Standard.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Standard.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override object CreateNativeView() => throw new NotImplementedException();
 
-		public static void MapIsToggled(SwitchHandler handler, ISwitch view) { }
+		public static void MapIsOn(SwitchHandler handler, ISwitch view) { }
 		public static void MapTrackColor(SwitchHandler handler, ISwitch view) { }
 		public static void MapThumbColor(SwitchHandler handler, ISwitch view) { }
 	}

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
@@ -7,8 +6,10 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override ToggleSwitch CreateNativeView() => new ToggleSwitch();
 
-		[MissingMapper]
-		public static void MapIsToggled(SwitchHandler handler, ISwitch view) { }
+		public static void MapIsToggled(SwitchHandler handler, ISwitch view)
+		{
+			handler.NativeView?.UpdateIsToggled(view);
+		}
 
 		[MissingMapper]
 		public static void MapTrackColor(SwitchHandler handler, ISwitch view) { }

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
@@ -16,5 +16,25 @@ namespace Microsoft.Maui.Handlers
 
 		[MissingMapper]
 		public static void MapThumbColor(SwitchHandler handler, ISwitch view) { }
+
+		protected override void DisconnectHandler(ToggleSwitch nativeView)
+		{
+			base.DisconnectHandler(nativeView);
+			nativeView.Toggled -= OnToggled;
+		}
+
+		protected override void ConnectHandler(ToggleSwitch nativeView)
+		{
+			base.ConnectHandler(nativeView);
+			nativeView.Toggled += OnToggled;
+		}
+
+		void OnToggled(object sender, UI.Xaml.RoutedEventArgs e)
+		{
+			if (VirtualView == null || NativeView == null)
+				return;
+
+			VirtualView.IsOn = NativeView.IsOn;
+		}
 	}
 }

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override ToggleSwitch CreateNativeView() => new ToggleSwitch();
 
-		public static void MapIsToggled(SwitchHandler handler, ISwitch view)
+		public static void MapIsOn(SwitchHandler handler, ISwitch view)
 		{
 			handler.NativeView?.UpdateIsToggled(view);
 		}

--- a/src/Core/src/Handlers/Switch/SwitchHandler.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static PropertyMapper<ISwitch, SwitchHandler> SwitchMapper = new PropertyMapper<ISwitch, SwitchHandler>(ViewHandler.ViewMapper)
 		{
-			[nameof(ISwitch.IsToggled)] = MapIsToggled,
+			[nameof(ISwitch.IsOn)] = MapIsOn,
 			[nameof(ISwitch.ThumbColor)] = MapThumbColor,
 			[nameof(ISwitch.TrackColor)] = MapTrackColor,
 		};

--- a/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Handlers
 			DefaultThumbColor = UISwitch.Appearance.ThumbTintColor;
 		}
 
-		public static void MapIsToggled(SwitchHandler handler, ISwitch view)
+		public static void MapIsOn(SwitchHandler handler, ISwitch view)
 		{
 			handler.NativeView?.UpdateIsToggled(view);
 		}

--- a/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			if (NativeView != null)
-				VirtualView.IsToggled = NativeView.On;
+				VirtualView.IsOn = NativeView.On;
 		}
 	}
 }

--- a/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapIsOn(SwitchHandler handler, ISwitch view)
 		{
-			handler.NativeView?.UpdateIsToggled(view);
+			handler.NativeView?.UpdateIsOn(view);
 		}
 
 		public static void MapTrackColor(SwitchHandler handler, ISwitch view)

--- a/src/Core/src/Platform/Android/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Android/SwitchExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui
 {
 	public static class SwitchExtensions
 	{
-		public static void UpdateIsToggled(this ASwitch aSwitch, ISwitch view) =>
+		public static void UpdateIsOn(this ASwitch aSwitch, ISwitch view) =>
 			aSwitch.Checked = view.IsOn;
 
 		public static void UpdateTrackColor(this ASwitch aSwitch, ISwitch view, ColorStateList? defaultTrackColor)

--- a/src/Core/src/Platform/Android/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Android/SwitchExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui
 	public static class SwitchExtensions
 	{
 		public static void UpdateIsToggled(this ASwitch aSwitch, ISwitch view) =>
-			aSwitch.Checked = view.IsToggled;
+			aSwitch.Checked = view.IsOn;
 
 		public static void UpdateTrackColor(this ASwitch aSwitch, ISwitch view, ColorStateList? defaultTrackColor)
 		{

--- a/src/Core/src/Platform/Windows/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Windows/SwitchExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.Maui
+{
+	public static class SwitchExtensions
+	{
+		public static void UpdateIsToggled(this ToggleSwitch toggleSwitch, ISwitch view)
+		{
+			toggleSwitch.IsOn = view.IsToggled;
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Windows/SwitchExtensions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui
 	{
 		public static void UpdateIsToggled(this ToggleSwitch toggleSwitch, ISwitch view)
 		{
-			toggleSwitch.IsOn = view.IsToggled;
+			toggleSwitch.IsOn = view.IsOn;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/SwitchExtensions.cs
+++ b/src/Core/src/Platform/iOS/SwitchExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui
 	{
 		public static void UpdateIsToggled(this UISwitch uiSwitch, ISwitch view)
 		{
-			uiSwitch.SetState(view.IsToggled, true);
+			uiSwitch.SetState(view.IsOn, true);
 		}
 
 		public static void UpdateTrackColor(this UISwitch uiSwitch, ISwitch view, UIColor? defaultOnTrackColor, UIColor? defaultOffTrackColor)

--- a/src/Core/src/Platform/iOS/SwitchExtensions.cs
+++ b/src/Core/src/Platform/iOS/SwitchExtensions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui
 {
 	public static class SwitchExtensions
 	{
-		public static void UpdateIsToggled(this UISwitch uiSwitch, ISwitch view)
+		public static void UpdateIsOn(this UISwitch uiSwitch, ISwitch view)
 		{
 			uiSwitch.SetState(view.IsOn, true);
 		}

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.Android.cs
@@ -9,10 +9,13 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SwitchHandlerTests
 	{
+		void SetIsOn(SwitchHandler switchHandler, bool value) =>
+			GetNativeSwitch(switchHandler).Checked = value;
+
 		ASwitch GetNativeSwitch(SwitchHandler switchHandler) =>
 			(ASwitch)switchHandler.NativeView;
 
-		bool GetNativeIsChecked(SwitchHandler switchHandler) =>
+		bool GetNativeIsOn(SwitchHandler switchHandler) =>
 			GetNativeSwitch(switchHandler).Checked;
 
 		Task ValidateTrackColor(ISwitch switchStub, Color color, Action action = null) =>

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
@@ -69,7 +69,11 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateThumbColor(switchStub, Colors.Red, () => switchStub.ThumbColor = Colors.Red);
 		}
 
-		[Fact(DisplayName = "Updating Native Is On property updates Virtual View")]
+		[Fact(DisplayName = "Updating Native Is On property updates Virtual View",
+#if __IOS__
+			  Skip = "iOS doesn't throw ValueChanged events when changing property via code."
+#endif
+			)]
 		public async Task NativeIsOnPropagatesToVirtual()
 		{
 			var switchStub = new SwitchStub()

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var switchStub = new SwitchStub()
 			{
-				IsToggled = true
+				IsOn = true
 			};
 
-			await ValidatePropertyInitValue(switchStub, () => switchStub.IsToggled, GetNativeIsChecked, switchStub.IsToggled);
+			await ValidatePropertyInitValue(switchStub, () => switchStub.IsOn, GetNativeIsOn, switchStub.IsOn);
 		}
 
 		[Theory(DisplayName = "Track Color Initializes Correctly")]
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var switchStub = new SwitchStub()
 			{
-				IsToggled = isToggled,
+				IsOn = isToggled,
 				TrackColor = Colors.Red
 			};
 
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var switchStub = new SwitchStub()
 			{
-				IsToggled = true
+				IsOn = true
 			};
 
 			await ValidateTrackColor(switchStub, Colors.Red, () => switchStub.TrackColor = Colors.Red);
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var switchStub = new SwitchStub()
 			{
-				IsToggled = true,
+				IsOn = true,
 				ThumbColor = Colors.Blue
 			};
 
@@ -63,10 +63,29 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var switchStub = new SwitchStub()
 			{
-				IsToggled = true
+				IsOn = true
 			};
 
 			await ValidateThumbColor(switchStub, Colors.Red, () => switchStub.ThumbColor = Colors.Red);
+		}
+
+		[Fact(DisplayName = "Updating Native Is On property updates Virtual View")]
+		public async Task NativeIsOnPropagatesToVirtual()
+		{
+			var switchStub = new SwitchStub()
+			{
+				IsOn = false
+			};
+
+			bool isOn = false;
+			switchStub.IsOnDelegate += () =>
+			{
+				isOn = switchStub.IsOn;
+			};
+
+			await SetValueAsync(switchStub, true, SetIsOn);
+
+			Assert.True(isOn);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateThumbColor(switchStub, Colors.Red, () => switchStub.ThumbColor = Colors.Red);
 		}
 
-		[Fact(DisplayName = "Updating Native Is On property updates Virtual View",
+		[Fact(DisplayName = "Updating Native Is On property updates Virtual View"
 #if __IOS__
-			  Skip = "iOS doesn't throw ValueChanged events when changing property via code."
+			  ,Skip = "iOS doesn't throw ValueChanged events when changing property via code."
 #endif
 			)]
 		public async Task NativeIsOnPropagatesToVirtual()

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.iOS.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests
 		UISwitch GetNativeSwitch(SwitchHandler switchHandler) =>
 			(UISwitch)switchHandler.NativeView;
 
-		// This will not fire a ValueChanged/Toggle on native
+		// This will not fire a ValueChanged event on native
 		void SetIsOn(SwitchHandler switchHandler, bool value) =>
 			switchHandler.NativeView.SetState(value, true);
 

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.iOS.cs
@@ -12,8 +12,9 @@ namespace Microsoft.Maui.DeviceTests
 		UISwitch GetNativeSwitch(SwitchHandler switchHandler) =>
 			(UISwitch)switchHandler.NativeView;
 
+		// This will not fire a ValueChanged/Toggle on native
 		void SetIsOn(SwitchHandler switchHandler, bool value) =>
-			GetNativeSwitch(switchHandler).On = value;
+			switchHandler.NativeView.SetState(value, true);
 
 		bool GetNativeIsOn(SwitchHandler switchHandler) =>
 		  GetNativeSwitch(switchHandler).On;

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.iOS.cs
@@ -12,7 +12,10 @@ namespace Microsoft.Maui.DeviceTests
 		UISwitch GetNativeSwitch(SwitchHandler switchHandler) =>
 			(UISwitch)switchHandler.NativeView;
 
-		bool GetNativeIsChecked(SwitchHandler switchHandler) =>
+		void SetIsOn(SwitchHandler switchHandler, bool value) =>
+			GetNativeSwitch(switchHandler).On = value;
+
+		bool GetNativeIsOn(SwitchHandler switchHandler) =>
 		  GetNativeSwitch(switchHandler).On;
 
 		async Task ValidateTrackColor(ISwitch switchStub, Color color, Action action = null)

--- a/src/Core/tests/DeviceTests/Stubs/SwitchStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/SwitchStub.cs
@@ -5,11 +5,21 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public partial class SwitchStub : StubBase, ISwitch
 	{
-		public Action ToggledDelegate;
+		public Action IsOnDelegate;
 		Color _thumbColor;
 		Color _trackColor;
+		bool _isOn;
 
-		public bool IsToggled { get; set; }
+		public bool IsOn
+		{
+			get => _isOn;
+			set
+			{
+				SetProperty(ref _isOn, value);
+				IsOnDelegate?.Invoke();
+			}
+		}
+
 		public Color TrackColor
 		{
 			get => _trackColor;
@@ -21,7 +31,5 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 			get => _thumbColor;
 			set => SetProperty(ref _thumbColor, value);
 		}
-
-		public void Toggled() => ToggledDelegate?.Invoke();
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `IsOn` property in WinUI SwitchHandler.

### PR Checklist ###

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
No