### PR TITLE
[Build] Restore dotnet tools before using them

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -38,17 +38,20 @@ steps:
       provisioning_script: $(provisionator.path)
       provisioning_extra_args: $(provisionator.extraArguments)
 
-  - pwsh: |
-      ./build.ps1 --target provision --TeamProject="$(System.TeamProject)"
-    displayName: 'Cake Provision'
-    condition: eq(variables['provisioningCake'], 'true')
-
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'
     condition: ne(variables['DOTNET_VERSION'], '')
     inputs:
       version: $(DOTNET_VERSION)
       packageType: 'sdk'
+
+  - script: dotnet tool restore
+    displayName: install dotnet tools
+
+  - pwsh: |
+      ./build.ps1 --target provision --TeamProject="$(System.TeamProject)"
+    displayName: 'Cake Provision'
+    condition: eq(variables['provisioningCake'], 'true')
 
   - pwsh: |
       ./build.ps1 --target=BuildTasks --configuration=Debug --Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"


### PR DESCRIPTION
### Description of Change ###

We need to restore dotnet tools before using, specially if it's a blank new machine


### Additions made ###

None

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
