### PR TITLE
[buildtasks] fix Microsoft.Maui.Graphics dependency

### DIFF
--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
@@ -29,6 +29,7 @@
 		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Maui.Graphics" GeneratePathProperty="true" />
 		<!-- <PackageReference Include="StrongNamer" Version="0.2.5" PrivateAssets="all" GeneratePathProperty="true" /> -->
 		<PackageReference Include="XliffTasks" Version="1.0.0-beta.21110.1" PrivateAssets="all" />
 	</ItemGroup>
@@ -51,6 +52,7 @@
 		<None Include="..\..\..\..\.nuspec\Microsoft.Maui.Controls.DefaultItems.props" Visible="False" Pack="True" PackagePath="buildTransitive" />
 		<None Include="..\..\..\..\.nuspec\Microsoft.Maui.Controls.DefaultItems.targets" Visible="False" Pack="True" PackagePath="buildTransitive" />
 
+		<None Include="$(PkgMicrosoft_Maui_Graphics)\lib\netstandard2.0\Microsoft.Maui.Graphics.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 		<None Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 		<None Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.Mdb.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />
 		<None Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.Pdb.dll" Visible="False" Pack="True" PackagePath="buildTransitive" />


### PR DESCRIPTION
### Description of Change ###

Since b1866fd1, it appears the MSBuild tasks are broken when consuming
Maui's `.nupkg` files:

    App.xaml : error : Could not load file or assembly 'Microsoft.Maui.Graphics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified. [C:\src\maui\foo\foo.csproj]
    MainPage.xaml : error : Could not load file or assembly 'Microsoft.Maui.Graphics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified. [C:\src\maui\foo\foo.csproj]

I discovered this after building a `dotnet new maui` project against
local packages in `artifacts\*.nupkg`.

It looks like `Controls.Build.Tasks-net6.csproj` just needs to
redistribute `netstandard2.0\Microsoft.Maui.Graphics.dll` to be used
at build time.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests
