### PR TITLE
Remove NET6 WinUI workarounds

### DIFF
--- a/src/Compatibility/ControlGallery/src/WinUI (Package)/Compatibility.ControlGallery.WinUI (Package).wapproj
+++ b/src/Compatibility/ControlGallery/src/WinUI (Package)/Compatibility.ControlGallery.WinUI (Package).wapproj
@@ -3,9 +3,6 @@
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
     <VisualStudioVersion>15.0</VisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <SkipImportNetSdk>true</SkipImportNetSdk>
-  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x86">
       <Configuration>Debug</Configuration>

--- a/src/Controls/samples/Controls.Sample.WinUI (Package)/Maui.Controls.Sample.WinUI (Package).wapproj
+++ b/src/Controls/samples/Controls.Sample.WinUI (Package)/Maui.Controls.Sample.WinUI (Package).wapproj
@@ -3,9 +3,6 @@
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
     <VisualStudioVersion>15.0</VisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <SkipImportNetSdk>true</SkipImportNetSdk>
-  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x86">
       <Configuration>Debug</Configuration>
@@ -41,6 +38,7 @@
     <ProjectGuid>503b7824-7376-450b-9ef7-ea587df2c8be</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <AppxTargetsLocation Condition="'$(AppxTargetsLocation)'==''">$(MSBuildThisFileDirectory)build\</AppxTargetsLocation>


### PR DESCRIPTION
This removes workarounds that were being used to fix WinUI conflicts with NET6