### PR TITLE
[singleproject] no threading in DetectInvalidResourceOutputFilenamesTask

### DIFF
--- a/src/SingleProject/Resizetizer/src/Utils.cs
+++ b/src/SingleProject/Resizetizer/src/Utils.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Resizetizer
 	internal class Utils
 	{
 		static readonly Regex rxResourceFilenameValidation
-			= new Regex(@"^[a-z]+[a-z0-9_]{0,}[^_]$", RegexOptions.Singleline);
+			= new Regex(@"^[a-z]+[a-z0-9_]{0,}[^_]$", RegexOptions.Singleline | RegexOptions.Compiled);
 
 		public static bool IsValidResourceFilename(string filename)
 			=> rxResourceFilenameValidation.IsMatch(Path.GetFileNameWithoutExtension(filename));

--- a/src/SingleProject/Resizetizer/test/UnitTests/DetectInvalidResourceOutputFilenamesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/DetectInvalidResourceOutputFilenamesTests.cs
@@ -23,14 +23,14 @@ namespace Microsoft.Maui.Resizetizer.Tests
 					BuildEngine = this,
 				};
 
-			protected ITaskItem GetInvalidFilename(DetectInvalidResourceOutputFilenamesTask task, string path) =>
-				task.InvalidItems.Single(c => c.ItemSpec.Replace("\\", "/").EndsWith(path));
+			protected string GetInvalidFilename(DetectInvalidResourceOutputFilenamesTask task, string path) =>
+				task.InvalidItems.Single(c => c.Replace("\\", "/").EndsWith(path));
 
 			protected void AssertValidFilename(DetectInvalidResourceOutputFilenamesTask task, ITaskItem item)
-				=> Assert.DoesNotContain(task.InvalidItems, c => c.ItemSpec == item.ItemSpec);
+				=> Assert.DoesNotContain(task.InvalidItems ?? Enumerable.Empty<string>(), c => c == item.ItemSpec);
 
 			protected void AssertInvalidFilename(DetectInvalidResourceOutputFilenamesTask task, ITaskItem item)
-				=> Assert.Contains(task.InvalidItems, c => c.ItemSpec == item.ItemSpec);
+				=> Assert.Contains(task.InvalidItems ?? Enumerable.Empty<string>(), c => c == item.ItemSpec);
 
 			[Fact]
 			public void NoItemsSucceed()


### PR DESCRIPTION
### Description of Change ###

Reviewing the code in this task, it does not appear to be doing
sufficient work to justify parallelization. It basically runs a
`Regex` on each item in `@(MauiImage)`.

We are also hitting some deadlocks inside VS, which can commonly be
caused by usage of `System.Threading.Tasks` in MSBuild tasks.

Let's simplify this task:

* `AsyncTask` -> `Task`
* Use regular `foreach`
* `ConcurrentBag<T>` -> `List<T>`

To improve performance, in general:

* Use `string[]` instead of `ITaskItem[]`, so we don't need `Select()`
* Remove remaining `System.Linq` usage
* Use `RegexOptions.Compiled`
* Use `StringBuilder` for combining the long error message.

I think these changes will prevent possible VS hangs in this task.

I will make future changes for the `<ResizetizeImages/>` MSBuild task.
But it does sufficient work to justify usage of
`System.Threading.Tasks`.

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests
