### PR TITLE
Simplify layout (and make BoxRenderer work on Android)

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/BoxRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/BoxRenderer.cs
@@ -169,5 +169,35 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			UpdateBackgroundColor();
 		}
+
+		public override SizeRequest GetDesiredSize(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
+			var specWidth = MeasureSpec.GetSize(widthMeasureSpec);
+			var specHeight = MeasureSpec.GetSize(heightMeasureSpec);
+			var widthRequest = Element.WidthRequest;
+			var heightRequest = Element.HeightRequest;
+
+			if (widthMode != MeasureSpecMode.Exactly && widthRequest >= 0)
+			{
+				if (widthMode == MeasureSpecMode.Unspecified || widthRequest <= specWidth)
+				{
+					var deviceWidth = (int)Context.ToPixels(widthRequest);
+					widthMeasureSpec = MeasureSpec.MakeMeasureSpec(deviceWidth, MeasureSpecMode.Exactly);
+				}
+			}
+
+			if (heightMode != MeasureSpecMode.Exactly && heightRequest >= 0)
+			{
+				if (heightMode == MeasureSpecMode.Unspecified || heightRequest <= specHeight)
+				{
+					var deviceheight = (int)Context.ToPixels(heightRequest);
+					heightMeasureSpec = MeasureSpec.MakeMeasureSpec(deviceheight, MeasureSpecMode.Exactly);
+				}
+			}
+
+			return base.GetDesiredSize(widthMeasureSpec, heightMeasureSpec);
+		}
 	}
 }

--- a/src/Compatibility/Core/src/Android/VisualElementTracker.cs
+++ b/src/Compatibility/Core/src/Android/VisualElementTracker.cs
@@ -96,9 +96,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				formsViewGroup.MeasureAndLayout(MeasureSpecFactory.MakeMeasureSpec(width, MeasureSpecMode.Exactly), MeasureSpecFactory.MakeMeasureSpec(height, MeasureSpecMode.Exactly), x, y, x + width, y + height);
 				Performance.Stop(reference, "MeasureAndLayout");
 			}
-			else if (aview is LayoutViewGroup && width == 0 && height == 0)
+			else if (aview is LayoutViewGroup)
 			{
-				// Nothing to do here; just chill.
+				// Are we in a shim? Force a layout via the Frame rather than explicitly; that way,
+				// the Frame is also correctly set
+				_renderer.Element.Frame = new Graphics.Rectangle(x, y, width, height);
 			}
 			else
 			{

--- a/src/Compatibility/Core/src/RendererToHandlerShim.Android.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.Android.cs
@@ -39,6 +39,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		public override void SetNativeFrame(Rectangle frame)
 		{
+			// TODO ezhart It might be worthwhile here to check the view's Frame
+			// and avoid a layout call; VisualElementTracker has probably already laid this out
+
+
 			// This is a hack to force the shimmed control to actually do layout; without this, some controls won't actually
 			// call OnLayout after updating their frame if their sizes haven't changed (e.g., ScrollView)
 			// Luckily, measuring with MeasureSpecMode.Exactly is pretty fast, since it just returns the value you give it.

--- a/src/Compatibility/Core/src/RendererToHandlerShim.Android.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.Android.cs
@@ -34,19 +34,18 @@ namespace Microsoft.Maui.Controls.Compatibility
 			if (VisualElementRenderer == null)
 				return Size.Zero;
 
-			return GetNativeSize(
-				VisualElementRenderer, widthConstraint, heightConstraint);
+			return GetNativeSize(VisualElementRenderer, widthConstraint, heightConstraint);
 		}
 
-		public override void NativeArrange(Rectangle frame)
+		public override void SetNativeFrame(Rectangle frame)
 		{
 			// This is a hack to force the shimmed control to actually do layout; without this, some controls won't actually
-			// call OnLayout after SetFrame if their sizes haven't changed (e.g., ScrollView)
+			// call OnLayout after updating their frame if their sizes haven't changed (e.g., ScrollView)
 			// Luckily, measuring with MeasureSpecMode.Exactly is pretty fast, since it just returns the value you give it.
 			NativeView?.Measure(MeasureSpecMode.Exactly.MakeMeasureSpec((int)frame.Width),
 				MeasureSpecMode.Exactly.MakeMeasureSpec((int)frame.Height));
 
-			base.NativeArrange(frame);
+			base.SetNativeFrame(frame);
 		}
 	}
 }

--- a/src/Compatibility/Core/src/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Graphics;
 #if __ANDROID__
 using static Microsoft.Maui.Controls.Compatibility.Platform.Android.Platform;
 using NativeView = Android.Views.View;
