### PR TITLE
ShapeDrawable: adjust DrawStrokePath

### DIFF
--- a/src/Core/src/Graphics/ShapeDrawable.cs
+++ b/src/Core/src/Graphics/ShapeDrawable.cs
@@ -68,7 +68,7 @@
 
 			canvas.DrawPath(path);
 
-			canvas.SaveState();
+			canvas.RestoreState();
 		}
 
 		void DrawFillPath(ICanvas canvas, RectangleF dirtyRect, PathF path)


### PR DESCRIPTION
### Description of Change ###

Core.csproj: ShapeDrawable.cs: 

DrawStrokePath 
canvas.RestoreState()
not
canvas.SaveState()
