### PR TITLE
Fix WinUI and Control Gallery builds  

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 
     <BuildForWinUI Condition="'$(SolutionFileName)' == 'Microsoft.Maui.WinUI.sln' AND '$(Packing)' == ''">true</BuildForWinUI>
     <BuildForAndroid Condition="'$(SolutionFileName)' == 'Microsoft.Maui.Droid.sln' AND '$(Packing)' == ''">true</BuildForAndroid>
-    <BuildForNet6 Condition="$(SolutionFileName.Contains('net6')) == true OR '$(BuildForWinUI)' == 'true' OR '$(BuildForAndroid)' == 'true'">true</BuildForNet6>
+    <BuildForNet6 Condition="'$(Packing)' == 'true' OR $(SolutionFileName.Contains('net6')) == true OR '$(BuildForWinUI)' == 'true' OR '$(BuildForAndroid)' == 'true'">true</BuildForNet6>
     <MauiPlatforms>net6.0-ios;net6.0-maccatalyst;net6.0-android</MauiPlatforms>
     <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362</WindowsTargetFramework>
     <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);$(WindowsTargetFramework)</MauiPlatforms>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,10 +3,9 @@
 
   <PropertyGroup>
 
-    <BuildForWinUI Condition="'$(SolutionFileName)' == 'Microsoft.Maui.WinUI.sln'">true</BuildForWinUI>
-    <BuildForAndroid Condition="'$(SolutionFileName)' == 'Microsoft.Maui.Droid.sln'">true</BuildForAndroid>
-    
-    <BuildForNet6 Condition="'$(SolutionFileName)' == 'Microsoft.Maui-net6.sln' or '$(BuildForWinUI)' == 'true'">true</BuildForNet6>
+    <BuildForWinUI Condition="'$(SolutionFileName)' == 'Microsoft.Maui.WinUI.sln' AND '$(Packing)' == ''">true</BuildForWinUI>
+    <BuildForAndroid Condition="'$(SolutionFileName)' == 'Microsoft.Maui.Droid.sln' AND '$(Packing)' == ''">true</BuildForAndroid>
+    <BuildForNet6 Condition="$(SolutionFileName.Contains('net6')) == true OR '$(BuildForWinUI)' == 'true' OR '$(BuildForAndroid)' == 'true'">true</BuildForNet6>
     <MauiPlatforms>net6.0-ios;net6.0-maccatalyst;net6.0-android</MauiPlatforms>
     <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362</WindowsTargetFramework>
     <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);$(WindowsTargetFramework)</MauiPlatforms>

--- a/Microsoft.Maui.BuildTasks-net6.sln
+++ b/Microsoft.Maui.BuildTasks-net6.sln
@@ -30,6 +30,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Resizetizer.UnitTests", "sr
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{FF16050F-B905-4DE1-92FA-8B9EC93EE009}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.SourceGen-net6", "src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj", "{3E40598B-A52D-417D-B856-240847F6A43F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{900BA626-5A26-4123-9A0E-43A0953B9053}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{900BA626-5A26-4123-9A0E-43A0953B9053}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{900BA626-5A26-4123-9A0E-43A0953B9053}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E40598B-A52D-417D-B856-240847F6A43F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E40598B-A52D-417D-B856-240847F6A43F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E40598B-A52D-417D-B856-240847F6A43F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E40598B-A52D-417D-B856-240847F6A43F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.Maui.BuildTasks.sln
+++ b/Microsoft.Maui.BuildTasks.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.Build.Tasks", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Resizetizer", "src\SingleProject\Resizetizer\src\Resizetizer.csproj", "{3E1D0DED-6B13-42C8-AA15-2EDFD8ECE80C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.SourceGen", "src\Controls\src\SourceGen\Controls.SourceGen.csproj", "{A33C2BD2-293C-4890-91C0-4665BC6E2AD3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,10 @@ Global
 		{3E1D0DED-6B13-42C8-AA15-2EDFD8ECE80C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E1D0DED-6B13-42C8-AA15-2EDFD8ECE80C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E1D0DED-6B13-42C8-AA15-2EDFD8ECE80C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A33C2BD2-293C-4890-91C0-4665BC6E2AD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A33C2BD2-293C-4890-91C0-4665BC6E2AD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A33C2BD2-293C-4890-91C0-4665BC6E2AD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A33C2BD2-293C-4890-91C0-4665BC6E2AD3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.Maui.Droid.sln
+++ b/Microsoft.Maui.Droid.sln
@@ -64,6 +64,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Compon
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiRazorClassLibrarySample", "src\BlazorWebView\samples\MauiRazorClassLibrarySample\MauiRazorClassLibrarySample.csproj", "{A33803A8-D398-49F3-B5E8-8C812237829A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.SourceGen-net6", "src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj", "{FE48D482-1E5A-4CD6-A3D8-C3FBC0AE1DA1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -135,6 +137,10 @@ Global
 		{A33803A8-D398-49F3-B5E8-8C812237829A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A33803A8-D398-49F3-B5E8-8C812237829A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A33803A8-D398-49F3-B5E8-8C812237829A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE48D482-1E5A-4CD6-A3D8-C3FBC0AE1DA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE48D482-1E5A-4CD6-A3D8-C3FBC0AE1DA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE48D482-1E5A-4CD6-A3D8-C3FBC0AE1DA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE48D482-1E5A-4CD6-A3D8-C3FBC0AE1DA1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -159,6 +165,7 @@ Global
 		{50C758FE-4E10-409A-94F5-A75480960864} = {459BF674-83CB-46F6-881F-A2D2117DBF4D}
 		{F7F2B379-52CE-4802-9EC9-0D7967B6BFB7} = {1614D1A4-5C3D-4D5B-8C89-426E37A564EF}
 		{A33803A8-D398-49F3-B5E8-8C812237829A} = {1614D1A4-5C3D-4D5B-8C89-426E37A564EF}
+		{FE48D482-1E5A-4CD6-A3D8-C3FBC0AE1DA1} = {50C758FE-4E10-409A-94F5-A75480960864}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B8ABEAD-D2B5-4370-A187-62B5ABE4EE50}

--- a/Microsoft.Maui.WinUI.sln
+++ b/Microsoft.Maui.WinUI.sln
@@ -82,6 +82,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUI.UITests", "src\Compat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiRazorClassLibrarySample", "src\BlazorWebView\samples\MauiRazorClassLibrarySample\MauiRazorClassLibrarySample.csproj", "{1373F90D-D4BA-4A76-BDB8-FAD569BD682B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.SourceGen-net6", "src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj", "{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compatibility\ControlGallery\src\Issues.Shared\Compatibility.ControlGallery.Issues.Shared.projitems*{0a39a74b-6f7a-4d41-84f2-b0ccdce899df}*SharedItemsImports = 4
@@ -433,6 +435,22 @@ Global
 		{1373F90D-D4BA-4A76-BDB8-FAD569BD682B}.Release|x64.Build.0 = Release|Any CPU
 		{1373F90D-D4BA-4A76-BDB8-FAD569BD682B}.Release|x86.ActiveCfg = Release|Any CPU
 		{1373F90D-D4BA-4A76-BDB8-FAD569BD682B}.Release|x86.Build.0 = Release|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Debug|arm64.Build.0 = Debug|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Debug|x64.Build.0 = Debug|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Release|arm64.ActiveCfg = Release|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Release|arm64.Build.0 = Release|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Release|x64.ActiveCfg = Release|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Release|x64.Build.0 = Release|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -469,6 +487,7 @@ Global
 		{E175485B-3C8C-47D7-8DD5-F7FED627EB25} = {10F4E7CB-E20E-4393-BD88-FD7075AC4525}
 		{0A39A74B-6F7A-4D41-84F2-B0CCDCE899DF} = {10F4E7CB-E20E-4393-BD88-FD7075AC4525}
 		{1373F90D-D4BA-4A76-BDB8-FAD569BD682B} = {17CD1D1D-B4EA-4E7E-ABEF-945AC320936B}
+		{8E6FFD4B-1D9E-4CAF-A798-33D81F22EA8E} = {459BF674-83CB-46F6-881F-A2D2117DBF4D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B8ABEAD-D2B5-4370-A187-62B5ABE4EE50}

--- a/Microsoft.Maui.iOS.sln
+++ b/Microsoft.Maui.iOS.sln
@@ -120,6 +120,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Compatibility.ControlGaller
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Compatibility", "src\Compatibility\Core\src\Compatibility.csproj", "{80A66694-25A7-456F-9C95-9CB9B262B885}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Controls.SourceGen", "src\Controls\src\SourceGen\Controls.SourceGen.csproj", "{F763B742-A403-44EC-B3AD-B8631054BF3D}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compatibility\ControlGallery\src\Issues.Shared\Compatibility.ControlGallery.Issues.Shared.projitems*{ae2513cb-4e5e-4e5c-8237-88954d4c9433}*SharedItemsImports = 13
@@ -881,6 +883,34 @@ Global
 		{80A66694-25A7-456F-9C95-9CB9B262B885}.Release|x64.Build.0 = Release|Any CPU
 		{80A66694-25A7-456F-9C95-9CB9B262B885}.Release|x86.ActiveCfg = Release|Any CPU
 		{80A66694-25A7-456F-9C95-9CB9B262B885}.Release|x86.Build.0 = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|x64.Build.0 = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Debug|x86.Build.0 = Debug|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|ARM.Build.0 = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|ARM64.Build.0 = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|iPhone.Build.0 = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|x64.ActiveCfg = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|x64.Build.0 = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|x86.ActiveCfg = Release|Any CPU
+		{F763B742-A403-44EC-B3AD-B8631054BF3D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -927,6 +957,7 @@ Global
 		{AE2513CB-4E5E-4E5C-8237-88954D4C9433} = {75A2CD30-BB85-4CA6-AC95-86A8A538A690}
 		{B5F94CCB-5868-43BD-89B5-B66C97C3A741} = {75A2CD30-BB85-4CA6-AC95-86A8A538A690}
 		{80A66694-25A7-456F-9C95-9CB9B262B885} = {29AC50BF-B4FB-450B-9386-0C5AD4B84226}
+		{F763B742-A403-44EC-B3AD-B8631054BF3D} = {D5B986A3-7FC9-437E-8030-349AA4698DFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {650AE971-2F29-46A8-822C-FB4FCDC6A9A0}

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -116,7 +116,7 @@ Task("VS-WINUI")
         {
             Configuration = configuration,
             ToolPath = FindMSBuild(),
-	        BinaryLogger = new MSBuildBinaryLogSettings
+            BinaryLogger = new MSBuildBinaryLogSettings
             {
                 Enabled  = true,
                 FileName = "artifacts/winui-buildtasks.binlog",
@@ -129,7 +129,7 @@ Task("VS-WINUI")
         {
             Configuration = configuration,
             ToolPath = FindMSBuild(),
-	        BinaryLogger = new MSBuildBinaryLogSettings
+            BinaryLogger = new MSBuildBinaryLogSettings
             {
                 Enabled  = true,
                 FileName = "artifacts/winui.binlog",

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -94,11 +94,21 @@ Task("VS-NET6")
         StartVisualStudioForDotNet6();
     });
 
+Task("VS-WINUI-CI")
+    .Description("Validates that WinUI can build with the cake scripts.")
+    .IsDependentOn("Clean")
+    .IsDependentOn("dotnet")
+    .Does(() =>
+    {
+        RunMSBuildWithLocalDotNet("./Microsoft.Maui.BuildTasks-net6.sln", settings => ((MSBuildSettings)settings).WithProperty("BuildForWinUI", "true"));
+        RunMSBuildWithLocalDotNet("./Microsoft.Maui.WinUI.sln");
+    });
+
 Task("VS-WINUI")
     .Description("Provisions .NET 6 and launches an instance of Visual Studio with WinUI projects.")
-    .IsDependentOn("Clean")
-    // .IsDependentOn("dotnet") WINUI currently can't launch application with local dotnet 
-    // .IsDependentOn("dotnet-buildtasks")
+        .IsDependentOn("Clean")
+    //  .IsDependentOn("dotnet") WINUI currently can't launch application with local dotnet 
+    //  .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
         string sln = "./Microsoft.Maui.WinUI.sln";
@@ -106,10 +116,27 @@ Task("VS-WINUI")
         {
             Configuration = configuration,
             ToolPath = FindMSBuild(),
-        };
+	        BinaryLogger = new MSBuildBinaryLogSettings
+            {
+                Enabled  = true,
+                FileName = "artifacts/winui-buildtasks.binlog",
+            }
+        }.WithRestore().WithProperty("BuildForWinUI", "true");
 
-        MSBuild("./Microsoft.Maui.BuildTasks-net6.sln", msbuildSettings.WithRestore());
-        MSBuild(sln, msbuildSettings.WithRestore());
+	    MSBuild("./Microsoft.Maui.BuildTasks-net6.sln", msbuildSettings);
+
+	    msbuildSettings = new MSBuildSettings
+        {
+            Configuration = configuration,
+            ToolPath = FindMSBuild(),
+	        BinaryLogger = new MSBuildBinaryLogSettings
+            {
+                Enabled  = true,
+                FileName = "artifacts/winui.binlog",
+            }
+        }.WithRestore();
+
+        MSBuild(sln, msbuildSettings);
 
         var vsLatest = VSWhereLatest(new VSWhereLatestSettings { IncludePrerelease = true, });
         if (vsLatest == null)

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -144,7 +144,7 @@ stages:
             - powershell: |
                   & dotnet cake --target=dotnet
                   $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
-                  & dotnet cake --target=VS-WINUI-CI
+                  & dotnet cake --target=VS-WINUI-CI --configuration=$(BuildCondition)
 
   # - stage: windows_controlgallery
   #   displayName: Build Windows ControlGallery

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -142,6 +142,7 @@ stages:
             demands: [ msbuild ]
           steps:
             - powershell: |
+                  & dotnet cake --target=dotnet
                   $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
                   & dotnet cake --target=VS-WINUI-CI --configuration=${{ BuildCondition }}
 

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -142,8 +142,8 @@ stages:
             demands: [ msbuild ]
           steps:
             - powershell: |
-                  & dotnet build src\DotNet\DotNet.csproj -bl:${{ parameters.artifactsTargetFolder }}\$(BuildConfiguration)-dotnet.binlog
-                  & dotnet tool restore
+                  & dotnet build src/DotNet/DotNet.csproj -bl:$(LogDirectory)/$(BuildConfiguration)-dotnet.binlog
+                  $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
                   & dotnet cake --target=VS-WINUI
 
   # - stage: windows_controlgallery

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -124,6 +124,7 @@ stages:
 
   - stage: windows_cake_validation
     displayName: Windows Cake Validation
+    dependsOn: []
     jobs:
       - ${{ each BuildCondition in parameters.BuildConfigurations }}:
         - job: win_hosted_${{ BuildCondition }}

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -142,7 +142,6 @@ stages:
             demands: [ msbuild ]
           steps:
             - powershell: |
-                  & dotnet cake --target=dotnet
                   $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
                   & dotnet cake --target=VS-WINUI-CI --configuration=${{ BuildCondition }}
 

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -146,27 +146,6 @@ stages:
                   $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
                   & dotnet cake --target=VS-WINUI-CI --configuration=${{ BuildCondition }}
 
-  # - stage: windows_controlgallery
-  #   displayName: Build Windows ControlGallery
-  #   dependsOn: []
-  #   jobs:
-  #     - ${{ each BuildCondition in parameters.BuildConfigurations }}:
-  #       - job: win_hosted_${{ BuildCondition }}
-  #         workspace:
-  #           clean: all
-  #         displayName: Build Windows Phase (${{ BuildCondition }})
-  #         condition: or(
-  #           ${{ parameters.BuildEverything }},
-  #           ne(variables['Build.Reason'], 'PullRequest'),
-  #           eq('${{ BuildCondition }}', 'Release'))
-  #         timeoutInMinutes: 60
-  #         pool:
-  #           name: $(vs2019VmPool)
-  #           vmImage: $(vs2019VmImage)
-  #           demands: [ msbuild ]
-  #         steps:
-  #           - template: common/controlgallery-windows.yml
-
   - stage: build_osx
     displayName: iOS
     dependsOn: []

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -144,7 +144,7 @@ stages:
             - powershell: |
                   & dotnet cake --target=dotnet
                   $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
-                  & dotnet cake --target=VS-WINUI-CI --configuration=$(BuildCondition)
+                  & dotnet cake --target=VS-WINUI-CI --configuration=${{ BuildCondition }}
 
   # - stage: windows_controlgallery
   #   displayName: Build Windows ControlGallery

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -122,6 +122,28 @@ stages:
           steps:
             - template: common/build-windows.yml
 
+  - stage: windows_cake_validation
+    displayName: Windows Cake Validation
+    jobs:
+      - ${{ each BuildCondition in parameters.BuildConfigurations }}:
+        - job: win_hosted_${{ BuildCondition }}
+          workspace:
+            clean: all
+          displayName: Build Windows Phase (${{ BuildCondition }})
+          condition: or(
+            ${{ parameters.BuildEverything }},
+            ne(variables['Build.Reason'], 'PullRequest'),
+            eq('${{ BuildCondition }}', 'Release'))
+          timeoutInMinutes: 60
+          pool:
+            name: $(vs2019VmPool)
+            vmImage: $(vs2019VmImage)
+            demands: [ msbuild ]
+          steps:
+            - powershell: |
+                  & dotnet tool restore
+                  & dotnet cake --target=VS-WINUI-CI
+
   # - stage: windows_controlgallery
   #   displayName: Build Windows ControlGallery
   #   dependsOn: []

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -144,7 +144,7 @@ stages:
             - powershell: |
                   & dotnet cake --target=dotnet
                   $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
-                  & dotnet cake --target=VS-WINUI
+                  & dotnet cake --target=VS-WINUI-CI
 
   # - stage: windows_controlgallery
   #   displayName: Build Windows ControlGallery

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -142,8 +142,9 @@ stages:
             demands: [ msbuild ]
           steps:
             - powershell: |
+                  & dotnet build src\DotNet\DotNet.csproj -bl:${{ parameters.artifactsTargetFolder }}\$(BuildConfiguration)-dotnet.binlog
                   & dotnet tool restore
-                  & dotnet cake --target=VS-WINUI-CI
+                  & dotnet cake --target=VS-WINUI
 
   # - stage: windows_controlgallery
   #   displayName: Build Windows ControlGallery

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -142,7 +142,7 @@ stages:
             demands: [ msbuild ]
           steps:
             - powershell: |
-                  & dotnet build src/DotNet/DotNet.csproj -bl:$(LogDirectory)/$(BuildConfiguration)-dotnet.binlog
+                  & dotnet cake --target=dotnet
                   $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
                   & dotnet cake --target=VS-WINUI
 

--- a/src/Compatibility/ControlGallery/src/Core/Directory.Build.props
+++ b/src/Compatibility/ControlGallery/src/Core/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
   <Import Project="..\..\..\..\..\Directory.Build.props" />
-  <Import Project="..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.props" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.props"/>
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.props"/>
 </Project> 

--- a/src/Compatibility/ControlGallery/src/Core/Directory.Build.targets
+++ b/src/Compatibility/ControlGallery/src/Core/Directory.Build.targets
@@ -2,10 +2,10 @@
   <Import Project="..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 
-  <ItemGroup Condition="$(TargetFramework.Contains('net6')) != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('net6')) == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Compatibility/ControlGallery/src/Core/Directory.Build.targets
+++ b/src/Compatibility/ControlGallery/src/Core/Directory.Build.targets
@@ -1,11 +1,15 @@
 <Project>
-  <Import Project="..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
-  <Import Project="..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.dll')" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets"  />
+  <Import Project="..\..\..\..\..\Directory.Build.targets" />
 
   <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Controls/samples/Directory.Build.targets
+++ b/src/Controls/samples/Directory.Build.targets
@@ -7,9 +7,9 @@
   <Import Project="..\..\..\Directory.Build.targets" />
 
   <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\rc\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Controls/samples/Directory.Build.targets
+++ b/src/Controls/samples/Directory.Build.targets
@@ -7,9 +7,9 @@
   <Import Project="..\..\..\Directory.Build.targets" />
 
   <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\rc\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Controls/samples/Directory.Build.targets
+++ b/src/Controls/samples/Directory.Build.targets
@@ -6,10 +6,10 @@
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets"  />
   <Import Project="..\..\..\Directory.Build.targets" />
 
-  <ItemGroup Condition="$(TargetFramework.Contains('net6')) != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('net6')) == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Controls/tests/Xaml.UnitTests/Directory.Build.targets
+++ b/src/Controls/tests/Xaml.UnitTests/Directory.Build.targets
@@ -4,9 +4,9 @@
   <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 
   <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Controls/tests/Xaml.UnitTests/Directory.Build.targets
+++ b/src/Controls/tests/Xaml.UnitTests/Directory.Build.targets
@@ -3,10 +3,10 @@
   <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 
-  <ItemGroup Condition="$(TargetFramework.Contains('net6')) != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('net6')) == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Controls/tests/Xaml.UnitTests/Directory.Build.targets
+++ b/src/Controls/tests/Xaml.UnitTests/Directory.Build.targets
@@ -4,9 +4,9 @@
   <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 
   <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Essentials/samples/Directory.Build.targets
+++ b/src/Essentials/samples/Directory.Build.targets
@@ -6,10 +6,10 @@
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets"  />
   <Import Project="..\..\..\Directory.Build.targets" />
 
-  <ItemGroup Condition="$(TargetFramework.Contains('net6')) != 'true'">
+  <ItemGroup Condition="'$(BuildForNet6)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('net6')) == 'true'">
+  <ItemGroup Condition="'$(BuildForNet6)' == 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\src\Controls\src\SourceGen\Controls.SourceGen-net6.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

- Added SourceGen projects to all of our sln's
- Added references to all the transitive targets/props files to the control gallery core targets file
- Added YAML step to validate that our WinUI cake target is working properly
- Instead of checking `$(TargetFramework.Contains('net6'))` I changed it to check for our own property `Condition="'$(BuildForNet6)' != 'true'"` . Currently we still compile libraries as netstandard2.0 so this was causing the non net6 version of the source gen code to get referenced. Once we are only building net6.0 targets then we can change it back