### PR TITLE
Update dependencies to .NET 6 preview 5

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup Condition="'$(TargetFramework.Contains(net6.0))' == 'true'">
-    <_MicrosoftHostingVersion>6.0.0-preview.4.21253.7</_MicrosoftHostingVersion>
+    <_MicrosoftHostingVersion>6.0.0-preview.5.21301.5</_MicrosoftHostingVersion>
     <_MicrosoftDependencyInjectionVersion>$(_MicrosoftHostingVersion)</_MicrosoftDependencyInjectionVersion>
-    <_MicrosoftFileProvidersVersion>6.0.0-preview.4.21253.5</_MicrosoftFileProvidersVersion>
-    <_MicrosoftSystemCodeDomVersion>6.0.0-preview.4.21253.7</_MicrosoftSystemCodeDomVersion>
+    <_MicrosoftFileProvidersVersion>6.0.0-preview.5.21301.5</_MicrosoftFileProvidersVersion>
+    <_MicrosoftSystemCodeDomVersion>6.0.0-preview.5.21301.5</_MicrosoftSystemCodeDomVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework.Contains(net6.0))' != 'true'">
     <_MicrosoftHostingVersion>5.0.0</_MicrosoftHostingVersion>
@@ -16,7 +16,7 @@
     <_MicrosoftGraphicsWin2DVersion>0.5.0.13</_MicrosoftGraphicsWin2DVersion>
     <_MicrosoftMauiGraphics>6.0.100-preview.5.229</_MicrosoftMauiGraphics>
     <_MicrosoftMauiGraphicsWin2D>6.0.100-preview.5.229</_MicrosoftMauiGraphicsWin2D>
-    <_MicrosoftAspNetCoreVersion>6.0.0-preview.4.21253.5</_MicrosoftAspNetCoreVersion>
+    <_MicrosoftAspNetCoreVersion>6.0.0-preview.5.21301.17</_MicrosoftAspNetCoreVersion>
     <_MicrosoftWebWebView2Version>1.0.705.50</_MicrosoftWebWebView2Version>
     <_XamarinAndroidGlideVersion>4.11.0.1</_XamarinAndroidGlideVersion>
   </PropertyGroup>

--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -113,4 +113,13 @@
         Version="$(_MicrosoftWebWebView2Version)"
     />
   </ItemGroup>
+
+  <!-- Workaround for https://github.com/dotnet/sdk/issues/18148 where an analyzer from a new version of a package
+       is not found in the older version of that same package. So we just remove usage of the analyzer entirely
+       because we don't use it in this repo.  -->
+  <Target Name="RemoveLoggingAnalyzer" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="%(FileName) == 'Microsoft.Extensions.Logging.Generators'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -33,7 +33,7 @@
         "type": "parameter",
         "dataType": "string",
         "replaces": "MICROSOFT_EXTENSIONS_VERSION",
-        "defaultValue": "6.0.0-preview.4.*"
+        "defaultValue": "6.0.0-preview.5.*"
       },
       "projectReunionVersion": {
         "type": "parameter",

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -29,7 +29,7 @@
         "type": "parameter",
         "dataType": "string",
         "replaces": "MICROSOFT_EXTENSIONS_VERSION",
-        "defaultValue": "6.0.0-preview.4.*"
+        "defaultValue": "6.0.0-preview.5.*"
       },
       "projectReunionVersion": {
         "type": "parameter",


### PR DESCRIPTION
Updating MS Extensions and ASP.NET Core dependencies to .NET 6 preview 5 versions. I took the versions from the feed that has the versions that will be published as part of the release.

Note that I ran into a bug in the .NET SDK where analyzers weren't found where they shouldn't be, so I added a workaround to the targets to avoid the bug.