### PR TITLE
Don't extract native defaults, meaning users can no longer reset a color back to a platform theme

### DIFF
--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.Windows.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.Windows.cs
@@ -11,11 +11,9 @@ namespace Microsoft.Maui.Handlers
 			Style = UI.Xaml.Application.Current.Resources["MauiActivityIndicatorStyle"] as UI.Xaml.Style
 		};
 
-		protected override void SetupDefaults(MauiActivityIndicator nativeView)
+		void SetupDefaults(MauiActivityIndicator nativeView)
 		{
 			_foregroundDefault = nativeView.GetForegroundCache();
-
-			base.SetupDefaults(nativeView);
 		}
 
 		public static void MapIsRunning(ActivityIndicatorHandler handler, IActivityIndicator activityIndicator)

--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Handlers
 			return nativeButton;
 		}
 
-		protected override void SetupDefaults(AppCompatButton nativeView)
+		void SetupDefaults(AppCompatButton nativeView)
 		{
 			DefaultPadding = new Thickness(
 				nativeView.PaddingLeft,
@@ -34,8 +34,6 @@ namespace Microsoft.Maui.Handlers
 				nativeView.PaddingBottom);
 
 			DefaultBackground = nativeView.Background;
-
-			base.SetupDefaults(nativeView);
 		}
 
 		protected override void ConnectHandler(AppCompatButton nativeView)

--- a/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
@@ -14,13 +14,11 @@ namespace Microsoft.Maui.Handlers
 		protected override MauiButton CreateNativeView() 
 			=> new MauiButton();
 
-		protected override void SetupDefaults(MauiButton nativeView)
+		void SetupDefaults(MauiButton nativeView)
 		{
 			DefaultPadding = (UI.Xaml.Thickness)MauiWinUIApplication.Current.Resources["ButtonPadding"];
 			DefaultForeground = (UI.Xaml.Media.Brush)MauiWinUIApplication.Current.Resources["ButtonForegroundThemeBrush"];
 			DefaultBackground = (UI.Xaml.Media.Brush)MauiWinUIApplication.Current.Resources["ButtonBackgroundThemeBrush"];
-
-			base.SetupDefaults(nativeView);
 		}
 
 		protected override void ConnectHandler(MauiButton nativeView)

--- a/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
@@ -37,13 +37,11 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(nativeView);
 		}
 
-		protected override void SetupDefaults(UIButton nativeView)
+		void SetupDefaults(UIButton nativeView)
 		{
 			ButtonTextColorDefaultNormal = nativeView.TitleColor(UIControlState.Normal);
 			ButtonTextColorDefaultHighlighted = nativeView.TitleColor(UIControlState.Highlighted);
 			ButtonTextColorDefaultDisabled = nativeView.TitleColor(UIControlState.Disabled);
-
-			base.SetupDefaults(nativeView);
 		}
 
 		public static void MapText(ButtonHandler handler, IButton button)

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -27,12 +27,12 @@ namespace Microsoft.Maui.Handlers
 			return mauiDatePicker;
 		}
 
-		protected override void SetupDefaults(MauiDatePicker nativeView)
+		void SetupDefaults(MauiDatePicker nativeView)
 		{
 			_defaultBackground = nativeView.Background;
 			_defaultTextColors = nativeView.TextColors;
 
-			base.SetupDefaults(nativeView);
+			
 		}
 
 		internal DatePickerDialog? DatePickerDialog { get { return _dialog; } }

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Windows.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Maui.Handlers
 			nativeView.DateChanged -= DateChanged;
 		}
 
-		protected override void SetupDefaults(CalendarDatePicker nativeView)
+		void SetupDefaults(CalendarDatePicker nativeView)
 		{
 			_defaultForeground = nativeView.Foreground;
 
-			base.SetupDefaults(nativeView);
+			
 		}
 
 		public static void MapFormat(DatePickerHandler handler, IDatePicker datePicker)

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
@@ -64,11 +64,9 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(nativeView);
 		}
 
-		protected override void SetupDefaults(MauiDatePicker nativeView)
+		void SetupDefaults(MauiDatePicker nativeView)
 		{
 			_defaultTextColor = nativeView.TextColor;
-
-			base.SetupDefaults(nativeView);
 		}
 
 		public static void MapFormat(DatePickerHandler handler, IDatePicker datePicker)

