### PR TITLE
Implement TextColor in WinUI SearchBar

### DIFF
--- a/src/Compatibility/Core/src/WinUI/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/WinUI/SearchBarRenderer.cs
@@ -258,6 +258,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			Control.Text = Element.UpdateFormsText(Element.Text, Element.TextTransform);
 		}
 
+		[PortHandler]
 		void UpdateTextColor()
 		{
 			if (_queryTextBox == null)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class SearchBarHandler : ViewHandler<ISearchBar, AutoSuggestBox>
 	{
+		Brush? _defaultTextColorBrush;
+		Brush? _defaultTextColorFocusBrush;
+
 		Brush? _defaultDeleteButtonForegroundColorBrush;
 		Brush? _defaultDeleteButtonBackgroundColorBrush;
 
@@ -60,8 +63,10 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateCharacterSpacing(searchBar);
 		}
 
-		[MissingMapper]
-		public static void MapTextColor(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapTextColor(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.NativeView?.UpdateTextColor(searchBar, handler._defaultTextColorBrush, handler._defaultTextColorFocusBrush, handler._queryTextBox);
+		}
 
 		[MissingMapper]
 		public static void MapIsTextPredictionEnabled(IViewHandler handler, ISearchBar searchBar) { }
@@ -82,6 +87,13 @@ namespace Microsoft.Maui.Handlers
 		void OnLoaded(object sender, UI.Xaml.RoutedEventArgs e)
 		{
 			_queryTextBox = NativeView?.GetFirstDescendant<MauiTextBox>();
+
+			if(_queryTextBox != null)
+			{
+				_defaultTextColorBrush = _queryTextBox.Foreground;
+				_defaultTextColorFocusBrush = _queryTextBox.ForegroundFocusBrush;
+			}
+
 			_cancelButton = _queryTextBox?.GetFirstDescendant<MauiCancelButton>();
 
 			if (_cancelButton != null)
@@ -103,6 +115,7 @@ namespace Microsoft.Maui.Handlers
 
 			if (VirtualView != null)
 			{
+				NativeView?.UpdateTextColor(VirtualView, _defaultTextColorBrush, _defaultTextColorFocusBrush, _queryTextBox);
 				NativeView?.UpdateHorizontalTextAlignment(VirtualView, _queryTextBox);
 				NativeView?.UpdateMaxLength(VirtualView, _queryTextBox);
 			}

--- a/src/Core/src/Platform/Windows/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/Windows/SearchBarExtensions.cs
@@ -21,6 +21,20 @@ namespace Microsoft.Maui
 			nativeControl.Text = searchBar.Text;
 		}
 
+		public static void UpdateTextColor(this AutoSuggestBox nativeControl, ISearchBar searchBar, Brush? defaultTextColorBrush, Brush? defaultTextColorFocusBrush, MauiTextBox? queryTextBox)
+		{
+			if (queryTextBox == null)
+				return;
+
+			Color textColor = searchBar.TextColor;
+
+			BrushHelpers.UpdateColor(textColor, ref defaultTextColorBrush,
+				() => queryTextBox.Foreground, brush => queryTextBox.Foreground = brush);
+
+			BrushHelpers.UpdateColor(textColor, ref defaultTextColorFocusBrush,
+				() => queryTextBox.ForegroundFocusBrush, brush => queryTextBox.ForegroundFocusBrush = brush);
+		}
+
 		public static void UpdateFont(this AutoSuggestBox nativeControl, ISearchBar searchBar, IFontManager fontManager) =>
 			nativeControl.UpdateFont(searchBar.Font, fontManager);
 


### PR DESCRIPTION
### Description of Change ###

Implement `TextColor` in WinUI SearchBar.

<img width="337" alt="winui-searchbar-textcolor" src="https://user-images.githubusercontent.com/6755973/124460630-e3645f80-dd8f-11eb-8f34-b27321772267.png">

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- No.
