### PR TITLE
[workload] the maui-core workload needs to be abstract

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -23,6 +23,7 @@
       ]
     },
     "maui-core": {
+      "abstract": true,
       "description": ".NET MAUI SDK Core Packages",
       "packs": [
           "Microsoft.AspNetCore.Components.WebView.Maui",


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/dotnet/designs/blob/02486c962c09113deec777cabd9a54e9acfef437/accepted/2020/workloads/workload-manifest.md#workload-definitions

The `maui-core` workload isn't something we intend developers to
install directly. It is a set of packs that are shared by all
platform-specific workloads.

We need to make the `maui-core` workload "abstract":

> If `true`, this workload can only be extended, and is never exposed
> directly as an installable workload. Default is `false`.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No

/cc @mhutch @lutzroeder 