@@ -99,7 +100,12 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 			if (e.NewElement is IView newView)
 			{
+				var currentContext = newView.Handler?.MauiContext;
 				newView.Handler = this;
+				if (this.MauiContext == null && currentContext != null)
+				{
+					this.SetMauiContext(currentContext);
+				}
 
 				if (VirtualView != newView)
 					this.SetVirtualView(newView);
@@ -149,6 +155,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 				base.SetVirtualView(view);
 			}
 		}
+
 #else
 		protected override NativeView CreateNativeView()
 		{

--- a/src/Compatibility/Core/src/RendererToHandlerShim.iOS.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.iOS.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			base.UpdateValue(property);
 			if (property == "Frame" && VisualElementRenderer != null)
 			{
-				NativeArrange(VisualElementRenderer.Element.Bounds);
+				SetNativeFrame(VisualElementRenderer.Element.Bounds);
 			}
 		}
 	}

--- a/src/Compatibility/Core/src/RendererToHandlerShim.iOS.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.iOS.cs
@@ -25,15 +25,5 @@ namespace Microsoft.Maui.Controls.Compatibility
 			return Internals.Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(view)
 										?? new DefaultRenderer();
 		}
-
-		// TODO ezhart 2021-06-18 This is almost certainly unnecessary; review it along with the OnBatchCommitted method in HandlerToRendererShim
-		public override void UpdateValue(string property)
-		{
-			base.UpdateValue(property);
-			if (property == "Frame" && VisualElementRenderer != null)
-			{
-				SetNativeFrame(VisualElementRenderer.Element.Bounds);
-			}
-		}
 	}
 }

--- a/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
@@ -37,13 +37,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			if (oldElement != null)
 			{
 				oldElement.PropertyChanged -= OnElementPropertyChanged;
-				oldElement.BatchCommitted -= OnBatchCommitted;
 			}
 
 			if (element != null)
 			{
 				element.PropertyChanged += OnElementPropertyChanged;
-				element.BatchCommitted += OnBatchCommitted;
 			}
 
 			Element = element;
@@ -53,13 +51,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				ViewHandler.SetVirtualView((IView)element);
 
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(oldElement, Element));
-		}
-
-		// TODO ezhart 2021-06-18 Review this; a control calling Arrange on itself is almost certainly wrong, but removing this right now is breaking
-		// any layout that's inside a shimmed ScrollView. 
-		void OnBatchCommitted(object sender, EventArg<VisualElement> e)
-		{
-			ViewHandler?.NativeArrange(Element.Bounds);
 		}
 
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
@@ -37,11 +37,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			if (oldElement != null)
 			{
 				oldElement.PropertyChanged -= OnElementPropertyChanged;
+				oldElement.BatchCommitted -= Element_BatchCommitted;
 			}
 
 			if (element != null)
 			{
 				element.PropertyChanged += OnElementPropertyChanged;
+				element.BatchCommitted += Element_BatchCommitted;
 			}
 
 			Element = element;
@@ -51,6 +53,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				ViewHandler.SetVirtualView((IView)element);
 
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(oldElement, Element));
+		}
+
+		private void Element_BatchCommitted(object sender, EventArg<VisualElement> e)
+		{
+			((VisualElement)sender).Frame = e.Data.Bounds;
 		}
 
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
@@ -37,13 +37,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			if (oldElement != null)
 			{
 				oldElement.PropertyChanged -= OnElementPropertyChanged;
-				oldElement.BatchCommitted -= Element_BatchCommitted;
+				oldElement.BatchCommitted -= OnBatchCommitted;
 			}
 
 			if (element != null)
 			{
 				element.PropertyChanged += OnElementPropertyChanged;
-				element.BatchCommitted += Element_BatchCommitted;
+				element.BatchCommitted += OnBatchCommitted;
 			}
 
 			Element = element;
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(oldElement, Element));
 		}
 
-		private void Element_BatchCommitted(object sender, EventArg<VisualElement> e)
+		void OnBatchCommitted(object sender, EventArg<VisualElement> e)
 		{
 			((VisualElement)sender).Frame = e.Data.Bounds;
 		}

--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -25,18 +25,7 @@ namespace Microsoft.Maui.Controls
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
 			// Update the Bounds (Frame) for this page
-			Layout(bounds);
-
-			if (Content is IFrameworkElement element)
-			{
-				// The size checks here are a guard against legacy layouts which try to lay things out before the
-				// native side is ready. We just ignore those invalid values.
-				if (element.Frame.Size.Width >= 0 && element.Frame.Size.Height >= 0)
-				{
-					element.Handler?.NativeArrange(element.Frame);
-				}
-			}
-
+			Layout(bounds); 
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -25,24 +25,14 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
+			_ = base.ArrangeOverride(bounds);
+
 			// Update the Bounds (Frame) for this page
-			// Ideally, this would be happening from a higher level; controls should not be responsible for setting their own Frames
-			// But until we've got Window fully worked out, Pages will have to handle that themselves. 
 			Layout(bounds);
