### PR TITLE
Debugger hang workaround for .NET6 P3 maccatalyst/ios

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -10,6 +10,10 @@
   <PropertyGroup>
     <_MicrosoftProjectReunionVersion>0.5.0</_MicrosoftProjectReunionVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0-ios' Or '$(TargetFramework)' == 'net6.0-maccatalyst'">
+    <!-- Debugger workaround -->
+    <MtouchExtraArgs>$(MtouchExtraArgs) --setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference
         Update="Microsoft.Maui.Graphics"


### PR DESCRIPTION
There was a change in P3 to stop setting this environment variable in maccatalyst and ios which is causing the debugger to hang while connecting on macOS.  This is a temporary fix to bring back the env variable until the issue is addressed.

https://github.com/dotnet/runtime/issues/50966

