### PR TITLE
Revert to using Navigation Page Shims

### DIFF
--- a/src/Compatibility/ControlGallery/src/WinUI/App.xaml
+++ b/src/Compatibility/ControlGallery/src/WinUI/App.xaml
@@ -1,4 +1,5 @@
-﻿<Application
+﻿<local1:MiddleApp
+    xmlns:local1="using:Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI"
     x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -12,4 +13,4 @@
 		</ResourceDictionary>
     </Application.Resources>
 
-</Application>
+</local1:MiddleApp>

--- a/src/Compatibility/ControlGallery/src/WinUI/App.xaml
+++ b/src/Compatibility/ControlGallery/src/WinUI/App.xaml
@@ -7,10 +7,11 @@
 
 	<Application.Resources>
 		<ResourceDictionary>
-			<ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="ms-appx:///Microsoft.Maui.Controls.Compatibility/WinUI/Resources.xbf" />
-			</ResourceDictionary.MergedDictionaries>
-		</ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <!-- Other merged dictionaries here -->
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 
 </local1:MiddleApp>

--- a/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
@@ -23,10 +23,6 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 {
 	public class MiddleApp : MauiWinUIApplication<Startup>
 	{
-		public override MauiWinUIWindow CreateWindow()
-		{
-			return new MainPage();
-		}
 	}
 
 	/// <summary>

--- a/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
@@ -21,12 +21,19 @@ using Windows.UI.ViewManagement;
 
 namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 {
+	public class MiddleApp : MauiWinUIApplication<Startup>
+	{
+		public override UI.Xaml.Window CreateWindow()
+		{
+			return base.CreateWindow();
+		}
+	}
+
 	/// <summary>
 	/// Provides application-specific behavior to supplement the default Application class.
 	/// </summary>
-	sealed partial class App : Microsoft.UI.Xaml.Application
+	sealed partial class App
 	{
-		private UI.Xaml.Window m_window;
 		public static bool RunningAsUITests { get; private set; }
 		/// <summary>
 		/// Initializes the singleton application object.  This is the first line of authored code
@@ -51,9 +58,6 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 				RunningAsUITests = true;
 				ControlGallery.App.PreloadTestCasesIssuesList = false;
 			}
-
-			m_window = new MainPage();
-			Maui.Controls.Compatibility.Forms.Init(m_window as MainPage);
 		}
 
 		/// <summary>

--- a/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
@@ -23,16 +23,16 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 {
 	public class MiddleApp : MauiWinUIApplication<Startup>
 	{
-		public override UI.Xaml.Window CreateWindow()
+		public override MauiWinUIWindow CreateWindow()
 		{
-			return base.CreateWindow();
+			return new MainPage();
 		}
 	}
 
 	/// <summary>
 	/// Provides application-specific behavior to supplement the default Application class.
 	/// </summary>
-	sealed partial class App
+	sealed partial class App : MiddleApp
 	{
 		public static bool RunningAsUITests { get; private set; }
 		/// <summary>
@@ -45,6 +45,11 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 			//Suspending += OnSuspending;
 		}
 
+		public override MauiWinUIWindow CreateWindow()
+		{
+			return new MainPage();
+		}
+
 		/// <summary>
 		/// Invoked when the application is launched normally by the end user.  Other entry points
 		/// will be used such as when the application is launched to open a specific file.
@@ -52,6 +57,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 		/// <param name="e">Details about the launch request and process.</param>
 		protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs e)
 		{
+			base.OnLaunched(e);
 			if (!String.IsNullOrWhiteSpace(e.Arguments) &&
 				e.Arguments.Contains("RunningAsUITests"))
 			{

--- a/src/Compatibility/ControlGallery/src/WinUI/MainPage.xaml
+++ b/src/Compatibility/ControlGallery/src/WinUI/MainPage.xaml
@@ -1,4 +1,5 @@
-﻿<Window
+﻿<local1:MauiWinUIWindow
+    xmlns:local1="using:Microsoft.Maui"
     x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,4 +8,4 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:forms="using:Microsoft.Maui.Controls.Compatibility.Platform.UWP"
     mc:Ignorable="d">
-</Window>
+</local1:MauiWinUIWindow>

--- a/src/Compatibility/ControlGallery/src/WinUI/MainPage.xaml
+++ b/src/Compatibility/ControlGallery/src/WinUI/MainPage.xaml
@@ -1,4 +1,4 @@
-﻿<forms:WindowsPage
+﻿<Window
     x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,4 +7,4 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:forms="using:Microsoft.Maui.Controls.Compatibility.Platform.UWP"
     mc:Ignorable="d">
-</forms:WindowsPage>
+</Window>

--- a/src/Compatibility/ControlGallery/src/WinUI/MainPage.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/MainPage.xaml.cs
@@ -22,10 +22,8 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 	/// <summary>
 	/// An empty page that can be used on its own or navigated to within a Frame.
 	/// </summary>
-	public sealed partial class MainPage
+	public sealed partial class MainPage : UI.Xaml.Window
 	{
-		ControlGallery.App _app;
-
 		public MainPage()
 		{
 			InitializeComponent();
@@ -47,19 +45,12 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
 			MessagingCenter.Subscribe<NativeBindingGalleryPage>(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
 
+			this.Activated += MainPage_Activated;
 		}
 
-		public override Application CreateApplication()
+		private void MainPage_Activated(object sender, UI.Xaml.WindowActivatedEventArgs args)
 		{
-			_app = new ControlGallery.App();
-			return _app;
-		}
-
-		public override void LoadApplication(Application application)
-		{
-			base.LoadApplication(application);
-
-			_app.PropertyChanged += _app_PropertyChanged;
+			Application.Current.PropertyChanged += _app_PropertyChanged;
 			WireUpKeyDown();
 		}
 
@@ -92,12 +83,15 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 		{
 			if (args.Key == VirtualKey.Escape)
 			{
-				_app.Reset();
+				(Application.Current as ControlGallery.App)
+					.Reset();
+
 				args.Handled = true;
 			}
 			else if (args.Key == VirtualKey.F1)
 			{
-				_app.PlatformTest();
+				(Application.Current as ControlGallery.App)
+					.PlatformTest();
 			}
 		}
 

--- a/src/Compatibility/ControlGallery/src/WinUI/MainPage.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/MainPage.xaml.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 	/// <summary>
 	/// An empty page that can be used on its own or navigated to within a Frame.
 	/// </summary>
-	public sealed partial class MainPage : UI.Xaml.Window
+	public sealed partial class MainPage : MauiWinUIWindow
 	{
 		public MainPage()
 		{

--- a/src/Compatibility/Core/src/Android/AppCompat/FormsAppCompatActivity.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/FormsAppCompatActivity.cs
@@ -203,14 +203,14 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			Profile.FramePartition("SetSupportActionBar");
 			AToolbar bar = null;
 
-			if (ToolbarResource == 0)
+			if (_toolbarResource == 0)
 			{
 				ToolbarResource = Resource.Layout.toolbar;
 			}
 
-			if (TabLayoutResource == 0)
+			if (_tabLayoutResource == 0)
 			{
-				TabLayoutResource = Resource.Layout.tabbar;
+				_tabLayoutResource = Resource.Layout.tabbar;
 			}
 
 			if (ToolbarResource != 0)
@@ -504,9 +504,31 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		public static event BackButtonPressedEventHandler BackPressed;
 
-		public static int TabLayoutResource { get; set; }
+		static int _tabLayoutResource;
+		public static int TabLayoutResource
+		{
+			get
+			{
+				if (_tabLayoutResource == 0)
+					return Resource.Layout.tabbar;
 
-		public static int ToolbarResource { get; set; }
+				return _tabLayoutResource;
+			}
+			set => _tabLayoutResource = value;
+		}
+
+		static int _toolbarResource;
+		public static int ToolbarResource
+		{
+			get
+			{
+				if (_toolbarResource == 0)
+					return Resource.Layout.toolbar;
+
+				return _toolbarResource;
+			}
+			set => _toolbarResource = value; 
+		}
 
 		#endregion
 	}

--- a/src/Compatibility/Core/src/Android/AppCompat/NavigationPageRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/NavigationPageRenderer.cs
@@ -958,8 +958,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 						toggle.SyncState();
 					}
 
-					var activity = (AppCompatActivity)context.GetActivity();
-					var icon = new DrawerArrowDrawable(activity.SupportActionBar.ThemedContext);
+					var icon = new DrawerArrowDrawable(context.GetThemedContext());
 					icon.Progress = 1;
 					bar.NavigationIcon = icon;
 

--- a/src/Compatibility/Core/src/WinUI/Resources.xaml
+++ b/src/Compatibility/Core/src/WinUI/Resources.xaml
@@ -49,7 +49,7 @@
 		<Setter Property="FontWeight" Value="Bold" />
 	</Style>
 
-	<Style x:Key="MauiRootContainerStyle" TargetType="Panel">
+	<Style x:Key="CompatibilityRootContainerStyle" TargetType="Panel">
 		<Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
 	</Style>
 

--- a/src/Compatibility/Core/src/WinUI/Resources.xaml
+++ b/src/Compatibility/Core/src/WinUI/Resources.xaml
@@ -49,7 +49,7 @@
 		<Setter Property="FontWeight" Value="Bold" />
 	</Style>
 
-	<Style x:Key="CompatibilityRootContainerStyle" TargetType="Panel">
+	<Style x:Key="RootContainerStyle" TargetType="Panel">
 		<Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
 	</Style>
 

--- a/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
@@ -1472,10 +1472,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		public override UIViewController ChildViewControllerForStatusBarHidden()
 		{
-			return (UIViewController)Platform.GetRenderer(Current);
+			return Platform.GetRenderer(Current).ViewController;
 		}
 
-		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden => (UIViewController)Platform.GetRenderer(Current);
+		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden => Platform.GetRenderer(Current).ViewController;
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)
 		{

--- a/src/Controls/src/Core/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/AppHostBuilderExtensions.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Maui.Controls.Hosting
 	{
 		static readonly Dictionary<Type, Type> DefaultMauiControlHandlers = new Dictionary<Type, Type>
 		{
-			{ typeof(NavigationPage), typeof(NavigationPageHandler) },
 #if WINDOWS
 			{ typeof(Shell), typeof(ShellHandler) },
 #endif

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -59,8 +59,6 @@ namespace Microsoft.Maui
 
 		RootPanel CreateRootContainer()
 		{
-			Resources.TryGetValue("MauiRootContainerStyle", out object style2);
-
 			// TODO WINUI should this be some other known constant or via some mechanism? Or done differently?
 			return Resources.TryGetValue("MauiRootContainerStyle", out object style)
 				? new RootPanel

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Maui
 	public class MauiWinUIApplication<TStartup> : MauiWinUIApplication
 		where TStartup : IStartup, new()
 	{
+		public virtual UI.Xaml.Window CreateWindow() =>
+			new MauiWinUIWindow();
+
 		protected override void OnLaunched(UI.Xaml.LaunchActivatedEventArgs args)
 		{
 			LaunchActivatedEventArgs = args;

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Maui
 
 		RootPanel CreateRootContainer()
 		{
+			Resources.TryGetValue("MauiRootContainerStyle", out object style2);
+
 			// TODO WINUI should this be some other known constant or via some mechanism? Or done differently?
 			return Resources.TryGetValue("MauiRootContainerStyle", out object style)
 				? new RootPanel

--- a/src/Core/src/Platform/Windows/Styles/Resources.xaml
+++ b/src/Core/src/Platform/Windows/Styles/Resources.xaml
@@ -18,5 +18,9 @@
     <x:Boolean x:Key="MicrosoftMauiCoreIncluded">true</x:Boolean>
 
     <uwp:ColorConverter x:Key="ColorConverter" />
+    
+    <Style x:Key="MauiRootContainerStyle" TargetType="Panel">
+		<Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+	</Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
### Description of Change ###

- Use the Navigation Pages shims for now so that all related Navigation Page features light up
- Convert WinUI gallery to a Maui Application
- Fix Android to wire up to resource ids correctly for toolbar
