### PR TITLE
Android life cycle and Shell Tweaks

### DIFF
--- a/src/Compatibility/Core/src/Android/Forms.cs
+++ b/src/Compatibility/Core/src/Android/Forms.cs
@@ -184,15 +184,15 @@ namespace Microsoft.Maui.Controls.Compatibility
 			return _ColorButtonNormal;
 		}
 
-		public static void Init(IActivationState activationState) =>
-			Init(activationState.Context, activationState.SavedInstance);
+		public static void Init(IActivationState activationState, InitializationOptions? options = null) =>
+			Init(activationState.Context, activationState.SavedInstance, options);
 
 		// Provide backwards compat for Forms.Init and AndroidActivity
 		// Why is bundle a param if never used?
 		public static void Init(Context activity, Bundle bundle) =>
 			Init(new MauiContext(activity), bundle);
 
-		public static void Init(IMauiContext context, Bundle bundle)
+		public static void Init(IMauiContext context, Bundle bundle, InitializationOptions? options = null)
 		{
 			Assembly resourceAssembly;
 
@@ -201,7 +201,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			Profile.FrameEnd("Assembly.GetCallingAssembly");
 
 			Profile.FrameBegin();
-			SetupInit(context, resourceAssembly, null);
+			SetupInit(context, resourceAssembly, options);
 			Profile.FrameEnd();
 		}
 

--- a/src/Compatibility/Core/src/Android/Renderers/ShellContentFragment.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ShellContentFragment.cs
@@ -15,12 +15,27 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
 	public class ShellContentFragment : Fragment, AndroidAnimation.IAnimationListener, IShellObservableFragment, IAppearanceObserver
 	{
+		// AndroidX.Fragment packaged stopped calling CreateAnimation for every call
+		// of creating a fragment
+		bool _isAnimating = false;
+
 		#region IAnimationListener
 
 		void AndroidAnimation.IAnimationListener.OnAnimationEnd(AndroidAnimation animation)
 		{
 			View?.SetLayerType(LayerType.None, null);
 			AnimationFinished?.Invoke(this, EventArgs.Empty);
+			_isAnimating = false;
+		}
+
+		public override void OnResume()
+		{
+			base.OnResume();
+			if (!_isAnimating)
+			{
+				View?.SetLayerType(LayerType.None, null);
+				AnimationFinished?.Invoke(this, EventArgs.Empty);
+			}
 		}
 
 		void AndroidAnimation.IAnimationListener.OnAnimationRepeat(AndroidAnimation animation)
@@ -75,6 +90,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public override AndroidAnimation OnCreateAnimation(int transit, bool enter, int nextAnim)
 		{
 			var result = base.OnCreateAnimation(transit, enter, nextAnim);
+			_isAnimating = true;
 
 			if (result == null && nextAnim != 0)
 			{

--- a/src/Compatibility/Core/src/Android/Renderers/ShellRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ShellRenderer.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			FragmentTransaction transaction = manager.BeginTransactionEx();
 
 			if (animate)
-				transaction.SetTransitionEx((int)global::Android.App.FragmentTransit.EnterMask);
+				transaction.SetTransitionEx((int)global::Android.App.FragmentTransit.FragmentOpen);
 
 			transaction.ReplaceEx(_frameLayout.Id, fragment);
 			transaction.CommitAllowingStateLossEx();

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -23,7 +23,6 @@ namespace Maui.Controls.Sample
 
 		protected override IWindow CreateWindow(IActivationState activationState)
 		{
-			Microsoft.Maui.Controls.Compatibility.Forms.Init(activationState);
 			return Services.GetRequiredService<IWindow>();
 		}
 	}

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -23,6 +23,7 @@ namespace Maui.Controls.Sample
 
 		protected override IWindow CreateWindow(IActivationState activationState)
 		{
+			Microsoft.Maui.Controls.Compatibility.Forms.Init(activationState);
 			return Services.GetRequiredService<IWindow>();
 		}
 	}

--- a/src/Controls/src/Core/Platform/Android/ViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/ViewExtensions.cs
@@ -15,15 +15,6 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	public static class ViewExtensions
 	{
-		public static void RemoveFromParent(this AView view)
-		{
-			if (view == null)
-				return;
-			if (view.Parent == null)
-				return;
-			((ViewGroup)view.Parent).RemoveView(view);
-		}
-
 		public static void SetBackground(this AView view, Drawable drawable)
 		{
 

--- a/src/Core/src/Handlers/Page/PageHandler.Android.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Android.cs
@@ -51,5 +51,12 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateContent();
 		}
+
+		protected override void DisconnectHandler(PageViewGroup nativeView)
+		{
+			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
+			NativeView?.RemoveAllViews();
+			base.DisconnectHandler(nativeView);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -11,8 +11,20 @@ namespace Microsoft.Maui
 {
 	public partial class MauiAppCompatActivity : AppCompatActivity
 	{
+		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
+		protected virtual bool AllowFragmentRestore => false;
+
 		protected override void OnCreate(Bundle? savedInstanceState)
 		{
+			if (!AllowFragmentRestore)
+			{
+				// Remove the automatically persisted fragment structure; we don't need them
+				// because we're rebuilding everything from scratch. This saves a bit of memory
+				// and prevents loading errors from child fragment managers
+				savedInstanceState?.Remove("android:support:fragments");
+				savedInstanceState?.Remove("androidx.lifecycle.BundlableSavedStateRegistry.key");
+			}
+
 			// If the theme has the maui_splash attribute, change the theme
 			if (Theme.TryResolveAttribute(Resource.Attribute.maui_splash))
 			{

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -106,5 +106,15 @@ namespace Microsoft.Maui
 				nativeView.RequestLayout();
 			}
 		}
+
+		public static void RemoveFromParent(this AView view)
+		{
+			if (view == null)
+				return;
+			if (view.Parent == null)
+				return;
+			((ViewGroup)view.Parent).RemoveView(view);
+		}
+
 	}
 }


### PR DESCRIPTION
### Description of Change ###

- Wire up Forms.Init to get called from Maui Life Cycle events. Currently we are only calling Forms.Init from createwindow. The problem with this is that when the Activity gets created `Forms.Init` isn't called again so any of the bits that use the statics inside Forms start crashing
- Copied some shell fixes from here https://github.com/xamarin/Xamarin.Forms/pull/14101 required to make shell work
- Fixed an issue on PageHandler so when it's disconnected it removes all of its children views