### PR TITLE
Setup Page Content to Update via Mapper

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -97,12 +97,25 @@ Task("VS-NET6")
 Task("VS-WINUI")
     .Description("Provisions .NET 6 and launches an instance of Visual Studio with WinUI projects.")
     .IsDependentOn("Clean")
-    .IsDependentOn("dotnet")
-    .IsDependentOn("dotnet-buildtasks")
+    // .IsDependentOn("dotnet") WINUI currently can't launch application with local dotnet 
+    // .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
-        RunMSBuildWithLocalDotNet("./Microsoft.Maui.WinUI.sln");
-        StartVisualStudioForDotNet6("./Microsoft.Maui.WinUI.sln");
+        string sln = "./Microsoft.Maui.WinUI.sln";
+        var msbuildSettings = new MSBuildSettings
+        {
+            Configuration = configuration,
+            ToolPath = FindMSBuild(),
+        };
+
+        MSBuild("./Microsoft.Maui.BuildTasks-net6.sln", msbuildSettings.WithRestore());
+        MSBuild(sln, msbuildSettings.WithRestore());
+
+        var vsLatest = VSWhereLatest(new VSWhereLatestSettings { IncludePrerelease = true, });
+        if (vsLatest == null)
+            throw new Exception("Unable to find Visual Studio!");
+        Environment.SetEnvironmentVariable("_ExcludeMauiProjectCapability", "true", EnvironmentVariableTarget.Process);
+        StartProcess(vsLatest.CombineWithFilePath("./Common7/IDE/devenv.exe"), sln);
     });
 
 Task("VS-ANDROID")

--- a/src/Core/src/Handlers/Page/PageHandler.Android.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Android.cs
@@ -24,13 +24,19 @@ namespace Microsoft.Maui.Handlers
 		public override void SetVirtualView(IView view)
 		{
 			base.SetVirtualView(view);
-
-			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
-			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 
 			NativeView.CrossPlatformMeasure = VirtualView.Measure;
 			NativeView.CrossPlatformArrange = VirtualView.Arrange;
+		}
+
+		void UpdateContent()
+		{
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+
 			NativeView.RemoveAllViews();
 
 			if (VirtualView.Content != null)
@@ -39,6 +45,11 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapTitle(PageHandler handler, IPage page)
 		{
+		}
+
+		public static void MapContent(PageHandler handler, IPage page)
+		{
+			handler.UpdateContent();
 		}
 	}
 }

--- a/src/Core/src/Handlers/Page/PageHandler.Standard.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Standard.cs
@@ -9,5 +9,8 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTitle(PageHandler handler, IPage page)
 		{
 		}
+		public static void MapContent(PageHandler handler, IPage page)
+		{
+		}
 	}
 }

--- a/src/Core/src/Handlers/Page/PageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Windows.cs
@@ -6,16 +6,23 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class PageHandler : ViewHandler<IPage, PagePanel>
 	{
+
 		public override void SetVirtualView(IView view)
 		{
 			base.SetVirtualView(view);
 
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
-			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			NativeView.CrossPlatformMeasure = VirtualView.Measure;
 			NativeView.CrossPlatformArrange = VirtualView.Arrange;
+		}
+
+		void UpdateContent()
+		{
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			NativeView.Children.Clear();
 
@@ -41,6 +48,11 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapTitle(PageHandler handler, IPage page)
 		{
+		}
+
+		public static void MapContent(PageHandler handler, IPage page)
+		{
+			handler.UpdateContent();
 		}
 	}
 }

--- a/src/Core/src/Handlers/Page/PageHandler.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.Handlers
 		public static PropertyMapper<IPage, PageHandler> PageMapper = new PropertyMapper<IPage, PageHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(IPage.Title)] = MapTitle,
+			[nameof(IPage.Content)] = MapContent,
 		};
 
 		public PageHandler() : base(PageMapper)

