### PR TITLE
Fix building of csproj samples directly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,10 +2,9 @@
   <Import Project="eng\Versions.props" />
 
   <PropertyGroup>
-
     <BuildForWinUI Condition="'$(SolutionFileName)' == 'Microsoft.Maui.WinUI.sln' AND '$(Packing)' == ''">true</BuildForWinUI>
     <BuildForAndroid Condition="'$(SolutionFileName)' == 'Microsoft.Maui.Droid.sln' AND '$(Packing)' == ''">true</BuildForAndroid>
-    <BuildForNet6 Condition="'$(Packing)' == 'true' OR $(SolutionFileName.Contains('net6')) == true OR '$(BuildForWinUI)' == 'true' OR '$(BuildForAndroid)' == 'true'">true</BuildForNet6>
+    <BuildForNet6 Condition="'$(Packing)' == 'true' OR $(MSBuildProjectFile.Contains('SingleProject')) == true  OR $(MSBuildProjectFile.Contains('net6')) == true OR $(SolutionFileName.Contains('net6')) == true OR '$(BuildForWinUI)' == 'true' OR '$(BuildForAndroid)' == 'true'">true</BuildForNet6>
     <MauiPlatforms>net6.0-ios;net6.0-maccatalyst;net6.0-android</MauiPlatforms>
     <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362</WindowsTargetFramework>
     <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);$(WindowsTargetFramework)</MauiPlatforms>

--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@
 
 - Install the SDKs listed here https://github.com/dotnet/maui-samples
 
-- And/or run the following
-
-```
-dotnet tool install Cake.Tool -g
-```
-
 ### Running
 
 #### IDE
@@ -39,12 +33,17 @@ dotnet tool install Cake.Tool -g
 You can run a `Cake` target to bootstrap .NET 6 in `bin\dotnet` and launch Visual Studio:
 
 ```dotnetcli
+dotnet tool restore
 dotnet cake --target=VS-NET6
 ```
