### PR TITLE
[workload] add missing items to AutoImport.props

### DIFF
--- a/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/AutoImport.props
+++ b/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/AutoImport.props
@@ -28,7 +28,13 @@
 
   <!-- iOS -->
   <ItemGroup Condition=" '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'ios' and '$(iOSProjectFolder)' != '' ">
-    <None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
+    <None
+        Include="$(iOSProjectFolder)Info.plist"
+        Condition="Exists('$(iOSProjectFolder)Info.plist')"
+        LogicalName="Info.plist" />
+    <CodesignEntitlements
+        Include="$(iOSProjectFolder)Entitlements.plist"
+        Condition="Exists('$(iOSProjectFolder)Entitlements.plist')" />
     <ImageAsset
         Include="$(iOSProjectFolder)**/*.xcassets/**/*.png;$(iOSProjectFolder)**/*.xcassets/*/*.jpg;$(iOSProjectFolder)**/*.xcassets/**/*.pdf;$(iOSProjectFolder)**/*.xcassets/**/*.json"
         Exclude="$(_SingleProjectiOSExcludes)"
@@ -52,7 +58,13 @@
 
   <!-- MacCatalyst -->
   <ItemGroup Condition=" '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' ">
-    <None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
+    <None
+        Include="$(MacCatalystProjectFolder)Info.plist"
+        Condition="Exists('$(MacCatalystProjectFolder)Info.plist')"
+        LogicalName="Info.plist" />
+    <CodesignEntitlements
+        Include="$(MacCatalystProjectFolder)Entitlements.plist"
+        Condition="Exists('$(MacCatalystProjectFolder)Entitlements.plist')" />
     <ImageAsset
         Include="$(MacCatalystProjectFolder)**/*.xcassets/**/*.png;$(MacCatalystProjectFolder)**/*.xcassets/*/*.jpg;$(MacCatalystProjectFolder)**/*.xcassets/**/*.pdf;$(MacCatalystProjectFolder)**/*.xcassets/**/*.json"
         Exclude="$(_SingleProjectMacCatalystExcludes)"


### PR DESCRIPTION
### Description of Change ###

These changes were added to `SingleProject.props`, but did not get migrated over to `AutoImport.props`.

Eventually, we should find a solution to prevent the need for *both* of these files to exist.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No