--- a/src/Core/src/Handlers/Defaults.cs
+++ b/src/Core/src/Handlers/Defaults.cs
@@ -1,7 +1,0 @@
-﻿namespace Microsoft.Maui
-{
-	class Defaults<T>
-	{
-		public static bool HasSetDefaults;
-	}
-}

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Maui.Handlers
 			FocusChangeListener.Handler = null;
 		}
 
-		protected override void SetupDefaults(AppCompatEditText nativeView)
+		void SetupDefaults(AppCompatEditText nativeView)
 		{
-			base.SetupDefaults(nativeView);
+			
 
 			DefaultTextColors = nativeView.TextColors;
 			DefaultPlaceholderTextColors = nativeView.HintTextColors;

--- a/src/Core/src/Handlers/Editor/EditorHandler.Windows.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Windows.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Maui.Handlers
 			nativeView.LostFocus -= OnLostFocus;
 		}
 
-		protected override void SetupDefaults(MauiTextBox nativeView)
+		void SetupDefaults(MauiTextBox nativeView)
 		{
 			_placeholderDefaultBrush = nativeView.PlaceholderForeground;
 			_defaultPlaceholderColorFocusBrush = nativeView.PlaceholderForegroundFocusBrush;
 
-			base.SetupDefaults(nativeView);
+			
 		}
 
 		public static void MapText(EditorHandler handler, IEditor editor)

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Maui.Handlers
 		{
 		};
 
-		protected abstract bool HasSetDefaults { get; set; }
-
 		protected PropertyMapper _mapper;
 		protected readonly PropertyMapper _defaultMapper;
 
@@ -54,13 +52,6 @@ namespace Microsoft.Maui.Handlers
 				ConnectHandler(NativeView);
 			}
 
-			if (!HasSetDefaults)
-			{
-				SetupDefaults(NativeView);
-
-				HasSetDefaults = true;
-			}
-
 			_mapper = _defaultMapper;
 
 			if (VirtualView is IPropertyMapperView imv)
@@ -88,11 +79,6 @@ namespace Microsoft.Maui.Handlers
 
 		object CreateNativeElement() =>
 			OnCreateNativeElement();
-
-		private protected abstract void OnSetupDefaults(object nativeView);
-
-		void SetupDefaults(object nativeView) =>
-			OnSetupDefaults(nativeView);
 
 		private protected abstract void OnConnectHandler(object nativeView);
 

--- a/src/Core/src/Handlers/Element/ElementHandlerOfT.cs
+++ b/src/Core/src/Handlers/Element/ElementHandlerOfT.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Maui.Handlers
 		[HotReload.OnHotReload]
 		internal static void OnHotReload()
 		{
-			Defaults<ElementHandler<TVirtualView, TNativeView>>.HasSetDefaults = false;
 		}
 
 		protected ElementHandler(PropertyMapper mapper)
@@ -33,17 +32,7 @@ namespace Microsoft.Maui.Handlers
 
 		object? IElementHandler.NativeView => base.NativeView;
 
-		protected override bool HasSetDefaults
-		{
-			get => Defaults<ElementHandler<TVirtualView, TNativeView>>.HasSetDefaults;
-			set => Defaults<ElementHandler<TVirtualView, TNativeView>>.HasSetDefaults = value;
-		}
-
 		protected abstract TNativeView CreateNativeElement();
-
-		protected virtual void SetupDefaults(TNativeView nativeView)
-		{
-		}
 
 		protected virtual void ConnectHandler(TNativeView nativeView)
 		{
@@ -55,9 +44,6 @@ namespace Microsoft.Maui.Handlers
 
 		private protected override object OnCreateNativeElement() =>
 			CreateNativeElement();
-
-		private protected override void OnSetupDefaults(object nativeView) =>
-			SetupDefaults((TNativeView)nativeView);
 
 		private protected override void OnConnectHandler(object nativeView) =>
 			ConnectHandler((TNativeView)nativeView);

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Maui.Handlers
 			ActionListener.Handler = null;
 		}
 
-		protected override void SetupDefaults(AppCompatEditText nativeView)
+		void SetupDefaults(AppCompatEditText nativeView)
 		{
-			base.SetupDefaults(nativeView);
+			
 
 			ClearButtonDrawable = GetClearButtonDrawable();
 			DefaultTextColors = nativeView.TextColors;

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.ShouldChangeCharacters -= OnShouldChangeCharacters;
 		}
 