-							
-			if (Content is IFrameworkElement element)
+
+			if (Content is IFrameworkElement frameworkElement && Content is VisualElement visualElement)
 			{
-				// The size checks here are a guard against legacy layouts which try to lay things out before the
-				// native side is ready. We just ignore those invalid values.
-				if (bounds.Size.Width >= 0 && bounds.Size.Height >= 0)
-				{
-					// Yes, this looks weird. 
-					// Invoking the Frame property's setter will kick off the native "set location and size" step.
-					// The values whick make up Frame and Bounds are the same, but setting Bounds has other side effects
-					// (like laying out the Page and its content). We don't want to kick off another layout pass (it just finished),
-					// but we _do_ want the native control backing Content to run its native arrangement code. 
-					element.Frame = element.Frame;
-				}
+				frameworkElement.Frame = visualElement.Bounds;
 			}
 
 			return Frame.Size;

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
@@ -25,13 +25,9 @@ namespace Microsoft.Maui.Controls
 			// Update the Bounds (Frame) for this page
 			Layout(bounds);
 
-			if (Content is IFrameworkElement element)
+			if (Content is IFrameworkElement frameworkElement && Content is VisualElement visualElement)
 			{
-				if (bounds.Size.Width >= 0 && bounds.Size.Height >= 0)
-				{
-					// See ContentPage.Impl.cs for an explanation
-					element.Frame = element.Frame;
-				}
+				frameworkElement.Frame = visualElement.Bounds;
 			}
 
 			return Frame.Size;

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
@@ -24,6 +24,16 @@ namespace Microsoft.Maui.Controls
 		{
 			// Update the Bounds (Frame) for this page
 			Layout(bounds);
+
+			if (Content is IFrameworkElement element)
+			{
+				if (bounds.Size.Width >= 0 && bounds.Size.Height >= 0)
+				{
+					// See ContentPage.Impl.cs for an explanation
+					element.Frame = element.Frame;
+				}
+			}
+
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
@@ -24,13 +24,6 @@ namespace Microsoft.Maui.Controls
 		{
 			// Update the Bounds (Frame) for this page
 			Layout(bounds);
-
-			if (Content is IFrameworkElement element)
-			{
-				element.Arrange(bounds);
-				element.Handler?.NativeArrange(element.Frame);
-			}
-
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.Controls
 		// the interface has to be explicitly implemented to avoid conflict with the old Arrange method
 		protected virtual Size ArrangeOverride(Rectangle bounds)
 		{
-			// No child elements to arrange, so nothing to do here
+			Frame = bounds;
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -172,11 +172,7 @@ namespace Microsoft.Maui.Controls
 			if (_handler?.VirtualView != this)
 				_handler?.SetVirtualView((IView)this);
 
-				#if WINDOWS
-
-				#else
 			IsPlatformEnabled = _handler != null;
-			#endif
 
 			if (_handler != null)
 			{

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -10,7 +10,11 @@ namespace Microsoft.Maui.Controls
 		Semantics _semantics;
 		IViewHandler _handler;
 
-		public Rectangle Frame => Bounds;
+		public Rectangle Frame
+		{
+			get => Bounds;
+			set => Bounds = value;
+		}
 
 		public IViewHandler Handler
 		{
@@ -45,6 +49,9 @@ namespace Microsoft.Maui.Controls
 
 		public Size DesiredSize { get; protected set; }
 
+		// TODO ezhart 2021-06-24 Does anything actually _use_ this Arrange method? Because if not, we could remove it
+		// and if we can remove it, we might be able to drop the explicit arrange implementation below, and ArrangeOverride
+		// which would make all of this much easier to grok
 		public void Arrange(Rectangle bounds)
 		{
 			Layout(bounds);
@@ -59,7 +66,7 @@ namespace Microsoft.Maui.Controls
 		// the interface has to be explicitly implemented to avoid conflict with the old Arrange method
 		protected virtual Size ArrangeOverride(Rectangle bounds)
 		{
-			Bounds = this.ComputeFrame(bounds);
+			// No child elements to arrange, so nothing to do here
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -12,8 +12,17 @@ namespace Microsoft.Maui.Controls
 
 		public Rectangle Frame
 		{
-			get => Bounds;
-			set => Bounds = value;
+			get => Bounds; // TODO ezhart 2021-06-27 This will allocate a new rectangle every time, which isn't great for performance
+			set
+			{
+				// These next four lines are the same as setting Bounds, but without the layout side-effects
+				X = value.X;
+				Y = value.Y;
+				Width = value.Width;
+				Height = value.Height;
+
+				Handler?.UpdateValue(nameof(IFrameworkElement.Frame));
+			}
 		}
 
 		public IViewHandler Handler

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -10,18 +10,24 @@ namespace Microsoft.Maui.Controls
 		Semantics _semantics;
 		IViewHandler _handler;
 
+		Rectangle _frame;
+
 		public Rectangle Frame
 		{
-			get => Bounds; // TODO ezhart 2021-06-27 This will allocate a new rectangle every time, which isn't great for performance
+			get => _frame; 
 			set
 			{
-				// These next four lines are the same as setting Bounds, but without the layout side-effects
-				X = value.X;
-				Y = value.Y;
-				Width = value.Width;
-				Height = value.Height;
+				if (value != _frame)
+				{
+					_frame = value;
 
-				Handler?.UpdateValue(nameof(IFrameworkElement.Frame));
+					X = _frame.X;
+					Y = _frame.Y;
+					Width = _frame.Width;
+					Height = _frame.Height;
+
+					Handler?.UpdateValue(nameof(IFrameworkElement.Frame));
+				}
 			}
 		}
 
@@ -172,7 +178,11 @@ namespace Microsoft.Maui.Controls
 			if (_handler?.VirtualView != this)
 				_handler?.SetVirtualView((IView)this);
 
+				#if WINDOWS
+
+				#else
 			IsPlatformEnabled = _handler != null;
+			#endif
 
 			if (_handler != null)
 			{

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -20,12 +20,6 @@ namespace Microsoft.Maui.Controls
 				if (value != _frame)
 				{
 					_frame = value;
-
-					X = _frame.X;
-					Y = _frame.Y;
-					Width = _frame.Width;
-					Height = _frame.Height;
-
 					Handler?.UpdateValue(nameof(IFrameworkElement.Frame));
 				}
 			}

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -523,20 +523,12 @@ namespace Microsoft.Maui.Controls
 		{
 			var size = base.ArrangeOverride(bounds);
 
-			// The SholdLayoutChildren check will catch impossible sizes (negative widths/heights), not-yet-loaded controls,
+			// The ShouldLayoutChildren check will catch impossible sizes (negative widths/heights), not-yet-loaded controls,
 			// and other weirdness that comes from the legacy layouts trying to run layout before the native side is ready. 
 			if (!ShouldLayoutChildren())
 				return size;
 
 			UpdateChildrenLayout();
-
-			foreach (var child in Children)
-			{
-				if (child is IFrameworkElement frameworkElement)
-				{
-					frameworkElement.Handler?.NativeArrange(frameworkElement.Frame);
-				}
-			}
 
 			return Frame.Size;
 		}

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -521,12 +521,10 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
-			var size = base.ArrangeOverride(bounds);
-
 			// The ShouldLayoutChildren check will catch impossible sizes (negative widths/heights), not-yet-loaded controls,
 			// and other weirdness that comes from the legacy layouts trying to run layout before the native side is ready. 
 			if (!ShouldLayoutChildren())
-				return size;
+				return bounds.Size;
 
 			UpdateChildrenLayout();
 

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -521,6 +521,8 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
+			_ = base.ArrangeOverride(bounds);
+
 			// The ShouldLayoutChildren check will catch impossible sizes (negative widths/heights), not-yet-loaded controls,
 			// and other weirdness that comes from the legacy layouts trying to run layout before the native side is ready. 
 			if (!ShouldLayoutChildren())
@@ -530,10 +532,9 @@ namespace Microsoft.Maui.Controls
 
 			foreach (var child in Children)
 			{
-				if (child is IFrameworkElement frameworkElement)
+				if (child is IFrameworkElement frameworkElement and VisualElement visualElement)
 				{
-					// See ContentPage.Impl.cs for an explanation
-					frameworkElement.Frame = frameworkElement.Frame;
+					frameworkElement.Frame = visualElement.Bounds;
 				}
 			}
 

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -530,6 +530,15 @@ namespace Microsoft.Maui.Controls
 
 			UpdateChildrenLayout();
 
+			foreach (var child in Children)
+			{
+				if (child is IFrameworkElement frameworkElement)
+				{
+					// See ContentPage.Impl.cs for an explanation
+					frameworkElement.Frame = frameworkElement.Frame;
+				}
+			}
+
 			return Frame.Size;
 		}
 	}

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -50,15 +50,8 @@ namespace Microsoft.Maui.Controls.Layout2
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
-			base.ArrangeOverride(bounds);
-
+			// The base implementation is empty, so we don't bother calling it here
 			LayoutManager.ArrangeChildren(Frame);
-
-			foreach (var child in Children)
-			{
-				child.Handler?.NativeArrange(child.Frame);
-			}
-
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Controls.Layout2
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
-			// The base implementation is empty, so we don't bother calling it here
+			_ = base.ArrangeOverride(bounds);
 			LayoutManager.ArrangeChildren(Frame);
 			return Frame.Size;
 		}

--- a/src/Controls/src/Core/Platform/ModalNavigationService/ModalNavigationService.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationService/ModalNavigationService.Android.cs
@@ -256,9 +256,10 @@ namespace Microsoft.Maui.Controls.Platform
 					var destination = Rectangle.FromLTRB(deviceIndependentLeft, deviceIndependentTop,
 						deviceIndependentRight, deviceIndependentBottom);
 
-					(_modal as IFrameworkElement).Frame = _modal.Frame;
 					(_modal as IFrameworkElement).Arrange(destination);
-					_backgroundView.Layout(0, 0, r - l, b - t);
+					(_modal as IFrameworkElement).Frame = destination;
+
+					_backgroundView.Layout(l, t, r, b);
 				}
 
 				// _renderer.UpdateLayout();

--- a/src/Controls/src/Core/Platform/ModalNavigationService/ModalNavigationService.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationService/ModalNavigationService.Android.cs
@@ -256,8 +256,8 @@ namespace Microsoft.Maui.Controls.Platform
 					var destination = Rectangle.FromLTRB(deviceIndependentLeft, deviceIndependentTop,
 						deviceIndependentRight, deviceIndependentBottom);
 
+					(_modal as IFrameworkElement).Frame = _modal.Frame;
 					(_modal as IFrameworkElement).Arrange(destination);
-					(_modal.Handler as INativeViewHandler)?.NativeArrange(_modal.Frame);
 					_backgroundView.Layout(0, 0, r - l, b - t);
 				}
 

--- a/src/Controls/src/Core/Platform/iOS/ModalWrapper.cs
+++ b/src/Controls/src/Core/Platform/iOS/ModalWrapper.cs
@@ -117,7 +117,12 @@ namespace Microsoft.Maui.Controls.Platform
 		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
-			_modal?.NativeArrange(new Rectangle(0, 0, View.Bounds.Width, View.Bounds.Height));
+			if (_modal == null)
+			{
+				return;
+			}
+
+			_modal.VirtualView.Frame = new Rectangle(0, 0, View.Bounds.Width, View.Bounds.Height);
 		}
 
 		public override void ViewWillAppear(bool animated)

--- a/src/Controls/src/Core/Platform/iOS/ModalWrapper.cs
+++ b/src/Controls/src/Core/Platform/iOS/ModalWrapper.cs
@@ -122,7 +122,10 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			_modal.VirtualView.Frame = new Rectangle(0, 0, View.Bounds.Width, View.Bounds.Height);
+			var destination = new Rectangle(0, 0, View.Bounds.Width, View.Bounds.Height);
+
+			_modal.VirtualView.Arrange(destination);
+			_modal.VirtualView.Frame = destination;
 		}
 
 		public override void ViewWillAppear(bool animated)

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -403,6 +403,7 @@ namespace Microsoft.Maui.Controls
 
 		public Rectangle Bounds
 		{
+			// TODO ezhart 2021-06-26 It seems ... wrong that this should return a brand new rectangle on every access
 			get { return new Rectangle(X, Y, Width, Height); }
 			private set
 			{
@@ -413,8 +414,6 @@ namespace Microsoft.Maui.Controls
 				Y = value.Y;
 				SetSize(value.Width, value.Height);
 				BatchCommit();
-
-				Handler?.UpdateValue(nameof(IFrameworkElement.Frame));
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			// Normally this would get called from the native platform
 			(verticalStackLayout as IFrameworkElement).Arrange(rect);
 
-			Assert.AreEqual(expectedSize, button.Bounds.Size);
+			Assert.AreEqual(expectedSize, button.Frame.Size);
 		}
 
 		[Test]
@@ -82,7 +82,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			(verticalStackLayout as IFrameworkElement).Arrange(expectedRect);
 
 			Assert.AreEqual(expectedRect, stackLayout.Frame);
-			Assert.AreEqual(expectedSize, stackLayout.Bounds.Size);
 		}
 
 		[Test]
