### PR TITLE
[workload] fixes for WinUI

### DIFF
--- a/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/AutoImport.props
+++ b/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/AutoImport.props
@@ -74,4 +74,32 @@
     />
   </ItemGroup>
 
+  <!-- Windows -->
+  <ItemGroup Condition=" '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'windows' and '$(WindowsProjectFolder)' != '' ">
+    <Manifest
+        Include="$(ApplicationManifest)"
+        Condition="Exists('$(ApplicationManifest)')" />
+    <AppxManifest
+        Include="$(PackageManifest)"
+        Condition="Exists('$(PackageManifest)')" />
+    <ApplicationDefinition
+        Condition="Exists('$(WindowsProjectFolder)App.xaml')"
+        Include="$(WindowsProjectFolder)App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </ApplicationDefinition>
+    <ApplicationDefinition
+        Condition="Exists('$(WindowsProjectFolder)\Application.xaml')"
+        Include="$(WindowsProjectFolder)Application.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </ApplicationDefinition>
+    <Page
+        Include="$(WindowsProjectFolder)**/*.xaml"
+        Exclude="$(_SingleProjectWindowsExcludes);@(ApplicationDefinition)">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+  </ItemGroup>
+
 </Project>

--- a/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/BundledVersions.in.targets
@@ -1,11 +1,14 @@
 <Project>
   <PropertyGroup>
     <MicrosoftMauiSdkVersion Condition=" '$(MicrosoftMauiSdkVersion)' == '' ">@VERSION@</MicrosoftMauiSdkVersion>
+    <!-- $(_MauiPlatformName) is used as RIDs as well as a suffix to targeting pack names -->
+    <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">win</_MauiPlatformName>
+    <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' != 'windows' ">$(TargetPlatformIdentifier.ToLowerInvariant())</_MauiPlatformName>
   </PropertyGroup>
 
   <!-- Framework references -->
   <ItemGroup>
-    <_MauiRuntimeIdentifiers Include="android;ios;maccatalyst;windows" />
+    <_MauiRuntimeIdentifiers Include="android;ios;maccatalyst;win" />
     <KnownFrameworkReference
         Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' "
         Include="Microsoft.Maui.Extensions"
@@ -25,10 +28,10 @@
         RuntimeFrameworkName="Microsoft.Maui.Core"
         DefaultRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
         LatestRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
-        TargetingPackName="Microsoft.Maui.Core.Ref.$(TargetPlatformIdentifier.ToLowerInvariant())"
+        TargetingPackName="Microsoft.Maui.Core.Ref.$(_MauiPlatformName)"
         TargetingPackVersion="$(MicrosoftMauiSdkVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Core.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="@(_MauiRuntimeIdentifiers)"
+        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"
     />
     <KnownFrameworkReference
@@ -38,10 +41,10 @@
         RuntimeFrameworkName="Microsoft.Maui.Controls"
         DefaultRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
         LatestRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
-        TargetingPackName="Microsoft.Maui.Controls.Ref.$(TargetPlatformIdentifier.ToLowerInvariant())"
+        TargetingPackName="Microsoft.Maui.Controls.Ref.$(_MauiPlatformName)"
         TargetingPackVersion="$(MicrosoftMauiSdkVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Controls.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="@(_MauiRuntimeIdentifiers)"
+        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"
     />
     <KnownFrameworkReference
@@ -51,10 +54,10 @@
         RuntimeFrameworkName="Microsoft.Maui.Essentials"
         DefaultRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
         LatestRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
-        TargetingPackName="Microsoft.Maui.Essentials.Ref.$(TargetPlatformIdentifier.ToLowerInvariant())"
+        TargetingPackName="Microsoft.Maui.Essentials.Ref.$(_MauiPlatformName)"
         TargetingPackVersion="$(MicrosoftMauiSdkVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Essentials.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="@(_MauiRuntimeIdentifiers)"
