### PR TITLE
[singleproject] use SKColor and SKSize instead of System.Drawing

### DIFF
--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Globalization;
 using System.IO;
 using Newtonsoft.Json.Linq;

--- a/src/SingleProject/Resizetizer/src/ColorTable.cs
+++ b/src/SingleProject/Resizetizer/src/ColorTable.cs
@@ -1,0 +1,37 @@
+﻿// Based on: https://github.com/dotnet/runtime/blob/776dd1d3318760bf2328f66a544ed377d78b2099/src/libraries/Common/src/System/Drawing/ColorTable.cs
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using SkiaSharp;
+
+namespace Microsoft.Maui.Resizetizer
+{
+	static class ColorTable
+	{
+		static readonly Lazy<Dictionary<string, SKColor>> ColorConstants = new Lazy<Dictionary<string, SKColor>>(GetColors);
+
+		static Dictionary<string, SKColor> GetColors()
+		{
+			var colors = new Dictionary<string, SKColor>(StringComparer.OrdinalIgnoreCase);
+			FillWithProperties(colors, typeof(SKColors));
+			return colors;
+		}
+
+		static void FillWithProperties(Dictionary<string, SKColor> dictionary, Type typeWithColors)
+		{
+			foreach (FieldInfo field in typeWithColors.GetFields(BindingFlags.Public | BindingFlags.Static))
+			{
+				if (field.FieldType == typeof(SKColor))
+					dictionary[field.Name] = (SKColor)field.GetValue(null)!;
+			}
+		}
+
+		static Dictionary<string, SKColor> Colors => ColorConstants.Value;
+
+		public static bool TryGetNamedColor(string name, out SKColor result) => Colors.TryGetValue(name, out result);
+
+		public static bool IsKnownNamedColor(string name) => Colors.TryGetValue(name, out _);
+	}
+}