@@ -102,14 +101,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			grid.Children.Add(label);
 			contentPage.Content = stackLayout;
 
-			var rect = new Rectangle(0, 0, 50, 100);
+			var rect = new Rectangle(0, 0, 50, 50);
 			(contentPage as IFrameworkElement).Measure(expectedSize.Width, expectedSize.Height);
 			(contentPage as IFrameworkElement).Arrange(rect);
 
 			// This simulates the arrange call that happens from the native LayoutViewGroup
 			(grid as IFrameworkElement).Arrange(rect);
 
-			Assert.AreEqual(expectedSize, grid.Bounds.Size);
+			Assert.AreEqual(expectedSize, grid.Frame.Size);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			(page as IFrameworkElement).Measure(expectedSize.Width, expectedSize.Height);
 			(page as IFrameworkElement).Arrange(expectedRect);
 
-			buttonHandler.Received().NativeArrange(expectedRect);
+			Assert.AreEqual(expectedRect, button.Frame);
 			Assert.AreEqual(expectedSize, button.Bounds.Size);
 		}
 
@@ -78,9 +78,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			stackLayout.Children.Add(button);
 
 			(verticalStackLayout as IFrameworkElement).Measure(expectedRect.Width, expectedRect.Height);
+			(verticalStackLayout as IFrameworkElement).Frame = expectedRect;
 			(verticalStackLayout as IFrameworkElement).Arrange(expectedRect);
 
