### PR TITLE
Make layouts responsive to control size changes

### DIFF
--- a/src/Compatibility/Core/src/Android/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/Android/RendererToHandlerShim.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 				VisualElementRenderer, widthConstraint, heightConstraint);
 		}
 
-		public override void SetFrame(Rectangle frame)
+		public override void NativeArrange(Rectangle frame)
 		{
 			// This is a hack to force the shimmed control to actually do layout; without this, some controls won't actually
 			// call OnLayout after SetFrame if their sizes haven't changed (e.g., ScrollView)
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			NativeView.Measure(MeasureSpecMode.Exactly.MakeMeasureSpec((int)frame.Width),
 				MeasureSpecMode.Exactly.MakeMeasureSpec((int)frame.Height));
 
-			base.SetFrame(frame);
+			base.NativeArrange(frame);
 		}
 	}
 }

--- a/src/Compatibility/Core/src/WinUI/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/WinUI/HandlerToRendererShim.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		void OnBatchCommitted(object sender, EventArg<VisualElement> e)
 		{
-			ViewHandler?.SetFrame(Element.Bounds);
+			ViewHandler?.NativeArrange(Element.Bounds);
 		}
 
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		void OnBatchCommitted(object sender, EventArg<VisualElement> e)
 		{
-			ViewHandler?.SetFrame(Element.Bounds);
+			ViewHandler?.NativeArrange(Element.Bounds);
 		}
 
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Compatibility/Core/src/iOS/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/iOS/RendererToHandlerShim.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			base.UpdateValue(property);
 			if (property == "Frame")
 			{
-				SetFrame(VisualElementRenderer.Element.Bounds);
+				NativeArrange(VisualElementRenderer.Element.Bounds);
 			}
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -49,6 +49,8 @@ namespace Maui.Controls.Sample.Pages
 			var horizontalStack = new HorizontalStackLayout() { Spacing = 2, BackgroundColor = Colors.CornflowerBlue };
 
 			verticalStack.Add(CreateSampleGrid());
+			verticalStack.Add(CreateResizingButton());
+
 			AddTextResizeDemo(verticalStack);
 
 			verticalStack.Add(new Label { Text = " ", Padding = new Thickness(10) });
@@ -235,6 +237,45 @@ namespace Maui.Controls.Sample.Pages
 			{
 				Content = verticalStack
 			};
+		}
+
+		Button CreateResizingButton() 
+		{
+			var initialWidth = 200;
+			var otherWidth = 100;
+
+			var initialHeight = 80;
+			var otherHeight = 140;
+
+			var count = 1;
+
+			var resizeButton = new Button { Text = "Resize", BackgroundColor = Colors.Gray,
+				WidthRequest = initialWidth, HeightRequest = initialHeight };
+
+			resizeButton.Clicked += (sender, args) => {
+
+				count += 1;
+
+				if (count == 1)
+				{
+					resizeButton.WidthRequest = initialWidth;
+					resizeButton.HeightRequest = initialHeight;
+				}
+				else if (count == 2)
+				{
+					resizeButton.WidthRequest = otherWidth;
+					resizeButton.HeightRequest = otherHeight;
+				}
+				else
+				{
+					// Go back to using whatever the layout gives us
+					resizeButton.WidthRequest = -1;
+					resizeButton.HeightRequest = -1;
+					count = 0;
+				}
+			};
+
+			return resizeButton;
 		}
 
 		void SetupCompatibilityLayout()

--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls
 			if (Content is IFrameworkElement element)
 			{
 				element.Arrange(bounds);
-				element.Handler?.SetFrame(element.Frame);
+				element.Handler?.NativeArrange(element.Frame);
 			}
 
 			return Frame.Size;

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls
 			if (Content is IFrameworkElement element)
 			{
 				element.Arrange(bounds);
-				element.Handler?.SetFrame(element.Frame);
+				element.Handler?.NativeArrange(element.Frame);
 			}
 
 			return Frame.Size;

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -66,9 +66,7 @@ namespace Microsoft.Maui.Controls
 
 		// InvalidateMeasureOverride provides a way to allow subclasses (e.g., Layout) to override InvalidateMeasure even though
 		// the interface has to be explicitly implemented to avoid conflict with the VisualElement.InvalidateMeasure method
