### PR TITLE
Remove XamlC from page in templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1/MainPage.xaml.cs
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/MainPage.xaml.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
 
 namespace MauiApp1
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class MainPage : ContentPage, IPage
 	{
 		public MainPage()

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
 
 namespace MauiApp1
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class MainPage : ContentPage, IPage
 	{
 		public MainPage()


### PR DESCRIPTION
XamlC is running in Debug builds currently and this causes issues with C# Hot Reload.