### PR TITLE
Implement Themes

### DIFF
--- a/src/Controls/samples/Controls.Sample.Droid/MainActivity.cs
+++ b/src/Controls/samples/Controls.Sample.Droid/MainActivity.cs
@@ -1,9 +1,14 @@
 using Android.App;
+using Android.Content.PM;
 using Microsoft.Maui;
 
 namespace Maui.Controls.Sample.Droid
 {
-	[Activity(Label = "@string/app_name", Theme = "@style/Maui.SplashTheme", MainLauncher = true)]
+	[Activity(
+		Label = "@string/app_name",
+		Theme = "@style/Maui.SplashTheme",
+		MainLauncher = true,
+		ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode)]
 	[IntentFilter(
 		new[] { Microsoft.Maui.Essentials.Platform.Intent.ActionAppAction },
 		Categories = new[] { Android.Content.Intent.CategoryDefault })]

--- a/src/Controls/samples/Controls.Sample.Droid/Resources/values/strings.xml
+++ b/src/Controls/samples/Controls.Sample.Droid/Resources/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="app_name">Controls</string>
+    <string name="app_name">.NET MAUI Gallery</string>
 </resources>

--- a/src/Controls/samples/Controls.Sample/Pages/CompatibilityPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/CompatibilityPage.xaml
@@ -32,8 +32,8 @@
                     Grid.Column="1"
                     Placeholder="Filter"
                     Text="{Binding FilterValue, Mode=TwoWay}"
-                    PlaceholderColor="{DynamicResource TextSecondaryColor}"
-                    TextColor="{DynamicResource TextPrimaryColor}"
+                    PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
                     FontSize="Medium"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="Center"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ActivityIndicatorPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ActivityIndicatorPage.xaml
@@ -23,7 +23,7 @@
                 Style="{StaticResource Subhead}"/>
             <ActivityIndicator
                 IsRunning="True"
-                Color="{StaticResource AccentColor}" />
+                Color="{AppThemeBinding Light={StaticResource LightAccentColor}, Dark={StaticResource DarkAccentColor}}" />
         </VerticalStackLayout>
     </ContentPage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/ControlsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/ControlsPage.xaml
@@ -32,8 +32,8 @@
                     Grid.Column="1"
                     Placeholder="Filter"
                     Text="{Binding FilterValue, Mode=TwoWay}"
-                    PlaceholderColor="{DynamicResource TextSecondaryColor}"
-                    TextColor="{DynamicResource TextPrimaryColor}"
+                    PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
                     FontSize="Medium"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="Center"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/AppThemeBindingPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/AppThemeBindingPage.xaml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.AppThemeBindingPage"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    Title="AppThemeBinding">
+    <views:BasePage.Resources>
+        <ResourceDictionary>
+            
+            <!-- Light colors -->
+            <Color x:Key="LightPrimaryColor">Orange</Color>
+
+            <!-- Dark colors -->
+            <Color x:Key="DarkPrimaryColor">Teal</Color>
+             
+        </ResourceDictionary>
+    </views:BasePage.Resources>
+    <views:BasePage.Content>
+        <StackLayout
+            Margin="12">
+            <Label
+                Text="AppThemeBinding"
+                Style="{StaticResource Headline}"/>
+            <Label 
+                Text="This text is green in light mode, and red in dark mode."
+                TextColor="{AppThemeBinding Light=Green, Dark=Red}" />
+            <Label
+                Text="Using AppThemeBinding in a ResourceDictionary"
+                Style="{StaticResource Headline}"/>
+            <Label 
+                Text="This text use LightSecondaryColor Resource (Orange Color) in light mode, and DarkSecondaryColor Resource (Teal Color) in dark mode."
+                TextColor="{AppThemeBinding Light={StaticResource LightPrimaryColor}, Dark={StaticResource DarkPrimaryColor}}"/>
+        </StackLayout>
+    </views:BasePage.Content>
+</views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/AppThemeBindingPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/AppThemeBindingPage.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Maui.Controls.Sample.Pages
+{
+	public partial class AppThemeBindingPage
+	{
+		public AppThemeBindingPage()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/CorePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/CorePage.xaml
@@ -32,8 +32,8 @@
                     Grid.Column="1"
                     Placeholder="Filter"
                     Text="{Binding FilterValue, Mode=TwoWay}"
-                    PlaceholderColor="{DynamicResource TextSecondaryColor}"
-                    TextColor="{DynamicResource TextPrimaryColor}"
+                    PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
                     FontSize="Medium"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="Center"/>

--- a/src/Controls/samples/Controls.Sample/Pages/CustomNavigationPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/CustomNavigationPage.xaml
@@ -2,6 +2,6 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.CustomNavigationPage"
-    BarBackgroundColor="{StaticResource AccentColor}"
+    BarBackgroundColor="{AppThemeBinding Light={StaticResource LightAccentColor}, Dark={StaticResource DarkAccentColor}}"
     BarTextColor="{StaticResource WhiteColor}">
 </NavigationPage>

--- a/src/Controls/samples/Controls.Sample/Pages/GesturesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/GesturesPage.xaml
@@ -35,8 +35,8 @@
                     Text="{Binding FilterValue, Mode=OneWayToSource}"
                     ReturnCommand="{Binding FilterCommand}"
                     ReturnType="Search"
-                    PlaceholderColor="{DynamicResource TextSecondaryColor}"
-                    TextColor="{DynamicResource TextPrimaryColor}"
+                    PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
                     FontSize="Medium"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="Center"/>

--- a/src/Controls/samples/Controls.Sample/Pages/LayoutsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/LayoutsPage.xaml
@@ -32,8 +32,8 @@
                     Grid.Column="1"
                     Placeholder="Filter"
                     Text="{Binding FilterValue, Mode=TwoWay}"
-                    PlaceholderColor="{DynamicResource TextSecondaryColor}"
-                    TextColor="{DynamicResource TextPrimaryColor}"
+                    PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
                     FontSize="Medium"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="Center"/>

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
@@ -29,6 +29,7 @@
             <Color x:Key="SectionItemBorderColor">#C8C8C8</Color>
 
             <Style x:Key="SectionItemContainerStyle" TargetType="Frame">
+                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />
                 <Setter Property="BorderColor" Value="{StaticResource SectionItemBorderColor}" />
                 <Setter Property="CornerRadius" Value="0" />
                 <Setter Property="HasShadow" Value="False" />

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
@@ -12,7 +12,7 @@
             <Style x:Key="TitleStyle" TargetType="Label">
                 <Setter Property="FontSize" Value="Title" />
                 <Setter Property="FontFamily" Value="Segoe UI Bold" />
-                <Setter Property="TextColor" Value="{StaticResource WhiteColor}" />
+                <Setter Property="TextColor" Value="{DynamicResource DarkTextPrimaryColor}" />
                 <Setter Property="HorizontalOptions" Value="Center" />
                 <Setter Property="Margin" Value="0, 24, 0, 0" />
             </Style>
@@ -20,7 +20,7 @@
             <Style x:Key="SubTitleStyle" TargetType="Label">
                 <Setter Property="FontSize" Value="Small" />
                 <Setter Property="FontFamily" Value="Segoe UI" />
-                <Setter Property="TextColor" Value="{StaticResource WhiteColor}" />
+                <Setter Property="TextColor" Value="{DynamicResource DarkTextPrimaryColor}" />
                 <Setter Property="HorizontalTextAlignment" Value="Center" />
                 <Setter Property="HorizontalOptions" Value="Center" />
                 <Setter Property="Margin" Value="24, 12" />

--- a/src/Controls/samples/Controls.Sample/Pages/OthersPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/OthersPage.xaml
@@ -32,8 +32,8 @@
                     Grid.Column="1"
                     Placeholder="Filter"
                     Text="{Binding FilterValue, Mode=TwoWay}"
-                    PlaceholderColor="{DynamicResource TextSecondaryColor}"
-                    TextColor="{DynamicResource TextPrimaryColor}"
+                    PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
                     FontSize="Medium"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="Center"/>

--- a/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml
@@ -11,6 +11,7 @@
                 Margin="12">
                 <Label 
                     Text="Welcome to .NET MAUI!"
+                    TextColor="{AppThemeBinding Light={StaticResource LightAccentColor}, Dark={StaticResource DarkAccentColor}}"
                     SemanticProperties.HeadingLevel="Level1"
                     FontSize="32"
                     HorizontalOptions="CenterAndExpand" />

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterfacePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterfacePage.xaml
@@ -32,8 +32,8 @@
                     Grid.Column="1"
                     Placeholder="Filter"
                     Text="{Binding FilterValue, Mode=TwoWay}"
-                    PlaceholderColor="{DynamicResource TextSecondaryColor}"
-                    TextColor="{DynamicResource TextPrimaryColor}"
+                    PlaceholderColor="{AppThemeBinding Light={StaticResource LightTextSecondaryColor}, Dark={StaticResource DarkTextSecondaryColor}}"
+                    TextColor="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}"
                     FontSize="Medium"
                     HorizontalOptions="FillAndExpand"
                     VerticalOptions="Center"/>

--- a/src/Controls/samples/Controls.Sample/ViewModels/CoreViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/CoreViewModel.cs
@@ -12,6 +12,9 @@ namespace Maui.Controls.Sample.ViewModels
 			new SectionModel(typeof(AlertsPage), "Alerts",
 				"Displaying an alert, asking a user to make a choice, or displaying a prompt."),
 
+			new SectionModel(typeof(AppThemeBindingPage), "AppThemeBindings",
+				"Devices typically include light and dark themes, which each refer to a broad set of appearance preferences that can be set at the operating system level. Applications should respect these system themes, and respond immediately when the system theme changes."),
+
 			new SectionModel(typeof(BrushesPage), "Brushes",
 				"A brush enables you to paint an area, such as the background of a control, using different approaches."),
 

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml
@@ -40,6 +40,7 @@
             </Style>
 
             <Style x:Key="GalleryItemContainerStyle" TargetType="Frame">
+                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />
                 <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource LightBorderColor}, Dark={StaticResource DarkBorderColor}}" />
                 <Setter Property="CornerRadius" Value="0" />
                 <Setter Property="HasShadow" Value="False" />

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml
@@ -8,19 +8,30 @@
     <Application.Resources>
         <ResourceDictionary>
 
-            <!-- COLORS -->
+            <!-- COMMON COLORS -->
             <Color x:Key="BlackColor">#150303</Color>
             <Color x:Key="WhiteColor">#F8F8FF</Color>
-            <Color x:Key="AccentColor">#4423A8</Color>
-            <Color x:Key="BackgroundColor">#F9F8FF</Color>
-            <Color x:Key="BackgroundSecondaryColor">#F9F9FF</Color>
-            <Color x:Key="TextPrimaryColor">#B0150303</Color>
-            <Color x:Key="TextSecondaryColor">#B01d1d1d</Color>
-            <Color x:Key="BorderColor">#C8C8C8</Color>
+
+
+            <!-- LIGHT COLORS -->
+            <Color x:Key="LightAccentColor">#5639b0</Color>
+            <Color x:Key="LightBackgroundColor">#F9F8FF</Color>
+            <Color x:Key="LightBackgroundSecondaryColor">#F9F9FF</Color>
+            <Color x:Key="LightTextPrimaryColor">#B0150303</Color>
+            <Color x:Key="LightTextSecondaryColor">#B01d1d1d</Color>
+            <Color x:Key="LightBorderColor">#C8C8C8</Color>
+            
+            <!-- DARK COLORS -->
+            <Color x:Key="DarkAccentColor">#7e2bea</Color>
+            <Color x:Key="DarkBackgroundColor">#181819</Color>
+            <Color x:Key="DarkBackgroundSecondaryColor">#313133</Color>
+            <Color x:Key="DarkTextPrimaryColor">#fcfcfc</Color>
+            <Color x:Key="DarkTextSecondaryColor">#f5f5f5</Color>
+            <Color x:Key="DarkBorderColor">#fefefe</Color>
 
             <!-- STYLES -->
             <Style x:Key="SearchBorderStyle" TargetType="Frame">
-                <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundSecondaryColor}" />
+                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />
                 <Setter Property="HasShadow" Value="True" />
                 <Setter Property="Padding" Value="0" />
                 <Setter Property="HeightRequest" Value="40" />
