### PR TITLE
Only register Blazor Components when using FullDI

### DIFF
--- a/Microsoft.Maui.Droid.sln
+++ b/Microsoft.Maui.Droid.sln
@@ -62,6 +62,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BlazorWebView", "BlazorWebV
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Components.WebView.Maui", "src\BlazorWebView\src\core\Microsoft.AspNetCore.Components.WebView.Maui.csproj", "{F7F2B379-52CE-4802-9EC9-0D7967B6BFB7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiRazorClassLibrarySample", "src\BlazorWebView\samples\MauiRazorClassLibrarySample\MauiRazorClassLibrarySample.csproj", "{A33803A8-D398-49F3-B5E8-8C812237829A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +131,10 @@ Global
 		{F7F2B379-52CE-4802-9EC9-0D7967B6BFB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7F2B379-52CE-4802-9EC9-0D7967B6BFB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7F2B379-52CE-4802-9EC9-0D7967B6BFB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A33803A8-D398-49F3-B5E8-8C812237829A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A33803A8-D398-49F3-B5E8-8C812237829A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A33803A8-D398-49F3-B5E8-8C812237829A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A33803A8-D398-49F3-B5E8-8C812237829A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -152,6 +158,7 @@ Global
 		{C564DDD6-DE79-45CD-88EA-3F690481572A} = {09C264E9-E3F3-4586-9151-DCBB1F6DA7AB}
 		{50C758FE-4E10-409A-94F5-A75480960864} = {459BF674-83CB-46F6-881F-A2D2117DBF4D}
 		{F7F2B379-52CE-4802-9EC9-0D7967B6BFB7} = {1614D1A4-5C3D-4D5B-8C89-426E37A564EF}
+		{A33803A8-D398-49F3-B5E8-8C812237829A} = {1614D1A4-5C3D-4D5B-8C89-426E37A564EF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B8ABEAD-D2B5-4370-A187-62B5ABE4EE50}

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -36,12 +36,7 @@ namespace Maui.Controls.Sample
 
 		public void Configure(IAppHostBuilder appBuilder)
 		{
-			bool useFullDIAndBlazor = UseFullDI
-
-#if BLAZOR_ENABLED
-				|| _pageType == PageType.Blazor
-#endif
-				;
+			bool useFullDIAndBlazor = UseFullDI || _pageType == PageType.Blazor;
 
 			appBuilder
 				.UseFormsCompatibility()

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -36,6 +36,13 @@ namespace Maui.Controls.Sample
 
 		public void Configure(IAppHostBuilder appBuilder)
 		{
+			bool useFullDIAndBlazor = UseFullDI
+
+#if BLAZOR_ENABLED
+				|| _pageType == PageType.Blazor
+#endif
+				;
+
 			appBuilder
 				.UseFormsCompatibility()
 				.UseMauiControlsHandlers();
@@ -65,21 +72,24 @@ namespace Maui.Controls.Sample
 					});
 				 });
 
+			if (useFullDIAndBlazor)
+			{
 #if BLAZOR_ENABLED
-			appBuilder
-				.RegisterBlazorMauiWebView(typeof(Startup).Assembly);
+				appBuilder
+					.RegisterBlazorMauiWebView(typeof(Startup).Assembly);
 #endif
-
-			if (_pageType == PageType.Blazor || UseFullDI)
 				appBuilder.UseMicrosoftExtensionsServiceProviderFactory();
+			}
 			else
+			{
 				appBuilder.UseMauiServiceProviderFactory(constructorInjection: true);
+			}
 
 			appBuilder
 				.ConfigureServices(services =>
 				{
 					// The MAUI DI does not support generic argument resolution
-					if (UseFullDI)
+					if (useFullDIAndBlazor)
 					{
 						services.AddLogging(logging =>
 						{
@@ -94,7 +104,8 @@ namespace Maui.Controls.Sample
 					services.AddSingleton<ITextService, TextService>();
 					services.AddTransient<MainPageViewModel>();
 #if BLAZOR_ENABLED
-					services.AddBlazorWebView();
+					if (useFullDIAndBlazor)
+						services.AddBlazorWebView();
 #endif
 					services.AddTransient(
 						serviceType: _pageType == PageType.Blazor ? typeof(Page) : typeof(IPage),


### PR DESCRIPTION
### Description of Change ###

`AddBlazorWebView` registers the Extension Hosting Logging Factory that can only be instantiated via the Extension Hosting DI

So we need to not call `AddBlazorWebView` if we aren't using FullDI or the BlazorWebView