### PR TITLE
ContainerViewControllers should use the correct background color.

### DIFF
--- a/src/Core/src/Platform/iOS/ContainerViewController.cs
+++ b/src/Core/src/Platform/iOS/ContainerViewController.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Maui
 				return;
 			_view = view;
 
+			if (view is IPage page)
+				Title = page.Title;
+
 			if (_view is IHotReloadableView ihr)
 			{
 				ihr.ReloadHandler = this;
@@ -59,6 +62,8 @@ namespace Microsoft.Maui
 			currentNativeView = _pendingLoadedView ?? CreateNativeView(view);
 			_pendingLoadedView = null;
 			View!.AddSubview(currentNativeView);
+			if (view.BackgroundColor == null)
+				View.BackgroundColor = UIColor.SystemBackgroundColor;
 		}
 
 		protected virtual UIView CreateNativeView(IView view)


### PR DESCRIPTION
The Container ViewController has a default value of null. This clashes with Light/Dark themes. This change sets the background color to match the correct background color if no color was set on the View/Page.

We also set the ViewController Title if its a page.