### PR TITLE
Implement TextColor property in DatePickerHandlers

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/DatePickerPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/DatePickerPage.xaml
@@ -16,6 +16,10 @@
                 Style="{StaticResource Headline}"/>
             <DatePicker
                 IsEnabled="False"/>
+            <Label
+                Text="TextColor"
+                Style="{StaticResource Headline}"/>
+            <DatePicker TextColor="Red"/>
         </VerticalStackLayout>
-    </views:BasePage.Content>
+    </views:BasePage.Content>               
 </views:BasePage>

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using Android.App;
+﻿using Android.App;
+using Android.Content.Res;
 using Android.Graphics.Drawables;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class DatePickerHandler : ViewHandler<IDatePicker, MauiDatePicker>
 	{
-		static Drawable? DefaultBackground;
+		Drawable? _defaultBackground;
+		ColorStateList? _defaultTextColors;
 
 		DatePickerDialog? _dialog;
 
@@ -29,7 +29,8 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void SetupDefaults(MauiDatePicker nativeView)
 		{
-			DefaultBackground = nativeView.Background;
+			_defaultBackground = nativeView.Background;
+			_defaultTextColors = nativeView.TextColors;
 
 			base.SetupDefaults(nativeView);
 		}
@@ -62,7 +63,7 @@ namespace Microsoft.Maui.Handlers
 		// This is a Android-specific mapping
 		public static void MapBackground(DatePickerHandler handler, IDatePicker datePicker)
 		{
-			handler.NativeView?.UpdateBackground(datePicker, DefaultBackground);
+			handler.NativeView?.UpdateBackground(datePicker, handler._defaultBackground);
 		}
 
 		public static void MapFormat(DatePickerHandler handler, IDatePicker datePicker)
@@ -97,8 +98,10 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateFont(datePicker, fontManager);
 		}
 