-			slHandler.Received().NativeArrange(expectedRect);
+			Assert.AreEqual(expectedRect, stackLayout.Frame);
 			Assert.AreEqual(expectedSize, stackLayout.Bounds.Size);
 		}
 

--- a/src/Core/src/Core/IFrameworkElement.cs
+++ b/src/Core/src/Core/IFrameworkElement.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Maui
 
 		// TODO ezhart 2021-06-24 AFAIK, we don't actually use the value returned from Arrange anywhere; can we drop it?
 		/// <summary>
-		/// Positions child elements and determines a size for an Element.
+		/// Sets the Frame for an element and positions child elements.
 		/// </summary>
 		/// <param name="bounds">The size that the parent computes for the child element.</param>
 		/// <returns>Return the actual arranged Size for this element.</returns>

--- a/src/Core/src/Core/IFrameworkElement.cs
+++ b/src/Core/src/Core/IFrameworkElement.cs
@@ -60,9 +60,9 @@ namespace Microsoft.Maui
 		Paint? Background { get; }
 
 		/// <summary>
-		/// Gets the bounds of the FrameworkElement.
+		/// Gets or sets the Rectangle which specifies the bounds of the element in relation to its container
 		/// </summary>
-		Rectangle Frame { get; }
+		Rectangle Frame { get; set; }
 
 		/// <summary>
 		/// Gets the specified width of this FrameworkElement. 
