### PR TITLE
Implement Visibility property in ViewHandlers

### DIFF
--- a/src/Compatibility/Core/src/Android/VisualElementTracker.cs
+++ b/src/Compatibility/Core/src/Android/VisualElementTracker.cs
@@ -332,6 +332,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			aView?.Invalidate();
 		}
 
+		[PortHandler]
 		void UpdateIsVisible()
 		{
 			VisualElement view = _renderer.Element;

--- a/src/Compatibility/Core/src/WinUI/CollectionView/FormsGridView.cs
+++ b/src/Compatibility/Core/src/WinUI/CollectionView/FormsGridView.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 using UWPApp = Microsoft.UI.Xaml.Application;
 using UWPControls = Microsoft.UI.Xaml.Controls;
 using WScrollMode = Microsoft.UI.Xaml.Controls.ScrollMode;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -41,11 +42,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		public static readonly DependencyProperty EmptyViewVisibilityProperty =
 			DependencyProperty.Register(nameof(EmptyViewVisibility), typeof(Visibility),
-				typeof(FormsGridView), new PropertyMetadata(Visibility.Collapsed));
+				typeof(FormsGridView), new PropertyMetadata(WVisibility.Collapsed));
 
-		public Visibility EmptyViewVisibility
+		public WVisibility EmptyViewVisibility
 		{
-			get { return (Visibility)GetValue(EmptyViewVisibilityProperty); }
+			get { return (WVisibility)GetValue(EmptyViewVisibilityProperty); }
 			set { SetValue(EmptyViewVisibilityProperty, value); }
 		}
 

--- a/src/Compatibility/Core/src/WinUI/CollectionView/FormsListView.cs
+++ b/src/Compatibility/Core/src/WinUI/CollectionView/FormsListView.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 using UwpApp = Microsoft.UI.Xaml.Application;
 using UwpControlTemplate = Microsoft.UI.Xaml.Controls.ControlTemplate;
 using UwpScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -25,11 +26,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		public static readonly DependencyProperty EmptyViewVisibilityProperty =
 			DependencyProperty.Register(nameof(EmptyViewVisibility), typeof(Visibility),
-				typeof(FormsListView), new PropertyMetadata(Visibility.Collapsed));
+				typeof(FormsListView), new PropertyMetadata(WVisibility.Collapsed));
 
-		public Visibility EmptyViewVisibility
+		public WVisibility EmptyViewVisibility
 		{
-			get { return (Visibility)GetValue(EmptyViewVisibilityProperty); }
+			get { return (WVisibility)GetValue(EmptyViewVisibilityProperty); }
 			set { SetValue(EmptyViewVisibilityProperty, value); }
 		}
 

--- a/src/Compatibility/Core/src/WinUI/CollectionView/IEmptyView.cs
+++ b/src/Compatibility/Core/src/WinUI/CollectionView/IEmptyView.cs
@@ -1,10 +1,11 @@
 using Microsoft.UI.Xaml;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	internal interface IEmptyView
 	{
-		Visibility EmptyViewVisibility { get; set; }
+		WVisibility EmptyViewVisibility { get; set; }
 		void SetEmptyView(FrameworkElement emptyView, View formsEmptyView);
 	}
 }

--- a/src/Compatibility/Core/src/WinUI/CollectionView/ItemsViewRenderer.cs
+++ b/src/Compatibility/Core/src/WinUI/CollectionView/ItemsViewRenderer.cs
@@ -13,6 +13,7 @@ using UwpScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility;
 using WRect = Windows.Foundation.Rect;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Controls.Platform;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -472,7 +473,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 				if (_emptyView != null && ListViewBase is IEmptyView emptyView)
 				{
-					emptyView.EmptyViewVisibility = Visibility.Visible;
+					emptyView.EmptyViewVisibility = WVisibility.Visible;
 
 					if (ActualWidth >= 0 && ActualHeight >= 0)
 						_formsEmptyView?.Layout(new Rectangle(0, 0, ActualWidth, ActualHeight));
@@ -485,7 +486,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				if (_emptyViewDisplayed)
 				{
 					if (_emptyView != null && ListViewBase is IEmptyView emptyView)
-						emptyView.EmptyViewVisibility = Visibility.Collapsed;
+						emptyView.EmptyViewVisibility = WVisibility.Collapsed;
 
 					ItemsView.RemoveLogicalChild(_formsEmptyView);
 				}
@@ -582,7 +583,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (element == null || container == null)
 				return false;
 
-			if (element.Visibility != Visibility.Visible)
+			if (element.Visibility != WVisibility.Visible)
 				return false;
 
 			var elementBounds = element.TransformToVisual(container).TransformBounds(new WRect(0, 0, element.ActualWidth, element.ActualHeight));

--- a/src/Compatibility/Core/src/WinUI/FlyoutPageControl.cs
+++ b/src/Compatibility/Core/src/WinUI/FlyoutPageControl.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -82,7 +83,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		{
 			DefaultStyleKey = typeof(FlyoutPageControl);
 
-			DetailTitleVisibility = Visibility.Collapsed;
+			DetailTitleVisibility = WVisibility.Collapsed;
 
 			CollapseStyle = CollapseStyle.Full;
 		}
@@ -133,9 +134,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			set { SetValue(DetailTitleViewProperty, value); }
 		}
 
-		public Visibility DetailTitleVisibility
+		public WVisibility DetailTitleVisibility
 		{
-			get { return (Visibility)GetValue(DetailTitleVisibilityProperty); }
+			get { return (WVisibility)GetValue(DetailTitleVisibilityProperty); }
 			set { SetValue(DetailTitleVisibilityProperty, value); }
 		}
 
@@ -187,15 +188,15 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			set { SetValue(FlyoutTitleProperty, value); }
 		}
 
-		public Visibility FlyoutTitleVisibility
+		public WVisibility FlyoutTitleVisibility
 		{
-			get { return (Visibility)GetValue(FlyoutTitleVisibilityProperty); }
+			get { return (WVisibility)GetValue(FlyoutTitleVisibilityProperty); }
 			set { SetValue(FlyoutTitleVisibilityProperty, value); }
 		}
 
-		public Visibility FlyoutToolbarVisibility
+		public WVisibility FlyoutToolbarVisibility
 		{
-			get { return (Visibility)GetValue(FlyoutToolbarVisibilityProperty); }
+			get { return (WVisibility)GetValue(FlyoutToolbarVisibilityProperty); }
 			set { SetValue(FlyoutToolbarVisibilityProperty, value); }
 		}
 
@@ -231,9 +232,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 		}
 
-		public Visibility ContentTogglePaneButtonVisibility
+		public WVisibility ContentTogglePaneButtonVisibility
 		{
-			get { return (Visibility)GetValue(ContentTogglePaneButtonVisibilityProperty); }
+			get { return (WVisibility)GetValue(ContentTogglePaneButtonVisibilityProperty); }
 			set { SetValue(ContentTogglePaneButtonVisibilityProperty, value); }
 		}
 
@@ -349,20 +350,20 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				// If we've determined that the pane will always be open, then there's no
 				// reason to display the show/hide pane button in the master
-				FlyoutToolbarVisibility = Visibility.Collapsed;
+				FlyoutToolbarVisibility = WVisibility.Collapsed;
 			}
 
 			// If we're in compact mode or the pane is always open,
 			// we don't need to display the content pane's toggle button
 			ContentTogglePaneButtonVisibility = _split.DisplayMode == SplitViewDisplayMode.Overlay
-				? Visibility.Visible
-				: Visibility.Collapsed;
+				? WVisibility.Visible
+				: WVisibility.Collapsed;
 
-			if (ContentTogglePaneButtonVisibility == Visibility.Visible)
-				DetailTitleVisibility = Visibility.Visible;
+			if (ContentTogglePaneButtonVisibility == WVisibility.Visible)
+				DetailTitleVisibility = WVisibility.Visible;
 
-			if (DetailTitleVisibility == Visibility.Visible && !ShouldShowNavigationBar)
-				DetailTitleVisibility = Visibility.Collapsed;
+			if (DetailTitleVisibility == WVisibility.Visible && !ShouldShowNavigationBar)
+				DetailTitleVisibility = WVisibility.Collapsed;
 
 			_firstLoad = true;
 		}
@@ -401,13 +402,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			set => FlyoutTitle = value;
 		}
 
