### PR TITLE
[singleproject] fix @(MauiSplashScreen) on iOS

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -79,6 +79,7 @@
         <ResizetizeDependsOnTargets>
             $(ResizetizeDependsOnTargets);
             ResizetizeCollectItems;
+            ProcessMauiSplashScreens;
         </ResizetizeDependsOnTargets>
         <ProcessMauiFontsDependsOnTargets>
             $(ProcessMauiFontsDependsOnTargets);


### PR DESCRIPTION
### Description of Change ###

On iOS if you have a project with:

    <MauiSplashScreen Include="foo.svg" Color="Red" />

The color red displays, but the image is missing?

However, a project like this works fine:

    <MauiSplashScreen Include="foo.svg" Color="Red" />
    <MauiImage Include="foo.svg" />

It turns out that targets were running in the order:

    Target Name=ResizetizeCollectItems Project=SplashDemo.csproj
    Target Name=ResizetizeImages Project=SplashDemo.csproj
    Target Name=ProcessMauiSplashScreens Project=SplashDemo.csproj
    Target Name=ProcessMauiFonts Project=SplashDemo.csproj

`ProcessMauiSplashScreens` adds the splash screen to `@(MauiImage)`,
so we need to make sure `ProcessMauiSplashScreens` runs before
`ResizetizeImages`.

For iOS the build ordering is slightly different than Android, which
is why it appears to work without this change on Android.

It also worked in the samples I tried, because I was using the app
icon foreground as the splash screen image:

    <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
    <MauiSplashScreen Include="Resources\AppIcons\appicon_foreground.svg" Color="#FF69B4" />

/cc @davidortinau 

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests
