### PR TITLE
Take FlowDirection into account when setting iOS horizontal text alignment

### DIFF
--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -32,10 +32,7 @@ namespace Microsoft.Maui
 
 		public static void UpdateHorizontalTextAlignment(this UILabel nativeLabel, ILabel label)
 		{
-			// We don't have a FlowDirection yet, so there's nothing to pass in here. 
-			// TODO ezhart Update this when FlowDirection is available 
-			// (or update the extension to take an ILabel instead of an alignment and work it out from there) 
-			nativeLabel.TextAlignment = label.HorizontalTextAlignment.ToNative(true);
+			nativeLabel.TextAlignment = label.HorizontalTextAlignment.ToNative(label.FlowDirection == FlowDirection.LeftToRight);
 		}
 
 		public static void UpdateLineBreakMode(this UILabel nativeLabel, ILabel label)

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
@@ -174,6 +174,33 @@ namespace Microsoft.Maui.DeviceTests
 			attributedText.AssertHasUnderline();
 		}
 
+		[Theory(DisplayName = "HorizontalTextAlignment adjusts for FlowDirection")]
+		[InlineData(TextAlignment.Start, FlowDirection.LeftToRight, UITextAlignment.Left)]
+		[InlineData(TextAlignment.End, FlowDirection.LeftToRight, UITextAlignment.Right)]
+		[InlineData(TextAlignment.Start, FlowDirection.RightToLeft, UITextAlignment.Right)]
+		[InlineData(TextAlignment.End, FlowDirection.RightToLeft, UITextAlignment.Left)]
+		public async Task HorizontalTextAlignmentAdjustsForFlowDirection(TextAlignment alignment, FlowDirection flowDirection, UITextAlignment expected)
+		{
+			var label = new LabelStub
+			{
+				Text = "This is TEXT!",
+				HorizontalTextAlignment = alignment,
+				FlowDirection = flowDirection
+			};
+
+
+			var values = await GetValueAsync(label, (handler) =>
+			{
+				return new
+				{
+					ViewValue = label.HorizontalTextAlignment,
+					NativeViewValue = GetNativeHorizontalTextAlignment(handler)
+				};
+			});
+
+			Assert.Equal(expected, values.NativeViewValue);
+		}
+
 		UILabel GetNativeLabel(LabelHandler labelHandler) =>
 			(UILabel)labelHandler.NativeView;
 


### PR DESCRIPTION
Now that we have a FlowDirection property in Core, passing it in to the alignment-setting method.