### PR TITLE
Fix handling of margins during layout alignment

### DIFF
--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -138,14 +138,6 @@ namespace Microsoft.Maui.Controls
 
 		public static void LayoutChildIntoBoundingRegion(VisualElement child, Rectangle region)
 		{
-			if (child is IFrameworkElement fe)
-			{
-				// The MAUI stuff doesn't need all the layout alignment and margin stuff below;
-				// that's all handled in Core
-				fe.Arrange(region);
-				return;
-			}
-
 			bool isRightToLeft = false;
 			if (child.Parent is IFlowDirectionController parent && (isRightToLeft = parent.ApplyEffectiveFlowDirectionToChildContainer && parent.EffectiveFlowDirection.IsRightToLeft()))
 				region = new Rectangle(parent.Width - region.Right, region.Y, region.Width, region.Height);

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -138,6 +138,14 @@ namespace Microsoft.Maui.Controls
 
 		public static void LayoutChildIntoBoundingRegion(VisualElement child, Rectangle region)
 		{
+			if (child is IFrameworkElement fe)
+			{
+				// The MAUI stuff doesn't need all the layout alignment and margin stuff below;
+				// that's all handled in Core
+				fe.Arrange(region);
+				return;
+			}
+
 			bool isRightToLeft = false;
 			if (child.Parent is IFlowDirectionController parent && (isRightToLeft = parent.ApplyEffectiveFlowDirectionToChildContainer && parent.EffectiveFlowDirection.IsRightToLeft()))
 				region = new Rectangle(parent.Width - region.Right, region.Y, region.Width, region.Height);

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -33,25 +33,31 @@ namespace Microsoft.Maui.Layouts
 		{
 			Thickness margin = frameworkElement.GetMargin();
 
-			// Normally the frame's width will be the element's desired width
-			var frameWidth = frameworkElement.DesiredSize.Width;
+			// We need to determine the width the element wants to consume; normally that's the element's DesiredSize.Width
+			var consumedWidth = frameworkElement.DesiredSize.Width;
 
-			// But, if the element is set to fill horizontally and it doesn't have an explicitly set width,
-			// the frame width will be large enough to fill the space
 			if (frameworkElement.HorizontalLayoutAlignment == LayoutAlignment.Fill && frameworkElement.Width == -1)
 			{
-				frameWidth = Math.Max(0, bounds.Width - margin.HorizontalThickness);
+				// But if the element is set to fill horizontally and it doesn't have an explicitly set width,
+				// then we want the width of the entire bounds
+				consumedWidth = bounds.Width;
 			}
+			
+			// And the actual frame width needs to subtract the margins
+			var frameWidth = Math.Max(0, consumedWidth - margin.HorizontalThickness);
 
-			// Normally the frame's height will be the element's desired height
-			var frameHeight = frameworkElement.DesiredSize.Height;
+			// We need to determine the height the element wants to consume; normally that's the element's DesiredSize.Height
+			var consumedHeight = frameworkElement.DesiredSize.Height;
 
 			// But, if the element is set to fill vertically and it doesn't have an explicitly set height,
-			// the frame height will be large enough to fill the space
+			// then we want the height of the entire bounds
 			if (frameworkElement.VerticalLayoutAlignment == LayoutAlignment.Fill && frameworkElement.Height == -1)
 			{
-				frameHeight = Math.Max(0, bounds.Height - margin.VerticalThickness);
+				consumedHeight = bounds.Height;
 			}
+
+			// And the actual frame height needs to subtract the margins
+			var frameHeight = Math.Max(0, consumedHeight - margin.VerticalThickness);
 
 			var frameX = AlignHorizontal(frameworkElement, bounds, margin);
 			var frameY = AlignVertical(frameworkElement, bounds, margin);

--- a/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
@@ -92,16 +92,16 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			// Even margin
 			margin = new Thickness(10);
-			yield return new object[] { LayoutAlignment.Start, margin, 10, 80 };
-			yield return new object[] { LayoutAlignment.Center, margin, 100, 80 };
-			yield return new object[] { LayoutAlignment.End, margin, 190, 80 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 10, 80 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 80 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 190, 80 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 280 };
 
 			// Lopsided margin
 			margin = new Thickness(5, 5, 10, 10);
-			yield return new object[] { LayoutAlignment.Start, margin, 5, 85 };
-			yield return new object[] { LayoutAlignment.Center, margin, 97.5, 85 };
-			yield return new object[] { LayoutAlignment.End, margin, 190, 85 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 5, 85 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 97.5, 85 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 190, 85 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 5, 285 };
 
 			// X and Y offsets (e.g., GridLayout columns and rows)
@@ -173,16 +173,16 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			// Even margin
 			margin = new Thickness(10);
-			yield return new object[] { LayoutAlignment.Start, margin, 190, 80 };
-			yield return new object[] { LayoutAlignment.Center, margin, 100, 80 };
-			yield return new object[] { LayoutAlignment.End, margin, 10, 80 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 190, 80 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 80 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 10, 80 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 280 };
 
 			// Lopsided margin
 			margin = new Thickness(5, 5, 10, 10);
-			yield return new object[] { LayoutAlignment.Start, margin, 195, 85 };
-			yield return new object[] { LayoutAlignment.Center, margin, 102.5, 85 };
-			yield return new object[] { LayoutAlignment.End, margin, 10, 85 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 195, 85 };
+			yield return new object[] { LayoutAlignment.Center, point, margin, 102.5, 85 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 10, 85 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 285 };
 
 			// X and Y offsets (e.g., GridLayout columns and rows)

--- a/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
@@ -92,16 +92,16 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			// Even margin
 			margin = new Thickness(10);
-			yield return new object[] { LayoutAlignment.Start, point, margin, 10, 100 };
-			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 100 };
-			yield return new object[] { LayoutAlignment.End, point, margin, 190, 100 };
+			yield return new object[] { LayoutAlignment.Start, margin, 10, 80 };
+			yield return new object[] { LayoutAlignment.Center, margin, 100, 80 };
+			yield return new object[] { LayoutAlignment.End, margin, 190, 80 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 280 };
 
-			//// Lopsided margin
+			// Lopsided margin
 			margin = new Thickness(5, 5, 10, 10);
-			yield return new object[] { LayoutAlignment.Start, point, margin, 5, 100 };
-			yield return new object[] { LayoutAlignment.Center, point, margin, 97.5, 100 };
-			yield return new object[] { LayoutAlignment.End, point, margin, 190, 100 };
+			yield return new object[] { LayoutAlignment.Start, margin, 5, 85 };
+			yield return new object[] { LayoutAlignment.Center, margin, 97.5, 85 };
+			yield return new object[] { LayoutAlignment.End, margin, 190, 85 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 5, 285 };
 
 			// X and Y offsets (e.g., GridLayout columns and rows)
@@ -121,12 +121,12 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		{
 			var widthConstraint = 300;
 			var heightConstraint = 50;
-			var viewSize = new Size(100, 50);
+			var viewSizeIncludingMargins = new Size(100, 50);
 
 			var element = Substitute.For<IView>();
 
 			element.Margin.Returns(margin);
-			element.DesiredSize.Returns(viewSize);
+			element.DesiredSize.Returns(viewSizeIncludingMargins);
 			element.HorizontalLayoutAlignment.Returns(layoutAlignment);
 			element.Width.Returns(-1);
 			element.Height.Returns(-1);
@@ -173,16 +173,16 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			// Even margin
 			margin = new Thickness(10);
-			yield return new object[] { LayoutAlignment.Start, point, margin, 190, 100 };
-			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 100 };
-			yield return new object[] { LayoutAlignment.End, point, margin, 10, 100 };
+			yield return new object[] { LayoutAlignment.Start, margin, 190, 80 };
+			yield return new object[] { LayoutAlignment.Center, margin, 100, 80 };
+			yield return new object[] { LayoutAlignment.End, margin, 10, 80 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 280 };
 
 			// Lopsided margin
 			margin = new Thickness(5, 5, 10, 10);
-			yield return new object[] { LayoutAlignment.Start, point, margin, 195, 100 };
-			yield return new object[] { LayoutAlignment.Center, point, margin, 102.5, 100 };
-			yield return new object[] { LayoutAlignment.End, point, margin, 10, 100 };
+			yield return new object[] { LayoutAlignment.Start, margin, 195, 85 };
+			yield return new object[] { LayoutAlignment.Center, margin, 102.5, 85 };
+			yield return new object[] { LayoutAlignment.End, margin, 10, 85 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 285 };
 
 			// X and Y offsets (e.g., GridLayout columns and rows)
@@ -201,12 +201,12 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		{
 			var widthConstraint = 300;
 			var heightConstraint = 50;
-			var viewSize = new Size(100, 50);
+			var viewSizeIncludingMargins = new Size(100, 50);
 
 			var element = Substitute.For<IView>();
 
 			element.Margin.Returns(margin);
-			element.DesiredSize.Returns(viewSize);
+			element.DesiredSize.Returns(viewSizeIncludingMargins);
 			element.FlowDirection.Returns(FlowDirection.RightToLeft);
 			element.HorizontalLayoutAlignment.Returns(layoutAlignment);
 			element.Width.Returns(-1);


### PR DESCRIPTION
The layout alignment code in ComputeFrame includes the margins in the final frame if the layout alignment isn't `Fill`. These changes fix that error, and also remove a double-application of margins to Core MAUI controls which are hosted in a legacy Layout.