### PR TITLE
Don't pack and force a signing failure

### DIFF
--- a/src/Core/tests/Benchmarks/Core.Benchmarks-net6.csproj
+++ b/src/Core/tests/Benchmarks/Core.Benchmarks-net6.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <AssemblyName>Microsoft.Maui.Handlers.Benchmarks</AssemblyName>
-    <RootNamespace>Microsoft.Maui.Handlers.Benchmarks</RootNamespace>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

There was a signing failure which is good because this should not have been signed.