### PR TITLE
A few things to help profiling

### DIFF
--- a/src/Core/src/Fonts/EmbeddedFontLoader.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.cs
@@ -24,10 +24,18 @@ namespace Microsoft.Maui
 
 		public EmbeddedFontLoader(ILogger<EmbeddedFontLoader>? logger = null)
 #if __ANDROID__
-			: base(Path.GetTempPath(), logger)
+			: base(GetTempPath(), logger)
 #endif
 		{
 			_logger = logger;
 		}
+
+#if __ANDROID__
+		static string GetTempPath()
+		{
+			var ctx = Android.App.Application.Context;
+			return ctx.CacheDir?.AbsolutePath ?? Path.GetTempPath();
+		}
+#endif
 	}
 }

--- a/src/Core/src/Fonts/FontFile.cs
+++ b/src/Core/src/Fonts/FontFile.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Maui
 {
@@ -31,11 +30,16 @@ namespace Microsoft.Maui
 			//Get the fontFamily name;
 			var fontFamilyName = hashIndex > 0 ? input.Substring(0, hashIndex) : input;
 
-			var foundExtension = Extensions.
-				FirstOrDefault(x => fontFamilyName.EndsWith(x, StringComparison.OrdinalIgnoreCase));
-
-			if (!string.IsNullOrWhiteSpace(foundExtension))
-				fontFamilyName = fontFamilyName.Substring(0, fontFamilyName.Length - foundExtension.Length);
+			string? foundExtension = null;
+			foreach (var extension in Extensions)
+			{
+				if (fontFamilyName.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+				{
+					foundExtension = extension;
+					fontFamilyName = fontFamilyName.Substring(0, fontFamilyName.Length - foundExtension.Length);
+					break;
+				}
+			}
 
 			return new FontFile
 			{

--- a/src/Core/src/Fonts/FontManager.Windows.cs
+++ b/src/Core/src/Fonts/FontManager.Windows.cs
@@ -142,7 +142,10 @@ namespace Microsoft.Maui
 					using (var fontSet = new CanvasFontSet(fontUri))
 					{
 						if (fontSet.Fonts.Count != 0)
-							return fontSet.GetPropertyValues(CanvasFontPropertyIdentifier.FamilyName).FirstOrDefault().Value;
+						{
+							var props = fontSet.GetPropertyValues(CanvasFontPropertyIdentifier.FamilyName);
+							return props.Length == 0 ? null : props[0].Value;
+						}
 					}
 				}
 

--- a/src/Core/src/Fonts/FontManager.Windows.cs
+++ b/src/Core/src/Fonts/FontManager.Windows.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graphics.Canvas.Text;
 using Microsoft.UI.Xaml.Media;

--- a/src/Core/src/Fonts/FontManager.iOS.cs
+++ b/src/Core/src/Fonts/FontManager.iOS.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using UIKit;
 
@@ -107,7 +106,7 @@ namespace Microsoft.Maui
 				{
 					UIFont? result = null;
 
-					if (UIFont.FamilyNames.Contains(family))
+					if (Array.IndexOf(UIFont.FamilyNames, family) != -1)
 					{
 						var descriptor = new UIFontDescriptor().CreateWithFamily(family);
 						if (hasAttributes)
@@ -125,7 +124,10 @@ namespace Microsoft.Maui
 
 					if (family.StartsWith(".SFUI", StringComparison.InvariantCultureIgnoreCase))
 					{
-						var fontWeight = family.Split('-').LastOrDefault();
+						var weights = family.Split('-');
+						var fontWeight = weights.Length == 0
+							? null
+							: weights[weights.Length - 1];
 
 						if (!string.IsNullOrWhiteSpace(fontWeight) && Enum.TryParse<UIFontWeight>(fontWeight, true, out var uIFontWeight))
 						{

--- a/src/Core/src/Fonts/FontRegistrar.cs
+++ b/src/Core/src/Fonts/FontRegistrar.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 
@@ -82,29 +81,18 @@ namespace Microsoft.Maui
 			return _fontLookupCache[cacheKey] = result;
 		}
 
-		Stream GetEmbeddedResourceStream((string Filename, string? Alias, Assembly Assembly) embeddedFont)
+		static Stream GetEmbeddedResourceStream((string Filename, string? Alias, Assembly Assembly) embeddedFont)
 		{
 			var resourceNames = embeddedFont.Assembly.GetManifestResourceNames();
+			var searchName = "." + embeddedFont.Filename;
 
-			var resourcePaths = resourceNames
-				.Where(x => x.EndsWith(embeddedFont.Filename, StringComparison.CurrentCultureIgnoreCase))
-				.ToArray();
+			foreach (var name in resourceNames)
+			{
+				if (name.EndsWith(searchName, StringComparison.CurrentCultureIgnoreCase))
+					return embeddedFont.Assembly.GetManifestResourceStream(name)!;
+			}
 
-			if (resourcePaths.Length == 0)
-				throw new FileNotFoundException($"Resource ending with {embeddedFont.Filename} not found.");
-
-			if (resourcePaths.Length > 1)
-				resourcePaths = resourcePaths.Where(x => IsFile(x, embeddedFont.Filename)).ToArray();
-
-			return embeddedFont.Assembly.GetManifestResourceStream(resourcePaths[0])!;
-		}
-
-		bool IsFile(string path, string file)
-		{
-			if (!path.EndsWith(file, StringComparison.Ordinal))
-				return false;
-
-			return path.Replace(file, "").EndsWith(".", StringComparison.Ordinal);
+			throw new FileNotFoundException($"Resource ending with {embeddedFont.Filename} not found.");
 		}
 	}
 }

--- a/src/Templates/src/templates/maui-blazor/MauiApp1/Startup.cs
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/Startup.cs
@@ -3,7 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Controls.Xaml;
 using MauiApp1.Data;
+
+[assembly: XamlCompilationAttribute(XamlCompilationOptions.Compile)]
 
 namespace MauiApp1
 {

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/Startup.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/Startup.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Controls.Xaml;
+
+[assembly: XamlCompilationAttribute(XamlCompilationOptions.Compile)]
 
 namespace MauiApp1
 {


### PR DESCRIPTION
### Description of Change ###

 - Add XamlC to the templates
 - Avoid the use of `Path.GetTempPath()` in the font loader because the first access to IO is slow. move it on a bit and see what changes
 - Remove some LINQ