-		protected virtual void InvalidateMeasureOverride()
-		{
-		}
+		protected virtual void InvalidateMeasureOverride() => Handler?.UpdateValue(nameof(IFrameworkElement.InvalidateMeasure));
 
 		void IFrameworkElement.InvalidateArrange()
 		{

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls.Layout2
 
 			foreach (var child in Children)
 			{
-				child.Handler?.SetFrame(child.Frame);
+				child.Handler?.NativeArrange(child.Frame);
 			}
 
 			return Frame.Size;

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Controls
 			if (width >= 0 && height >= 0)
 			{
 				// This is a temporary measure to keep the old layouts working 
-				Handler?.SetFrame(Bounds);
+				Handler?.NativeArrange(Bounds);
 			}
 		}
 

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1080,6 +1080,13 @@ namespace Microsoft.Maui.Controls
 			}
 
 			element.SelfConstraint = constraint;
+
+			if (element is IFrameworkElement fe)
+			{
+				fe.Handler?.UpdateValue(nameof(IFrameworkElement.Width));
+				fe.Handler?.UpdateValue(nameof(IFrameworkElement.Height));
+			}
+
 			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.SizeRequestChanged);
 		}
 

--- a/src/Core/src/Handlers/IViewHandler.cs
+++ b/src/Core/src/Handlers/IViewHandler.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Maui
 		IMauiContext? MauiContext { get; }
 		bool HasContainer { get; set; }
 		Size GetDesiredSize(double widthConstraint, double heightConstraint);
-		void SetFrame(Rectangle frame);
+		void NativeArrange(Rectangle frame);
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -21,9 +21,13 @@ namespace Microsoft.Maui.Handlers
 		{
 			[nameof(IView.AutomationId)] = MapAutomationId,
 			[nameof(IView.BackgroundColor)] = MapBackgroundColor,
-			[nameof(IView.Frame)] = MapFrame,
+			[nameof(IView.Width)] = MapWidth,
+			[nameof(IView.Height)] = MapHeight,
 			[nameof(IView.IsEnabled)] = MapIsEnabled,
 			[nameof(IView.Semantics)] = MapSemantics,
+			Actions = {
+					[nameof(IFrameworkElement.InvalidateMeasure)] = MapInvalidateMeasure
+				}
 		};
 
 		internal ViewHandler()
@@ -71,8 +75,7 @@ namespace Microsoft.Maui.Handlers
 
 		public abstract Size GetDesiredSize(double widthConstraint, double heightConstraint);
 
-		// TODO ezhart This should maybe be called NativeArrange or something
-		public abstract void SetFrame(Rectangle frame);
+		public abstract void NativeArrange(Rectangle frame);
 
 		private protected void ConnectHandler(NativeView? nativeView)
 		{
@@ -90,9 +93,14 @@ namespace Microsoft.Maui.Handlers
 			VirtualView = null;
 		}
 
-		public static void MapFrame(IViewHandler handler, IView view)
+		public static void MapWidth(IViewHandler handler, IView view)
 		{
-			handler.SetFrame(view.Frame);
+			((NativeView?)handler.NativeView)?.UpdateWidth(view);
+		}
+
+		public static void MapHeight(IViewHandler handler, IView view)
+		{
+			((NativeView?)handler.NativeView)?.UpdateHeight(view);
 		}
 
 		public static void MapIsEnabled(IViewHandler handler, IView view)
@@ -116,6 +124,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			MappingSemantics(handler, view);
 			((NativeView?)handler.NativeView)?.UpdateSemantics(view);
