### PR TITLE
[build] skip signing for Microsoft.Extensions assemblies

### DIFF
--- a/eng/automation/SignList.xml
+++ b/eng/automation/SignList.xml
@@ -37,6 +37,7 @@
     <Skip Include="NuGet.*.dll" />
     <Skip Include="Mono.*.dll" />
     <Skip Include="Microsoft.Build.*.dll" />
+    <Skip Include="Microsoft.Extensions.*.dll" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of Change ###

Since 3f78ce00, signing is failing with:

    Unknown assemblies:
        C:\A\1\_temp\artifact-signing\extracted\Microsoft.Maui.Extensions.6.0.100-ci.main.803\lib\net6.0\Microsoft.Extensions.Configuration.dll;
        C:\A\1\_temp\artifact-signing\extracted\Microsoft.Maui.Extensions.6.0.100-ci.main.803\lib\net6.0\Microsoft.Extensions.DependencyInjection.dll;
        C:\A\1\_temp\artifact-signing\extracted\Microsoft.Maui.Extensions.6.0.100-ci.main.803\lib\net6.0\Microsoft.Extensions.FileProviders.Embedded.dll;
        C:\A\1\_temp\artifact-signing\extracted\Microsoft.Maui.Extensions.6.0.100-ci.main.803\lib\net6.0\Microsoft.Extensions.Hosting.Abstractions.dll;
        C:\A\1\_temp\artifact-signing\extracted\Microsoft.Maui.Extensions.6.0.100-ci.main.803\lib\net6.0\Microsoft.Extensions.Logging.Abstractions.dll

Reviewing these assemblies, they are already signed by `.NET` and we
are just redistributing them in the .NET MAUI workload.

I think we just need to add a `<Skip/>` entry in `SignList.xml`.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No
