### PR TITLE
Subclass WinUI Window to hook native win32 events

### DIFF
--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycle.cs
@@ -7,6 +7,7 @@
 		public delegate void OnLaunched(UI.Xaml.Application application, UI.Xaml.LaunchActivatedEventArgs args);
 		public delegate void OnLaunching(UI.Xaml.Application application, UI.Xaml.LaunchActivatedEventArgs args);
 		public delegate void OnVisibilityChanged(UI.Xaml.Window window, UI.Xaml.WindowVisibilityChangedEventArgs args);
+		public delegate void OnNativeMessage(UI.Xaml.Window window, WindowsNativeMessageEventArgs args);
 
 		// Internal events
 		internal delegate void OnMauiContextCreated(IMauiContext mauiContext);

--- a/src/Core/src/Platform/Windows/IWindowNative.cs
+++ b/src/Core/src/Platform/Windows/IWindowNative.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Maui
+{
+	[ComImport]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	[Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB")]
+	internal interface IWindowNative
+	{
+		IntPtr WindowHandle { get; }
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Maui.LifecycleEvents;
+﻿using System;
+using System.Runtime.InteropServices;
+using Microsoft.Maui.LifecycleEvents;
+using WinRT;
 
 namespace Microsoft.Maui
 {
@@ -6,9 +9,17 @@ namespace Microsoft.Maui
 	{
 		public MauiWinUIWindow()
 		{
+			NativeMessage += OnNativeMessage;
 			Activated += OnActivated;
 			Closed += OnClosed;
 			VisibilityChanged += OnVisibilityChanged;
+
+			SubClassingWin32();
+		}
+
+		protected virtual void OnNativeMessage(object? sender, WindowsNativeMessageEventArgs args)
+		{
+			MauiWinUIApplication.Current.Services?.InvokeLifecycleEvents<WindowsLifecycle.OnNativeMessage>(m => m(this, args));
 		}
 
 		protected virtual void OnActivated(object sender, UI.Xaml.WindowActivatedEventArgs args)
@@ -25,5 +36,39 @@ namespace Microsoft.Maui
 		{
 			MauiWinUIApplication.Current.Services?.InvokeLifecycleEvents<WindowsLifecycle.OnVisibilityChanged>(del => del(this, args));
 		}
+
+		public event EventHandler<WindowsNativeMessageEventArgs> NativeMessage;
+
+		#region Native Window
+		IntPtr _hwnd = IntPtr.Zero;
+		delegate IntPtr WinProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+		WinProc? newWndProc = null;
+		IntPtr oldWndProc = IntPtr.Zero;
+
+		[DllImport("user32")]
+		static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, WinProc newProc);
+		[DllImport("user32.dll")]
+		static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+		void SubClassingWin32()
+		{
+			//Get the Window's HWND
+			_hwnd = this.As<IWindowNative>().WindowHandle;
+			if (_hwnd == IntPtr.Zero)
+				throw new NullReferenceException("The Window Handle is null.");
+
+			newWndProc = new WinProc(NewWindowProc);
+			oldWndProc = SetWindowLongPtr(_hwnd, /* GWL_WNDPROC */ -4, newWndProc);
+		}
+
+		IntPtr NewWindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+		{
+			var args = new WindowsNativeMessageEventArgs(hWnd, msg, wParam, lParam);
+
+			NativeMessage?.Invoke(this, args);
+
+			return CallWindowProc(oldWndProc, hWnd, msg, wParam, lParam);
+		}
+		#endregion
 	}
 }

--- a/src/Core/src/Platform/Windows/WindowsNativeMessageEventArgs.cs
+++ b/src/Core/src/Platform/Windows/WindowsNativeMessageEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Microsoft.Maui
+{
+	public class WindowsNativeMessageEventArgs : EventArgs
+	{
+		public WindowsNativeMessageEventArgs(IntPtr hwnd, uint messageId, IntPtr wParam, IntPtr lParam)
+		{
+			Hwnd = hwnd;
+			MessageId = messageId;
+			WParam = wParam;
+			LParam = lParam;
+		}
+
+		public IntPtr Hwnd { get; private set; }
+		public uint MessageId { get; private set; }
+		public IntPtr WParam { get; private set; }
+		public IntPtr LParam { get; private set; }
+	}
+}

--- a/src/Core/src/Platform/Windows/WindowsNativeMessageIds.cs
+++ b/src/Core/src/Platform/Windows/WindowsNativeMessageIds.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.Maui
 {
-	static class WindowsNativeMessageIds
+	public static class WindowsNativeMessageIds
 	{
 		public const int WM_DPICHANGED = 0x02E0;
 		public const int WM_DISPLAYCHANGE = 0x007E;

--- a/src/Core/src/Platform/Windows/WindowsNativeMessageIds.cs
+++ b/src/Core/src/Platform/Windows/WindowsNativeMessageIds.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Maui
+{
+	static class WindowsNativeMessageIds
+	{
+		public const int WM_DPICHANGED = 0x02E0;
+		public const int WM_DISPLAYCHANGE = 0x007E;
+		public const int WM_SETTINGCHANGE = 0x001A;
+		public const int WM_THEMECHANGE = 0x031A;
+	}
+}

--- a/src/Core/src/Platform/Windows/WindowsNativeMessageIds.cs
+++ b/src/Core/src/Platform/Windows/WindowsNativeMessageIds.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.Maui
 {
-	public static class WindowsNativeMessageIds
+	internal static class WindowsNativeMessageIds
 	{
 		public const int WM_DPICHANGED = 0x02E0;
 		public const int WM_DISPLAYCHANGE = 0x007E;


### PR DESCRIPTION
To do some things in WinUI we need to use win32 API's still.

This adds support to subclass the Window and start listening for windows native messages, and exposes them as a lifecycle event for other things to use.

For instance you could now use this:

```csharp
public void Configure(IAppHostBuilder appBuilder)
{
	appBuilder
		.UseMauiApp<App>()
		.ConfigureLifecycleEvents(lifecycle => {
#if WINDOWS
			lifecycle
				.AddWindows(windows => windows.OnNativeMessage((window, args) => {
					if (args.MessageId == WindowsNativeMessageIds.WM_DPICHANGED) {
						// The DPI has changed on the system
					}
				}));
#endif
	});
}
```