### PR TITLE
Make project template GUIDs unique on each instantiation

### DIFF
--- a/src/Templates/src/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/maui-blazor/.template.config/template.json
@@ -18,6 +18,11 @@
       { "path": "MauiApp1.WinUI3 (Package)\\MauiApp1.WinUI3 (Package).csproj" },
       { "path": "MauiApp1.sln" }
     ],
+    "guids": [
+      "07CD65EF-6238-4365-AF5D-F6D433967F48",
+      "202C61B5-A2D9-4817-8020-731D9F855561",
+      "A88FCF8C-EC35-4623-B126-C591EEF99C70"
+    ],
     "symbols": {
       "applicationId": {
         "type": "parameter",

--- a/src/Templates/src/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/maui-mobile/.template.config/template.json
@@ -18,6 +18,11 @@
       { "path": "MauiApp1.WinUI3 (Package)\\MauiApp1.WinUI3 (Package).csproj" },
       { "path": "MauiApp1.sln" }
     ],
+    "guids": [
+      "07CD65EF-6238-4365-AF5D-F6D433967F48",
+      "202C61B5-A2D9-4817-8020-731D9F855561",
+      "A88FCF8C-EC35-4623-B126-C591EEF99C70"
+    ],
     "symbols": {
       "applicationId": {
         "type": "parameter",


### PR DESCRIPTION
Every time you `dotnet new maui` or `dotnet new maui-blazor` the project templates (as listed in the SLN) have the exact same GUIDs, because they are hard-coded in the project template. In template.json there's a feature to replace GUIDs so that every time you get new GUIDs.