### PR TITLE
Handle bounds loop ejection when bounds are very, very close but not quite equal

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -44,6 +44,40 @@ namespace Microsoft.Maui.Controls
 			return ArrangeOverride(bounds);
 		}
 
+		// The CloseEnough methods will likely go away once we get rid of the cause (see comments below); if not, we'll
+		// add a proper extension method or add a compare method to MG with a tolerance parameter
+		bool CloseEnough(double a, double b) 
+		{
+			const double tolerance = 0.0001;
+
+			return (Math.Abs(a - b) < tolerance);
+		}
+
+		bool CloseEnough(Rectangle currentBounds, Rectangle newBounds) 
+		{
+			if (!CloseEnough(currentBounds.X, newBounds.X))
+			{
+				return false;
+			}
+
+			if (!CloseEnough(currentBounds.Y, newBounds.Y))
+			{
+				return false;
+			}
+
+			if (!CloseEnough(currentBounds.Width, newBounds.Width))
+			{
+				return false;
+			}
+
+			if (!CloseEnough(currentBounds.Height, newBounds.Height))
+			{
+				return false;
+			}
+
+			return true;
+		}
+
 		// ArrangeOverride provides a way to allow subclasses (e.g., Layout) to override Arrange even though
 		// the interface has to be explicitly implemented to avoid conflict with the old Arrange method
 		protected virtual Size ArrangeOverride(Rectangle bounds)
@@ -52,7 +86,7 @@ namespace Microsoft.Maui.Controls
 			// in View.cs; the arrange it forces ends up back here and if we have a margin, ComputeFrame will 
 			// keep applying it in a loop until the element disappears. Hopefully we can remove the OnSizeAllocated 
 			// hack at some point and avoid this extra check.
-			if(Bounds != bounds)
+			if(!CloseEnough(Bounds, bounds))
 			{
 				// Setting Bounds here is equivalent to setting the Frame
 				Bounds = this.ComputeFrame(bounds);


### PR DESCRIPTION
Previous bounds loop check was using Rectangle != Rectangle, which fails us when one aspect of the new bounds is different from the old bounds by a very, very small amount.

Adds a compare method with a tolerance when checking whether we're in a bounds loop.