### PR TITLE
[workload] WinUI apps can launch again

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/MauiApp1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/MauiApp1.WinUI.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-windows10.0.19041</TargetFrameworks>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 		<OutputType>WinExe</OutputType>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<UseMaui>true</UseMaui>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/MauiApp1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/MauiApp1.WinUI.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-windows10.0.19041</TargetFrameworks>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 		<OutputType>WinExe</OutputType>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<UseMaui>true</UseMaui>

--- a/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/Microsoft.Maui.Controls.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/Microsoft.Maui.Controls.Sdk.After.targets
@@ -6,6 +6,7 @@
     <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
   <Import Project="../targets/Microsoft.Maui.Controls.targets" />
+  <Import Project="WinUI.targets" Condition=" '$(TargetPlatformIdentifier)' == 'windows' " />
   <ItemGroup Condition=" '$(DisableMauiAnalyzers)' != 'true' ">
     <Analyzer Include="$(MSBuildThisFileDirectory)../targets/Microsoft.Maui.Controls.dll" />
     <Analyzer Include="$(MSBuildThisFileDirectory)../targets/Microsoft.Maui.Controls.Xaml.dll" />

--- a/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/WinUI.targets
+++ b/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/WinUI.targets
@@ -1,0 +1,11 @@
+<!-- Workarounds for WinUI -->
+<Project>
+  <Target Name="_AddMauiPriFiles" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_ReferenceRelatedPaths
+          Include="@(ReferencePath->'%(RootDir)%(Directory)%(FileName).pri')"
+          Condition="Exists('%(RootDir)%(Directory)%(FileName).pri')"
+      />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
+++ b/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <Import Project="../Shared/LibraryPacks.targets" />
-  <Import Project="../Shared/WinUI.targets" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Graphics" />
@@ -28,6 +27,7 @@
     <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == '$(WindowsTargetFramework)' ">
+    <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" />
     <PackageReference Include="Microsoft.ProjectReunion" />
     <PackageReference Include="Microsoft.ProjectReunion.Foundation" />
     <PackageReference Include="Microsoft.ProjectReunion.WinUI" />

--- a/src/Workload/Shared/FrameworkList.targets
+++ b/src/Workload/Shared/FrameworkList.targets
@@ -36,6 +36,19 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_AddWindowsPriFiles"
+      AfterTargets="_GenerateFrameworkListFile"
+      Condition=" '$(MauiPlatformName)' == 'win' and $(MSBuildProjectName.Contains('.Ref')) ">
+    <ItemGroup>
+      <!-- Look for WinUI .pri files a directory above ref/*.dll files -->
+      <Content
+          Include="@(_AssemblyFiles->'%(RootDir)%(Directory)../%(FileName).pri')"
+          TargetPath=""
+          Condition="Exists('%(RootDir)%(Directory)../%(FileName).pri')"
+      />
+    </ItemGroup>
+  </Target>
+
   <!--
     HACK: temporarily put runtime packs in 'library-packs', until they can be resolved from 'packs'
     See: https://github.com/dotnet/sdk/issues/14044

--- a/src/Workload/Shared/WinUI.targets
+++ b/src/Workload/Shared/WinUI.targets
@@ -1,7 +1,0 @@
-<Project>
-  <Target Name="_WinUIFix" BeforeTargets="_GetSdkToolsPathsFromSdk" Condition="$(TargetFramework.Contains('-windows'))">
-    <PropertyGroup>
-      <TargetPlatformIdentifierAdjusted>UAP</TargetPlatformIdentifierAdjusted>
-    </PropertyGroup>
-  </Target>
-</Project>


### PR DESCRIPTION
### Description of Change ###

When trying to run a `dotnet new maui` WinUI app, I was getting a
popup that says:

    To run this application you must install .NET.
    The framework 'Microsoft.Maui.Core', version '0.0.1-alpha1' was not found.
    Would you like to download it now? Yes/No

I found that simply adding `<RuntimeIdentifier>win-x64</RuntimeIdentifier>`
solved this issue. I added this to WinUI project templates.

Next, I discovered that `Microsoft.Maui*.pri` files were missing from
our workload packs. I added all `*.pri` files to the `*.Ref` packs
that exist.

Even after the files were added, `ResolveAssemblyReference` was
*still* not finding the `*.pri` files!

Example when Maui was a NuGet:

    Primary reference "Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null".
        Resolved file path is "C:\Users\...\.nuget\packages\microsoft.maui.core\6.0.100-preview.5.794\lib\net6.0-windows10.0.18362\Microsoft.Maui.dll".
        Reference found at search path location "{HintPathFromItem}".
        Found related file "C:\Users\...\.nuget\packages\microsoft.maui.core\6.0.100-preview.5.794\lib\net6.0-windows10.0.18362\Microsoft.Maui.pdb".
        Found related file "C:\Users\...\.nuget\packages\microsoft.maui.core\6.0.100-preview.5.794\lib\net6.0-windows10.0.18362\Microsoft.Maui.pri".
        This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".

Example *now* when Maui is a workload:

    Primary reference "Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null".
        Resolved file path is "C:\Program Files\dotnet\packs\Microsoft.Maui.Core.Ref.win\0.0.1-alpha1\ref\net6.0-windows10.0.18362\Microsoft.Maui.dll".
        Reference found at search path location "{RawFileName}".
        This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".

I believe that this was happening due to code in MSBuild:

https://github.com/dotnet/msbuild/blob/2013004e99daa2e0b50f3581abd90640b63d4fd5/src/Tasks/AssemblyDependency/ReferenceTable.cs#L1722-L1723

It appears that `*.pri` files won't automatically be located for
`@(FrameworkReference)` items?

To solve this issue, I added a new `_AddMauiPriFiles` MSBuild target
to add the missing files. We can investigate if there is a better way
to do this down the road.

Other changes:

* Delete `src/Workload/Shared/WinUI.targets`, it is no longer needed.
* `Microsoft.Maui.Graphics.Win2D.WinUI.Desktop` was missing from
  `Microsoft.Maui.Dependencies`.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No