### PR TITLE
[build] remove EnableWorkloadResolver.sentinel

### DIFF
--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -7,7 +7,6 @@
     <DotNetToolPath>$(DotNetDirectory)dotnet</DotNetToolPath>
     <DotNetPacksDirectory>$(DotNetDirectory)packs/</DotNetPacksDirectory>
     <DotNetSdkManifestsDirectory>$(DotNetDirectory)sdk-manifests/$(DotNetPreviewVersionBand)/</DotNetSdkManifestsDirectory>
-    <DotNetSentinelPath>$(DotNetDirectory)sdk/$(MicrosoftDotnetSdkInternalPackageVersion)/EnableWorkloadResolver.sentinel</DotNetSentinelPath>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <DotNetInstallScriptUrl>https://dot.net/v1/dotnet-install.ps1</DotNetInstallScriptUrl>
@@ -29,7 +28,6 @@
       _InstallDotNet;
       _AcquireWorkloads;
       _AcquirePacks;
-      _CreateWorkloadSentinel;
     </_ProvisionDependsOn>
   </PropertyGroup>
   <Target Name="_Provision" BeforeTargets="Build" DependsOnTargets="$(_ProvisionDependsOn)" />
@@ -107,12 +105,6 @@
     />
     <RemoveDir Directories="@(_PacksToRemove->'$(DotNetPacksDirectory)%(Identity)')" />
     <Touch Files="$(DotNetPacksDirectory).stamp" AlwaysCreate="true" />
-  </Target>
-
-  <Target Name="_CreateWorkloadSentinel"
-      Inputs="$(_Inputs)"
-      Outputs="$(DotNetSentinelPath)">
-    <Touch Files="$(DotNetSentinelPath)" AlwaysCreate="true" />
   </Target>
 
   <UsingTask TaskName="ReplaceText"


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/xamarin/xamarin-android/pull/5909

This file is no longer needed in .NET 6 Preview 4 and higher. We should stop creating it now.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me