### PR TITLE
Implement MaxLines property in WinUI LabelHandler

### DIFF
--- a/src/Compatibility/Core/src/Windows/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/LabelRenderer.cs
@@ -394,6 +394,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 		}
 
+		[PortHandler]
 		void UpdateMaxLines(TextBlock textBlock)
 		{
 			if (Element.MaxLines >= 0)

--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Maui.Handlers
 		[MissingMapper]
 		public static void MapTextDecorations(LabelHandler handler, ILabel label) { }
 
-		[MissingMapper]
-		public static void MapMaxLines(LabelHandler handler, ILabel label) { }
+		public static void MapMaxLines(LabelHandler handler, ILabel label) =>
+			handler.TextBlock?.UpdateMaxLines(label);
 
 		public static void MapPadding(LabelHandler handler, ILabel label) =>
 			handler.TextBlock?.UpdatePadding(label);

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -23,5 +23,17 @@ namespace Microsoft.Maui
 
 		public static void UpdatePadding(this TextBlock nativeControl, ILabel label) =>
 			nativeControl.UpdateProperty(TextBlock.PaddingProperty, label.Padding.ToNative());
+
+		public static void UpdateMaxLines(this TextBlock nativeControl, ILabel label)
+		{
+			if (label.MaxLines >= 0)
+			{
+				nativeControl.MaxLines = label.MaxLines;
+			}
+			else
+			{
+				nativeControl.MaxLines = 0;
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `MaxLines` property in WinUI LabelHandler.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
No