### PR TITLE
[templates] add ProjectReunion packages to WinUI template

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -29,11 +29,11 @@
         "datatype": "string",
         "replaces": "com.companyname.MauiApp1"
       },
-      "windowsSdkVersion": {
+      "projectReunionVersion": {
         "type": "parameter",
         "dataType": "string",
-        "replaces": "WINDOWS_SDK_VERSION",
-        "defaultValue": "10.0.19041.16"
+        "replaces": "PROJECT_REUNION_VERSION",
+        "defaultValue": "0.8.0-preview"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/MauiApp1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/MauiApp1.WinUI.csproj
@@ -61,8 +61,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="WINDOWS_SDK_VERSION" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="WINDOWS_SDK_VERSION" />
+		<PackageReference Include="Microsoft.ProjectReunion" Version="PROJECT_REUNION_VERSION" />
+		<PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="PROJECT_REUNION_VERSION" />
+		<PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="PROJECT_REUNION_VERSION" />
 	</ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -25,11 +25,11 @@
         "datatype": "string",
         "replaces": "com.companyname.MauiApp1"
       },
-      "windowsSdkVersion": {
+      "projectReunionVersion": {
         "type": "parameter",
         "dataType": "string",
-        "replaces": "WINDOWS_SDK_VERSION",
-        "defaultValue": "10.0.19041.16"
+        "replaces": "PROJECT_REUNION_VERSION",
+        "defaultValue": "0.8.0-preview"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/MauiApp1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/MauiApp1.WinUI.csproj
@@ -52,8 +52,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="WINDOWS_SDK_VERSION" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="WINDOWS_SDK_VERSION" />
+		<PackageReference Include="Microsoft.ProjectReunion" Version="PROJECT_REUNION_VERSION" />
+		<PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="PROJECT_REUNION_VERSION" />
+		<PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="PROJECT_REUNION_VERSION" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of Change ###

This partially reverts c061b5cd.

It turns out you *must* include ProjectReunion packages to a WinUI
project, because the NuGet packages do not use a `buildTransitive`
folder. They only have a `build` folder:

https://www.nuget.org/packages/Microsoft.ProjectReunion/0.8.0-preview

Contents:

    build
    package
    tools
    Microsoft.ProjectReunion.nuspec
    license.txt

Adding this to the template gets the WinUI projects working without
any manual changes.

We can remove the `@(FrameworkReference)` in the template as well.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No