### PR TITLE
Allow derived image sources to indicate changes

### DIFF
--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		private protected void OnSourceChanged()
+		protected void OnSourceChanged()
 		{
 			_weakEventManager.HandleEvent(this, EventArgs.Empty, nameof(SourceChanged));
 		}


### PR DESCRIPTION
### Description of Change ###

Derived types that have bindable properties need to call `OnSourceChanged` when things change internally so the various view can reload.

This was originally protected, but then I went and made all the internal methods private, seems this one was actually meant to be used.