### PR TITLE
[templates] fix maui-blazor template

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -29,6 +29,12 @@
         "datatype": "string",
         "replaces": "com.companyname.MauiApp1"
       },
+      "microsoftExtensionsVersion": {
+        "type": "parameter",
+        "dataType": "string",
+        "replaces": "MICROSOFT_EXTENSIONS_VERSION",
+        "defaultValue": "6.0.0-preview.5.*"
+      },
       "projectReunionVersion": {
         "type": "parameter",
         "dataType": "string",

--- a/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/MauiApp1.WinUI.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/MauiApp1.WinUI.csproj
@@ -61,6 +61,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="MICROSOFT_EXTENSIONS_VERSION" />
 		<PackageReference Include="Microsoft.ProjectReunion" Version="PROJECT_REUNION_VERSION" />
 		<PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="PROJECT_REUNION_VERSION" />
 		<PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="PROJECT_REUNION_VERSION" />

--- a/src/Templates/src/templates/maui-blazor/MauiApp1/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/MauiApp1.csproj
@@ -37,6 +37,10 @@
 		<MauiFont Include="Resources\Fonts\*" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="MICROSOFT_EXTENSIONS_VERSION" />
+	</ItemGroup>
+
 	<PropertyGroup>
 		<InvariantGlobalization Condition="$(TargetFramework.Contains('-maccatalyst'))">true</InvariantGlobalization>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-ios'))">iossimulator-x64</RuntimeIdentifier>


### PR DESCRIPTION
### Description of Change ###

In c061b5cd, I inadvertently broke the `maui-blazor` template. It
crashes on startup with:

    System.InvalidOperationException: Could not load the embedded file manifest 'Microsoft.Extensions.FileProviders.Embedded.Manifest.xml' for assembly 'foo'.

It turns out that `Microsoft.Extensions.FileProviders.Embedded` is
also missing the `buildTransitive` folder--the same problem we saw
with the ProjectReunion packages:

https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Embedded/6.0.0-preview.5.21301.17

Contents:

    build
    buildMultiTargeting
    lib
    package
    tasks
    Microsoft.Extensions.FileProviders.Embedded.nuspec
    Icon.png

Adding the package to the `.csproj` directly solves this issue, so we
have to include this in the `maui-blazor` template.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No
