### PR TITLE
Remove need for call to Forms.Init inside CreateWindow

### DIFF
--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Controls.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Controls.cs
@@ -91,6 +91,56 @@ namespace Microsoft.Maui.Controls.Hosting
 								   }
 							   }
 						   }));
+#elif __IOS__
+				events.AddiOS(iOS =>
+				{
+					iOS.FinishedLaunching((x,y) =>
+					{
+						// This calls Init again so that the MauiContext that's part of
+						// Forms.Init matches the rest of the maui application
+						var mauiApp = MauiUIApplicationDelegate.Current.Application;
+						if (mauiApp.Windows.Count > 0)
+						{
+							var window = mauiApp.Windows[0];
+							var mauiContext = window.Handler?.MauiContext ?? window.View.Handler?.MauiContext;
+
+							if (mauiContext != null)
+							{
+								Forms.Init(new ActivationState(mauiContext));
+							}
+						}
+						return true;
+					});
+				});
+#elif WINDOWS
+				events.AddWindows(windows => windows
+							.OnLaunching((_, args) =>
+							{								
+								// We need to call Forms.Init so the Window and Root Page can new up successfully
+								// The dispatcher that's inside of Forms.Init needs to be setup before the initial 
+								// window and root page start creating
+								// Inside OnLaunched we grab the MauiContext that's on the window so we can have the correct
+								// MauiContext inside Forms
+								MauiContext mauiContext = new MauiContext(MauiWinUIApplication.Current.Services);
+								ActivationState state = new ActivationState(mauiContext, args);
+								Forms.Init(state, new InitializationOptions() { Flags = InitializationFlags.SkipRenderers });
+							})
+						   .OnLaunched((_, args) =>
+						   {
+							   // This calls Init again so that the MauiContext that's part of
+							   // Forms.Init matches the rest of the maui application
+							   var mauiApp = MauiWinUIApplication.Current.Application;
+							   if (mauiApp.Windows.Count > 0)
+							   {
+								   var window = mauiApp.Windows[0];
+								   var mauiContext = window.Handler?.MauiContext ?? window.View.Handler?.MauiContext;
+
+								   if (mauiContext != null)
+								   {
+									   Forms.Init(new ActivationState(mauiContext, args));
+								   }
+							   }
+						   }));
 #endif
 			});
 
@@ -180,6 +230,12 @@ namespace Microsoft.Maui.Controls.Hosting
 				myResourceDictionary.Source = new Uri("ms-appx:///Microsoft.Maui.Controls/Platform/Windows/Styles/Resources.xbf");
 				Microsoft.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(myResourceDictionary);
 			}
