### PR TITLE
Port Image.Aspect

### DIFF
--- a/src/Compatibility/Core/src/Android/FastRenderers/ImageElementManager.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/ImageElementManager.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 				image.SetValueFromRenderer(Image.IsAnimationPlayingProperty, false);
 		}
 
+		[PortHandler]
 		static void UpdateAspect(IImageRendererController rendererController, ImageView Control, IImageElement newImage, IImageElement previous = null)
 		{
 			if (newImage == null || rendererController.IsDisposed)

--- a/src/Compatibility/Core/src/Android/Renderers/ImageExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ImageExtensions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		static ImageView.ScaleType s_aspectFill;
 		static ImageView.ScaleType s_aspectFit;
 
+		[PortHandler]
 		public static ImageView.ScaleType ToScaleType(this Aspect aspect)
 		{
 			switch (aspect)

--- a/src/Compatibility/Core/src/Android/Renderers/ImageRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ImageRenderer.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			Log.Warning(nameof(ImageRenderer), "Animations do not work with Legacy Renderers. Please remove the \"UseLegacyRenderers\" flag or change your renderer to inherit from the fast image renderer.");
 		}
 
+		[PortHandler]
 		void UpdateAspect()
 		{
 			if (Element == null || Control == null || Control.IsDisposed())

--- a/src/Compatibility/Core/src/iOS/Renderers/ImageElementManager.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/ImageElementManager.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 
 
+		[PortHandler("Only the __MOBILE__ reference was ported.")]
 		public static void SetAspect(IImageVisualElementRenderer renderer, IImageElement imageElement)
 		{
 			var Element = renderer.Element;

--- a/src/Compatibility/Core/src/iOS/Renderers/ImageRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/ImageRenderer.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {
 	public static class ImageExtensions
 	{
+		[PortHandler]
 		public static UIViewContentMode ToUIViewContentMode(this Aspect aspect)
 		{
 			switch (aspect)

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -9,6 +9,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Essentials;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.LifecycleEvents;
+using Aspect = Microsoft.Maui.Aspect;
 using Debug = System.Diagnostics.Debug;
 
 namespace Maui.Controls.Sample.Pages
@@ -212,6 +213,7 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new TimePicker { Time = TimeSpan.FromHours(8), CharacterSpacing = 6 });
 
 			verticalStack.Add(new Image() { Source = "dotnet_bot.png" });
+			verticalStack.Add(new Image() { Source = "dotnet_bot.png", Aspect = Aspect.AspectFill });
 
 			Content = new ScrollView
 			{

--- a/src/Core/src/Core/IAspect.cs
+++ b/src/Core/src/Core/IAspect.cs
@@ -1,0 +1,7 @@
+namespace Microsoft.Maui
+{
+	public interface IAspect
+	{
+		Aspect Aspect { get; }
+	}
+}

--- a/src/Core/src/Core/IImage.cs
+++ b/src/Core/src/Core/IImage.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.Maui
+{
+	public interface IImage : IAspect
+	{
+	}
+}

--- a/src/Core/src/Core/IImage.cs
+++ b/src/Core/src/Core/IImage.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.Maui
 {
-	public interface IImage : IAspect
+	public interface IImage : IView, IAspect
 	{
 	}
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapAspect(ImageHandler handler, IImage image)
 		{
-			// TODO NATIVE IMPLEMENTATION
+			handler.NativeView?.UpdateAspect(image);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -1,0 +1,17 @@
+using AndroidX.AppCompat.Widget;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ImageHandler : ViewHandler<IImage, AppCompatImageView>
+	{
+		protected override AppCompatImageView CreateNativeView()
+		{
+			return new AppCompatImageView(Context);
+		}
+
+		public static void MapAspect(ImageHandler handler, IImage image)
+		{
+			// TODO NATIVE IMPLEMENTATION
+		}
+	}
+}

--- a/src/Core/src/Handlers/Image/ImageHandler.Standard.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Standard.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ImageHandler : ViewHandler<IImage, object>
+	{
+		protected override object CreateNativeView() => throw new NotImplementedException();
+		
+		public static void MapAspect(IViewHandler handler, IImage image) { }
+	}
+}

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -1,0 +1,20 @@
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ImageHandler
+	{
+		public static PropertyMapper<IImage, ImageHandler> ImageMapper = new PropertyMapper<IImage, ImageHandler>(ViewHandler.ViewMapper)
+		{
+			[nameof(IImage.Aspect)] = MapAspect,
+		};
+
+		public ImageHandler() : base(ImageMapper)
+		{
+			
+		}
+
+		public ImageHandler(PropertyMapper? mapper = null) : base(mapper ?? ImageMapper)
+		{
+			
+		}
+	}
+}

--- a/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
@@ -1,0 +1,17 @@
+using UIKit;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ImageHandler : ViewHandler<IImage, UIImageView>
+	{
+		protected override UIImageView CreateNativeView()
+		{
+			return new UIImageView();
+		}
+		
+		public static void MapAspect(ImageHandler handler, IImage image)
+		{
+			// TODO NATIVE IMPLEMENTATION
+		}
+	}
+}

--- a/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Handlers
 		
 		public static void MapAspect(ImageHandler handler, IImage image)
 		{
-			// TODO NATIVE IMPLEMENTATION
+			handler.NativeView?.UpdateAspect(image);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageViewExtensions.cs
@@ -1,0 +1,21 @@
+using Android.Widget;
+using AndroidX.AppCompat.Widget;
+
+namespace Microsoft.Maui
+{
+	public static class ImageViewExtensions
+	{
+		public static void UpdateAspect(this AppCompatImageView imageView, IImage image)
+		{
+			var scaleType = image.Aspect switch
+			{
+				Aspect.Fill => ImageView.ScaleType.FitXy,
+				Aspect.AspectFill => ImageView.ScaleType.CenterCrop,
+				Aspect.AspectFit => ImageView.ScaleType.FitCenter,
+				_ => ImageView.ScaleType.FitCenter
+			};
+			
+			imageView.SetScaleType(scaleType);
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageViewExtensions.cs
@@ -5,14 +5,18 @@ namespace Microsoft.Maui
 {
 	public static class ImageViewExtensions
 	{
+		static ImageView.ScaleType? s_fill;
+		static ImageView.ScaleType? s_aspectFill;
+		static ImageView.ScaleType? s_aspectFit;
+		
 		public static void UpdateAspect(this AppCompatImageView imageView, IImage image)
 		{
 			var scaleType = image.Aspect switch
 			{
-				Aspect.Fill => ImageView.ScaleType.FitXy,
-				Aspect.AspectFill => ImageView.ScaleType.CenterCrop,
-				Aspect.AspectFit => ImageView.ScaleType.FitCenter,
-				_ => ImageView.ScaleType.FitCenter
+				Aspect.Fill => s_fill ??= ImageView.ScaleType.FitXy,
+				Aspect.AspectFill => s_aspectFill ??= ImageView.ScaleType.CenterCrop,
+				Aspect.AspectFit => s_aspectFit ??= ImageView.ScaleType.FitCenter,
+				_ => s_aspectFit ??= ImageView.ScaleType.FitCenter
 			};
 			
 			imageView.SetScaleType(scaleType);

--- a/src/Core/src/Platform/iOS/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ImageViewExtensions.cs
@@ -1,0 +1,20 @@
+using UIKit;
+
+namespace Microsoft.Maui
+{
+	public static class ImageViewExtensions
+	{
+		public static void UpdateAspect(this UIImageView imageView, IImage image)
+		{
+			var contentMode = image.Aspect switch
+			{
+				Aspect.Fill => UIViewContentMode.ScaleToFill,
+				Aspect.AspectFill => UIViewContentMode.ScaleAspectFill,
+				Aspect.AspectFit => UIViewContentMode.ScaleAspectFit,
+				_ => UIViewContentMode.ScaleAspectFit
+			};
+
+			imageView.ContentMode = contentMode;
+		}
+	}
+}

--- a/src/Core/src/Primitives/Aspect.cs
+++ b/src/Core/src/Primitives/Aspect.cs
@@ -1,4 +1,4 @@
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui
 {
 	public enum Aspect
 	{

--- a/src/Core/src/Primitives/Aspect.cs
+++ b/src/Core/src/Primitives/Aspect.cs
@@ -1,9 +1,0 @@
-namespace Microsoft.Maui
-{
-	public enum Aspect
-	{
-		AspectFit,
-		AspectFill,
-		Fill
-	}
-}

--- a/src/Core/src/Primitives/Aspect.cs
+++ b/src/Core/src/Primitives/Aspect.cs
@@ -1,0 +1,9 @@
+namespace Microsoft.Maui
+{
+	public enum Aspect
+	{
+		AspectFit,
+		AspectFill,
+		Fill
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using Android.Widget;
+using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ImageHandlerTests
+	{
+		[Fact(DisplayName = "Aspect Initializes Correctly")]
+		public async Task AspectInitializesCorrectly()
+		{
+			var xplatAspect = Aspect.Fill;
+			var image = new ImageStub()
+			{
+				Aspect = xplatAspect
+			};
+			
+			ImageView.ScaleType expectedValue = ImageView.ScaleType.FitXy;
+
+			var values = await GetValueAsync(image, (handler) =>
+			{
+				return new
+				{
+					ViewValue = image.Aspect,
+					NativeViewValue = GetNativeAspect(handler)
+				};
+			});
+			
+			Assert.Equal(xplatAspect, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue);
+		}
+
+		AppCompatImageView GetNativeImage(ImageHandler imageHandler) =>
+			(AppCompatImageView)imageHandler.NativeView;
+
+		ImageView.ScaleType GetNativeAspect(ImageHandler imageHandler) =>
+			GetNativeImage(imageHandler).GetScaleType();
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Image)]
+	public partial class ImageHandlerTests : HandlerTestBase<ImageHandler, ImageStub>
+	{
+		
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.iOS.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ImageHandlerTests
+	{
+		[Fact(DisplayName = "Aspect Initializes Correctly")]
+		public async Task AspectInitializesCorrectly()
+		{
+			var xplatAspect = Aspect.Fill;
+			var image = new ImageStub()
+			{
+				Aspect = xplatAspect
+			};
+			
+			UIViewContentMode expectedValue = UIViewContentMode.ScaleToFill;
+
+			var values = await GetValueAsync(image, (handler) =>
+			{
+				return new
+				{
+					ViewValue = image.Aspect,
+					NativeViewValue = GetNativeAspect(handler)
+				};
+			});
+			
+			Assert.Equal(xplatAspect, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue);
+		}
+
+		UIImageView GetNativeImage(ImageHandler imageHandler) =>
+			(UIImageView)imageHandler.NativeView;
+
+		UIViewContentMode GetNativeAspect(ImageHandler imageHandler) =>
+			GetNativeImage(imageHandler).ContentMode;
+	}
+}

--- a/src/Core/tests/DeviceTests/Stubs/ImageStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ImageStub.cs
@@ -1,0 +1,7 @@
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public partial class ImageStub : StubBase, IImage
+	{
+		public Aspect Aspect { get; set; }
+	}
+}

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -18,5 +18,6 @@
 		public const string TextFormatting = "Formatting";
 		public const string TimePicker = "TimePicker";
 		public const string View = "View";
+		public const string Image = "Image";
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implements #400

### Additions made ###

* Moves Aspect enum to Maui core project
* Creates IAspect interface with Aspect property
* Creates IImage interface and implement IAspect and IView
* Adds Aspect property map to ImageHandler
* Adds Aspect mapping methods to ImageHandler for Android and iOS
* Adds extension methods to apply Aspect on Android and iOS
* Adds DeviceTests for initial Aspect values on Android and iOS

### PR Checklist ###

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

### Doubts

#### Original reference of Aspect enum
The Aspect enum already existed inside the `Controls.Core` project, so I needed to move this implementation to the `Core` project. It is right?

#### Custom ImageView implementations
There are custom implementations of ImageView inside Android and iOS renderers. These classes are `FormsImageView` and `FormsUIImageView`. I didn't use them to specify in the `ImageHandler`, but I believe that should be important to do this. Should I use these custom ImageView implementations? Should I move these implementations to `Core` project?

#### ImageView Android implementation
The original implementation of Android custom renderer uses the `ImageView` class of `Android.Widget`. However, in the handler implementation, I used `AppCompatImageView` class of `AndroidX.AppCompat.Widget`. I believe that is the best way, but I was in doubt if I need to maintain the original implementation. Should I use the `AppCompatImageView`?