### PR TITLE
Fix Shims to return underlying ViewController

### DIFF
--- a/src/Compatibility/Core/src/RendererToHandlerShim.iOS.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.iOS.cs
@@ -1,14 +1,18 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
+using UIKit;
 using static Microsoft.Maui.Controls.Compatibility.Platform.iOS.Platform;
 using NativeView = UIKit.UIView;
 
 namespace Microsoft.Maui.Controls.Compatibility
 {
-	public partial class RendererToHandlerShim
+	public partial class RendererToHandlerShim : INativeViewHandler
 	{
+		UIViewController? INativeViewHandler.ViewController => VisualElementRenderer?.ViewController;
+
 		protected override NativeView CreateNativeView()
 		{
 			return VisualElementRenderer.NativeView;

--- a/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		public UIView NativeView => (UIView)ViewHandler.NativeView;
 
-		public UIViewController ViewController => null;
+		public UIViewController ViewController => (ViewHandler as INativeViewHandler)?.ViewController;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;


### PR DESCRIPTION
### Description of Change ###

On iOS the Shims need to surface the viewcontroller for whatever concept they are wrapping.  This is particularly relevant for Shell or NavigationPages that need to retrieve the ViewController to use with the UINavigationController
