### PR TITLE
Add extra bounds check to avoid margin loop

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -48,9 +48,16 @@ namespace Microsoft.Maui.Controls
 		// the interface has to be explicitly implemented to avoid conflict with the old Arrange method
 		protected virtual Size ArrangeOverride(Rectangle bounds)
 		{
-			// Setting Bounds here is equivalent to setting the Frame
-			Bounds = this.ComputeFrame(bounds);
-
+			// We check the previous bounds here to avoid getting into a loop caused by the OnSizeAllocated override
+			// in View.cs; the arrange it forces ends up back here and if we have a margin, ComputeFrame will 
+			// keep applying it in a loop until the element disappears. Hopefully we can remove the OnSizeAllocated 
+			// hack at some point and avoid this extra check.
+			if(Bounds != bounds)
+			{
+				// Setting Bounds here is equivalent to setting the Frame
+				Bounds = this.ComputeFrame(bounds);
+			}
+			
 			return Frame.Size;
 		}
 


### PR DESCRIPTION
We've got a hack in to keep the legacy layouts working, but it causes an extra bounds set when it forces an arrange. Which is fine if the bounds don't have a margin; the bounds are set to the same value, which does nothing and the loop is broken.

But if we have a margin, the arrange will account for it by setting the bounds smaller (by the margin size); since this is a new value, the the process starts looping with the bounds getting smaller each time until the view collapses entirely.

This adds an extra check to prevent that problem until we can get rid of the legacy layout hack.