### PR TITLE
Convert Handler Events to Changing/Changed

### DIFF
--- a/eng/pipelines/common/controlgallery-ios.yml
+++ b/eng/pipelines/common/controlgallery-ios.yml
@@ -36,16 +36,27 @@ steps:
       version: $(DOTNET_VERSION)
       packageType: 'sdk'
 
-  - task: InstallAppleCertificate@2
-    displayName: 'Install an Apple certificate'
-    inputs:
-      certSecureFile: 'Maui.p12'
-      certPwd: $(P12password)
-
   - task: InstallAppleProvisioningProfile@1
-    displayName: 'Install an Apple provisioning profile'
+    displayName: 'Install the iOS provisioning profile'
     inputs:
-      provProfileSecureFile: 'Maui_iOS_Provisioning.mobileprovision'
+      provProfileSecureFile: 'Components iOS Provisioning.mobileprovision'
+  - task: InstallAppleProvisioningProfile@1
+    displayName: 'Install the macOS provisioning profile'
+    inputs:
+      provProfileSecureFile: 'Components Mac Provisioning.mobileprovision'
+  - task: InstallAppleProvisioningProfile@1
+    displayName: 'Install the tvOS provisioning profile'
+    inputs:
+      provProfileSecureFile: 'Components tvOS Provisioning.mobileprovision'
+  - task: InstallAppleCertificate@2
+    displayName: 'Install the iOS certificate'
+    inputs:
+      certSecureFile: 'Components iOS Certificate.p12'
+  - task: InstallAppleCertificate@2
+    condition: eq(variables['System.JobName'], 'macos')
+    displayName: 'Install the macOS certificate'
+    inputs:
+      certSecureFile: 'Components Mac Certificate.p12'
 
   - task: Bash@3
     displayName: 'Build Control Gallery IPA'

--- a/src/Compatibility/ControlGallery/src/Core/CoreGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/CoreGallery.cs
@@ -555,9 +555,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 		bool registrarValidated;
 		CoreRootView CoreRootView { get; }
 
