### PR TITLE
Do RazorComponent/Content remapping only when DesignTimeBuild=false

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -7,10 +7,8 @@
 
   <!-- Prevent Razor files from being packaged as bundle resources in iOS/MacCatalyst targets by declaring them
        as RazorComponent instead of Content. -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(DesignTimeBuild)' != 'true'">
     <Content Remove="**\*.razor" />
-  </ItemGroup>
-  <ItemGroup>
     <RazorComponent Include="**\*.razor" />
   </ItemGroup>
 


### PR DESCRIPTION
This way tooling doesn't see the remapping and you will get IntelliSense, syntax highlighting, etc.

Fixes #1516
Fixes #1623