-		public Visibility MasterTitleVisibility
+		public WVisibility MasterTitleVisibility
 		{
 			get => FlyoutTitleVisibility;
 			set => FlyoutTitleVisibility = value;
 		}
 
-		public Visibility MasterToolbarVisibility
+		public WVisibility MasterToolbarVisibility
 		{
 			get => FlyoutToolbarVisibility;
 			set => FlyoutToolbarVisibility = value;

--- a/src/Compatibility/Core/src/WinUI/FlyoutPageRenderer.cs
+++ b/src/Compatibility/Core/src/WinUI/FlyoutPageRenderer.cs
@@ -11,6 +11,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Controls.Platform;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -76,7 +77,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 					return;
 
 				_showTitle = value;
-				Control.DetailTitleVisibility = _showTitle ? Visibility.Visible : Visibility.Collapsed;
+				Control.DetailTitleVisibility = _showTitle ? WVisibility.Visible : WVisibility.Collapsed;
 			}
 		}
 

--- a/src/Compatibility/Core/src/WinUI/FormsCommandBar.cs
+++ b/src/Compatibility/Core/src/WinUI/FormsCommandBar.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -60,26 +61,26 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				// If there's no title to display (e.g., toolbarplacement is set to bottom)
 				// or the title is collapsed (e.g., because it's empty)
-				if (frameworkElement == null || frameworkElement.Visibility != Visibility.Visible)
+				if (frameworkElement == null || frameworkElement.Visibility != WVisibility.Visible)
 				{
 					// Just collapse the whole thing
-					Visibility = Visibility.Collapsed;
+					Visibility = WVisibility.Collapsed;
 					return;
 				}
 			
 				// The title needs to be visible, but we're not allowed to show a toolbar
 				// So we need to hide the toolbar items
 
-				Visibility = Visibility.Visible;
+				Visibility = WVisibility.Visible;
 
 				if (_moreButton != null)
 				{
-					_moreButton.Visibility = Visibility.Collapsed;
+					_moreButton.Visibility = WVisibility.Collapsed;
 				}
 
 				if (_primaryItemsControl != null)
 				{
-					_primaryItemsControl.Visibility = Visibility.Collapsed;
+					_primaryItemsControl.Visibility = WVisibility.Collapsed;
 				}
 
 				return;
@@ -90,11 +91,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (_primaryItemsControl != null)
 			{
 				// This is normally visible by default, but it might have been collapsed by the toolbar consistency rules above
-				_primaryItemsControl.Visibility = Visibility.Visible;
+				_primaryItemsControl.Visibility = WVisibility.Visible;
 			}
 
 			// Are there any commands to display?
-			var visibility = PrimaryCommands.Count + SecondaryCommands.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+			var visibility = PrimaryCommands.Count + SecondaryCommands.Count > 0 ? WVisibility.Visible : WVisibility.Collapsed;
 
 			if (_moreButton != null)
 			{
@@ -105,10 +106,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				// but it became available in 10.0.14393.0 and we have to support 10.0.10240
 			}
 			
-			if (frameworkElement != null && frameworkElement.Visibility != Visibility.Collapsed)
+			if (frameworkElement != null && frameworkElement.Visibility != WVisibility.Collapsed)
 			{
 				// If there's a title to display, we have to be visible whether or not we have commands
-				Visibility = Visibility.Visible;
+				Visibility = WVisibility.Visible;
 			}
 			else
 			{

--- a/src/Compatibility/Core/src/WinUI/FormsFlyout.xaml.cs
+++ b/src/Compatibility/Core/src/WinUI/FormsFlyout.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Maui.Controls.Internals;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -54,8 +55,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 					RightBtn.Content = options.Destruction;
 			}
 
-			LeftBtn.Visibility = LeftBtn.Content == null ? Visibility.Collapsed : Visibility.Visible;
-			RightBtn.Visibility = RightBtn.Content == null ? Visibility.Collapsed : Visibility.Visible;
+			LeftBtn.Visibility = LeftBtn.Content == null ? WVisibility.Collapsed : WVisibility.Visible;
+			RightBtn.Visibility = RightBtn.Content == null ? WVisibility.Collapsed : WVisibility.Visible;
 		}
 
 		void ListItemSelected (object sender, ItemClickEventArgs e)

--- a/src/Compatibility/Core/src/WinUI/FormsSlider.cs
+++ b/src/Compatibility/Core/src/WinUI/FormsSlider.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media.Imaging;
 using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -32,13 +33,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			if (slider.ThumbImageSource != null)
 			{
-				slider.Thumb.Visibility = Visibility.Collapsed;
-				slider.ImageThumb.Visibility = Visibility.Visible;
+				slider.Thumb.Visibility = WVisibility.Collapsed;
+				slider.ImageThumb.Visibility = WVisibility.Visible;
 			}
 			else
 			{
-				slider.Thumb.Visibility = Visibility.Visible;
-				slider.ImageThumb.Visibility = Visibility.Collapsed;
+				slider.Thumb.Visibility = WVisibility.Visible;
+				slider.ImageThumb.Visibility = WVisibility.Collapsed;
 			}
 		}
 

--- a/src/Compatibility/Core/src/WinUI/PageControl.cs
+++ b/src/Compatibility/Core/src/WinUI/PageControl.cs
@@ -4,12 +4,13 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	public sealed class PageControl : ContentControl, IToolbarProvider, ITitleViewRendererController
 	{
-		public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register(nameof(TitleVisibility), typeof(Visibility), typeof(PageControl), new PropertyMetadata(Visibility.Visible));
+		public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register(nameof(TitleVisibility), typeof(WVisibility), typeof(PageControl), new PropertyMetadata(WVisibility.Visible));
 
 		public static readonly DependencyProperty ToolbarBackgroundProperty = DependencyProperty.Register(nameof(ToolbarBackground), typeof(WBrush), typeof(PageControl),
 			new PropertyMetadata(default(WBrush)));
@@ -23,7 +24,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		public static readonly DependencyProperty TitleViewProperty = DependencyProperty.Register(nameof(TitleView), typeof(View), typeof(PageControl), new PropertyMetadata(default(View), OnTitleViewPropertyChanged));
 
-		public static readonly DependencyProperty TitleViewVisibilityProperty = DependencyProperty.Register(nameof(TitleViewVisibility), typeof(Visibility), typeof(PageControl), new PropertyMetadata(Visibility.Collapsed));
+		public static readonly DependencyProperty TitleViewVisibilityProperty = DependencyProperty.Register(nameof(TitleViewVisibility), typeof(WVisibility), typeof(PageControl), new PropertyMetadata(WVisibility.Collapsed));
 
 		public static readonly DependencyProperty TitleInsetProperty = DependencyProperty.Register("TitleInset", typeof(double), typeof(PageControl), new PropertyMetadata(default(double)));
 

--- a/src/Compatibility/Core/src/WinUI/Platform.cs
+++ b/src/Compatibility/Core/src/WinUI/Platform.cs
@@ -12,6 +12,7 @@ using WFlowDirection = Microsoft.UI.Xaml.FlowDirection;
 using WImage = Microsoft.UI.Xaml.Controls.Image;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Controls.Platform;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -139,7 +140,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			MessagingCenter.Subscribe(this, Page.BusySetSignalName, (Page sender, bool enabled) =>
 			{
 				Microsoft.UI.Xaml.Controls.ProgressBar indicator = GetBusyIndicator();
-				indicator.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
+				indicator.Visibility = enabled ? WVisibility.Visible : WVisibility.Collapsed;
 			});
 
 			_toolbarTracker.CollectionChanged += OnToolbarItemsChanged;
@@ -317,7 +318,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				_busyIndicator = new Microsoft.UI.Xaml.Controls.ProgressBar
 				{
 					IsIndeterminate = true,
-					Visibility = Visibility.Collapsed,
+					Visibility = WVisibility.Collapsed,
 					VerticalAlignment = UI.Xaml.VerticalAlignment.Top
 				};
 

--- a/src/Compatibility/Core/src/WinUI/Shell/ShellFlyoutItemRenderer.cs
+++ b/src/Compatibility/Core/src/WinUI/Shell/ShellFlyoutItemRenderer.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using WRect = Windows.Foundation.Rect;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -123,11 +124,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				if (!_content.IsVisible)
 				{
-					fe.Visibility = Visibility.Collapsed;
+					fe.Visibility = WVisibility.Collapsed;
 				}
 				else
 				{
-					fe.Visibility = Visibility.Visible;
+					fe.Visibility = WVisibility.Visible;
 				}
 			}
 

