### PR TITLE
Reference SetupDefaults methods from Handler ctor

### DIFF
--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.Windows.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.Windows.cs
@@ -5,11 +5,18 @@ namespace Microsoft.Maui.Handlers
 	{
 		object? _foregroundDefault;
 
-		protected override MauiActivityIndicator CreateNativeView() => new MauiActivityIndicator
+		protected override MauiActivityIndicator CreateNativeView()
 		{
-			IsIndeterminate = true,
-			Style = UI.Xaml.Application.Current.Resources["MauiActivityIndicatorStyle"] as UI.Xaml.Style
-		};
+			var nativeActivityIndicator = new MauiActivityIndicator
+			{
+				IsIndeterminate = true,
+				Style = UI.Xaml.Application.Current.Resources["MauiActivityIndicatorStyle"] as UI.Xaml.Style
+			};
+
+			SetupDefaults(nativeActivityIndicator);
+
+			return nativeActivityIndicator;
+		}
 
 		void SetupDefaults(MauiActivityIndicator nativeView)
 		{

--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Maui.Handlers
 				SoundEffectsEnabled = false
 			};
 
+			SetupDefaults(nativeButton);
+
 			return nativeButton;
 		}
 

--- a/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
@@ -11,8 +11,14 @@ namespace Microsoft.Maui.Handlers
 
 		PointerEventHandler? _pointerPressedHandler;
 
-		protected override MauiButton CreateNativeView() 
-			=> new MauiButton();
+		protected override MauiButton CreateNativeView()
+		{ 
+			var nativeButton = new MauiButton();
+
+			SetupDefaults(nativeButton);
+
+			return nativeButton;
+		}
 
 		void SetupDefaults(MauiButton nativeView)
 		{

--- a/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
@@ -14,9 +14,12 @@ namespace Microsoft.Maui.Handlers
 
 		protected override UIButton CreateNativeView()
 		{
-			var button = new UIButton(UIButtonType.System);
-			SetControlPropertiesFromProxy(button);
-			return button;
+			var nativeButton = new UIButton(UIButtonType.System);
+
+			SetupDefaults(nativeButton);
+			SetControlPropertiesFromProxy(nativeButton);
+
+			return nativeButton;
 		}
 
 		protected override void ConnectHandler(UIButton nativeView)

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Maui.Handlers
 				HidePicker = HidePickerDialog
 			};
 
+			SetupDefaults(mauiDatePicker);
+
 			var date = VirtualView?.Date;
 
 			if (date != null)
@@ -31,8 +33,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			_defaultBackground = nativeView.Background;
 			_defaultTextColors = nativeView.TextColors;
-
-
 		}
 
 		internal DatePickerDialog? DatePickerDialog { get { return _dialog; } }

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Windows.cs
@@ -8,7 +8,14 @@ namespace Microsoft.Maui.Handlers
 	{
 		WBrush? _defaultForeground;
 
-		protected override CalendarDatePicker CreateNativeView() => new CalendarDatePicker();
+		protected override CalendarDatePicker CreateNativeView()
+		{
+			var nativeDatePicker = new CalendarDatePicker();
+
+			SetupDefaults(nativeDatePicker);
+
+			return nativeDatePicker;
+		}
 
 		protected override void ConnectHandler(CalendarDatePicker nativeView)
 		{
@@ -22,9 +29,7 @@ namespace Microsoft.Maui.Handlers
 
 		void SetupDefaults(CalendarDatePicker nativeView)
 		{
-			_defaultForeground = nativeView.Foreground;
-
-			
+			_defaultForeground = nativeView.Foreground;	
 		}
 
 		public static void MapFormat(DatePickerHandler handler, IDatePicker datePicker)

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Maui.Handlers
 
 			nativeDatePicker.AccessibilityTraits = UIAccessibilityTrait.Button;
 
+			SetupDefaults(nativeDatePicker);
+
 			return nativeDatePicker;
 		}
 

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Maui.Handlers
 			editText.TextAlignment = Android.Views.TextAlignment.ViewStart;
 			editText.SetHorizontallyScrolling(false);
 
+			SetupDefaults(editText);
+
 			return editText;
 		}
 
