### PR TITLE
Account for starting coordinates when handling layout alignment

### DIFF
--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -130,10 +130,6 @@ namespace Microsoft.Maui.Layouts
 			switch (frameworkElement.VerticalLayoutAlignment)
 			{
 				case LayoutAlignment.Fill:
-
-					frameY = startY + margin.Top;
-					break;
-
 				case LayoutAlignment.Start:
 
 					frameY = startY + margin.Top;

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -108,14 +108,14 @@ namespace Microsoft.Maui.Layouts
 
 				case LayoutAlignment.Center:
 
-					frameX = (boundsWidth - desiredWidth) / 2;
+					frameX = startX + ((boundsWidth - desiredWidth) / 2);
 					var marginOffset = (startMargin - endMargin) / 2;
 					frameX += marginOffset;
 
 					break;
 				case LayoutAlignment.End:
 
-					frameX = boundsWidth - endMargin - desiredWidth;
+					frameX = startX + boundsWidth - endMargin - desiredWidth;
 					break;
 			}
 
@@ -125,29 +125,30 @@ namespace Microsoft.Maui.Layouts
 		static double AlignVertical(IFrameworkElement frameworkElement, Rectangle bounds, Thickness margin)
 		{
 			double frameY = 0;
+			var startY = bounds.Y;
 
 			switch (frameworkElement.VerticalLayoutAlignment)
 			{
 				case LayoutAlignment.Fill:
 
-					frameY = bounds.Y + margin.Top;
+					frameY = startY + margin.Top;
 					break;
 
 				case LayoutAlignment.Start:
 
-					frameY = bounds.Y + margin.Top;
+					frameY = startY + margin.Top;
 					break;
 
 				case LayoutAlignment.Center:
 
-					frameY = (bounds.Height - frameworkElement.DesiredSize.Height) / 2;
+					frameY = startY + ((bounds.Height - frameworkElement.DesiredSize.Height) / 2);
 					var offset = (margin.Top - margin.Bottom) / 2;
 					frameY += offset;
 					break;
 
 				case LayoutAlignment.End:
 
-					frameY = bounds.Height - margin.Bottom - frameworkElement.DesiredSize.Height;
+					frameY = startY + bounds.Height - margin.Bottom - frameworkElement.DesiredSize.Height;
 					break;
 			}
 

--- a/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
@@ -82,31 +82,41 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		public static IEnumerable<object[]> AlignmentTestData()
 		{
 			var margin = Thickness.Zero;
+			var point = Point.Zero;
 
 			// No margin
-			yield return new object[] { LayoutAlignment.Start, margin, 0, 100 };
-			yield return new object[] { LayoutAlignment.Center, margin, 100, 100 };
-			yield return new object[] { LayoutAlignment.End, margin, 200, 100 };
-			yield return new object[] { LayoutAlignment.Fill, margin, 0, 300 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 0, 100 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 100 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 200, 100 };
+			yield return new object[] { LayoutAlignment.Fill, point, margin, 0, 300 };
 
 			// Even margin
 			margin = new Thickness(10);
-			yield return new object[] { LayoutAlignment.Start, margin, 10, 100 };
-			yield return new object[] { LayoutAlignment.Center, margin, 100, 100 };
-			yield return new object[] { LayoutAlignment.End, margin, 190, 100 };
-			yield return new object[] { LayoutAlignment.Fill, margin, 10, 280 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 10, 100 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 100 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 190, 100 };
+			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 280 };
 
 			//// Lopsided margin
 			margin = new Thickness(5, 5, 10, 10);
-			yield return new object[] { LayoutAlignment.Start, margin, 5, 100 };
-			yield return new object[] { LayoutAlignment.Center, margin, 97.5, 100 };
-			yield return new object[] { LayoutAlignment.End, margin, 190, 100 };
-			yield return new object[] { LayoutAlignment.Fill, margin, 5, 285 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 5, 100 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 97.5, 100 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 190, 100 };
+			yield return new object[] { LayoutAlignment.Fill, point, margin, 5, 285 };
+
+			// X and Y offsets (e.g., GridLayout columns and rows)
+			margin = Thickness.Zero;
+			point = new Point(10, 10);
+			yield return new object[] { LayoutAlignment.Start, point, margin, 10, 100 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 110, 100 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 210, 100 };
+			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 300 };
+
 		}
 
 		[Theory]
 		[MemberData(nameof(AlignmentTestData))]