--- a/src/Core/src/Handlers/Page/PageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.iOS.cs
@@ -26,7 +26,14 @@ namespace Microsoft.Maui.Handlers
 		public override void SetVirtualView(IView view)
 		{
 			base.SetVirtualView(view);
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
+			NativeView.CrossPlatformArrange = VirtualView.Arrange;
+		}
+
+		void UpdateContent()
+		{
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
@@ -34,8 +41,6 @@ namespace Microsoft.Maui.Handlers
 			//Cleanup the old view when reused
 			var oldChildren = NativeView.Subviews.ToList();
 			oldChildren.ForEach(x => x.RemoveFromSuperview());
-
-			NativeView.CrossPlatformArrange = VirtualView.Arrange;
 
 			if (VirtualView.Content != null)
 				NativeView.AddSubview(VirtualView.Content.ToNative(MauiContext));
@@ -45,6 +50,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (handler._pageViewController != null)
 				handler._pageViewController.Title = page.Title;
+		}
+
+		public static void MapContent(PageHandler handler, IPage page)
+		{
+			handler.UpdateContent();
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.Android.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Android.Views;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Xunit;
+using ATextAlignment = Android.Views.TextAlignment;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class PageHandlerTests
+	{
+		public View GetNativePageContent(IPage page)
+		{
+			int childCount = 0;
+			if (page.Handler.NativeView is ViewGroup view)
+			{
+				childCount = view.ChildCount;
+				if (childCount == 1)
+					return view.GetChildAt(0);
+			}
+
+
+			Assert.Equal(1, childCount);
+			return null;
+		}
+
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.cs
@@ -6,8 +6,8 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	[Category(TestCategory.Picker)]
-	public partial class PageHandlerTests : HandlerTestBase<PickerHandler, PickerStub>
+	[Category(TestCategory.Page)]
+	public partial class PageHandlerTests : HandlerTestBase<PageHandler, PageStub>
 	{
 		[Fact(DisplayName = "Title Initializes Correctly")]
 		public async Task ContentInitializes()

--- a/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Picker)]
+	public partial class PageHandlerTests : HandlerTestBase<PickerHandler, PickerStub>
+	{
+		[Fact(DisplayName = "Title Initializes Correctly")]
+		public async Task ContentInitializes()
+		{
+			var slider = new SliderStub();
+			var page = new PageStub
+			{
+				Content = slider
+			};
+
+			await CreateHandlerAsync(page);
+			Assert.Equal(slider.Handler.NativeView, GetNativePageContent(page));
+		}
+
+		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
+		public async Task ContentUpdates()
+		{
+			var slider = new SliderStub();
+			var page = new PageStub
+			{
+				Content = new SliderStub()
+			};
+
+			await CreateHandlerAsync(page);
+			await InvokeOnMainThreadAsync(() => page.Content = slider);
+			Assert.Equal(slider.Handler.NativeView, GetNativePageContent(page));
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.iOS.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class PageHandlerTests
+	{
+
+		public UIView GetNativePageContent(IPage page)
+		{
+			int childCount = 0;
+			if (page.Handler.NativeView is UIView view)
+			{
+				childCount = view.Subviews.Length;
+				if (childCount == 1)
+					return view.Subviews[0];
+			}
+
+
+			Assert.Equal(1, childCount);
+			return null;
+		}
+
+	}
+}

--- a/src/Core/tests/DeviceTests/Stubs/PageStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/PageStub.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public partial class PageStub : StubBase, IPage
+	{
+		private IView _content;
+		private string _title;
+
+		public IView Content { get => _content; set => this.SetProperty(ref _content, value); }
+
+		public string Title { get => _title; set => this.SetProperty(ref _title, value); }
+	}
+}

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -12,6 +12,7 @@
 		public const string ImageSource = "ImageSource";
 		public const string Label = "Label";
 		public const string Layout = "Layout";
+		public const string Page = "Page";
 		public const string Picker = "Picker";
 		public const string SearchBar = "SearchBar";
 		public const string Slider = "Slider";


### PR DESCRIPTION
### Description of Change ###

Move the code that sets up the IPage.Content to a static method so that it's updateable

### Additions made ###
* Adds MapContent

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
