### PR TITLE
Fix crash in CollectionView/CarouselView without setting the BackgroundColor

### DIFF
--- a/src/Compatibility/Core/src/Android/CollectionView/ItemsViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/ItemsViewRenderer.cs
@@ -461,11 +461,14 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		protected virtual void UpdateBackgroundColor(Color color = null)
 		{
 			if (Element == null)
-			{
 				return;
-			}
+			
+			var backgroundColor = color ?? Element.BackgroundColor;
 
-			SetBackgroundColor((color ?? Element.BackgroundColor).ToAndroid());
+			if (backgroundColor == null)
+				return;
+
+			SetBackgroundColor(backgroundColor.ToAndroid());
 		}
 
 		protected virtual void UpdateBackground(Brush brush = null)


### PR DESCRIPTION
### Description of Change ###

Fix crash in CollectionView/CarouselView without setting the BackgroundColor. This is because in Xamarin.Forms the default Color value was Color.Default and now is null.

This PR add changes to not set the native control BackgroundColor if the color property is null.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No