### PR TITLE
Remove duplicate XSAppIconAssets in MacCatalyst template (#1335)

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1/MacCatalyst/Info.plist
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/MacCatalyst/Info.plist
@@ -9,8 +9,6 @@
 		<integer>1</integer>
 		<integer>2</integer>
 	</array>
-	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/appicon.appiconset</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MacCatalyst/Info.plist
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MacCatalyst/Info.plist
@@ -9,8 +9,6 @@
 		<integer>1</integer>
 		<integer>2</integer>
 	</array>
-	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/appicon.appiconset</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
### Description of Change ###

Fix #1335

@Eilon @Redth