@@ -84,6 +84,7 @@ namespace Microsoft.Maui
 		/// </summary>
 		IFrameworkElement? Parent { get; }
 
+		// TODO ezhart 2021-06-24 AFAIK, we don't actually use the value returned from Arrange anywhere; can we drop it?
 		/// <summary>
 		/// Positions child elements and determines a size for an Element.
 		/// </summary>

--- a/src/Core/src/Handlers/IViewHandler.cs
+++ b/src/Core/src/Handlers/IViewHandler.cs
@@ -14,6 +14,5 @@ namespace Microsoft.Maui
 		bool HasContainer { get; set; }
 		object? ContainerView { get; }
 		Size GetDesiredSize(double widthConstraint, double heightConstraint);
-		void NativeArrange(Rectangle frame);
 	}
 }

--- a/src/Core/src/Handlers/Page/PageHandler.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.cs
@@ -7,12 +7,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			[nameof(IPage.Title)] = MapTitle,
 			[nameof(IPage.Content)] = MapContent,
-#if __IOS__
-			Actions =
-			{
-				[nameof(IFrameworkElement.Frame)] = MapFrame,
-			}
-#endif
+			[nameof(IFrameworkElement.Frame)] = MapFrame,
 		};
 
 		public PageHandler() : base(PageMapper)

--- a/src/Core/src/Handlers/Page/PageHandler.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			[nameof(IPage.Title)] = MapTitle,
 			[nameof(IPage.Content)] = MapContent,
-			[nameof(IFrameworkElement.Frame)] = MapFrame,
 		};
 
 		public PageHandler() : base(PageMapper)

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -36,11 +36,12 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IView.RotationY)] = MapRotationY,
 			[nameof(IView.AnchorX)] = MapAnchorX,
 			[nameof(IView.AnchorY)] = MapAnchorY,
-			[nameof(IFrameworkElement.Frame)] = MapFrame,
+			
 			Actions =
 			{
 				[nameof(IViewHandler.ContainerView)] = MapContainerView,
 				[nameof(IFrameworkElement.InvalidateMeasure)] = MapInvalidateMeasure,
+				[nameof(IFrameworkElement.Frame)] = MapFrame,
 			}
 		};
 

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -36,12 +36,11 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IView.RotationY)] = MapRotationY,
 			[nameof(IView.AnchorX)] = MapAnchorX,
 			[nameof(IView.AnchorY)] = MapAnchorY,
+			[nameof(IFrameworkElement.Frame)] = MapFrame,
 			Actions =
 			{
 				[nameof(IViewHandler.ContainerView)] = MapContainerView,
 				[nameof(IFrameworkElement.InvalidateMeasure)] = MapInvalidateMeasure,
-				[nameof(IFrameworkElement.Frame)] = MapFrame, // TODO ezhart 2021-06-24 Should this be a regular mapping? I think it's on actions to prevent it running immediately on creation
-				// Which might be fine? Or maybe it just needs a guard clause to discard invalid values?
 			}
 		};
 

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Maui.Handlers
 			{
 				[nameof(IViewHandler.ContainerView)] = MapContainerView,
 				[nameof(IFrameworkElement.InvalidateMeasure)] = MapInvalidateMeasure,
-				[nameof(IFrameworkElement.Frame)] = MapFrame,
+				[nameof(IFrameworkElement.Frame)] = MapFrame, // TODO ezhart 2021-06-24 Should this be a regular mapping? I think it's on actions to prevent it running immediately on creation
+				// Which might be fine? Or maybe it just needs a guard clause to discard invalid values?
 			}
 		};
 
