### PR TITLE
[android] use Xamarin.AndroidX stable from NuGet.org

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -1,51 +1,52 @@
 <Project>
   <PropertyGroup>
-    <_AndroidXVersion>net6preview03.4680155</_AndroidXVersion>
+    <!-- Uncomment to use preview packages -->
+    <!-- <_AndroidXVersion>-net6preview03.4680155</_AndroidXVersion> -->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference
         Update="Xamarin.AndroidX.AppCompat.AppCompatResources"
-        Version="1.2.0.7-$(_AndroidXVersion)"
+        Version="1.2.0.7$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Browser"
-        Version="1.3.0.5-$(_AndroidXVersion)"
+        Version="1.3.0.5$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Legacy.Support.V4"
-        Version="1.0.0.7-$(_AndroidXVersion)"
+        Version="1.0.0.7$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Lifecycle.LiveData"
-        Version="2.3.1-$(_AndroidXVersion)"
+        Version="2.3.1$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.UI"
-        Version="2.3.5-$(_AndroidXVersion)"
+        Version="2.3.5$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Fragment"
-        Version="2.3.5-$(_AndroidXVersion)"
+        Version="2.3.5$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Runtime"
-        Version="2.3.5-$(_AndroidXVersion)"
+        Version="2.3.5$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Common"
-        Version="2.3.5-$(_AndroidXVersion)"
+        Version="2.3.5$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.MediaRouter"
-        Version="1.2.2.1-$(_AndroidXVersion)"
+        Version="1.2.2.1$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Palette"
-        Version="1.0.0.7-$(_AndroidXVersion)"
+        Version="1.0.0.7$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.AndroidX.RecyclerView"
-        Version="1.2.0-$(_AndroidXVersion)"
+        Version="1.2.0$(_AndroidXVersion)"
     />
     <PackageReference
         Update="Xamarin.Build.Download"
@@ -53,7 +54,7 @@
     />
     <PackageReference
         Update="Xamarin.Google.Android.Material"
-        Version="1.3.0.1-$(_AndroidXVersion)"
+        Version="1.3.0.1$(_AndroidXVersion)"
     />
   </ItemGroup>
 </Project>

--- a/src/Compatibility/Core/src/Android/CollectionView/SelectableItemsViewAdapter.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/SelectableItemsViewAdapter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			for (int i = 0; i < _currentViewHolders.Count; i++)
 			{
-				if (_currentViewHolders[i].BindingAdapterPosition == position)
+				if (_currentViewHolders[i].AdapterPosition == position)
 				{
 					_currentViewHolders[i].IsSelected = true;
 					return;

--- a/src/Compatibility/Core/src/Android/CollectionView/SelectableViewHolder.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/SelectableViewHolder.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		{
 			if (_isSelectionEnabled)
 			{
-				OnViewHolderClicked(BindingAdapterPosition);
+				OnViewHolderClicked(AdapterPosition);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

In the short term, we need to be able to use AndroidX packages from NuGet.org -- so we can get rid of the need for any NuGet.config files in samples or customer projects in .NET 6 Preview 5.

For now, let's use the stable Xamarin AndroidX packages. There is only a couple minor API changes after downgrading.

In the long term, we will be able to push preview packages that contain .NET 6 assemblies for AndroidX.

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No