### PR TITLE
Correctly register Windows resource dictionaries

### DIFF
--- a/src/Compatibility/Core/src/WinUI/Forms.cs
+++ b/src/Compatibility/Core/src/WinUI/Forms.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 		public static UI.Xaml.Window MainWindow { get; set; }
 
 		public static bool IsInitialized { get; private set; }
-		static bool WinUIResourcesAdded { get; set; }
 
 		public static IMauiContext MauiContext { get; private set; }
 
@@ -67,24 +66,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 			{
 				Log.Listeners.Add(new DelegateLogListener((c, m) => Debug.WriteLine(LogFormat, c, m)));
 
-			}
-
-			if (!UI.Xaml.Application.Current.Resources.ContainsKey("RootContainerStyle"))
-			{
-				UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(GetTabletResources());
-			}
-
-			try
-			{
-				if (!WinUIResourcesAdded)
-				{
-					WinUIResourcesAdded = true;
-					UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(new UI.Xaml.Controls.XamlControlsResources());
-				}
-			}
-			catch
-			{
-				Log.Warning("Resources", "Unable to load WinUI resources. Try adding Microsoft.Maui.Controls.Compatibility nuget to UWP project");
 			}
 
 			Device.SetIdiom(TargetIdiom.Tablet);
@@ -160,16 +141,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 				return FlowDirection.RightToLeft;
 
 			return FlowDirection.MatchParent;
-		}
-
-		internal static UI.Xaml.ResourceDictionary GetTabletResources()
-		{
-			var dict = new UI.Xaml.ResourceDictionary
-			{
-				Source = new Uri("ms-appx:///Microsoft.Maui.Controls.Compatibility/WinUI/Resources.xbf")
-			};
-
-			return dict;
 		}
 	}
 }

--- a/src/Compatibility/Core/src/WinUI/Platform.cs
+++ b/src/Compatibility/Core/src/WinUI/Platform.cs
@@ -128,11 +128,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			var current = Microsoft.UI.Xaml.Application.Current;
 
-			if (!current.Resources.ContainsKey("RootContainerStyle"))
-			{
-				Microsoft.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(Forms.GetTabletResources());
-			}
-
 			_container = new Canvas
 			{
 				Style = (Microsoft.UI.Xaml.Style)current.Resources["RootContainerStyle"]

--- a/src/Compatibility/Core/src/WinUI/Resources.xaml
+++ b/src/Compatibility/Core/src/WinUI/Resources.xaml
@@ -19,6 +19,8 @@
         <ResourceDictionary Source="PickerStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
+    <x:Boolean x:Key="MicrosoftMauiControlsCompatibilityIncluded">true</x:Boolean>
+
     <uwp:CaseConverter x:Key="LowerConverter" ConvertToUpper="False" />
 	<uwp:CaseConverter x:Key="UpperConverter" ConvertToUpper="True" />
 	<uwp:HeightConverter x:Key="HeightConverter" />

--- a/src/Controls/samples/Controls.Sample.WinUI/App.xaml
+++ b/src/Controls/samples/Controls.Sample.WinUI/App.xaml
@@ -3,13 +3,5 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Maui.Controls.Sample.WinUI">
-    <Application.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Other merged dictionaries here -->
-            </ResourceDictionary.MergedDictionaries>
-            <!-- Other app resources here -->
-        </ResourceDictionary>
-    </Application.Resources>
+
 </local:MiddleApp>

--- a/src/Controls/src/Core/Platform/Windows/Styles/Resources.xaml
+++ b/src/Controls/src/Core/Platform/Windows/Styles/Resources.xaml
@@ -1,12 +1,14 @@
 <ResourceDictionary
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	x:Class="Microsoft.Maui.Controls.Platform.Resources">
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="Microsoft.Maui.Controls.Platform.Resources">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="MauiControlsPageControlStyle.xaml" />
         <ResourceDictionary Source="ShellPageWrapper.xaml" />
         <ResourceDictionary Source="ShellStyles.xaml" />
     </ResourceDictionary.MergedDictionaries>
-	
+
+    <x:Boolean x:Key="MicrosoftMauiControlsIncluded">true</x:Boolean>
+
 </ResourceDictionary>

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -11,13 +11,6 @@ namespace Microsoft.Maui
 			Activated += OnActivated;
 			Closed += OnClosed;
 			VisibilityChanged += OnVisibilityChanged;
-
-			if (!Application.Current.Resources.ContainsKey("MauiRootContainerStyle"))
-			{
-				var myResourceDictionary = new Microsoft.UI.Xaml.ResourceDictionary();
-				myResourceDictionary.Source = new Uri("ms-appx:///Microsoft.Maui/Platform/Windows/Styles/Resources.xbf");
-				Microsoft.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(myResourceDictionary);
-			}
 		}
 
 		protected virtual void OnActivated(object sender, UI.Xaml.WindowActivatedEventArgs args)

--- a/src/Core/src/Platform/Windows/Styles/Resources.xaml
+++ b/src/Core/src/Platform/Windows/Styles/Resources.xaml
@@ -1,8 +1,8 @@
 <ResourceDictionary
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:uwp="using:Microsoft.Maui"
-	x:Class="Microsoft.Maui.Resources">
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:uwp="using:Microsoft.Maui"
+    x:Class="Microsoft.Maui.Resources">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="MauiActivityIndicatorStyle.xaml" />
@@ -14,7 +14,9 @@
         <ResourceDictionary Source="MauiTextBoxStyle.xaml" />
         <ResourceDictionary Source="MauiCheckBoxStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
-     
+
+    <x:Boolean x:Key="MicrosoftMauiCoreIncluded">true</x:Boolean>
+
     <uwp:ColorConverter x:Key="ColorConverter" />
-    
+
 </ResourceDictionary>

--- a/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/Platforms/Windows/App.xaml
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/Platforms/Windows/App.xaml
@@ -3,13 +3,5 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:MauiApp1.WinUI">
-    <Application.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Other merged dictionaries here -->
-            </ResourceDictionary.MergedDictionaries>
-            <!-- Other app resources here -->
-        </ResourceDictionary>
-    </Application.Resources>
+
 </local:MiddleApp>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/Platforms/Windows/App.xaml
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/Platforms/Windows/App.xaml
@@ -3,13 +3,5 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:MauiApp1.WinUI">
-    <Application.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Other merged dictionaries here -->
-            </ResourceDictionary.MergedDictionaries>
-            <!-- Other app resources here -->
-        </ResourceDictionary>
-    </Application.Resources>
+
 </local:MiddleApp>


### PR DESCRIPTION
### Description of Change ###

Previously, there was a mixup of keys and resources. In some places there was a `ContainsKey(xxx)` and then and add, but that key did not actually exist in that dictionary. And the reverse. In the end, sometimes it worked, sometimes it did not. And there are quite a few places where it was "just added again".