### PR TITLE
[workload] fix Microsoft.Maui.Extensions package

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -45,8 +45,20 @@
         Version="$(_MicrosoftHostingVersion)"
     />
     <PackageReference
+        Update="Microsoft.Extensions.Configuration.Abstractions"
+        Version="$(_MicrosoftHostingVersion)"
+    />
+    <PackageReference
         Update="Microsoft.Extensions.DependencyInjection"
         Version="$(_MicrosoftDependencyInjectionVersion)"
+    />
+    <PackageReference
+        Update="Microsoft.Extensions.DependencyInjection.Abstractions"
+        Version="$(_MicrosoftDependencyInjectionVersion)"
+    />
+    <PackageReference
+        Update="Microsoft.Extensions.FileProviders.Abstractions"
+        Version="$(_MicrosoftFileProvidersVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.FileProviders.Embedded"

--- a/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
+++ b/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
@@ -9,15 +9,29 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration"          GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"    GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"   GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"   GeneratePathProperty="true" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration)/lib/netstandard2.0/Microsoft.Extensions.Configuration.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration)/lib/netstandard2.0/Microsoft.Extensions.Configuration.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Configuration.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Configuration.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.Hosting.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.Hosting.Abstractions.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Embedded)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Embedded)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.xml" />
     <None Include="@(_ExtensionsFiles)" FullTfm="@(_TargetPlatform->'%(FullTfm)')" Tfm="@(_TargetPlatform->'%(Tfm)')" Profile="@(_TargetPlatform->'%(Profile)')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/net6.0/%(FileName)%(Extension)" />
     <_PackageFiles Include="@(None)" PackagePath="lib/net6.0" TargetPath="lib/net6.0" />


### PR DESCRIPTION
### Description of Change ###

Since 3f78ce00, using the workload in an app causes a crash on startup:

     System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' or one of its dependencies.

I missed this assembly, which is a dependency of
`Microsoft.Extensions.DependencyInjection`.

In total, the following were missing:

* `Microsoft.Extensions.Configuration.Abstractions`
* `Microsoft.Extensions.DependencyInjection.Abstractions`
* `Microsoft.Extensions.FileProviders.Abstractions`

I also included the `*.xml` documentation files for these assemblies
that were left out by mistake.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No