### PR TITLE
Android should use handler's GetDesiredSize for HandlerToRendererShim

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 			{
 				returnValue = new SizeRequest(Size.Zero, Size.Zero);
 			}
-			else if (visualElementRenderer == null && view is IView iView)
+			else if ((visualElementRenderer == null || visualElementRenderer is HandlerToRendererShim) && view is IView iView)
 			{
 				returnValue = iView.Handler.GetDesiredSize(widthConstraint, heightConstraint);
 			}

--- a/src/Compatibility/Core/src/Android/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/Android/RendererToHandlerShim.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			// This is a hack to force the shimmed control to actually do layout; without this, some controls won't actually
 			// call OnLayout after SetFrame if their sizes haven't changed (e.g., ScrollView)
 			// Luckily, measuring with MeasureSpecMode.Exactly is pretty fast, since it just returns the value you give it.
-			NativeView.Measure(MeasureSpecMode.Exactly.MakeMeasureSpec((int)frame.Width),
+			NativeView?.Measure(MeasureSpecMode.Exactly.MakeMeasureSpec((int)frame.Width),
 				MeasureSpecMode.Exactly.MakeMeasureSpec((int)frame.Height));
 
 			base.NativeArrange(frame);


### PR DESCRIPTION
Platform.GetNativeSize was not using the handler's GetDesiredSize method when measuring a HandlerToRendererShim. This meant that it was missing a conversion between native size and cross-platform device-independent size, and squashing the contents of some controls (e.g., Frame/FrameRenderer). 

This change checks for a HandlerToRendererShim and uses the correct measuring method.