+		}
+
+		public static void MapInvalidateMeasure(IViewHandler handler, IView view) 
+		{
+			((NativeView?)handler.NativeView)?.InvalidateMeasure(view);
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Handlers
 		View? INativeViewHandler.NativeView => (View?)base.NativeView;
 		public Context? Context => MauiContext?.Context;
 
-		public override void SetFrame(Rectangle frame)
+		public override void NativeArrange(Rectangle frame)
 		{
 			var nativeView = NativeView;
 

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.MaciOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.MaciOS.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Graphics;
 using UIKit;
 
@@ -14,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 		UIView? INativeViewHandler.NativeView => (UIView?)base.NativeView;
 		UIViewController? INativeViewHandler.ViewController => null;
 
-		public override void SetFrame(Rectangle rect)
+		public override void NativeArrange(Rectangle rect)
 		{
 			if (NativeView != null)
 				NativeView.Frame = rect.ToCGRect();
@@ -22,10 +23,15 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			if (NativeView == null)
+			if (NativeView == null || VirtualView == null)
 			{
 				return new Size(widthConstraint, heightConstraint);
 			}
+
+			var explicitWidth = VirtualView.Width;
+			var explicitHeight = VirtualView.Height;
+			var hasExplicitWidth = explicitWidth >= 0;
+			var hasExplicitHeight = explicitHeight >= 0;
 
 			var sizeThatFits = NativeView.SizeThatFits(new CoreGraphics.CGSize((float)widthConstraint, (float)heightConstraint));
 
@@ -36,11 +42,11 @@ namespace Microsoft.Maui.Handlers
 			if (double.IsInfinity(size.Width) || double.IsInfinity(size.Height))
 			{
 				NativeView.SizeToFit();
-
 				size = new Size(NativeView.Frame.Width, NativeView.Frame.Height);
 			}
 
-			return size;
+			return new Size( hasExplicitWidth ? explicitWidth : size.Width, 
+				hasExplicitHeight ? explicitHeight : size.Height);
 		}
 
 		protected override void SetupContainer()
@@ -50,7 +56,6 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void RemoveContainer()
 		{
-
 
 		}
 	}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Standard.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Standard.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class ViewHandler<TVirtualView, TNativeView>
 	{
-		public override void SetFrame(Rectangle rect)
+		public override void NativeArrange(Rectangle rect)
 		{
 
 		}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
 
@@ -9,7 +8,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		FrameworkElement? INativeViewHandler.NativeView => (FrameworkElement?)base.NativeView;
 
-		public override void SetFrame(Rectangle rect)
+		public override void NativeArrange(Rectangle rect)
 		{
 			var nativeView = NativeView;
 
@@ -30,37 +29,11 @@ namespace Microsoft.Maui.Handlers
 			if (widthConstraint < 0 || heightConstraint < 0)
 				return Size.Zero;
 
-			var explicitWidth = VirtualView.Width;
-			var explicitHeight = VirtualView.Height;
-			var useExplicitWidth = explicitWidth >= 0;
-			var useExplicitHeight = explicitHeight >= 0;
-
-			if (useExplicitWidth)
-			{
-				widthConstraint = Math.Min(VirtualView.Width, widthConstraint);
-			}
-
-			if (useExplicitHeight)
-			{
-				heightConstraint = Math.Min(VirtualView.Height, heightConstraint);
-			}
-
 			var measureConstraint = new Windows.Foundation.Size(widthConstraint, heightConstraint);
 
 			NativeView.Measure(measureConstraint);
 
-			var desiredWidth = NativeView.DesiredSize.Width;
-			var desiredHeight = NativeView.DesiredSize.Height;
-
-			var resultWidth = useExplicitWidth 
-				? Math.Max(desiredWidth, explicitWidth) 
-				: desiredWidth;
-
-			var resultHeight = useExplicitHeight
-				? Math.Max(desiredHeight, explicitHeight)
-				: desiredHeight;
-
-			return new Size(resultWidth, resultHeight);
+			return new Size(NativeView.DesiredSize.Width, NativeView.DesiredSize.Height);
 		}
 
 		protected override void SetupContainer()

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -12,9 +12,7 @@ namespace Microsoft.Maui.Layouts
 
 		public override Size Measure(double widthConstraint, double heightConstraint)
 		{
-			var heightMeasureConstraint = ResolveConstraints(heightConstraint, Stack.Height);
-
-			var measure = Measure(heightMeasureConstraint, Stack.Spacing, Stack.Children);
+			var measure = Measure(heightConstraint, Stack.Spacing, Stack.Children);
 
 			var finalWidth = ResolveConstraints(widthConstraint, Stack.Width, measure.Width);
 

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -21,10 +21,6 @@ namespace Microsoft.Maui.Layouts
 			widthConstraint -= margin.HorizontalThickness;
 			heightConstraint -= margin.VerticalThickness;
 
-			// Determine whether the external constraints or the requested size values will determine the measurements
-			widthConstraint = LayoutManager.ResolveConstraints(widthConstraint, frameworkElement.Width);
-			heightConstraint = LayoutManager.ResolveConstraints(heightConstraint, frameworkElement.Height);
-
 			// Ask the handler to do the actual measuring								
 			var measureWithMargins = frameworkElement.Handler.GetDesiredSize(widthConstraint, heightConstraint);
 

--- a/src/Core/src/Layouts/LayoutManager.cs
+++ b/src/Core/src/Layouts/LayoutManager.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Layouts
 		public abstract Size Measure(double widthConstraint, double heightConstraint);
 		public abstract void ArrangeChildren(Rectangle childBounds);
 
+		// TODO ezhart after checking Android and iOS, refactor this
 		public static double ResolveConstraints(double externalConstraint, double desiredLength)
 		{
 			if (desiredLength == -1)
@@ -23,7 +24,9 @@ namespace Microsoft.Maui.Layouts
 				return externalConstraint;
 			}
 
-			return Math.Min(externalConstraint, desiredLength);
+			//return Math.Min(externalConstraint, desiredLength);
+
+			return externalConstraint;
 		}
 
 		public static double ResolveConstraints(double externalConstraint, double desiredLength, double measuredLength)
@@ -35,7 +38,8 @@ namespace Microsoft.Maui.Layouts
 			}
 
 			// User-specified length wins, subject to external constraints
-			return Math.Min(desiredLength, externalConstraint);
+			//return Math.Min(desiredLength, externalConstraint);
+			return externalConstraint;
 		}
 	}
 }

