### PR TITLE
Set handler to shimmed handler so it doesn't get reshimmed

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -355,6 +355,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				else if (handler is INativeViewHandler vh)
 				{
 					renderer = new HandlerToRendererShim(vh);
+					element.Handler = handler;
 					SetRenderer(element, renderer);
 				}
 			}

--- a/src/Compatibility/Core/src/WinUI/Platform.cs
+++ b/src/Compatibility/Core/src/WinUI/Platform.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				else if (handler is INativeViewHandler vh)
 				{
 					renderer = new HandlerToRendererShim(vh);
+					element.Handler = handler;
 					SetRenderer(element, renderer);
 				}
 			}

--- a/src/Compatibility/Core/src/iOS/Platform.cs
+++ b/src/Compatibility/Core/src/iOS/Platform.cs
@@ -280,6 +280,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				else if (handler is INativeViewHandler vh)
 				{
 					renderer = new HandlerToRendererShim(vh);
+					element.Handler = handler;
+					SetRenderer(element, renderer);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

When the Renderer Bindable property changed event will set the handler to a shimmed renderer if no handler has been set on the control. This way every control will have a handler. Currently this logic is causing handlers that are shimmed to renderers to get shimmed one more time so on the handler property you end up with

`RendererToHandlerShim => HandlerToRendererShim => LayoutHandler`

This PR sets the Handler property to the handler being shimmed so now all you have is

`LayoutHandler`

