### PR TITLE
Stop nulling out the Handler

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -46,8 +46,8 @@ namespace Microsoft.Maui.Handlers
 		{
 			_ = view ?? throw new ArgumentNullException(nameof(view));
 
-			if (VirtualView?.Handler != null)
-				VirtualView.Handler = null;
+			if(VirtualView != null && VirtualView.Handler != this)
+				VirtualView.Handler = this;
 
 			bool setupNativeView = VirtualView == null;
 

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -46,13 +46,19 @@ namespace Microsoft.Maui.Handlers
 		{
 			_ = view ?? throw new ArgumentNullException(nameof(view));
 
-			if(VirtualView != null && VirtualView.Handler != this)
-				VirtualView.Handler = this;
+			if(VirtualView == view)
+				return;
+
+			if (VirtualView?.Handler != null)
+				VirtualView.Handler = null;
 
 			bool setupNativeView = VirtualView == null;
 
 			VirtualView = (TVirtualView)view;
 			NativeView ??= CreateNativeView();
+
+			if(VirtualView != null && VirtualView.Handler != this)
+				VirtualView.Handler = this;
 
 			if (setupNativeView && NativeView != null)
 			{


### PR DESCRIPTION
Right now we null out the handler every time.  You can see from the [ToNative](https://github.com/dotnet/maui/blob/main/src/Core/src/Platform/iOS/HandlerExtensions.cs#L16-L28) we set the handler on the view, only to null it out instantly.


This will make sure if a Handler sets the view, we are now the correct handler.