### PR TITLE
Implement CharacterSpacing property in WinUI Entry

### DIFF
--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -62,8 +62,10 @@ using Windows.System;
 		[MissingMapper]
 		public static void MapClearButtonVisibility(IViewHandler handler, IEntry entry) { }
 
-		[MissingMapper]
-		public static void MapCharacterSpacing(IViewHandler handler, IEntry entry) { }
+		public static void MapCharacterSpacing(EntryHandler handler, IEntry entry)
+		{
+			handler.NativeView?.UpdateCharacterSpacing(entry);
+		}
 
 		[MissingMapper]
 		public static void MapKeyboard(IViewHandler handler, IEntry entry) { }

--- a/src/Core/src/Platform/Windows/TextBoxExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBoxExtensions.cs
@@ -30,12 +30,17 @@ namespace Microsoft.Maui
 			textBox.ForegroundFocusBrush = brush;
 		}
 
+		public static void UpdateCharacterSpacing(this MauiTextBox textBox, IEntry entry)
+		{
+			textBox.CharacterSpacing = entry.CharacterSpacing.ToEm();
+		}
+
 		public static void UpdateReturnType(this MauiTextBox textBox, IEntry entry)
 		{
 			textBox.InputScope = entry.ReturnType.ToNative();
-    }
+		}
 
-    public static void UpdatePlaceholder(this MauiTextBox textBox, IEditor editor)
+		public static void UpdatePlaceholder(this MauiTextBox textBox, IEditor editor)
 		{
 			textBox.PlaceholderText = editor.Placeholder ?? string.Empty;
 		}
@@ -45,7 +50,7 @@ namespace Microsoft.Maui
 			textBox.PlaceholderText = entry.Placeholder ?? string.Empty;
 		}
 
-		public static void UpdateFont(this MauiTextBox nativeControl, IText text, IFontManager fontManager) =>		
+		public static void UpdateFont(this MauiTextBox nativeControl, IText text, IFontManager fontManager) =>
 			nativeControl.UpdateFont(text.Font, fontManager);
 
 		public static void UpdateFont(this MauiTextBox nativeControl, Font font, IFontManager fontManager)


### PR DESCRIPTION
### Description of Change ###

Implement `CharacterSpacing` property in WinUI Entry

<img width="1524" alt="winui-entry-characterspacing" src="https://user-images.githubusercontent.com/6755973/120465216-04efb700-c39e-11eb-8c83-bd644f9c7051.png">

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No