-		protected override void SetupDefaults(MauiTextField nativeView)
+		void SetupDefaults(MauiTextField nativeView)
 		{
 			DefaultTextColor = nativeView.TextColor;
 		}

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override TextView CreateNativeView() => new TextView(Context);
 
-		protected override void SetupDefaults(TextView nativeView)
+		void SetupDefaults(TextView nativeView)
 		{
 			if (nativeView.TextColors == null)
 			{

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(nativeView);
 		}
 
-		protected override void SetupDefaults(MauiPicker nativeView)
+		void SetupDefaults(MauiPicker nativeView)
 		{
-			base.SetupDefaults(nativeView);
+			
 
 			DefaultBackground = nativeView.Background;
 			DefaultTitleColors = nativeView.HintTextColors;

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Maui.Handlers
 			nativeView.SelectionChanged -= OnControlSelectionChanged;
 		}
 
-		protected override void SetupDefaults(MauiComboBox nativeView)
+		void SetupDefaults(MauiComboBox nativeView)
 		{
 			_defaultForeground = nativeView.Foreground;
 
-			base.SetupDefaults(nativeView);
+			
 		}
 		void Reload()
 		{

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Maui.Handlers
 			return searchView;
 		}
 
-		protected override void SetupDefaults(SearchView nativeView)
+		void SetupDefaults(SearchView nativeView)
 		{
 			DefaultBackground = nativeView.Background;
 
-			base.SetupDefaults(nativeView);
+			
 		}
 
 		// This is a Android-specific mapping

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(nativeView);
 		}
 
-		protected override void SetupDefaults(UISearchBar nativeView)
+		void SetupDefaults(UISearchBar nativeView)
 		{
 			_defaultTextColor = QueryEditor?.TextColor;
 
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Handlers
 				_cancelButtonTextColorDefaultDisabled = cancelButton.TitleColor(UIControlState.Disabled);
 			}
 
-			base.SetupDefaults(nativeView);
+			
 		}
 
 		public static void MapText(SearchBarHandler handler, ISearchBar searchBar)

--- a/src/Core/src/Handlers/Slider/SliderHandler.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.Android.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.SetOnSeekBarChangeListener(null);
 		}
 
-		protected override void SetupDefaults(SeekBar nativeView)
+		void SetupDefaults(SeekBar nativeView)
 		{
 			DefaultThumbColorFilter = nativeView.Thumb?.GetColorFilter();
 			DefaultProgressTintMode = nativeView.ProgressTintMode;

--- a/src/Core/src/Handlers/Slider/SliderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.Windows.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Handlers
 			_pointerReleasedHandler = null;
 		}
 
-		protected override void SetupDefaults(MauiSlider nativeView)
+		void SetupDefaults(MauiSlider nativeView)
 		{
 			DefaultForegroundColor = nativeView.Foreground;
 			DefaultBackgroundColor = nativeView.Background;

--- a/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.RemoveTarget(OnTouchUpControlEvent, UIControlEvent.TouchUpInside | UIControlEvent.TouchUpOutside);
 		}
 
-		protected override void SetupDefaults(UISlider nativeView)
+		void SetupDefaults(UISlider nativeView)
 		{
 			DefaultMinTrackColor = nativeView.MinimumTrackTintColor;
 			DefaultMaxTrackColor = nativeView.MaximumTrackTintColor;

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.SetOnCheckedChangeListener(null);
 		}
 
-		protected override void SetupDefaults(ASwitch nativeView)
+		void SetupDefaults(ASwitch nativeView)
 		{
 			DefaultTrackColorStateList = nativeView.GetDefaultSwitchTrackColorStateList();
 			DefaultThumbColorStateList = nativeView.GetDefaultSwitchThumbColorStateList();

--- a/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.ValueChanged -= OnControlValueChanged;
 		}
 
-		protected override void SetupDefaults(UISwitch nativeView)
+		void SetupDefaults(UISwitch nativeView)
 		{
 			DefaultOnTrackColor = UISwitch.Appearance.OnTintColor;
 			DefaultOffTrackColor = nativeView.GetOffTrackColor();

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Android.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Maui.Handlers
 			return _timePicker;
 		}
 
