### PR TITLE
Templates - ContentPage item template

### DIFF
--- a/src/Templates/src/maui-contentpage/.template.config/template.json
+++ b/src/Templates/src/maui-contentpage/.template.config/template.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "David Ortinau",
+    "classifications": [ "Common", "Code" ],
+    "identity": "Maui.ContentPage",
+    "name": ".NET MAUI ContentPage",
+    "shortName": "maui-page",
+    "tags": {
+      "language": "C#",
+      "type": "item"
+    },
+    "sourceName": "NewPage1",
+    "defaultName": "NewPage1"
+  }

--- a/src/Templates/src/maui-contentpage/.template.config/template.json
+++ b/src/Templates/src/maui-contentpage/.template.config/template.json
@@ -2,7 +2,7 @@
     "$schema": "http://json.schemastore.org/template",
     "author": "David Ortinau",
     "classifications": [ "Common", "Code" ],
-    "identity": "Maui.ContentPage",
+    "identity": "Microsoft.Maui.ContentPage",
     "name": ".NET MAUI ContentPage",
     "shortName": "maui-page",
     "tags": {
@@ -10,5 +10,12 @@
       "type": "item"
     },
     "sourceName": "NewPage1",
-    "defaultName": "NewPage1"
+    "defaultName": "NewPage1",
+    "symbols": {
+      "namespace": {
+        "description": "namespace for the generated code",
+        "replaces": "MauiApp1",
+        "type": "parameter"
+      }
+    }
   }

--- a/src/Templates/src/maui-contentpage/NewPage1.xaml
+++ b/src/Templates/src/maui-contentpage/NewPage1.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MauiApp1.NewPage1"
+             Title="NewPage1"
+             BackgroundColor="White">
+
+</ContentPage>

--- a/src/Templates/src/maui-contentpage/NewPage1.xaml.cs
+++ b/src/Templates/src/maui-contentpage/NewPage1.xaml.cs
@@ -1,0 +1,15 @@
+using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace MauiApp1
+{
+	public partial class NewPage1 : ContentPage
+	{
+		public NewPage1()
+		{
+			InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
Create a `ContentPage`from CLI like:

```cli
dotnet new maui-contentpage -n MyPage
```

Currently renames the page, but doesn't do anything to update the namespace yet. Not sure that's possible here. Would be nice if the command were aware of the project/solution it's running in and automatically would pick up that namespace and folder.

Might change this to differentiate XAML from C#.

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
