### PR TITLE
Change Cake help text to show new 'dotnet-pack' target

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -7,12 +7,12 @@
 /*
 
 Windows CMD:
-build.cmd -Target NugetPack
-build.cmd -Target NugetPack -ScriptArgs '--packageVersion="9.9.9-custom"','--configuration="Release"'
+build.cmd -Target dotnet-pack
+build.cmd -Target dotnet-pack -ScriptArgs '--packageVersion="9.9.9-custom"','--configuration="Release"'
 
 PowerShell:
-./build.ps1 -Target NugetPack
-./build.ps1 -Target NugetPack -ScriptArgs '--packageVersion="9.9.9-custom"'
+./build.ps1 -Target dotnet-pack
+./build.ps1 -Target dotnet-pack -ScriptArgs '--packageVersion="9.9.9-custom"'
 
  */
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Some targets for 'pack' were changed in https://github.com/dotnet/maui/pull/926, but the help text is out-of-date, so I'm updating that.