@@ -29,7 +40,7 @@
             </Style>
 
             <Style x:Key="GalleryItemContainerStyle" TargetType="Frame">
-                <Setter Property="BorderColor" Value="{StaticResource BorderColor}" />
+                <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource LightBorderColor}, Dark={StaticResource DarkBorderColor}}" />
                 <Setter Property="CornerRadius" Value="0" />
                 <Setter Property="HasShadow" Value="False" />
                 <Setter Property="Padding" Value="12" />
@@ -40,14 +51,14 @@
                 <Setter Property="FontSize" Value="Small" />
                 <Setter Property="FontFamily" Value="Segoe UI" />
                 <Setter Property="FontAttributes" Value="Bold" />
-                <Setter Property="TextColor" Value="{StaticResource AccentColor}" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightAccentColor}, Dark={StaticResource DarkAccentColor}}" />
                 <Setter Property="Margin" Value="0, 0, 0, 6" />
             </Style>
 
             <Style x:Key="GalleryItemDescriptionStyle" TargetType="Label">
                 <Setter Property="FontSize" Value="Caption" />
                 <Setter Property="FontFamily" Value="Segoe UI" />
-                <Setter Property="TextColor" Value="{StaticResource BlackColor}" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />
                 <Setter Property="LineBreakMode" Value="WordWrap" />
             </Style>
 