-		public void FrameAccountsForHorizontalLayoutAlignment(LayoutAlignment layoutAlignment, Thickness margin,
+		public void FrameAccountsForHorizontalLayoutAlignment(LayoutAlignment layoutAlignment, Point offset, Thickness margin,
 			double expectedX, double expectedWidth)
 		{
 			var widthConstraint = 300;
@@ -121,7 +131,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			element.Width.Returns(-1);
 			element.Height.Returns(-1);
 
-			var frame = element.ComputeFrame(new Rectangle(0, 0, widthConstraint, heightConstraint));
+			var frame = element.ComputeFrame(new Rectangle(offset.X, offset.Y, widthConstraint, heightConstraint));
 
 			Assert.Equal(expectedX, frame.Left);
 			Assert.Equal(expectedWidth, frame.Width);
@@ -129,7 +139,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 		[Theory]
 		[MemberData(nameof(AlignmentTestData))]
-		public void FrameAccountsForVerticalLayoutAlignment(LayoutAlignment layoutAlignment, Thickness margin,
+		public void FrameAccountsForVerticalLayoutAlignment(LayoutAlignment layoutAlignment, Point offset, Thickness margin,
 			double expectedY, double expectedHeight)
 		{
 			var widthConstraint = 50;
@@ -144,7 +154,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			element.Width.Returns(-1);
 			element.Height.Returns(-1);
 
-			var frame = element.ComputeFrame(new Rectangle(0, 0, widthConstraint, heightConstraint));
+			var frame = element.ComputeFrame(new Rectangle(offset.X, offset.Y, widthConstraint, heightConstraint));
 
 			Assert.Equal(expectedY, frame.Top);
 			Assert.Equal(expectedHeight, frame.Height);
@@ -153,31 +163,40 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		public static IEnumerable<object[]> AlignmentTestDataRtl()
 		{
 			var margin = Thickness.Zero;
+			var point = Point.Zero;
 
 			// No margin
-			yield return new object[] { LayoutAlignment.Start, margin, 200, 100 };
-			yield return new object[] { LayoutAlignment.Center, margin, 100, 100 };
-			yield return new object[] { LayoutAlignment.End, margin, 0, 100 };
-			yield return new object[] { LayoutAlignment.Fill, margin, 0, 300 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 200, 100 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 100 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 0, 100 };
+			yield return new object[] { LayoutAlignment.Fill, point, margin, 0, 300 };
 
 			// Even margin
 			margin = new Thickness(10);
-			yield return new object[] { LayoutAlignment.Start, margin, 190, 100 };
-			yield return new object[] { LayoutAlignment.Center, margin, 100, 100 };
-			yield return new object[] { LayoutAlignment.End, margin, 10, 100 };
-			yield return new object[] { LayoutAlignment.Fill, margin, 10, 280 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 190, 100 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 100 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 10, 100 };
+			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 280 };
 
 			// Lopsided margin
 			margin = new Thickness(5, 5, 10, 10);
-			yield return new object[] { LayoutAlignment.Start, margin, 195, 100 };
-			yield return new object[] { LayoutAlignment.Center, margin, 102.5, 100 };
-			yield return new object[] { LayoutAlignment.End, margin, 10, 100 };
-			yield return new object[] { LayoutAlignment.Fill, margin, 10, 285 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 195, 100 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 102.5, 100 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 10, 100 };
+			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 285 };
+
+			// X and Y offsets (e.g., GridLayout columns and rows)
+			margin = Thickness.Zero;
+			point = new Point(10, 10);
+			yield return new object[] { LayoutAlignment.Start, point, margin, 210, 100 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 110, 100 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 10, 100 };
+			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 300 };
 		}
 
 		[Theory]
 		[MemberData(nameof(AlignmentTestDataRtl))]
-		public void FrameAccountsForHorizontalLayoutAlignmentRtl(LayoutAlignment layoutAlignment, Thickness margin,
+		public void FrameAccountsForHorizontalLayoutAlignmentRtl(LayoutAlignment layoutAlignment, Point offset, Thickness margin,
 			double expectedX, double expectedWidth)
 		{
 			var widthConstraint = 300;
@@ -193,7 +212,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			element.Width.Returns(-1);
 			element.Height.Returns(-1);
 
-			var frame = element.ComputeFrame(new Rectangle(0, 0, widthConstraint, heightConstraint));
+			var frame = element.ComputeFrame(new Rectangle(offset.X, offset.Y, widthConstraint, heightConstraint));
 
 			Assert.Equal(expectedX, frame.Left);
 			Assert.Equal(expectedWidth, frame.Width);


### PR DESCRIPTION
### Description of Change ###

Layout alignment was not accounting for the rectangle's X,Y coordinates when handling Center and End alignments. This would result in situations where multi-column or multi-row GridLayouts would have items from rows/columns beyond the first showing up in the first row/column if their alignment was Center or End. 

This fixes that.

