### PR TITLE
Request layout for iOS Label when text change invalidates content size

### DIFF
--- a/src/Core/src/Platform/iOS/CoreGraphicsExtensions.cs
+++ b/src/Core/src/Platform/iOS/CoreGraphicsExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using CoreGraphics;
 using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
@@ -29,6 +30,12 @@ namespace Microsoft.Maui
 		public static CGRect ToCGRect(this Rectangle rect)
 		{
 			return new CGRect(rect.X, rect.Y, rect.Width, rect.Height);
+		}
+
+		public static bool IsCloseTo(this CGSize size0, CGSize size1, nfloat tolerance) 
+		{
+			var diff = size0 - size1;
+			return Math.Abs(diff.Width) < tolerance && Math.Abs(diff.Height) < tolerance;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiLabel.cs
+++ b/src/Core/src/Platform/iOS/MauiLabel.cs
@@ -1,4 +1,5 @@
 ﻿using CoreGraphics;
+using System;
 using UIKit;
 
 namespace Microsoft.Maui.Platform.iOS
@@ -13,6 +14,24 @@ namespace Microsoft.Maui.Platform.iOS
 
 		public MauiLabel()
 		{
+		}
+
+		public override void InvalidateIntrinsicContentSize()
+		{
+			base.InvalidateIntrinsicContentSize();
+
+			if (Frame.Width == 0 && Frame.Height == 0)
+			{
+				// The Label hasn't actually been laid out on screen yet; no reason to request a layout
+				return;
+			}
+
+			if (!Frame.Size.IsCloseTo(AddInsets(IntrinsicContentSize), (nfloat)0.001))
+			{
+				// The text or its attributes have changed enough that the size no longer matches the set Frame. It's possible
+				// that the Label needs to be laid out again at a different size, so we request that the parent do so. 
+				Superview?.SetNeedsLayout();
+			}
 		}
 
 		public override void DrawText(CGRect rect) => base.DrawText(TextInsets.InsetRect(rect));


### PR DESCRIPTION
Add override for InvalidateIntrinsicContentSize on MauiLabel to listen for content size changes (text, fonts, etc.) and request a layout update from the parent view if the current Frame size is no longer valid. 

Fixes #783

MauiLabel is smart enough to avoid a layout request if the updated size would be the same as the old size (e.g. when changing from "Text" to "txeT" with a fixed-width Font); in that case, the updated text will draw but a layout pass will not be requested. 

However, the MauiLabel class doesn't currently have enough information to ignore content size invalidation for every situation where the cross-platform Label specifications would allow it (e.g., if the width is fixed and MaxLines is 1). So there are some opportunities for minor performance optimizations to be made later. 



