### PR TITLE
Default to MS DI

### DIFF
--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -89,10 +89,6 @@ namespace Maui.Controls.Sample
 #endif
 				appBuilder.UseMicrosoftExtensionsServiceProviderFactory();
 			}
-			else
-			{
-				appBuilder.UseMauiServiceProviderFactory(constructorInjection: true);
-			}
 
 			appBuilder
 				.ConfigureServices(services =>
@@ -117,7 +113,7 @@ namespace Maui.Controls.Sample
 						services.AddBlazorWebView();
 #endif
 					services.AddTransient(
-						serviceType: _pageType == PageType.Blazor ? typeof(Page) : typeof(IPage),
+						serviceType: typeof(Page),
 						implementationType: _pageType switch
 						{
 							PageType.Shell => typeof(AppShell),

--- a/src/Core/src/Hosting/AppHost.cs
+++ b/src/Core/src/Hosting/AppHost.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Hosting
 		{
 			var builder = new AppHostBuilder();
 
-			builder.UseMauiServiceProviderFactory(false);
+			builder.UseMicrosoftExtensionsServiceProviderFactory();
 			builder.ConfigureFonts();
 			builder.ConfigureImageSources();
 


### PR DESCRIPTION
### Description of Change ###

At this point we need to start tuning for the MS.Ext.DI implementation. Blazor needs Scoped containers so the ideal situation when we release is that we can tune our startup performance against Ms.Ext.DI

Also, using our own implementation vs Ms.Ext.Di is currently leading to odd differences in how resolution works

For example this code inside our startup
```C#
serviceType: _pageType == PageType.Blazor ? typeof(Page) : typeof(IPage),
```

Just to accommodate different  ServiceProviderFactories doesn't really make sense
