### PR TITLE
lazy load SystemResources

### DIFF
--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls
 		{
 			SetCurrentApplication(this);
 			NavigationProxy = new NavigationImpl(this);
-			_systemResources = new Lazy(() => {
+			_systemResources = new Lazy<IResourceDictionary>(() => {
 				var systemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
 				systemResources.ValuesChanged += OnParentResourcesChanged;
 				return systemResources;

--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Controls
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 		Task<IDictionary<string, object>> _propertiesTask;
 		readonly Lazy<PlatformConfigurationRegistry<Application>> _platformConfigurationRegistry;
+		readonly Lazy<IResourceDictionary> _systemResources;
 
 		public override IDispatcher Dispatcher => this.GetDispatcher();
 
@@ -26,8 +27,11 @@ namespace Microsoft.Maui.Controls
 		{
 			SetCurrentApplication(this);
 			NavigationProxy = new NavigationImpl(this);
-			SystemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
-			SystemResources.ValuesChanged += OnParentResourcesChanged;
+			_systemResources = new Lazy(() => {
+				var systemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
+				systemResources.ValuesChanged += OnParentResourcesChanged;
+				return systemResources;
+			});
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Application>>(() => new PlatformConfigurationRegistry<Application>(this));
 		}
 
@@ -158,7 +162,7 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int PanGestureId { get; set; }
 
-		internal IResourceDictionary SystemResources { get; }
+		internal IResourceDictionary SystemResources => _systemResources.Value;
 
 		ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 


### PR DESCRIPTION
### Description of Change ###

Removes need for Forms Init or Shims when creating a new Application by making the SystemResources lazy loaded. This should allow developers to implement IStartup on the actual Application rather than having to maintain a separate Startup class.

### Additions made ###

* Adds
  - none
* Removes
  - none
* Changes
  - SystemResources is now lazy loaded

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch (per @mattleibow)
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