-		protected override void OnAttachedHandler()
+		private protected override void OnHandlerChangedCore()
 		{
-			base.OnAttachedHandler();
+			base.OnHandlerChangedCore();
 
 			if (!registrarValidated)
 				ValidateRegistrar();

--- a/src/Controls/src/Core/HandlerChangingEventArgs.cs
+++ b/src/Controls/src/Core/HandlerChangingEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Maui.Controls
+{
+	public class HandlerChangingEventArgs
+	{
+		public IElementHandler NewHandler { get; }
+		public IElementHandler OldHandler { get; }
+
+		public HandlerChangingEventArgs(IElementHandler oldHandler, IElementHandler newHandler)
+		{
+			NewHandler = newHandler;
+			OldHandler = oldHandler;
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Maui.Controls
 	public partial class Element : Maui.IElement, IEffectControlProvider
 	{
 		IElementHandler _handler;
-		EventHandler _handlerChanged;
 		EffectsFactory _effectsFactory;
 
 		Maui.IElement Maui.IElement.Parent => Parent;
@@ -20,19 +19,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public event EventHandler<HandlerChangingEventArgs> HandlerChanging;
-		public event EventHandler HandlerChanged
-		{
-			add
-			{
-				_handlerChanged += value;
-				if (Handler != null)
-					value?.Invoke(this, EventArgs.Empty);
-			}
-			remove
-			{
-				_handlerChanged -= value;
-			}
-		}
+		public event EventHandler HandlerChanged;
 
 		protected virtual void OnHandlerChanging(HandlerChangingEventArgs args) { }
 
@@ -41,8 +28,7 @@ namespace Microsoft.Maui.Controls
 		private protected virtual void OnHandlerChangedCore()
 		{
 			EffectControlProvider = (Handler != null) ? this : null;
-
-			_handlerChanged?.Invoke(this, EventArgs.Empty);
+			HandlerChanged?.Invoke(this, EventArgs.Empty);
 			OnHandlerChanged();
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/View.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/View.Impl.cs
@@ -10,18 +10,21 @@ namespace Microsoft.Maui.Controls
 	public partial class View
 	{
 		GestureManager? _gestureManager;
-		private protected override void OnAttachedHandlerCore()
+		private protected override void OnHandlerChangedCore()
 		{
-			base.OnAttachedHandlerCore();
+			base.OnHandlerChangedCore();
 			_gestureManager?.Dispose();
-			_gestureManager = new GestureManager(Handler);
+
+			if (Handler != null)
+				_gestureManager = new GestureManager(Handler);
 		}
 
-		private protected override void OnDetachingHandlerCore()
+		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
 		{
-			base.OnDetachingHandlerCore();
 			_gestureManager?.Dispose();
 			_gestureManager = null;
+
+			base.OnHandlerChangingCore(args);
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Maui.Controls
 			set => base.Handler = value;
 		}
 
-		private protected override void OnHandlerSet()
+		private protected override void OnHandlerChangedCore()
 		{
-			base.OnHandlerSet();
+			base.OnHandlerChangedCore();
 
 			IsPlatformEnabled = Handler != null;
 		}

--- a/src/Controls/src/Core/HandlerImpl/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window.Impl.cs
@@ -118,8 +118,8 @@ namespace Microsoft.Maui.Controls
 			if (oldPage != null)
 			{
 				window.InternalChildren.Remove(oldPage);
-				oldPage.HandlerChanged -= OnPageAttachedHandler;
-				oldPage.HandlerChanging -= OnPageDetachedHandler;
+				oldPage.HandlerChanged -= OnPageHandlerChanged;
+				oldPage.HandlerChanging -= OnPageHandlerChanging;
 			}
 
 			var newPage = newValue as Page;
@@ -133,17 +133,20 @@ namespace Microsoft.Maui.Controls
 
 			if (newPage != null)
 			{
-				newPage.HandlerChanged += OnPageAttachedHandler;
-				newPage.HandlerChanging += OnPageDetachedHandler;
+				newPage.HandlerChanged += OnPageHandlerChanged;
+				newPage.HandlerChanging += OnPageHandlerChanging;
+
+				if (newPage.Handler != null)
+					OnPageHandlerChanged(newPage, EventArgs.Empty);
 			}
 
-			void OnPageAttachedHandler(object? sender, EventArgs e)
+			void OnPageHandlerChanged(object? sender, EventArgs e)
 			{
 				window.ModalNavigationManager.PageAttachedHandler();
 				window.AlertManager.Subscribe();
 			}
 
-			void OnPageDetachedHandler(object? sender, HandlerChangingEventArgs e)
+			void OnPageHandlerChanging(object? sender, HandlerChangingEventArgs e)
 			{
 				window.AlertManager.Unsubscribe();
 			}

--- a/src/Controls/src/Core/HandlerImpl/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window.Impl.cs
@@ -118,8 +118,8 @@ namespace Microsoft.Maui.Controls
 			if (oldPage != null)
 			{
 				window.InternalChildren.Remove(oldPage);
-				oldPage.AttachedHandler -= OnPageAttachedHandler;
-				oldPage.DetachedHandler -= OnPageDetachedHandler;
+				oldPage.HandlerChanged -= OnPageAttachedHandler;
+				oldPage.HandlerChanging -= OnPageDetachedHandler;
 			}
 
 			var newPage = newValue as Page;
@@ -133,8 +133,8 @@ namespace Microsoft.Maui.Controls
 
 			if (newPage != null)
 			{
-				newPage.AttachedHandler += OnPageAttachedHandler;
-				newPage.DetachedHandler += OnPageDetachedHandler;
+				newPage.HandlerChanged += OnPageAttachedHandler;
+				newPage.HandlerChanging += OnPageDetachedHandler;
 			}
 
 			void OnPageAttachedHandler(object? sender, EventArgs e)
@@ -143,7 +143,7 @@ namespace Microsoft.Maui.Controls
 				window.AlertManager.Subscribe();
 			}
 
-			void OnPageDetachedHandler(object? sender, EventArgs e)
+			void OnPageDetachedHandler(object? sender, HandlerChangingEventArgs e)
 			{
 				window.AlertManager.Unsubscribe();
 			}

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -13,22 +13,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class HandlerLifeCycleTests : BaseTestFixture
 	{
 		[Test]
-		public void ChangedFiresWhenSubscribedAfterHandlerIsSet()
-		{
-			LifeCycleButton button = new LifeCycleButton();
-			bool changed = false;
-
-			button.Handler = new HandlerStub();
-			button.HandlerChanged += (_, __) =>
-			{
-				changed = true;
-			};
-
-			Assert.IsTrue(changed);
-			Assert.AreEqual(1, button.changed);
-		}
-
-		[Test]
 		public void ChangingAndChangedBothFireInitially()
 		{
 			LifeCycleButton button = new LifeCycleButton();

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -13,124 +13,94 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class HandlerLifeCycleTests : BaseTestFixture
 	{
 		[Test]
-		public void VirtualViewSet()
+		public void ChangedFiresWhenSubscribedAfterHandlerIsSet()
 		{
-			Button button = new Button();
-			HandlerStub handlerStub = new HandlerStub();
+			LifeCycleButton button = new LifeCycleButton();
+			bool changed = false;
 
-			button.Handler = handlerStub;
+			button.Handler = new HandlerStub();
+			button.HandlerChanged += (_, __) =>
+			{
+				changed = true;
+			};
 
-			Assert.IsNotNull(handlerStub.VirtualView);
+			Assert.IsTrue(changed);
+			Assert.AreEqual(1, button.changed);
 		}
 
 		[Test]
-		public void BasicAttachEvents()
+		public void ChangingAndChangedBothFireInitially()
 		{
-			Button button = new Button();
-			bool attaching = false;
-			bool attached = false;
+			LifeCycleButton button = new LifeCycleButton();
+			bool changing = false;
+			bool changed = false;
 
-			button.AttachingHandler += (_, __) => attaching = true;
-			button.AttachedHandler += (_, __) =>
+			button.HandlerChanging += (_, __) => changing = true;
+			button.HandlerChanged += (_, __) =>
 			{
-				if (!attaching)
-					Assert.Fail("Attached fired before attaching");
+				if (!changing)
+					Assert.Fail("Attached fired before changing");
 
-				attached = true;
+				changed = true;
 			};
+
+			Assert.AreEqual(0, button.changing);
+			Assert.AreEqual(0, button.changed);
+			Assert.IsFalse(changing);
+			Assert.IsFalse(changed);
 
 			button.Handler = new HandlerStub();
 
-			Assert.IsTrue(attaching);
-			Assert.IsTrue(attached);
+			Assert.IsTrue(changing);
+			Assert.IsTrue(changed);
+			Assert.AreEqual(1, button.changing);
+			Assert.AreEqual(1, button.changed);
 		}
-
-
-		[TestCase(null)]
-		[TestCase(typeof(HandlerStub))]
-		public void BasicDetachEvents(Type handlerType)
-		{
-			Button button = new Button();
-			bool detaching = false;
-			bool detached = false;
-
-			button.DetachingHandler += (_, __) => detaching = true;
-			button.DetachedHandler += (_, __) =>
-			{
-				if (!detaching)
-					Assert.Fail("Detached fired before detaching");
-
-				detached = true;
-			};
-
-			button.Handler = new HandlerStub();
-
-			Assert.IsFalse(detaching);
-			Assert.IsFalse(detached);
-
-			if (handlerType != null)
-				button.Handler = (IViewHandler)Activator.CreateInstance(handlerType);
-			else
-				button.Handler = null;
-
-			Assert.IsTrue(detaching);
-			Assert.IsTrue(detached);
-		}
-
 
 		[Test]
-		public void BasicAttachMethods()
-		{
-			LifeCycleButton button = new LifeCycleButton();
-			button.Handler = new HandlerStub();
-
-			Assert.AreEqual(1, button.attaching);
-			Assert.AreEqual(1, button.attached);
-		}
-
-
-		[TestCase(null)]
-		[TestCase(typeof(HandlerStub))]
-		public void BasicDetachMethods(Type handlerType)
+		public void ChangingArgsAreSetCorrectly()
 		{
 			LifeCycleButton button = new LifeCycleButton();
 
-			button.Handler = new HandlerStub();
+			Assert.IsNull(button.Handler);
+			var firstHandler = new HandlerStub();
+			button.Handler = firstHandler;
 
-			Assert.Zero(button.detaching);
-			Assert.Zero(button.detached);
+			Assert.AreEqual(button.LastHandlerChangingEventArgs.NewHandler, firstHandler);
+			Assert.IsNull(button.LastHandlerChangingEventArgs.OldHandler);
 
-			if (handlerType != null)
-				button.Handler = (IViewHandler)Activator.CreateInstance(handlerType);
-			else
-				button.Handler = null;
+			var secondHandler = new HandlerStub();
+			button.Handler = secondHandler;
+			Assert.AreEqual(button.LastHandlerChangingEventArgs.OldHandler, firstHandler);
+			Assert.AreEqual(button.LastHandlerChangingEventArgs.NewHandler, secondHandler);
 
-			Assert.AreEqual(1, button.detached);
-			Assert.AreEqual(1, button.detaching);
+			button.Handler = null;
+			Assert.AreEqual(button.LastHandlerChangingEventArgs.OldHandler, secondHandler);
+			Assert.AreEqual(button.LastHandlerChangingEventArgs.NewHandler, null);
+
+			Assert.AreEqual(3, button.changing);
+			Assert.AreEqual(3, button.changed);
 		}
 
 		public class LifeCycleButton : Button
 		{
-			public int attaching = 0;
-			public int attached = 0;
-			public int detaching = 0;
-			public int detached = 0;
+			public int changing = 0;
+			public int changed = 0;
+			public HandlerChangingEventArgs LastHandlerChangingEventArgs { get; set; }
 
-			protected override void OnAttachedHandler()
+			protected override void OnHandlerChanging(HandlerChangingEventArgs args)
 			{
-				attached++;
-
-				if (attached != attaching)
-					Assert.Fail("Attaching/Attached fire mismatch");
+				LastHandlerChangingEventArgs = args;
+				changing++;
+				base.OnHandlerChanging(args);
 			}
 
-			protected override void OnAttachingHandler() => attaching++;
-			protected override void OnDetachingHandler() => detaching++;
-			protected override void OnDetachedHandler()
+			protected override void OnHandlerChanged()
 			{
-				detached++;
+				changed++;
+				base.OnHandlerChanged();
 
-				if (detached != detaching)
+				if (changed != changing)
 					Assert.Fail("Attaching/Attached fire mismatch");
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Attaching/Attached/Detaching/Detached are difficult to interpret when a Handler is changed to a new handler. Using a "Changing" approach that has the Old and New handler on it provides a more useful context for action.

For Changed we are still just using EventArgs because at the point that you've hit changed it's not recommended to access the previous handler. So if users want to access the old handler it's on them to do so and understand the risks

### Additions made ###

- Adds `Microsoft.Maui.Controls.HandlerChangingEventArgs`
- Adds HandlerChanging
- Adds HandlerChanged
- Removes Attaching/Attached/Detaching/Detached