--- a/src/Compatibility/Core/src/WinUI/Shell/ShellItemRenderer.cs
+++ b/src/Compatibility/Core/src/WinUI/Shell/ShellItemRenderer.cs
@@ -18,6 +18,7 @@ using Microsoft.UI.Xaml.Media;
 using UwpApplication = Microsoft.UI.Xaml.Application;
 using UwpSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 using Microsoft.Maui.Controls.Platform;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -361,12 +362,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		{
 			if (DisplayedPage == null || Shell.GetNavBarIsVisible(DisplayedPage))
 			{
-				_HeaderArea.Visibility = Visibility.Visible;
+				_HeaderArea.Visibility = WVisibility.Visible;
 				Shell.SetFlyoutBehavior(Shell.Current, Microsoft.Maui.Controls.FlyoutBehavior.Flyout);
 			}
 			else
 			{
-				_HeaderArea.Visibility = Visibility.Collapsed;
+				_HeaderArea.Visibility = WVisibility.Collapsed;
 				Shell.SetFlyoutBehavior(Shell.Current, Microsoft.Maui.Controls.FlyoutBehavior.Disabled);
 			}
 		}
@@ -379,7 +380,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		void UpdateBottomBarVisibility()
 		{
 			bool isVisible = ShellItemController?.ShowTabs ?? false;
-			_BottomBar.Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
+			_BottomBar.Visibility = isVisible ? WVisibility.Visible : WVisibility.Collapsed;
 		}
 
 		void UpdateToolbar()

--- a/src/Compatibility/Core/src/WinUI/TitleViewManager.cs
+++ b/src/Compatibility/Core/src/WinUI/TitleViewManager.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -70,7 +71,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			double buttonWidth = 0;
 			foreach (var item in CommandBar.GetDescendantsByName<Microsoft.UI.Xaml.Controls.Button>("MoreButton"))
-				if (item.Visibility == Visibility.Visible)
+				if (item.Visibility == WVisibility.Visible)
 					buttonWidth += item.ActualWidth;
 
 			if (!CommandBar.IsDynamicOverflowEnabled)

--- a/src/Compatibility/Core/src/WinUI/VisualElementTracker.cs
+++ b/src/Compatibility/Core/src/WinUI/VisualElementTracker.cs
@@ -18,6 +18,7 @@ using Microsoft.Maui.Controls.Internals;
 using WCompositeTransform = Microsoft.UI.Xaml.Media.CompositeTransform;
 using WScaleTransform = Microsoft.UI.Xaml.Media.ScaleTransform;
 using Microsoft.Maui.Graphics;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -781,7 +782,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		[PortHandler]
 		static void UpdateVisibility(VisualElement view, FrameworkElement frameworkElement)
 		{
-			frameworkElement.Visibility = view.IsVisible ? Visibility.Visible : Visibility.Collapsed;
+			frameworkElement.Visibility = view.IsVisible ? WVisibility.Visible : WVisibility.Collapsed;
 		}
 
 		void UpdateDragAndDropGestureRecognizers()

--- a/src/Compatibility/Core/src/WinUI/VisualElementTracker.cs
+++ b/src/Compatibility/Core/src/WinUI/VisualElementTracker.cs
@@ -778,6 +778,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			UpdateRotation(view, frameworkElement);
 		}
 
+		[PortHandler]
 		static void UpdateVisibility(VisualElement view, FrameworkElement frameworkElement)
 		{
 			frameworkElement.Visibility = view.IsVisible ? Visibility.Visible : Visibility.Collapsed;

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -32,11 +32,93 @@ namespace Maui.Controls.Sample.Pages
 			_services = services;
 			BindingContext = _viewModel = viewModel;
 
-			SetupMauiLayout();
+			//SetupMauiLayout();
+			SetupVisibilityTest();
 
 			NavigationPage.SetHasNavigationBar(this, false);
 
 			//SetupCompatibilityLayout();
+		}
+
+		public class VisibilityLabel : Label
+		{
+			private Visibility _visibility;
+
+			public void SetVisibility(Visibility visibility) 
+			{
+				_visibility = visibility;
+				Handler?.UpdateValue(nameof(Visibility));
+			}
+
+			public override Visibility Visibility
+			{
+				get 
+				{
+					return _visibility; 
+				}
+			}
+		}
+
+		void SetupVisibilityTest()
+		{
+			var layout = new VerticalStackLayout() { BackgroundColor = Colors.BurlyWood };
+			//var layout = new Microsoft.Maui.Controls.Layout2.GridLayout() { BackgroundColor = Colors.AntiqueWhite };
+
+			var button1 = new Button { Text = "Controls", Margin = new Thickness(0, 40) };
+
+			var button2 = new Button { Text = "MAUI" };
+
+			var controlsLabel = new Label { Text = "Controls Label" };
+			controlsLabel.IsVisible = true;
+
+			var alwaysVisible = new Label { Text = "Always visible" };
+
+			var mauiLabel = new VisibilityLabel() { Text = "Core Label" };
+
+			button1.Clicked += (sender, args) => {
+				controlsLabel.IsVisible = !controlsLabel.IsVisible;
+			};
+			
+			button2.Clicked += (sender, args) => 
+			{ 
+				switch (mauiLabel.Visibility) 
+				{ 
+					case Visibility.Visible:
+						mauiLabel.SetVisibility(Visibility.Hidden);
+						break; 
+					case Visibility.Hidden:
+						mauiLabel.SetVisibility(Visibility.Collapsed);
+						break; 
+					case Visibility.Collapsed:
+						mauiLabel.SetVisibility(Visibility.Visible);
+						break; 
+				} 
+			};
+
+			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
+			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
+			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
+			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
+			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
+
+			//layout.AddColumnDefinition(new ColumnDefinition { Width = new GridLength(300) });
+
+			layout.Add(button1);
+			//layout.SetRow(button1, 0);
+
+			layout.Add(button2);
+			//layout.SetRow(button2, 1);
+
+			layout.Add(controlsLabel);
+			//layout.SetRow(controlsLabel, 2);
+
+			layout.Add(mauiLabel);
+			//layout.SetRow(mauiLabel, 3);
+
+			layout.Add(alwaysVisible);
+			//layout.SetRow(alwaysVisible, 4);
+
+			Content = layout;
 		}
 
 		const string LoremIpsum =
@@ -53,7 +135,7 @@ namespace Maui.Controls.Sample.Pages
 			var verticalStack = new VerticalStackLayout() { Spacing = 5, BackgroundColor = Colors.AntiqueWhite };
 			var horizontalStack = new HorizontalStackLayout() { Spacing = 2, BackgroundColor = Colors.CornflowerBlue };
 
-			verticalStack.Add(CreateSampleGrid());
+			//verticalStack.Add(CreateSampleGrid());
 			verticalStack.Add(CreateResizingButton());
 
 			AddTextResizeDemo(verticalStack);

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -32,15 +32,15 @@ namespace Maui.Controls.Sample.Pages
 			_services = services;
 			BindingContext = _viewModel = viewModel;
 
-			//SetupMauiLayout();
-			SetupVisibilityTest();
+			SetupMauiLayout();
 
 			NavigationPage.SetHasNavigationBar(this, false);
 
 			//SetupCompatibilityLayout();
+			//SetupVisibilityTest();
 		}
 
-		public class VisibilityLabel : Label
+		public class VisibilityLabel : Label, IFrameworkElement
 		{
 			private Visibility _visibility;
 
@@ -50,75 +50,13 @@ namespace Maui.Controls.Sample.Pages
 				Handler?.UpdateValue(nameof(Visibility));
 			}
 
-			public override Visibility Visibility
+			Visibility IFrameworkElement.Visibility
 			{
 				get 
 				{
 					return _visibility; 
 				}
 			}