@@ -46,8 +48,6 @@ namespace Microsoft.Maui.Handlers
 
 		void SetupDefaults(AppCompatEditText nativeView)
 		{
-
-
 			DefaultTextColors = nativeView.TextColors;
 			DefaultPlaceholderTextColors = nativeView.HintTextColors;
 			DefaultBackground = nativeView.Background;

--- a/src/Core/src/Handlers/Editor/EditorHandler.Windows.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Windows.cs
@@ -9,14 +9,21 @@ namespace Microsoft.Maui.Handlers
 		Brush? _placeholderDefaultBrush;
 		Brush? _defaultPlaceholderColorFocusBrush;
 
-		protected override MauiTextBox CreateNativeView() => new MauiTextBox
+		protected override MauiTextBox CreateNativeView()
 		{
-			AcceptsReturn = true,
-			TextWrapping = TextWrapping.Wrap,
-			Style = Application.Current.Resources["MauiTextBoxStyle"] as Style,
-			UpdateVerticalAlignmentOnLoad = false,
-			VerticalContentAlignment = VerticalAlignment.Top
-		};
+			var nativeEditor = new MauiTextBox
+			{
+				AcceptsReturn = true,
+				TextWrapping = TextWrapping.Wrap,
+				Style = Application.Current.Resources["MauiTextBoxStyle"] as Style,
+				UpdateVerticalAlignmentOnLoad = false,
+				VerticalContentAlignment = VerticalAlignment.Top
+			};
+
+			SetupDefaults(nativeEditor);
+
+			return nativeEditor;
+		}
 
 		protected override void ConnectHandler(MauiTextBox nativeView)
 		{
@@ -31,9 +38,7 @@ namespace Microsoft.Maui.Handlers
 		void SetupDefaults(MauiTextBox nativeView)
 		{
 			_placeholderDefaultBrush = nativeView.PlaceholderForeground;
-			_defaultPlaceholderColorFocusBrush = nativeView.PlaceholderForegroundFocusBrush;
-
-			
+			_defaultPlaceholderColorFocusBrush = nativeView.PlaceholderForegroundFocusBrush;		
 		}
 
 		public static void MapText(EditorHandler handler, IEditor editor)

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -25,7 +25,11 @@ namespace Microsoft.Maui.Handlers
 
 		protected override AppCompatEditText CreateNativeView()
 		{
-			return new AppCompatEditText(Context);
+			var appCompatEditText = new AppCompatEditText(Context);
+
+			SetupDefaults(appCompatEditText);
+
+			return appCompatEditText;
 		}
 
 		// Returns the default 'X' char drawable in the AppCompatEditText.
@@ -60,8 +64,6 @@ namespace Microsoft.Maui.Handlers
 
 		void SetupDefaults(AppCompatEditText nativeView)
 		{
-
-
 			ClearButtonDrawable = GetClearButtonDrawable();
 			DefaultTextColors = nativeView.TextColors;
 			DefaultBackground = nativeView.Background;

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -12,11 +12,15 @@ namespace Microsoft.Maui.Handlers
 
 		protected override MauiTextField CreateNativeView()
 		{
-			return new MauiTextField
+			var nativeEntry = new MauiTextField
 			{
 				BorderStyle = UITextBorderStyle.RoundedRect,
 				ClipsToBounds = true
 			};
+
+			SetupDefaults(nativeEntry);
+
+			return nativeEntry;
 		}
 
 		protected override void ConnectHandler(MauiTextField nativeView)

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -1,11 +1,4 @@
-using System;
-using Android.Content;
-using Android.Runtime;
-using Android.Util;
-using Android.Views;
 using Android.Widget;
-using Java.Lang;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Handlers
@@ -16,7 +9,14 @@ namespace Microsoft.Maui.Handlers
 		static float? LineSpacingAddDefault { get; set; }
 		static float? LineSpacingMultDefault { get; set; }
 
-		protected override TextView CreateNativeView() => new TextView(Context);
+		protected override TextView CreateNativeView()
+		{
+			var textView = new TextView(Context);
+
+			SetupDefaults(textView);
+
+			return textView;
+		}
 
 		void SetupDefaults(TextView nativeView)
 		{

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Specialized;
-using System.Linq;
 using Android.App;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Text.Style;
-using Microsoft.Maui.Graphics;
 using AResource = Android.Resource;
 
 namespace Microsoft.Maui.Handlers
@@ -19,8 +16,14 @@ namespace Microsoft.Maui.Handlers
 
 		static ColorStateList? DefaultTitleColors { get; set; }
 
-		protected override MauiPicker CreateNativeView() =>
-			new MauiPicker(Context);
+		protected override MauiPicker CreateNativeView()
+		{
+			var nativePicker = new MauiPicker(Context);
+
+			SetupDefaults(nativePicker);
+
+			return nativePicker;
+		}
 
 		protected override void ConnectHandler(MauiPicker nativeView)
 		{
@@ -40,8 +43,6 @@ namespace Microsoft.Maui.Handlers
 
 		void SetupDefaults(MauiPicker nativeView)
 		{
-
-
 			DefaultBackground = nativeView.Background;
 			DefaultTitleColors = nativeView.HintTextColors;
 		}
@@ -141,7 +142,7 @@ namespace Microsoft.Maui.Handlers
 					{
 						var selectedIndex = e.Which;
 						VirtualView.SelectedIndex = selectedIndex;
-						base.NativeView?.UpdatePicker(VirtualView);
+						NativeView?.UpdatePicker(VirtualView);
 					});
 
 					builder.SetNegativeButton(AResource.String.Cancel, (o, args) => { });

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView != null)
 				nativePicker.ItemsSource = new ItemDelegateList<string>(VirtualView);
 
+			SetupDefaults(nativePicker);
+
 			return nativePicker;
 		}
 
@@ -30,15 +32,14 @@ namespace Microsoft.Maui.Handlers
 
 		void SetupDefaults(MauiComboBox nativeView)
 		{
-			_defaultForeground = nativeView.Foreground;
-
-			
+			_defaultForeground = nativeView.Foreground;	
 		}
+
 		void Reload()
 		{
-
 			if (VirtualView == null || NativeView == null)
 				return;
+
 			NativeView.ItemsSource = new ItemDelegateList<string>(VirtualView);
 		}
 

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Android.Graphics.Drawables;
+﻿using Android.Graphics.Drawables;
 using Android.Widget;
-using Microsoft.Extensions.DependencyInjection;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
 
 namespace Microsoft.Maui.Handlers
@@ -11,11 +9,14 @@ namespace Microsoft.Maui.Handlers
 		static Drawable? DefaultBackground;
 
 		EditText? _editText;
+
 		public EditText? QueryEditor => _editText;
 
 		protected override SearchView CreateNativeView()
 		{
 			var searchView = new SearchView(Context);
+
+			SetupDefaults(searchView);
 
 			_editText = searchView.GetFirstChildOfType<EditText>();
 
@@ -25,8 +26,6 @@ namespace Microsoft.Maui.Handlers
 		void SetupDefaults(SearchView nativeView)
 		{
 			DefaultBackground = nativeView.Background;
-
-
 		}
 
 		// This is a Android-specific mapping

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Drawing;
 using Foundation;
-using Microsoft.Extensions.DependencyInjection;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers
@@ -23,6 +22,8 @@ namespace Microsoft.Maui.Handlers
 			var searchBar = new UISearchBar(RectangleF.Empty) { ShowsCancelButton = true, BarStyle = UIBarStyle.Default };
 
 			_editor = searchBar.FindDescendantView<UITextField>();
+
+			SetupDefaults(searchBar);
 
 			return searchBar;
 		}
@@ -59,8 +60,6 @@ namespace Microsoft.Maui.Handlers
 				_cancelButtonTextColorDefaultHighlighted = cancelButton.TitleColor(UIControlState.Highlighted);
 				_cancelButtonTextColorDefaultDisabled = cancelButton.TitleColor(UIControlState.Disabled);
 			}
