### PR TITLE
Lower the Blazor Desktop WPF/WinForms TFM down to Win7

### DIFF
--- a/src/BlazorWebView/samples/BlazorWinFormsApp/BlazorWinFormsApp.csproj
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/BlazorWinFormsApp.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <IsPackable>false</IsPackable>

--- a/src/BlazorWebView/samples/BlazorWpfApp/BlazorWpfApp.csproj
+++ b/src/BlazorWebView/samples/BlazorWpfApp/BlazorWpfApp.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>

--- a/src/BlazorWebView/src/WindowsForms/Microsoft.AspNetCore.Components.WebView.WindowsForms.csproj
+++ b/src/BlazorWebView/src/WindowsForms/Microsoft.AspNetCore.Components.WebView.WindowsForms.csproj
@@ -4,8 +4,8 @@
     <!-- Use TargetFrameworks (plural) instead of TargetFramework (singular) here even though there is only one target
       framework. This is to work around an issue with the Microsoft.Web.WebView2 package:
       https://github.com/MicrosoftEdge/WebView2Feedback/issues/710 -->
-    <TargetFrameworks>net6.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <Description>Build Windows Forms applications with Blazor and WebView2.</Description>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>disable</Nullable>

--- a/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
+++ b/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
@@ -4,8 +4,8 @@
     <!-- Use TargetFrameworks (plural) instead of TargetFramework (singular) here even though there is only one target
       framework. This is to work around an issue with the Microsoft.Web.WebView2 package:
       https://github.com/MicrosoftEdge/WebView2Feedback/issues/710 -->
-    <TargetFrameworks>net6.0-windows10.0.19041.0</TargetFrameworks>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <Description>Build WPF applications with Blazor and WebView2.</Description>
     <UseWPF>true</UseWPF>
     <Nullable>disable</Nullable>


### PR DESCRIPTION
In theory this should run all the way down to Win7 (as opposed to requiring Win10, which is way too high a requirement).

Fixes #1685