@@ -57,16 +68,19 @@
                 <Setter Property="HorizontalTextAlignment" Value="Center" />
                 <Setter Property="HorizontalOptions" Value="Center" />
                 <Setter Property="VerticalOptions" Value="Center" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />
             </Style>
 
             <Style x:Key="Headline" TargetType="Label">
                 <Setter Property="FontFamily" Value="Segoe UI" />
                 <Setter Property="FontSize" Value="10" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />
             </Style>
 
             <Style x:Key="Subhead" TargetType="Label">
                 <Setter Property="FontFamily" Value="Segoe UI" />
                 <Setter Property="FontSize" Value="9" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />
             </Style>
 
         </ResourceDictionary>

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -15,10 +15,15 @@ namespace Maui.Controls.Sample
 
 			Services = services;
 
-			Debug.WriteLine($"The AccentColor color is {Resources["AccentColor"]}");
 			Debug.WriteLine($"The injected text service had a message: '{textService.GetText()}'");
 
 			MainPage = Services.GetRequiredService<Page>();
+
+			RequestedThemeChanged += (sender, args) =>
+			{
+				// Respond to the theme change
+				Debug.WriteLine($"Requested theme changed: {args.RequestedTheme}");
+			};
 		}
 
 		public IServiceProvider Services { get; }

