### PR TITLE
Make sure all children of the GridLayout get measured at the final cell size

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -252,23 +252,7 @@ namespace Microsoft.Maui.Layouts
 				ResolveStarColumns();
 				ResolveStarRows();
 
-				foreach (var cell in _cells)
-				{
-					double width = 0;
-					double height = 0;
-
-					for (int n = cell.Row; n < cell.Row + cell.RowSpan; n++)
-					{
-						height += _rows[n].Size;
-					}
-
-					for (int n = cell.Column; n < cell.Column + cell.ColumnSpan; n++)
-					{
-						width += _columns[n].Size;
-					}
-
-					_children[cell.ViewIndex].Measure(width, height);
-				}
+				EnsureFinalMeasure();
 			}
 
 			void TrackSpan(Span span)
@@ -436,13 +420,34 @@ namespace Microsoft.Maui.Layouts
 				ResolveStars(_columns, availableSpace, cellCheck, getDimension);
 			}
 
-			private void ResolveStarRows()
+			void ResolveStarRows()
 			{
 				var availableSpace = _gridHeightConstraint - GridHeight();
 				static bool cellCheck(Cell cell) => cell.IsRowSpanStar;
 				static double getDimension(Size size) => size.Height;
 
 				ResolveStars(_rows, availableSpace, cellCheck, getDimension);
+			}
+
+			void EnsureFinalMeasure() 
+			{
+				foreach (var cell in _cells)
+				{
+					double width = 0;
+					double height = 0;
+
+					for (int n = cell.Row; n < cell.Row + cell.RowSpan; n++)
+					{
+						height += _rows[n].Size;
+					}
+
+					for (int n = cell.Column; n < cell.Column + cell.ColumnSpan; n++)
+					{
+						width += _columns[n].Size;
+					}
+
+					_children[cell.ViewIndex].Measure(width, height);
+				}
 			}
 		}
 

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -215,31 +215,35 @@ namespace Microsoft.Maui.Layouts
 					var availableWidth = _gridWidthConstraint - GridWidth();
 					var availableHeight = _gridHeightConstraint - GridHeight();
 
-					var measure = _children[cell.ViewIndex].Measure(availableWidth, availableHeight);
-
-					if (cell.IsColumnSpanAuto)
+					if (cell.IsColumnSpanAuto || cell.IsRowSpanAuto)
 					{
-						if (cell.ColumnSpan == 1)
-						{
-							_columns[cell.Column].Update(measure.Width);
-						}
-						else
-						{
-							var span = new Span(cell.Column, cell.ColumnSpan, true, measure.Width);
-							TrackSpan(span);
-						}
-					}
+						var measure = _children[cell.ViewIndex].Measure(availableWidth, availableHeight);
+						//cell.IsMeasured = true;
 
-					if (cell.IsRowSpanAuto)
-					{
-						if (cell.RowSpan == 1)
+						if (cell.IsColumnSpanAuto)
 						{
-							_rows[cell.Row].Update(measure.Height);
+							if (cell.ColumnSpan == 1)
+							{
+								_columns[cell.Column].Update(measure.Width);
+							}
+							else
+							{
+								var span = new Span(cell.Column, cell.ColumnSpan, true, measure.Width);
+								TrackSpan(span);
+							}
 						}
-						else
+
+						if (cell.IsRowSpanAuto)
 						{
-							var span = new Span(cell.Row, cell.RowSpan, false, measure.Height);
-							TrackSpan(span);
+							if (cell.RowSpan == 1)
+							{
+								_rows[cell.Row].Update(measure.Height);
+							}
+							else
+							{
+								var span = new Span(cell.Row, cell.RowSpan, false, measure.Height);
+								TrackSpan(span);
+							}
 						}
 					}
 				}
@@ -248,6 +252,31 @@ namespace Microsoft.Maui.Layouts
 
 				ResolveStarColumns();
 				ResolveStarRows();
