### PR TITLE
net6.0 may be causing issues with NuGet

### DIFF
--- a/src/Essentials/src/Essentials-net6.csproj
+++ b/src/Essentials/src/Essentials-net6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Net.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;$(MauiPlatforms)</TargetFrameworks>
     <AssemblyName>Microsoft.Maui.Essentials</AssemblyName>
     <RootNamespace>Microsoft.Maui.Essentials</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>


### PR DESCRIPTION

### Description of Change ###

Remove net6.0 as it may be causing issues with NuGet restore on net6.0-android. Seems Android is picking net6.0 over net6.0-android30 for some reason.