### PR TITLE
Shims should use the container view if there is one

### DIFF
--- a/src/Compatibility/Core/src/Android/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/Android/HandlerToRendererShim.cs
@@ -13,20 +13,20 @@ namespace Microsoft.Maui.Controls.Compatibility
 	{
 		int? _defaultLabelFor;
 
-		public HandlerToRendererShim(IViewHandler vh)
+		public HandlerToRendererShim(INativeViewHandler vh)
 		{
 			ViewHandler = vh;
 		}
 
-		IViewHandler ViewHandler { get; }
+		INativeViewHandler ViewHandler { get; }
 
 		public VisualElement Element { get; private set; }
 
 		public VisualElementTracker Tracker { get; private set; }
 
-		public ViewGroup ViewGroup => ViewHandler.NativeView as ViewGroup;
+		public ViewGroup ViewGroup => null;
 
-		public global::Android.Views.View View => ViewHandler.NativeView as global::Android.Views.View;
+		public global::Android.Views.View View => ViewHandler.ContainerView ?? ViewHandler.NativeView;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;

--- a/src/Compatibility/Core/src/WinUI/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/WinUI/HandlerToRendererShim.cs
@@ -10,18 +10,16 @@ namespace Microsoft.Maui.Controls.Compatibility
 {
 	public class HandlerToRendererShim : IVisualElementRenderer
 	{
-		public HandlerToRendererShim(IViewHandler vh)
+		public HandlerToRendererShim(INativeViewHandler vh)
 		{
 			ViewHandler = vh;
 		}
 
-		IViewHandler ViewHandler { get; }
+		INativeViewHandler ViewHandler { get; }
 
 		public VisualElement Element { get; private set; }
 
-		public FrameworkElement NativeView => (FrameworkElement)ViewHandler.NativeView;
-
-		public FrameworkElement ContainerElement => (FrameworkElement)ViewHandler.NativeView;
+		public FrameworkElement ContainerElement => ViewHandler.ContainerView ?? ViewHandler.NativeView;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;

--- a/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
@@ -9,18 +9,18 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {
 	public class HandlerToRendererShim : IVisualElementRenderer
 	{
-		public HandlerToRendererShim(IViewHandler vh)
+		public HandlerToRendererShim(INativeViewHandler vh)
 		{
 			ViewHandler = vh;
 		}
 
-		IViewHandler ViewHandler { get; }
+		INativeViewHandler ViewHandler { get; }
 
 		public VisualElement Element { get; private set; }
 
-		public UIView NativeView => (UIView)ViewHandler.NativeView;
+		public UIView NativeView => ViewHandler.ContainerView ?? ViewHandler.NativeView;
 
-		public UIViewController ViewController => (ViewHandler as INativeViewHandler)?.ViewController;
+		public UIViewController ViewController => ViewHandler.ViewController;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;

--- a/src/Core/src/Platform/Android/WrapperView.cs
+++ b/src/Core/src/Platform/Android/WrapperView.cs
@@ -25,7 +25,10 @@ namespace Microsoft.Maui
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{
 			if (ChildCount == 0 || GetChildAt(0) is not View child)
+			{
+				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
 				return;
+			}
 
 			child.Measure(widthMeasureSpec, heightMeasureSpec);
 


### PR DESCRIPTION
### Description of Change ###

Make sure to use the container view first, and then use the actual view.

Fixes #1318