### PR TITLE
Port FlexLayout to Core

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5765.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue5765.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Maui.Controls.CustomAttributes;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
 
 #if UITEST
 using Microsoft.Maui.Controls.Compatibility.UITests;

--- a/src/Controls/src/Core/FlexEnums.cs
+++ b/src/Controls/src/Core/FlexEnums.cs
@@ -1,19 +1,10 @@
 using System;
 using System.Globalization;
+using Microsoft.Maui.Layouts;
+using Flex = Microsoft.Maui.Layouts.Flex;
 
 namespace Microsoft.Maui.Controls
 {
-	[TypeConverter(typeof(FlexJustifyTypeConverter))]
-	public enum FlexJustify
-	{
-		Start = Flex.Justify.Start,
-		Center = Flex.Justify.Center,
-		End = Flex.Justify.End,
-		SpaceBetween = Flex.Justify.SpaceBetween,
-		SpaceAround = Flex.Justify.SpaceAround,
-		SpaceEvenly = Flex.Justify.SpaceEvenly,
-	}
-
 	[Xaml.TypeConversion(typeof(FlexJustify))]
 	public class FlexJustifyTypeConverter : TypeConverter
 	{
@@ -43,21 +34,6 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	public enum FlexPosition
-	{
-		Relative = Flex.Position.Relative,
-		Absolute = Flex.Position.Absolute,
-	}
-
-	[TypeConverter(typeof(FlexDirectionTypeConverter))]
-	public enum FlexDirection
-	{
-		Column = Flex.Direction.Column,
-		ColumnReverse = Flex.Direction.ColumnReverse,
-		Row = Flex.Direction.Row,
-		RowReverse = Flex.Direction.RowReverse,
-	}
-
 	[Xaml.TypeConversion(typeof(FlexDirection))]
 	public class FlexDirectionTypeConverter : TypeConverter
 	{
@@ -81,18 +57,6 @@ namespace Microsoft.Maui.Controls
 				throw new NotSupportedException();
 			return fd.ToString();
 		}
-	}
-
-	[TypeConverter(typeof(FlexAlignContentTypeConverter))]
-	public enum FlexAlignContent
-	{
-		Stretch = Flex.AlignContent.Stretch,
-		Center = Flex.AlignContent.Center,
-		Start = Flex.AlignContent.Start,
-		End = Flex.AlignContent.End,
-		SpaceBetween = Flex.AlignContent.SpaceBetween,
-		SpaceAround = Flex.AlignContent.SpaceAround,
-		SpaceEvenly = Flex.AlignContent.SpaceEvenly,
 	}
 
 	[Xaml.TypeConversion(typeof(FlexAlignContent))]
@@ -124,16 +88,6 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	[TypeConverter(typeof(FlexAlignItemsTypeConverter))]
-	public enum FlexAlignItems
-	{
-		Stretch = Flex.AlignItems.Stretch,
-		Center = Flex.AlignItems.Center,
-		Start = Flex.AlignItems.Start,
-		End = Flex.AlignItems.End,
-		//Baseline = Flex.AlignItems.Baseline,
-	}
-
 	[Xaml.TypeConversion(typeof(FlexAlignItems))]
 	public class FlexAlignItemsTypeConverter : TypeConverter
 	{
@@ -157,17 +111,6 @@ namespace Microsoft.Maui.Controls
 				throw new NotSupportedException();
 			return fai.ToString();
 		}
-	}
-
-	[TypeConverter(typeof(FlexAlignSelfTypeConverter))]
-	public enum FlexAlignSelf
-	{
-		Auto = Flex.AlignSelf.Auto,
-		Stretch = Flex.AlignSelf.Stretch,
-		Center = Flex.AlignSelf.Center,
-		Start = Flex.AlignSelf.Start,
-		End = Flex.AlignSelf.End,
-		//Baseline = Flex.AlignSelf.Baseline,
 	}
 
 	[Xaml.TypeConversion(typeof(FlexAlignSelf))]
