### PR TITLE
Implement WinUI SliderHandler events (DragStarted, etc)

### DIFF
--- a/src/Compatibility/Core/src/WinUI/SliderRenderer.cs
+++ b/src/Compatibility/Core/src/WinUI/SliderRenderer.cs
@@ -228,16 +228,19 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		protected override bool PreventGestureBubbling { get; set; } = true;
 
+		[PortHandler]
 		void OnNativeValueChanged(object sender, RangeBaseValueChangedEventArgs e)
 		{
 			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, e.NewValue);
 		}
 
+		[PortHandler]
 		void OnPointerPressed(object sender, PointerRoutedEventArgs e)
 		{
 			((ISliderController)Element)?.SendDragStarted();
 		}
 
+		[PortHandler]
 		void OnPointerReleased(object sender, PointerRoutedEventArgs e)
 		{
 			((ISliderController)Element)?.SendDragCompleted();

--- a/src/Controls/src/Core/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/AppHostBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			if (!UI.Xaml.Application.Current.Resources.ContainsKey("MauiControlsPageControlStyle"))
 			{
 				var myResourceDictionary = new Microsoft.UI.Xaml.ResourceDictionary();
-				myResourceDictionary.Source = new Uri("ms-appx:///Microsoft.Maui.Controls/Maui/Platform/Windows/Styles/Resources.xbf");
+				myResourceDictionary.Source = new Uri("ms-appx:///Microsoft.Maui.Controls/Platform/Windows/Styles/Resources.xbf");
 				Microsoft.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(myResourceDictionary);
 			}
 #endif

--- a/src/Core/src/Platform/Windows/SliderExtensions.cs
+++ b/src/Core/src/Platform/Windows/SliderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 
@@ -6,14 +7,23 @@ namespace Microsoft.Maui
 {
 	public static class SliderExtensions
 	{
+		static void UpdateIncrement(this Slider nativeSlider, ISlider slider)
+		{
+			double stepping = Math.Min((slider.Maximum - slider.Minimum) / 1000, 1);
+			nativeSlider.StepFrequency = stepping;
+			nativeSlider.SmallChange = stepping;
+		}
+
 		public static void UpdateMinimum(this Slider nativeSlider, ISlider slider)
 		{
 			nativeSlider.Minimum = slider.Minimum;
+			nativeSlider.UpdateIncrement(slider);
 		}
 
 		public static void UpdateMaximum(this Slider nativeSlider, ISlider slider)
 		{
 			nativeSlider.Maximum = slider.Maximum;
+			nativeSlider.UpdateIncrement(slider);
 		}
 
 		public static void UpdateValue(this Slider nativeSlider, ISlider slider)


### PR DESCRIPTION
### Description of Change ###

Implement WinUI SliderHandler events:
- DragStarted
- DragCompleted

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
No