### PR TITLE
Revert WinUI to use Layout Renderer

### DIFF
--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Controls.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Controls.cs
@@ -197,6 +197,8 @@ namespace Microsoft.Maui.Controls.Hosting
 					handlers.TryAddCompatibilityRenderer(typeof(TabbedPage), typeof(TabbedPageRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(Shell), typeof(ShellRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(OpenGLView), typeof(OpenGLViewRenderer));
+#else
+					handlers.TryAddCompatibilityRenderer(typeof(Element), typeof(DefaultRenderer));
 #endif
 					handlers.TryAddCompatibilityRenderer(typeof(NavigationPage), typeof(NavigationPageRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(CarouselPage), typeof(CarouselPageRenderer));

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.Controls.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.Controls.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Maui.Controls.Hosting
 					handlers.TryAddCompatibilityRenderer(typeof(Shell), typeof(ShellRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(OpenGLView), typeof(OpenGLViewRenderer));
 #else
-					handlers.TryAddCompatibilityRenderer(typeof(Element), typeof(DefaultRenderer));
+					handlers.TryAddCompatibilityRenderer(typeof(Layout), typeof(LayoutRenderer));
 #endif
 					handlers.TryAddCompatibilityRenderer(typeof(NavigationPage), typeof(NavigationPageRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(CarouselPage), typeof(CarouselPageRenderer));

--- a/src/Controls/src/Core/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/AppHostBuilderExtensions.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(GraphicsView), typeof(GraphicsViewHandler) },
 			{ typeof(Image), typeof(ImageHandler) },
 			{ typeof(Label), typeof(LabelHandler) },
-			{ typeof(Layout), typeof(LayoutHandler) },
 			{ typeof(Layout2.Layout), typeof(LayoutHandler) },
 			{ typeof(Picker), typeof(PickerHandler) },
 			{ typeof(ProgressBar), typeof(ProgressBarHandler) },
@@ -41,6 +40,12 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(Shapes.Polygon), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Polyline), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Rectangle), typeof(ShapeViewHandler) },
+
+			// Set LayoutHandler as default Handler
+#if !WINDOWS
+			{ typeof(Layout), typeof(LayoutHandler) },
+			{ typeof(Element), typeof(LayoutHandler) }
+#endif
 		};
 
 		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)

--- a/src/Controls/src/Core/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/AppHostBuilderExtensions.cs
@@ -45,9 +45,6 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(Layout), typeof(LayoutHandler) },
 			#endif
 
-			// Set LayoutHandler as default Handler,
-			{ typeof(Element), typeof(LayoutHandler) },
-
 		};
 
 		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)

--- a/src/Controls/src/Core/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/AppHostBuilderExtensions.cs
@@ -41,11 +41,13 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(Shapes.Polyline), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Rectangle), typeof(ShapeViewHandler) },
 
-			// Set LayoutHandler as default Handler
-#if !WINDOWS
+			#if !WINDOWS
 			{ typeof(Layout), typeof(LayoutHandler) },
-			{ typeof(Element), typeof(LayoutHandler) }
-#endif
+			#endif
+
+			// Set LayoutHandler as default Handler,
+			{ typeof(Element), typeof(LayoutHandler) },
+
 		};
 
 		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)


### PR DESCRIPTION
### Description of Change ###

When we were registering via assembly scanning WinUI was registering LayoutRenderer against Layout (who knew?). 

After we removed assembly scanning WinUI started using LayoutHandler which doesn't appear to be working for WinUI and legacy layouts. This PR reverts WinUI back to using LayoutRenderer for anything subclassing Layout 

### Fixes

- #1257