-		protected override void SetupDefaults(MauiTimePicker nativeView)
+		void SetupDefaults(MauiTimePicker nativeView)
 		{
 			DefaultBackground = nativeView.Background;
 
-			base.SetupDefaults(nativeView);
+			
 		}
 
 		protected override void DisconnectHandler(MauiTimePicker nativeView)

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Maui.Handlers
 			nativeView.TimeChanged -= OnControlTimeChanged;
 		}
 
-    protected override void SetupDefaults(TimePicker nativeView)
+    void SetupDefaults(TimePicker nativeView)
 		{
 			_defaultForeground = nativeView.Foreground;
 
-			base.SetupDefaults(nativeView);
+			
 		}
 
 	  public static void MapFormat(TimePickerHandler handler, ITimePicker timePicker)

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -105,11 +105,6 @@ namespace Microsoft.Maui.Handlers
 			OnCreateNativeView();
 
 #if !NETSTANDARD
-		private protected abstract void OnSetupDefaults(NativeView nativeView);
-
-		private protected sealed override void OnSetupDefaults(object nativeView) =>
-			OnSetupDefaults((NativeView)nativeView);
-
 		private protected abstract void OnConnectHandler(NativeView nativeView);
 
 		partial void ConnectingHandler(NativeView? nativeView);

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Maui.Handlers
 		[HotReload.OnHotReload]
 		internal static void OnHotReload()
 		{
-			Defaults<ViewHandler<TVirtualView, TNativeView>>.HasSetDefaults = false;
 		}
 
 		protected ViewHandler(PropertyMapper mapper)
@@ -48,12 +47,6 @@ namespace Microsoft.Maui.Handlers
 
 		object? IElementHandler.NativeView => base.NativeView;
 
-		protected override bool HasSetDefaults
-		{
-			get => Defaults<ViewHandler<TVirtualView, TNativeView>>.HasSetDefaults;
-			set => Defaults<ViewHandler<TVirtualView, TNativeView>>.HasSetDefaults = value;
-		}
-
 		public virtual void SetVirtualView(IView view) =>
 			base.SetVirtualView(view);
 
@@ -61,10 +54,6 @@ namespace Microsoft.Maui.Handlers
 			SetVirtualView((IView)view);
 
 		protected abstract TNativeView CreateNativeView();
-
-		protected virtual void SetupDefaults(TNativeView nativeView)
-		{
-		}
 
 		protected virtual void ConnectHandler(TNativeView nativeView)
 		{
@@ -76,9 +65,6 @@ namespace Microsoft.Maui.Handlers
 
 		private protected override NativeView OnCreateNativeView() =>
 			CreateNativeView();
-
-		private protected override void OnSetupDefaults(NativeView nativeView) =>
-			SetupDefaults((TNativeView)nativeView);
 
 		private protected override void OnConnectHandler(NativeView nativeView) =>
 			ConnectHandler((TNativeView)nativeView);


### PR DESCRIPTION
### Description of Change ###

The change to Maui.Graphics caused us to get rid of `Color.Default` . Since that point we've been discussing what should be the behavior of setting a Color to null.

This PR gets rid of the ability for a user to reset a color back to whatever the platform theme defines

#### Xamarin.Forms Behavior
```C#
button.BackgroundColor = Color.Green
button.BackgroundColor = Color.Default

// At this point the buttons back ground color would change back to whatever the native platform theme defined that backgroundColor to be
```

#### MAUI Behavior
```C#
button.BackgroundColor = Color.Green
button.BackgroundColor = null //Color.Default no longer exists

// Null will be considered a NOOP and the background color will still be green
```

Reading the platform defaults can be problematic for some cases and difficult to extract correctly. For example, 

https://github.com/dotnet/maui/blob/d1823cdc1508c149f2e4179ba6c000155361ab68/src/Core/src/Platform/Android/SwitchExtensions.cs#L60

For now we are going to operate on the premise that users don't use the behavior of `Color.Default` enough to warrant the effort of implementation and the performance implications of pulling those values during startup.

With .NET MAUI and multi-targeting it is also much easier to read values from the native platform so if a user wants the native defaults then they can tap into the handler property for that color and save off the default themselves

#### NOTE
Currently I've left the methods that we implemented to pull and set defaults. We can clean this up a later date. I didn't want to just remove that code in case parts of it are still useful. It's not reachable by the user so we don't need to worry about API breaks