### PR TITLE
Cache grid structure to prevent extra measure calls during arrange

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Maui.Layouts
 {
 	public class GridLayoutManager : LayoutManager
 	{
+		GridStructure? _gridStructure;
+
 		public GridLayoutManager(IGridLayout layout) : base(layout)
 		{
 			Grid = layout;
@@ -16,14 +18,14 @@ namespace Microsoft.Maui.Layouts
 
 		public override Size Measure(double widthConstraint, double heightConstraint)
 		{
-			var structure = new GridStructure(Grid, widthConstraint, heightConstraint);
+			_gridStructure = new GridStructure(Grid, widthConstraint, heightConstraint);
 
-			return new Size(structure.GridWidth(), structure.GridHeight());
+			return new Size(_gridStructure.GridWidth(), _gridStructure.GridHeight());
 		}
 
 		public override void ArrangeChildren(Rectangle childBounds)
 		{
-			var structure = new GridStructure(Grid, childBounds.Width, childBounds.Height);
+			var structure = _gridStructure ?? new GridStructure(Grid, childBounds.Width, childBounds.Height);
 
 			foreach (var view in Grid.Children)
 			{
@@ -173,6 +175,7 @@ namespace Microsoft.Maui.Layouts
 					if (cell.ColumnGridLengthType == GridLengthType.Absolute
 						&& cell.RowGridLengthType == GridLengthType.Absolute)
 					{
+						//_grid.Children[cell.ViewIndex].Measure(_columns[cell.Column].Size, _rows[cell.Row].Size);
 						continue;
 					}
 

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -175,7 +175,6 @@ namespace Microsoft.Maui.Layouts
 					if (cell.ColumnGridLengthType == GridLengthType.Absolute
 						&& cell.RowGridLengthType == GridLengthType.Absolute)
 					{
-						//_grid.Children[cell.ViewIndex].Measure(_columns[cell.Column].Size, _rows[cell.Row].Size);
 						continue;
 					}
 


### PR DESCRIPTION
When determining the grid structure and cell sizes, the contents of the grid need to be measured (for Auto cells). The measure and arrange steps in the GridLayoutManager were recreating the grid structure each time, which meant that controls were getting a second (and unnecessary) measure pass during arrangement. 

This change caches the structure during measure to avoid the extra passes (and avoid an incorrect native-side setting of DesiredSize for grids on Windows, which would result in Auto rows/columns disappearing entirely). 

Calls to Arrange with different size values than those used during Measure shouldn't be happening, so the naïve caching between the two calls should be fine. If that starts to be a problem with more complex layouts later, we'll cross that bridge then.