-		[MissingMapper]
-		public static void MapTextColor(DatePickerHandler handler, IDatePicker datePicker) { }
+		public static void MapTextColor(DatePickerHandler handler, IDatePicker datePicker)
+		{
+			handler.NativeView?.UpdateTextColor(datePicker, handler._defaultTextColors);
+		}
 
 		void ShowPickerDialog()
 		{

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Foundation;
-using Microsoft.Extensions.DependencyInjection;
 using UIKit;
 using RectangleF = CoreGraphics.CGRect;
 
@@ -8,6 +7,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class DatePickerHandler : ViewHandler<IDatePicker, MauiDatePicker>
 	{
+		UIColor? _defaultTextColor;
 		UIDatePicker? _picker;
 
 		protected override MauiDatePicker CreateNativeView()
@@ -64,6 +64,13 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(nativeView);
 		}
 
+		protected override void SetupDefaults(MauiDatePicker nativeView)
+		{
+			_defaultTextColor = nativeView.TextColor;
+
+			base.SetupDefaults(nativeView);
+		}
+
 		public static void MapFormat(DatePickerHandler handler, IDatePicker datePicker)
 		{
 			handler.NativeView?.UpdateFormat(datePicker);
@@ -96,8 +103,10 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateFont(datePicker, fontManager);
 		}
 
-		[MissingMapper]
-		public static void MapTextColor(DatePickerHandler handler, IDatePicker datePicker) { }
+		public static void MapTextColor(DatePickerHandler handler, IDatePicker datePicker)
+		{
+			handler.NativeView?.UpdateTextColor(datePicker, handler._defaultTextColor);
+		}
 
 		void OnValueChanged(object? sender, EventArgs? e)
 		{

--- a/src/Core/src/Platform/Android/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/Android/DatePickerExtensions.cs
@@ -1,10 +1,17 @@
 ﻿using System;
 using Android.App;
+using Android.Content.Res;
 
 namespace Microsoft.Maui
 {
 	public static class DatePickerExtensions
 	{
+		static readonly int[][] ColorStates =
+		{
+			new[] { Android.Resource.Attribute.StateEnabled },
+			new[] { -Android.Resource.Attribute.StateEnabled }
+		};
+
 		public static void UpdateFormat(this MauiDatePicker nativeDatePicker, IDatePicker datePicker)
 		{
 			nativeDatePicker.SetText(datePicker);
@@ -13,6 +20,32 @@ namespace Microsoft.Maui
 		public static void UpdateDate(this MauiDatePicker nativeDatePicker, IDatePicker datePicker)
 		{
 			nativeDatePicker.SetText(datePicker);
+		}
+
+		public static void UpdateTextColor(this MauiDatePicker nativeDatePicker, IDatePicker datePicker)
+		{
+			nativeDatePicker.UpdateTextColor(datePicker, null);
+		}
+
+		public static void UpdateTextColor(this MauiDatePicker nativeDatePicker, IDatePicker datePicker, ColorStateList? defaultTextColor)
+		{
+			var textColor = datePicker.TextColor;
+
+			if (textColor == null)
+			{
+				if (defaultTextColor != null)
+					nativeDatePicker.SetTextColor(defaultTextColor);
+			}
+			else
+			{
+				var androidColor = textColor.ToNative();
+
+				if (!nativeDatePicker.TextColors.IsOneColor(ColorStates, androidColor))
+				{
+					var acolor = androidColor.ToArgb();
+					nativeDatePicker.SetTextColor(new ColorStateList(ColorStates, new[] { acolor, acolor }));
+				}
+			}
 		}
 
 		public static void UpdateMinimumDate(this MauiDatePicker nativeDatePicker, IDatePicker datePicker)

--- a/src/Core/src/Platform/iOS/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/DatePickerExtensions.cs
@@ -19,6 +19,19 @@ namespace Microsoft.Maui
 			nativeDatePicker.UpdateDate(datePicker, null);
 		}
 
+		public static void UpdateTextColor(this MauiDatePicker nativeDatePicker, IDatePicker datePicker, UIColor? defaultTextColor)
+		{
+			var textColor = datePicker.TextColor;
+
+			if (textColor == null)
+				nativeDatePicker.TextColor = defaultTextColor;
+			else
+				nativeDatePicker.TextColor = textColor.ToNative();
+
+			// HACK This forces the color to update; there's probably a more elegant way to make this happen
+			nativeDatePicker.UpdateDate(datePicker);
+		}
+
 		public static void UpdateDate(this MauiDatePicker nativeDatePicker, IDatePicker datePicker, UIDatePicker? picker)
 		{
 			if (picker != null && picker.Date.ToDateTime().Date != datePicker.Date.Date)

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Android.cs
@@ -3,7 +3,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Graphics;
 using Xunit;
+using AColor = Android.Graphics.Color;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -116,7 +118,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		MauiDatePicker GetNativeDatePicker(DatePickerHandler datePickerHandler) =>
-			(MauiDatePicker)datePickerHandler.NativeView;
+			datePickerHandler.NativeView;
 
 		DateTime GetNativeDate(DatePickerHandler datePickerHandler)
 		{
@@ -124,6 +126,13 @@ namespace Microsoft.Maui.DeviceTests
 			DateTime.TryParse(dateString, out DateTime result);
 
 			return result;
+		}
+
+		Color GetNativeTextColor(DatePickerHandler datePickerHandler)
+		{
+			int currentTextColorInt = GetNativeDatePicker(datePickerHandler).CurrentTextColor;
+			AColor currentTextColor = new AColor(currentTextColorInt);
+			return currentTextColor.ToColor();
 		}
 
 		long GetNativeMinimumDate(DatePickerHandler datePickerHandler)

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Xunit;
 
@@ -17,6 +18,18 @@ namespace Microsoft.Maui.DeviceTests
 			datePicker.Date = DateTime.Today;
 
 			await ValidatePropertyInitValue(datePicker, () => datePicker.Date, GetNativeDate, datePicker.Date);
+		}
+
+		[Fact(DisplayName = "TextColor Initializes Correctly")]
+		public async Task TextColorInitializesCorrectly()
+		{
+			var datePicker = new DatePickerStub()
+			{
+				Date = DateTime.Today,
+				TextColor = Colors.Yellow
+			};
+
+			await ValidatePropertyInitValue(datePicker, () => datePicker.TextColor, GetNativeTextColor, datePicker.TextColor);
 		}
 
 		[Theory(DisplayName = "Font Size Initializes Correctly")]

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.iOS.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Xunit;
 
@@ -113,7 +114,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		MauiDatePicker GetNativeDatePicker(DatePickerHandler datePickerHandler) =>
-			(MauiDatePicker)datePickerHandler.NativeView;
+			datePickerHandler.NativeView;
 
 		DateTime GetNativeDate(DatePickerHandler datePickerHandler)
 		{
@@ -122,6 +123,9 @@ namespace Microsoft.Maui.DeviceTests
 
 			return result;
 		}
+
+		Color GetNativeTextColor(DatePickerHandler datePickerHandler) =>
+			GetNativeDatePicker(datePickerHandler).TextColor.ToColor();
 
 		DateTime GetNativeMinimumDate(DatePickerHandler datePickerHandler)
 		{


### PR DESCRIPTION
### Description of Change ###

Implement TextColor property in DatePickerHandlers (Android and iOS).

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No