+#elif __IOS__
+			// Services on iOS are set inside FinishedLaunching so we don't have a life cycle hook to grab these before
+			// we need Forms.Init to get called
+			// The second call to Forms.Init inside the FinishedLaunching Life cycle will setup the proper MauiContext
+			MauiContext mauiContext = new MauiContext();
+			Forms.Init(new ActivationState(mauiContext), new InitializationOptions() { Flags = InitializationFlags.SkipRenderers });
 #endif
 		}
 	}

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Controls.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Controls.cs
@@ -94,6 +94,13 @@ namespace Microsoft.Maui.Controls.Hosting
 #elif __IOS__
 				events.AddiOS(iOS =>
 				{
+					iOS.WillFinishLaunching((x, y) =>
+					{
+						MauiContext mauiContext = new MauiContext(MauiUIApplicationDelegate.Current.Services);
+						Forms.Init(new ActivationState(mauiContext), new InitializationOptions() { Flags = InitializationFlags.SkipRenderers });
+						return true;
+					});
+
 					iOS.FinishedLaunching((x,y) =>
 					{
 						// This calls Init again so that the MauiContext that's part of
@@ -230,12 +237,6 @@ namespace Microsoft.Maui.Controls.Hosting
 				myResourceDictionary.Source = new Uri("ms-appx:///Microsoft.Maui.Controls/Platform/Windows/Styles/Resources.xbf");
 				Microsoft.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(myResourceDictionary);
 			}
-#elif __IOS__
-			// Services on iOS are set inside FinishedLaunching so we don't have a life cycle hook to grab these before
-			// we need Forms.Init to get called
-			// The second call to Forms.Init inside the FinishedLaunching Life cycle will setup the proper MauiContext
-			MauiContext mauiContext = new MauiContext();
-			Forms.Init(new ActivationState(mauiContext), new InitializationOptions() { Flags = InitializationFlags.SkipRenderers });
 #endif
 		}
 	}

--- a/src/Compatibility/Core/src/WinUI/Forms.cs
+++ b/src/Compatibility/Core/src/WinUI/Forms.cs
@@ -26,34 +26,33 @@ namespace Microsoft.Maui.Controls.Compatibility
 	public static partial class Forms
 	{
 		const string LogFormat = "[{0}] {1}";
-		private static ApplicationExecutionState s_state;
 
 		//TODO WINUI3 This is set by main page currently because
 		// it's only a single window
 		public static UI.Xaml.Window MainWindow { get; set; }
 
 		public static bool IsInitialized { get; private set; }
+		static bool WinUIResourcesAdded { get; set; }
+
 		public static IMauiContext MauiContext { get; private set; }
 
-		public static void Init(IActivationState state)
+		public static void Init(IActivationState state, InitializationOptions? options = null)
 		{
-			SetupInit(state.Context, state.LaunchActivatedEventArgs, null, null);
+			SetupInit(state.Context, null, maybeOptions: options);
 		}
 
 		public static void Init(
-			UI.Xaml.LaunchActivatedEventArgs launchActivatedEventArgs,
 			WindowsBasePage mainWindow,
 			IEnumerable<Assembly> rendererAssemblies = null)
 		{
-			SetupInit(new MauiContext(), launchActivatedEventArgs, mainWindow, rendererAssemblies);
+			SetupInit(new MauiContext(), mainWindow, rendererAssemblies);
 		}
 
 		public static void Init(InitializationOptions options) =>
-			SetupInit(new MauiContext(), options.LaunchActivatedEventArgs, null, null, options);
+			SetupInit(new MauiContext(), null, null, options);
 
 		static void SetupInit(
 			IMauiContext mauiContext,
-			UI.Xaml.LaunchActivatedEventArgs launchActivatedEventArgs,
 			WindowsBasePage mainWindow,
 			IEnumerable<Assembly> rendererAssemblies = null,
 			InitializationOptions? maybeOptions = null)
@@ -77,7 +76,11 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 			try
 			{
-				UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(new UI.Xaml.Controls.XamlControlsResources());
+				if (!WinUIResourcesAdded)
+				{
+					WinUIResourcesAdded = true;
+					UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(new UI.Xaml.Controls.XamlControlsResources());
+				}
 			}
 			catch
 			{
@@ -123,7 +126,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 			ExpressionSearch.Default = new WindowsExpressionSearch();
 
 			Registrar.ExtraAssemblies = rendererAssemblies?.ToArray();
-			s_state = launchActivatedEventArgs.UWPLaunchActivatedEventArgs.PreviousExecutionState;
 
 			var dispatcher = mainWindow?.DispatcherQueue ?? System.DispatcherQueue.GetForCurrentThread();
 

--- a/src/Compatibility/Core/src/iOS/Forms.cs
+++ b/src/Compatibility/Core/src/iOS/Forms.cs
@@ -187,8 +187,8 @@ namespace Microsoft.Maui.Controls.Compatibility
 		public static void Init(InitializationOptions options) =>
 			SetupInit(new MauiContext(), options);
 
-		public static void Init(IActivationState activationState) =>
-			SetupInit(activationState.Context);
+		public static void Init(IActivationState activationState, InitializationOptions? options = null) =>
+			SetupInit(activationState.Context, options);
 
 		static void SetupInit(IMauiContext context, InitializationOptions? maybeOptions = null)
 		{

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -23,7 +23,6 @@ namespace Maui.Controls.Sample
 
 		protected override IWindow CreateWindow(IActivationState activationState)
 		{
-			Microsoft.Maui.Controls.Compatibility.Forms.Init(activationState);
 			return Services.GetRequiredService<IWindow>();
 		}
 	}

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycle.cs
@@ -5,6 +5,7 @@
 		public delegate void OnActivated(UI.Xaml.Window window, UI.Xaml.WindowActivatedEventArgs args);
 		public delegate void OnClosed(UI.Xaml.Window window, UI.Xaml.WindowEventArgs args);
 		public delegate void OnLaunched(UI.Xaml.Application application, UI.Xaml.LaunchActivatedEventArgs args);
+		public delegate void OnLaunching(UI.Xaml.Application application, UI.Xaml.LaunchActivatedEventArgs args);
 		public delegate void OnVisibilityChanged(UI.Xaml.Window window, UI.Xaml.WindowVisibilityChangedEventArgs args);
 	}
 }

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
@@ -4,6 +4,7 @@
 	{
 		public static IWindowsLifecycleBuilder OnActivated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnActivated del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnClosed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnClosed del) => lifecycle.OnEvent(del);
+		public static IWindowsLifecycleBuilder OnLaunching(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnLaunching del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnLaunched(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnLaunched del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnVisibilityChanged(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnVisibilityChanged del) => lifecycle.OnEvent(del);
 	}

--- a/src/Core/src/LifecycleEvents/iOS/iOSLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/iOS/iOSLifecycle.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.LifecycleEvents
 	{
 		public delegate bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler);
 		public delegate void DidEnterBackground(UIApplication application);
+		public delegate bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions);
 		public delegate bool FinishedLaunching(UIApplication application, NSDictionary launchOptions);
 		public delegate void OnActivated(UIApplication application);
 		public delegate void OnResignActivation(UIApplication application);

--- a/src/Core/src/LifecycleEvents/iOS/iOSLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/iOS/iOSLifecycleBuilderExtensions.cs
@@ -4,6 +4,7 @@
 	{
 		public static IiOSLifecycleBuilder ContinueUserActivity(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.ContinueUserActivity del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder DidEnterBackground(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.DidEnterBackground del) => lifecycle.OnEvent(del);
+		public static IiOSLifecycleBuilder WillFinishLaunching(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.WillFinishLaunching del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder FinishedLaunching(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.FinishedLaunching del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder OnActivated(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.OnActivated del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder OnResignActivation(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.OnResignActivation del) => lifecycle.OnEvent(del);

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui
 
 			Services = host.Services;
 			Application = Services.GetRequiredService<IApplication>();
+			Current.Services?.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 
 			var mauiContext = new MauiContext(Services);
 

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Maui
 	public class MauiUIApplicationDelegate<TStartup> : MauiUIApplicationDelegate
 		where TStartup : IStartup, new()
 	{
-		public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+
+		public override bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions)
 		{
 			var startup = new TStartup();
 
@@ -22,7 +23,14 @@ namespace Microsoft.Maui
 				.Build();
 
 			Services = host.Services;
-			Application = Services.GetRequiredService<IApplication>();
+
+			Current.Services?.InvokeLifecycleEvents<iOSLifecycle.WillFinishLaunching>(del => del(application, launchOptions));
+			return true;
+		}
+
+		public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+		{
+			Application = Services.GetRequiredService<IApplication>();	
 
 			var mauiContext = new MauiContext(Services);
 


### PR DESCRIPTION
### Description of Change ###

Most of these changes aren't that exciting. The largest change is that WinUI gained a lifecycle hook

### Additions made ###
- Adds `OnLaunching` to WinUI so that we can setup things before the xplat window/page are created.  `Forms.Init` needed this because it needs to assign the dispatcher inside Forms.Init. This will get less awkward once we figure out the new home for Device.BeginOnInvoke