### PR TITLE
Copy all upstream XBF files downstream

### DIFF
--- a/eng/package.ps1
+++ b/eng/package.ps1
@@ -56,14 +56,14 @@ if ($IsWindows)
             /p:SymbolPackageFormat=snupkg `
             /restore `
             /t:build `
-            /p:Packing=true `
+            /p:Packing=true /p:DisableEmbeddedXbf=false `
             /bl:"$artifacts/maui-build-$configuration.binlog"
 
         & $msbuild $sln `
             /p:configuration=$configuration `
             /p:SymbolPackageFormat=snupkg `
             /t:pack `
-            /p:Packing=true `
+            /p:Packing=true /p:DisableEmbeddedXbf=false `
             /bl:"$artifacts/maui-pack-$configuration.binlog"
     }
     finally

--- a/eng/package.ps1
+++ b/eng/package.ps1
@@ -1,5 +1,5 @@
 param(
-  [string] $configuration = 'Debug',
+  [string] $configuration = 'Release',
   [string] $msbuild = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
 )
 
@@ -56,14 +56,14 @@ if ($IsWindows)
             /p:SymbolPackageFormat=snupkg `
             /restore `
             /t:build `
-            /p:Packing=true /p:DisableEmbeddedXbf=false `
+            /p:Packing=true `
             /bl:"$artifacts/maui-build-$configuration.binlog"
 
         & $msbuild $sln `
             /p:configuration=$configuration `
             /p:SymbolPackageFormat=snupkg `
             /t:pack `
-            /p:Packing=true /p:DisableEmbeddedXbf=false `
+            /p:Packing=true `
             /bl:"$artifacts/maui-pack-$configuration.binlog"
     }
     finally

--- a/eng/package.ps1
+++ b/eng/package.ps1
@@ -1,5 +1,5 @@
 param(
-  [string] $configuration = 'Release',
+  [string] $configuration = 'Debug',
   [string] $msbuild = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
 )
 

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -211,6 +211,7 @@ stages:
                   **/Microsoft.AspNetCore.Components.WebView.Maui.*.nupkg
                   **/Microsoft.AspNetCore.Components.WebView.Maui.*.snupkg
                   **/SignList.xml
+                  **/*.binlog
                 TargetFolder: $(build.artifactstagingdirectory)
                 flattenFolders: true
             - task: PublishBuildArtifacts@1

--- a/src/Compatibility/Core/src/Compatibility-net6.csproj
+++ b/src/Compatibility/Core/src/Compatibility-net6.csproj
@@ -97,6 +97,6 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />
-    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui.Controls.Compatibility\%(RecursiveDir)%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui.Controls.Compatibility\%(RecursiveDir)%(FileName)%(Extension)" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\%(RecursiveDir)%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/src/Controls/src/Core/Controls.Core-net6.csproj
+++ b/src/Controls/src/Core/Controls.Core-net6.csproj
@@ -25,4 +25,8 @@
       <TargetPlatformIdentifierAdjusted>UAP</TargetPlatformIdentifierAdjusted>
     </PropertyGroup>
   </Target>
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.Controls.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\%(RecursiveDir)%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\%(RecursiveDir)%(FileName)%(Extension)" />
+  </ItemGroup>
 </Project>

--- a/src/Controls/src/Core/Platform/Windows/Styles/Resources.xaml
+++ b/src/Controls/src/Core/Platform/Windows/Styles/Resources.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	x:Class="Microsoft.Maui.Resources">
+	x:Class="Microsoft.Maui.Controls.Platform.Resources">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="MauiControlsCommandBarStyle.xaml" />

--- a/src/Core/src/Core-net6.csproj
+++ b/src/Core/src/Core-net6.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui.pri" Visible="False" Pack="True" PackagePath="runtimes\$(WindowsTargetFramework)\native" />
-    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\Microsoft.Maui\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\Microsoft.Maui\%(RecursiveDir)%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\Microsoft.Maui\%(RecursiveDir)%(FileName)%(Extension)" />
+    <None Include="bin\$(Configuration)\$(WindowsTargetFramework)\**\*.xbf" Visible="False" Pack="True" PackagePath="lib\$(WindowsTargetFramework)\%(RecursiveDir)%(FileName)%(Extension);runtimes\$(WindowsTargetFramework)\native\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION

### Description of Change ###

- Copy all upstream xbf files to downstream nugets (this is probably wrong but not sure how to do it a different way)
- Fixed the binlogs so those copy up
- fixed the name space on the resource file inside controls
