### PR TITLE
Add MAUI IView check to WinUI Platform GetNativeSize

### DIFF
--- a/src/Compatibility/Core/src/WinUI/Platform.cs
+++ b/src/Compatibility/Core/src/WinUI/Platform.cs
@@ -276,6 +276,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				IVisualElementRenderer elementRenderer = GetRenderer(element);
 				if (elementRenderer != null)
 					return elementRenderer.GetDesiredSize(widthConstraint, heightConstraint);
+				
+				if (element is IView iView)
+					return new SizeRequest(iView.Handler.GetDesiredSize(widthConstraint, heightConstraint));
 			}
 
 			return new SizeRequest();

--- a/src/Controls/src/Core/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/AppHostBuilderExtensions.cs
@@ -40,11 +40,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(Shapes.Polygon), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Polyline), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Rectangle), typeof(ShapeViewHandler) },
-
-			#if !WINDOWS
 			{ typeof(Layout), typeof(LayoutHandler) },
-			#endif
-
 		};
 
 		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)


### PR DESCRIPTION
Platform's GetNativeSize implementation for didn't know to look for MAUI IViews when doing sizing.

Fixes #1265