### PR TITLE
Delete Entitlements for MacCatalyst

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1/Platforms/MacCatalyst/Entitlements.plist
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/Platforms/MacCatalyst/Entitlements.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-    <dict>
-    </dict>
-</plist>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/Platforms/MacCatalyst/Entitlements.plist
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/Platforms/MacCatalyst/Entitlements.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-    <dict>
-    </dict>
-</plist>


### PR DESCRIPTION
In p6 this appears to cause the build to look for a provisioning profile when it should not be needed.  This file is empty at the moment and should be safe to remove.