-
-
 		}
 
 		public static void MapText(SearchBarHandler handler, ISearchBar searchBar)

--- a/src/Core/src/Handlers/Slider/SliderHandler.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.Android.cs
@@ -18,11 +18,15 @@ namespace Microsoft.Maui.Handlers
 
 		protected override SeekBar CreateNativeView()
 		{
-			return new SeekBar(Context)
+			var seekBar = new SeekBar(Context)
 			{
 				DuplicateParentStateEnabled = false,
 				Max = (int)SliderExtensions.NativeMaxValue
 			};
+
+			SetupDefaults(seekBar);
+
+			return seekBar;
 		}
 
 		protected override void ConnectHandler(SeekBar nativeView)

--- a/src/Core/src/Handlers/Slider/SliderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.Windows.cs
@@ -16,12 +16,15 @@ namespace Microsoft.Maui.Handlers
 
 		protected override MauiSlider CreateNativeView()
 		{
-			var slider = new MauiSlider
+			var nativeSlider = new MauiSlider
 			{
 				IsThumbToolTipEnabled = false
 			};
 
-			return slider;
+
+			SetupDefaults(nativeSlider);
+
+			return nativeSlider;
 		}
 
 		protected override void ConnectHandler(MauiSlider nativeView)

--- a/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
@@ -9,7 +9,14 @@ namespace Microsoft.Maui.Handlers
 		static UIColor? DefaultMaxTrackColor;
 		static UIColor? DefaultThumbColor;
 
