### PR TITLE
Dispose Blazor stuff on .NET MAUI, WinForms, and WPF

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -47,6 +47,22 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			nativeView.StopLoading();
 
+			if (_webviewManager != null)
+			{
+				// Dispose this component's contents and block on completion so that user-written disposal logic and
+				// Blazor disposal logic will complete first. Then call base.Dispose(), which will dispose the WebView2
+				// control. This order is critical because once the WebView2 is disposed it will prevent and Blazor
+				// code from working because it requires the WebView to exist.
+				_webviewManager?
+					.DisposeAsync()
+					.AsTask()
+					.ConfigureAwait(false)
+					.GetAwaiter()
+					.GetResult();
+
+				_webviewManager = null;
+			}
+
 			_webViewClient?.Dispose();
 			_webChromeClient?.Dispose();
 		}

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -19,10 +19,21 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 		protected override void DisconnectHandler(WebView2Control nativeView)
 		{
-			//nativeView.StopLoading();
+			if (_webviewManager != null)
+			{
+				// Dispose this component's contents and block on completion so that user-written disposal logic and
+				// Blazor disposal logic will complete first. Then call base.Dispose(), which will dispose the WebView2
+				// control. This order is critical because once the WebView2 is disposed it will prevent and Blazor
+				// code from working because it requires the WebView to exist.
+				_webviewManager?
+					.DisposeAsync()
+					.AsTask()
+					.ConfigureAwait(false)
+					.GetAwaiter()
+					.GetResult();
 
-			//_webViewClient?.Dispose();
-			//_webChromeClient?.Dispose();
+				_webviewManager = null;
+			}
 		}
 
 		private bool RequiredStartupPropertiesSet =>

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -91,10 +91,23 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 		protected override void DisconnectHandler(WKWebView nativeView)
 		{
-			//nativeView.StopLoading();
+			nativeView.StopLoading();
 
-			//_webViewClient?.Dispose();
-			//_webChromeClient?.Dispose();
+			if (_webviewManager != null)
+			{
+				// Dispose this component's contents and block on completion so that user-written disposal logic and
+				// Blazor disposal logic will complete first. Then call base.Dispose(), which will dispose the WebView2
+				// control. This order is critical because once the WebView2 is disposed it will prevent and Blazor
+				// code from working because it requires the WebView to exist.
+				_webviewManager?
+					.DisposeAsync()
+					.AsTask()
+					.ConfigureAwait(false)
+					.GetAwaiter()
+					.GetResult();
+
+				_webviewManager = null;
+			}
 		}
 
 		private bool RequiredStartupPropertiesSet =>

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -217,8 +217,14 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 
         public async ValueTask DisposeAsync()
         {
-            // Perform async cleanup.
-            await DisposeAsyncCore();
+			if (_isDisposed)
+			{
+				return;
+			}
+			_isDisposed = true;
+
+			// Perform async cleanup.
+			await DisposeAsyncCore();
 
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
             // Suppress finalization.

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -191,15 +191,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
             }
         }
 
-        /// <summary>
-        /// Performs the final cleanup before the garbage collector destroys the object.
-        /// </summary>
-        ~BlazorWebView()
-        {
-            // Do not change this code. Put cleanup code in 'DisposeAsyncCore()' method
-            _ = DisposeAsync();
-        }
-
         private void CheckDisposed()
         {
             if (_isDisposed)

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.AspNetCore.Components.WebView.WebView2;
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
     /// <summary>
     /// A Windows Presentation Foundation (WPF) control for hosting Blazor web components locally in Windows desktop applications.
     /// </summary>
-    public class BlazorWebView : Control, IDisposable
+    public class BlazorWebView : Control, IAsyncDisposable
     {
         #region Dependency property definitions
         /// <summary>
@@ -190,40 +191,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
             }
         }
 
-        private void Dispose(bool disposing)
-        {
-            if (!_isDisposed)
-            {
-                if (disposing)
-                {
-                    // Dispose managed state (managed objects)
-                    _webviewManager?.Dispose();
-                    _webview?.Dispose();
-                }
-
-                // Also: free unmanaged resources (unmanaged objects) and override finalizer
-                // Also: set large fields to null
-                _isDisposed = true;
-            }
-        }
-
         /// <summary>
         /// Performs the final cleanup before the garbage collector destroys the object.
         /// </summary>
         ~BlazorWebView()
         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: false);
-        }
-
-        /// <summary>
-        /// Releases all resources used by the control.
-        /// </summary>
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
+            // Do not change this code. Put cleanup code in 'DisposeAsyncCore()' method
+            _ = DisposeAsync();
         }
 
         private void CheckDisposed()
@@ -232,6 +206,33 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
             {
                 throw new ObjectDisposedException(GetType().Name);
             }
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+			// Dispose this component's contents that user-written disposal logic and Blazor disposal logic will complete
+			// first. Then dispose the WebView2 control. This order is critical because once the WebView2 is disposed it
+			// will prevent and Blazor code from working because it requires the WebView to exist.
+			if (_webviewManager != null)
+            {
+                await _webviewManager.DisposeAsync()
+                    .ConfigureAwait(false);
+                _webviewManager = null;
+            }
+
+            _webview?.Dispose();
+            _webview = null;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // Perform async cleanup.
+            await DisposeAsyncCore();
+
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize	
         }
     }
 }


### PR DESCRIPTION
Each platform has a different pattern:
- .NET MAUI supports sync dispose. In each platform handler's disconnect the web view is instructed to stop, and Blazor's WebViewManager's async dispose is called and _blocked_ to ensure that all Blazor dispose code, including user-created async disposal, is run before the web view is destroyed.
- WinForms supports sync dispose and follows a similar pattern to .NET MAUI.
- WPF doesn't support any disposal. An app developer can manually call DisposeAsync() to await completion of disposal, or the destructor uses fire-and-forget to trigger async disposal that will remain unobserved.

Fixes #1280 

NOTE: This PR is blocked (and won't even compile) until https://github.com/dotnet/aspnetcore/pull/33482 is merged and maestro updates dependencies in this repo.