### PR TITLE
Handler Attached/Detached events

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Maui.Controls
 			get => _handler;
 			set
 			{
-				_handler = value;
-				IsPlatformEnabled = _handler != null;
+				SetHandler(value);
 			}
 		}
 
@@ -154,5 +153,51 @@ namespace Microsoft.Maui.Controls
 
 		double IFrameworkElement.Width => WidthRequest;
 		double IFrameworkElement.Height => HeightRequest;
+
+		public event EventHandler AttachingHandler;
+		public event EventHandler AttachedHandler;
+		public event EventHandler DetachingHandler;
+		public event EventHandler DetachedHandler;
+
+		void SetHandler(IViewHandler newHandler)
+		{
+			if (newHandler == _handler)
+				return;
+
+			var previousHandler = _handler;
+
+			if (_handler != null)
+			{
+				DetachingHandler?.Invoke(this, EventArgs.Empty);
+				OnDetachingHandler();
+			}
+
+			if (newHandler != null)
+			{
+				AttachingHandler?.Invoke(this, EventArgs.Empty);
+				OnAttachingHandler();
+			}
+
+			_handler = newHandler;
+			_handler?.SetVirtualView((IView)this);
+			IsPlatformEnabled = _handler != null;
+
+			if (_handler != null)
+			{
+				AttachedHandler?.Invoke(this, EventArgs.Empty);
+				OnAttachedHandler();
+			}
+
+			if (previousHandler != null)
+			{
+				DetachedHandler?.Invoke(this, EventArgs.Empty);
+				OnDetachedHandler();
+			}
+		}
+
+		public virtual void OnAttachingHandler() { }
+		public virtual void OnAttachedHandler() { }
+		public virtual void OnDetachingHandler() { }
+		public virtual void OnDetachedHandler() { }
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	[TestFixture]
+	public class HandlerLifeCycleTests : BaseTestFixture
+	{
+		[Test]
+		public void VirtualViewSet()
+		{
+			Button button = new Button();
+			HandlerStub handlerStub = new HandlerStub();
+
+			button.Handler = handlerStub;
+
+			Assert.IsNotNull(handlerStub.VirtualView);
+		}
+
+		[Test]
+		public void BasicAttachEvents()
+		{
+			Button button = new Button();
+			bool attaching = false;
+			bool attached = false;
+
+			button.AttachingHandler += (_, __) => attaching = true;
+			button.AttachedHandler += (_, __) =>
+			{
+				if (!attaching)
+					Assert.Fail("Attached fired before attaching");
+
+				attached = true;
+			};
+
+			button.Handler = new HandlerStub();
+
+			Assert.IsTrue(attaching);
+			Assert.IsTrue(attached);
+		}
+
+
+		[TestCase(null)]
+		[TestCase(typeof(HandlerStub))]
+		public void BasicDetachEvents(Type handlerType)
+		{
+			Button button = new Button();
+			bool detaching = false;
+			bool detached = false;
+
+			button.DetachingHandler += (_, __) => detaching = true;
+			button.DetachedHandler += (_, __) =>
+			{
+				if (!detaching)
+					Assert.Fail("Detached fired before detaching");
+
+				detached = true;
+			};
+
+			button.Handler = new HandlerStub();
+
+			Assert.IsFalse(detaching);
+			Assert.IsFalse(detached);
+
+			if (handlerType != null)
+				button.Handler = (IViewHandler)Activator.CreateInstance(handlerType);
+			else
+				button.Handler = null;
+
+			Assert.IsTrue(detaching);
+			Assert.IsTrue(detached);
+		}
+
+
+		[Test]
+		public void BasicAttachMethods()
+		{
+			LifeCycleButton button = new LifeCycleButton();
+			button.Handler = new HandlerStub();
+
+			Assert.AreEqual(1, button.attaching);
+			Assert.AreEqual(1, button.attached);
+		}
+
+
+		[TestCase(null)]
+		[TestCase(typeof(HandlerStub))]
+		public void BasicDetachMethods(Type handlerType)
+		{
+			LifeCycleButton button = new LifeCycleButton();
+
+			button.Handler = new HandlerStub();
+
+			Assert.Zero(button.detaching);
+			Assert.Zero(button.detached);
+
+			if (handlerType != null)
+				button.Handler = (IViewHandler)Activator.CreateInstance(handlerType);
+			else
+				button.Handler = null;
+
+			Assert.AreEqual(1, button.detached);
+			Assert.AreEqual(1, button.detaching);
+		}
+
+		public class LifeCycleButton : Button
+		{
+			public int attaching = 0;
+			public int attached = 0;
+			public int detaching = 0;
+			public int detached = 0;
+
+			public override void OnAttachedHandler()
+			{
+				attached++;
+
+				if (attached != attaching)
+					Assert.Fail("Attaching/Attached fire mismatch");
+			}
+
+			public override void OnAttachingHandler() => attaching++;
+			public override void OnDetachingHandler() => detaching++;
+			public override void OnDetachedHandler()
+			{
+				detached++;
+
+				if (detached != detaching)
+					Assert.Fail("Attaching/Attached fire mismatch");
+			}
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/TestClasses/HandlerStub.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/HandlerStub.cs
@@ -1,0 +1,35 @@
+using Microsoft.Maui.Handlers;
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class HandlerStub : ViewHandler<Maui.Controls.Button, object>
+	{
+		public bool IsDisconnected { get; private set; }
+		public int ConnectHandlerCount { get; set; } = 0;
+		public int DisconnectHandlerCount { get; set; } = 0;
+
+		public HandlerStub() : base(new PropertyMapper<IView>())
+		{
+		}
+
+		public HandlerStub(PropertyMapper mapper) : base(mapper)
+		{
+		}
+
+		protected override object CreateNativeView()
+		{
+			return new object();
+		}
+
+		protected override void ConnectHandler(object nativeView)
+		{
+			base.ConnectHandler(nativeView);
+			ConnectHandlerCount++;
+		}
+
+		protected override void DisconnectHandler(object nativeView)
+		{
+			base.DisconnectHandler(nativeView);
+			DisconnectHandlerCount++;
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/TestClasses/HandlersContextStub.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/HandlersContextStub.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{ 
+	class HandlersContextStub : IMauiContext
+	{
+		IServiceProvider _services;
+		IMauiHandlersServiceProvider _mauiHandlersServiceProvider;
+		public HandlersContextStub(IServiceProvider services)
+		{
+			_services = services;
+			_mauiHandlersServiceProvider = Services.GetService<IMauiHandlersServiceProvider>() ?? throw new NullReferenceException(nameof(IMauiServiceProvider));
+		}
+
+		public IServiceProvider Services => _services;
+
+		public IMauiHandlersServiceProvider Handlers => _mauiHandlersServiceProvider;
+	}
+}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == view)
 				return;
 
-			if (VirtualView?.Handler != null)
+			if (VirtualView?.Handler != null && VirtualView.Handler != this)
 				VirtualView.Handler = null;
 
 			bool setupNativeView = VirtualView == null;
@@ -92,9 +92,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				var map = imv.GetPropertyMapperOverrides();
 				var instancePropertyMapper = map as PropertyMapper<TVirtualView>;
-				if (map != null && instancePropertyMapper == null)
-				{
-				}
+				
 				if (instancePropertyMapper != null)
 				{
 					instancePropertyMapper.Chained = _defaultMapper;

--- a/src/Core/src/Platform/Android/HandlerExtensions.cs
+++ b/src/Core/src/Platform/Android/HandlerExtensions.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Maui
 			if (handler?.MauiContext != null &&
 				handler.MauiContext != context)
 			{
-				view.Handler = null;
 				handler = null;
 			}
 


### PR DESCRIPTION
### Description of Change ###

Implements #1198

### Additions made ###
- Overrides: VisualElement.OnHandlerAttached/OnHandlerDetached/OnHandlerAttaching/OnHandlerDetaching
- Events: VisualElement.HandlerAttached/HandlerDetached/HandlerAttaching/HandlerDetaching



| Event   | Description   |  Use Cases |
|---|---|---|
|  AttachingHandler  |  Fires before handler has created native view  | This is used to make sure all properties on your xplat view have been initialized so they are correctly set on inception of the native view |
|  AttachedHandler  |   Fires after handler has created and set the native view   | The NativeView is present and all of the VirtualView properties have been applied. This is where you can interact with native element |
|  DetachingHandler  |  Fires before the handler is going to get removed from the virtual view  | The NativeView is about to get removed from this Virtual element so you should unwire any native events  |
|  DetachedHandler  |   Fires after native handler has removed the native view   | |