+
+				foreach (var cell in _cells)
+				{
+					//if (cell.IsMeasured)
+					//{
+					//	continue;
+					//}
+
+					double width = 0;
+					double height = 0;
+
+					for (int n = cell.Row; n < cell.Row + cell.RowSpan; n++)
+					{
+						height += _rows[n].Size;
+					}
+
+					for (int n = cell.Column; n < cell.Column + cell.ColumnSpan; n++)
+					{
+						width += _columns[n].Size;
+					}
+
+					_children[cell.ViewIndex].Measure(width, height);
+
+					//cell.IsMeasured = true;
+				}
 			}
 
 			void TrackSpan(Span span)
@@ -455,6 +484,7 @@ namespace Microsoft.Maui.Layouts
 			public int Column { get; }
 			public int RowSpan { get; }
 			public int ColumnSpan { get; }
+			//public bool IsMeasured { get; set; }
 
 			public GridLengthType ColumnGridLengthType { get; }
 			public GridLengthType RowGridLengthType { get; }

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -218,7 +218,6 @@ namespace Microsoft.Maui.Layouts
 					if (cell.IsColumnSpanAuto || cell.IsRowSpanAuto)
 					{
 						var measure = _children[cell.ViewIndex].Measure(availableWidth, availableHeight);
-						//cell.IsMeasured = true;
 
 						if (cell.IsColumnSpanAuto)
 						{
@@ -255,11 +254,6 @@ namespace Microsoft.Maui.Layouts
 
 				foreach (var cell in _cells)
 				{
-					//if (cell.IsMeasured)
-					//{
-					//	continue;
-					//}
-
 					double width = 0;
 					double height = 0;
 
@@ -274,8 +268,6 @@ namespace Microsoft.Maui.Layouts
 					}
 
 					_children[cell.ViewIndex].Measure(width, height);
-
-					//cell.IsMeasured = true;
 				}
 			}
 
@@ -484,7 +476,6 @@ namespace Microsoft.Maui.Layouts
 			public int Column { get; }
 			public int RowSpan { get; }
 			public int ColumnSpan { get; }
-			//public bool IsMeasured { get; set; }
 
 			public GridLengthType ColumnGridLengthType { get; }
 			public GridLengthType RowGridLengthType { get; }

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -199,6 +199,13 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Assuming no constraints on space
 			MeasureAndArrange(grid, double.PositiveInfinity, double.NegativeInfinity);
 
+			// Verify that the views are getting measured at all, and that they're being measured at 
+			// the appropriate sizes
+			view0.Received().Measure(Arg.Is<double>(100), Arg.Is<double>(10));
+			view1.Received().Measure(Arg.Is<double>(100), Arg.Is<double>(10));
+			view2.Received().Measure(Arg.Is<double>(100), Arg.Is<double>(30));
+			view3.Received().Measure(Arg.Is<double>(100), Arg.Is<double>(30));
+
 			AssertArranged(view0, 0, 0, 100, 10);
 
 			// Since the first column is 100 wide, we expect the view in the second column to start at x = 100
@@ -781,6 +788,12 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Columns are *,*,*, so each view should be arranged at 1/3 the width
 			var expectedWidth = screenWidth / 3;
 			var expectedHeight = viewSize.Height;
+
+			// Make sure that the views in the columns are actually getting measured at the column width,
+			// and not just at the width of the whole grid
+			view1.Received().Measure(Arg.Is<double>(expectedWidth), Arg.Any<double>());
+			view2.Received().Measure(Arg.Is<double>(expectedWidth), Arg.Any<double>());
+
 			AssertArranged(view0, 0, 0, expectedWidth, expectedHeight);
 			AssertArranged(view1, expectedWidth, 0, expectedWidth, expectedHeight);
 			AssertArranged(view2, expectedWidth * 2, 0, expectedWidth, expectedHeight);


### PR DESCRIPTION
Previously, the GridLayout didn't bother calling Measure on children in fixed-size cells (the intersection of an absolute width column and absolute height row). This means that the DesiredSize might be incorrect for those children, and not calling measure can have some side effects depending on the platform.

Also, children in star rows/columns were getting Measure called, but not at the final width/height of the cell.

These changes make sure that all the children get Measure called with the appropriate constraints.