@@ -95,7 +96,7 @@ namespace Microsoft.Maui.Handlers
 
 		public abstract Size GetDesiredSize(double widthConstraint, double heightConstraint);
 
-		public abstract void NativeArrange(Rectangle frame);
+		public abstract void SetNativeFrame(Rectangle frame);
 
 		partial void ConnectingHandler(NativeView? nativeView);
 
@@ -192,6 +193,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapFrame(ViewHandler handler, IView view)
 		{
+			handler.SetNativeFrame(view.Frame);
 			MappingFrame(handler, view);
 #if WINDOWS
 			MapClip(handler, view);

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using Android.Content;
 using Android.Views;
 using Microsoft.Maui.Graphics;
@@ -22,21 +21,18 @@ namespace Microsoft.Maui.Handlers
 
 		public Context Context => MauiContext?.Context ?? throw new InvalidOperationException($"Context cannot be null here");
 
-		public override void NativeArrange(Rectangle frame)
+		public override void SetNativeFrame(Rectangle frame)
 		{
 			var nativeView = WrappedNativeView;
 
 			if (nativeView == null)
 				return;
 
-			if (frame.Width < 0 || frame.Height < 0)
+			if (MauiContext == null || frame.Width < 0 || frame.Height < 0)
 			{
-				// This is a legacy layout value from Controls, nothing is actually laying out yet so we just ignore it
+				// This is just legacy layout stuff from Controls jumping the gun; we aren't ready to actually lay things out yet
 				return;
 			}
-
-			if (Context == null)
-				return;
 
 			var left = Context.ToPixels(frame.Left);
 			var top = Context.ToPixels(frame.Top);

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Standard.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Standard.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class ViewHandler<TVirtualView, TNativeView>
 	{
-		public override void NativeArrange(Rectangle rect)
+		public override void SetNativeFrame(Rectangle frame)
 		{
 
 		}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Handlers
 			protected set => base.ContainerView = value;
 		}
 
-		public override void NativeArrange(Rectangle rect)
+		public override void SetNativeFrame(Rectangle rect)
 		{
 			var nativeView = WrappedNativeView;
 

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Handlers
 
 		UIViewController? INativeViewHandler.ViewController => null;
 
-		public override void NativeArrange(Rectangle rect)
+		public override void SetNativeFrame(Rectangle frame)
 		{
 			var nativeView = WrappedNativeView;
 
@@ -28,8 +28,8 @@ namespace Microsoft.Maui.Handlers
 
 			// We set Center and Bounds rather than Frame because Frame is undefined if the CALayer's transform is 
 			// anything other than the identity (https://developer.apple.com/documentation/uikit/uiview/1622459-transform)
-			nativeView.Center = new CoreGraphics.CGPoint(rect.Center.X, rect.Center.Y);
-			nativeView.Bounds = new CoreGraphics.CGRect(0, 0, rect.Width, rect.Height);
+			nativeView.Center = new CoreGraphics.CGPoint(frame.Center.X, frame.Center.Y);
+			nativeView.Bounds = new CoreGraphics.CGRect(0, 0, frame.Width, frame.Height);
 
 			nativeView.UpdateBackgroundLayerFrame();
 		}

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -36,11 +36,8 @@ namespace Microsoft.Maui.Layouts
 
 				var cell = structure.GetCellBoundsFor(child);
 
-				// Set the actual position and size for the child
-				child.Frame = child.ComputeFrame(cell);
-
-				// And allow the child to arrange its children, if any
-				child.Arrange(child.Frame);
+				// Tell the child to set its position/size and arrange its own children
+				child.Arrange(child.ComputeFrame(cell));
 			}
 		}
 

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -27,15 +27,20 @@ namespace Microsoft.Maui.Layouts
 		{
 			var structure = _gridStructure ?? new GridStructure(Grid, childBounds.Width, childBounds.Height);
 
-			foreach (var view in Grid.Children)
+			foreach (var child in Grid.Children)
 			{
-				if (view.Visibility == Visibility.Collapsed)
+				if (child.Visibility == Visibility.Collapsed)
 				{
 					continue;
 				}
 
-				var cell = structure.GetCellBoundsFor(view);
-				view.Arrange(cell);
+				var cell = structure.GetCellBoundsFor(child);
+
+				// Set the actual position and size for the child
+				child.Frame = child.ComputeFrame(cell);
+
+				// And allow the child to arrange its children, if any
+				child.Arrange(child.Frame);
 			}
 		}
 

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -95,12 +95,9 @@ namespace Microsoft.Maui.Layouts
 		static double ArrangeChild(IView child, double height, int spacing, double x)
 		{
 			var destination = new Rectangle(x, 0, child.DesiredSize.Width, height);
-			
-			// Set the actual position and size for the child
-			child.Frame = child.ComputeFrame(destination);
 
-			// And allow the child to arrange its children, if any
-			child.Arrange(child.Frame);
+			// Tell the child to set its position/size and arrange its own children
+			child.Arrange(child.ComputeFrame(destination));
 			
 			return destination.Width + spacing;
 		}

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -95,7 +95,13 @@ namespace Microsoft.Maui.Layouts
 		static double ArrangeChild(IView child, double height, int spacing, double x)
 		{
 			var destination = new Rectangle(x, 0, child.DesiredSize.Width, height);
-			child.Arrange(destination);
+			
+			// Set the actual position and size for the child
+			child.Frame = child.ComputeFrame(destination);
+
+			// And allow the child to arrange its children, if any
+			child.Arrange(child.Frame);
+			
 			return destination.Width + spacing;
 		}
 	}

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -56,12 +56,9 @@ namespace Microsoft.Maui.Layouts
 				}
 
 				var destination = new Rectangle(0, stackHeight, width, child.DesiredSize.Height);
