### PR TITLE
app name should match template name

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI3 (Package)/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI3 (Package)/Package.appxmanifest
@@ -12,7 +12,7 @@
     Version="1.0.0.0" />
 
   <Properties>
-    <DisplayName>WeatherTwentyOne</DisplayName>
+    <DisplayName>MauiApp1</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
@@ -31,8 +31,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="WeatherTwentyOne"
-        Description="WeatherTwentyOne"
+        DisplayName="MauiApp1"
+        Description="MauiApp1"
         BackgroundColor="transparent"
         Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png">

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI3 (Package)/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI3 (Package)/Package.appxmanifest
@@ -12,7 +12,7 @@
     Version="1.0.0.0" />
 
   <Properties>
-    <DisplayName>WeatherTwentyOne</DisplayName>
+    <DisplayName>MauiApp1</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
@@ -31,8 +31,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="WeatherTwentyOne"
-        Description="WeatherTwentyOne"
+        DisplayName="MauiApp1"
+        Description="MauiApp1"
         BackgroundColor="transparent"
         Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png">


### PR DESCRIPTION
### Description of Change ###

Updates the Templates so that the package name of the WinUI project matches the template name which will be replaced during the project creation by dotnet new.

Implements #

n/a

### Additions made ###

n/a

### PR Checklist ###

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? no
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
