### PR TITLE
[singleproject] preserve folder structure for @(MauiAsset)

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -32,6 +32,10 @@
         AssemblyFile="$(_ResizetizerTaskAssemblyName)"
         TaskName="Microsoft.Maui.Resizetizer.GenerateSplashStoryboard" />
 
+    <UsingTask
+        AssemblyFile="$(_ResizetizerTaskAssemblyName)"
+        TaskName="Microsoft.Maui.Resizetizer.GetMauiAssetPath" />
+
     <PropertyGroup>
         <CleanDependsOn>
             $(CleanDependsOn);
@@ -167,7 +171,7 @@
             <MauiItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' == ''" />
             <MauiItem Include="@(MauiImage)" ItemGroupName="MauiImage" Condition="'%(MauiImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(MauiImage.ForegroundFile)'))" />
             <MauiItem Include="@(MauiFont)"  ItemGroupName="MauiFont" />
-            <MauiItem Include="@(MauiAsset)" ItemGroupName="MauiAsset" />
+            <MauiItem Include="@(MauiAsset)" ItemGroupName="MauiAsset" ProjectDirectory="$(MSBuildProjectDirectory)" />
             <MauiItem Include="@(MauiSplashScreen)" ItemGroupName="MauiSplashScreen" />
         </ItemGroup>
 
@@ -247,15 +251,19 @@
     </Target>
 
     <Target Name="ProcessMauiAssets">
-        <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">
-            <AndroidAsset Include="@(MauiAsset)" Link="%(FileName)%(Extension)" />
-        </ItemGroup>
-        <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True'">
-            <Content Include="@(MauiAsset)" Link="%(FileName)%(Extension)" />
-        </ItemGroup>
-        <ItemGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWinUIApp)' == 'True'">
-            <ContentWithTargetPath Include="@(MauiAsset)" TargetPath="Assets\%(Filename)%(Extension)" />
-        </ItemGroup>
+        <PropertyGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWinUIApp)' == 'True'">
+            <_MauiAssetFolderName>Assets</_MauiAssetFolderName>
+            <_MauiAssetItemMetadata>TargetPath</_MauiAssetItemMetadata>
+        </PropertyGroup>
+        <GetMauiAssetPath
+            ProjectDirectory="$(MSBuildProjectDirectory)"
+            FolderName="$(_MauiAssetFolderName)"
+            ItemMetadata="$(_MauiAssetItemMetadata)"
+            Input="@(MauiAsset)">
+            <Output ItemName="AndroidAsset"          TaskParameter="Output" Condition="'$(_ResizetizerIsAndroidApp)' == 'True'" />
+            <Output ItemName="Content"               TaskParameter="Output" Condition="'$(_ResizetizerIsiOSApp)' == 'True'" />
+            <Output ItemName="ContentWithTargetPath" TaskParameter="Output" Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWinUIApp)' == 'True'" />
+        </GetMauiAssetPath>
     </Target>
 
     <Target Name="ProcessMauiSplashScreens"

--- a/src/Controls/samples/Controls.Sample.SingleProject/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample.SingleProject/MainPage.xaml
@@ -8,6 +8,6 @@
           <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Label Text="Hello, .NET MAUI Single Project!" TextColor="Black" FontSize="32" HorizontalOptions="CenterAndExpand" />
-        <WebView Grid.Row="1" Source="index.html" />
+        <WebView Grid.Row="1" Source="Resources/Raw/index.html" />
     </Grid>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.SingleProject/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample.SingleProject/MainPage.xaml
@@ -8,6 +8,6 @@
           <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Label Text="Hello, .NET MAUI Single Project!" TextColor="Black" FontSize="32" HorizontalOptions="CenterAndExpand" />
-        <WebView Grid.Row="1" Source="Resources/Raw/index.html" />
+        <WebView Grid.Row="1" Source="index.html" />
     </Grid>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
+++ b/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
-    <MauiAsset Include="Resources\Raw\*" />
+    <MauiAsset Include="Resources\Raw\*" Link="%(Filename)%(Extension)" />
     <MauiSplashScreen Include="Resources\AppIcons\appicon_foreground.svg" Color="#FF69B4" />
   </ItemGroup>
 </Project>

--- a/src/Controls/samples/Controls.Sample/Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Controls.Sample.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Embedded\*" />
-    <MauiAsset Include="Resources\Raw\*" />
+    <MauiAsset Include="Resources\Raw\*" Link="%(Filename)%(Extension)" />
     <MauiImage Include="Resources\Images\*" />
     <MauiImage Update="Resources\Images\*.gif" Resize="false" />
     <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />

