### PR TITLE
Implement HorizontalTextAlignment property in WinUI Picker

### DIFF
--- a/eng/package.ps1
+++ b/eng/package.ps1
@@ -60,6 +60,7 @@ if ($IsWindows)
             /t:build `
             /p:Packing=true `
             /bl:"$artifacts/maui-build-$configuration.binlog"
+        if (!$?) { throw "Build failed." }
 
         & $msbuild $sln `
             /p:configuration=$configuration `
@@ -67,6 +68,7 @@ if ($IsWindows)
             /t:pack `
             /p:Packing=true `
             /bl:"$artifacts/maui-pack-$configuration.binlog"
+        if (!$?) { throw "Build failed." }
     }
     finally
     {
@@ -88,4 +90,5 @@ else
         -c:$configuration `
         -p:SymbolPackageFormat=snupkg `
         -bl:$artifacts/maui-pack-$configuration.binlog
+    if (!$?) { throw "Build failed." }
 }

--- a/eng/package.ps1
+++ b/eng/package.ps1
@@ -3,6 +3,8 @@ param(
   [string] $msbuild = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
 )
 
+$ErrorActionPreference = "Stop"
+
 $artifacts = Join-Path $PSScriptRoot ../artifacts
 $sln = Join-Path $PSScriptRoot ../Microsoft.Maui-net6.sln
 

--- a/src/Compatibility/Core/src/WinUI/AlignmentExtensions.cs
+++ b/src/Compatibility/Core/src/WinUI/AlignmentExtensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 		}
 
+		[PortHandler]
 		internal static HorizontalAlignment ToNativeHorizontalAlignment(this TextAlignment alignment)
 		{
 			switch (alignment)

--- a/src/Compatibility/Core/src/WinUI/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/WinUI/PickerRenderer.cs
@@ -235,10 +235,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			Control.DataContext = Element;
 		}
 
+		[PortHandler]
 		void UpdateHorizontalTextAlignment()
 		{
 			Control.HorizontalContentAlignment = Element.HorizontalTextAlignment.ToNativeHorizontalAlignment();
 		}
+
 		void UpdateVerticalTextAlignment()
 		{
 			Control.VerticalContentAlignment = Element.VerticalTextAlignment.ToNativeVerticalAlignment();

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -62,8 +62,10 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateTextColor(picker, handler._defaultForeground);
 		}
 
-		[MissingMapper]
-		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker view) { }
+		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker view)
+		{
+			handler.NativeView?.UpdateHorizontalTextAlignment(picker);
+		}
 
 		void OnControlSelectionChanged(object? sender, WSelectionChangedEventArgs e)
 		{

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateTextColor(picker, handler._defaultForeground);
 		}
 
-		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker view)
+		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker picker)
 		{
 			handler.NativeView?.UpdateHorizontalTextAlignment(picker);
 		}

--- a/src/Core/src/Platform/Windows/AlignmentExtensions.cs
+++ b/src/Core/src/Platform/Windows/AlignmentExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.UI.Xaml;
+
+namespace Microsoft.Maui
+{
+	public static class AlignmentExtensions
+	{
+		public static HorizontalAlignment ToNativeHorizontalAlignment(this TextAlignment alignment)
+		{
+			switch (alignment)
+			{
+				case TextAlignment.Center:
+					return HorizontalAlignment.Center;
+				case TextAlignment.End:
+					return HorizontalAlignment.Right;
+				default:
+					return HorizontalAlignment.Left;
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/PickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/PickerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using Microsoft.Maui.Graphics;
-using Microsoft.UI.Xaml.Controls;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui
@@ -41,6 +40,11 @@ namespace Microsoft.Maui
 		}
 
 		public static void UpdateFont(this MauiComboBox nativeComboBox, IPicker picker, IFontManager fontManager) =>
-			nativeComboBox.UpdateFont(picker.Font, fontManager);
+			nativeComboBox.UpdateFont(picker.Font, fontManager); 
+		
+		public static void UpdateHorizontalTextAlignment(this MauiComboBox nativeComboBox, IPicker picker)
+		{
+			nativeComboBox.HorizontalContentAlignment = picker.HorizontalTextAlignment.ToNativeHorizontalAlignment();
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `HorizontalTextAlignment` property in WinUI Picker.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
No