### PR TITLE
Don't try to load slider thumb if source is null

### DIFF
--- a/src/Core/src/Platform/Android/SliderExtensions.cs
+++ b/src/Core/src/Platform/Android/SliderExtensions.cs
@@ -76,11 +76,15 @@ namespace Microsoft.Maui
 			if (context == null)
 				return;
 
+			Drawable? thumbDrawable = null;
 			var thumbImageSource = slider.ThumbImageSource;
 
-			var service = provider.GetRequiredImageSourceService(thumbImageSource);
-			var result = await service.GetDrawableAsync(thumbImageSource, context);
-			var thumbDrawable = result?.Value;
+			if (thumbImageSource != null)
+			{
+				var service = provider.GetRequiredImageSourceService(thumbImageSource);
+				var result = await service.GetDrawableAsync(thumbImageSource, context);
+				thumbDrawable = result?.Value;
+			}
 
 			seekBar.SetThumb(thumbDrawable ?? defaultThumb);
 		}


### PR DESCRIPTION
### Description of Change ###

If the Slider Thumb Image Source Url is null then it throws an NRE exception