### PR TITLE
[workload] add missing description for packs

### DIFF
--- a/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
@@ -4,6 +4,7 @@
   <Import Project="../Shared/Frameworks.targets" />
 
   <PropertyGroup>
+    <Description>.NET MAUI Controls targeting pack</Description>
     <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 

--- a/src/Workload/Microsoft.Maui.Controls.Runtime/Microsoft.Maui.Controls.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Runtime/Microsoft.Maui.Controls.Runtime.csproj
@@ -3,6 +3,10 @@
   <Import Project="../Shared/Common.targets" />
   <Import Project="../Shared/Frameworks.targets" />
 
+  <PropertyGroup>
+    <Description>.NET MAUI Controls runtime pack</Description>
+  </PropertyGroup>
+
   <!-- Android-only files -->
   <ItemGroup Condition=" '$(MauiPlatformName)' == 'android' ">
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Core/src/Android.FormsViewGroup/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.dll" />

--- a/src/Workload/Microsoft.Maui.Controls.Sdk/Microsoft.Maui.Controls.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Sdk/Microsoft.Maui.Controls.Sdk.csproj
@@ -3,6 +3,7 @@
   <Import Project="../Shared/Common.targets" />
 
   <PropertyGroup>
+    <Description>.NET MAUI SDK. Enabled via &lt;UseMaui&gt;true&lt;/UseMaui&gt;.</Description>
     <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 

--- a/src/Workload/Microsoft.Maui.Core.Ref/Microsoft.Maui.Core.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Core.Ref/Microsoft.Maui.Core.Ref.csproj
@@ -4,6 +4,7 @@
   <Import Project="../Shared/Frameworks.targets" />
 
   <PropertyGroup>
+    <Description>.NET MAUI Core targeting pack</Description>
     <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 

--- a/src/Workload/Microsoft.Maui.Core.Runtime/Microsoft.Maui.Core.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Core.Runtime/Microsoft.Maui.Core.Runtime.csproj
@@ -3,6 +3,10 @@
   <Import Project="../Shared/Common.targets" />
   <Import Project="../Shared/Frameworks.targets" />
 
+  <PropertyGroup>
+    <Description>.NET MAUI Core runtime pack</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Core/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.dll')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/%(FullTfm)/%(FileName)%(Extension)" />

--- a/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
+++ b/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <PackageId>$(MSBuildProjectName)</PackageId>
+    <Description>.NET MAUI NuGet dependencies pack</Description>
     <TargetFrameworks>$(MauiPlatforms)</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GenerateDependencyFile>false</GenerateDependencyFile>

--- a/src/Workload/Microsoft.Maui.Essentials.Ref/Microsoft.Maui.Essentials.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Essentials.Ref/Microsoft.Maui.Essentials.Ref.csproj
@@ -4,6 +4,7 @@
   <Import Project="../Shared/Frameworks.targets" />
 
   <PropertyGroup>
+    <Description>.NET MAUI Essentials targeting pack</Description>
     <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 

--- a/src/Workload/Microsoft.Maui.Essentials.Runtime/Microsoft.Maui.Essentials.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Essentials.Runtime/Microsoft.Maui.Essentials.Runtime.csproj
@@ -3,6 +3,10 @@
   <Import Project="../Shared/Common.targets" />
   <Import Project="../Shared/Frameworks.targets" />
 
+  <PropertyGroup>
+    <Description>.NET MAUI Essentials runtime pack</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Essentials/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Essentials.dll')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/%(FullTfm)/%(FileName)%(Extension)" />

--- a/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
+++ b/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
@@ -4,6 +4,7 @@
   <Import Project="../Shared/FrameworkList.targets" />
 
   <PropertyGroup>
+    <Description>Microsoft.Extensions dependencies for .NET MAUI</Description>
     <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 

--- a/src/Workload/Microsoft.Maui.Resizetizer.Sdk/Microsoft.Maui.Resizetizer.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Resizetizer.Sdk/Microsoft.Maui.Resizetizer.Sdk.csproj
@@ -4,6 +4,7 @@
   <Import Project="$(MauiRootDirectory)src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems" />
 
   <PropertyGroup>
+    <Description>.NET MAUI SDK support for images, fonts, etc. Enabled via &lt;UseMauiAssets&gt;true&lt;/UseMauiAssets&gt;.</Description>
     <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <PackageId>$(PackageId).Manifest-$(DotNetPreviewVersionBand)</PackageId>
+    <Description>.NET MAUI workload manifest</Description>
   </PropertyGroup>
 
   <Import Project="$(MauiRootDirectory)eng/ReplaceText.targets" />


### PR DESCRIPTION
### Description of Change ###

I think this is probably a requirement if we pushed these packages to NuGet.org, added the missing `$(Description)` for each pack.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No