--- a/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
@@ -21,6 +21,19 @@ namespace Microsoft.Maui.Controls
 			return window;
 		}
 
+		public void ThemeChanged()
+		{
+			Current?.TriggerThemeChanged(new AppThemeChangedEventArgs(Current.RequestedTheme));
+		}
+
+		protected virtual Window CreateWindow(IActivationState activationState)
+		{
+			if (Windows.Count > 0)
+				return Windows[0];
+
+			throw new NotImplementedException($"Either set {nameof(MainPage)} or override {nameof(Application.CreateWindow)}.");
+		}
+	
 		void AddWindow(Window window)
 		{
 			_windows.Add(window);
@@ -34,14 +47,6 @@ namespace Microsoft.Maui.Controls
 
 			if (window is NavigableElement ne)
 				ne.NavigationProxy.Inner = NavigationProxy;
-		}
-
-		protected virtual Window CreateWindow(IActivationState activationState)
-		{
-			if (Windows.Count > 0)
-				return Windows[0];
-
-			throw new NotImplementedException($"Either set {nameof(MainPage)} or override {nameof(Application.CreateWindow)}.");
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/TestClasses/ApplicationStub.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/ApplicationStub.cs
@@ -4,13 +4,17 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	class ApplicationStub : IApplication
 	{
-		List<IWindow> _windows = new List<IWindow>();
+		readonly List<IWindow> _windows = new List<IWindow>();
+
 		public IReadOnlyList<IWindow> Windows => _windows.AsReadOnly();
+
 		public string Property { get; set; } = "Default";
 
 		public IWindow CreateWindow(IActivationState activationState)
 		{
 			throw new System.NotImplementedException();
 		}
+
+		public void ThemeChanged() { }
 	}
 }