-		}
-
-		void SetupVisibilityTest()
-		{
-			var layout = new VerticalStackLayout() { BackgroundColor = Colors.BurlyWood };
-			//var layout = new Microsoft.Maui.Controls.Layout2.GridLayout() { BackgroundColor = Colors.AntiqueWhite };
-
-			var button1 = new Button { Text = "Controls", Margin = new Thickness(0, 40) };
-
-			var button2 = new Button { Text = "MAUI" };
-
-			var controlsLabel = new Label { Text = "Controls Label" };
-			controlsLabel.IsVisible = true;
-
-			var alwaysVisible = new Label { Text = "Always visible" };
-
-			var mauiLabel = new VisibilityLabel() { Text = "Core Label" };
-
-			button1.Clicked += (sender, args) => {
-				controlsLabel.IsVisible = !controlsLabel.IsVisible;
-			};
-			
-			button2.Clicked += (sender, args) => 
-			{ 
-				switch (mauiLabel.Visibility) 
-				{ 
-					case Visibility.Visible:
-						mauiLabel.SetVisibility(Visibility.Hidden);
-						break; 
-					case Visibility.Hidden:
-						mauiLabel.SetVisibility(Visibility.Collapsed);
-						break; 
-					case Visibility.Collapsed:
-						mauiLabel.SetVisibility(Visibility.Visible);
-						break; 
-				} 
-			};
-
-			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
-			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
-			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
-			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
-			//layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
-
-			//layout.AddColumnDefinition(new ColumnDefinition { Width = new GridLength(300) });
-
-			layout.Add(button1);
-			//layout.SetRow(button1, 0);
-
-			layout.Add(button2);
-			//layout.SetRow(button2, 1);
-
-			layout.Add(controlsLabel);
-			//layout.SetRow(controlsLabel, 2);
-
-			layout.Add(mauiLabel);
-			//layout.SetRow(mauiLabel, 3);
-
-			layout.Add(alwaysVisible);
-			//layout.SetRow(alwaysVisible, 4);
-
-			Content = layout;
 		}
 
 		const string LoremIpsum =
@@ -571,6 +509,50 @@ namespace Maui.Controls.Sample.Pages
 			layout.Add(resizeTestLabel);
 			layout.Add(widthAndHeightTestLabel);
 			layout.Add(explicitWidthTestLabel);