--- a/src/SingleProject/Resizetizer/src/DpiPath.cs
+++ b/src/SingleProject/Resizetizer/src/DpiPath.cs
@@ -1,10 +1,10 @@
-﻿using System.Drawing;
+﻿using SkiaSharp;
 
 namespace Microsoft.Maui.Resizetizer
 {
 	internal class DpiPath
 	{
-		public DpiPath(string path, decimal scale, string suffix = null, SizeF? size = null, string[] idioms = null)
+		public DpiPath(string path, decimal scale, string suffix = null, SKSize? size = null, string[] idioms = null)
 		{
 			Path = path;
 			Scale = scale;
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		public string FileSuffix { get; set; }
 
-		public SizeF? Size { get; set; }
+		public SKSize? Size { get; set; }
 
 		public bool Optimize { get; set; } = true;
 
@@ -39,11 +39,11 @@ namespace Microsoft.Maui.Resizetizer
 		public static DpiPath[] AndroidAppIcon
 			=> new[]
 			{
-				new DpiPath("mipmap-mdpi", 1.0m, size: new SizeF(48, 48)),
-				new DpiPath("mipmap-hdpi", 1.5m, size: new SizeF(48, 48)),
-				new DpiPath("mipmap-xhdpi", 2.0m, size: new SizeF(48, 48)),
-				new DpiPath("mipmap-xxhdpi", 3.0m, size: new SizeF(48, 48)),
-				new DpiPath("mipmap-xxxhdpi", 4.0m, size: new SizeF(48, 48)),
+				new DpiPath("mipmap-mdpi", 1.0m, size: new SKSize(48, 48)),
+				new DpiPath("mipmap-hdpi", 1.5m, size: new SKSize(48, 48)),
+				new DpiPath("mipmap-xhdpi", 2.0m, size: new SKSize(48, 48)),
+				new DpiPath("mipmap-xxhdpi", 3.0m, size: new SKSize(48, 48)),
+				new DpiPath("mipmap-xxxhdpi", 4.0m, size: new SKSize(48, 48)),
 			};
 
 		static DpiPath AndroidOriginal => new DpiPath("drawable", 1.0m);
@@ -63,27 +63,27 @@ namespace Microsoft.Maui.Resizetizer
 			=> new[]
 			{
 				// Notification
-				new DpiPath(IosAppIconPath, 2.0m, "20x20@2x", new SizeF(20, 20), new [] { "iphone", "ipad" }),
-				new DpiPath(IosAppIconPath, 3.0m, "20x20@3x", new SizeF(20, 20), new [] { "iphone" }),
+				new DpiPath(IosAppIconPath, 2.0m, "20x20@2x", new SKSize(20, 20), new [] { "iphone", "ipad" }),
+				new DpiPath(IosAppIconPath, 3.0m, "20x20@3x", new SKSize(20, 20), new [] { "iphone" }),
 
 				// Settings
-				new DpiPath(IosAppIconPath, 2.0m, "29x29@2x", new SizeF(29, 29), new [] { "iphone", "ipad" }),
-				new DpiPath(IosAppIconPath, 3.0m, "29x29@3x", new SizeF(29, 29), new [] { "iphone" }),
+				new DpiPath(IosAppIconPath, 2.0m, "29x29@2x", new SKSize(29, 29), new [] { "iphone", "ipad" }),
+				new DpiPath(IosAppIconPath, 3.0m, "29x29@3x", new SKSize(29, 29), new [] { "iphone" }),
 
 				// Spotlight
-				new DpiPath(IosAppIconPath, 2.0m, "40x40@2x", new SizeF(40, 40), new [] { "iphone", "ipad" }),
-				new DpiPath(IosAppIconPath, 3.0m, "40x40@3x", new SizeF(40, 40), new [] { "iphone" }),
+				new DpiPath(IosAppIconPath, 2.0m, "40x40@2x", new SKSize(40, 40), new [] { "iphone", "ipad" }),
+				new DpiPath(IosAppIconPath, 3.0m, "40x40@3x", new SKSize(40, 40), new [] { "iphone" }),
 
 				// App Icon - iPhone
-				new DpiPath(IosAppIconPath, 2.0m, "60x60@2x", new SizeF(60, 60), new [] { "iphone" }),
-				new DpiPath(IosAppIconPath, 3.0m, "60x60@3x", new SizeF(60, 60), new [] { "iphone" }),
+				new DpiPath(IosAppIconPath, 2.0m, "60x60@2x", new SKSize(60, 60), new [] { "iphone" }),
+				new DpiPath(IosAppIconPath, 3.0m, "60x60@3x", new SKSize(60, 60), new [] { "iphone" }),
 
 				// App Icon - ipad
-				new DpiPath(IosAppIconPath, 2.0m, "76x76@2x", new SizeF(76, 76), new [] { "ipad" }),
-				new DpiPath(IosAppIconPath, 2.0m, "83.5x83.5@2x", new SizeF(83.5f, 83.5f), new [] { "ipad" }),
+				new DpiPath(IosAppIconPath, 2.0m, "76x76@2x", new SKSize(76, 76), new [] { "ipad" }),
+				new DpiPath(IosAppIconPath, 2.0m, "83.5x83.5@2x", new SKSize(83.5f, 83.5f), new [] { "ipad" }),
 				
 				// App Store
-				new DpiPath(IosAppIconPath, 1.0m, "ItunesArtwork", new SizeF(1024, 1024), new [] { "ios-marketing" }),
+				new DpiPath(IosAppIconPath, 1.0m, "ItunesArtwork", new SKSize(1024, 1024), new [] { "ios-marketing" }),
 			};
 
 		static DpiPath IosOriginal => new DpiPath("Resources", 1.0m);

--- a/src/SingleProject/Resizetizer/src/ResizeImageInfo.cs
+++ b/src/SingleProject/Resizetizer/src/ResizeImageInfo.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Drawing;
 using System.IO;
-using System.Text.RegularExpressions;
+using SkiaSharp;
 
 namespace Microsoft.Maui.Resizetizer
 {
@@ -21,11 +20,11 @@ namespace Microsoft.Maui.Resizetizer
 				? Path.GetExtension(Filename)
 				: Path.GetExtension(Alias);
 
-		public Size? BaseSize { get; set; }
+		public SKSize? BaseSize { get; set; }
 
 		public bool Resize { get; set; } = true;
 
-		public Color? TintColor { get; set; }
+		public SKColor? TintColor { get; set; }
 
 		public bool IsVector => IsVectorFilename(Filename);
 

--- a/src/SingleProject/Resizetizer/src/Resizetizer.csproj
+++ b/src/SingleProject/Resizetizer/src/Resizetizer.csproj
@@ -23,7 +23,6 @@
     <None Include="$(PkgSystem_Buffers)\lib\netstandard2.0\System.Buffers.dll" Visible="False" Pack="True" PackagePath="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgSystem_Numerics_Vectors)\lib\netstandard2.0\System.Numerics.Vectors.dll" Visible="False" Pack="True" PackagePath="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll" Visible="False" Pack="True" PackagePath="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(PkgSystem_Drawing_Common)\lib\netstandard2.0\System.Drawing.Common.dll" Visible="False" Pack="True" PackagePath="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgSystem_ObjectModel)\lib\netstandard1.3\System.ObjectModel.dll" Visible="False" Pack="True" PackagePath="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgSvg_Custom)\lib\net461\Svg.Custom.dll" Visible="False" Pack="True" PackagePath="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(PkgSvg_Picture)\lib\net461\Svg.Picture.dll" Visible="False" Pack="True" PackagePath="buildTransitive" CopyToOutputDirectory="PreserveNewest" />
@@ -71,7 +70,6 @@
     <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Svg2VectorDrawable.Net" Version="0.3.0" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>

--- a/src/SingleProject/Resizetizer/src/SkiaSharpBitmapTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpBitmapTools.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Drawing;
 using SkiaSharp;
 
 namespace Microsoft.Maui.Resizetizer
@@ -14,7 +13,7 @@ namespace Microsoft.Maui.Resizetizer
 		{
 		}
 
-		public SkiaSharpBitmapTools(string filename, Size? baseSize, Color? tintColor, ILogger logger)
+		public SkiaSharpBitmapTools(string filename, SKSize? baseSize, SKColor? tintColor, ILogger logger)
 			: base(filename, baseSize, tintColor, logger)
 		{
 			var sw = new Stopwatch();

--- a/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpSvgTools.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Drawing;
 using SkiaSharp;
 using Svg.Skia;
 
@@ -15,7 +14,7 @@ namespace Microsoft.Maui.Resizetizer
 		{
 		}
 
-		public SkiaSharpSvgTools(string filename, Size? baseSize, Color? tintColor, ILogger logger)
+		public SkiaSharpSvgTools(string filename, SKSize? baseSize, SKColor? tintColor, ILogger logger)
 			: base(filename, baseSize, tintColor, logger)
 		{
 			var sw = new Stopwatch();

--- a/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpTools.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using SkiaSharp;
 
@@ -8,7 +7,7 @@ namespace Microsoft.Maui.Resizetizer
 {
 	internal abstract class SkiaSharpTools
 	{
-		public static SkiaSharpTools Create(bool isVector, string filename, Size? baseSize, Color? tintColor, ILogger logger)
+		public static SkiaSharpTools Create(bool isVector, string filename, SKSize? baseSize, SKColor? tintColor, ILogger logger)
 			=> isVector
 				? new SkiaSharpSvgTools(filename, baseSize, tintColor, logger) as SkiaSharpTools
 				: new SkiaSharpBitmapTools(filename, baseSize, tintColor, logger);
@@ -18,27 +17,26 @@ namespace Microsoft.Maui.Resizetizer
 		{
 		}
 
-		public SkiaSharpTools(string filename, Size? baseSize, Color? tintColor, ILogger logger)
+		public SkiaSharpTools(string filename, SKSize? baseSize, SKColor? tintColor, ILogger logger)
 		{
 			Logger = logger;
 			Filename = filename;
 			BaseSize = baseSize;
 
-			if (tintColor is Color tint)
+			if (tintColor is SKColor tint)
 			{
-				var color = new SKColor(unchecked((uint)tint.ToArgb()));
-				Logger?.Log($"Detected a tint color of {color}");
+				Logger?.Log($"Detected a tint color of {tint}");
 
 				Paint = new SKPaint
 				{
-					ColorFilter = SKColorFilter.CreateBlendMode(color, SKBlendMode.SrcIn)
+					ColorFilter = SKColorFilter.CreateBlendMode(tint, SKBlendMode.SrcIn)
 				};
 			}
 		}
 
 		public string Filename { get; }
 
-		public Size? BaseSize { get; }
+		public SKSize? BaseSize { get; }
 		public ILogger Logger { get; }
 
 		public SKPaint Paint { get; }
@@ -84,7 +82,7 @@ namespace Microsoft.Maui.Resizetizer
 				return GetScaledSize(originalSize, dpi.Scale);
 		}
 
-		(SKSizeI, float) GetScaledSize(SKSize originalSize, decimal scale, SizeF absoluteSize)
+		(SKSizeI, float) GetScaledSize(SKSize originalSize, decimal scale, SKSize absoluteSize)
 		{
 			var ratio = (decimal)absoluteSize.Width / (decimal)originalSize.Width;
 
@@ -93,8 +91,8 @@ namespace Microsoft.Maui.Resizetizer
 
 		public (SKSizeI, float) GetScaledSize(SKSize originalSize, decimal resizeRatio)
 		{
-			int sourceNominalWidth = BaseSize?.Width ?? (int)originalSize.Width;
-			int sourceNominalHeight = BaseSize?.Height ?? (int)originalSize.Height;
+			int sourceNominalWidth = (int)(BaseSize?.Width ?? originalSize.Width);
+			int sourceNominalHeight = (int)(BaseSize?.Height ?? originalSize.Height);
 
 			// Find the actual size of the image
 			var sourceActualWidth = originalSize.Width;

--- a/src/SingleProject/Resizetizer/src/Utils.cs
+++ b/src/SingleProject/Resizetizer/src/Utils.cs
@@ -1,7 +1,6 @@
-﻿using System.Drawing;
-using System.Globalization;
-using System.IO;
+﻿using System.IO;
 using System.Text.RegularExpressions;
+using SkiaSharp;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Maui.Resizetizer.Tests")]
 
@@ -15,26 +14,25 @@ namespace Microsoft.Maui.Resizetizer
 		public static bool IsValidResourceFilename(string filename)
 			=> rxResourceFilenameValidation.IsMatch(Path.GetFileNameWithoutExtension(filename));
 
-		public static Color? ParseColorString(string tint)
+		public static SKColor? ParseColorString(string tint)
 		{
 			if (string.IsNullOrEmpty(tint))
 				return null;
 
-			if (int.TryParse(tint.Trim('#'), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var value))
-				return Color.FromArgb(value);
-
-			try
+			if (SKColor.TryParse(tint, out var color))
 			{
-				return Color.FromName(tint);
+				return color;
 			}
-			catch
+
+			if (ColorTable.TryGetNamedColor (tint, out color))
 			{
+				return color;
 			}
 
 			return null;
 		}
 
-		public static Size? ParseSizeString(string size)
+		public static SKSize? ParseSizeString(string size)
 		{
 			if (string.IsNullOrEmpty(size))
 				return null;
@@ -44,9 +42,9 @@ namespace Microsoft.Maui.Resizetizer
 			if (parts.Length > 0 && int.TryParse(parts[0], out var width))
 			{
 				if (parts.Length > 1 && int.TryParse(parts[1], out var height))
-					return new Size(width, height);
+					return new SKSize(width, height);
 				else
-					return new Size(width, width);
+					return new SKSize(width, width);
 			}
 
 			return null;

--- a/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpBitmapToolsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpBitmapToolsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing;
 using System.IO;
 using SkiaSharp;
 using Xunit;
@@ -110,7 +109,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
-				info.BaseSize = new Size(512, 512);
+				info.BaseSize = new SKSize(512, 512);
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -132,7 +131,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
-				info.BaseSize = new Size(512, 512);
+				info.BaseSize = new SKSize(512, 512);
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 0.5m);
 
@@ -154,7 +153,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
-				info.TintColor = Color.Red;
+				info.TintColor = SKColors.Red;
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -174,7 +173,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
-				info.TintColor = Color.FromArgb(127, Color.Red);
+				info.TintColor = SKColors.Red.WithAlpha(127);
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -194,7 +193,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.png";
-				info.TintColor = Color.FromName("Red");
+				info.TintColor = SKColors.Red;
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -214,7 +213,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
-				info.TintColor = Color.Red;
+				info.TintColor = SKColors.Red;
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -236,7 +235,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.png";
-				info.TintColor = Color.FromArgb(127, Color.Red);
+				info.TintColor = SKColors.Red.WithAlpha(127);
 				var tools = new SkiaSharpBitmapTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpSvgToolsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/SkiaSharpSvgToolsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing;
 using System.IO;
 using SkiaSharp;
 using Xunit;
@@ -110,7 +109,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
-				info.BaseSize = new Size(512, 512);
+				info.BaseSize = new SKSize(512, 512);
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -132,7 +131,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
-				info.BaseSize = new Size(512, 512);
+				info.BaseSize = new SKSize(512, 512);
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 0.5m);
 
@@ -154,7 +153,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
-				info.TintColor = Color.Red;
+				info.TintColor = SKColors.Red;
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -174,7 +173,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
-				info.TintColor = Color.FromArgb(127, Color.Red);
+				info.TintColor = SKColors.Red.WithAlpha(127);
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -194,7 +193,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera.svg";
-				info.TintColor = Color.FromName("Red");
+				info.TintColor = SKColors.Red;
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -214,7 +213,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
-				info.TintColor = Color.Red;
+				info.TintColor = SKColors.Red;
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 
@@ -236,7 +235,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			{
 				var info = new ResizeImageInfo();
 				info.Filename = "images/camera_color.svg";
-				info.TintColor = Color.FromArgb(127, Color.Red);
+				info.TintColor = SKColors.Red.WithAlpha(127);
 				var tools = new SkiaSharpSvgTools(info, Logger);
 				var dpiPath = new DpiPath("", 1);
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/UtilsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/UtilsTests.cs
@@ -1,4 +1,4 @@
-using System.Drawing;
+using SkiaSharp;
 using Xunit;
 
 namespace Microsoft.Maui.Resizetizer.Tests
@@ -8,23 +8,27 @@ namespace Microsoft.Maui.Resizetizer.Tests
 		public class ParseColorString
 		{
 			[Theory]
-			[InlineData("#12345678")]
-			[InlineData("12345678")]
-			public void ParsesHexValues(string hex)
+			[InlineData("#abcdef", 0xffabcdef)]
+			[InlineData("#12345678", 0x12345678)]
+			[InlineData("12345678", 0x12345678)]
+			public void ParsesHexValues(string hex, uint argb)
 			{
 				var parsed = Utils.ParseColorString(hex);
 
 				Assert.NotNull(parsed);
-				Assert.Equal(0x12345678, parsed?.ToArgb());
+				Assert.Equal(argb, parsed.Value);
 			}
 
-			[Fact]
-			public void ParsesNamedColors()
+			[Theory]
+			[InlineData("Red", 0xFFFF0000)]
+			[InlineData("Green", 0xFF008000)]
+			[InlineData("Blue", 0xFF0000FF)]
+			public void ParsesNamedColors(string name, uint argb)
 			{
-				var parsed = Utils.ParseColorString("Red");
+				var parsed = Utils.ParseColorString(name);
 
 				Assert.NotNull(parsed);
-				Assert.Equal(0xFFFF0000, unchecked((uint)parsed?.ToArgb()));
+				Assert.Equal(argb, parsed.Value);
 			}
 		}
 
@@ -38,7 +42,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var parsed = Utils.ParseSizeString(hex);
 
 				Assert.NotNull(parsed);
-				Assert.Equal(new Size(1, 2), parsed);
+				Assert.Equal(new SKSize(1, 2), parsed);
 			}
 
 			[Theory]


### PR DESCRIPTION
### Description of Change ###

I originally found `Utils.ParseColorString()` couldn't parse a color
like `#abcdef` correctly: the alpha comes out as zero.

I found that `SKColor.TryParse()` works correctly, so we should use
`SKColor`?

We are using SkiaSharp to render images, so it makes sense that we can
use SkiaSharp types here.

After these changes, the only place `System.Drawing` was still used
was `System.Drawing.Color.FromName()`, as I didn't find a `SKColor`
equivalent.

I ported `ColorTable` from System.Drawing.Common in dotnet/runtime:

https://github.com/dotnet/runtime/blob/776dd1d3318760bf2328f66a544ed377d78b2099/src/libraries/Common/src/System/Drawing/ColorTable.cs

Our version supports `SKColor` and `SKColors`, and should be fast
enough for our use within MSBuild tasks.

I was able to remove `System.Drawing.Common` completely.

### Additions made ###

* `internal ColorTable` class

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests