### PR TITLE
[blazorwebview] fix <ProjectReference/> in .NET 6 sample

### DIFF
--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
@@ -27,11 +27,8 @@
     <PackageReference Include="Microsoft.Graphics.Win2D" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
-    <ProjectReference Include="..\..\..\BlazorWebView\src\core\Microsoft.AspNetCore.Components.WebView.Maui.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
+    <ProjectReference Include="..\..\..\BlazorWebView\src\core\Microsoft.AspNetCore.Components.WebView.Maui.csproj" />
     <ProjectReference Include="..\..\..\Essentials\src\Essentials-net6.csproj" />
     <ProjectReference Include="..\..\src\Core\Controls.Core-net6.csproj" />
     <ProjectReference Include="..\..\src\Xaml\Controls.Xaml-net6.csproj" />


### PR DESCRIPTION
### Description of Change ###

When I build `Maui.Controls.Sample-net6.csproj` by itself I get lots of errors like:

    Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator\_Pages_Index.razor.cs(65,59): error CS0234: The type or namespace name 'AspNetCore' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
    12 Warning(s)
    81 Error(s)

I don't think we need the `$(BuildForNet6)` condition here, because this is a .NET 6 project.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests
