### PR TITLE
Allow legacy layouts to set IsArrangeValid on children

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls
 				return base.IsArrangeValid && Content.IsArrangeValid; 
 			} 
 
-			protected set => base.IsArrangeValid = value; 
+			internal protected set => base.IsArrangeValid = value; 
 		}
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Maui.Controls
 
 		public virtual bool IsMeasureValid { get; protected set; }
 
-		public virtual bool IsArrangeValid { get; protected set; }
+		// The set is `internal protected` here to allow the legacy Layouts to set IsArrangeValid on their children
+		public virtual bool IsArrangeValid { get; internal protected set; }
 
 		public void Arrange(Rectangle bounds)
 		{

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -320,6 +320,7 @@ namespace Microsoft.Maui.Controls
 			region.Y += margin.Top;
 			region.Height -= margin.VerticalThickness;
 
+			child.IsArrangeValid = true;
 			child.Layout(region);
 		}
 
@@ -519,6 +520,13 @@ namespace Microsoft.Maui.Controls
 					fe.InvalidateMeasure();
 				}
 			}
+		}
+
+		protected override Size ArrangeOverride(Rectangle bounds)
+		{
+			//return base.ArrangeOverride(bounds);
+			IsArrangeValid = true;
+			return bounds.Size;
 		}
 	}
 }

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -521,12 +521,5 @@ namespace Microsoft.Maui.Controls
 				}
 			}
 		}
-
-		protected override Size ArrangeOverride(Rectangle bounds)
-		{
-			//return base.ArrangeOverride(bounds);
-			IsArrangeValid = true;
-			return bounds.Size;
-		}
 	}
 }

--- a/src/Controls/src/Core/Layout/StackLayout.cs
+++ b/src/Controls/src/Core/Layout/StackLayout.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.Layout2
 				return true;
 			}
 
-			protected set
+			internal protected set
 			{
 				_isArrangeValid = value;
 			}


### PR DESCRIPTION
Frames weren't getting set on child controls of legacy layouts because the IsArrangeValid flag was not getting set; this allow the legacy layouts to set that flag (and does so in LayoutChildIntoBoundingRegion). 

Fixes #782

