### PR TITLE
Remove children from native layout when disconnecting handler

### DIFF
--- a/src/Compatibility/Core/src/Android/Cells/ViewCellRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Cells/ViewCellRenderer.cs
@@ -217,7 +217,17 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				RemoveView(_view.View);
 				AppCompat.Platform.SetRenderer(_viewCell.View, null);
 				_viewCell.View.IsPlatformEnabled = false;
-				_view.View.Dispose();
+
+				// Adding a special case for HandlerToRendererShim so that DisconnectHandler gets called;
+				// Pending https://github.com/xamarin/Xamarin.Forms/pull/14288 being merged, we won't need the special case
+				if (_view is HandlerToRendererShim htrs)
+				{
+					htrs.Dispose();
+				}
+				else
+				{
+					_view.View.Dispose();
+				}
 
 				_viewCell = cell;
 				_view = AppCompat.Platform.CreateRenderer(_viewCell.View, Context);

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -32,11 +32,9 @@ namespace Microsoft.Maui.Handlers
 			NativeView.CrossPlatformMeasure = VirtualView.Measure;
 			NativeView.CrossPlatformArrange = VirtualView.Arrange;
 
-			this.NativeView.RemoveAllViews();
+			NativeView.RemoveAllViews();
 			foreach (var child in VirtualView.Children)
 			{
-				//var wrap = ViewGroup.LayoutParams.WrapContent;
-				//NativeView.AddView(child.ToNative(MauiContext), new ViewGroup.LayoutParams(wrap, wrap));
 				NativeView.AddView(child.ToNative(MauiContext));
 			}
 		}
@@ -59,6 +57,13 @@ namespace Microsoft.Maui.Handlers
 			{
 				NativeView.RemoveView(view);
 			}
+		}
+
+		protected override void DisconnectHandler(LayoutViewGroup nativeView)
+		{
+			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
+			NativeView?.RemoveAllViews();
+			base.DisconnectHandler(nativeView);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -58,5 +58,12 @@ namespace Microsoft.Maui.Handlers
 
 			return view;
 		}
+
+		protected override void DisconnectHandler(LayoutPanel nativeView)
+		{
+			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
+			NativeView?.Children.Clear();
+			base.DisconnectHandler(nativeView);
+		}
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -65,5 +65,16 @@ namespace Microsoft.Maui.Handlers
 				NativeView.SetNeedsLayout();
 			}
 		}
+
+		protected override void DisconnectHandler(LayoutView nativeView)
+		{
+			base.DisconnectHandler(nativeView);
+			var subViews = nativeView.Subviews;
+
+			foreach (var subView in subViews)
+			{
+				subView.RemoveFromSuperview();
+			}
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -44,5 +44,23 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			Assert.Equal(0, count);
 		}
+
+		[Fact(DisplayName = "DisconnectHandler removes child from native layout")]
+		public async Task DisconnectHandlerRemovesChildFromNativeLayout()
+		{
+			var layout = new LayoutStub();
+			var slider = new SliderStub();
+			layout.Add(slider);
+
+			var handler = await CreateHandlerAsync(layout);
+
+			var count = await InvokeOnMainThreadAsync(() =>
+			{
+				layout.Handler.DisconnectHandler();
+				return GetNativeChildCount(handler);
+			});
+
+			Assert.Equal(0, count);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

After a handler is disconnected from a cross-platform layout control, the native layout control should no longer be managing the cross-platform layout's children's native controls.

This change removes the native children from the native layout control on disconnect.

