### PR TITLE
[build] remove .NET Workload versions workaround

### DIFF
--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -84,33 +84,6 @@
         VersionBand="$(DotNetPreviewVersionBand)"
     />
 
-    <!-- In order to support older MSBuild versions, change the version string to an integer -->
-    <ReplaceText
-        Input="$(DotNetSdkManifestsDirectory)microsoft.net.sdk.android/WorkloadManifest.json"
-        OldValue="&quot;version&quot;: &quot;$(MicrosoftAndroidSdkWindowsPackageVersion)&quot;"
-        NewValue="&quot;version&quot;: 6"
-    />
-    <ReplaceText
-        Input="$(DotNetSdkManifestsDirectory)microsoft.net.sdk.maccatalyst/WorkloadManifest.json"
-        OldValue="&quot;version&quot;: &quot;$(MicrosoftMacCatalystSdkPackageVersion)&quot;"
-        NewValue="&quot;version&quot;: 6"
-    />
-    <ReplaceText
-        Input="$(DotNetSdkManifestsDirectory)microsoft.net.sdk.ios/WorkloadManifest.json"
-        OldValue="&quot;version&quot;: &quot;$(MicrosoftiOSSdkPackageVersion)&quot;"
-        NewValue="&quot;version&quot;: 6"
-    />
-    <ReplaceText
-        Input="$(DotNetSdkManifestsDirectory)microsoft.net.sdk.tvos/WorkloadManifest.json"
-        OldValue="&quot;version&quot;: &quot;$(MicrosofttvOSSdkPackageVersion)&quot;"
-        NewValue="&quot;version&quot;: 6"
-    />
-    <ReplaceText
-        Input="$(DotNetSdkManifestsDirectory)microsoft.net.sdk.macos/WorkloadManifest.json"
-        OldValue="&quot;version&quot;: &quot;$(MicrosoftmacOSSdkPackageVersion)&quot;"
-        NewValue="&quot;version&quot;: 6"
-    />
-
     <Touch Files="$(DotNetSdkManifestsDirectory).stamp" AlwaysCreate="true" />
   </Target>
 
@@ -147,25 +120,6 @@
               Log.LogMessage($"Copying {file} to {destination}");
               File.Copy(file, destination, overwrite: true);
           }
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-  <UsingTask TaskName="ReplaceText"
-      TaskFactory="RoslynCodeTaskFactory"
-      AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <Input ParameterType="System.String" Required="true" />
-      <OldValue ParameterType="System.String" Required="true" />
-      <NewValue ParameterType="System.String" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text.RegularExpressions" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-          var regex = new Regex(Regex.Escape(OldValue));
-          File.WriteAllText(Input, regex.Replace(File.ReadAllText(Input), NewValue, count: 1));
         ]]>
       </Code>
     </Task>


### PR DESCRIPTION
### Description of Change ###

Previously, I had to replace the `version` in `WorkloadManifest.json`
files so it was an integer. This was so we could build with older
versions of MSBuild & the .NET workload resolver. String values would
cause any `dotnet build` command to fail.

I believe we can remove these workarounds now, since Visual Studio
16.10 went GA.

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No
