### PR TITLE
Give added views the default row/column

### DIFF
--- a/src/Controls/src/Core/Layout/GridLayout.cs
+++ b/src/Controls/src/Core/Layout/GridLayout.cs
@@ -15,7 +15,13 @@ namespace Microsoft.Maui.Controls.Layout2
 		public double RowSpacing { get; set; }
 		public double ColumnSpacing { get; set; }
 
-		Dictionary<IView, GridInfo> _viewInfo = new Dictionary<IView, GridInfo>();
+		readonly Dictionary<IView, GridInfo> _viewInfo = new();
+
+		public override void Add(IView child)
+		{
+			base.Add(child);
+			_viewInfo[child] = new GridInfo();
+		}
 
 		public override void Remove(IView child)
 		{

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Controls.Layout2
 			}
 		}
 
-		public void Add(IView child)
+		public virtual void Add(IView child)
 		{
 			if (child == null)
 				return;

--- a/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
@@ -4,10 +4,10 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 {
-	public class GridLayoutTests 
+	public class GridLayoutTests
 	{
 		[Test]
-		public void RemovedViewsHaveNoRowColumnInfo() 
+		public void RemovedViewsHaveNoRowColumnInfo()
 		{
 			var gl = new GridLayout();
 			var view = new Label();
@@ -26,6 +26,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			Assert.Throws(typeof(KeyNotFoundException), () => gl.GetRowSpan(view));
 			Assert.Throws(typeof(KeyNotFoundException), () => gl.GetColumn(view));
 			Assert.Throws(typeof(KeyNotFoundException), () => gl.GetColumnSpan(view));
+		}
+
+		[Test]
+		public void AddedViewGetsDefaultRowAndColumn()
+		{
+			var gl = new GridLayout();
+			var view = new Label();
+
+			gl.Add(view);
+			Assert.AreEqual(0, gl.GetRow(view));
+			Assert.AreEqual(0, gl.GetColumn(view));
+			Assert.AreEqual(1, gl.GetRowSpan(view));
+			Assert.AreEqual(1, gl.GetColumnSpan(view));
 		}
 	}
 }


### PR DESCRIPTION
When views are added to the GridLayout, they should have Row 0, Column 0, ColumnSpan 1, and RowSpan 1 by default.