### PR TITLE
Remove extra create on WinUI Window

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -23,9 +23,6 @@ namespace Microsoft.Maui
 		{
 			LaunchActivatedEventArgs = args;
 
-			// TODO: This should not be here. CreateWindow should do it.
-			MainWindow = new MauiWinUIWindow();
-
 			var startup = OnCreateStartup() ??
 				throw new InvalidOperationException($"A valid startup object must be provided by overriding {nameof(OnCreateStartup)}.");
 


### PR DESCRIPTION
### Description of Change ###

Remove extra creation of WinUI Window which was leading to some initialization exceptions. 

Currently with WinUI you can only ever new up a window once. Just calling the constructor on a window twice will cause it to throw an exception that second time