### PR TITLE
Convert key for span tracking in grids to a record type

### DIFF
--- a/src/Core/src/IsExternalInit.cs
+++ b/src/Core/src/IsExternalInit.cs
@@ -1,0 +1,11 @@
+﻿#nullable enable
+
+// https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.isexternalinit?view=net-5.0
+// https://developercommunity.visualstudio.com/t/error-cs0518-predefined-type-systemruntimecompiler/1244809
+// Adding this because at least one of the target frameworks doesn't include it; hopefully we can drop this at some point
+// (and hopefully before release)
+// TODO ezhart Evaluate whether we still need this
+namespace System.Runtime.CompilerServices
+{
+	internal static class IsExternalInit { }
+}

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -318,6 +318,9 @@ namespace Microsoft.Maui.Layouts
 			}
 		}
 
+		// Dictionary key for tracking a Span
+		record SpanKey(int Start, int Length, bool IsColumn);
+
 		class Span
 		{
 			public int Start { get; }
@@ -335,33 +338,6 @@ namespace Microsoft.Maui.Layouts
 				Requested = value;
 
 				Key = new SpanKey(Start, Length, IsColumn);
-			}
-		}
-
-		class SpanKey
-		{
-			public SpanKey(int start, int length, bool isColumn)
-			{
-				Start = start;
-				Length = length;
-				IsColumn = isColumn;
-			}
-
-			public int Start { get; }
-			public int Length { get; }
-			public bool IsColumn { get; }
-
-			public override bool Equals(object? obj)
-			{
-				return obj is SpanKey key &&
-					   Start == key.Start &&
-					   Length == key.Length &&
-					   IsColumn == key.IsColumn;
-			}
-
-			public override int GetHashCode()
-			{
-				return Start.GetHashCode() ^ Length.GetHashCode() ^ IsColumn.GetHashCode();
 			}
 		}
 


### PR DESCRIPTION
Converts the `SpanKey` type (used for tracking spans in an internal dictionary for grid layout) to a `record` type. 

Also adds an `IsExternalInit` class to source (hopefully temporarily) so we can use the C# 9 new features while targeting older frameworks. 

There's probably more code in GridLayoutManager we could convert (the `Cell` type is a strong candidate), but I'd like to wait until the implementation is complete before making that call. 