### PR TITLE
[Housekeeping, Android] Avoid create a drawable to set the Background if is not necessary

### DIFF
--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -52,7 +52,17 @@ namespace Microsoft.Maui
 			if (paint.IsNullOrEmpty())
 				nativeView.Background = defaultBackground;
 			else
-				nativeView.Background = paint!.ToDrawable();
+			{
+				if (paint is SolidPaint solidPaint)
+				{
+					Color backgroundColor = solidPaint.Color;
+
+					if (backgroundColor != null)
+						nativeView.SetBackgroundColor(backgroundColor.ToNative());
+				}
+				else
+					nativeView.Background = paint!.ToDrawable();
+			}
 		}
 
 		public static void UpdateOpacity(this AView nativeView, IView view)


### PR DESCRIPTION
### Description of Change ###

Avoid create a drawable to set the Background if is not necessary. If a solid color is assigned, directly set the background color without creating a Drawable which further penalizes performance.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No.