--- a/src/Core/src/Layouts/LayoutManager.cs
+++ b/src/Core/src/Layouts/LayoutManager.cs
@@ -1,5 +1,4 @@
 using System;
-using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Layouts
@@ -16,30 +15,16 @@ namespace Microsoft.Maui.Layouts
 		public abstract Size Measure(double widthConstraint, double heightConstraint);
 		public abstract void ArrangeChildren(Rectangle childBounds);
 
-		// TODO ezhart after checking Android and iOS, refactor this
-		public static double ResolveConstraints(double externalConstraint, double desiredLength)
+		public static double ResolveConstraints(double externalConstraint, double explicitLength, double measuredLength)
 		{
-			if (desiredLength == -1)
-			{
-				return externalConstraint;
-			}
-
-			//return Math.Min(externalConstraint, desiredLength);
-
-			return externalConstraint;
-		}
-
-		public static double ResolveConstraints(double externalConstraint, double desiredLength, double measuredLength)
-		{
-			if (desiredLength == -1)
+			if (explicitLength == -1)
 			{
 				// No user-specified length, so the measured value will be limited by the external constraint
 				return Math.Min(measuredLength, externalConstraint);
 			}
 
 			// User-specified length wins, subject to external constraints
-			//return Math.Min(desiredLength, externalConstraint);
-			return externalConstraint;
+			return Math.Min(explicitLength, externalConstraint);
 		}
 	}
 }

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -12,9 +12,7 @@ namespace Microsoft.Maui.Layouts
 
 		public override Size Measure(double widthConstraint, double heightConstraint)
 		{
-			var widthMeasureConstraint = ResolveConstraints(widthConstraint, Stack.Width);
-
-			var measure = Measure(widthMeasureConstraint, Stack.Spacing, Stack.Children);
+			var measure = Measure(widthConstraint, Stack.Spacing, Stack.Children);
 
 			var finalHeight = ResolveConstraints(heightConstraint, Stack.Height, measure.Height);
 

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -51,7 +51,10 @@ namespace Microsoft.Maui
 			ViewCompat.SetAccessibilityHeading(nativeView, semantics.IsHeading);
 		}
 
