### PR TITLE
Ignore handler mappings that are already processed by VisualElementRenderer

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -35,6 +35,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 				var view = bindable as VisualElement;
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;
+
+				if (view.Handler == null && newvalue is IVisualElementRenderer ver)
+					view.Handler = new RendererToHandlerShim(ver);
+
 			});
 
 		public Platform(Context context) : this(context, false)

--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 
 				if (view.Handler == null && newvalue is IVisualElementRenderer ver)
 					view.Handler = new RendererToHandlerShim(ver);
+				else if (view.Handler != null && newvalue == null)
+					view.Handler = null;
 
 			});
 

--- a/src/Compatibility/Core/src/Android/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/Android/HandlerToRendererShim.cs
@@ -56,8 +56,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 			Element = element;
 
-			ViewHandler.SetVirtualView((IView)element);
 			((IView)element).Handler = ViewHandler;
+
+			if (ViewHandler.VirtualView != element)
+				ViewHandler.SetVirtualView((IView)element);
 
 			if (Tracker == null)
 			{

--- a/src/Compatibility/Core/src/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.cs
@@ -24,7 +24,39 @@ namespace Microsoft.Maui.Controls.Compatibility
 {
 	public partial class RendererToHandlerShim : ViewHandler
 	{
-		public RendererToHandlerShim() : base(ViewHandler.ViewMapper)
+		public static PropertyMapper<IView, ViewHandler> ShimMapper = new PropertyMapper<IView, ViewHandler>(ViewHandler.ViewMapper)
+		{
+			[nameof(IView.AutomationId)] = MapAutomationId,
+			[nameof(IView.Visibility)] = MapVisibility,
+			[nameof(IView.Background)] = MapIgnore,
+			[nameof(IView.Width)] = MapWidth,
+			[nameof(IView.Height)] = MapHeight,
+			[nameof(IView.IsEnabled)] = MapIgnore,
+			[nameof(IView.Opacity)] = MapIgnore,
+			[nameof(IView.Semantics)] = MapSemantics,
+			[nameof(IView.TranslationX)] = MapIgnore,
+			[nameof(IView.TranslationY)] = MapIgnore,
+			[nameof(IView.Scale)] = MapIgnore,
+			[nameof(IView.ScaleX)] = MapIgnore,
+			[nameof(IView.ScaleY)] = MapIgnore,
+			[nameof(IView.Rotation)] = MapIgnore,
+			[nameof(IView.RotationX)] = MapIgnore,
+			[nameof(IView.RotationY)] = MapIgnore,
+			[nameof(IView.AnchorX)] = MapIgnore,
+			[nameof(IView.AnchorY)] = MapIgnore,
+			Actions =
+			{
+				[nameof(IViewHandler.ContainerView)] = MapContainerView,
+				[nameof(IFrameworkElement.InvalidateMeasure)] = MapInvalidateMeasure,
+				[nameof(IFrameworkElement.Frame)] = MapFrame,
+			}
+		};
+
+		static void MapIgnore(ViewHandler arg1, IView arg2)
+		{
+		}
+
+		public RendererToHandlerShim() : base(ShimMapper)
 		{
 		}
 
@@ -55,7 +87,9 @@ namespace Microsoft.Maui.Controls.Compatibility
 			if (VisualElementRenderer.Element is IView view)
 			{
 				view.Handler = this;
-				SetVirtualView(view);
+
+				if (VirtualView != view)
+					SetVirtualView(view);
 			}
 			else if (VisualElementRenderer.Element != null)
 				throw new Exception($"{VisualElementRenderer.Element} must implement: {nameof(Microsoft.Maui.IView)}");
@@ -71,7 +105,9 @@ namespace Microsoft.Maui.Controls.Compatibility
 			if (e.NewElement is IView newView)
 			{
 				newView.Handler = this;
-				this.SetVirtualView(newView);
+
+				if (VirtualView != newView)
+					this.SetVirtualView(newView);
 			}
 			else if (e.NewElement != null)
 				throw new Exception($"{e.NewElement} must implement: {nameof(Microsoft.Maui.IView)}");
@@ -110,7 +146,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			{
 				VisualElementRenderer.SetElement((VisualElement)view);
 			}
-			else
+			else if(view != VirtualView)
 			{
 				base.SetVirtualView(view);
 			}

--- a/src/Compatibility/Core/src/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.cs
@@ -26,14 +26,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 	{
 		public static PropertyMapper<IView, ViewHandler> ShimMapper = new PropertyMapper<IView, ViewHandler>(ViewHandler.ViewMapper)
 		{
-			[nameof(IView.AutomationId)] = MapAutomationId,
-			[nameof(IView.Visibility)] = MapVisibility,
+			// These properties are already being handled by the shimmed renderer
 			[nameof(IView.Background)] = MapIgnore,
-			[nameof(IView.Width)] = MapWidth,
-			[nameof(IView.Height)] = MapHeight,
 			[nameof(IView.IsEnabled)] = MapIgnore,
 			[nameof(IView.Opacity)] = MapIgnore,
-			[nameof(IView.Semantics)] = MapSemantics,
 			[nameof(IView.TranslationX)] = MapIgnore,
 			[nameof(IView.TranslationY)] = MapIgnore,
 			[nameof(IView.Scale)] = MapIgnore,
@@ -43,17 +39,13 @@ namespace Microsoft.Maui.Controls.Compatibility
 			[nameof(IView.RotationX)] = MapIgnore,
 			[nameof(IView.RotationY)] = MapIgnore,
 			[nameof(IView.AnchorX)] = MapIgnore,
-			[nameof(IView.AnchorY)] = MapIgnore,
-			Actions =
-			{
-				[nameof(IViewHandler.ContainerView)] = MapContainerView,
-				[nameof(IFrameworkElement.InvalidateMeasure)] = MapInvalidateMeasure,
-				[nameof(IFrameworkElement.Frame)] = MapFrame,
-			}
+			[nameof(IView.AnchorY)] = MapIgnore
 		};
 
 		static void MapIgnore(ViewHandler arg1, IView arg2)
 		{
+			// These are properties that are already being handled by the shimmed renderer
+			// So if we also process these properties on the ViewHandler then we might get competing results
 		}
 
 		public RendererToHandlerShim() : base(ShimMapper)

--- a/src/Compatibility/Core/src/WinUI/Platform.cs
+++ b/src/Compatibility/Core/src/WinUI/Platform.cs
@@ -22,7 +22,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		static Task<string> s_currentPrompt;
 
 		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer",
-			typeof(IVisualElementRenderer), typeof(Windows.Foundation.Metadata.Platform), default(IVisualElementRenderer));
+			typeof(IVisualElementRenderer), typeof(Windows.Foundation.Metadata.Platform), default(IVisualElementRenderer),
+			propertyChanged: (bindable, oldvalue, newvalue) =>
+			{
+				if (bindable is IView view && view.Handler == null && newvalue is IVisualElementRenderer ver)
+					view.Handler = new RendererToHandlerShim(ver);
+			});
 
 		public static IVisualElementRenderer GetRenderer(VisualElement element)
 		{

--- a/src/Compatibility/Core/src/WinUI/Platform.cs
+++ b/src/Compatibility/Core/src/WinUI/Platform.cs
@@ -25,8 +25,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			typeof(IVisualElementRenderer), typeof(Windows.Foundation.Metadata.Platform), default(IVisualElementRenderer),
 			propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
-				if (bindable is IView view && view.Handler == null && newvalue is IVisualElementRenderer ver)
-					view.Handler = new RendererToHandlerShim(ver);
+				if (bindable is IView view)
+				{
+					if (view.Handler == null && newvalue is IVisualElementRenderer ver)
+						view.Handler = new RendererToHandlerShim(ver);
+					else if (newvalue == null && view.Handler != null)
+						view.Handler = null;
+				}
 			});
 
 		public static IVisualElementRenderer GetRenderer(VisualElement element)

--- a/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
@@ -47,8 +47,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			}
 
 			Element = element;
