### PR TITLE
Implement MaxLength property in WinUI SearchBar

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -248,7 +248,8 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new SearchBar { CharacterSpacing = 4, Text = "A search query" });
 			verticalStack.Add(new SearchBar { Placeholder = "Placeholder" });
 			verticalStack.Add(new SearchBar { HorizontalTextAlignment = TextAlignment.End, Text = "SearchBar HorizontalTextAlignment" });
-		
+			verticalStack.Add(new SearchBar { Text = "SearchBar MaxLength", MaxLength = 50 });
+
 			var monkeyList = new List<string>
 			{
 				"Baboon",

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -57,8 +57,10 @@ namespace Microsoft.Maui.Handlers
 		[MissingMapper]
 		public static void MapIsTextPredictionEnabled(IViewHandler handler, ISearchBar searchBar) { }
 
-		[MissingMapper]
-		public static void MapMaxLength(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapMaxLength(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.NativeView?.UpdateMaxLength(searchBar, handler._queryTextBox);
+		}
 
 		[MissingMapper]
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }
@@ -68,7 +70,10 @@ namespace Microsoft.Maui.Handlers
 			_queryTextBox = NativeView?.GetFirstDescendant<MauiTextBox>();
 
 			if (VirtualView != null)
+			{
 				NativeView?.UpdateHorizontalTextAlignment(VirtualView, _queryTextBox);
+				NativeView?.UpdateMaxLength(VirtualView, _queryTextBox);
+			}
 		}
 
 		void OnQuerySubmitted(AutoSuggestBox? sender, AutoSuggestBoxQuerySubmittedEventArgs e)

--- a/src/Core/src/Platform/Windows/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/Windows/SearchBarExtensions.cs
@@ -26,5 +26,18 @@ namespace Microsoft.Maui
 
 			queryTextBox.TextAlignment = searchBar.HorizontalTextAlignment.ToNative();
 		}
+
+		public static void UpdateMaxLength(this AutoSuggestBox nativeControl, ISearchBar searchBar, MauiTextBox? queryTextBox)
+		{
+			if (queryTextBox == null)
+				return;
+
+			queryTextBox.MaxLength = searchBar.MaxLength;
+
+			var currentControlText = nativeControl.Text;
+
+			if (currentControlText.Length > searchBar.MaxLength)
+				nativeControl.Text = currentControlText.Substring(0, searchBar.MaxLength);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `MaxLength` property in WinUI SearchBar

![winui-searchbar-max](https://user-images.githubusercontent.com/6755973/120501366-d8e62d00-c3c1-11eb-81a0-832a56bbcd12.gif)

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No