### PR TITLE
Force PageContainer to call Layout on PageViewGroup

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;
 
-				if (view is IView mauiView)
+				if (bindable is IView mauiView)
 				{
 					if (mauiView.Handler == null && newvalue is IVisualElementRenderer ver)
 						mauiView.Handler = new RendererToHandlerShim(ver);

--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -36,10 +36,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;
 
-				if (view.Handler == null && newvalue is IVisualElementRenderer ver)
-					view.Handler = new RendererToHandlerShim(ver);
-				else if (view.Handler != null && newvalue == null)
-					view.Handler = null;
+				if (view is IView mauiView)
+				{
+					if (mauiView.Handler == null && newvalue is IVisualElementRenderer ver)
+						mauiView.Handler = new RendererToHandlerShim(ver);
+					else if (mauiView.Handler != null && newvalue == null)
+						mauiView.Handler = null;
+				}
 
 			});
 

--- a/src/Compatibility/Core/src/Android/Renderers/PageContainer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/PageContainer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			if (Child.View is PageViewGroup pageViewGroup)
 			{
-				// This is a way to handle situations where the root page uses fragments to host other pages (e.g., NavigationPageRenderer)
+				// This is a way to handle situations where the root page is shimmed and uses fragments to host other pages (e.g., NavigationPageRenderer)
 				// The old layout system would have set the width/height of the contained Page by now; the xplat layout call would have come
 				// down the tree from PlatformRenderer and Platform's OnLayout. 
 

--- a/src/Compatibility/Core/src/Android/Renderers/PageContainer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/PageContainer.cs
@@ -2,6 +2,7 @@ using System;
 using Android.Content;
 using Android.Runtime;
 using Android.Views;
+using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
@@ -28,6 +29,20 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			Child.UpdateLayout();
+
+			if (Child.View is PageViewGroup pageViewGroup)
+			{
+				// This is a way to handle situations where the root page uses fragments to host other pages (e.g., NavigationPageRenderer)
+				// The old layout system would have set the width/height of the contained Page by now; the xplat layout call would have come
+				// down the tree from PlatformRenderer and Platform's OnLayout. 
+
+				// But if we're not using PlatformRenderer at the root, then this never happens. We're relying on native OnLayout calls, which 
+				// PageContainer (in its override of ViewGroup's OnLayout) _should_ be doing, under normal circumstances. So we're special-casing
+				// things here for PageViewGroup (the backing View for MAUI pages) and calling Layout. We'll skip calling it for any other types,
+				// because we don't want to interfere with un-shimmed legacy renderers.
+
+				pageViewGroup.Layout(l, t, r, b);
+			}
 		}
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)

--- a/src/Compatibility/Core/src/iOS/Platform.cs
+++ b/src/Compatibility/Core/src/iOS/Platform.cs
@@ -29,10 +29,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;
 
-				if (view.Handler == null && newvalue is IVisualElementRenderer ver)
-					view.Handler = new RendererToHandlerShim(ver);
-				else if (view.Handler != null && newvalue == null)
-					view.Handler = null;
+				if (view is IView mauiView)
+				{
+					if (mauiView.Handler == null && newvalue is IVisualElementRenderer ver)
+						mauiView.Handler = new RendererToHandlerShim(ver);
+					else if (mauiView.Handler != null && newvalue == null)
+						mauiView.Handler = null;
+				}
 			});
 
 		readonly int _alertPadding = 10;

--- a/src/Compatibility/Core/src/iOS/Platform.cs
+++ b/src/Compatibility/Core/src/iOS/Platform.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;
 
-				if (view is IView mauiView)
+				if (bindable is IView mauiView)
 				{
 					if (mauiView.Handler == null && newvalue is IVisualElementRenderer ver)
 						mauiView.Handler = new RendererToHandlerShim(ver);

--- a/src/Controls/samples/Controls.Sample/Pages/TabPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/TabPage.xaml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<TabbedPage  xmlns:local="clr-namespace:Maui.Controls.Sample.Pages" 
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Pages.TabPage">
+    <local:SemanticsPage Title="Page 1"></local:SemanticsPage>
+    <local:SemanticsPage Title="Page 2"></local:SemanticsPage>
+</TabbedPage>

--- a/src/Controls/samples/Controls.Sample/Pages/TabPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/TabPage.xaml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Pages
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class TabPage : TabbedPage
+	{
+		public TabPage()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -31,9 +31,8 @@ namespace Maui.Controls.Sample
 
 	public class Startup : IStartup
 	{
-		enum PageType { Xaml, Semantics, Main, Blazor, NavigationPage, Shell }
-		private PageType _pageType = PageType.NavigationPage;
 		enum PageType { Xaml, Semantics, Main, Blazor, NavigationPage, Shell, TabbedPage }
+		private PageType _pageType = PageType.NavigationPage;
 
 		public readonly static bool UseXamlApp = true;
 		public readonly static bool UseFullDI = false;

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -33,6 +33,7 @@ namespace Maui.Controls.Sample
 	{
 		enum PageType { Xaml, Semantics, Main, Blazor, NavigationPage, Shell }
 		private PageType _pageType = PageType.NavigationPage;
+		enum PageType { Xaml, Semantics, Main, Blazor, NavigationPage, Shell, TabbedPage }
 
 		public readonly static bool UseXamlApp = true;
 		public readonly static bool UseFullDI = false;
@@ -124,6 +125,7 @@ namespace Maui.Controls.Sample
 							PageType.NavigationPage => typeof(NavPage),
 							PageType.Xaml => typeof(XamlPage),
 							PageType.Semantics => typeof(SemanticsPage),
+							PageType.TabbedPage => typeof(TabPage),
 							PageType.Blazor =>
 #if BLAZOR_ENABLED
 								typeof(BlazorPage),


### PR DESCRIPTION
Fixes #1062

If the root page is shimmed and uses fragments to host other pages, the Layout method will never be called on a PageViewGroup that's backing the hosted page. 

The old layout system relied on PlatformRenderer/Platform to force a layout that would set the width/height for the hosted page, and those values would be picked up during VisualElementTracker's OnLayout method.

Since PlatformRenderer is not in play in MauiAppCompatActivity, there's nothing to force the layout call to set those values. Normally the native layout system takes care of this for MAUI, but when the root is a shimmed legacy renderer that never happens. 

This change modifies the PageContainer class to call Layout on the child control if the child control is a PageViewGroup (the backing class for MAUI pages on Android). 
