### PR TITLE
Fix colors for ToAndroid

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/ImageButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/ImageButtonRenderer.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		float IBorderVisualElementRenderer.ShadowRadius => Context.ToPixels(OnThisPlatform().GetShadowRadius());
 		float IBorderVisualElementRenderer.ShadowDx => Context.ToPixels(OnThisPlatform().GetShadowOffset().Width);
 		float IBorderVisualElementRenderer.ShadowDy => Context.ToPixels(OnThisPlatform().GetShadowOffset().Height);
-		AColor IBorderVisualElementRenderer.ShadowColor => OnThisPlatform().GetShadowColor().ToAndroid();
+		AColor IBorderVisualElementRenderer.ShadowColor => OnThisPlatform().GetShadowColor().ToAndroid(Colors.Black);
 		bool IBorderVisualElementRenderer.IsShadowEnabled() => OnThisPlatform().GetIsShadowEnabled();
 		bool IBorderVisualElementRenderer.UseDefaultPadding() => false;
 		bool IBorderVisualElementRenderer.UseDefaultShadow() => false;

--- a/src/Compatibility/Core/src/Android/Renderers/BorderDrawable.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/BorderDrawable.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				path.AddRoundRect(rect, borderRadius, borderRadius, APath.Direction.Cw);
 				paint.StrokeWidth = borderWidth;
 				paint.SetStyle(Paint.Style.Stroke);
-				paint.Color = BorderElement.BorderColor.ToAndroid();
+				paint.Color = BorderElement.BorderColor.ToAndroid(Graphics.Colors.Black);
 
 				canvas.DrawPath(path, paint);
 			}


### PR DESCRIPTION
### Description of Change ###

This most probably would resolve to black since default was all -1 and then cast to byte, which == 0.
