### PR TITLE
Don't call SetVirtualView if View is set

### DIFF
--- a/src/Compatibility/Core/src/WinUI/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/WinUI/HandlerToRendererShim.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		public void SetElement(VisualElement element)
 		{
+			if (element == Element)
+				return;
+
 			var oldElement = Element;
 
 			if (oldElement != null)
@@ -48,8 +51,13 @@ namespace Microsoft.Maui.Controls.Compatibility
 			}
 
 			Element = element;
-			ViewHandler.SetVirtualView((IView)element);
+
 			((IView)element).Handler = ViewHandler;
+
+			if (ViewHandler.VirtualView != element)
+			{
+				ViewHandler.SetVirtualView((IView)element);
+			}
 
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(oldElement, Element));
 		}

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -179,7 +179,10 @@ namespace Microsoft.Maui.Controls
 			}
 
 			_handler = newHandler;
-			_handler?.SetVirtualView((IView)this);
+
+			if (_handler?.VirtualView != this)
+				_handler?.SetVirtualView((IView)this);
+
 			IsPlatformEnabled = _handler != null;
 
 			if (_handler != null)

--- a/src/Core/src/Platform/Windows/HandlerExtensions.cs
+++ b/src/Core/src/Platform/Windows/HandlerExtensions.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Maui
 				view.Handler = handler;
 			}
 
-			handler.SetVirtualView(view);
+			if (handler.VirtualView != view)
+				handler.SetVirtualView(view);
 
 			if (((INativeViewHandler)handler).NativeView is not FrameworkElement result)
 			{


### PR DESCRIPTION
### Description of Change ###

SetVirtualView is being called too eagerly in a few different places which causes the LayoutHandler and/or other places that override `SetVirtualView` to get called multiple times.

I created a tracking issue here to better track a more core implementation
https://github.com/dotnet/maui/issues/1213
