### PR TITLE
Use PageController ContainerArea when laying out PageContainer

### DIFF
--- a/src/Compatibility/Core/src/Android/ContextExtensions.cs
+++ b/src/Compatibility/Core/src/Android/ContextExtensions.cs
@@ -132,5 +132,16 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			return null;
 		}
+
+		public static (int left, int top, int right, int bottom) ToPixels(this Context context, Graphics.Rectangle rectangle) 
+		{
+			return 
+			(
+				(int)context.ToPixels(rectangle.Left),
+				(int)context.ToPixels(rectangle.Top),
+				(int)context.ToPixels(rectangle.Right),
+				(int)context.ToPixels(rectangle.Bottom)
+			);
+		}
 	}
 }

--- a/src/Compatibility/Core/src/Android/Renderers/PageContainer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/PageContainer.cs
@@ -41,6 +41,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				// things here for PageViewGroup (the backing View for MAUI pages) and calling Layout. We'll skip calling it for any other types,
 				// because we don't want to interfere with un-shimmed legacy renderers.
 
+				if (Child.Element.Parent is IPageController ipc && !ipc.ContainerArea.IsEmpty)
+				{
+					(l, t, r, b) = Context.ToPixels(ipc.ContainerArea);
+				}
+				
 				pageViewGroup.Layout(l, t, r, b);
 			}
 		}


### PR DESCRIPTION
The PageContainer layout call was not taking into account other chrome on the page (e.g., Tabs). This change puts the PageContainer layout call into the correct bounds.