### PR TITLE
Implement CancelButtonColor property in WinUI SearchBar

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -249,6 +249,7 @@ namespace Maui.Controls.Sample.Pages
 			verticalStack.Add(new SearchBar { Placeholder = "Placeholder" });
 			verticalStack.Add(new SearchBar { HorizontalTextAlignment = TextAlignment.End, Text = "SearchBar HorizontalTextAlignment" });
 			verticalStack.Add(new SearchBar { Text = "SearchBar MaxLength", MaxLength = 50 });
+			verticalStack.Add(new SearchBar { Text = "SearchBar CancelButtonColor", CancelButtonColor = Colors.IndianRed });
 
 			var monkeyList = new List<string>
 			{

--- a/src/Core/src/Core/ISearchBar.cs
+++ b/src/Core/src/Core/ISearchBar.cs
@@ -1,10 +1,14 @@
-﻿namespace Microsoft.Maui
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
 {
 	/// <summary>
 	/// Represents a View used to initiating a search.
 	/// </summary>
 	public interface ISearchBar : IView, ITextInput, ITextAlignment
 	{
+		Color CancelButtonColor { get; }
+
 		/// <summary>
 		/// Notify when the user presses the Search button.
 		/// </summary>

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -74,5 +74,8 @@ namespace Microsoft.Maui.Handlers
 
 		[MissingMapper]
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }
+
+		[MissingMapper]
+		public static void MapCancelButtonColor(IViewHandler handler, ISearchBar searchBar) { }
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Standard.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Standard.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapHorizontalTextAlignment(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapCharacterSpacing(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapTextColor(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapCancelButtonColor(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapIsTextPredictionEnabled(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapMaxLength(IViewHandler handler, ISearchBar searchBar) { }
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -1,11 +1,16 @@
 ﻿#nullable enable
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class SearchBarHandler : ViewHandler<ISearchBar, AutoSuggestBox>
 	{
+		Brush? _defaultDeleteButtonForegroundColorBrush;
+		Brush? _defaultDeleteButtonBackgroundColorBrush;
+
 		MauiTextBox? _queryTextBox;
+		MauiCancelButton? _cancelButton;
 
 		protected override AutoSuggestBox CreateNativeView() => new AutoSuggestBox
 		{
@@ -46,7 +51,7 @@ namespace Microsoft.Maui.Handlers
 		[MissingMapper]
 		public static void MapFont(IViewHandler handler, ISearchBar searchBar) { }
 
-		public static void MapCharacterSpacing(SearchBarHandler handler, ISearchBar searchBar) 
+		public static void MapCharacterSpacing(SearchBarHandler handler, ISearchBar searchBar)
 		{
 			handler.NativeView?.UpdateCharacterSpacing(searchBar);
 		}
@@ -65,9 +70,32 @@ namespace Microsoft.Maui.Handlers
 		[MissingMapper]
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }
 
+		public static void MapCancelButtonColor(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.NativeView?.UpdateCancelButtonColor(searchBar, handler._cancelButton, handler._defaultDeleteButtonBackgroundColorBrush, handler._defaultDeleteButtonForegroundColorBrush);
+		}
+
 		void OnLoaded(object sender, UI.Xaml.RoutedEventArgs e)
 		{
 			_queryTextBox = NativeView?.GetFirstDescendant<MauiTextBox>();
+			_cancelButton = _queryTextBox?.GetFirstDescendant<MauiCancelButton>();
+
+			if (_cancelButton != null)
+			{
+				if (_defaultDeleteButtonBackgroundColorBrush == null)
+					_defaultDeleteButtonBackgroundColorBrush = _cancelButton.Background;
+
+				if (_defaultDeleteButtonForegroundColorBrush == null)
+					_defaultDeleteButtonForegroundColorBrush = _cancelButton.Foreground;
+
+				// The Cancel button's content won't be loaded right away (because the default Visibility is Collapsed)
+				// So we need to wait until it's ready, then force an update of the button color
+				_cancelButton.ReadyChanged += (o, args) =>
+				{
+					if (VirtualView != null)
+						NativeView?.UpdateCancelButtonColor(VirtualView, _cancelButton, _defaultDeleteButtonBackgroundColorBrush, _defaultDeleteButtonForegroundColorBrush);
+				};
+			}
 
 			if (VirtualView != null)
 			{

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ISearchBar.Placeholder)] = MapPlaceholder,
 			[nameof(ISearchBar.Text)] = MapText,
 			[nameof(ISearchBar.TextColor)] = MapTextColor,
+			[nameof(ISearchBar.CancelButtonColor)] = MapCancelButtonColor
 		};
 
 		public SearchBarHandler() : base(SearchBarMapper)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -70,5 +70,8 @@ namespace Microsoft.Maui.Handlers
 
 		[MissingMapper]
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }
+
+		[MissingMapper]
+		public static void MapCancelButtonColor(IViewHandler handler, ISearchBar searchBar) { }
 	}
 }

--- a/src/Core/src/Platform/Windows/BrushHelpers.cs
+++ b/src/Core/src/Platform/Windows/BrushHelpers.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using System;
+using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml.Media;
+
+namespace Microsoft.Maui
+{
+	internal static class BrushHelpers
+	{
+		public static void UpdateColor(Color? color, ref Brush? defaultbrush, Func<Brush> getter, Action<Brush> setter)
+		{
+			if (color == null)
+			{
+				if (defaultbrush == null)
+				{
+					return;
+				}
+
+				setter(defaultbrush);
+				return;
+			}
+
+			if (defaultbrush == null)
+			{
+				defaultbrush = getter();
+			}
+
+			setter(color.ToNative());
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiCancelButton.cs
+++ b/src/Core/src/Platform/Windows/MauiCancelButton.cs
@@ -5,7 +5,7 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui
 {
-	internal class MauiCancelButton : Button
+	public class MauiCancelButton : Button
 	{
 		TextBlock _cancelButtonGlyph;
 		Border _cancelButtonBackground;

--- a/src/Core/src/Platform/Windows/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/Windows/SearchBarExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui
 {
@@ -38,6 +40,30 @@ namespace Microsoft.Maui
 
 			if (currentControlText.Length > searchBar.MaxLength)
 				nativeControl.Text = currentControlText.Substring(0, searchBar.MaxLength);
+		}
+
+		public static void UpdateCancelButtonColor(this AutoSuggestBox nativeControl, ISearchBar searchBar, MauiCancelButton? cancelButton, Brush? defaultDeleteButtonBackgroundColorBrush, Brush? defaultDeleteButtonForegroundColorBrush)
+		{
+			if (cancelButton == null || !cancelButton.IsReady)
+				return;
+
+			Color cancelColor = searchBar.CancelButtonColor;
+
+			BrushHelpers.UpdateColor(cancelColor, ref defaultDeleteButtonForegroundColorBrush,
+				() => cancelButton.ForegroundBrush, brush => cancelButton.ForegroundBrush = brush);
+
+			if (cancelColor == null)
+			{
+				BrushHelpers.UpdateColor(null, ref defaultDeleteButtonBackgroundColorBrush,
+					() => cancelButton.BackgroundBrush, brush => cancelButton.BackgroundBrush = brush);
+			}
+			else
+			{
+				// Determine whether the background should be black or white (in order to make the foreground color visible) 
+				var bcolor = cancelColor.ToWindowsColor().GetContrastingColor().ToColor();
+				BrushHelpers.UpdateColor(bcolor, ref defaultDeleteButtonBackgroundColorBrush,
+					() => cancelButton.BackgroundBrush, brush => cancelButton.BackgroundBrush = brush);
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/SearchBarStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/SearchBarStub.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Color TextColor { get; set; }
 
+		public Color CancelButtonColor { get; set; }
+
 		public double CharacterSpacing { get; set; }
 
 		public Font Font { get; set; }


### PR DESCRIPTION
### Description of Change ###

Implement `CancelButtonColor` property in WinUI SearchBar

<img width="1519" alt="winui-searchbar-cancelcolor" src="https://user-images.githubusercontent.com/6755973/121177527-cbb3bd00-c85d-11eb-9e4c-b82b000c2283.png">

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No