-		public static void InvalidateMeasure(this AView nativeView, IView view) { }
+		public static void InvalidateMeasure(this AView nativeView, IView view) 
+		{
+			nativeView.RequestLayout();
+		}
 
 		public static void UpdateWidth(this AView nativeView, IView view) 
 		{

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -50,5 +50,19 @@ namespace Microsoft.Maui
 			nativeView.ContentDescription = semantics.Description;
 			ViewCompat.SetAccessibilityHeading(nativeView, semantics.IsHeading);
 		}
+
+		public static void InvalidateMeasure(this AView nativeView, IView view) { }
+
+		public static void UpdateWidth(this AView nativeView, IView view) 
+		{
+			// GetDesiredSize will take the specified Width into account during the layout
+			nativeView.RequestLayout();
+		}
+
+		public static void UpdateHeight(this AView nativeView, IView view) 
+		{
+			// GetDesiredSize will take the specified Height into account during the layout
+			nativeView.RequestLayout();
+		}
 	}
 }

--- a/src/Core/src/Platform/Standard/ViewExtensions.cs
+++ b/src/Core/src/Platform/Standard/ViewExtensions.cs
@@ -9,5 +9,11 @@ namespace Microsoft.Maui
 		public static void UpdateAutomationId(this object nativeView, IView view) { }
 
 		public static void UpdateSemantics(this object nativeView, IView view) { }
+
+		public static void InvalidateMeasure(this object nativeView, IView view) { }
+
+		public static void UpdateWidth(this object nativeView, IView view) { }
+
+		public static void UpdateHeight(this object nativeView, IView view) { }
 	}
 }

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -60,5 +60,22 @@ namespace Microsoft.Maui
 			else
 				nativeControl.SetValue(property, value);
 		}
+
+		public static void InvalidateMeasure(this FrameworkElement nativeView, IView view) 
+		{
+			nativeView.InvalidateMeasure();
+		}
+
+		public static void UpdateWidth(this FrameworkElement nativeView, IView view)
+		{
+			// WinUI uses NaN for "unspecified"
+			nativeView.Width = view.Width >= 0 ? view.Width : double.NaN;
+		}
+
+		public static void UpdateHeight(this FrameworkElement nativeView, IView view)
+		{
+			// WinUI uses NaN for "unspecified"
+			nativeView.Height = view.Height >= 0 ? view.Height : double.NaN;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -1,6 +1,5 @@
 using System;
 using CoreGraphics;
-using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
 using UIKit;
 
@@ -75,5 +74,4 @@ namespace Microsoft.Maui
 			};
 		}
 	}
-
 }

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UIKit;
 
@@ -62,6 +63,38 @@ namespace Microsoft.Maui
 			}
 
 			return null;
+		}
+
+		public static void InvalidateMeasure(this UIView nativeView, IView view) { }
+
+		public static void UpdateWidth(this UIView nativeView, IView view)
+		{
+			if (view.Width == -1)
+			{
+				// Ignore the initial set of the height; the initial layout will take care of it
+				return;
+			}
+
+			UpdateFrame(nativeView, view);
+		}
+
+		public static void UpdateHeight(this UIView nativeView, IView view)
+		{
+			if (view.Height == -1)
+			{
+				// Ignore the initial set of the height; the initial layout will take care of it
+				return;
+			}
+
+			UpdateFrame(nativeView, view);
+		}
+
+		public static void UpdateFrame(UIView nativeView, IView view) 
+		{
+			// Updating the frame (assuming it's an actual change) will kick off a layout update
+			// Handling of the default (-1) width/height will be taken care of by GetDesiredSize
+			var currentFrame = nativeView.Frame;
+			nativeView.Frame = new CoreGraphics.CGRect(currentFrame.X, currentFrame.Y, view.Width, view.Height);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -65,7 +65,10 @@ namespace Microsoft.Maui
 			return null;
 		}
 
