### PR TITLE
Gestures Support (initially adding TapGesture)

### DIFF
--- a/src/Compatibility/Core/src/Android/GestureManager.cs
+++ b/src/Compatibility/Core/src/Android/GestureManager.cs
@@ -11,6 +11,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
+	[PortHandler("Partially ported")]
 	internal class GestureManager : IDisposable
 	{
 		IVisualElementRenderer _renderer;
@@ -156,9 +157,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				new TapGestureHandler(() => View, () =>
 				{
 					if (Element is View view)
-						return view.GetChildElements(Point.Zero) ?? new List<GestureElement>();
+						return view.GetChildElements(Point.Zero) ?? new List<IGestureView>();
 
-					return new List<GestureElement>();
+					return new List<IGestureView>();
 				}),
 				new PanGestureHandler(() => View, context.FromPixels),
 				new SwipeGestureHandler(() => View, context.FromPixels),

--- a/src/Compatibility/Core/src/Android/TapGestureHandler.cs
+++ b/src/Compatibility/Core/src/Android/TapGestureHandler.cs
@@ -6,15 +6,16 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
+	[PortHandler]
 	internal class TapGestureHandler
 	{
-		public TapGestureHandler(Func<View> getView, Func<IList<GestureElement>> getChildElements)
+		public TapGestureHandler(Func<View> getView, Func<IList<IGestureView>> getChildElements)
 		{
 			GetView = getView;
 			GetChildElements = getChildElements;
 		}
 
-		Func<IList<GestureElement>> GetChildElements { get; }
+		Func<IList<IGestureView>> GetChildElements { get; }
 		Func<View> GetView { get; }
 
 		public void OnSingleClick()

--- a/src/Compatibility/Core/src/iOS/EventTracker.cs
+++ b/src/Compatibility/Core/src/iOS/EventTracker.cs
@@ -25,6 +25,7 @@ using Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 #endif
 {
+	[PortHandler("Partially ported")]
 	public class EventTracker : IDisposable
 	{
 		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
@@ -100,7 +101,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			OnElementChanged(this, new VisualElementChangedEventArgs(null, _renderer.Element));
 		}
 
-		static IList<GestureElement> GetChildGestures(
+		static IList<IGestureView> GetChildGestures(
 			NativeGestureRecognizer sender,
 			WeakReference weakEventTracker, WeakReference weakRecognizer, EventTracker eventTracker, View view)
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -1,0 +1,570 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Maui.Controls.Sample.Controls;
+using Maui.Controls.Sample.ViewModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Essentials;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.LifecycleEvents;
+using Debug = System.Diagnostics.Debug;
+using GradientStop = Microsoft.Maui.Controls.GradientStop;
+
+namespace Maui.Controls.Sample.Pages
+{
+	public class MainPage : BasePage
+	{
+		readonly IServiceProvider _services;
+		readonly MainPageViewModel _viewModel;
+
+		public MainPage(IServiceProvider services, MainPageViewModel viewModel)
+		{
+			BackgroundColor = Colors.White;
+			ToolbarItems.Add(new ToolbarItem()
+			{
+				Text = "Page"
+			});
+
+			Title = "Welcome to the Samples";
+			_services = services;
+			BindingContext = _viewModel = viewModel;
+
+			SetupMauiLayout();
+
+			NavigationPage.SetHasNavigationBar(this, false);
+
+			//SetupCompatibilityLayout();
+			//SetupVisibilityTest();
+		}
+
+		public class VisibilityLabel : Label, IFrameworkElement
+		{
+			private Visibility _visibility;
+
+			public void SetVisibility(Visibility visibility)
+			{
+				_visibility = visibility;
+				Handler?.UpdateValue(nameof(Visibility));
+			}
+
+			Visibility IFrameworkElement.Visibility
+			{
+				get
+				{
+					return _visibility;
+				}
+			}
+		}
+
+		const string LoremIpsum =
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+			"Quisque ut dolor metus. Duis vel iaculis mauris, sit amet finibus mi. " +
+			"Etiam congue ornare risus, in facilisis libero tempor eget. " +
+			"Phasellus mattis mollis libero ut semper. In sit amet sapien odio. " +
+			"Sed interdum ullamcorper dui eu rutrum. Vestibulum non sagittis justo. " +
+			"Cras rutrum scelerisque elit, et porta est lobortis ac. " +
+			"Pellentesque eu ornare tortor. Sed bibendum a nisl at laoreet.";
+
+		void SetupMauiLayout()
+		{
+			var verticalStack = new VerticalStackLayout() { Spacing = 5, BackgroundColor = Colors.AntiqueWhite };
+			var horizontalStack = new HorizontalStackLayout() { Spacing = 2, BackgroundColor = Colors.CornflowerBlue };
+
+			//verticalStack.Add(CreateSampleGrid());
+			verticalStack.Add(CreateResizingButton());
+
+			AddTextResizeDemo(verticalStack);
+
+			verticalStack.Add(new Label { Text = " ", Padding = new Thickness(10) });
+			var label = new Label { Text = "End-aligned text", BackgroundColor = Colors.Fuchsia, HorizontalTextAlignment = TextAlignment.End };
+			label.Margin = new Thickness(15, 10, 20, 15);
+
+			SemanticProperties.SetHint(label, "Hint Text");
+			SemanticProperties.SetDescription(label, "Description Text");
+
+			verticalStack.Add(label);
+			verticalStack.Add(new Label { Text = "This should be BIG text!", FontSize = 24, HorizontalOptions = LayoutOptions.End });
+
+			SemanticProperties.SetHeadingLevel((BindableObject)verticalStack.Children.Last(), SemanticHeadingLevel.Level1);
+			verticalStack.Add(new Label { Text = "This should be BOLD text!", FontAttributes = FontAttributes.Bold, HorizontalOptions = LayoutOptions.Center });
+			verticalStack.Add(new Label { Text = "This should have character spacing!", CharacterSpacing = 3 });
+			verticalStack.Add(new Label { Text = "This should be a CUSTOM font!", FontFamily = "Dokdo" });
+			verticalStack.Add(
+				new Button
+				{
+					Text = "Push a Page",
+					Command = new Command(async () =>
+					{
+						await Navigation.PushAsync(new SemanticsPage());
+					})
+				}
+			);
+
+			var tapGestureRecognizer = new TapGestureRecognizer
+			{
+				Command = new Command(async () =>
+				{
+					await Navigation.PushAsync(new SemanticsPage());
+				})
+			};
+			var navigateLabel = new Label { BackgroundColor = Colors.PaleGreen, Text = "Tap to Navigate" };
+			navigateLabel.GestureRecognizers.Add(tapGestureRecognizer);
+			verticalStack.Add(navigateLabel);
+
+			verticalStack.Add(new Label { Text = "This should have padding", Padding = new Thickness(40), BackgroundColor = Colors.LightBlue });
+			verticalStack.Add(new Label { Text = LoremIpsum });
+			verticalStack.Add(new Label { Text = LoremIpsum, MaxLines = 2 });
+			verticalStack.Add(new Label { Text = LoremIpsum, LineBreakMode = LineBreakMode.TailTruncation });
+			verticalStack.Add(new Label { Text = LoremIpsum, MaxLines = 2, LineBreakMode = LineBreakMode.TailTruncation });
+			verticalStack.Add(new Label { Text = "This should have five times the line height! " + LoremIpsum, LineHeight = 5, MaxLines = 2 });
+			verticalStack.Add(new Label
+			{
+				FontSize = 24,
+				Text = "LinearGradient Text",
+				Background = new LinearGradientBrush(
+				new GradientStopCollection
+				{
+ 					new GradientStop(Colors.Green, 0),
+ 					new GradientStop(Colors.Blue, 1)
+				},
+				new Point(0, 0),
+				new Point(1, 0))
+			});
+			verticalStack.Add(new Label
+			{
+				Text = "RadialGradient",
+				Padding = new Thickness(30),
+				Background = new RadialGradientBrush(
+ 				new GradientStopCollection
+ 				{
+ 					new GradientStop(Colors.DarkBlue, 0),
+ 					new GradientStop(Colors.Yellow, 0.6f),
+ 					new GradientStop(Colors.LightPink, 1)
+ 				},
+ 				new Point(0.5, 0.5),
+ 				0.3f)
+			});
+
+			SemanticProperties.SetHeadingLevel((BindableObject)verticalStack.Children.Last(), SemanticHeadingLevel.Level2);
+
+			var visibleClearButtonEntry = new Entry() { ClearButtonVisibility = ClearButtonVisibility.WhileEditing, Placeholder = "This Entry will show clear button if has input." };
+			var hiddenClearButtonEntry = new Entry() { ClearButtonVisibility = ClearButtonVisibility.Never, Placeholder = "This Entry will not..." };
+
+			verticalStack.Add(visibleClearButtonEntry);
+			verticalStack.Add(hiddenClearButtonEntry);
+
+			verticalStack.Add(new Editor { Placeholder = "This is an editor placeholder." });
+			verticalStack.Add(new Editor { Placeholder = "Green Text Color.", TextColor = Colors.Green });
+			var paddingButton = new Button
+			{
+				Padding = new Thickness(40),
+				Text = "This button has a padding!!",
+				BackgroundColor = Colors.Purple,
+			};
+
+			verticalStack.Add(paddingButton);
+
+			var underlineLabel = new Label { Text = "underline", TextDecorations = TextDecorations.Underline };
+			verticalStack.Add(underlineLabel);
+
+			verticalStack.Add(new ActivityIndicator());
+			verticalStack.Add(new ActivityIndicator { Color = Colors.Red, IsRunning = true });
+
+			var button = new Button() { Text = _viewModel.Text, WidthRequest = 200 };
+			button.Clicked += async (sender, e) =>
+			{
+				var events = _services.GetRequiredService<ILifecycleEventService>();
+				events.InvokeEvents<Action<string>>("CustomEventName", action => action("VALUE"));
+
+				var location = await Geolocation.GetLocationAsync(new GeolocationRequest(GeolocationAccuracy.Lowest));
+				Debug.WriteLine($"I tracked you down to {location.Latitude}, {location.Longitude}! You can't hide!");
+			};
+
+			var button2 = new Button()
+			{
+				TextColor = Colors.Green,
+				Text = "Hello I'm a button",
+				//	BackgroundColor = Color.Purple,
+				Margin = new Thickness(12)
+			};
+
+			horizontalStack.Add(button);
+			horizontalStack.Add(button2);
+
+			horizontalStack.Add(new Label { Text = "And these buttons are in a HorizontalStackLayout", VerticalOptions = LayoutOptions.Center });
+
+			verticalStack.Add(horizontalStack);
+
+			verticalStack.Add(new Button { Text = "CharacterSpacing" });
+			verticalStack.Add(new Button { CharacterSpacing = 8, Text = "CharacterSpacing" });
+
+			verticalStack.Add(new RedButton { Text = "Dynamically Registered" });
+
+			var checkbox = new CheckBox();
+			checkbox.CheckedChanged += (sender, e) =>
+			{
+				Debug.WriteLine($"Checked Changed to '{e.Value}'");
+			};
+			verticalStack.Add(checkbox);
+			verticalStack.Add(new CheckBox { BackgroundColor = Colors.LightPink });
+			verticalStack.Add(new CheckBox { IsChecked = true, Color = Colors.Aquamarine });
+
+			var editor = new Editor();
+			editor.Completed += (sender, args) =>
+			{
+				Debug.WriteLine($"Editor Completed");
+			};
+
+			verticalStack.Add(editor);
+			verticalStack.Add(new Editor { Text = "Editor" });
+			verticalStack.Add(new Editor { Text = "Lorem ipsum dolor sit amet", MaxLength = 10 });
+			verticalStack.Add(new Editor { Text = "Predictive Text Off", IsTextPredictionEnabled = false });
+			verticalStack.Add(new Editor { Text = "Lorem ipsum dolor sit amet", FontSize = 10, FontFamily = "Dokdo" });
+			verticalStack.Add(new Editor { Text = "ReadOnly Editor", IsReadOnly = true });
+
+
+			var entry = new Entry();
+			entry.TextChanged += (sender, e) =>
+			{
+				Debug.WriteLine($"Text Changed from '{e.OldTextValue}' to '{e.NewTextValue}'");
+			};
+
+			var entryMargin = new Thickness(10, 0);
+
+			verticalStack.Add(entry);
+			verticalStack.Add(new Entry { Text = "Entry", TextColor = Colors.DarkRed, FontFamily = "Dokdo", MaxLength = -1, Margin = entryMargin });
+			verticalStack.Add(new Entry { IsPassword = true, TextColor = Colors.Black, Placeholder = "Pasword Entry", Margin = entryMargin });
+			verticalStack.Add(new Entry { IsTextPredictionEnabled = false });
+			verticalStack.Add(new Entry { Placeholder = "This should be placeholder text", Margin = entryMargin });
+			verticalStack.Add(new Entry { Text = "This should be read only property", IsReadOnly = true, Margin = entryMargin });
+			verticalStack.Add(new Entry { MaxLength = 5, Placeholder = "MaxLength text", Margin = entryMargin });
+			verticalStack.Add(new Entry { Text = "This should be text with character spacing", CharacterSpacing = 10 });
+			verticalStack.Add(new Entry { Keyboard = Keyboard.Numeric, Placeholder = "Numeric Entry" });
+			verticalStack.Add(new Entry { Keyboard = Keyboard.Email, Placeholder = "Email Entry" });
+
+			verticalStack.Add(new ProgressBar { Progress = 0.5 });
+			verticalStack.Add(new ProgressBar { Progress = 0.5, BackgroundColor = Colors.LightCoral });
+			verticalStack.Add(new ProgressBar { Progress = 0.5, ProgressColor = Colors.Purple });
+
+			var searchBar = new SearchBar
+			{
+				CharacterSpacing = 4,
+				Text = "A search query"
+			};
+			verticalStack.Add(searchBar);
+
+			var placeholderSearchBar = new SearchBar
+			{
+				Placeholder = "Placeholder"
+			};
+			verticalStack.Add(placeholderSearchBar);
+
+			var monkeyList = new List<string>
+			{
+				"Baboon",
+				"Capuchin Monkey",
+				"Blue Monkey",
+				"Squirrel Monkey",
+				"Golden Lion Tamarin",
+				"Howler Monkey",
+				"Japanese Macaque"
+			};
+
+			var picker = new Picker { Title = "Select a monkey", FontFamily = "Dokdo", HorizontalTextAlignment = TextAlignment.Center };
+
+			picker.ItemsSource = monkeyList;
+			verticalStack.Add(picker);
+
+			verticalStack.Add(new Slider());
+
+			verticalStack.Add(new Stepper());
+			verticalStack.Add(new Stepper { BackgroundColor = Colors.IndianRed });
+			verticalStack.Add(new Stepper { Minimum = 0, Maximum = 10, Value = 5 });
+
+			verticalStack.Add(new Switch());
+			verticalStack.Add(new Switch() { OnColor = Colors.Green });
+			verticalStack.Add(new Switch() { ThumbColor = Colors.Yellow });
+			verticalStack.Add(new Switch() { OnColor = Colors.Green, ThumbColor = Colors.Yellow });
+
+			verticalStack.Add(new DatePicker());
+			verticalStack.Add(new DatePicker { CharacterSpacing = 6 });
+			verticalStack.Add(new DatePicker { FontSize = 24 });
+
+			verticalStack.Add(new TimePicker());
+			verticalStack.Add(new TimePicker { Time = TimeSpan.FromHours(8), CharacterSpacing = 6 });
+
+			verticalStack.Add(new Label { Text = "IMAGES (static | animated):" });
+			verticalStack.Add(CreateImagesGrid());
+
+			Content = new ScrollView
+			{
+				Content = verticalStack
+			};
+		}
+
+		Button CreateResizingButton()
+		{
+			var initialWidth = 200;
+			var otherWidth = 100;
+
+			var initialHeight = 80;
+			var otherHeight = 140;
+
+			var count = 1;
+
+			var resizeButton = new Button
+			{
+				Text = "Resize",
+				BackgroundColor = Colors.Gray,
+				WidthRequest = initialWidth,
+				HeightRequest = initialHeight
+			};
+
+			resizeButton.Clicked += (sender, args) =>
+			{
+
+				count += 1;
+
+				if (count == 1)
+				{
+					resizeButton.WidthRequest = initialWidth;
+					resizeButton.HeightRequest = initialHeight;
+				}
+				else if (count == 2)
+				{
+					resizeButton.WidthRequest = otherWidth;
+					resizeButton.HeightRequest = otherHeight;
+				}
+				else
+				{
+					// Go back to using whatever the layout gives us
+					resizeButton.WidthRequest = -1;
+					resizeButton.HeightRequest = -1;
+					count = 0;
+				}
+			};
+
+			return resizeButton;
+		}
+
+		void SetupCompatibilityLayout()
+		{
+			var verticalStack = new StackLayout() { Spacing = 5, BackgroundColor = Colors.AntiqueWhite };
+			var horizontalStack = new StackLayout() { Orientation = StackOrientation.Horizontal, Spacing = 2, BackgroundColor = Colors.CornflowerBlue };
+
+			var label = new Label { Text = "This will disappear in ~5 seconds", BackgroundColor = Colors.Fuchsia };
+			label.Margin = new Thickness(15, 10, 20, 15);
+
+			verticalStack.Add(label);
+
+			var button = new Button() { Text = _viewModel.Text, WidthRequest = 200 };
+			var button2 = new Button()
+			{
+				TextColor = Colors.Green,
+				Text = "Hello I'm a button",
+				BackgroundColor = Colors.Purple,
+				Margin = new Thickness(12)
+			};
+
+			horizontalStack.Add(button);
+			horizontalStack.Add(button2);
+			horizontalStack.Add(new Label { Text = "And these buttons are in a HorizontalStackLayout" });
+
+			verticalStack.Add(horizontalStack);
+			verticalStack.Add(new Slider());
+			verticalStack.Add(new Switch());
+			verticalStack.Add(new Switch() { OnColor = Colors.Green });
+			verticalStack.Add(new Switch() { ThumbColor = Colors.Yellow });
+			verticalStack.Add(new Switch() { OnColor = Colors.Green, ThumbColor = Colors.Yellow });
+			verticalStack.Add(new DatePicker());
+			verticalStack.Add(new TimePicker());
+			verticalStack.Add(new Image()
+			{
+				Source = "dotnet_bot.png"
+			});
+
+			Content = verticalStack;
+		}
+
+		IView CreateImagesGrid()
+		{
+			var layout = new Microsoft.Maui.Controls.Layout2.GridLayout { ColumnSpacing = 10, RowSpacing = 10, Margin = 10 };
+
+			layout.AddRowDefinition(new RowDefinition { Height = GridLength.Auto });
+			layout.AddRowDefinition(new RowDefinition { Height = new GridLength(120) });
+			layout.AddRowDefinition(new RowDefinition { Height = GridLength.Auto });
+			layout.AddRowDefinition(new RowDefinition { Height = new GridLength(120) });
+			layout.AddRowDefinition(new RowDefinition { Height = GridLength.Auto });
+			layout.AddRowDefinition(new RowDefinition { Height = new GridLength(120) });
+			layout.AddRowDefinition(new RowDefinition { Height = GridLength.Auto });
+			layout.AddRowDefinition(new RowDefinition { Height = new GridLength(120) });
+			layout.AddRowDefinition(new RowDefinition { Height = GridLength.Auto });
+			layout.AddRowDefinition(new RowDefinition { Height = new GridLength(120) });
+
+			layout.AddColumnDefinition(new ColumnDefinition { Width = new GridLength(120) });
+			layout.AddColumnDefinition(new ColumnDefinition { Width = new GridLength(120) });
+
+			var row = -1;
+
+			Add(new Label { Text = "App Bundle", WidthRequest = 150 }, row: (row += 2) - 1, col: 0, colSpan: 2);
+			Add(new Image { Source = "dotnet_bot.png" }, row: row, col: 0);
+			Add(new Image { Source = "animated_heart.gif", IsAnimationPlaying = true }, row: row, col: 1);
+
+			Add(new Label { Text = "File", WidthRequest = 150 }, row: (row += 2) - 1, col: 0, colSpan: 2);
+			Add(new Image { Source = CopyLocal("dotnet_bot.png") }, row: row, col: 0);
+			Add(new Image { Source = CopyLocal("animated_heart.gif"), IsAnimationPlaying = true }, row: row, col: 1);
+
+			Add(new Label { Text = "Font", WidthRequest = 150 }, row: (row += 2) - 1, col: 0, colSpan: 2);
+			Add(new Image { Source = new FontImageSource { FontFamily = "Ionicons", Glyph = "\uf2fe" }, BackgroundColor = Color.FromUint(0xFF512BD4), Aspect = Aspect.Center }, row: row, col: 0);
+			Add(new Image { Source = new FontImageSource { FontFamily = "Dokdo", Glyph = "M" }, BackgroundColor = Color.FromUint(0xFF512BD4), Aspect = Aspect.Center }, row: row, col: 1);
+
+			Add(new Label { Text = "URI", WidthRequest = 150 }, row: (row += 2) - 1, col: 0, colSpan: 2);
+			Add(new Image { Source = "https://raw.githubusercontent.com/dotnet-foundation/swag/05cc70d33fa8c310147b9bd70ae9e103a072cae0/dotnet-bot/dotnet-bot-pot.png" }, row: row, col: 0);
+			Add(new Image { Source = "https://raw.githubusercontent.com/mono/SkiaSharp/6753bfad91dce1894c69084555dab6494efa90eb/samples/Gallery/Shared/Media/animated-heart.gif", IsAnimationPlaying = true }, row: row, col: 1);
+
+			Add(new Label { Text = "Stream", WidthRequest = 150 }, row: (row += 2) - 1, col: 0, colSpan: 2);
+			Add(new Image { Source = ImageSource.FromStream(() => GetEmbedded("dotnet_bot.png")) }, row: row, col: 0);
+			Add(new Image { Source = ImageSource.FromStream(() => GetEmbedded("animated_heart.gif")), IsAnimationPlaying = true }, row: row, col: 1);
+
+			return layout;
+
+			void Add(IView view, int row = 0, int col = 0, int rowSpan = 1, int colSpan = 1)
+			{
+				layout.Add(view);
+				layout.SetRow(view, row);
+				layout.SetRowSpan(view, rowSpan);
+				layout.SetColumn(view, col);
+				layout.SetColumnSpan(view, colSpan);
+			}
+
+			string CopyLocal(string embeddedPath)
+			{
+				var path = Path.Combine(FileSystem.CacheDirectory, Guid.NewGuid().ToString("N"));
+
+				using var stream = GetEmbedded(embeddedPath);
+				using var file = File.Create(path);
+				stream.CopyTo(file);
+
+				return path;
+			}
+
+			Stream GetEmbedded(string embeddedPath)
+			{
+				var assembly = GetType().Assembly;
+				var name = assembly
+					.GetManifestResourceNames()
+					.First(n => n.EndsWith(embeddedPath, StringComparison.InvariantCultureIgnoreCase));
+				return assembly.GetManifestResourceStream(name);
+			}
+		}
+
+		IView CreateSampleGrid()
+		{
+			var layout = new Microsoft.Maui.Controls.Layout2.GridLayout() { ColumnSpacing = 0, RowSpacing = 0 };
+
+			layout.AddRowDefinition(new RowDefinition() { Height = new GridLength(40) });
+			layout.AddRowDefinition(new RowDefinition() { Height = GridLength.Auto });
+
+			layout.AddColumnDefinition(new ColumnDefinition() { Width = new GridLength(100) });
+			layout.AddColumnDefinition(new ColumnDefinition() { Width = new GridLength(100) });
+
+			var topLeft = new Label { Text = "Top Left", BackgroundColor = Colors.LightBlue };
+			layout.Add(topLeft);
+
+			var bottomLeft = new Label { Text = "Bottom Left", BackgroundColor = Colors.Lavender };
+			layout.Add(bottomLeft);
+			layout.SetRow(bottomLeft, 1);
+
+			var topRight = new Label { Text = "Top Right", BackgroundColor = Colors.Orange };
+			layout.Add(topRight);
+			layout.SetColumn(topRight, 1);
+
+			var bottomRight = new Label { Text = "Bottom Right", BackgroundColor = Colors.MediumPurple };
+			layout.Add(bottomRight);
+			layout.SetRow(bottomRight, 1);
+			layout.SetColumn(bottomRight, 1);
+
+			layout.BackgroundColor = Colors.Chartreuse;
+
+			return layout;
+		}
+
+		void AddTextResizeDemo(Microsoft.Maui.ILayout layout)
+		{
+			var resizeTestButton = new Button { Text = "Resize Test" };
+
+			var resizeTestLabel = new Label { Text = "Short Text", BackgroundColor = Colors.LightBlue, HorizontalOptions = LayoutOptions.Start };
+			var explicitWidthTestLabel = new Label { Text = "Short Text", BackgroundColor = Colors.LightGreen, WidthRequest = 200 };
+			var widthAndHeightTestLabel = new Label { Text = "Short Text", BackgroundColor = Colors.MediumSeaGreen, WidthRequest = 150, HeightRequest = 40 };
+
+			resizeTestButton.Clicked += (sender, args) =>
+			{
+				if (resizeTestLabel.Text == "Short Text")
+				{
+					resizeTestLabel.Text = LoremIpsum;
+					explicitWidthTestLabel.Text = LoremIpsum;
+					widthAndHeightTestLabel.Text = LoremIpsum;
+				}
+				else
+				{
+					resizeTestLabel.Text = "Short Text";
+					explicitWidthTestLabel.Text = "Short Text";
+					widthAndHeightTestLabel.Text = "Short Text";
+				}
+			};
+
+			layout.Add(resizeTestButton);
+			layout.Add(resizeTestLabel);
+			layout.Add(widthAndHeightTestLabel);
+			layout.Add(explicitWidthTestLabel);
+		}
+
+		void SetupVisibilityTest()
+		{
+			var layout = new VerticalStackLayout() { BackgroundColor = Colors.BurlyWood };
+
+			var button1 = new Button { Text = "Controls", Margin = new Thickness(0, 40) };
+
+			var button2 = new Button { Text = "MAUI" };
+
+			var controlsLabel = new Label { Text = "Controls Label" };
+			controlsLabel.IsVisible = true;
+
+			var alwaysVisible = new Label { Text = "Always visible" };
+
+			var mauiLabel = new VisibilityLabel() { Text = "Core Label" };
+
+			button1.Clicked += (sender, args) =>
+			{
+				controlsLabel.IsVisible = !controlsLabel.IsVisible;
+			};
+
+			button2.Clicked += (sender, args) =>
+			{
+				switch ((mauiLabel as IFrameworkElement).Visibility)
+				{
+					case Visibility.Visible:
+						mauiLabel.SetVisibility(Visibility.Hidden);
+						break;
+					case Visibility.Hidden:
+						mauiLabel.SetVisibility(Visibility.Collapsed);
+						break;
+					case Visibility.Collapsed:
+						mauiLabel.SetVisibility(Visibility.Visible);
+						break;
+				}
+			};
+
+			layout.Add(button1);
+			layout.Add(button2);
+			layout.Add(controlsLabel);
+			layout.Add(mauiLabel);
+			layout.Add(alwaysVisible);
+
+			Content = layout;
+		}
+	}
+}

--- a/src/Controls/src/Core/GestureElement.cs
+++ b/src/Controls/src/Core/GestureElement.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls
 {
-	public class GestureElement : Element, ISpatialElement, IGestureRecognizers
+	public partial class GestureElement : Element, ISpatialElement, IGestureRecognizers
 	{
 		readonly GestureRecognizerCollection _gestureRecognizers = new GestureRecognizerCollection();
 		internal event NotifyCollectionChangedEventHandler GestureRecognizersCollectionChanged;

--- a/src/Controls/src/Core/GestureRecognizer.cs
+++ b/src/Controls/src/Core/GestureRecognizer.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.Maui.Controls
 {
-	public class GestureRecognizer : Element, IGestureRecognizer
+	public partial class GestureRecognizer : Element, IGestureRecognizer
 	{
 		public GestureRecognizer()
 		{

--- a/src/Controls/src/Core/HandlerImpl/GestureElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/GestureElement.Impl.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	public partial class GestureElement : IGestureView
+	{
+	
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/GestureRecognizer.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/GestureRecognizer.Impl.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	public partial class GestureRecognizer : IGestureRecognizer
+	{
+
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Maui.Controls.Internals;
+﻿using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -9,5 +9,11 @@ namespace Microsoft.Maui.Controls
 
 		// TODO ezhart super sus
 		public Thickness Margin => Thickness.Zero;
+
+		public IList<IGestureRecognizer> GestureRecognizers { get; set; }
+
+		public IList<IGestureRecognizer> CompositeGestureRecognizers { get; set; }
+
+		public IList<IGestureView> GetChildElements(Point point) => null;
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/HandlerImpl/TapGestureRecognizer.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	public partial class TapGestureRecognizer : ITapGestureRecognizer
+	{
+		void ITapGestureRecognizer.Tapped(IView view) =>
+			SendTapped((View)view);
+	}
+}

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -342,12 +342,12 @@ namespace Microsoft.Maui.Controls
 		}
 
 
-		public override IList<GestureElement> GetChildElements(Point point)
+		public override IList<IGestureView> GetChildElements(Point point)
 		{
 			if (FormattedText?.Spans == null || FormattedText?.Spans.Count == 0)
 				return null;
 
-			var spans = new List<GestureElement>();
+			var spans = new List<IGestureView>();
 			for (int i = 0; i < FormattedText.Spans.Count; i++)
 			{
 				Span span = FormattedText.Spans[i];

--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -4,7 +4,7 @@ using System.Windows.Input;
 
 namespace Microsoft.Maui.Controls
 {
-	public sealed class TapGestureRecognizer : GestureRecognizer
+	public sealed partial class TapGestureRecognizer : GestureRecognizer
 	{
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(TapGestureRecognizer), null);
 

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Maui.Controls
 			get { return _compositeGestureRecognizers ?? (_compositeGestureRecognizers = new ObservableCollection<IGestureRecognizer>()); }
 		}
 
-		public virtual IList<GestureElement> GetChildElements(Point point)
+		public virtual IList<IGestureView> GetChildElements(Point point)
 		{
 			return null;
 		}

--- a/src/Core/src/Core/IView.cs
+++ b/src/Core/src/Core/IView.cs
@@ -1,13 +1,20 @@
+using System.Collections.Generic;
+
 namespace Microsoft.Maui
 {
 	/// <summary>
 	/// Represents a visual element that is used to place layouts and controls on the screen.
 	/// </summary>
-	public interface IView : IFrameworkElement
+	public interface IView : IFrameworkElement, IGestureController
 	{
 		/// <summary>
 		/// The Margin represents the distance between an view and its adjacent views.
 		/// </summary>
 		Thickness Margin { get; }
+
+		/// <summary>
+		/// Include support to tap, pinch, pan, swipe, and drag and drop gestures on views.
+		/// </summary>
+		IList<IGestureRecognizer> GestureRecognizers { get; }
 	}
 }

--- a/src/Core/src/Gestures/GestureManager.Android.cs
+++ b/src/Core/src/Gestures/GestureManager.Android.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using Android.Content;
+using Android.Views;
+using Microsoft.Maui.Graphics;
+using AView = Android.Views.View;
+
+namespace Microsoft.Maui
+{
+	public class GestureManager : IGestureManager
+	{
+		readonly Lazy<TapGestureDetector> _tapDetector;
+
+		IViewHandler? _handler;
+		bool _isDisposed;
+		IView? _virtualView;
+		AView? _nativeView;
+
+		public GestureManager()
+		{
+			_tapDetector = new Lazy<TapGestureDetector>(InitializeTapDetector);
+		}
+
+		public void SetViewHandler(IViewHandler handler)
+		{
+			if (_isDisposed)
+				throw new ObjectDisposedException(null);
+
+			_handler = handler ?? throw new ArgumentNullException(nameof(handler));
+
+			_virtualView = _handler.VirtualView as IView;
+			_nativeView = _handler.NativeView as AView;
+		}
+
+		public bool OnTouchEvent(MotionEvent? e)
+		{
+			if (_nativeView == null)
+			{
+				return false;
+			}
+
+			if (_virtualView != null && !_virtualView.IsEnabled)
+			{
+				return false;
+			}
+
+			if (!DetectorsValid())
+			{
+				return false;
+			}
+
+			var eventConsumed = _tapDetector.Value.OnTouchEvent(e);
+
+			return eventConsumed;
+		}
+				
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected void Dispose(bool disposing)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			_isDisposed = true;
+
+			if (disposing)
+			{
+				if (_tapDetector.IsValueCreated)
+				{
+					_tapDetector.Value.Dispose();
+				}
+
+				_handler = null;
+			}
+		}
+
+		bool DetectorsValid()
+		{
+			// Make sure we're not testing for gestures on old motion events after our 
+			// detectors have already been disposed
+
+			if (_tapDetector.IsValueCreated && _tapDetector.Value.Handle == IntPtr.Zero)
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		TapGestureDetector InitializeTapDetector()
+		{
+			var context = _nativeView?.Context;
+
+			var listener = new InnerGestureListener(new TapGestureHandler(() => _virtualView!, () =>
+			{
+				if (_virtualView is IView view)
+					return view.GetChildElements(Point.Zero) ?? new List<IGestureView>();
+
+				return new List<IGestureView>();
+			}));
+
+			return new TapGestureDetector(context, listener);
+		}
+
+		public class TapGestureDetector : GestureDetector
+		{
+			InnerGestureListener? _listener;
+
+			public TapGestureDetector(Context? context, InnerGestureListener listener) : base(context, listener)
+			{
+				_listener = listener;
+			}
+
+			public override bool OnTouchEvent(MotionEvent? ev)
+			{
+				if (base.OnTouchEvent(ev))
+					return true;
+
+				return false;
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				base.Dispose(disposing);
+
+				if (disposing)
+				{
+					if (_listener != null)
+					{
+						_listener.Dispose();
+						_listener = null;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Core/src/Gestures/GestureManager.Standard.cs
+++ b/src/Core/src/Gestures/GestureManager.Standard.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Maui
+{
+	public class GestureManager : IGestureManager
+	{
+		public void SetViewHandler(IViewHandler handler) { }
+
+		public void Dispose() { }
+	}
+}

--- a/src/Core/src/Gestures/GestureManager.Windows.cs
+++ b/src/Core/src/Gestures/GestureManager.Windows.cs
@@ -31,16 +31,13 @@ namespace Microsoft.Maui
 
 			_handler = handler ?? throw new ArgumentNullException(nameof(handler));
 
-			_virtualView = _handler.VirtualView as IView;
+			_virtualView = _handler.VirtualView;
 			_nativeView = _handler.NativeView as FrameworkElement;
 
-			if (_virtualView != null)
+			if (_virtualView is IView view && view.GestureRecognizers != null)
 			{
-				if (_virtualView is IView view)
-				{
-					var gestureRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
-					gestureRecognizers.CollectionChanged += _collectionChangedHandler;
-				}
+				var gestureRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
+				gestureRecognizers.CollectionChanged += _collectionChangedHandler;
 			}
 
 			UpdatingGestureRecognizers();
@@ -62,13 +59,10 @@ namespace Microsoft.Maui
 			if (!disposing)
 				return;
 
-			if (_virtualView != null)
+			if (_virtualView is IView view && view.GestureRecognizers != null)
 			{
-				if (_virtualView is IView view)
-				{
-					var oldRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
-					oldRecognizers.CollectionChanged -= _collectionChangedHandler;
-				}
+				var oldRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
+				oldRecognizers.CollectionChanged -= _collectionChangedHandler;
 			}
 
 			if (_nativeView != null)

--- a/src/Core/src/Gestures/GestureManager.Windows.cs
+++ b/src/Core/src/Gestures/GestureManager.Windows.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Input;
 
 namespace Microsoft.Maui
 {
-	public class GestureMananger : IGestureManager
+	public class GestureManager : IGestureManager
 	{
 		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
 
@@ -19,7 +19,7 @@ namespace Microsoft.Maui
 		IView? _virtualView;
 		FrameworkElement? _nativeView;
 
-		public GestureMananger()
+		public GestureManager()
 		{
 			_collectionChangedHandler = OnGestureRecognizersCollectionChanged;
 		}

--- a/src/Core/src/Gestures/GestureManager.iOS.cs
+++ b/src/Core/src/Gestures/GestureManager.iOS.cs
@@ -1,0 +1,291 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using UIKit;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
+{
+	public class GestureManager : IGestureManager
+	{
+		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
+		readonly Dictionary<IGestureRecognizer, UIGestureRecognizer> _gestureRecognizers;
+
+		bool _isDisposed;
+		IViewHandler? _handler; 
+		IView? _virtualView;
+		UIView? _nativeView;
+		UITouchEventArgs? _shouldReceiveTouch;
+
+		public GestureManager()
+		{
+			_collectionChangedHandler = OnGestureRecognizersCollectionChanged;
+			_gestureRecognizers = new Dictionary<IGestureRecognizer, UIGestureRecognizer>();
+		}
+
+		internal ObservableCollection<IGestureRecognizer>? VirtualViewGestureRecognizers =>
+			_virtualView?.CompositeGestureRecognizers as ObservableCollection<IGestureRecognizer>;
+
+		public void SetViewHandler(IViewHandler handler)
+		{
+			if (_isDisposed)
+				throw new ObjectDisposedException(null);
+
+			_handler = handler ?? throw new ArgumentNullException(nameof(handler));
+
+			_virtualView = _handler.VirtualView as IView;
+			_nativeView = _handler.NativeView as UIView;
+
+			if (VirtualViewGestureRecognizers != null)
+				VirtualViewGestureRecognizers.CollectionChanged += _collectionChangedHandler;
+
+			LoadRecognizers();
+		}
+
+		public void Dispose()
+		{
+			if (_isDisposed)
+				return;
+
+			_isDisposed = true;
+
+			if (_gestureRecognizers != null)
+			{
+				foreach (var kvp in _gestureRecognizers)
+				{
+					_nativeView?.RemoveGestureRecognizer(kvp.Value);
+
+					kvp.Value.ShouldReceiveTouch = null;
+
+					kvp.Value.Dispose();
+				}
+
+				_gestureRecognizers.Clear();
+			}
+
+			if (VirtualViewGestureRecognizers != null)
+				VirtualViewGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
+
+			_nativeView = null;
+		}
+				
+		static IList<IGestureView>? GetChildGestures(
+			UIGestureRecognizer sender,
+			WeakReference weakEventTracker, WeakReference weakRecognizer, GestureManager? gestureManager, IView? view)
+		{
+			if (weakEventTracker == null)
+				return null;
+
+			if (!weakRecognizer.IsAlive)
+				return null;
+
+			if (gestureManager == null || gestureManager._isDisposed || view == null)
+				return null;
+
+			var nativeView = (UIView?)gestureManager._handler?.NativeView;
+
+			if (nativeView == null)
+				return null;
+
+			var originPoint = sender.LocationInView(nativeView);
+			var childGestures = view.GetChildElements(new Point(originPoint.X, originPoint.Y));
+
+			return childGestures;
+		}
+
+		Action<UITapGestureRecognizer> CreateRecognizerHandler(WeakReference weakEventTracker, WeakReference weakRecognizer, ITapGestureRecognizer clickRecognizer)
+		{
+			return new Action<UITapGestureRecognizer>((sender) =>
+			{
+				GestureManager? eventTracker = weakEventTracker.Target as GestureManager;
+				IView? virtualView = (IView?)eventTracker?._handler?.VirtualView;
+
+				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, eventTracker, virtualView);
+
+				if (childGestures?.GetChildGesturesFor<ITapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired).Count() > 0)
+					return;
+
+				if (weakRecognizer.Target is ITapGestureRecognizer tapGestureRecognizer && virtualView != null)
+					tapGestureRecognizer.Tapped(virtualView);
+			});
+		}
+
+		Action<UITapGestureRecognizer> CreateChildRecognizerHandler(WeakReference weakEventTracker, WeakReference weakRecognizer)
+		{
+			return new Action<UITapGestureRecognizer>((sender) =>
+			{
+				GestureManager? gestureManager = weakEventTracker.Target as GestureManager;
+				IView? virtualView = (IView?)gestureManager?._handler?.VirtualView;
+
+				var childGestures = GetChildGestures(sender, weakEventTracker, weakRecognizer, gestureManager, virtualView);
+
+				var recognizers = childGestures?.GetChildGesturesFor<ITapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired);
+
+				if (recognizers == null)
+					return;
+
+				var tapGestureRecognizer = (weakRecognizer.Target as IChildGestureRecognizer)?.GestureRecognizer as ITapGestureRecognizer;
+
+				foreach (var item in recognizers)
+					if (item == tapGestureRecognizer && virtualView != null)
+						tapGestureRecognizer?.Tapped(virtualView);
+			});
+		}
+
+		protected virtual UIGestureRecognizer? GetNativeRecognizer(IGestureRecognizer recognizer)
+		{
+			if (recognizer == null)
+				return null;
+
+			var weakRecognizer = new WeakReference(recognizer);
+			var weakEventTracker = new WeakReference(this);
+
+			if (recognizer is ITapGestureRecognizer tapRecognizer)
+			{
+				var returnAction = CreateRecognizerHandler(weakEventTracker, weakRecognizer, tapRecognizer);
+				var nativeRecognizer = CreateTapRecognizer(tapRecognizer.NumberOfTapsRequired, returnAction);
+
+				return nativeRecognizer;
+			}
+
+			if (recognizer is IChildGestureRecognizer childRecognizer)
+			{
+				if (childRecognizer.GestureRecognizer is ITapGestureRecognizer tapChildRecognizer)
+				{
+					var returnAction = CreateChildRecognizerHandler(weakEventTracker, weakRecognizer);
+					var nativeRecognizer = CreateTapRecognizer(tapChildRecognizer.NumberOfTapsRequired, returnAction);
+
+					return nativeRecognizer;
+				}
+			}
+
+			return null;
+		}
+
+		UITapGestureRecognizer CreateTapRecognizer(int numTaps, Action<UITapGestureRecognizer> action, int numFingers = 1)
+		{
+			var result = new UITapGestureRecognizer(action)
+			{
+				NumberOfTouchesRequired = (uint)numFingers,
+				NumberOfTapsRequired = (uint)numTaps,
+				ShouldRecognizeSimultaneously = ShouldRecognizeTapsTogether
+			};
+
+			return result;
+		}
+
+		static bool ShouldRecognizeTapsTogether(UIGestureRecognizer gesture, UIGestureRecognizer other)
+		{
+			// If multiple tap gestures are potentially firing (because multiple tap gesture recognizers have been
+			// added to the XF Element), we want to allow them to fire simultaneously if they have the same number
+			// of taps and touches
+
+			if (gesture is not UITapGestureRecognizer tap)
+			{
+				return false;
+			}
+
+			if (other is not UITapGestureRecognizer otherTap)
+			{
+				return false;
+			}
+
+			if (!Equals(tap.View, otherTap.View))
+			{
+				return false;
+			}
+
+			if (tap.NumberOfTapsRequired != otherTap.NumberOfTapsRequired)
+			{
+				return false;
+			}
+
+			if (tap.NumberOfTouchesRequired != otherTap.NumberOfTouchesRequired)
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		void LoadRecognizers()
+		{
+			if (VirtualViewGestureRecognizers == null)
+				return;
+
+			if (_shouldReceiveTouch == null)
+			{
+				// Cache this so we don't create a new UITouchEventArgs instance for every recognizer
+				_shouldReceiveTouch = ShouldReceiveTouch;
+			}
+
+			for (int i = 0; i < VirtualViewGestureRecognizers.Count; i++)
+			{
+				IGestureRecognizer recognizer = VirtualViewGestureRecognizers[i];
+				if (_gestureRecognizers.ContainsKey(recognizer))
+					continue;
+
+				var nativeRecognizer = GetNativeRecognizer(recognizer);
+				if (nativeRecognizer != null && _nativeView != null)
+				{
+					nativeRecognizer.ShouldReceiveTouch = _shouldReceiveTouch;
+
+					_nativeView.AddGestureRecognizer(nativeRecognizer);
+
+					_gestureRecognizers[recognizer] = nativeRecognizer;
+				}
+			}
+
+			var toRemove = _gestureRecognizers.Keys.Where(key => !VirtualViewGestureRecognizers.Contains(key)).ToArray();
+
+			for (int i = 0; i < toRemove.Length; i++)
+			{
+				IGestureRecognizer gestureRecognizer = toRemove[i];
+				var uiRecognizer = _gestureRecognizers[gestureRecognizer];
+				_gestureRecognizers.Remove(gestureRecognizer);
+
+				_nativeView?.RemoveGestureRecognizer(uiRecognizer);
+				uiRecognizer.Dispose();
+			}
+		}
+
+		bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
+		{
+			if (touch.View is IViewHandler)
+			{
+				return true;
+			}
+
+			// If the touch is coming from the UIView our renderer is wrapping (e.g., if it's  
+			// wrapping a UIView which already has a gesture recognizer), then we should let it through
+			// (This goes for children of that control as well)
+			if (_handler?.NativeView == null)
+			{
+				return false;
+			}
+
+			var nativeView = (UIView?)_handler.NativeView;
+
+			if (nativeView == null)
+			{
+				return false;
+			}
+
+			if (touch.View.IsDescendantOfView(nativeView) &&
+				(touch.View.GestureRecognizers?.Length > 0 || nativeView.GestureRecognizers?.Length > 0))
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		void OnGestureRecognizersCollectionChanged(object? sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
+		{
+			LoadRecognizers();
+		}
+	}
+}

--- a/src/Core/src/Gestures/GestureMananger.Windows.cs
+++ b/src/Core/src/Gestures/GestureMananger.Windows.cs
@@ -1,0 +1,170 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+
+namespace Microsoft.Maui
+{
+	public class GestureMananger : IGestureManager
+	{
+		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
+
+		bool _isDisposed;
+		IViewHandler? _handler;
+		IView? _virtualView;
+		FrameworkElement? _nativeView;
+
+		public GestureMananger()
+		{
+			_collectionChangedHandler = OnGestureRecognizersCollectionChanged;
+		}
+
+		public void SetViewHandler(IViewHandler handler)
+		{
+			if (_isDisposed)
+				throw new ObjectDisposedException(null);
+
+			_handler = handler ?? throw new ArgumentNullException(nameof(handler));
+
+			_virtualView = _handler.VirtualView as IView;
+			_nativeView = _handler.NativeView as FrameworkElement;
+
+			if (_virtualView != null)
+			{
+				if (_virtualView is IView view)
+				{
+					var gestureRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
+					gestureRecognizers.CollectionChanged += _collectionChangedHandler;
+				}
+			}
+
+			UpdatingGestureRecognizers();
+		}
+
+		public void Dispose() 
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected void Dispose(bool disposing)
+		{
+			if (_isDisposed)
+				return;
+
+			_isDisposed = true;
+
+			if (!disposing)
+				return;
+
+			if (_virtualView != null)
+			{
+				if (_virtualView is IView view)
+				{
+					var oldRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
+					oldRecognizers.CollectionChanged -= _collectionChangedHandler;
+				}
+			}
+
+			if (_nativeView != null)
+			{
+				_nativeView.Tapped -= OnTap;
+				_nativeView.DoubleTapped -= OnDoubleTap;
+			}
+		}
+
+		void UpdatingGestureRecognizers()
+		{
+			if (_nativeView == null)
+				return;
+
+			IList<IGestureRecognizer>? gestures = _virtualView?.GestureRecognizers;
+
+			if (gestures == null)
+				return;
+
+			var children = _virtualView?.GetChildElements(Point.Zero);
+			IList<ITapGestureRecognizer>? childGestures = children?.GetChildGesturesFor<ITapGestureRecognizer>().ToList();
+
+			if (gestures.GetGesturesFor<ITapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any()
+				|| children?.GetChildGesturesFor<ITapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any() == true)
+			{
+				_nativeView.Tapped += OnTap;
+			}
+		
+			if (gestures.GetGesturesFor<ITapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2).Any()
+				|| children?.GetChildGesturesFor<ITapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2).Any() == true)
+			{
+				_nativeView.DoubleTapped += OnDoubleTap;
+			}
+		}
+
+		void OnTap(object? sender, TappedRoutedEventArgs e)
+		{
+			if (_virtualView is not IView view)
+				return;
+
+			if (view == null)
+				return;
+
+			var tapPosition = e.GetPosition(_nativeView);
+			var children = view.GetChildElements(new Point(tapPosition.X, tapPosition.Y));
+
+			if (children != null)
+				foreach (var recognizer in children.GetChildGesturesFor<ITapGestureRecognizer>(g => g.NumberOfTapsRequired == 1))
+				{
+					recognizer.Tapped(view);
+					e.Handled = true;
+				}
+
+			if (e.Handled)
+				return;
+
+			IEnumerable<ITapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<ITapGestureRecognizer>(g => g.NumberOfTapsRequired == 1);
+			foreach (var recognizer in tapGestures)
+			{
+				recognizer.Tapped(view);
+				e.Handled = true;
+			}
+		}
+
+		void OnDoubleTap(object? sender, DoubleTappedRoutedEventArgs e)
+		{
+			if (_virtualView is not IView view)
+				return;
+
+			if (view == null)
+				return;
+
+			var tapPosition = e.GetPosition(_nativeView);
+			var children = view.GetChildElements(new Point(tapPosition.X, tapPosition.Y));
+
+			if (children != null)
+				foreach (var recognizer in children.GetChildGesturesFor<ITapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2))
+				{
+					recognizer.Tapped(view);
+					e.Handled = true;
+				}
+
+			if (e.Handled)
+				return;
+
+			IEnumerable<ITapGestureRecognizer> doubleTapGestures = view.GestureRecognizers.GetGesturesFor<ITapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2);
+			foreach (ITapGestureRecognizer recognizer in doubleTapGestures)
+			{
+				recognizer.Tapped(view);
+				e.Handled = true;
+			}
+		}
+
+		void OnGestureRecognizersCollectionChanged(object? sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
+		{
+			UpdatingGestureRecognizers();
+		}
+	}
+}

--- a/src/Core/src/Gestures/IChildGestureRecognizer.cs
+++ b/src/Core/src/Gestures/IChildGestureRecognizer.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Maui
+{
+	public interface IChildGestureRecognizer : IGestureRecognizer
+	{
+		public IGestureRecognizer GestureRecognizer { get; set; }
+	}
+}

--- a/src/Core/src/Gestures/IGestureController.cs
+++ b/src/Core/src/Gestures/IGestureController.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
+{
+	public interface IGestureController
+	{
+		IList<IGestureView> GetChildElements(Point point);
+
+		IList<IGestureRecognizer> CompositeGestureRecognizers { get; }
+	}
+}

--- a/src/Core/src/Gestures/IGestureManager.cs
+++ b/src/Core/src/Gestures/IGestureManager.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Microsoft.Maui
+{
+	public interface IGestureManager : IDisposable
+	{
+		void SetViewHandler(IViewHandler handler);
+	}
+}

--- a/src/Core/src/Gestures/IGestureRecognizer.cs
+++ b/src/Core/src/Gestures/IGestureRecognizer.cs
@@ -1,8 +1,9 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui
 {
 	public interface IGestureRecognizer : INotifyPropertyChanged
 	{
+
 	}
 }

--- a/src/Core/src/Gestures/IGestureView.cs
+++ b/src/Core/src/Gestures/IGestureView.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Maui
+{
+	public interface IGestureView
+	{
+		public IList<IGestureRecognizer> GestureRecognizers { get; }
+	}
+}

--- a/src/Core/src/Gestures/ITapGestureRecognizer.cs
+++ b/src/Core/src/Gestures/ITapGestureRecognizer.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Input;
+
+namespace Microsoft.Maui
+{
+	public interface ITapGestureRecognizer : IGestureRecognizer
+	{
+		public ICommand Command { get; set; }
+
+		public object CommandParameter { get; set; }
+
+		public int NumberOfTapsRequired { get; set; }
+
+		void Tapped(IView view);
+	}
+}

--- a/src/Core/src/Gestures/InnerGestureListener.Android.cs
+++ b/src/Core/src/Gestures/InnerGestureListener.Android.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Android.Runtime;
+using Android.Views;
+using Microsoft.Maui.Graphics;
+using Object = Java.Lang.Object;
+
+namespace Microsoft.Maui
+{
+	public class InnerGestureListener : Object, GestureDetector.IOnGestureListener, GestureDetector.IOnDoubleTapListener
+	{
+		TapGestureHandler? _tapGestureHandler;
+		bool _disposed;
+
+		Func<int, Point, bool>? _tapDelegate;
+		Func<int, IEnumerable<ITapGestureRecognizer>>? _tapGestureRecognizers;
+
+		public InnerGestureListener(TapGestureHandler tapGestureHandler)
+		{
+			_ = tapGestureHandler ?? throw new ArgumentNullException(nameof(tapGestureHandler));
+
+			_tapGestureHandler = tapGestureHandler;
+
+			_tapDelegate = tapGestureHandler.OnTap;
+			_tapGestureRecognizers = tapGestureHandler.TapGestureRecognizers;
+		}
+
+		bool HasAnyGestures() =>
+			_tapGestureHandler?.HasAnyGestures() ?? false;
+
+		// This is needed because GestureRecognizer callbacks can be delayed several hundred milliseconds
+		// which can result in the need to resurrect this object if it has already been disposed. We dispose
+		// eagerly to allow easier garbage collection of the renderer
+		internal InnerGestureListener(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+		{
+		}
+
+		bool GestureDetector.IOnDoubleTapListener.OnDoubleTap(MotionEvent? e)
+		{
+			if (_disposed)
+				return false;
+
+			if (HasDoubleTapHandler())
+			{
+				if (_tapDelegate != null && e != null)
+					return _tapDelegate(2, new Point(e.GetX(), e.GetY()));
+
+				return false;
+			}
+
+			if (HasSingleTapHandler())
+			{
+				// If we're registering double taps and we don't actually have a double-tap handler,
+				// but we _do_ have a single-tap handler, then we're really just seeing two singles in a row
+				// Fire off the delegate for the second single-tap (OnSingleTapUp already did the first one)
+				if (_tapDelegate != null && e != null)
+					return _tapDelegate(1, new Point(e.GetX(), e.GetY()));
+
+				return false;
+			}
+
+			return false;
+		}
+
+		bool GestureDetector.IOnDoubleTapListener.OnDoubleTapEvent(MotionEvent? e)
+		{
+			return false;
+		}
+
+		bool GestureDetector.IOnGestureListener.OnDown(MotionEvent? e)
+		{
+			if (HasAnyGestures())
+			{
+				// If we have any gestures to listen for, we need to return true to show we're interested in the rest
+				// of the events.		
+				return true;
+			}
+
+			// Since we don't have any gestures we're listening for, we return false to show we're not interested
+			// and let parent controls have a whack at the events
+			return false;
+		}
+
+		bool GestureDetector.IOnGestureListener.OnFling(MotionEvent? e1, MotionEvent? e2, float velocityX, float velocityY)
+		{
+			return false;
+		}
+
+		void GestureDetector.IOnGestureListener.OnLongPress(MotionEvent? e)
+		{
+
+		}
+
+		bool GestureDetector.IOnGestureListener.OnScroll(MotionEvent? e1, MotionEvent? e2, float distanceX, float distanceY)
+		{
+			return false;
+		}
+
+		void GestureDetector.IOnGestureListener.OnShowPress(MotionEvent? e)
+		{
+		}
+
+		bool GestureDetector.IOnGestureListener.OnSingleTapUp(MotionEvent? e)
+		{
+			if (_disposed)
+				return false;
+
+			if (HasDoubleTapHandler())
+			{
+				// Because we have a handler for double-tap, we need to wait for
+				// OnSingleTapConfirmed (to verify it's really just a single tap) before running the delegate
+				return false;
+			}
+
+			// A single tap has occurred and there's no handler for double tap to worry about,
+			// so we can go ahead and run the delegate	
+			if (_tapDelegate != null && e != null)
+				return _tapDelegate(1, new Point(e.GetX(), e.GetY()));
+
+			return false;
+		}
+
+		bool GestureDetector.IOnDoubleTapListener.OnSingleTapConfirmed(MotionEvent? e)
+		{
+			if (_disposed)
+				return false;
+
+			if (!HasDoubleTapHandler())
+			{
+				// We're not worried about double-tap, so OnSingleTapUp has already run the delegate
+				// there's nothing for us to do here
+				return false;
+			}
+
+			// Since there was a double-tap handler, we had to wait for OnSingleTapConfirmed;
+			// Now that we're sure it's a single tap, we can run the delegate
+			if (_tapDelegate != null && e != null)
+				return _tapDelegate(1, new Point(e.GetX(), e.GetY()));
+
+			return false;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				_tapGestureHandler = null;
+
+				_tapDelegate = null;
+				_tapGestureRecognizers = null;
+			}
+
+			base.Dispose(disposing);
+		}
+
+		bool HasDoubleTapHandler()
+		{
+			if (_tapGestureRecognizers == null)
+				return false;
+
+			return _tapGestureRecognizers(2).Any();
+		}
+
+		bool HasSingleTapHandler()
+		{
+			if (_tapGestureRecognizers == null)
+				return false;
+
+			return _tapGestureRecognizers(1).Any();
+		}
+	}
+}

--- a/src/Core/src/Gestures/TapGestureHandler.Android.cs
+++ b/src/Core/src/Gestures/TapGestureHandler.Android.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
+{
+	public class TapGestureHandler
+	{
+		public TapGestureHandler(Func<IView> getView, Func<IList<IGestureView>> getChildElements)
+		{
+			GetView = getView;
+			GetChildElements = getChildElements;
+		}
+
+		Func<IList<IGestureView>> GetChildElements { get; }
+		Func<IView> GetView { get; }
+
+		public void OnSingleClick()
+		{
+			// Only handle click if we don't have double tap registered
+			if (TapGestureRecognizers(2).Any())
+				return;
+
+			OnTap(1, new Point(-1, -1));
+		}
+
+		public bool OnTap(int count, Point point)
+		{
+			IView view = GetView();
+
+			if (view == null)
+				return false;
+
+			var captured = false;
+
+			var children = view.GetChildElements(point);
+
+			if (children != null)
+				foreach (var recognizer in children.GetChildGesturesFor<ITapGestureRecognizer>(recognizer => recognizer.NumberOfTapsRequired == count))
+				{
+					recognizer.Tapped(view);
+					captured = true;
+				}
+
+			if (captured)
+				return captured;
+
+			IEnumerable<ITapGestureRecognizer> gestureRecognizers = TapGestureRecognizers(count);
+			foreach (var gestureRecognizer in gestureRecognizers)
+			{
+				gestureRecognizer.Tapped(view);
+				captured = true;
+			}
+
+			return captured;
+		}
+
+		public bool HasAnyGestures()
+		{
+			IView view = GetView();
+
+			return view != null && view.GestureRecognizers.OfType<ITapGestureRecognizer>().Any()				
+				|| GetChildElements().GetChildGesturesFor<ITapGestureRecognizer>().Any();
+		}
+
+		public IEnumerable<ITapGestureRecognizer> TapGestureRecognizers(int count)
+		{
+			IView view = GetView();
+
+			if (view == null)
+				return Enumerable.Empty<ITapGestureRecognizer>();
+
+			return view.GestureRecognizers.GetGesturesFor<ITapGestureRecognizer>(recognizer => recognizer.NumberOfTapsRequired == count);
+		}
+	}
+}

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -11,8 +11,20 @@ namespace Microsoft.Maui.Handlers
 	{
 		MauiAccessibilityDelegate? AccessibilityDelegate { get; set; }
 
+		MauiTouchListener TouchListener { get; } = new MauiTouchListener();
+
+
+		partial void ConnectingHandler(NativeView? nativeView)
+		{
+			TouchListener.GestureManager = GestureManager;
+			nativeView?.SetOnTouchListener(TouchListener);
+		}
+
 		partial void DisconnectingHandler(NativeView? nativeView)
 		{
+			TouchListener.GestureManager = null;
+			nativeView?.SetOnTouchListener(null);
+
 			if (nativeView.IsAlive() && AccessibilityDelegate != null)
 			{
 				AccessibilityDelegate.Handler = null;
@@ -191,6 +203,14 @@ namespace Microsoft.Maui.Handlers
 				base.OnInitializeAccessibilityNodeInfo(host, info);
 				Handler?.OnInitializeAccessibilityNodeInfo(host, info);
 			}
+		}
+
+		class MauiTouchListener : Java.Lang.Object, NativeView.IOnTouchListener
+		{
+			public GestureManager? GestureManager { get; set; }
+
+			public bool OnTouch(NativeView? v, Android.Views.MotionEvent? e) =>
+				GestureManager?.OnTouchEvent(e) ?? false;
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -85,6 +85,8 @@ namespace Microsoft.Maui.Handlers
 
 		public IView? VirtualView { get; private protected set; }
 
+		internal GestureManager? GestureManager { get; private set; }
+
 		public void SetMauiContext(IMauiContext mauiContext) => MauiContext = mauiContext;
 
 		public abstract void SetVirtualView(IView view);
@@ -101,6 +103,12 @@ namespace Microsoft.Maui.Handlers
 
 		private protected void ConnectHandler(NativeView? nativeView)
 		{
+			if (VirtualView is IGestureController)
+			{
+				GestureManager = new GestureManager();
+				GestureManager.SetViewHandler(this);
+			}
+
 			ConnectingHandler(nativeView);
 		}
 
@@ -109,6 +117,12 @@ namespace Microsoft.Maui.Handlers
 		private protected void DisconnectHandler(NativeView? nativeView)
 		{
 			DisconnectingHandler(nativeView);
+
+			if (GestureManager != null)
+			{
+				GestureManager.Dispose();
+				GestureManager = null;
+			}
 
 			if (VirtualView != null)
 				VirtualView.Handler = null;

--- a/src/Core/src/Platform/GestureExtensions.cs
+++ b/src/Core/src/Platform/GestureExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Maui
+{
+	public static class GestureExtensions
+	{
+		public static IEnumerable<T> GetChildGesturesFor<T>(this IEnumerable<IGestureView> views, Func<T, bool>? predicate = null) where T : IGestureRecognizer
+		{
+			if (views == null)
+				yield break;
+
+			if (predicate == null)
+				predicate = x => true;
+
+			foreach (var view in views)
+				foreach (var item in view.GestureRecognizers)
+				{
+					if (item is T gesture && predicate(gesture))
+						yield return gesture;
+				}
+		}
+
+		public static IEnumerable<T> GetGesturesFor<T>(this IEnumerable<IGestureRecognizer> gestures, Func<T, bool>? predicate = null) where T : IGestureRecognizer
+		{
+			if (gestures == null)
+				yield break;
+
+			if (predicate == null)
+				predicate = x => true;
+
+			foreach (IGestureRecognizer item in new List<IGestureRecognizer>(gestures))
+			{
+				if (item is T gesture && predicate(gesture))
+				{
+					yield return gesture;
+				}
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Maui
 
 		public static void UpdateIsEnabled(this UIView nativeView, IView view)
 		{
+			nativeView.UpdateInteractionEnabled(view);
+
 			if (nativeView is not UIControl uiControl)
 				return;
 
@@ -233,6 +235,12 @@ namespace Microsoft.Maui
 			}
 
 			return false;
+		}
+
+		internal static void UpdateInteractionEnabled(this UIView nativeView, IFrameworkElement view)
+		{
+			// TODO: Also check if InputTransparent is false
+			nativeView.UserInteractionEnabled = view.IsEnabled;
 		}
 
 		static void InsertBackgroundLayer(this UIView control, CALayer backgroundLayer, int index = -1)

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Primitives;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	public class StubBase : IFrameworkElement
+	public class StubBase : IView
 	{
 		public bool IsEnabled { get; set; } = true;
 
@@ -62,6 +62,10 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Semantics Semantics { get; set; } = new Semantics();
 
+		public IList<IGestureRecognizer> GestureRecognizers { get; set; }
+
+		public IList<IGestureRecognizer> CompositeGestureRecognizers { get; set; }
+
 		public Size Arrange(Rectangle bounds)
 		{
 			Frame = bounds;
@@ -95,5 +99,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		{
 			return new Size(widthConstraint, heightConstraint);
 		}
+
+		public IList<IGestureView> GetChildElements(Point point) => null;
 	}
 }

--- a/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Primitives;
 
@@ -43,6 +44,9 @@ namespace Microsoft.Maui.UnitTests
 
 		public Paint Background { get; set; }
 
+		public IList<IGestureRecognizer> GestureRecognizers { get; set; }
+
+		public IList<IGestureRecognizer> CompositeGestureRecognizers { get; set; }
 		public double TranslationX { get; set; }
 
 		public double TranslationY { get; set; }
@@ -64,6 +68,8 @@ namespace Microsoft.Maui.UnitTests
 		public double AnchorY { get; set; }
 
 		public Size Arrange(Rectangle bounds) => Size.Zero;
+
+		public IList<IGestureView> GetChildElements(Point point) => null;
 
 		public void InvalidateArrange() { }
 


### PR DESCRIPTION
### Description of Change ###


Add **TapGestureRecognizer** support.
Grouping the functionality in the same way on all platforms in a `GestureManater` class.

![maui-gestures](https://user-images.githubusercontent.com/6755973/118171907-0a578280-b42c-11eb-93e4-6e4d2d8a3fb5.gif)

Tested on Android, iOS and Windows.

We have different gestures in Xamarin.Forms like Pan, Swipe, etc. This PR begins by adding Tap gesture. More gestures will be added in different PRs.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might effect accessibility?
No