### PR TITLE
Implement Fonts properties in WinUI SearchBar

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
@@ -11,6 +11,22 @@
                 Text="Default"
                 Style="{StaticResource Headline}"/>
             <SearchBar/>
+            <Label
+                Text="Disabled"
+                Style="{StaticResource Headline}"/>
+            <SearchBar
+                IsEnabled="False"/>
+            <Label
+                Text="TextColor"
+                Style="{StaticResource Headline}"/>
+            <SearchBar
+                TextColor="Green"/>
+            <Label
+                Text="Fonts"
+                Style="{StaticResource Headline}"/>
+            <SearchBar
+                FontSize="24"
+                FontAttributes="Italic"/>
         </VerticalStackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -48,8 +48,12 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateHorizontalTextAlignment(searchBar, handler._queryTextBox);
 		}
 
-		[MissingMapper]
-		public static void MapFont(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapFont(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			var fontManager = handler.GetRequiredService<IFontManager>();
+
+			handler.NativeView?.UpdateFont(searchBar, fontManager);
+		}
 
 		public static void MapCharacterSpacing(SearchBarHandler handler, ISearchBar searchBar)
 		{

--- a/src/Core/src/Platform/Windows/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/Windows/SearchBarExtensions.cs
@@ -15,11 +15,14 @@ namespace Microsoft.Maui
 		{
 			nativeControl.PlaceholderText = searchBar.Placeholder ?? string.Empty;
 		}
-  
+
 		public static void UpdateText(this AutoSuggestBox nativeControl, ISearchBar searchBar)
 		{
 			nativeControl.Text = searchBar.Text;
 		}
+
+		public static void UpdateFont(this AutoSuggestBox nativeControl, ISearchBar searchBar, IFontManager fontManager) =>
+			nativeControl.UpdateFont(searchBar.Font, fontManager);
 
 		public static void UpdateHorizontalTextAlignment(this AutoSuggestBox nativeControl, ISearchBar searchBar, MauiTextBox? queryTextBox)
 		{


### PR DESCRIPTION
### Description of Change ###

Implement `Fonts` properties in WinUI SearchBar.

<img width="1517" alt="winui-searchbar-fonts" src="https://user-images.githubusercontent.com/6755973/123815586-e4f8d800-d8f6-11eb-881d-c223d4ef8923.png">

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No