--- a/src/Core/src/IApplication.cs
+++ b/src/Core/src/IApplication.cs
@@ -2,9 +2,26 @@ using System.Collections.Generic;
 
 namespace Microsoft.Maui
 {
+	/// <summary>
+	/// Class that represents a cross-platform .NET MAUI application.
+	/// </summary>
 	public interface IApplication
 	{
+		/// <summary>
+		/// Gets the instantiated windows in an application.
+		/// </summary>
 		IReadOnlyList<IWindow> Windows { get; }
+
+		/// <summary>
+		/// Instantiate a new window.
+		/// </summary>
+		/// <param name="activationState">Argument containing specific information on each platform.</param>
+		/// <returns>The created window.</returns>
 		IWindow CreateWindow(IActivationState activationState);
+
+		/// <summary>
+		/// Notify a theme change.
+		/// </summary>
+		void ThemeChanged();
 	}
 }

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
@@ -37,7 +37,14 @@ namespace Microsoft.Maui
 		{
 			base.OnConfigurationChanged(newConfig);
 
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnConfigurationChanged>(del => del(this, newConfig));
+			var mauiApp = MauiApplication.Current;
+
+			if (mauiApp != null)
+			{
+				mauiApp.Application?.ThemeChanged();
+
+				mauiApp.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnConfigurationChanged>(del => del(this, newConfig));
+			}
 		}
 
 		protected override void OnNewIntent(Intent? intent)

--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
     <!-- Base application theme. -->
-    <style name="Maui.MainTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="Maui.MainTheme" parent="Theme.AppCompat.DayNight">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
@@ -9,6 +9,7 @@
     <style name="Maui.MainTheme.NoActionBar" parent="Maui.MainTheme">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="windowActionModeOverlay">true</item>
     </style>
     <style name="Maui.MainTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
     <style name="Maui.MainTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Maui
 
 		protected virtual void OnNativeMessage(object? sender, WindowsNativeMessageEventArgs args)
 		{
+			if (args.MessageId == WindowsNativeMessageIds.WM_SETTINGCHANGE || args.MessageId == WindowsNativeMessageIds.WM_THEMECHANGE)
+				MauiWinUIApplication.Current.Application?.ThemeChanged();
+
 			MauiWinUIApplication.Current.Services?.InvokeLifecycleEvents<WindowsLifecycle.OnNativeMessage>(m => m(this, args));
 		}
 
@@ -36,10 +39,10 @@ namespace Microsoft.Maui
 		{
 			MauiWinUIApplication.Current.Services?.InvokeLifecycleEvents<WindowsLifecycle.OnVisibilityChanged>(del => del(this, args));
 		}
-
 		public event EventHandler<WindowsNativeMessageEventArgs> NativeMessage;
 
 		#region Native Window
+
 		IntPtr _hwnd = IntPtr.Zero;
 		delegate IntPtr WinProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 		WinProc? newWndProc = null;
@@ -69,6 +72,7 @@ namespace Microsoft.Maui
 
 			return CallWindowProc(oldWndProc, hWnd, msg, wParam, lParam);
 		}