@@ -195,14 +138,6 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	[TypeConverter(typeof(FlexWrapTypeConverter))]
-	public enum FlexWrap
-	{
-		NoWrap = Flex.Wrap.NoWrap,
-		Wrap = Flex.Wrap.Wrap,
-		Reverse = Flex.Wrap.WrapReverse,
-	}
-
 	[Xaml.TypeConversion(typeof(FlexWrap))]
 	public class FlexWrapTypeConverter : TypeConverter
 	{
@@ -226,59 +161,33 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	[TypeConverter(typeof(FlexBasisTypeConverter))]
-	public struct FlexBasis
+	[Xaml.TypeConversion(typeof(FlexBasis))]
+	public class FlexBasisTypeConverter : TypeConverter
 	{
-		bool _isLength;
-		bool _isRelative;
-		public static FlexBasis Auto = new FlexBasis();
-		public float Length { get; }
-		internal bool IsAuto => !_isLength && !_isRelative;
-		internal bool IsRelative => _isRelative;
-		public FlexBasis(float length, bool isRelative = false)
+		public override object ConvertFromInvariantString(string value)
 		{
-			if (length < 0)
-				throw new ArgumentException("should be a positive value", nameof(length));
-			if (isRelative && length > 1)
-				throw new ArgumentException("relative length should be in [0, 1]", nameof(length));
-			_isLength = !isRelative;
-			_isRelative = isRelative;
-			Length = length;
+			if (value != null)
+			{
+				if (value.Equals("auto", StringComparison.OrdinalIgnoreCase))
+					return FlexBasis.Auto;
+				value = value.Trim();
+				if (value.EndsWith("%", StringComparison.OrdinalIgnoreCase) && float.TryParse(value.Substring(0, value.Length - 1), NumberStyles.Number, CultureInfo.InvariantCulture, out float relflex))
+					return new FlexBasis(relflex / 100, isRelative: true);
+				if (float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out float flex))
+					return new FlexBasis(flex);
+			}
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexBasis)));
 		}
 
-		public static implicit operator FlexBasis(float length)
+		public override string ConvertToInvariantString(object value)
 		{
-			return new FlexBasis(length);
-		}
-
-		[Xaml.TypeConversion(typeof(FlexBasis))]
-		public class FlexBasisTypeConverter : TypeConverter
-		{
-			public override object ConvertFromInvariantString(string value)
-			{
-				if (value != null)
-				{
-					if (value.Equals("auto", StringComparison.OrdinalIgnoreCase))
-						return Auto;
-					value = value.Trim();
-					if (value.EndsWith("%", StringComparison.OrdinalIgnoreCase) && float.TryParse(value.Substring(0, value.Length - 1), NumberStyles.Number, CultureInfo.InvariantCulture, out float relflex))
-						return new FlexBasis(relflex / 100, isRelative: true);
-					if (float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out float flex))
-						return new FlexBasis(flex);
-				}
-				throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(FlexBasis)));
-			}
-
-			public override string ConvertToInvariantString(object value)
-			{
-				if (!(value is FlexBasis basis))
-					throw new NotSupportedException();
-				if (basis.IsAuto)
-					return "auto";
-				if (basis.IsRelative)
-					return $"{(basis.Length * 100).ToString(CultureInfo.InvariantCulture)}%";
-				return $"{basis.Length.ToString(CultureInfo.InvariantCulture)}";
-			}
+			if (!(value is FlexBasis basis))
+				throw new NotSupportedException();
+			if (basis.IsAuto)
+				return "auto";
+			if (basis.IsRelative)
+				return $"{(basis.Length * 100).ToString(CultureInfo.InvariantCulture)}%";
+			return $"{basis.Length.ToString(CultureInfo.InvariantCulture)}";
 		}
 	}
 }

--- a/src/Controls/src/Core/FlexLayout.cs
+++ b/src/Controls/src/Core/FlexLayout.cs
@@ -3,6 +3,8 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+using Flex = Microsoft.Maui.Layouts.Flex;
 
 namespace Microsoft.Maui.Controls
 {
@@ -448,7 +450,7 @@ namespace Microsoft.Maui.Controls
 					heightConstraint = Math.Max(heightConstraint, item.Frame[1] + item.Frame[3] + item.MarginBottom);
 			}
 
-			//3. reset Shrink, algin-self, and image.aspect
+			//3. reset Shrink, align-self, and image.aspect
 			foreach (var child in Children)
 			{
 				if (GetFlexItem(child) is Flex.Item item)

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -1,0 +1,533 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Layouts;
+using Flex = Microsoft.Maui.Layouts.Flex;
+
+// This is a temporary namespace until we rename everything and move the legacy layouts
+namespace Microsoft.Maui.Controls.Layout2
+{
+	[ContentProperty(nameof(Children))]
+	public class FlexLayout : Layout, IFlexLayout
+	{
+		Flex.Item _root;
+
+		public static readonly BindableProperty DirectionProperty =
+			BindableProperty.Create(nameof(Direction), typeof(FlexDirection), typeof(FlexLayout), FlexDirection.Row,
+									propertyChanged: OnDirectionPropertyChanged);
+
+		public static readonly BindableProperty JustifyContentProperty =
+			BindableProperty.Create(nameof(JustifyContent), typeof(FlexJustify), typeof(FlexLayout), FlexJustify.Start,
+									propertyChanged: OnJustifyContentPropertyChanged);
+
+		public static readonly BindableProperty AlignContentProperty =
+			BindableProperty.Create(nameof(AlignContent), typeof(FlexAlignContent), typeof(FlexLayout), FlexAlignContent.Stretch,
+									propertyChanged: OnAlignContentPropertyChanged);
+
+		public static readonly BindableProperty AlignItemsProperty =
+			BindableProperty.Create(nameof(AlignItems), typeof(FlexAlignItems), typeof(FlexLayout), FlexAlignItems.Stretch,
+									propertyChanged: OnAlignItemsPropertyChanged);
+
+		public static readonly BindableProperty PositionProperty =
+			BindableProperty.Create(nameof(Position), typeof(FlexPosition), typeof(FlexLayout), FlexPosition.Relative,
+									propertyChanged: OnPositionPropertyChanged);
+
+		public static readonly BindableProperty WrapProperty =
+			BindableProperty.Create(nameof(Wrap), typeof(FlexWrap), typeof(FlexLayout), FlexWrap.NoWrap,
+									propertyChanged: OnWrapPropertyChanged);
+
+		public static readonly BindableProperty OrderProperty =
+			BindableProperty.CreateAttached("Order", typeof(int), typeof(FlexLayout), default(int),
+											propertyChanged: OnOrderPropertyChanged);
+
+		public static readonly BindableProperty GrowProperty =
+			BindableProperty.CreateAttached("Grow", typeof(float), typeof(FlexLayout), default(float),
+											propertyChanged: OnGrowPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
+
+		public static readonly BindableProperty ShrinkProperty =
+			BindableProperty.CreateAttached("Shrink", typeof(float), typeof(FlexLayout), 1f,
+											propertyChanged: OnShrinkPropertyChanged, validateValue: (bindable, value) => (float)value >= 0);
+
+		public static readonly BindableProperty AlignSelfProperty =
+			BindableProperty.CreateAttached("AlignSelf", typeof(FlexAlignSelf), typeof(FlexLayout), FlexAlignSelf.Auto,
+											propertyChanged: OnAlignSelfPropertyChanged);
+
+		public static readonly BindableProperty BasisProperty =
+			BindableProperty.CreateAttached("Basis", typeof(FlexBasis), typeof(FlexLayout), FlexBasis.Auto,
+											propertyChanged: OnBasisPropertyChanged);
+
+		public FlexDirection Direction
+		{
+			get => (FlexDirection)GetValue(DirectionProperty);
+			set => SetValue(DirectionProperty, value);
+		}
+
+		public FlexJustify JustifyContent
+		{
+			get => (FlexJustify)GetValue(JustifyContentProperty);
+			set => SetValue(JustifyContentProperty, value);
+		}
+
+		public FlexAlignContent AlignContent
+		{
+			get => (FlexAlignContent)GetValue(AlignContentProperty);
+			set => SetValue(AlignContentProperty, value);
+		}
+
+		public FlexAlignItems AlignItems
+		{
+			get => (FlexAlignItems)GetValue(AlignItemsProperty);
+			set => SetValue(AlignItemsProperty, value);
+		}
+
+		public FlexPosition Position
+		{
+			get => (FlexPosition)GetValue(PositionProperty);
+			set => SetValue(PositionProperty, value);
+		}
+
+		public FlexWrap Wrap
+		{
+			get => (FlexWrap)GetValue(WrapProperty);
+			set => SetValue(WrapProperty, value);
+		}
+
+		public static int GetOrder(BindableObject bindable)
+			=> (int)bindable.GetValue(OrderProperty);
+
+		public static void SetOrder(BindableObject bindable, int value)
+			=> bindable.SetValue(OrderProperty, value);
+
+		public static float GetGrow(BindableObject bindable)
+			=> (float)bindable.GetValue(GrowProperty);
+
+		public static void SetGrow(BindableObject bindable, float value)
+			=> bindable.SetValue(GrowProperty, value);
+
+		public static float GetShrink(BindableObject bindable)
+			=> (float)bindable.GetValue(ShrinkProperty);
+
+		public static void SetShrink(BindableObject bindable, float value)
+			=> bindable.SetValue(ShrinkProperty, value);
+
+		public static FlexAlignSelf GetAlignSelf(BindableObject bindable)
+			=> (FlexAlignSelf)bindable.GetValue(AlignSelfProperty);
+
+		public static void SetAlignSelf(BindableObject bindable, FlexAlignSelf value)
+			=> bindable.SetValue(AlignSelfProperty, value);
+
+		public static FlexBasis GetBasis(BindableObject bindable)
+			=> (FlexBasis)bindable.GetValue(BasisProperty);
+
+		public static void SetBasis(BindableObject bindable, FlexBasis value)
+			=> bindable.SetValue(BasisProperty, value);
+
+		static readonly BindableProperty FlexItemProperty =
+			BindableProperty.CreateAttached("FlexItem", typeof(Flex.Item), typeof(FlexLayout), null);
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		static Flex.Item GetFlexItem(BindableObject bindable)
+			=> (Flex.Item)bindable.GetValue(FlexItemProperty);
+
+		static void OnOrderPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (!bindable.IsSet(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).Order = (int)newValue;
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.Undefined);
+		}
+
+		static void OnGrowPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (!bindable.IsSet(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).Grow = (float)newValue;
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		}
+
+		static void OnShrinkPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (!bindable.IsSet(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).Shrink = (float)newValue;
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		}
+
+		static void OnAlignSelfPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (!bindable.IsSet(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).AlignSelf = (Flex.AlignSelf)(FlexAlignSelf)newValue;
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		}
+
+		static void OnBasisPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (!bindable.IsSet(FlexItemProperty))
+				return;
+			GetFlexItem(bindable).Basis = ((FlexBasis)newValue).ToFlexBasis();
+			((VisualElement)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		}
+
+		static void OnDirectionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = bindable as FlexLayout;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.Direction = (Flex.Direction)(FlexDirection)newValue;
+			flexLayout.InvalidateMeasure();
+		}
+
+		static void OnJustifyContentPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = bindable as FlexLayout;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.JustifyContent = (Flex.Justify)(FlexJustify)newValue;
+			flexLayout.InvalidateMeasure();
+		}
+
+		static void OnAlignContentPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = bindable as FlexLayout;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.AlignContent = (Flex.AlignContent)(FlexAlignContent)newValue;
+			flexLayout.InvalidateMeasure();
+		}
+
+		static void OnAlignItemsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = (FlexLayout)bindable;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.AlignItems = (Flex.AlignItems)(FlexAlignItems)newValue;
+			flexLayout.InvalidateMeasure();
+		}
+
+		static void OnPositionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = (FlexLayout)bindable;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.Position = (Flex.Position)(FlexPosition)newValue;
+			flexLayout.InvalidateMeasure();
+		}
+
+		static void OnWrapPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var flexLayout = bindable as FlexLayout;
+			if (flexLayout._root == null)
+				return;
+			flexLayout._root.Wrap = (Flex.Wrap)(FlexWrap)newValue;
+			flexLayout.InvalidateMeasure();
+		}
+
+		readonly Dictionary<IView, FlexInfo> _viewInfo = new();
+
+		class FlexInfo
+		{
+			public int Order { get; set; }
+			public float Grow { get; set; }
+			public float Shrink { get; set; }
+			public FlexAlignSelf AlignSelf { get; set; }
+			public FlexBasis Basis { get; set; }
+			public Flex.Item FlexItem { get; set; }
+		}
+
+		public int GetOrder(IView view)
+		{
+			return view switch
+			{
+				BindableObject bo => (int)bo.GetValue(OrderProperty),
+				_ => _viewInfo[view].Order,
+			};
+		}
+
+		public void SetOrder(IView view, int order)
+		{
+			switch (view)
+			{
+				case BindableObject bo:
+					bo.SetValue(OrderProperty, order);
+					break;
+				default:
+					_viewInfo[view].Order = order;
+					break;
+			}
+		}
+
+		public float GetGrow(IView view)
+		{
+			return view switch
+			{
+				BindableObject bo => (float)bo.GetValue(GrowProperty),
+				_ => _viewInfo[view].Grow,
+			};
+		}
+
+		public void SetGrow(IView view, float grow)
+		{
+			switch (view)
+			{
+				case BindableObject bo:
+					bo.SetValue(GrowProperty, grow);
+					break;
+				default:
+					_viewInfo[view].Grow = grow;
+					break;
+			}
+		}
+
+		public float GetShrink(IView view)
+		{
+			return view switch
+			{
+				BindableObject bo => (float)bo.GetValue(ShrinkProperty),
+				_ => _viewInfo[view].Shrink,
+			};
+		}
+
+		public void SetShrink(IView view, float shrink)
+		{
+			switch (view)
+			{
+				case BindableObject bo:
+					bo.SetValue(ShrinkProperty, shrink);
+					break;
+				default:
+					_viewInfo[view].Shrink = shrink;
+					break;
+			}
+		}
+
+		public FlexAlignSelf GetAlignSelf(IView view)
+		{
+			return view switch
+			{
+				BindableObject bo => (FlexAlignSelf)bo.GetValue(AlignSelfProperty),
+				_ => _viewInfo[view].AlignSelf,
+			};
+		}
+
+		public void SetAlignSelf(IView view, FlexAlignSelf alignSelf)
+		{
+			switch (view)
+			{
+				case BindableObject bo:
+					bo.SetValue(AlignSelfProperty, alignSelf);
+					break;
+				default:
+					_viewInfo[view].AlignSelf = alignSelf;
+					break;
+			}
+		}
+
+		public FlexBasis GetBasis(IView view)
+		{
+			return view switch
+			{
+				BindableObject bo => (FlexBasis)bo.GetValue(BasisProperty),
+				_ => _viewInfo[view].Basis,
+			};
+		}
+
+		public void SetBasis(IView view, FlexBasis basis)
+		{
+			switch (view)
+			{
+				case BindableObject bo:
+					bo.SetValue(BasisProperty, basis);
+					break;
+				default:
+					_viewInfo[view].Basis = basis;
+					break;
+			}
+		}
+
+		internal Flex.Item GetFlexItem(IView view) 
+		{
+			return view switch
+			{
+				BindableObject bo => (Flex.Item)bo.GetValue(FlexItemProperty),
+				_ => _viewInfo[view].FlexItem,
+			};
+		}
+
+		void SetFlexItem(IView view, Flex.Item flexItem) 
+		{
+			switch (view)
+			{
+				case BindableObject bo:
+					bo.SetValue(FlexItemProperty, flexItem);
+					break;
+				default:
+					_viewInfo[view].FlexItem = flexItem;
+					break;
+			}
+		}
+
+		Thickness GetMargin(IView view) 
+		{
+			return view switch
+			{
+				BindableObject bo => (Thickness)bo.GetValue(MarginProperty),
+				_ => view.Margin
+			};
+		}
+
+		double GetWidth(IView view) 
+		{
+			return view switch
+			{
+				BindableObject bo => (double)bo.GetValue(WidthRequestProperty),
+				_ => view.Width
+			};
+		}
+
+		double GetHeight(IView view)
+		{
+			return view switch
+			{
+				BindableObject bo => (double)bo.GetValue(HeightRequestProperty),
+				_ => view.Height
+			};
+		}
+
+		bool GetIsVisible(IView view)
+		{
+			return view switch
+			{
+				BindableObject bo => (bool)bo.GetValue(IsVisibleProperty),
+				_ => view.Visibility != Visibility.Collapsed
+			};
+		}
+
+		void InitItemProperties(IView view, Flex.Item item)
+		{
+			item.Order = GetOrder(view);
+			item.Grow = GetGrow(view);
+			item.Shrink = GetShrink(view);
+			item.Basis = GetBasis(view).ToFlexBasis();
+			item.AlignSelf = (Flex.AlignSelf)GetAlignSelf(view);
+			var (mleft, mtop, mright, mbottom) = GetMargin(view);
+			item.MarginLeft = (float)mleft;
+			item.MarginTop = (float)mtop;
+			item.MarginRight = (float)mright;
+			item.MarginBottom = (float)mbottom;
+			var width = GetWidth(view);
+			item.Width = width < 0 ? float.NaN : (float)width;
+			var height = GetHeight(view);
+			item.Height = height < 0 ? float.NaN : (float)height;
+			item.IsVisible = GetIsVisible(view);
+
+			// TODO ezhart The Core layout interfaces don't have the padding property yet; when that's available, we should add a check for it here
+			if (view is FlexLayout && view is Controls.Layout layout)
+			{
+				var (pleft, ptop, pright, pbottom) = (Thickness)layout.GetValue(Controls.Layout.PaddingProperty);
+				item.PaddingLeft = (float)pleft;
+				item.PaddingTop = (float)ptop;
+				item.PaddingRight = (float)pright;
+				item.PaddingBottom = (float)pbottom;
+			}
+		}
+
+		void AddFlexItem(IView child)
+		{
+			if (_root == null)
+				return;
+			var item = (child as FlexLayout)?._root ?? new Flex.Item();
+			InitItemProperties(child, item);
+			if (!(child is FlexLayout))
+			{ //inner layouts don't get measured
+				item.SelfSizing = (Flex.Item it, ref float w, ref float h) =>
+				{
+					var sizeConstraints = item.GetConstraints();
+					sizeConstraints.Width = (sizeConstraints.Width == 0) ? double.PositiveInfinity : sizeConstraints.Width;
+					sizeConstraints.Height = (sizeConstraints.Height == 0) ? double.PositiveInfinity : sizeConstraints.Height;
+					var request = child.Measure(sizeConstraints.Width, sizeConstraints.Height);
+					w = (float)request.Width;
+					h = (float)request.Height;
+				};
+			}
+
+			_root.InsertAt(Children.IndexOf(child), item);
+			SetFlexItem(child, item);
+		}
+
+		void RemoveFlexItem(IView child)
+		{
+			if (_root == null)
+				return;
+			
+			var item = GetFlexItem(child);
+			_root.Remove(item);
+
+			switch (child)
+			{
+				case BindableObject bo:
+					bo.ClearValue(FlexItemProperty);
+					break;
+				default:
+					_viewInfo.Remove(child);
+					break;
+			}
+		}
+
+		protected override ILayoutManager CreateLayoutManager()
+		{
+			return new FlexLayoutManager(this);
+		}
+
+		public Graphics.Rectangle GetFlexFrame(IView view)
+		{
+			return view switch
+			{
+				BindableObject bo => ((Flex.Item)bo.GetValue(FlexItemProperty)).GetFrame(),
+				_ => _viewInfo[view].FlexItem.GetFrame(),
+			};
+		}
+
+		public void Layout(double width, double height)
+		{
+			if (_root.Parent != null)   //Layout is only computed at root level
+				return;
+			_root.Width = !double.IsPositiveInfinity((width)) ? (float)width : 0;
+			_root.Height = !double.IsPositiveInfinity((height)) ? (float)height : 0;
+			_root.Layout();
+		}
+
+		protected override void OnParentSet()
+		{
+			base.OnParentSet();
+			if (Parent != null && _root == null)
+				PopulateLayout();
+			else if (Parent == null && _root != null)
+				ClearLayout();
+		}
+
+		void PopulateLayout()
+		{
+			InitLayoutProperties(_root = new Flex.Item());
+			foreach (var child in Children)
+				AddFlexItem(child);
+		}
+
+		void ClearLayout()
+		{
+			foreach (var child in Children)
+				RemoveFlexItem(child);
+			_root = null;
+		}
+
+		void InitLayoutProperties(Flex.Item item)
+		{
+			item.AlignContent = (Flex.AlignContent)(FlexAlignContent)GetValue(AlignContentProperty);
+			item.AlignItems = (Flex.AlignItems)(FlexAlignItems)GetValue(AlignItemsProperty);
+			item.Direction = (Flex.Direction)(FlexDirection)GetValue(DirectionProperty);
+			item.JustifyContent = (Flex.Justify)(FlexJustify)GetValue(JustifyContentProperty);
+			item.Wrap = (Flex.Wrap)(FlexWrap)GetValue(WrapProperty);
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutAlignContentTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutAlignContentTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutAlignItemsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutAlignItemsTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutAlignSelfTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutAlignSelfTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutFlexDirectionTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutFlexDirectionTests.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutMarginTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutMarginTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Threading;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Controls/tests/Core.UnitTests/FlexOrderTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexOrderTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Threading;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Core/src/Core/IFlexLayout.cs
+++ b/src/Core/src/Core/IFlexLayout.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+using Flex = Microsoft.Maui.Layouts.Flex;
+
+namespace Microsoft.Maui
+{
+	public interface IFlexLayout : ILayout 
+	{ 
+		FlexDirection Direction { get; }
+		FlexJustify JustifyContent { get; }
+		FlexAlignContent AlignContent { get; }
+		FlexAlignItems AlignItems { get; }
+		FlexPosition Position { get; }
+		FlexWrap Wrap { get; }
+
+		int GetOrder(IView view);
+		float GetGrow(IView view);
+		float GetShrink(IView view);
+		FlexAlignSelf GetAlignSelf(IView view);
+		FlexBasis GetBasis(IView view);
+
+		Rectangle GetFlexFrame(IView view);
+
+		void Layout(double width, double height);
+	}
+}

--- a/src/Core/src/Core/IGridLayout.cs
+++ b/src/Core/src/Core/IGridLayout.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui
 {
@@ -55,4 +56,6 @@ namespace Microsoft.Maui
 		/// <returns>The row that the child element is in.</returns>
 		int GetColumnSpan(IView view);
 	}
+
+
 }

--- a/src/Core/src/Layouts/Flex.cs
+++ b/src/Core/src/Layouts/Flex.cs
@@ -10,7 +10,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Microsoft.Maui.Controls.Flex
+namespace Microsoft.Maui.Layouts.Flex
 {
 	/// <summary>
 	/// Values for <see cref="P:Microsoft.Maui.Controls.Flex.Item.AlignContent" />.
@@ -238,8 +238,8 @@ namespace Microsoft.Maui.Controls.Flex
 
 		/// <summary>The parent item.</summary>
 		/// <value>The parent item, or null if the item is a root item.</value>
-		public Item Parent { get; private set; }
-		IList<Item> Children { get; set; }
+		public Item? Parent { get; private set; }
+		IList<Item>? Children { get; set; }
 		bool ShouldOrderChildren { get; set; }
 
 		///<summary>This property defines how the layout engine will distribute space between and around child items that have been laid out on multiple lines. This property is ignored if the root item does not have its <see cref="P:Microsoft.Maui.Controls.Flex.Item.Wrap" /> property set to Wrap or WrapReverse.</summary>
@@ -410,7 +410,7 @@ namespace Microsoft.Maui.Controls.Flex
 
 		public Item RemoveAt(uint index)
 		{
-			var child = Children[(int)index];
+			var child = Children![(int)index];
 			child.Parent = null;
 			Children.RemoveAt((int)index);
 			return child;
@@ -420,7 +420,7 @@ namespace Microsoft.Maui.Controls.Flex
 			(Children?.Count ?? 0);
 
 		public Item ItemAt(int index) =>
-			Children?[index];
+			Children![index];
 
 		public Item this[int index]
 		{
@@ -451,7 +451,7 @@ namespace Microsoft.Maui.Controls.Flex
 
 		public delegate void SelfSizingDelegate(Item item, ref float width, ref float height);
 
-		public SelfSizingDelegate SelfSizing { get; set; }
+		public SelfSizingDelegate? SelfSizing { get; set; }
 
 		IEnumerator IEnumerable.GetEnumerator() =>
 			((IEnumerable<Item>)this).GetEnumerator();
@@ -613,7 +613,7 @@ namespace Microsoft.Maui.Controls.Flex
 				for (uint i = 0; i < (layout.lines?.Length ?? 0); i++)
 				{
 
-					flex_layout.flex_layout_line line = layout.lines[i];
+					flex_layout.flex_layout_line line = layout.lines![i];
 
 					if (layout.reverse2)
 					{
@@ -906,7 +906,7 @@ namespace Microsoft.Maui.Controls.Flex
 			public uint frame_pos2_i;           // cross axis position
 			public uint frame_size_i;           // main axis size
 			public uint frame_size2_i;          // cross axis size
-			int[] ordered_indices;
+			int[]? ordered_indices;
 
 			// Set for each line layout.
 			public float line_dim;              // the cross axis size
@@ -927,7 +927,7 @@ namespace Microsoft.Maui.Controls.Flex
 				public float size;
 			};
 
-			public flex_layout_line[] lines;
+			public flex_layout_line[]? lines;
 			public float lines_sizes;
 
 			//LAYOUT_RESET
@@ -993,7 +993,7 @@ namespace Microsoft.Maui.Controls.Flex
 						{
 							int prev = indices[j - 1];
 							int curr = indices[j];
-							if (item.Children[prev].Order <= item.Children[curr].Order)
+							if (item.Children![prev].Order <= item.Children[curr].Order)
 							{
 								break;
 							}
@@ -1029,7 +1029,7 @@ namespace Microsoft.Maui.Controls.Flex
 			}
 
 			public Item child_at(Item item, int i) =>
-				item.Children[(ordered_indices?[i] ?? i)];
+				item.Children![(ordered_indices?[i] ?? i)];
 
 			public void cleanup()
 			{

--- a/src/Core/src/Layouts/FlexEnums.cs
+++ b/src/Core/src/Layouts/FlexEnums.cs
@@ -1,0 +1,90 @@
+using System;
+
+namespace Microsoft.Maui.Layouts
+{
+	public enum FlexJustify
+	{
+		Start = Flex.Justify.Start,
+		Center = Flex.Justify.Center,
+		End = Flex.Justify.End,
+		SpaceBetween = Flex.Justify.SpaceBetween,
+		SpaceAround = Flex.Justify.SpaceAround,
+		SpaceEvenly = Flex.Justify.SpaceEvenly,
+	}
+
+	public enum FlexPosition
+	{
+		Relative = Flex.Position.Relative,
+		Absolute = Flex.Position.Absolute,
+	}
+
+	public enum FlexDirection
+	{
+		Column = Flex.Direction.Column,
+		ColumnReverse = Flex.Direction.ColumnReverse,
+		Row = Flex.Direction.Row,
+		RowReverse = Flex.Direction.RowReverse,
+	}
+
+	public enum FlexAlignContent
+	{
+		Stretch = Flex.AlignContent.Stretch,
+		Center = Flex.AlignContent.Center,
+		Start = Flex.AlignContent.Start,
+		End = Flex.AlignContent.End,
+		SpaceBetween = Flex.AlignContent.SpaceBetween,
+		SpaceAround = Flex.AlignContent.SpaceAround,
+		SpaceEvenly = Flex.AlignContent.SpaceEvenly,
+	}
+
+	public enum FlexAlignItems
+	{
+		Stretch = Flex.AlignItems.Stretch,
+		Center = Flex.AlignItems.Center,
+		Start = Flex.AlignItems.Start,
+		End = Flex.AlignItems.End,
+		//Baseline = Flex.AlignItems.Baseline,
+	}
+
+	public enum FlexAlignSelf
+	{
+		Auto = Flex.AlignSelf.Auto,
+		Stretch = Flex.AlignSelf.Stretch,
+		Center = Flex.AlignSelf.Center,
+		Start = Flex.AlignSelf.Start,
+		End = Flex.AlignSelf.End,
+		//Baseline = Flex.AlignSelf.Baseline,
+	}
+
+	public enum FlexWrap
+	{
+		NoWrap = Flex.Wrap.NoWrap,
+		Wrap = Flex.Wrap.Wrap,
+		Reverse = Flex.Wrap.WrapReverse,
+	}
+
+	public struct FlexBasis
+	{
+		bool _isLength;
+		bool _isRelative;
+		public static FlexBasis Auto = new();
+		public float Length { get; }
+		internal bool IsAuto => !_isLength && !_isRelative;
+		internal bool IsRelative => _isRelative;
+		public FlexBasis(float length, bool isRelative = false)
+		{
+			if (length < 0)
+				throw new ArgumentException("should be a positive value", nameof(length));
+			if (isRelative && length > 1)
+				throw new ArgumentException("relative length should be in [0, 1]", nameof(length));
+			_isLength = !isRelative;
+			_isRelative = isRelative;
+			Length = length;
+		}
+
+		public static implicit operator FlexBasis(float length)
+		{
+			return new FlexBasis(length);
+		}
+	}
+}

--- a/src/Core/src/Layouts/FlexLayoutManager.cs
+++ b/src/Core/src/Layouts/FlexLayoutManager.cs
@@ -1,0 +1,51 @@
+﻿#nullable enable
+using System;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Layouts
+{
+	public class FlexLayoutManager : ILayoutManager
+	{
+		IFlexLayout FlexLayout { get;}
+
+		public FlexLayoutManager(IFlexLayout flexLayout)
+		{
+			FlexLayout = flexLayout;
+		}
+
+		public void ArrangeChildren(Rectangle childBounds)
+		{
+			FlexLayout.Layout(childBounds.Width, childBounds.Height);
+			
+			foreach (var child in FlexLayout.Children)
+			{
+				var frame = FlexLayout.GetFlexFrame(child);
+				if (double.IsNaN(frame.X)
+					|| double.IsNaN(frame.Y)
+					|| double.IsNaN(frame.Width)
+					|| double.IsNaN(frame.Height))
+					throw new Exception("something is deeply wrong");
+				frame = frame.Offset(childBounds.X, childBounds.Y); 
+				child.Arrange(frame);
+			}
+		}
+
+		public Size Measure(double widthConstraint, double heightConstraint)
+		{
+			double width = 0;
+			double height = 0;
+
+			if (!double.IsInfinity(widthConstraint))
+			{
+				width = widthConstraint;
+			}
+
+			if (!double.IsInfinity(heightConstraint))
+			{
+				height = heightConstraint;
+			}
+
+			return new Size(width, height);
+		}
+	}
+}


### PR DESCRIPTION
This is a port of FlexLayout to Core. The behavior should be nearly identical to the legacy FlexLayout. This PR

- Moves the layout logic and data types for FlexLayout to MAUI Core
- Leaves existing Controls.FlexLayout in place and unchanged
- Adds Controls.Layout2.FlexLayout (for now)

Differences from the legacy version:

- The Layout2 version can also host MAUI `IView`s which don't derive from `BindableObject`
- The Layout2 version handles measure differently than the legacy version

That second bullet point is the only real change. FlexLayout doesn't really support measurement. The legacy version fakes measurement (when not given fixed constraints) by setting some known properties at the root, laying out the controls, resetting the root properties, and measuring the space the controls occupy. 

This version is opting for a simpler measurement strategy; if that doesn't play out, we may have to bring back the old measurement hacks. 