### PR TITLE
Disable interpreter for p6 templates on android

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/MauiApp1.csproj
@@ -45,7 +45,7 @@
 		<InvariantGlobalization Condition="$(TargetFramework.Contains('-maccatalyst'))">true</InvariantGlobalization>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-ios'))">iossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
-		<UseInterpreter Condition="$(TargetFramework.Contains('-android'))">True</UseInterpreter>
+		<UseInterpreter Condition="$(TargetFramework.Contains('-android'))">False</UseInterpreter>
 	</PropertyGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MauiApp1.csproj
@@ -41,7 +41,7 @@
 		<InvariantGlobalization Condition="$(TargetFramework.Contains('-maccatalyst'))">true</InvariantGlobalization>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-ios'))">iossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-maccatalyst'))">maccatalyst-x64</RuntimeIdentifier>
-		<UseInterpreter Condition="$(TargetFramework.Contains('-android'))">True</UseInterpreter>
+		<UseInterpreter Condition="$(TargetFramework.Contains('-android'))">False</UseInterpreter>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This is not working on android currently for p6, we will disable and evaluate again for p7