### PR TITLE
[singleproject] fix AsyncTask & System.Threading.Tasks usage

### DIFF
--- a/src/SingleProject/Resizetizer/src/AsyncTask.cs
+++ b/src/SingleProject/Resizetizer/src/AsyncTask.cs
@@ -8,6 +8,8 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.Maui.Resizetizer
 {
 	/// <summary>
+	/// Don't use AsyncTask directly, use MauiAsyncTask instead and override ExecuteAsync().
+	/// 
 	/// Base class for tasks that need long-running cancellable asynchronous tasks 
 	/// that don't block the UI thread in the IDE.
 	/// </summary>

--- a/src/SingleProject/Resizetizer/src/AsyncTaskExtensions.cs
+++ b/src/SingleProject/Resizetizer/src/AsyncTaskExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Based on: https://github.com/xamarin/xamarin-android-tools/blob/d92fc3e3a27e8240551baa813b15d6bf006a5620/src/Microsoft.Android.Build.BaseTasks/AsyncTaskExtensions.cs
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Resizetizer
+{
+	public static class AsyncTaskExtensions
+	{
+		/// <summary>
+		/// Calls Parallel.ForEach() with appropriate ParallelOptions and exception handling.
+		/// </summary>
+		public static ParallelLoopResult ParallelForEach<TSource>(this MauiAsyncTask asyncTask, IEnumerable<TSource> source, Action<TSource> body)
+		{
+			return Parallel.ForEach(source, ParallelOptions(asyncTask),
+				s =>
+				{
+					try
+					{
+						body(s);
+					}
+					catch (Exception exc)
+					{
+						asyncTask.LogCodedError("MAUI0000", exc.ToString());
+						asyncTask.Cancel();
+					}
+				});
+		}
+
+		static ParallelOptions ParallelOptions(MauiAsyncTask asyncTask) => new ParallelOptions
+		{
+			CancellationToken = asyncTask.CancellationToken,
+			TaskScheduler = TaskScheduler.Default,
+		};
+
+		/// <summary>
+		/// Calls Task.Run() with a proper CancellationToken.
+		/// </summary>
+		public static Task RunTask(this MauiAsyncTask asyncTask, Action body) =>
+			Task.Run(body, asyncTask.CancellationToken);
+
+
+		/// <summary>
+		/// Calls Task.Run<T>() with a proper CancellationToken.
+		/// </summary>
+		public static Task<TSource> RunTask<TSource>(this MauiAsyncTask asyncTask, Func<TSource> body) =>
+			Task.Run(body, asyncTask.CancellationToken);
+	}
+}

--- a/src/SingleProject/Resizetizer/src/MauiAsyncTask.cs
+++ b/src/SingleProject/Resizetizer/src/MauiAsyncTask.cs
@@ -1,0 +1,43 @@
+﻿// Based on: https://github.com/xamarin/xamarin-android-tools/blob/d92fc3e3a27e8240551baa813b15d6bf006a5620/src/Microsoft.Android.Build.BaseTasks/AndroidAsyncTask.cs
+
+using System;
+using static System.Threading.Tasks.TaskExtensions;
+
+namespace Microsoft.Maui.Resizetizer
+{
+	public abstract class MauiAsyncTask : AsyncTask
+	{
+		/// <summary>
+		/// Typically `ExecuteAsync` will be the preferred method to override instead of this one.
+		/// </summary>
+		public override bool Execute()
+		{
+			Yield();
+			try
+			{
+				this.RunTask(() => ExecuteAsync())
+					.Unwrap()
+					.ContinueWith(Complete);
+
+				// This blocks on AsyncTask.Execute, until Complete is called
+				return base.Execute();
+			}
+			catch (Exception exc)
+			{
+				LogCodedError("MAUI0000", exc.ToString());
+				return false;
+			}
+			finally
+			{
+				Reacquire();
+			}
+		}
+
+		/// <summary>
+		/// Override this method for simplicity of AsyncTask usage:
+		/// * Yield / Reacquire is handled for you
+		/// * RunTaskAsync is already on a background thread
+		/// </summary>
+		public virtual System.Threading.Tasks.Task ExecuteAsync() => System.Threading.Tasks.Task.CompletedTask;
+	}
+}

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -3,14 +3,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Maui.Resizetizer
 {
-	public class ResizetizeImages : AsyncTask, ILogger
+	public class ResizetizeImages : MauiAsyncTask, ILogger
 	{
 		[Required]
 		public string PlatformType { get; set; } = "android";
@@ -29,29 +27,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		public ILogger Logger => this;
 
-		public override bool Execute()
-		{
-			System.Threading.Tasks.Task.Run(async () =>
-			{
-				try
-				{
-					await DoExecute();
-				}
-				catch (Exception ex)
-				{
-					Log.LogErrorFromException(ex);
-				}
-				finally
-				{
-					Complete();
-				}
-
-			});
-
-			return base.Execute();
-		}
-
-		System.Threading.Tasks.Task DoExecute()
+		public override System.Threading.Tasks.Task ExecuteAsync()
 		{
 			Svg.SvgDocument.SkipGdiPlusCapabilityCheck = true;
 
@@ -66,7 +42,7 @@ namespace Microsoft.Maui.Resizetizer
 
 			var resizedImages = new ConcurrentBag<ResizedImageInfo>();
 
-			System.Threading.Tasks.Parallel.ForEach(images, img =>
+			this.ParallelForEach(images, img =>
 			{
 				try
 				{
@@ -102,11 +78,11 @@ namespace Microsoft.Maui.Resizetizer
 
 					opStopwatch.Stop();
 
-					Log.LogMessage(MessageImportance.Low, $"{op} took {opStopwatch.ElapsedMilliseconds}ms");
+					LogDebugMessage($"{op} took {opStopwatch.ElapsedMilliseconds}ms");
 				}
 				catch (Exception ex)
 				{
-					Log.LogWarningFromException(ex, true);
+					LogWarning("MAUI0000", ex.ToString());
 
 					throw;
 				}
@@ -142,12 +118,12 @@ namespace Microsoft.Maui.Resizetizer
 			// Generate the actual bitmap app icons themselves
 			var appIconDpis = DpiPath.GetAppIconDpis(PlatformType, appIconName);
 
-			Log.LogMessage(MessageImportance.Low, $"App Icon");
+			LogDebugMessage($"App Icon");
 
 			// Apple and Android have special additional files to generate for app icons
 			if (PlatformType == "android")
 			{
-				Log.LogMessage(MessageImportance.Low, $"Android Adaptive Icon Generator");
+				LogDebugMessage($"Android Adaptive Icon Generator");
 
 				appIconName = appIconName.ToLowerInvariant();
 
@@ -159,7 +135,7 @@ namespace Microsoft.Maui.Resizetizer
 			}
 			else if (PlatformType == "ios")
 			{
-				Log.LogMessage(MessageImportance.Low, $"iOS Icon Assets Generator");
+				LogDebugMessage($"iOS Icon Assets Generator");
 
 				var appleAssetGen = new AppleIconAssetsGenerator(img, appIconName, IntermediateOutputPath, appIconDpis, this);
 
@@ -169,20 +145,20 @@ namespace Microsoft.Maui.Resizetizer
 					resizedImages.Add(assetGenerated);
 			}
 
-			Log.LogMessage(MessageImportance.Low, $"Generating App Icon Bitmaps for DPIs");
+			LogDebugMessage($"Generating App Icon Bitmaps for DPIs");
 
 			var appTool = new SkiaSharpAppIconTools(img, this);
 
-			Log.LogMessage(MessageImportance.Low, $"App Icon: Intermediate Path " + IntermediateOutputPath);
+			LogDebugMessage($"App Icon: Intermediate Path " + IntermediateOutputPath);
 
 			foreach (var dpi in appIconDpis)
 			{
-				Log.LogMessage(MessageImportance.Low, $"App Icon: " + dpi);
+				LogDebugMessage($"App Icon: " + dpi);
 
 				var destination = Resizer.GetFileDestination(img, dpi, IntermediateOutputPath)
 					.Replace("{name}", appIconName);
 
-				Log.LogMessage(MessageImportance.Low, $"App Icon Destination: " + destination);
+				LogDebugMessage($"App Icon Destination: " + destination);
 
 				appTool.Resize(dpi, Path.ChangeExtension(destination, ".png"));
 			}
@@ -194,12 +170,12 @@ namespace Microsoft.Maui.Resizetizer
 
 			foreach (var dpi in dpis)
 			{
-				Log.LogMessage(MessageImportance.Low, $"Resizing {img.Filename}");
+				LogDebugMessage($"Resizing {img.Filename}");
 
 				var r = resizer.Resize(dpi, InputsFile);
 				resizedImages.Add(r);
 
-				Log.LogMessage(MessageImportance.Low, $"Resized {img.Filename}");
+				LogDebugMessage($"Resized {img.Filename}");
 			}
 		}
 
@@ -207,12 +183,12 @@ namespace Microsoft.Maui.Resizetizer
 		{
 			var resizer = new Resizer(img, IntermediateOutputPath, this);
 
-			Log.LogMessage(MessageImportance.Low, $"Copying {img.Filename}");
+			LogDebugMessage($"Copying {img.Filename}");
 
 			var r = resizer.CopyFile(originalScaleDpi, InputsFile, PlatformType.ToLower().Equals("android"));
 			resizedImages.Add(r);
 
-			Log.LogMessage(MessageImportance.Low, $"Copied {img.Filename}");
+			LogDebugMessage($"Copied {img.Filename}");
 		}
 
 		void ILogger.Log(string message)


### PR DESCRIPTION
### Description of Change ###

This builds upon: https://github.com/dotnet/maui/pull/788

We've been seeing some hangs for Maui projects inside VS.

There are a couple things in the `<ResizetizeImages/>` MSBuild task
that can cause hangs:

* Using `AsyncTask` and accessing `this.Log`: should call the
  appropriate `AsyncTask.Log*()` methods instead.
* Use of `Parallel.ForEach()`: needs to pass `TaskScheduler.Default`
  and the `asyncTask.CancellationToken`.

To solve these problems systematically, we have helper methods in
Xamarin.Android:

* https://github.com/xamarin/xamarin-android-tools/blob/d92fc3e3a27e8240551baa813b15d6bf006a5620/src/Microsoft.Android.Build.BaseTasks/AndroidAsyncTask.cs
* https://github.com/xamarin/xamarin-android-tools/blob/d92fc3e3a27e8240551baa813b15d6bf006a5620/src/Microsoft.Android.Build.BaseTasks/AsyncTaskExtensions.cs

I brought versions of these methods over to Maui, as we probably don't
want to take a full dependency on xamarin/xamarin-android-tools.

Going forward, if you want to run an `AsyncTask` with a
`Parallel.ForEach()` and other `async` things you would do:

```csharp
public class MyTask : MauiAsyncTask
{
    // This method is already on a background thread
    public async override System.Threading.Tasks.Task ExecuteAsync()
    {
        // If I need to log something
        LogDebugMessage("HEYO!");

        // Calls Task.Run() with appropriate settings
        await this.RunTask (() => DoSomeStuff ());

        // Calls Parallel.ForEach() with appropriate settings
        this.ParallelForEach(Items, i => DoMoreStuff (i));
    }
}
```

Other fixes:

* `<CreatePartialInfoPlistTask/>` is not an `AsyncTask` at all
  anymore: I don't think it needs to be.

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests