### PR TITLE
Remove Entry measurement override on iOS

### DIFF
--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class EntryHandler : ViewHandler<IEntry, MauiTextField>
 	{
-		static readonly int BaseHeight = 30;
-
 		static UIColor? DefaultTextColor;
 
 		protected override MauiTextField CreateNativeView()
@@ -42,9 +40,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			DefaultTextColor = nativeView.TextColor;
 		}
-
-		public override Size GetDesiredSize(double widthConstraint, double heightConstraint) =>
-			new SizeRequest(new Size(widthConstraint, BaseHeight));
 
 		public static void MapText(EntryHandler handler, IEntry entry)
 		{


### PR DESCRIPTION
### Description of Change ###

Forms used a custom override for getting the desired size of an Entry which took the measured size of a string using the current font size into account. The full method didn't make the port over to the MAUI handler. The version that got ported returns an infinite width for an Entry measured with an infinite width constraint. This causes weird behaviors in some situations and straight-up crashes legacy horizontal StackLayouts when layout compression is applied.

This change removes that override and uses the default measurement method for measuring Entries.

Fixes #766

At some point in the future we may need to reinstate all or part of the Forms measurement method; we can worry about that when the time comes. For now the default method is working fine.