-		public static void InvalidateMeasure(this UIView nativeView, IView view) { }
+		public static void InvalidateMeasure(this UIView nativeView, IView view) 
+		{
+			nativeView.SetNeedsLayout();
+		}
 
 		public static void UpdateWidth(this UIView nativeView, IView view)
 		{

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -124,7 +124,6 @@ namespace Microsoft.Maui
 			_cachedKeys = null;
 		}
 
-
 		public override (Action<IViewHandler, IFrameworkElement>? Action, bool RunOnUpdateAll) Get(string key)
 		{
 			if (_mapper.TryGetValue(key, out var action))
@@ -141,9 +140,6 @@ namespace Microsoft.Maui
 
 		IEnumerator IEnumerable.GetEnumerator() => _mapper.GetEnumerator();
 	}
-
-
-
 
 	public class PropertyMapper<TVirtualView> : PropertyMapper<TVirtualView, IViewHandler>
 		where TVirtualView : IFrameworkElement

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Color BackgroundColor { get; set; }
 
-		public Rectangle Frame { get; set; } = new Rectangle(0, 0, 20, 20);
+		public Rectangle Frame { get; set; }
 
 		public IViewHandler Handler { get; set; }
 
@@ -20,9 +20,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Size DesiredSize { get; set; } = new Size(20, 20);
 
-		public double Width { get; set; }
+		public double Width { get; set; } = 20;
 
-		public double Height { get; set; }
+		public double Height { get; set; } = 20;
 
 		public Thickness Margin { get; set; }
 

--- a/src/Core/tests/UnitTests/Layouts/ConstraintTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/ConstraintTests.cs
@@ -7,21 +7,11 @@ namespace Microsoft.Maui.UnitTests.Layouts
 	public class ConstraintTests
 	{
 		[Theory("When resolving constraints, external constraints take precedence")]
-		[InlineData(100, 200, 100)]
-		[InlineData(100, 100, 100)]
-		[InlineData(100, -1, 100)]
-		public void ExternalWinsOverDesired(double externalConstraint, double desiredLength, double expected)
-		{
-			var resolution = LayoutManager.ResolveConstraints(externalConstraint, desiredLength);
-			Assert.Equal(expected, resolution);
-		}
-
-		[Theory("When resolving constraints, external constraints take precedence")]
 		[InlineData(100, 200, 130, 100)]
 		[InlineData(100, -1, 130, 100)]
-		public void ExternalWinsOverDesiredAndMeasured(double externalConstraint, double desiredLength, double measured, double expected)
+		public void ExternalWinsOverDesiredAndMeasured(double externalConstraint, double explicitLength, double measured, double expected)
 		{
-			var resolution = LayoutManager.ResolveConstraints(externalConstraint, desiredLength, measured);
+			var resolution = LayoutManager.ResolveConstraints(externalConstraint, explicitLength, measured);
 			Assert.Equal(expected, resolution);
 		}
 

--- a/src/Core/tests/UnitTests/PropertyMapperTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperTests.cs
@@ -133,8 +133,6 @@ namespace Microsoft.Maui.UnitTests
 			Assert.True(wasMapper2Called);
 		}
 
-
-
 		[Fact]
 		public void GenericMappersWorks()
 		{


### PR DESCRIPTION
These changes make the layouts and controls respond to explicit Height/Width changes on views. Works on Windows, Android, iOS.

This also 
- replaces MapFrame with MapWidth and MapHeight
- changes SetFrame -> NativeArrange
- makes explicit Height/Width work on iOS
- fixes some explicit Height/Width problems on Windows