-			ViewHandler.SetVirtualView((IView)element);
 			((IView)element).Handler = ViewHandler;
+
+			if (ViewHandler.VirtualView != element)
+				ViewHandler.SetVirtualView((IView)element);
 
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(oldElement, Element));
 		}

--- a/src/Compatibility/Core/src/iOS/Platform.cs
+++ b/src/Compatibility/Core/src/iOS/Platform.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				var view = bindable as VisualElement;
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;
+
+				if (view.Handler == null && newvalue is IVisualElementRenderer ver)
+					view.Handler = new RendererToHandlerShim(ver);
+				else if (view.Handler != null && newvalue == null)
+					view.Handler = null;
 			});
 
 		readonly int _alertPadding = 10;

--- a/src/Core/src/Platform/Android/HandlerExtensions.cs
+++ b/src/Core/src/Platform/Android/HandlerExtensions.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Maui
 				view.Handler = handler;
 			}
 
-			handler.SetVirtualView(view);
+			if (handler.VirtualView != view)
+				handler.SetVirtualView(view);
 
 			if (((INativeViewHandler)handler).NativeView is not AView result)
 			{

--- a/src/Core/src/Platform/iOS/HandlerExtensions.cs
+++ b/src/Core/src/Platform/iOS/HandlerExtensions.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Maui
 				view.Handler = handler;
 			}
 
-			handler.SetVirtualView(view);
+			if (handler.VirtualView != view)
+				handler.SetVirtualView(view);
 
 			if (((INativeViewHandler)handler).NativeView is not UIView result)
 			{


### PR DESCRIPTION
### Description of Change ###

If we're shimming a renderer to a handler then we don't want properties that are already being handled by VisualElementRenderer (Scale/ScaleX/Background/etc....) to also be handled by the ViewHandler. This has the potential to cause competing implementations.

