### PR TITLE
Implement CancelButtonColor property in SearchBarHandler

### DIFF
--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Maui.Handlers
 		[MissingMapper]
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }
 
-		[MissingMapper]
-		public static void MapCancelButtonColor(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapCancelButtonColor(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.NativeView?.UpdateCancelButtonColor(searchBar);
+		}
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -7,6 +7,10 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class SearchBarHandler : ViewHandler<ISearchBar, UISearchBar>
 	{
+		UIColor? _cancelButtonTextColorDefaultDisabled;
+		UIColor? _cancelButtonTextColorDefaultHighlighted;
+		UIColor? _cancelButtonTextColorDefaultNormal;
+
 		UITextField? _editor;
 		public UITextField? QueryEditor => _editor;
 
@@ -17,6 +21,20 @@ namespace Microsoft.Maui.Handlers
 			_editor = searchBar.FindDescendantView<UITextField>();
 
 			return searchBar;
+		}
+
+		protected override void SetupDefaults(UISearchBar nativeView)
+		{
+			var cancelButton = nativeView.FindDescendantView<UIButton>();
+
+			if (cancelButton != null)
+			{
+				_cancelButtonTextColorDefaultNormal = cancelButton.TitleColor(UIControlState.Normal);
+				_cancelButtonTextColorDefaultHighlighted = cancelButton.TitleColor(UIControlState.Highlighted);
+				_cancelButtonTextColorDefaultDisabled = cancelButton.TitleColor(UIControlState.Disabled);
+			}
+
+			base.SetupDefaults(nativeView);
 		}
 
 		public static void MapText(SearchBarHandler handler, ISearchBar searchBar)
@@ -71,7 +89,9 @@ namespace Microsoft.Maui.Handlers
 		[MissingMapper]
 		public static void MapIsReadOnly(IViewHandler handler, ISearchBar searchBar) { }
 
-		[MissingMapper]
-		public static void MapCancelButtonColor(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapCancelButtonColor(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.NativeView?.UpdateCancelButton(searchBar, handler._cancelButtonTextColorDefaultNormal, handler._cancelButtonTextColorDefaultHighlighted, handler._cancelButtonTextColorDefaultDisabled);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/SearchViewExtensions.cs
+++ b/src/Core/src/Platform/Android/SearchViewExtensions.cs
@@ -19,10 +19,32 @@ namespace Microsoft.Maui
 		public static void UpdateFont(this SearchView searchView, ISearchBar searchBar, IFontManager fontManager, EditText? editText = null)
 		{
 			editText ??= searchView.GetChildrenOfType<EditText>().FirstOrDefault();
+
 			if (editText == null)
 				return;
 
 			editText.UpdateFont(searchBar, fontManager);
+		}
+
+		public static void UpdateCancelButtonColor(this SearchView searchView, ISearchBar searchBar)
+		{
+			if (searchView.Resources == null)
+				return;
+
+			var searchCloseButtonIdentifier = Resource.Id.search_close_btn;
+		
+			if (searchCloseButtonIdentifier > 0)
+			{
+				var image = searchView.FindViewById<ImageView>(searchCloseButtonIdentifier);
+
+				if (image != null && image.Drawable != null)
+				{
+					if (searchBar.CancelButtonColor != null)
+						image.Drawable.SetColorFilter(searchBar.CancelButtonColor, FilterMode.SrcIn);
+					else
+						image.Drawable.ClearColorFilter();
+				}
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -22,10 +22,37 @@ namespace Microsoft.Maui
 		public static void UpdateFont(this UISearchBar uiSearchBar, ITextStyle textStyle, IFontManager fontManager, UITextField? textField)
 		{
 			textField ??= uiSearchBar.FindDescendantView<UITextField>();
+
 			if (textField == null)
 				return;
 
 			textField.UpdateFont(textStyle, fontManager);
+		}
+
+		public static void UpdateCancelButton(this UISearchBar uiSearchBar, ISearchBar searchBar,
+			UIColor? cancelButtonTextColorDefaultNormal, UIColor? cancelButtonTextColorDefaultHighlighted, UIColor? cancelButtonTextColorDefaultDisabled)
+		{
+			uiSearchBar.ShowsCancelButton = !string.IsNullOrEmpty(uiSearchBar.Text);
+
+			// We can't cache the cancel button reference because iOS drops it when it's not displayed
+			// and creates a brand new one when necessary, so we have to look for it each time
+			var cancelButton = uiSearchBar.FindDescendantView<UIButton>();
+
+			if (cancelButton == null)
+				return;
+
+			if (searchBar.CancelButtonColor == null)
+			{
+				cancelButton.SetTitleColor(cancelButtonTextColorDefaultNormal, UIControlState.Normal);
+				cancelButton.SetTitleColor(cancelButtonTextColorDefaultHighlighted, UIControlState.Highlighted);
+				cancelButton.SetTitleColor(cancelButtonTextColorDefaultDisabled, UIControlState.Disabled);
+			}
+			else
+			{
+				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToNative(), UIControlState.Normal);
+				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToNative(), UIControlState.Highlighted);
+				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToNative(), UIControlState.Disabled);
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Xunit;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
@@ -122,6 +124,16 @@ namespace Microsoft.Maui.DeviceTests
 				return false;
 
 			return editText.Typeface.IsItalic;
+		}
+
+		Task ValidateHasColor(ISearchBar searchBar, Color color, Action action = null)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeSearchBar = GetNativeSearchBar(CreateHandler(searchBar));
+				action?.Invoke();
+				nativeSearchBar.AssertContainsColor(color);
+			});
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Xunit;
 
@@ -84,6 +85,17 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
 			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.FontSlant == FontSlant.Italic, GetNativeIsItalic, isItalic);
+		}
+
+		[Fact(DisplayName = "CancelButtonColor Initialize Correctly")]
+		public async Task CancelButtonColorInitializeCorrectly()
+		{
+			var searchBar = new SearchBarStub()
+			{
+				CancelButtonColor = Colors.MediumPurple
+			};
+
+			await ValidateHasColor(searchBar, Colors.MediumPurple, () => searchBar.CancelButtonColor = Colors.MediumPurple);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using UIKit;
 using Xunit;
@@ -118,6 +120,16 @@ namespace Microsoft.Maui.DeviceTests
 				return false;
 
 			return textField.Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
+		}
+
+		Task ValidateHasColor(ISearchBar searchBar, Color color, Action action = null)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeSearchBar = GetNativeSearchBar(CreateHandler(searchBar));
+				action?.Invoke();
+				nativeSearchBar.AssertContainsColor(color);
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement `CancelButtonColor` property on Android and iOS SearchBarHandlers

<img width="316" alt="searchbar-cancelbuttoncolor" src="https://user-images.githubusercontent.com/6755973/121374554-448b4580-c940-11eb-8b9c-cde5be30ef35.png">

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No