### PR TITLE
Fix IndicatorView crash on Android

### DIFF
--- a/src/Compatibility/Core/src/Android/CollectionView/IndicatorViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/IndicatorViewRenderer.cs
@@ -179,7 +179,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				return;
 			}
 
-			SetBackgroundColor((color ?? Element.BackgroundColor).ToAndroid());
+			Color backgroundColor = color ?? Element.BackgroundColor;
+
+			if (backgroundColor != null)
+				SetBackgroundColor(backgroundColor.ToAndroid());
 		}
 
 		void SetUpNewElement(IndicatorView newElement)


### PR DESCRIPTION
### Description of Change ###

Fix shimmed `IndicatorView` crash on Android due to default null `BackgroundColor`.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No