+		}
+
+		void SetupVisibilityTest()
+		{
+			var layout = new VerticalStackLayout() { BackgroundColor = Colors.BurlyWood };
+
+			var button1 = new Button { Text = "Controls", Margin = new Thickness(0, 40) };
+
+			var button2 = new Button { Text = "MAUI" };
+
+			var controlsLabel = new Label { Text = "Controls Label" };
+			controlsLabel.IsVisible = true;
+
+			var alwaysVisible = new Label { Text = "Always visible" };
+
+			var mauiLabel = new VisibilityLabel() { Text = "Core Label" };
+
+			button1.Clicked += (sender, args) => {
+				controlsLabel.IsVisible = !controlsLabel.IsVisible;
+			};
+
+			button2.Clicked += (sender, args) =>
+			{
+				switch ((mauiLabel as IFrameworkElement).Visibility)
+				{
+					case Visibility.Visible:
+						mauiLabel.SetVisibility(Visibility.Hidden);
+						break;
+					case Visibility.Hidden:
+						mauiLabel.SetVisibility(Visibility.Collapsed);
+						break;
+					case Visibility.Collapsed:
+						mauiLabel.SetVisibility(Visibility.Visible);
+						break;
+				}
+			};
+
+			layout.Add(button1);
+			layout.Add(button2);
+			layout.Add(controlsLabel);
+			layout.Add(mauiLabel);
+			layout.Add(alwaysVisible);
+
+			Content = layout;
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Maui.Controls
 		Primitives.LayoutAlignment IFrameworkElement.HorizontalLayoutAlignment => default;
 		Primitives.LayoutAlignment IFrameworkElement.VerticalLayoutAlignment => default;
 
-		public virtual Visibility Visibility => IsVisible.ToVisibility();
+		Visibility IFrameworkElement.Visibility => IsVisible.ToVisibility();
 
 		Semantics IFrameworkElement.Semantics
 		{

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -7,7 +7,8 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class VisualElement : IFrameworkElement
 	{
-		private IViewHandler _handler;
+		Semantics _semantics;
+		IViewHandler _handler;
 
 		public Rectangle Frame => Bounds;
 
@@ -139,8 +140,10 @@ namespace Microsoft.Maui.Controls
 		Primitives.LayoutAlignment IFrameworkElement.HorizontalLayoutAlignment => default;
 		Primitives.LayoutAlignment IFrameworkElement.VerticalLayoutAlignment => default;
 
-		Maui.Semantics _semantics;
-		Maui.Semantics IFrameworkElement.Semantics
+		public Visibility Visibility =>
+			IsVisible.ToVisibility();
+
+		Semantics IFrameworkElement.Semantics
 		{
 			get => _semantics;
 		}
@@ -148,7 +151,7 @@ namespace Microsoft.Maui.Controls
 		// We don't want to initialize Semantics until someone explicitly 
 		// wants to modify some aspect of the semantics class
 		internal Semantics SetupSemantics() =>
-			_semantics ??= new Maui.Semantics();
+			_semantics ??= new Semantics();
 
 		double IFrameworkElement.Width => WidthRequest;
 		double IFrameworkElement.Height => HeightRequest;

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -140,8 +140,7 @@ namespace Microsoft.Maui.Controls
 		Primitives.LayoutAlignment IFrameworkElement.HorizontalLayoutAlignment => default;
 		Primitives.LayoutAlignment IFrameworkElement.VerticalLayoutAlignment => default;
 
-		public Visibility Visibility =>
-			IsVisible.ToVisibility();
+		public Visibility Visibility => IsVisible.ToVisibility();
 
 		Semantics IFrameworkElement.Semantics
 		{

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Maui.Controls
 		Primitives.LayoutAlignment IFrameworkElement.HorizontalLayoutAlignment => default;
 		Primitives.LayoutAlignment IFrameworkElement.VerticalLayoutAlignment => default;
 
-		public Visibility Visibility => IsVisible.ToVisibility();
+		public virtual Visibility Visibility => IsVisible.ToVisibility();
 
 		Semantics IFrameworkElement.Semantics
 		{

--- a/src/Controls/src/Core/Platform/Windows/MauiCommandBar.cs
+++ b/src/Controls/src/Core/Platform/Windows/MauiCommandBar.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -60,26 +61,26 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				// If there's no title to display (e.g., toolbarplacement is set to bottom)
 				// or the title is collapsed (e.g., because it's empty)
-				if (frameworkElement == null || frameworkElement.Visibility != Visibility.Visible)
+				if (frameworkElement == null || frameworkElement.Visibility != WVisibility.Visible)
 				{
 					// Just collapse the whole thing
-					Visibility = Visibility.Collapsed;
+					Visibility = WVisibility.Collapsed;
 					return;
 				}
 			
 				// The title needs to be visible, but we're not allowed to show a toolbar
 				// So we need to hide the toolbar items
 
-				Visibility = Visibility.Visible;
+				Visibility = WVisibility.Visible;
 
 				if (_moreButton != null)
 				{
-					_moreButton.Visibility = Visibility.Collapsed;
+					_moreButton.Visibility = WVisibility.Collapsed;
 				}
 
 				if (_primaryItemsControl != null)
 				{
-					_primaryItemsControl.Visibility = Visibility.Collapsed;
+					_primaryItemsControl.Visibility = WVisibility.Collapsed;
 				}
 
 				return;
@@ -90,11 +91,11 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_primaryItemsControl != null)
 			{
 				// This is normally visible by default, but it might have been collapsed by the toolbar consistency rules above
-				_primaryItemsControl.Visibility = Visibility.Visible;
+				_primaryItemsControl.Visibility = WVisibility.Visible;
 			}
 
 			// Are there any commands to display?
-			var visibility = PrimaryCommands.Count + SecondaryCommands.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
+			var visibility = PrimaryCommands.Count + SecondaryCommands.Count > 0 ? WVisibility.Visible : WVisibility.Collapsed;
 
 			if (_moreButton != null)
 			{
@@ -105,10 +106,10 @@ namespace Microsoft.Maui.Controls.Platform
 				// but it became available in 10.0.14393.0 and we have to support 10.0.10240
 			}
 			
-			if (frameworkElement != null && frameworkElement.Visibility != Visibility.Collapsed)
+			if (frameworkElement != null && frameworkElement.Visibility != WVisibility.Collapsed)
 			{
 				// If there's a title to display, we have to be visible whether or not we have commands
-				Visibility = Visibility.Visible;
+				Visibility = WVisibility.Visible;
 			}
 			else
 			{

--- a/src/Controls/src/Core/Platform/Windows/PageControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/PageControl.cs
@@ -4,12 +4,13 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Platform
 {
 	public sealed class PageControl : ContentControl, IToolbarProvider, ITitleViewRendererController
 	{
-		public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register(nameof(TitleVisibility), typeof(Visibility), typeof(PageControl), new PropertyMetadata(Visibility.Visible));
+		public static readonly DependencyProperty TitleVisibilityProperty = DependencyProperty.Register(nameof(TitleVisibility), typeof(WVisibility), typeof(PageControl), new PropertyMetadata(WVisibility.Visible));
 
 		public static readonly DependencyProperty ToolbarBackgroundProperty = DependencyProperty.Register(nameof(ToolbarBackground), typeof(WBrush), typeof(PageControl),
 			new PropertyMetadata(default(WBrush)));
@@ -23,7 +24,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static readonly DependencyProperty TitleViewProperty = DependencyProperty.Register(nameof(TitleView), typeof(View), typeof(PageControl), new PropertyMetadata(default(View), OnTitleViewPropertyChanged));
 
-		public static readonly DependencyProperty TitleViewVisibilityProperty = DependencyProperty.Register(nameof(TitleViewVisibility), typeof(Visibility), typeof(PageControl), new PropertyMetadata(Visibility.Collapsed));
+		public static readonly DependencyProperty TitleViewVisibilityProperty = DependencyProperty.Register(nameof(TitleViewVisibility), typeof(WVisibility), typeof(PageControl), new PropertyMetadata(WVisibility.Collapsed));
 
 		public static readonly DependencyProperty TitleInsetProperty = DependencyProperty.Register("TitleInset", typeof(double), typeof(PageControl), new PropertyMetadata(default(double)));
 

--- a/src/Controls/src/Core/Platform/Windows/TitleViewManager.cs
+++ b/src/Controls/src/Core/Platform/Windows/TitleViewManager.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -69,8 +70,9 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 
 			double buttonWidth = 0;
+
 			foreach (var item in CommandBar.GetDescendantsByName<Microsoft.UI.Xaml.Controls.Button>("MoreButton"))
-				if (item.Visibility == Visibility.Visible)
+				if (item.Visibility == WVisibility.Visible)
 					buttonWidth += item.ActualWidth;
 
 			if (!CommandBar.IsDynamicOverflowEnabled)

--- a/src/Controls/src/Core/Platform/Windows/VisualElementTracker.cs
+++ b/src/Controls/src/Core/Platform/Windows/VisualElementTracker.cs
@@ -20,6 +20,7 @@ using Microsoft.Maui.Controls.Internals;
 using WCompositeTransform = Microsoft.UI.Xaml.Media.CompositeTransform;
 using WScaleTransform = Microsoft.UI.Xaml.Media.ScaleTransform;
 using Microsoft.Maui.Graphics;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -790,7 +791,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		static void UpdateVisibility(VisualElement view, FrameworkElement frameworkElement)
 		{
-			frameworkElement.Visibility = view.IsVisible ? Visibility.Visible : Visibility.Collapsed;
+			frameworkElement.Visibility = view.IsVisible ? WVisibility.Visible : WVisibility.Collapsed;
 		}
 
 		void UpdateDragAndDropGestureRecognizers()

--- a/src/Controls/src/Core/VisibilityExtensions.cs
+++ b/src/Controls/src/Core/VisibilityExtensions.cs
@@ -7,7 +7,7 @@
 			if (isVisible)
 				return Visibility.Visible;
 
-			return Visibility.Hidden;
+			return Visibility.Collapsed;
 		}
 	}
 }

--- a/src/Controls/src/Core/VisibilityExtensions.cs
+++ b/src/Controls/src/Core/VisibilityExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Maui
+﻿namespace Microsoft.Maui.Controls
 {
 	public static class VisibilityExtensions
 	{

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -939,7 +939,15 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		internal virtual void OnIsVisibleChanged(bool oldValue, bool newValue) => InvalidateMeasureInternal(InvalidationTrigger.Undefined);
+		internal virtual void OnIsVisibleChanged(bool oldValue, bool newValue)
+		{
+			if (this is IFrameworkElement fe)
+			{
+				fe.Handler?.UpdateValue(nameof(IFrameworkElement.Visibility));
+			}
+
+			InvalidateMeasureInternal(InvalidationTrigger.Undefined);
+		}
 
 		internal override void OnParentResourcesChanged(IEnumerable<KeyValuePair<string, object>> values)
 		{

--- a/src/Core/src/Core/IFrameworkElement.cs
+++ b/src/Core/src/Core/IFrameworkElement.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Primitives;
 
@@ -15,6 +15,12 @@ namespace Microsoft.Maui
 		bool IsEnabled { get; }
 
 		/// <summary>
+		/// Gets a value that determines whether this FrameworkElement should be part of the visual tree or not.
+		/// </summary>
+		bool IsVisible { get; }
+
+		/// <summary>
+	
 		/// Gets the paint which will fill the background of a FrameworkElement.
 		/// </summary>
 		Paint? Background { get; }

--- a/src/Core/src/Core/IFrameworkElement.cs
+++ b/src/Core/src/Core/IFrameworkElement.cs
@@ -17,7 +17,12 @@ namespace Microsoft.Maui
 		/// <summary>
 		/// Gets a value that determines whether this FrameworkElement should be part of the visual tree or not.
 		/// </summary>
-		bool IsVisible { get; }
+		Visibility Visibility { get; }
+
+		/// <summary>
+		/// Gets the opacity value applied to the view when it is rendered.
+		/// </summary>
+		double Opacity { get; }
 
 		/// <summary>
 	

--- a/src/Core/src/Core/IFrameworkElement.cs
+++ b/src/Core/src/Core/IFrameworkElement.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Maui
 		double Opacity { get; }
 
 		/// <summary>
-	
 		/// Gets the paint which will fill the background of a FrameworkElement.
 		/// </summary>
 		Paint? Background { get; }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Maui.Handlers
 		public static PropertyMapper<IView> ViewMapper = new PropertyMapper<IView>
 		{
 			[nameof(IView.AutomationId)] = MapAutomationId,
+			[nameof(IView.Frame)] = MapFrame,
+			[nameof(IView.IsVisible)] = MapIsVisible,
 			[nameof(IView.Background)] = MapBackground,
 			[nameof(IView.Width)] = MapWidth,
 			[nameof(IView.Height)] = MapHeight,
@@ -104,6 +106,11 @@ namespace Microsoft.Maui.Handlers
 		public static void MapIsEnabled(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateIsEnabled(view);
+		}
+
+		public static void MapIsVisible(IViewHandler handler, IView view)
+		{
+			((NativeView?)handler.NativeView)?.UpdateIsVisible(view);
 		}
 
 		public static void MapBackground(IViewHandler handler, IView view)

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			[nameof(IView.AutomationId)] = MapAutomationId,
 			[nameof(IView.Visibility)] = MapVisibility,
-			[nameof(IView.Visibility)] = MapVisibility,
 			[nameof(IView.Background)] = MapBackground,
 			[nameof(IView.Width)] = MapWidth,
 			[nameof(IView.Height)] = MapHeight,

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui.Handlers
 		public static PropertyMapper<IView> ViewMapper = new PropertyMapper<IView>
 		{
 			[nameof(IView.AutomationId)] = MapAutomationId,
+			[nameof(IView.Visibility)] = MapVisibility,
 			[nameof(IView.Frame)] = MapFrame,
 			[nameof(IView.IsVisible)] = MapIsVisible,
 			[nameof(IView.Background)] = MapBackground,
@@ -108,9 +109,9 @@ namespace Microsoft.Maui.Handlers
 			((NativeView?)handler.NativeView)?.UpdateIsEnabled(view);
 		}
 
-		public static void MapIsVisible(IViewHandler handler, IView view)
+		public static void MapVisibility(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.NativeView)?.UpdateIsVisible(view);
+			((NativeView?)handler.NativeView)?.UpdateVisibility(view);
 		}
 
 		public static void MapBackground(IViewHandler handler, IView view)

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -19,8 +19,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			[nameof(IView.AutomationId)] = MapAutomationId,
 			[nameof(IView.Visibility)] = MapVisibility,
-			[nameof(IView.Frame)] = MapFrame,
-			[nameof(IView.IsVisible)] = MapIsVisible,
+			[nameof(IView.Visibility)] = MapVisibility,
 			[nameof(IView.Background)] = MapBackground,
 			[nameof(IView.Width)] = MapWidth,
 			[nameof(IView.Height)] = MapHeight,

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Maui.Layouts
 			for (int n = 0; n < views.Count; n++)
 			{
 				var child = views[n];
+
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
 				var measure = child.Measure(double.PositiveInfinity, heightConstraint);
 				totalRequestedWidth += measure.Width;
 				requestedHeight = Math.Max(requestedHeight, measure.Height);
@@ -59,6 +65,12 @@ namespace Microsoft.Maui.Layouts
 			for (int n = 0; n < views.Count; n++)
 			{
 				var child = views[n];
+
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
 				xPosition += ArrangeChild(child, height, spacing, xPosition);
 			}
 		}
@@ -70,6 +82,12 @@ namespace Microsoft.Maui.Layouts
 			for (int n = views.Count - 1; n >= 0; n--)
 			{
 				var child = views[n];
+
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
 				xPostition += ArrangeChild(child, height, spacing, xPostition);
 			}
 		}

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Maui.Layouts
 
 			foreach (var child in views)
 			{
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
 				var measure = child.Measure(widthConstraint, double.PositiveInfinity);
 				totalRequestedHeight += measure.Height;
 				requestedWidth = Math.Max(requestedWidth, measure.Width);
@@ -45,6 +50,11 @@ namespace Microsoft.Maui.Layouts
 
 			foreach (var child in views)
 			{
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
 				var destination = new Rectangle(0, stackHeight, width, child.DesiredSize.Height);
 				child.Arrange(destination);
 				stackHeight += destination.Height + spacing;

--- a/src/Core/src/Platform/Android/ActivityIndicatorExtensions.cs
+++ b/src/Core/src/Platform/Android/ActivityIndicatorExtensions.cs
@@ -5,8 +5,17 @@ namespace Microsoft.Maui
 {
 	public static class ActivityIndicatorExtensions
 	{
-		public static void UpdateIsRunning(this ProgressBar progressBar, IActivityIndicator activityIndicator) =>
-			progressBar.Visibility = activityIndicator.IsRunning ? ViewStates.Visible : ViewStates.Invisible;
+		public static void UpdateIsRunning(this ProgressBar progressBar, IActivityIndicator activityIndicator)
+		{
+			if (activityIndicator.Visibility == Visibility.Visible)
+			{
+				progressBar.Visibility = activityIndicator.IsRunning ? ViewStates.Visible : ViewStates.Invisible;
+			}
+			else
+			{
+				progressBar.Visibility = activityIndicator.Visibility.ToNativeVisibility();
+			}
+		}
 
 		public static void UpdateColor(this ProgressBar progressBar, IActivityIndicator activityIndicator)
 		{

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -18,18 +18,17 @@ namespace Microsoft.Maui
 
 		public static void UpdateVisibility(this AView nativeView, IView view)
 		{
-			switch (view.Visibility)
+			nativeView.Visibility = view.Visibility.ToNativeVisibility();
+		}
+
+		public static ViewStates ToNativeVisibility(this Visibility visibility) 
+		{
+			return visibility switch
 			{
-				case Visibility.Visible:
-					nativeView.Visibility = ViewStates.Visible;
-					break;
-				case Visibility.Hidden:
-					nativeView.Visibility = ViewStates.Invisible;
-					break;
-				case Visibility.Collapsed:
-					nativeView.Visibility = ViewStates.Gone;
-					break;
-			}
+				Visibility.Hidden => ViewStates.Invisible,
+				Visibility.Collapsed => ViewStates.Gone,
+				_ => ViewStates.Visible,
+			};
 		}
 
 		public static void UpdateBackground(this AView nativeView, IView view)

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -1,3 +1,4 @@
+using Android.Views;
 using AndroidX.Core.View;
 using Microsoft.Maui.Graphics;
 using AView = Android.Views.View;
@@ -13,6 +14,17 @@ namespace Microsoft.Maui
 		{
 			if (nativeView != null)
 				nativeView.Enabled = view.IsEnabled;
+		}
+
+		public static void UpdateIsVisible(this AView nativeView, IView view)
+		{
+			if (view.IsVisible && nativeView.Visibility != ViewStates.Visible)
+				nativeView.Visibility = ViewStates.Visible;
+			if (!view.IsVisible && nativeView.Visibility != ViewStates.Gone)
+				nativeView.Visibility = ViewStates.Gone;
+
+			nativeView.Invalidate();
+			nativeView.RequestLayout();
 		}
 
 		public static void UpdateBackground(this AView nativeView, IView view)

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -30,9 +30,6 @@ namespace Microsoft.Maui
 					nativeView.Visibility = ViewStates.Gone;
 					break;
 			}
-
-			nativeView.Invalidate();
-			nativeView.RequestLayout();
 		}
 
 		public static void UpdateBackground(this AView nativeView, IView view)

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -16,12 +16,20 @@ namespace Microsoft.Maui
 				nativeView.Enabled = view.IsEnabled;
 		}
 
-		public static void UpdateIsVisible(this AView nativeView, IView view)
+		public static void UpdateVisibility(this AView nativeView, IView view)
 		{
-			if (view.IsVisible && nativeView.Visibility != ViewStates.Visible)
-				nativeView.Visibility = ViewStates.Visible;
-			if (!view.IsVisible && nativeView.Visibility != ViewStates.Gone)
-				nativeView.Visibility = ViewStates.Gone;
+			switch (view.Visibility)
+			{
+				case Visibility.Visible:
+					nativeView.Visibility = ViewStates.Visible;
+					break;
+				case Visibility.Hidden:
+					nativeView.Visibility = ViewStates.Invisible;
+					break;
+				case Visibility.Collapsed:
+					nativeView.Visibility = ViewStates.Gone;
+					break;
+			}
 
 			nativeView.Invalidate();
 			nativeView.RequestLayout();

--- a/src/Core/src/Platform/Standard/ViewExtensions.cs
+++ b/src/Core/src/Platform/Standard/ViewExtensions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui
 	{
 		public static void UpdateIsEnabled(this object nativeView, IView view) { }
 
-		public static void UpdateIsVisible(this object nativeView, IView view) { }
+		public static void UpdateVisibility(this object nativeView, IView view) { }
 
 		public static void UpdateBackground(this object nativeView, IView view) { }
 

--- a/src/Core/src/Platform/Standard/ViewExtensions.cs
+++ b/src/Core/src/Platform/Standard/ViewExtensions.cs
@@ -4,6 +4,8 @@ namespace Microsoft.Maui
 	{
 		public static void UpdateIsEnabled(this object nativeView, IView view) { }
 
+		public static void UpdateIsVisible(this object nativeView, IView view) { }
+
 		public static void UpdateBackground(this object nativeView, IView view) { }
 
 		public static void UpdateAutomationId(this object nativeView, IView view) { }

--- a/src/Core/src/Platform/VisibilityExtensions.cs
+++ b/src/Core/src/Platform/VisibilityExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Maui
+{
+	public static class VisibilityExtensions
+	{
+		public static Visibility ToVisibility(this bool isVisible)
+		{
+			if (isVisible)
+				return Visibility.Visible;
+
+			return Visibility.Hidden;
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui
 		public static void UpdateIsEnabled(this FrameworkElement nativeView, IView view) =>
 			(nativeView as Control)?.UpdateIsEnabled(view.IsEnabled);
 		
-		public static void UpdateIsVisible(this FrameworkElement nativeView, IView view)
+		public static void UpdateVisibility(this FrameworkElement nativeView, IView view)
 		{
 			nativeView.Visibility = view.IsVisible ? Visibility.Visible : Visibility.Collapsed;
 		}

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Maui
 	{
 		public static void UpdateIsEnabled(this FrameworkElement nativeView, IView view) =>
 			(nativeView as Control)?.UpdateIsEnabled(view.IsEnabled);
+		
+		public static void UpdateIsVisible(this FrameworkElement nativeView, IView view)
+		{
+			nativeView.Visibility = view.IsVisible ? Visibility.Visible : Visibility.Collapsed;
+		}
 
 		public static void UpdateBackground(this FrameworkElement nativeView, IView view)
 		{

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -13,7 +13,23 @@ namespace Microsoft.Maui
 		
 		public static void UpdateVisibility(this FrameworkElement nativeView, IView view)
 		{
-			nativeView.Visibility = view.IsVisible ? Visibility.Visible : Visibility.Collapsed;
+			double opacity = view.Opacity;
+
+			switch (view.Visibility)
+			{
+				case Visibility.Visible:
+					nativeView.Opacity = opacity;
+					nativeView.Visibility = UI.Xaml.Visibility.Visible;
+					break;
+				case Visibility.Hidden:
+					nativeView.Opacity = 0;
+					nativeView.Visibility = UI.Xaml.Visibility.Visible;
+					break;
+				case Visibility.Collapsed:
+					nativeView.Opacity = opacity;
+					nativeView.Visibility = UI.Xaml.Visibility.Collapsed;
+					break;
+			}
 		}
 
 		public static void UpdateBackground(this FrameworkElement nativeView, IView view)

--- a/src/Core/src/Platform/iOS/CollapseConstraint.cs
+++ b/src/Core/src/Platform/iOS/CollapseConstraint.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using UIKit;
+
+namespace Microsoft.Maui
+{
+	/// <summary>
+	/// Constraint which forces a UIView's height to zero
+	/// </summary>
+	internal class CollapseConstraint : NSLayoutConstraint 
+	{
+		public override NSLayoutRelation Relation => NSLayoutRelation.Equal;
+		public override NSLayoutAttribute FirstAttribute => NSLayoutAttribute.Height;
+		public override nfloat Multiplier => 0;
+	}
+}

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -21,9 +21,25 @@ namespace Microsoft.Maui
 			uiControl.Enabled = view.IsEnabled;
 		}
 
-		public static void UpdateIsVisible(this UIView nativeView, IView view)
+		public static void UpdateVisibility(this UIView nativeView, IView view)
 		{
-			nativeView.Hidden = !view.IsVisible;
+			double opacity = view.Opacity;
+
+			switch (view.Visibility)
+			{
+				case Visibility.Visible:
+					nativeView.Alpha = (float)opacity;
+					nativeView.Hidden = false;
+					break;
+				case Visibility.Hidden:
+					nativeView.Alpha = 0;
+					nativeView.Hidden = false;
+					break;
+				case Visibility.Collapsed:
+					nativeView.Alpha = (float)opacity;
+					nativeView.Hidden = true;
+					break;
+			}
 		}
 
 		public static void UpdateBackground(this UIView nativeView, IView view)

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Maui
 			uiControl.Enabled = view.IsEnabled;
 		}
 
+		public static void UpdateIsVisible(this UIView nativeView, IView view)
+		{
+			nativeView.Hidden = !view.IsVisible;
+		}
+
 		public static void UpdateBackground(this UIView nativeView, IView view)
 		{
 			if (nativeView == null)

--- a/src/Core/src/Primitives/Visibility.cs
+++ b/src/Core/src/Primitives/Visibility.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Maui
+{
+	public enum Visibility
+	{
+		Visible = 0,
+		Hidden = 1,
+		Collapsed = 2
+	}
+}

--- a/src/Core/tests/Benchmarks/Stubs/StubBase.cs
+++ b/src/Core/tests/Benchmarks/Stubs/StubBase.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 	{
 		public bool IsEnabled { get; set; } = true;
 
-		public bool IsVisible { get; set; } = true;
+		public Visibility Visibility { get; set; } = Visibility.Visible;
+
+		public double Opacity { get; set; } = 1.0d;
 
 		public Paint Background { get; set; }
 

--- a/src/Core/tests/Benchmarks/Stubs/StubBase.cs
+++ b/src/Core/tests/Benchmarks/Stubs/StubBase.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 	{
 		public bool IsEnabled { get; set; } = true;
 
+		public bool IsVisible { get; set; } = true;
+
 		public Paint Background { get; set; }
 
 		public Rectangle Frame { get; set; } = new Rectangle(0, 0, 20, 20);

--- a/src/Core/tests/DeviceTests/Handlers/ActivityIndicator/ActivityIndicatorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ActivityIndicator/ActivityIndicatorHandlerTests.Android.cs
@@ -2,8 +2,10 @@
 using System.Threading.Tasks;
 using Android.Views;
 using Android.Widget;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -23,6 +25,21 @@ namespace Microsoft.Maui.DeviceTests
 				action?.Invoke();
 				nativeActivityIndicator.AssertContainsColor(color);
 			});
+		}
+
+		[Theory(DisplayName = "Visibility is set correctly")]
+		[InlineData(Visibility.Collapsed)]
+		[InlineData(Visibility.Hidden)]
+		public override async Task SetVisibility(Visibility visibility)
+		{
+			var view = new ActivityIndicatorStub
+			{
+				Visibility = visibility,
+				IsRunning = true
+			};
+
+			var id = await GetValueAsync(view, handler => GetVisibility(handler));
+			Assert.Equal(view.Visibility, id);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Android.cs
@@ -22,14 +22,16 @@ namespace Microsoft.Maui.DeviceTests
 			return viewHandler.VirtualView.Semantics.HeadingLevel;
 		}
 
-		protected bool GetIsVisible(IViewHandler viewHandler)
+		protected Visibility GetVisibility(IViewHandler viewHandler)
 		{
 			var nativeView = (View)viewHandler.NativeView;
 
 			if (nativeView.Visibility == ViewStates.Visible)
-				return true;
-
-			return false;
+				return Visibility.Visible;
+			else if (nativeView.Visibility == ViewStates.Gone)
+				return Visibility.Collapsed;
+			else
+				return Visibility.Hidden;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Android.cs
@@ -21,5 +21,15 @@ namespace Microsoft.Maui.DeviceTests
 
 			return viewHandler.VirtualView.Semantics.HeadingLevel;
 		}
+
+		protected bool GetIsVisible(IViewHandler viewHandler)
+		{
+			var nativeView = (View)viewHandler.NativeView;
+
+			if (nativeView.Visibility == ViewStates.Visible)
+				return true;
+
+			return false;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Threading.Tasks;
-using Microsoft.Maui.DeviceTests.Stubs;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -11,10 +9,23 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData()]
 		public async Task SetAutomationId()
 		{
-			var view = new TStub();
-			view.AutomationId = "TestId";
-			var id = await GetValueAsync((IView)view, handler => GetAutomationId(handler));
+			var view = new TStub
+			{
+				AutomationId = "TestId"
+			};
+			var id = await GetValueAsync(view, handler => GetAutomationId(handler));
 			Assert.Equal(view.AutomationId, id);
+		}
+
+		[Fact(DisplayName = "IsVisible is set correctly")]
+		public async Task SetIsVisible()
+		{
+			var view = new TStub
+			{
+				IsVisible = false
+			};
+			var id = await GetValueAsync(view, handler => GetIsVisible(handler));
+			Assert.Equal(view.IsVisible, id);
 		}
 
 		[Fact(DisplayName = "Semantic Description is set correctly")]
@@ -23,7 +34,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var view = new TStub();
 			view.Semantics.Description = "Test";
-			var id = await GetValueAsync((IView)view, handler => GetSemanticDescription(handler));
+			var id = await GetValueAsync(view, handler => GetSemanticDescription(handler));
 			Assert.Equal(view.Semantics.Description, id);
 		}
 
@@ -37,7 +48,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var view = new TStub();
 			view.Semantics.Description = "Test";
-			var id = await GetValueAsync((IView)view, handler => GetSemanticDescription(handler));
+			var id = await GetValueAsync(view, handler => GetSemanticDescription(handler));
 			Assert.Equal(view.Semantics.Description, id);
 		}
 
@@ -47,7 +58,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var view = new TStub();
 			view.Semantics.HeadingLevel = SemanticHeadingLevel.Level1;
-			var id = await GetValueAsync((IView)view, handler => GetSemanticHeading(handler));
+			var id = await GetValueAsync(view, handler => GetSemanticHeading(handler));
 			Assert.Equal(view.Semantics.HeadingLevel, id);
 		}
 
@@ -55,10 +66,12 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData()]
 		public async Task NullSemanticsClass()
 		{
-			var view = new TStub();
-			view.Semantics = null;
-			view.AutomationId = "CreationFailed";
-			var id = await GetValueAsync((IView)view, handler => GetAutomationId(handler));
+			var view = new TStub
+			{
+				Semantics = null,
+				AutomationId = "CreationFailed"
+			};
+			var id = await GetValueAsync(view, handler => GetAutomationId(handler));
 			Assert.Equal(view.AutomationId, id);
 		}
 	}

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
@@ -17,15 +17,17 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(view.AutomationId, id);
 		}
 
-		[Fact(DisplayName = "IsVisible is set correctly")]
-		public async Task SetIsVisible()
+		[Theory(DisplayName = "Visibility is set correctly")]
+		[InlineData(Visibility.Collapsed)]
+		[InlineData(Visibility.Hidden)]
+		public async Task SetVisibility(Visibility visibility)
 		{
 			var view = new TStub
 			{
-				IsVisible = false
+				Visibility = visibility
 			};
-			var id = await GetValueAsync(view, handler => GetIsVisible(handler));
-			Assert.Equal(view.IsVisible, id);
+			var id = await GetValueAsync(view, handler => GetVisibility(handler));
+			Assert.Equal(view.Visibility, id);
 		}
 
 		[Fact(DisplayName = "Semantic Description is set correctly")]

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
@@ -20,12 +20,13 @@ namespace Microsoft.Maui.DeviceTests
 		[Theory(DisplayName = "Visibility is set correctly")]
 		[InlineData(Visibility.Collapsed)]
 		[InlineData(Visibility.Hidden)]
-		public async Task SetVisibility(Visibility visibility)
+		public virtual async Task SetVisibility(Visibility visibility)
 		{
 			var view = new TStub
 			{
 				Visibility = visibility
 			};
+
 			var id = await GetValueAsync(view, handler => GetVisibility(handler));
 			Assert.Equal(view.Visibility, id);
 		}

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
@@ -17,7 +17,20 @@ namespace Microsoft.Maui.DeviceTests
 			((UIView)viewHandler.NativeView).AccessibilityTraits.HasFlag(UIAccessibilityTrait.Header)
 				? SemanticHeadingLevel.Level1 : SemanticHeadingLevel.None;
 
-		protected bool GetIsVisible(IViewHandler viewHandler) =>
-			!((UIView)viewHandler.NativeView).Hidden;
+		protected Visibility GetVisibility(IViewHandler viewHandler)
+		{
+			var nativeView = (UIView)viewHandler.NativeView;
+			var alpha = nativeView.Alpha;
+
+			if (alpha == 0)
+				return Visibility.Hidden;
+			else
+			{
+				if (nativeView.Hidden)
+					return Visibility.Collapsed;
+
+				return Visibility.Visible;
+			}
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
@@ -16,5 +16,8 @@ namespace Microsoft.Maui.DeviceTests
 		protected SemanticHeadingLevel GetSemanticHeading(IViewHandler viewHandler) =>
 			((UIView)viewHandler.NativeView).AccessibilityTraits.HasFlag(UIAccessibilityTrait.Header)
 				? SemanticHeadingLevel.Level1 : SemanticHeadingLevel.None;
+
+		protected bool GetIsVisible(IViewHandler viewHandler) =>
+			!((UIView)viewHandler.NativeView).Hidden;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
@@ -20,17 +20,25 @@ namespace Microsoft.Maui.DeviceTests
 		protected Visibility GetVisibility(IViewHandler viewHandler)
 		{
 			var nativeView = (UIView)viewHandler.NativeView;
-			var alpha = nativeView.Alpha;
 
-			if (alpha == 0)
-				return Visibility.Hidden;
-			else
+			foreach (var constraint in nativeView.Constraints)
 			{
-				if (nativeView.Hidden)
-					return Visibility.Collapsed;
-
-				return Visibility.Visible;
+				if (constraint is CollapseConstraint collapseConstraint)
+				{
+					// Active the collapse constraint; that will squish the view down to zero height
+					if (collapseConstraint.Active)
+					{
+						return Visibility.Collapsed;
+					}
+				}
 			}
+
+			if (nativeView.Hidden)
+			{
+				return Visibility.Hidden;
+			}
+
+			return Visibility.Visible;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 	{
 		public bool IsEnabled { get; set; } = true;
 
-		public bool IsVisible { get; set; } = true;
+		public Visibility Visibility { get; set; } = Visibility.Visible;
+
+		public double Opacity { get; set; } = 1.0d;
 
 		public Paint Background { get; set; }
 

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 	{
 		public bool IsEnabled { get; set; } = true;
 
+		public bool IsVisible { get; set; } = true;
+
 		public Paint Background { get; set; }
 
 		public Rectangle Frame { get; set; }

--- a/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Maui.UnitTests
 	{
 		public bool IsEnabled => { get; set; }
 
-		public bool IsVisible { get; set; }
+		public Visibility Visibility { get; set; }
+
+		public double Opacity { get; set; }
 
 
 		public Rectangle Frame => { get; set; }

--- a/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Primitives;
 
@@ -15,7 +14,7 @@ namespace Microsoft.Maui.UnitTests
 
 		public IViewHandler Handler { get; set; }
 
-		public double Width { get; set; }
+		public IFrameworkElement Parent => { get; set; }
 
 		public Size DesiredSize => { get; set; }
 
@@ -37,12 +36,14 @@ namespace Microsoft.Maui.UnitTests
 
 		public Semantics Semantics { get; set; }
 
-		public Size Arrange(Rectangle bounds) =>
+		public void Arrange(Rectangle bounds) { }
 			Size.Zero;
-
 		public void InvalidateArrange() { }
 
 		public void InvalidateMeasure() { }
+
+		public Size Arrange(Rectangle bounds) =>
+			Size.Zero;
 
 		public Size Measure(double widthConstraint, double heightConstraint) =>
 			Size.Zero;

--- a/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
@@ -5,29 +5,28 @@ namespace Microsoft.Maui.UnitTests
 {
 	class ViewStub : IViewStub
 	{
-		public bool IsEnabled => { get; set; }
+		public bool IsEnabled { get; set; }
 
 		public Visibility Visibility { get; set; }
 
 		public double Opacity { get; set; }
 
-
-		public Rectangle Frame => { get; set; }
+		public Rectangle Frame { get; set; }
 
 		public IViewHandler Handler { get; set; }
 
-		public IFrameworkElement Parent => { get; set; }
+		public IFrameworkElement Parent { get; set; }
 
-		public Size DesiredSize => { get; set; }
+		public Size DesiredSize { get; set; }
 
-		public bool IsMeasureValid => { get; set; }
+		public bool IsMeasureValid { get; set; }
 
-		public bool IsArrangeValid => { get; set; }
+		public bool IsArrangeValid { get; set; }
 
-		public double Width => { get; set; }
+		public double Width { get; set; }
 
-		public double Height => { get; set; }
-		public Thickness Margin => { get; set; }
+		public double Height { get; set; }
+		public Thickness Margin { get; set; }
 		public string AutomationId { get; set; }
 
 		public FlowDirection FlowDirection { get; set; }
@@ -38,14 +37,13 @@ namespace Microsoft.Maui.UnitTests
 
 		public Semantics Semantics { get; set; }
 
-		public void Arrange(Rectangle bounds) { }
-			Size.Zero;
+		public Paint Background { get; set; }
+
+		public Size Arrange(Rectangle bounds) => Size.Zero;
+
 		public void InvalidateArrange() { }
 
 		public void InvalidateMeasure() { }
-
-		public Size Arrange(Rectangle bounds) =>
-			Size.Zero;
 
 		public Size Measure(double widthConstraint, double heightConstraint) =>
 			Size.Zero;

--- a/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
@@ -6,24 +6,27 @@ namespace Microsoft.Maui.UnitTests
 {
 	class ViewStub : IViewStub
 	{
-		public Thickness Margin { get; set; }
+		public bool IsEnabled => { get; set; }
 
-		public bool IsEnabled { get; set; }
+		public bool IsVisible { get; set; }
 
-		public Paint Background { get; set; }
 
-		public Rectangle Frame { get; set; }
-
-		public double Width { get; set; }
-
-		public double Height { get; set; }
+		public Rectangle Frame => { get; set; }
 
 		public IViewHandler Handler { get; set; }
 
-		public IFrameworkElement Parent { get; set; }
+		public double Width { get; set; }
 
-		public Size DesiredSize { get; set; }
+		public Size DesiredSize => { get; set; }
 
+		public bool IsMeasureValid => { get; set; }
+
+		public bool IsArrangeValid => { get; set; }
+
+		public double Width => { get; set; }
+
+		public double Height => { get; set; }
+		public Thickness Margin => { get; set; }
 		public string AutomationId { get; set; }
 
 		public FlowDirection FlowDirection { get; set; }


### PR DESCRIPTION
### Description of Change ###

Implement `Visibility` property in ViewHandlers.

- Collapsed: Do not display the element, and do not reserve space for it in layout.
- Hidden: Do not display the element, but reserve space for the element in layout.
- Visible: Display the element.

Related with https://github.com/dotnet/maui/pull/707
We need to review which approach fits better.

### Platforms Affected ### 

- Core
- iOS
- macOS
- Android
- Windows

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests