### PR TITLE
Fix background on page and window checks inside appearance

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/ShellPageContainer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ShellPageContainer.cs
@@ -1,5 +1,8 @@
 using Android.Content;
+using AndroidX.Core.Content;
 using Microsoft.Maui.Graphics;
+using AColor = Android.Graphics.Color;
+using AColorRes = Android.Resource.Color;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
@@ -7,6 +10,15 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 	{
 		public ShellPageContainer(Context context, IVisualElementRenderer child, bool inFragment = false) : base(context, child, inFragment)
 		{
+			if (child.Element.Handler is INativeViewHandler nvh &&
+				nvh.VirtualView.Background == null)
+			{
+				var color = NativeVersion.IsAtLeast(23) ?
+								Context.Resources.GetColor(AColorRes.BackgroundLight, Context.Theme) :
+								new AColor(ContextCompat.GetColor(Context, AColorRes.BackgroundLight));
+
+				nvh.NativeView.SetBackgroundColor(color);
+			}
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Controls
 		{
 			var element = (Element)bindable;
 
-			while (!Application.IsApplicationOrNull(element))
+			while (!Application.IsApplicationOrWindowOrNull(element))
 			{
 				if (element is Shell shell)
 					shell.NotifyFlyoutBehaviorObservers();
@@ -220,7 +220,7 @@ namespace Microsoft.Maui.Controls
 			var item = (Element)bindable;
 			var source = item;
 
-			while (!Application.IsApplicationOrNull(item))
+			while (!Application.IsApplicationOrWindowOrNull(item))
 			{
 				if (item is IShellController shell)
 				{
@@ -358,7 +358,7 @@ namespace Microsoft.Maui.Controls
 					target = pivot;
 				}
 
-				while (!Application.IsApplicationOrNull(leaf))
+				while (!Application.IsApplicationOrWindowOrNull(leaf))
 				{
 					if (leaf == target)
 					{
@@ -1073,7 +1073,7 @@ namespace Microsoft.Maui.Controls
 			bool anySet = false;
 			ShellAppearance result = new ShellAppearance();
 			// Now we walk up
-			while (!Application.IsApplicationOrNull(pivot))
+			while (!Application.IsApplicationOrWindowOrNull(pivot))
 			{
 				if (pivot is ShellContent)
 					foundShellContent = true;


### PR DESCRIPTION
### Description of Change ###

- In XF there's some code inside PageRenderer that checks if it's inside shell and if it is it sets the DefaultBackground to a specific theme color. This PR moves that code to the ShellPageContainer so that it's not the responsibility of the pagehandler/renderer to figure that out
- Inside the Appearance calculation code change the checks to account for the Window