-				
-				// Set the actual position and size for the child
-				child.Frame = child.ComputeFrame(destination);
 
-				// And allow the child to arrange its children, if any
-				child.Arrange(child.Frame);
+				// Tell the child to set its position/size and arrange its own children
+				child.Arrange(child.ComputeFrame(destination));
 
 				stackHeight += destination.Height + spacing;
 			}

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -56,7 +56,13 @@ namespace Microsoft.Maui.Layouts
 				}
 
 				var destination = new Rectangle(0, stackHeight, width, child.DesiredSize.Height);
-				child.Arrange(destination);
+				
+				// Set the actual position and size for the child
+				child.Frame = child.ComputeFrame(destination);
+
+				// And allow the child to arrange its children, if any
+				child.Arrange(child.Frame);
+
 				stackHeight += destination.Height + spacing;
 			}
 		}

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Maui
 	{
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
 		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
+		
+		// Since we have to use Arrange to set the actual position/size of the native view, and Arrange can
+		// be triggered by the call to CrossPlatformArrange below, we can set a flag to prevent Arrange loops
+		bool _isArranging;
 
 		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
 		{
@@ -30,7 +34,7 @@ namespace Microsoft.Maui
 
 		protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
 		{
-			if (CrossPlatformArrange == null)
+			if (_isArranging || CrossPlatformArrange == null)
 			{
 				return base.ArrangeOverride(finalSize);
 			}
@@ -38,7 +42,9 @@ namespace Microsoft.Maui
 			var width = finalSize.Width;
 			var height = finalSize.Height;
 
+			_isArranging = true;
 			var actual = CrossPlatformArrange(new Rectangle(0, 0, width, height));
+			_isArranging = false;
 
 			return new Windows.Foundation.Size(actual.Width, actual.Height);
 		}

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
@@ -69,8 +69,9 @@ namespace Microsoft.Maui.DeviceTests
 			handler.SetVirtualView(view);
 			view.Handler = handler;
 
-			view.Arrange(new Rectangle(0, 0, view.Width, view.Height));
-			handler.NativeArrange(view.Frame);
+			// We're faking here as if we've measured the view
+			handler.VirtualView.Frame = new Rectangle(0, 0, handler.VirtualView.DesiredSize.Width, handler.VirtualView.DesiredSize.Height);
+			view.Arrange(view.Frame);
 
 			return handler;
 		}

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class StubBase : IFrameworkElement
 	{
+		Rectangle _frame;
+
 		public bool IsEnabled { get; set; } = true;
 
 		public Visibility Visibility { get; set; } = Visibility.Visible;
@@ -16,8 +18,12 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Paint Background { get; set; }
 
-		public Rectangle Frame { get; set; }
-
+		public Rectangle Frame
+		{
+			get => _frame;
+			set => SetProperty(ref _frame, value);
+		}
+		
 		public IViewHandler Handler { get; set; }
 
 		public IShape Clip { get; set; }


### PR DESCRIPTION
Add missing measurement code for BoxRenderer so it works with a shim.

Simplifications to the layout code:

- Rename ViewHandler.NativeArrange -> ViewHandle.SetNativeFrame
- Remove NativeArrange from IViewHandler
- Reinstate Frame mapping in handlers (to include SetNativeFrame)
- Disentangle Bounds/Frame in VisualElement; Frame still depends on Bounds, but updating Bounds does not immediately trigger Frame mapping updates (preventing several species of layout cycles and other weirdness)
- Add setter to IFrameworkElement.Frame
