### PR TITLE
Bump to new AndroidX packages

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <_AndroidXVersion>net6preview01</_AndroidXVersion>
+    <_AndroidXVersion>net6preview03.4680155</_AndroidXVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference
@@ -17,7 +17,7 @@
     />
     <PackageReference
         Update="Xamarin.AndroidX.Lifecycle.LiveData"
-        Version="2.3.0.1-$(_AndroidXVersion)"
+        Version="2.3.1-$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.MediaRouter"
@@ -29,7 +29,7 @@
     />
     <PackageReference
         Update="Xamarin.AndroidX.RecyclerView"
-        Version="1.1.0.8-net6preview01"
+        Version="1.2.0-$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.Build.Download"

--- a/src/Compatibility/Core/src/Android/CollectionView/SelectableItemsViewAdapter.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/SelectableItemsViewAdapter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			for (int i = 0; i < _currentViewHolders.Count; i++)
 			{
-				if (_currentViewHolders[i].AdapterPosition == position)
+				if (_currentViewHolders[i].BindingAdapterPosition == position)
 				{
 					_currentViewHolders[i].IsSelected = true;
 					return;

--- a/src/Compatibility/Core/src/Android/CollectionView/SelectableViewHolder.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/SelectableViewHolder.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		{
 			if (_isSelectionEnabled)
 			{
-				OnViewHolderClicked(AdapterPosition);
+				OnViewHolderClicked(BindingAdapterPosition);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

We have new AndroidX packages produced from:

https://github.com/xamarin/AndroidX/pull/247

After updating I ran into:

    C:\src\maui\src\Compatibility\Core\src\Android\CollectionView\SelectableViewHolder.cs(44,25):
        error CS0618: 'RecyclerView.ViewHolder.AdapterPosition' is obsolete: 'deprecated' [C:\src\maui\src\Compatibility\Core\src\Compatibility-net6.csproj]
    C:\src\maui\src\Compatibility\Core\src\Android\CollectionView\SelectableItemsViewAdapter.cs(70,9):
        error CS0618: 'RecyclerView.ViewHolder.AdapterPosition' is obsolete: 'deprecated' [C:\src\maui\src\Compatibility\Core\src\Compatibility-net6.csproj]
        0 Warning(s)
        2 Error(s)

`AdapterPosition` is indeed obsolete:

https://stackoverflow.com/a/63148812

It appears we can use `BindingAdapterPosition`, because the deprecated
code is basically:

```java
@Deprecated
public final int getAdapterPosition() {
    return getBindingAdapterPosition();
}
```

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests