### PR TITLE
[android] remove LoadLibrary workaround

### DIFF
--- a/src/Controls/samples/Controls.Sample.Droid/MainApplication.cs
+++ b/src/Controls/samples/Controls.Sample.Droid/MainApplication.cs
@@ -12,15 +12,5 @@ namespace Maui.Controls.Sample.Droid
 		public MainApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
 		{
 		}
-
-#if NET6_0_OR_GREATER
-		// TODO: https://github.com/dotnet/runtime/issues/51274
-		public override void OnCreate()
-		{
-			Java.Lang.JavaSystem.LoadLibrary("System.Security.Cryptography.Native.OpenSsl");
-
-			base.OnCreate();
-		}
-#endif
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/dotnet/maui/pull/1046
Context: https://github.com/dotnet/runtime/issues/51274

This partially reverts c4be5240.

This code crashes now:

    Java.Lang.JavaSystem.LoadLibrary("System.Security.Cryptography.Native.OpenSsl");

The library name has changed to:

    libSystem.Security.Cryptography.Native.Android.so

However, it seems we no longer need this workaround in .NET 6 Preview
5 at all. I removed the entire `LoadLibrary` call and the .NET 6
sample apps launch just fine.

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No