+        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"
     />
   </ItemGroup>

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -82,12 +82,12 @@
       "description": ".NET MAUI SDK for Windows",
       "extends": [ "maui-core" ],
       "packs": [
-          "Microsoft.Maui.Core.Ref.windows",
-          "Microsoft.Maui.Core.Runtime.windows",
-          "Microsoft.Maui.Controls.Ref.windows",
-          "Microsoft.Maui.Controls.Runtime.windows",
-          "Microsoft.Maui.Essentials.Ref.windows",
-          "Microsoft.Maui.Essentials.Runtime.windows"
+          "Microsoft.Maui.Core.Ref.win",
+          "Microsoft.Maui.Core.Runtime.win",
+          "Microsoft.Maui.Controls.Ref.win",
+          "Microsoft.Maui.Controls.Runtime.win",
+          "Microsoft.Maui.Essentials.Ref.win",
+          "Microsoft.Maui.Essentials.Runtime.win"
       ]
     }
   },
@@ -108,7 +108,7 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Core.Ref.windows": {
+    "Microsoft.Maui.Core.Ref.win": {
       "kind": "framework",
       "version": "@VERSION@"
     },
@@ -124,7 +124,7 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Core.Runtime.windows": {
+    "Microsoft.Maui.Core.Runtime.win": {
       "kind": "framework",
       "version": "@VERSION@"
     },
@@ -140,7 +140,7 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Controls.Ref.windows": {
+    "Microsoft.Maui.Controls.Ref.win": {
       "kind": "framework",
       "version": "@VERSION@"
     },
@@ -156,7 +156,7 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Controls.Runtime.windows": {
+    "Microsoft.Maui.Controls.Runtime.win": {
       "kind": "framework",
       "version": "@VERSION@"
     },
@@ -176,7 +176,7 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Essentials.Ref.windows": {
+    "Microsoft.Maui.Essentials.Ref.win": {
       "kind": "framework",
       "version": "@VERSION@"
     },
@@ -192,7 +192,7 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Essentials.Runtime.windows": {
+    "Microsoft.Maui.Essentials.Runtime.win": {
       "kind": "framework",
       "version": "@VERSION@"
     },

--- a/src/Workload/Shared/Frameworks.targets
+++ b/src/Workload/Shared/Frameworks.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Condition=" '$(MauiPlatformName)' != '' ">
-    <!-- NOTE: $(MauiPlatformName) is expected to be passed in: android, maccatalyst, ios, or windows -->
+    <!-- NOTE: $(MauiPlatformName) is expected to be passed in: android, maccatalyst, ios, or win -->
     <PackageId>$(PackageId).$(MauiPlatformName)</PackageId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(MauiPlatformName)' == '' ">
@@ -31,7 +31,7 @@
         Profile="MacCatalyst"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'windows' "
+        Condition=" '$(MauiPlatformName)' == 'win' "
         Include="$(WindowsTargetFramework)"
         FullTfm="%(Identity)"
         Tfm="$(WindowsTargetFramework)"
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <_Platforms Include="android;maccatalyst;ios" />
-    <_Platforms Include="windows" Condition=" '$(BuildForWinUI)' == 'true' or '$(Packing)' == 'true' " />
+    <_Platforms Include="win" Condition=" '$(BuildForWinUI)' == 'true' or '$(Packing)' == 'true' " />
   </ItemGroup>
 
   <Target Name="_PackPerPlatform" Condition=" '$(MauiPlatformName)' == '' " AfterTargets="Build">


### PR DESCRIPTION
### Description of Change ###

Initially when testing the workload & WinUI, I would get errors during
`restore` such as:

    There was no runtime pack for Microsoft.Maui.Essentials available for the specified RuntimeIdentifier 'win10-arm64'.
    There was no runtime pack for Microsoft.Maui.Essentials available for the specified RuntimeIdentifier 'win10-x64'.
    There was no runtime pack for Microsoft.Maui.Essentials available for the specified RuntimeIdentifier 'win10-x86'.

I mistakenly named several of the packs with the suffix `windows`,
when it should be `win`, which is a valid `$(RuntimeIdentifier)`.

Additionally, I found some missing item groups in `AutoImport.props`
that I brought over from `SingleProject.props`.

After these changes, I can `dotnet new maui` and *build* the WinUI
project successfully. There are still some future changes needed when
launching the application.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No