### PR TITLE
Set DesiredSize when calling IFrameworkElement.Arrange on legacy layout

### DIFF
--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -802,6 +802,7 @@ namespace Microsoft.Maui.Controls
 				result.Request = new Size(result.Request.Width + margin.HorizontalThickness, result.Request.Height + margin.VerticalThickness);
 			}
 
+			DesiredSize = result.Request;
 			return result;
 		}
 

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
@@ -78,5 +78,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			(contentPage as IFrameworkElement).Arrange(rect);
 			Assert.AreEqual(expectedSize, button.Bounds.Size);
 		}
+
+		[Test]
+		public void GridInsideStackLayout()
+		{
+			ContentPage contentPage = new ContentPage();
+			var stackLayout = new StackLayout() { IsPlatformEnabled = true };
+			var grid = new Grid() { IsPlatformEnabled = true, HeightRequest = 50 };
+			var label = new Label() { IsPlatformEnabled = true };
+			var expectedSize = new Size(50, 50);
+
+			var view = Substitute.For<IViewHandler>();
+			view.GetDesiredSize(default, default).ReturnsForAnyArgs(expectedSize);
+			label.Handler = view;
+
+			stackLayout.Add(grid);
+			grid.Children.Add(label);
+			contentPage.Content = stackLayout;
+
+			var rect = new Rectangle(0, 0, 50, 100);
+			(contentPage as IFrameworkElement).Measure(expectedSize.Width, expectedSize.Height);
+			(contentPage as IFrameworkElement).Arrange(rect);
+
+			// This simulates the arrange call that happens from the native LayoutViewGroup
+			(grid as IFrameworkElement).Arrange(rect);
+
+			Assert.AreEqual(expectedSize, grid.Bounds.Size);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implements #1049

When the native LayoutViewGroup executes it's layout method it calls `IFrameworkElement.Arrange` on the legacy layout.  This causes the ComputeFrame call to set the Bounds to zero if the DesiredSize hasn't been set on the IFrameworkElement