-_NOTE: VS Mac is not yet supported._
+_NOTES:_
+- _VS Mac is not yet supported._
+- _If the IDE doesn't show any android devices try unloading and reloading the `Sample.Droid-net6` project._
 
 You can also run commands individually:
 ```dotnetcli
+# install local tools required to build (cake, pwsh, etc..)
+dotnet tool restore
 # Provision .NET 6 in bin\dotnet
 dotnet build src\DotNet\DotNet.csproj
 # Builds Maui MSBuild tasks

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -161,7 +161,7 @@ Task("VS-ANDROID")
     });
 
 Task("SAMPLE-ANDROID")
-    .Description("Provisions .NET 6 and launches an instance of Visual Studio using it.")
+    .Description("Provisions .NET 6 and launches Android Sample.")
     .IsDependentOn("dotnet")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
@@ -170,12 +170,21 @@ Task("SAMPLE-ANDROID")
     });
 
 Task("SAMPLE-IOS")
-    .Description("Provisions .NET 6 and launches an instance of Visual Studio using it.")
+    .Description("Provisions .NET 6 and launches launches iOS Sample.")
     .IsDependentOn("dotnet")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
         RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj", deployAndRun:true);
+    });
+
+Task("SAMPLE-MAC")
+    .Description("Provisions .NET 6 and launches Mac Catalyst Sample.")
+    .IsDependentOn("dotnet")
+    .IsDependentOn("dotnet-buildtasks")
+    .Does(() =>
+    {
+        RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample.MacCatalyst/Maui.Controls.Sample.MacCatalyst-net6.csproj", deployAndRun:true);
     });
 
 

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -160,6 +160,25 @@ Task("VS-ANDROID")
         StartVisualStudioForDotNet6("./Microsoft.Maui.Droid.sln");
     });
 
+Task("SAMPLE-ANDROID")
+    .Description("Provisions .NET 6 and launches an instance of Visual Studio using it.")
+    .IsDependentOn("dotnet")
+    .IsDependentOn("dotnet-buildtasks")
+    .Does(() =>
+    {
+        RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj", deployAndRun:true);
+    });
+
+Task("SAMPLE-IOS")
+    .Description("Provisions .NET 6 and launches an instance of Visual Studio using it.")
+    .IsDependentOn("dotnet")
+    .IsDependentOn("dotnet-buildtasks")
+    .Does(() =>
+    {
+        RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj", deployAndRun:true);
+    });
+
+
 string FindMSBuild()
 {
     if (IsRunningOnWindows())
@@ -213,7 +232,7 @@ void StartVisualStudioForDotNet6(string sln = "./Microsoft.Maui-net6.sln")
 }
 
 // NOTE: this method works as long as the DotNet target has already run
-void RunMSBuildWithLocalDotNet(string sln, Action<object> settings = null)
+void RunMSBuildWithLocalDotNet(string sln, Action<object> settings = null, bool deployAndRun = false)
 {
     var name = System.IO.Path.GetFileNameWithoutExtension(sln);
     var binlog = $"artifacts/{name}-{configuration}.binlog";
@@ -221,7 +240,7 @@ void RunMSBuildWithLocalDotNet(string sln, Action<object> settings = null)
     SetDotNetEnvironmentVariables();
 
     // If we're not on Windows, use ./bin/dotnet/dotnet
-    if (!IsRunningOnWindows())
+    if (!IsRunningOnWindows() || deployAndRun)
     {
         var dotnetBuildSettings = new DotNetCoreMSBuildSettings
         {
@@ -240,6 +259,7 @@ void RunMSBuildWithLocalDotNet(string sln, Action<object> settings = null)
                 Configuration = configuration,
                 ToolPath = dotnetPath,
                 MSBuildSettings = dotnetBuildSettings,
+                ArgumentCustomization = args=> { if(deployAndRun) { args.Append("-t:Run"); } return args; }
             });
         return;
     }

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -339,7 +339,9 @@ stages:
                   & dotnet build src/DotNet/DotNet.csproj -bl:$(LogDirectory)/$(BuildConfiguration)-dotnet.binlog
                   $env:PATH = (Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet') + [IO.Path]::PathSeparator + $env:PATH
                   & $(DotNet.Path) build Microsoft.Maui.BuildTasks-net6.sln -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-buildtasks.binlog
-                  & $(DotNet.Path) build Microsoft.Maui-net6.sln -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration).binlog
+                  & $(DotNet.Path) build src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-android.binlog
+                  & $(DotNet.Path) build src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-iOS.binlog
+                  & $(DotNet.Path) build src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-SingleProject.binlog
                 displayName: build samples
                 errorActionPreference: stop
               - task: PublishBuildArtifacts@1

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -341,6 +341,7 @@ stages:
                   & $(DotNet.Path) build Microsoft.Maui.BuildTasks-net6.sln -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-buildtasks.binlog
                   & $(DotNet.Path) build src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-android.binlog
                   & $(DotNet.Path) build src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-iOS.binlog
+                  & $(DotNet.Path) build src/Controls/samples/Controls.Sample.MacCatalyst/Maui.Controls.Sample.MacCatalyst-net6.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-MacCatalyst.binlog
                   & $(DotNet.Path) build src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-SingleProject.binlog
                   & $(DotNet.Path) build Microsoft.Maui-net6.sln -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration).binlog
                 displayName: build samples

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -342,6 +342,7 @@ stages:
                   & $(DotNet.Path) build src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-android.binlog
                   & $(DotNet.Path) build src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-iOS.binlog
                   & $(DotNet.Path) build src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration)-SingleProject.binlog
+                  & $(DotNet.Path) build Microsoft.Maui-net6.sln -c $(BuildConfiguration) -bl:$(LogDirectory)/$(BuildConfiguration).binlog
                 displayName: build samples
                 errorActionPreference: stop
               - task: PublishBuildArtifacts@1


### PR DESCRIPTION
### Description of Change ###

- Add CI step that builds singleproject.csproj and the two net6 sample projects to make sure they don't break
- updated readme with some workarounds related to Android simulator
- Added cake targets for building and deploying android/ios samples 
 - "SAMPLE-ANDROID"
 - "Sample-IOS"
