### PR TITLE
[templates] update WinUI templates for workload

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -29,29 +29,11 @@
         "datatype": "string",
         "replaces": "com.companyname.MauiApp1"
       },
-      "microsoftExtensionsVersion": {
-        "type": "parameter",
-        "dataType": "string",
-        "replaces": "MICROSOFT_EXTENSIONS_VERSION",
-        "defaultValue": "6.0.0-preview.5.*"
-      },
-      "projectReunionVersion": {
-        "type": "parameter",
-        "dataType": "string",
-        "replaces": "PROJECT_REUNION_VERSION",
-        "defaultValue": "0.8.0-preview"
-      },
       "windowsSdkVersion": {
         "type": "parameter",
         "dataType": "string",
         "replaces": "WINDOWS_SDK_VERSION",
         "defaultValue": "10.0.19041.16"
-      },
-      "mauiVersion": {
-        "type": "parameter",
-        "dataType": "string",
-        "replaces": "MAUI_VERSION",
-        "defaultValue": "MAUI_VERSION_VALUE"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/MauiApp1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/MauiApp1.WinUI.csproj
@@ -4,6 +4,7 @@
 		<TargetFrameworks>net6.0-windows10.0.19041</TargetFrameworks>
 		<OutputType>WinExe</OutputType>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<RootNamespace>MauiApp1</RootNamespace>
 
@@ -59,15 +60,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="MAUI_VERSION" />
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="MICROSOFT_EXTENSIONS_VERSION" />
-		<PackageReference Include="Microsoft.Maui" Version="MAUI_VERSION" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.ProjectReunion" Version="PROJECT_REUNION_VERSION" />
-		<PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="PROJECT_REUNION_VERSION" />
-		<PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="PROJECT_REUNION_VERSION" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="WINDOWS_SDK_VERSION" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="WINDOWS_SDK_VERSION" />
 	</ItemGroup>

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -25,29 +25,11 @@
         "datatype": "string",
         "replaces": "com.companyname.MauiApp1"
       },
-      "microsoftExtensionsVersion": {
-        "type": "parameter",
-        "dataType": "string",
-        "replaces": "MICROSOFT_EXTENSIONS_VERSION",
-        "defaultValue": "6.0.0-preview.5.*"
-      },
-      "projectReunionVersion": {
-        "type": "parameter",
-        "dataType": "string",
-        "replaces": "PROJECT_REUNION_VERSION",
-        "defaultValue": "0.8.0-preview"
-      },
       "windowsSdkVersion": {
         "type": "parameter",
         "dataType": "string",
         "replaces": "WINDOWS_SDK_VERSION",
         "defaultValue": "10.0.19041.16"
-      },
-      "mauiVersion": {
-        "type": "parameter",
-        "dataType": "string",
-        "replaces": "MAUI_VERSION",
-        "defaultValue": "MAUI_VERSION_VALUE"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/MauiApp1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/MauiApp1.WinUI.csproj
@@ -4,6 +4,7 @@
 		<TargetFrameworks>net6.0-windows10.0.19041</TargetFrameworks>
 		<OutputType>WinExe</OutputType>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<RootNamespace>MauiApp1</RootNamespace>
 
@@ -50,13 +51,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui" Version="MAUI_VERSION" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.ProjectReunion" Version="PROJECT_REUNION_VERSION" />
-		<PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="PROJECT_REUNION_VERSION" />
-		<PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="PROJECT_REUNION_VERSION" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="WINDOWS_SDK_VERSION" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="WINDOWS_SDK_VERSION" />
 	</ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Since 3f78ce00, we don't actually need any of the following in project files:

    <PackageReference Include="Microsoft.Maui" Version="MAUI_VERSION" />
    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="MICROSOFT_EXTENSIONS_VERSION" />
    <PackageReference Include="Microsoft.ProjectReunion" Version="PROJECT_REUNION_VERSION" />
    <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="PROJECT_REUNION_VERSION" />
    <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="PROJECT_REUNION_VERSION" />

When you declare `<UseMaui>true</UseMaui>` these come in automatically.

I believe I missed these changes after fixing merge conflicts, etc.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No