-		protected override UISlider CreateNativeView() => new UISlider { Continuous = true };
+		protected override UISlider CreateNativeView()
+		{
+			var nativeSlider = new UISlider { Continuous = true };
+
+			SetupDefaults(nativeSlider);
+
+			return nativeSlider;
+		}
 
 		protected override void ConnectHandler(UISlider nativeView)
 		{

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
@@ -1,7 +1,5 @@
 using Android.Content.Res;
-using Android.Graphics.Drawables;
 using Android.Widget;
-using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
 using ASwitch = AndroidX.AppCompat.Widget.SwitchCompat;
 
@@ -15,7 +13,11 @@ namespace Microsoft.Maui.Handlers
 
 		protected override ASwitch CreateNativeView()
 		{
-			return new ASwitch(Context);
+			var nativeSwith = new ASwitch(Context);
+
+			SetupDefaults(nativeSwith);
+
+			return nativeSwith;
 		}
 
 		protected override void ConnectHandler(ASwitch nativeView)

--- a/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Maui.Handlers
 
 		protected override UISwitch CreateNativeView()
 		{
-			return new UISwitch(RectangleF.Empty);
+			var nativeSwitch = new UISwitch(RectangleF.Empty);
+
+			SetupDefaults(nativeSwitch);
+
+			return nativeSwitch;
 		}
 
 		protected override void ConnectHandler(UISwitch nativeView)

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Android.cs
@@ -2,7 +2,6 @@
 using Android.App;
 using Android.Graphics.Drawables;
 using Android.Text.Format;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -21,14 +20,14 @@ namespace Microsoft.Maui.Handlers
 				HidePicker = HidePickerDialog
 			};
 
+			SetupDefaults(_timePicker);
+
 			return _timePicker;
 		}
 
 		void SetupDefaults(MauiTimePicker nativeView)
 		{
 			DefaultBackground = nativeView.Background;
-
-
 		}
 
 		protected override void DisconnectHandler(MauiTimePicker nativeView)

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs
@@ -8,7 +8,14 @@ namespace Microsoft.Maui.Handlers
 	{
 		WBrush? _defaultForeground;
 
-		protected override TimePicker CreateNativeView() => new TimePicker();
+		protected override TimePicker CreateNativeView()
+		{
+			var nativeTimePicker = new TimePicker();
+
+			SetupDefaults(nativeTimePicker);
+
+			return nativeTimePicker;
+		}
 
 		protected override void ConnectHandler(TimePicker nativeView)
 		{


### PR DESCRIPTION
### Description of Change ###

Reference SetupDefaults methods from Handler constructor. It is related to something that we are still discussing, default values. For now, it seems that we are going to simplify everything by using cross-platform values but to avoid having non-referenced methods and the local variables of the handlers without value, this PR add a reference to the methods in the constructor.

This is probably going to change, so if we decide to continue as before, we can close this PR.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No