### PR TITLE
[WiP] Expose the current app host

### DIFF
--- a/src/Core/src/Hosting/AppHost.cs
+++ b/src/Core/src/Hosting/AppHost.cs
@@ -4,6 +4,8 @@ namespace Microsoft.Maui.Hosting
 {
 	public static class AppHost
 	{
+		public static IAppHost? Current { get; internal set; } = null;
+
 		public static IAppHostBuilder CreateDefaultBuilder()
 		{
 			var builder = new AppHostBuilder();

--- a/src/Core/src/Hosting/AppHostBuilder.cs
+++ b/src/Core/src/Hosting/AppHostBuilder.cs
@@ -64,7 +64,11 @@ namespace Microsoft.Maui.Hosting
 
 			ConfigureServiceCollectionBuilders(_serviceProvider);
 
-			return new Internal.AppHost(_serviceProvider, null);
+			var appHost = new Internal.AppHost(_serviceProvider, null);
+
+			AppHost.Current = appHost;
+
+			return appHost;
 		}
 
 		public IAppHostBuilder ConfigureAppConfiguration(Action<HostBuilderContext, IConfigurationBuilder> configureDelegate)


### PR DESCRIPTION
### Description of Change ###

The main reason for this is that some people do not like DI. This at least gives them a way to access parts of Maui as well as use a basic services architecture like we had with `DependencyService` in Controls. In fact, that version should probably use this under the hood, although that was very dynamic.

In `DependencyService`, services could be registered at _any_ time and was always available - even before the app was started.

We need to consolidate this, but not sure the best way.