### PR TITLE
[Tests] Ignore SourceInitializesCorrectly tests on Android

### DIFF
--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
@@ -13,7 +13,11 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Image)]
 	public partial class ImageHandlerTests : HandlerTestBase<ImageHandler, ImageStub>
 	{
-		[Theory]
+		[Theory(
+#if _ANDROID__
+			Skip = "Test failing on ANDROID"
+#endif
+			)]
 		[InlineData("red.png", "#FF0000")]
 		[InlineData("green.png", "#00FF00")]
 		[InlineData("black.png", "#000000")]
@@ -46,8 +50,8 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Theory(
-#if __IOS__
-			Skip = "Animated GIFs are not yet supported on iOS"
+#if __IOS__ || __ANDROID__
+			Skip = "Animated GIFs are not yet supported on iOS. Test failing on ANDROID"
 #endif
 		)]
 		[InlineData("animated_heart.gif", true)]


### PR DESCRIPTION
### Description of Change ###

These tests are failing on DevDiv main, skipping them for now

Implements #

### Additions made ###

None 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
