### PR TITLE
[workload] add missing Microsoft.Extensions.Primitives

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -85,6 +85,10 @@
         Version="$(_MicrosoftHostingVersion)"
     />
     <PackageReference
+        Update="Microsoft.Extensions.Primitives"
+        Version="$(_MicrosoftHostingVersion)"
+    />
+    <PackageReference
         Update="Microsoft.ProjectReunion"
         Version="$(_MicrosoftProjectReunionVersion)"
     />

--- a/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
+++ b/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"   GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.Primitives"             GeneratePathProperty="true" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration)/lib/netstandard2.0/Microsoft.Extensions.Configuration.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration)/lib/netstandard2.0/Microsoft.Extensions.Configuration.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Configuration.Abstractions.dll" />
@@ -33,6 +34,8 @@
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Embedded)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Primitives)/lib/netstandard2.0/Microsoft.Extensions.Primitives.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Primitives)/lib/netstandard2.0/Microsoft.Extensions.Primitives.xml" />
     <None Include="@(_ExtensionsFiles)" FullTfm="@(_TargetPlatform->'%(FullTfm)')" Tfm="@(_TargetPlatform->'%(Tfm)')" Profile="@(_TargetPlatform->'%(Profile)')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/net6.0/%(FileName)%(Extension)" />
     <_PackageFiles Include="@(None)" PackagePath="lib/net6.0" TargetPath="lib/net6.0" />


### PR DESCRIPTION
### Description of Change ###

Manually testing the workload again, I found one more dependency that
was missing:

    System.TypeLoadException: Could not load type of field 'Microsoft.Extensions.Configuration.ConfigurationRoot:_changeToken' (2) due to: Could not load file or assembly 'Microsoft.Extensions.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' or one of its dependencies.

I missed this one in a12e5147, because NuGet brought in transitive
dependencies when I was testing. I added each `@(PackageReference)` to
the project template until it ran successfully. This package came in
automatically, and I didn't notice...

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No