### PR TITLE
Implement WinUI ProgressBarHandler native events

### DIFF
--- a/src/Compatibility/Core/src/WinUI/ProgressBarRenderer.cs
+++ b/src/Compatibility/Core/src/WinUI/ProgressBarRenderer.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 		}
 
+		[PortHandler]
 		void ProgressBarOnValueChanged(object sender, RangeBaseValueChangedEventArgs rangeBaseValueChangedEventArgs)
 		{
 			((IVisualElementController)Element)?.InvalidateMeasure(InvalidationTrigger.MeasureChanged);

--- a/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.Windows.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -6,9 +7,24 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override ProgressBar CreateNativeView() => new ProgressBar { Minimum = 0, Maximum = 1 };
 
+		protected override void ConnectHandler(ProgressBar nativeView)
+		{
+			nativeView.ValueChanged += OnProgressBarValueChanged;
+		}
+
+		protected override void DisconnectHandler(ProgressBar nativeView)
+		{
+			nativeView.ValueChanged -= OnProgressBarValueChanged;
+		}
+
 		public static void MapProgress(ProgressBarHandler handler, IProgress progress)	
 		{
 			handler.NativeView?.UpdateProgress(progress);
+		}
+
+		void OnProgressBarValueChanged(object? sender, RangeBaseValueChangedEventArgs rangeBaseValueChangedEventArgs)
+		{
+			VirtualView?.InvalidateMeasure();
 		}
 	}
 }

--- a/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.Windows.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿#nullable enable
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 
 namespace Microsoft.Maui.Handlers


### PR DESCRIPTION
### Description of Change ###

Implement WinUI ProgressBarHandler native events

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
No