### PR TITLE
Enable Android WebKit WebView debugging

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -26,6 +26,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 #pragma warning restore 618
 			};
 
+			AWebView.SetWebContentsDebuggingEnabled(enabled: true);
+
 			if (aWebView.Settings != null)
 			{
 				aWebView.Settings.JavaScriptEnabled = true;


### PR DESCRIPTION
This enables Chrome to debug the WebView. Eventually we need to figure out _when_ to set this, but for now all the platforms have this enabled by default.

![image](https://user-images.githubusercontent.com/202643/122599751-ae33df80-d023-11eb-8f0e-d923a9490ccc.png)