--- a/src/Controls/samples/Controls.Sample/Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Controls.Sample.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Embedded\*" />
+    <MauiAsset Include="Resources\Raw\*" />
     <MauiImage Include="Resources\Images\*" />
     <MauiImage Update="Resources\Images\*.gif" Resize="false" />
     <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Embedded\*" />
+    <MauiAsset Include="Resources\Raw\*" />
     <MauiImage Include="Resources\Images\*" />
     <MauiImage Update="Resources\Images\*.gif" Resize="false" />
     <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />

--- a/src/Controls/samples/Controls.Sample/Resources/Raw/index.html
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/index.html
@@ -1,0 +1,5 @@
+<html>
+ <body>
+   <h1>Hello, this is embedded web content!<h1>
+ </body>
+</html>

--- a/src/SingleProject/Resizetizer/src/GetMauiAssetPath.cs
+++ b/src/SingleProject/Resizetizer/src/GetMauiAssetPath.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Maui.Resizetizer
+{
+	/// <summary>
+	/// Takes the incoming @(MauiAsset) item group, and returns the proper metadata to include it in the app.
+	/// The main reason we need a task for this is to preserve directory structure.
+	/// 
+	/// Some examples:
+	/// Resources\foo.mp3 -> Resources\foo.mp3
+	/// C:\src\code\MyProject\Resources\foo.mp3 -> Resources\foo.mp3
+	/// C:\some\random\path\foo.mp3 -> foo.mp3
+	/// </summary>
+	public class GetMauiAssetPath : Task
+	{
+		/// <summary>
+		/// The value for $(MSBuildProjectDirectory) in the current project
+		/// </summary>
+		[Required]
+		public string ProjectDirectory { get; set; }
+
+		/// <summary>
+		/// On Windows, 'Assets/' is prepended to the path
+		/// </summary>
+		public string FolderName { get; set; }
+
+		/// <summary>
+		/// On Windows, %(TargetPath) is passed in, %(Link) by default for other platforms
+		/// </summary>
+		public string ItemMetadata { get; set; } = "Link";
+
+		public ITaskItem[] Input { get; set; }
+
+		[Output]
+		public ITaskItem[] Output { get; set; }
+
+		public override bool Execute()
+		{
+			if (Input != null && Input.Length > 0)
+			{
+				foreach (var item in Input)
+				{
+					var link = item.GetMetadata("Link");
+					var path = string.IsNullOrEmpty(link) ? item.ItemSpec : link;
+					if (Path.IsPathRooted(path))
+					{
+						path = Path.GetFullPath(path);
+						if (!MakeRelative (item.GetMetadata("ProjectDirectory"), ref path) && !MakeRelative (ProjectDirectory, ref path))
+						{
+							// If this is a random path, the best we can do is use the file name
+							path = Path.GetFileName(path);
+						}
+					}
+					// Prepend FolderName if not blank
+					if (!string.IsNullOrEmpty(FolderName))
+					{
+						path = Path.Combine(FolderName, path);
+					}
+					item.SetMetadata(ItemMetadata, path);
+				}
+				Output = Input;
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		static bool MakeRelative (string projectDirectory, ref string path)
+		{
+			if (string.IsNullOrEmpty(projectDirectory))
+				return false;
+
+			projectDirectory = Path.GetFullPath(projectDirectory);
+			if (!projectDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()))
+			{
+				projectDirectory += Path.DirectorySeparatorChar;
+			}
+			if (path.StartsWith(projectDirectory, StringComparison.OrdinalIgnoreCase))
+			{
+				path = path.Substring(projectDirectory.Length);
+				return true;
+			}
+			return false;
+		}
+	}
+}

--- a/src/SingleProject/Resizetizer/test/UnitTests/GetMauiAssetsPathTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/GetMauiAssetsPathTests.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace Microsoft.Maui.Resizetizer.Tests
+{
+	public class GetMauiAssetsPathTests : MSBuildTaskTestFixture<GetMauiAssetPath>
+	{
+		const string ProjectDirectory = @"C:\src\code\MyProject";
+		const string LibraryProjectDirectory = ProjectDirectory + @"\ClassLibrary1";
+
+		protected GetMauiAssetPath GetNewTask(string folderName, params ITaskItem[] input) => new()
+		{
+			ProjectDirectory = ProjectDirectory,
+			FolderName = folderName,
+			Input = input
+		};
+
+		[Theory]
+		[InlineData("foo.mp3", "foo.mp3")]
+		[InlineData("foo.mp3", @"Assets\foo.mp3", "Assets")]
+		[InlineData("Resources/Assets/foo.mp3", "Resources/Assets/foo.mp3")]
+		[InlineData(@"Resources\Assets\foo.mp3", @"Resources\Assets\foo.mp3")]
+		[InlineData(ProjectDirectory + @"\foo.mp3", "foo.mp3")]
+		[InlineData(ProjectDirectory + @"\foo.mp3", @"Assets\foo.mp3", "Assets")]
+		public void LinkMetadataIsBlank(string input, string output, string folderName = null)
+		{
+			var item = new TaskItem(input);
+			var task = GetNewTask(folderName, item);
+			var success = task.Execute();
+			Assert.True(success, $"{task.GetType()}.Execute() failed.");
+			Assert.Equal(output, task.Output[0].GetMetadata("Link"));
+		}
+
+		[Theory]
+		[InlineData(@"C:\Program Files\foo.mp3", "foo.mp3", "foo.mp3")]
+		[InlineData(@"C:\Program Files\foo.mp3", "foo.mp3", @"Assets\foo.mp3", "Assets")]
+		[InlineData("/Resources/Assets/foo.mp3", "Resources/Assets/foo.mp3", "Resources/Assets/foo.mp3")]
+		[InlineData(@"C:\Resources\Assets\foo.mp3", @"Resources\Assets\foo.mp3", @"Resources\Assets\foo.mp3")]
+		[InlineData("foo.mp3", ProjectDirectory + @"\foo.mp3", "foo.mp3")]
+		[InlineData("foo.mp3", ProjectDirectory + @"\foo.mp3", @"Assets\foo.mp3", "Assets")]
+		public void UseLinkMetadata(string input, string link, string output, string folderName = null)
+		{
+			var item = new TaskItem(input);
+			item.SetMetadata("Link", link);
+			var task = GetNewTask(folderName, item);
+			var success = task.Execute();
+			Assert.True(success, $"{task.GetType()}.Execute() failed.");
+			Assert.Equal(output, task.Output[0].GetMetadata("Link"));
+		}
+
+		[Theory]
+		[InlineData("foo.mp3", "foo.mp3")]
+		[InlineData("foo.mp3", @"Assets\foo.mp3", "Assets")]
+		public void UseTargetPath(string input, string output, string folderName = null)
+		{
+			var item = new TaskItem(input);
+			var task = GetNewTask(folderName, item);
+			task.ItemMetadata = "TargetPath";
+			var success = task.Execute();
+			Assert.True(success, $"{task.GetType()}.Execute() failed.");
+			Assert.Equal(output, task.Output[0].GetMetadata("TargetPath"));
+		}
+
+		[Theory]
+		[InlineData(LibraryProjectDirectory + @"\foo.mp3", "foo.mp3")]
+		[InlineData(LibraryProjectDirectory + @"\foo.mp3", @"Assets\foo.mp3", "Assets")]
+		[InlineData(LibraryProjectDirectory + @"\foo.mp3", "foo.mp3", null, @"\")]
+		[InlineData(LibraryProjectDirectory + @"\foo.mp3", @"Assets\foo.mp3", "Assets", @"\")]
+		public void UseProjectDirectory(string input, string output, string folderName = null, string suffix = null)
+		{
+			var item = new TaskItem(input);
+			item.SetMetadata("ProjectDirectory", LibraryProjectDirectory + suffix);
+			var task = GetNewTask(folderName, item);
+			var success = task.Execute();
+			Assert.True(success, $"{task.GetType()}.Execute() failed.");
+			Assert.Equal(output, task.Output[0].GetMetadata("Link"));
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Fixes: https://github.com/dotnet/maui/issues/1016

Previously a file like:

    <ItemGroup>
      <MauiAsset Include="Resources\Assets\foo.mp3" />
    </ItemGroup>

Would end up as:

    <ItemGroup>
      <AndroidAsset Include="Resources\Assets\foo.mp3" Link="foo.mp3" />
    </ItemGroup>

This would put the `foo.mp3` in the root of the Android assets folder.
Ideally it should preserve the structure, such as:

    <ItemGroup>
      <AndroidAsset Include="Resources\Assets\foo.mp3" Link="Resources\Assets\foo.mp3" />
    </ItemGroup>

The only way to fix this is with an MSBuild task, where:

1. For absolute paths, make them relative by removing the project
   directory. Also needs to consider files coming from other projects.
2. For relative paths, use them as-is.

Other changes/considerations here are:

* Support the `%(Link)` item metadata.
* The `@(MauiAsset)` sample now needs to use:
  `<WebView Source="Resources/Raw/index.html" />`
* Added tests

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
