### PR TITLE
Implement TextColor property in WinUI DatePicker

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -286,6 +286,7 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new Switch() { OnColor = Colors.Green, ThumbColor = Colors.Yellow });
 
 			verticalStack.Add(new DatePicker());
+			verticalStack.Add(new DatePicker { TextColor = Colors.OrangeRed });
 			verticalStack.Add(new DatePicker { CharacterSpacing = 6 });
 			verticalStack.Add(new DatePicker { FontSize = 24 });
 

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Windows.cs
@@ -1,10 +1,13 @@
 ﻿#nullable enable
 using Microsoft.UI.Xaml.Controls;
+using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class DatePickerHandler : ViewHandler<IDatePicker, DatePicker>
 	{
+		WBrush? _defaultForeground;
+
 		protected override DatePicker CreateNativeView() => new DatePicker();
 
 		protected override void ConnectHandler(DatePicker nativeView)
@@ -15,6 +18,13 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(DatePicker nativeView)
 		{
 			nativeView.DateChanged -= OnControlDateChanged;
+		}
+
+		protected override void SetupDefaults(DatePicker nativeView)
+		{
+			_defaultForeground = nativeView.Foreground;
+
+			base.SetupDefaults(nativeView);
 		}
 
 		public static void MapFormat(DatePickerHandler handler, IDatePicker datePicker)
@@ -49,8 +59,10 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateFont(datePicker, fontManager);
 		}
 
-		[MissingMapper]
-		public static void MapTextColor(DatePickerHandler handler, IDatePicker datePicker) { }
+		public static void MapTextColor(DatePickerHandler handler, IDatePicker datePicker)
+		{
+			handler.NativeView?.UpdateTextColor(datePicker, handler._defaultForeground);
+		}
 
 		void OnControlDateChanged(object? sender, DatePickerValueChangedEventArgs e)
 		{

--- a/src/Core/src/Platform/Windows/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/DatePickerExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml.Controls;
+using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui
 {
@@ -51,6 +53,12 @@ namespace Microsoft.Maui
 
 		public static void UpdateFont(this DatePicker nativeDatePicker, IDatePicker datePicker, IFontManager fontManager) =>
 			nativeDatePicker.UpdateFont(datePicker.Font, fontManager);
+
+		public static void UpdateTextColor(this DatePicker nativeDatePicker, IDatePicker datePicker, WBrush? defaultForeground)
+		{
+			Color textColor = datePicker.TextColor;
+			nativeDatePicker.Foreground = textColor == null ? (defaultForeground ?? textColor?.ToNative()) : textColor.ToNative();
+		}
 
 		internal static void UpdateDay(this DatePicker nativeDatePicker, IDatePicker datePicker)
 		{


### PR DESCRIPTION
### Description of Change ###

Implement `TextColor` property in WinUI DatePicker

<img width="310" alt="winui-datepicker-textcolor" src="https://user-images.githubusercontent.com/6755973/120790563-69904a80-c533-11eb-91ce-fa22eaca6c5d.png">

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No