### PR TITLE
Implement TextColor property in WinUI TimePicker

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -290,6 +290,7 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new DatePicker { FontSize = 24 });
 
 			verticalStack.Add(new TimePicker());
+			verticalStack.Add(new TimePicker { TextColor = Colors.LightGreen });
 			verticalStack.Add(new TimePicker { Time = TimeSpan.FromHours(8), CharacterSpacing = 6 });
 
 			verticalStack.Add(new Label { Text = "IMAGES (static | animated):" });

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs
@@ -1,10 +1,20 @@
 ﻿using Microsoft.UI.Xaml.Controls;
+using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class TimePickerHandler : ViewHandler<ITimePicker, TimePicker>
 	{
+		WBrush? _defaultForeground;
+
 		protected override TimePicker CreateNativeView() => new TimePicker();
+
+		protected override void SetupDefaults(TimePicker nativeView)
+		{
+			_defaultForeground = nativeView.Foreground;
+
+			base.SetupDefaults(nativeView);
+		}
 
 		[MissingMapper]
 		public static void MapFormat(TimePickerHandler handler, ITimePicker view) { }
@@ -20,7 +30,9 @@ namespace Microsoft.Maui.Handlers
 		[MissingMapper]
 		public static void MapFont(TimePickerHandler handler, ITimePicker view) { }
 
-		[MissingMapper]
-		public static void MapTextColor(TimePickerHandler handler, ITimePicker timePicker) { }
+		public static void MapTextColor(TimePickerHandler handler, ITimePicker timePicker)
+		{
+			handler.NativeView?.UpdateTextColor(timePicker, handler._defaultForeground);
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/TimePickerExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml.Controls;
+using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui
 {
@@ -16,6 +18,12 @@ namespace Microsoft.Maui
 			{
 				nativeTimePicker.ClockIdentifier = "12HourClock";
 			}
+		}
+	
+		public static void UpdateTextColor(this TimePicker nativeTimePicker, ITimePicker timePicker,WBrush? defaultForeground)
+		{
+			Color textColor = timePicker.TextColor;
+			nativeTimePicker.Foreground = textColor == null ? (defaultForeground ?? textColor?.ToNative()) : textColor.ToNative();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `TextColor` property in WinUI TimePicker

<img width="251" alt="winui-timepicker-textcolor" src="https://user-images.githubusercontent.com/6755973/120795672-140b6c00-c53a-11eb-9087-7cdda654382a.png">

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No