+
 		#endregion
 	}
 }

--- a/src/Core/src/Platform/WindowsNativeMessageIds.cs
+++ b/src/Core/src/Platform/WindowsNativeMessageIds.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Maui
+{
+	internal static class WindowsNativeMessageIds
+	{
+		public const int WM_DPICHANGED = 0x02E0;
+		public const int WM_DISPLAYCHANGE = 0x007E;
+		public const int WM_SETTINGCHANGE = 0x001A;
+		public const int WM_THEMECHANGE = 0x031A;
+	}
+}

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -1,6 +1,7 @@
 using System;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
 using ObjCRuntime;
 using UIKit;
 
@@ -93,6 +94,17 @@ namespace Microsoft.Maui
 			{
 				CrossPlatformArrange = ((IPage)view).Arrange,
 			};
+		}
+
+		public override void TraitCollectionDidChange(UITraitCollection? previousTraitCollection)
+		{
+			if (CurrentView?.Handler is ElementHandler handler)
+			{
+				var application = handler.GetRequiredService<IApplication>();
+				application?.ThemeChanged();
+			}
+
+			base.TraitCollectionDidChange(previousTraitCollection);
 		}
 	}
 }

--- a/src/Core/tests/Benchmarks/Stubs/ApplicationStub.cs
+++ b/src/Core/tests/Benchmarks/Stubs/ApplicationStub.cs
@@ -4,7 +4,8 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 {
 	class ApplicationStub : IApplication
 	{
-		List<IWindow> _windows = new List<IWindow>();
+		readonly List<IWindow> _windows = new List<IWindow>();
+
 		public IReadOnlyList<IWindow> Windows => _windows.AsReadOnly();
 
 		public IWindow CreateWindow(IActivationState state)
@@ -13,5 +14,7 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 
 			return _windows[0];
 		}
+
+		public void ThemeChanged() { }
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/ApplicationStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ApplicationStub.cs
@@ -4,7 +4,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	class ApplicationStub : IApplication
 	{
-		List<IWindow> _windows = new List<IWindow>();
+		readonly List<IWindow> _windows = new List<IWindow>();
+
 		public IReadOnlyList<IWindow> Windows => _windows.AsReadOnly();
 
 		public IWindow CreateWindow(IActivationState state)
@@ -13,5 +14,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 			return _windows[0];
 		}
+
+		public void ThemeChanged() { }
 	}
 }

--- a/src/Core/tests/UnitTests/TestClasses/ApplicationStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ApplicationStub.cs
@@ -4,13 +4,17 @@ namespace Microsoft.Maui.UnitTests
 {
 	class ApplicationStub : IApplication
 	{
-		List<IWindow> _windows = new List<IWindow>();
+		readonly List<IWindow> _windows = new List<IWindow>();
+
 		public IReadOnlyList<IWindow> Windows => _windows.AsReadOnly();
+
 		public string Property { get; set; } = "Default";
 
 		public IWindow CreateWindow(IActivationState activationState)
 		{
 			throw new System.NotImplementedException();
 		}
+
+		public void ThemeChanged() { }
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Include support for `AppThemeBinding` in Android and iOS. Add dark theme support to the Gallery too.

Android

<img width="391" alt="gallery-light" src="https://user-images.githubusercontent.com/6755973/125429385-c155f190-6083-4503-8b45-8394c42d2e58.png">
<img width="390" alt="gallery-dark" src="https://user-images.githubusercontent.com/6755973/125429397-5c43ab7d-38c9-409a-ace1-31f52282df52.png">

iOS
![gallery-themes](https://user-images.githubusercontent.com/6755973/125429628-49b8fd72-e5d9-4a5d-94c1-e3509830ab27.gif)

Reviewing the Windows implementation. `UISettings.ColorValuesChanged`Event and `AccessibilitySettings.HighContrastChanged` Event are no longer working.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)


#### Does this PR touch anything that might affect accessibility?
- No