### PR TITLE
Make the non-generic apps the main type

### DIFF
--- a/src/Compatibility/ControlGallery/src/WinUI/App.xaml
+++ b/src/Compatibility/ControlGallery/src/WinUI/App.xaml
@@ -1,8 +1,8 @@
-﻿<local1:MiddleApp
-    xmlns:local1="using:Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI"
+﻿<maui:MauiWinUIApplication
     x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:maui="using:Microsoft.Maui"
     xmlns:local="using:WinUI3Desktop">
 
 	<Application.Resources>
@@ -14,4 +14,4 @@
         </ResourceDictionary>
     </Application.Resources>
 
-</local1:MiddleApp>
+</maui:MauiWinUIApplication>

--- a/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
@@ -5,7 +5,7 @@
 	/// </summary>
 	sealed partial class App : MauiWinUIApplication
 	{
-		public static bool RunningAsUITests { get; private set; }
+		public static bool RunningAsUITests { get; internal set; }
 
 		/// <summary>
 		/// Initializes the singleton application object.  This is the first line of authored code
@@ -14,44 +14,8 @@
 		public App()
 		{
 			InitializeComponent();
-			//Suspending += OnSuspending;
 		}
 
 		protected override IStartup OnCreateStartup() => new Startup();
-
-		public override MauiWinUIWindow CreateWindow()
-		{
-			return new MainPage();
-		}
-
-		/// <summary>
-		/// Invoked when the application is launched normally by the end user.  Other entry points
-		/// will be used such as when the application is launched to open a specific file.
-		/// </summary>
-		/// <param name="e">Details about the launch request and process.</param>
-		protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs e)
-		{
-			base.OnLaunched(e);
-			if (!String.IsNullOrWhiteSpace(e.Arguments) &&
-				e.Arguments.Contains("RunningAsUITests"))
-			{
-				RunningAsUITests = true;
-				ControlGallery.App.PreloadTestCasesIssuesList = false;
-			}
-		}
-
-		/// <summary>
-		/// Invoked when Navigation to a certain page fails
-		/// </summary>
-		/// <param name="sender">The Frame which failed navigation</param>
-		/// <param name="e">Details about the navigation failure</param>
-		void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
-		{
-			throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
-		}
-	}
-
-	public class MiddleApp : MauiWinUIApplication<WinUIStartup>
-	{
 	}
 }

--- a/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/App.xaml.cs
@@ -1,12 +1,53 @@
 ﻿namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 {
-	sealed partial class App : MiddleApp
+	/// <summary>
+	/// Provides application-specific behavior to supplement the default Application class.
+	/// </summary>
+	sealed partial class App : MauiWinUIApplication
 	{
-		public static bool RunningAsUITests { get; set; }
+		public static bool RunningAsUITests { get; private set; }
 
+		/// <summary>
+		/// Initializes the singleton application object.  This is the first line of authored code
+		/// executed, and as such is the logical equivalent of main() or WinMain().
+		/// </summary>
 		public App()
 		{
 			InitializeComponent();
+			//Suspending += OnSuspending;
+		}
+
+		protected override IStartup OnCreateStartup() => new Startup();
+
+		public override MauiWinUIWindow CreateWindow()
+		{
+			return new MainPage();
+		}
+
+		/// <summary>
+		/// Invoked when the application is launched normally by the end user.  Other entry points
+		/// will be used such as when the application is launched to open a specific file.
+		/// </summary>
+		/// <param name="e">Details about the launch request and process.</param>
+		protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs e)
+		{
+			base.OnLaunched(e);
+			if (!String.IsNullOrWhiteSpace(e.Arguments) &&
+				e.Arguments.Contains("RunningAsUITests"))
+			{
+				RunningAsUITests = true;
+				ControlGallery.App.PreloadTestCasesIssuesList = false;
+			}
+		}
+
+		/// <summary>
+		/// Invoked when Navigation to a certain page fails
+		/// </summary>
+		/// <param name="sender">The Frame which failed navigation</param>
+		/// <param name="e">Details about the navigation failure</param>
+		void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
+		{
+			throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
 		}
 	}
 

--- a/src/Controls/samples/Controls.Sample.WinUI/App.xaml
+++ b/src/Controls/samples/Controls.Sample.WinUI/App.xaml
@@ -1,7 +1,8 @@
-﻿<local:MiddleApp
+﻿<maui:MauiWinUIApplication
     x:Class="Maui.Controls.Sample.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:maui="using:Microsoft.Maui"
     xmlns:local="using:Maui.Controls.Sample.WinUI">
 
-</local:MiddleApp>
+</maui:MauiWinUIApplication>

--- a/src/Controls/samples/Controls.Sample.WinUI/App.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.WinUI/App.xaml.cs
@@ -2,16 +2,13 @@
 
 namespace Maui.Controls.Sample.WinUI
 {
-	// TODO: this is not nice.
-	public class MiddleApp : MauiWinUIApplication<Startup>
-	{
-	}
-
-	public partial class App : MiddleApp
+	public partial class App : MauiWinUIApplication
 	{
 		public App()
 		{
 			InitializeComponent();
 		}
+
+		protected override IStartup OnCreateStartup() => new Startup();
 	}
 }

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -18,11 +18,23 @@ namespace Microsoft.Maui
 		{
 		}
 
+		protected override IStartup OnCreateStartup() => new TStartup();
+	}
+
+	public abstract class MauiApplication : Application
+	{
+		protected MauiApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+		{
+			Current = this;
+		}
+
+		protected abstract IStartup OnCreateStartup();
+
 		public override void OnCreate()
 		{
 			RegisterActivityLifecycleCallbacks(new ActivityLifecycleCallbacks());
 
-			var startup = new TStartup();
+			var startup = OnCreateStartup();
 
 			var host = startup
 				.CreateAppHostBuilder()
@@ -65,14 +77,6 @@ namespace Microsoft.Maui
 		// Configure native services like HandlersContext, ImageSourceHandlers etc.. 
 		void ConfigureNativeServices(HostBuilderContext ctx, IServiceCollection services)
 		{
-		}
-	}
-
-	public abstract class MauiApplication : Application
-	{
-		protected MauiApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
-		{
-			Current = this;
 		}
 
 		public static MauiApplication Current { get; private set; } = null!;

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -9,11 +9,25 @@ namespace Microsoft.Maui
 	public class MauiWinUIApplication<TStartup> : MauiWinUIApplication
 		where TStartup : IStartup, new()
 	{
+		protected override IStartup OnCreateStartup() => new TStartup();
+	}
+
+	public abstract class MauiWinUIApplication : UI.Xaml.Application
+	{
+		protected abstract IStartup OnCreateStartup();
+
+		public virtual UI.Xaml.Window CreateWindow() =>
+			new MauiWinUIWindow();
+
 		protected override void OnLaunched(UI.Xaml.LaunchActivatedEventArgs args)
 		{
 			LaunchActivatedEventArgs = args;
 
-			var startup = new TStartup();
+			// TODO: This should not be here. CreateWindow should do it.
+			MainWindow = new MauiWinUIWindow();
+
+			var startup = OnCreateStartup() ??
+				throw new InvalidOperationException($"A valid startup object must be provided by overriding {nameof(OnCreateStartup)}.");
 
 			var host = startup
 				.CreateAppHostBuilder()
@@ -53,13 +67,6 @@ namespace Microsoft.Maui
 		}
 
 		void ConfigureNativeServices(HostBuilderContext ctx, IServiceCollection services)
-		{
-		}
-	}
-
-	public abstract class MauiWinUIApplication : UI.Xaml.Application
-	{
-		protected MauiWinUIApplication()
 		{
 		}
 

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -11,10 +11,21 @@ namespace Microsoft.Maui
 	public class MauiUIApplicationDelegate<TStartup> : MauiUIApplicationDelegate
 		where TStartup : IStartup, new()
 	{
+		protected override IStartup OnCreateStartup() => new TStartup();
+	}
+
+	public abstract class MauiUIApplicationDelegate : UIApplicationDelegate, IUIApplicationDelegate
+	{
+		protected MauiUIApplicationDelegate()
+		{
+			Current = this;
+		}
+
+		protected abstract IStartup OnCreateStartup();
 
 		public override bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions)
 		{
-			var startup = new TStartup();
+			var startup = OnCreateStartup();
 
 			var host = startup
 				.CreateAppHostBuilder()
@@ -117,14 +128,6 @@ namespace Microsoft.Maui
 		// Configure native services like HandlersContext, ImageSourceHandlers etc.. 
 		void ConfigureNativeServices(HostBuilderContext ctx, IServiceCollection services)
 		{
-		}
-	}
-
-	public abstract class MauiUIApplicationDelegate : UIApplicationDelegate, IUIApplicationDelegate
-	{
-		protected MauiUIApplicationDelegate()
-		{
-			Current = this;
 		}
 
 		public static MauiUIApplicationDelegate Current { get; private set; } = null!;

--- a/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/Platforms/Windows/App.xaml
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/Platforms/Windows/App.xaml
@@ -1,7 +1,8 @@
-﻿<local:MiddleApp
+﻿<maui:MauiWinUIApplication
     x:Class="MauiApp1.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:maui="using:Microsoft.Maui"
     xmlns:local="using:MauiApp1.WinUI">
 
-</local:MiddleApp>
+</maui:MauiWinUIApplication>

--- a/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/Platforms/Windows/App.xaml.cs
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.WinUI/Platforms/Windows/App.xaml.cs
@@ -10,7 +10,7 @@ namespace MauiApp1.WinUI
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    public partial class App : MiddleApp
+    public partial class App : MauiWinUIApplication
     {
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
@@ -21,14 +21,13 @@ namespace MauiApp1.WinUI
             this.InitializeComponent();
         }
 
+        protected override IStartup OnCreateStartup() => new Startup();
+
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
             base.OnLaunched(args);
 
             Microsoft.Maui.Essentials.Platform.OnLaunched(args);
         }
-    }
-    public class MiddleApp : MauiWinUIApplication<Startup>
-    {
     }
 }

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/Platforms/Windows/App.xaml
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/Platforms/Windows/App.xaml
@@ -1,7 +1,8 @@
-﻿<local:MiddleApp
+﻿<maui:MauiWinUIApplication
     x:Class="MauiApp1.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:maui="using:Microsoft.Maui"
     xmlns:local="using:MauiApp1.WinUI">
 
-</local:MiddleApp>
+</maui:MauiWinUIApplication>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/Platforms/Windows/App.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.WinUI/Platforms/Windows/App.xaml.cs
@@ -10,7 +10,7 @@ namespace MauiApp1.WinUI
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    public partial class App : MiddleApp
+    public partial class App : MauiWinUIApplication
     {
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
@@ -21,14 +21,13 @@ namespace MauiApp1.WinUI
             this.InitializeComponent();
         }
 
+        protected override IStartup OnCreateStartup() => new Startup();
+
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
             base.OnLaunched(args);
 
             Microsoft.Maui.Essentials.Platform.OnLaunched(args);
         }
-    }
-    public class MiddleApp : MauiWinUIApplication<Startup>
-    {
     }
 }


### PR DESCRIPTION
### Description of Change ###

The generics are still there, but are just a shortcut to getting the type. This is mainly for Windows which uses xaml, and xaml does not support generics.

