### PR TITLE
Preserve the debug logger

### DIFF
--- a/src/Core/src/Hosting/Internal/FallbackLogging.Debug.cs
+++ b/src/Core/src/Hosting/Internal/FallbackLogging.Debug.cs
@@ -1,0 +1,19 @@
+#nullable enable
+#define DEBUG
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Maui.Hosting.Internal
+{
+	partial class FallbackLoggerFactory
+	{
+		partial class FallbackLogger : ILogger
+		{
+			void DebugWriteLine(string message)
+			{
+				Debug.WriteLine(message, category: _categoryName);
+			}
+		}
+	}
+}

--- a/src/Core/src/Hosting/Internal/FallbackLogging.cs
+++ b/src/Core/src/Hosting/Internal/FallbackLogging.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui.Hosting.Internal
 {
-	class FallbackLoggerFactory : ILoggerFactory
+	partial class FallbackLoggerFactory : ILoggerFactory
 	{
 		public void AddProvider(ILoggerProvider provider) { }
 
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Hosting.Internal
 
 		public void Dispose() { }
 
-		class FallbackLogger : ILogger
+		partial class FallbackLogger : ILogger
 		{
 			private string _categoryName;
 
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Hosting.Internal
 				if (exception != null)
 					message += Environment.NewLine + Environment.NewLine + exception;
 
-				Debug.WriteLine(message, category: _categoryName);
+				DebugWriteLine(message);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

`Debug.WriteLine` will get removed in release builds, so make sure that method is always in a DEBUG build. Copying the tricks from dotnet/runtime: https://github.com/dotnet/runtime/blob/b90631f64809a77beb7a6aef787f0254956d522b/src/libraries/Microsoft.Extensions.Logging.Debug/src/DebugLogger.debug.cs#L7