### PR TITLE
Prevent GridLayout from holding on to removed Views

### DIFF
--- a/src/Controls/src/Core/Layout/GridLayout.cs
+++ b/src/Controls/src/Core/Layout/GridLayout.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Maui.Controls.Layout2
 {
 	public class GridLayout : Layout, IGridLayout
 	{
-		List<IGridRowDefinition> _rowDefinitions = new List<IGridRowDefinition>();
-		List<IGridColumnDefinition> _columnDefinitions = new List<IGridColumnDefinition>();
+		readonly List<IGridRowDefinition> _rowDefinitions = new();
+		readonly List<IGridColumnDefinition> _columnDefinitions = new();
 
 		public IReadOnlyList<IGridRowDefinition> RowDefinitions => _rowDefinitions;
 		public IReadOnlyList<IGridColumnDefinition> ColumnDefinitions => _columnDefinitions;
@@ -17,46 +17,30 @@ namespace Microsoft.Maui.Controls.Layout2
 
 		Dictionary<IView, GridInfo> _viewInfo = new Dictionary<IView, GridInfo>();
 
-		// TODO ezhart This needs to override Remove and clean up any row/column/span info for the removed child
+		public override void Remove(IView child)
+		{
+			_viewInfo.Remove(child);
+			base.Remove(child);
+		}
 
 		public int GetColumn(IView view)
 		{
-			if (_viewInfo.TryGetValue(view, out GridInfo gridInfo))
-			{
-				return gridInfo.Col;
-			}
-
-			return 0;
+			return _viewInfo[view].Col;
 		}
 
 		public int GetColumnSpan(IView view)
 		{
-			if (_viewInfo.TryGetValue(view, out GridInfo gridInfo))
-			{
-				return gridInfo.ColSpan;
-			}
-
-			return 1;
+			return _viewInfo[view].ColSpan;
 		}
 
 		public int GetRow(IView view)
 		{
-			if (_viewInfo.TryGetValue(view, out GridInfo gridInfo))
-			{
-				return gridInfo.Row;
-			}
-
-			return 0;
+			return _viewInfo[view].Row;
 		}
 
 		public int GetRowSpan(IView view)
 		{
-			if (_viewInfo.TryGetValue(view, out GridInfo gridInfo))
-			{
-				return gridInfo.RowSpan;
-			}
-
-			return 1;
+			return _viewInfo[view].RowSpan;
 		}
 
 		protected override ILayoutManager CreateLayoutManager() => new GridLayoutManager(this);

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Controls.Layout2
 			LayoutHandler?.Add(child);
 		}
 
-		public void Remove(IView child)
+		public virtual void Remove(IView child)
 		{
 			if (child == null)
 				return;

--- a/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using Microsoft.Maui.Controls.Layout2;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
+{
+	public class GridLayoutTests 
+	{
+		[Test]
+		public void RemovedViewsHaveNoRowColumnInfo() 
+		{
+			var gl = new GridLayout();
+			var view = new Label();
+
+			gl.Add(view);
+			gl.SetRow(view, 2);
+
+			// Check our assumptions
+			Assert.AreEqual(2, gl.GetRow(view));
+
+			// Okay, removing the View from the Grid should mean that any attempt to get row/column info
+			// for that View should fail
+			gl.Remove(view);
+
+			Assert.Throws(typeof(KeyNotFoundException), () => gl.GetRow(view));
+			Assert.Throws(typeof(KeyNotFoundException), () => gl.GetRowSpan(view));
+			Assert.Throws(typeof(KeyNotFoundException), () => gl.GetColumn(view));
+			Assert.Throws(typeof(KeyNotFoundException), () => gl.GetColumnSpan(view));
+		}
+	}
+}


### PR DESCRIPTION
GridLayout was holding references to Views which were removed from it in order to track row/column information. 

This change removes the tracking when the View is removed.