### PR TITLE
Unseal BlazorWebView for WPF/WinForms

### DIFF
--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
     /// <summary>
     /// A Windows Forms control for hosting Blazor web components locally in Windows desktop applications.
     /// </summary>
-    public sealed class BlazorWebView : ContainerControl, IDisposable
+    public class BlazorWebView : ContainerControl, IDisposable
     {
         private readonly WebView2Control _webview;
         private WebView2WebViewManager _webviewManager;

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
     /// <summary>
     /// A Windows Presentation Foundation (WPF) control for hosting Blazor web components locally in Windows desktop applications.
     /// </summary>
-    public sealed class BlazorWebView : Control, IDisposable
+    public class BlazorWebView : Control, IDisposable
     {
         #region Dependency property definitions
         /// <summary>


### PR DESCRIPTION
Fixes #1538

I can't think of any good reason for them to be sealed - it's very unusual to have sealed control types. So, un-seal!