### PR TITLE
Parent Changing/Changed Life Cycle Events

### DIFF
--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -145,12 +145,22 @@ namespace Microsoft.Maui.Controls
 				bool emitChange = Parent != value;
 
 				if (emitChange)
+				{
 					OnPropertyChanging(nameof(Parent));
+
+					if (value != null)
+						OnParentChangingCore(Parent, value);
+					else
+						OnParentChangingCore(Parent, RealParent);
+				}
 
 				_parentOverride = value;
 
 				if (emitChange)
+				{
 					OnPropertyChanged(nameof(Parent));
+					OnParentChangedCore();
+				}
 			}
 		}
 
@@ -175,6 +185,9 @@ namespace Microsoft.Maui.Controls
 					return;
 
 				OnPropertyChanging();
+
+				if (_parentOverride == null)
+					OnParentChangingCore(Parent, value);
 
 				if (RealParent != null)
 				{
@@ -202,6 +215,9 @@ namespace Microsoft.Maui.Controls
 				}
 
 				OnParentSet();
+
+				if (_parentOverride == null)
+					OnParentChangedCore();
 
 				OnPropertyChanged();
 			}
@@ -598,6 +614,29 @@ namespace Microsoft.Maui.Controls
 		void OnResourceChanged(BindableProperty property, object value)
 		{
 			SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearTwoWayBindings);
+		}
+
+		public event EventHandler<ParentChangingEventArgs> ParentChanging;
+		public event EventHandler ParentChanged;
+
+		protected virtual void OnParentChanging(ParentChangingEventArgs args) { }
+
+		protected virtual void OnParentChanged() { }
+
+		private protected virtual void OnParentChangedCore()
+		{
+			ParentChanged?.Invoke(this, EventArgs.Empty);
+			OnParentChanged();
+		}
+
+		private protected virtual void OnParentChangingCore(Element oldParent, Element newParent)
+		{
+			if (oldParent == newParent)
+				return;
+
+			var args = new ParentChangingEventArgs(oldParent, newParent);
+			ParentChanging?.Invoke(this, args);
+			OnParentChanging(args);
 		}
 	}
 }

--- a/src/Controls/src/Core/ParentChangingEventArgs.cs
+++ b/src/Controls/src/Core/ParentChangingEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Maui.Controls
+{
+	public class ParentChangingEventArgs
+	{
+		public Element NewParent { get; }
+		public Element OldParent { get; }
+
+		public ParentChangingEventArgs(Element oldParent, Element newParent)
+		{
+			NewParent = newParent;
+			OldParent = oldParent;
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/ParentLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ParentLifeCycleTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	[TestFixture]
+	public class ParentLifeCycleTests : BaseTestFixture
+	{
+		[Test]
+		public void ChangingAndChangedBothFireForParentOverride()
+		{
+			LifeCycleButton button = new LifeCycleButton();
+			bool changing = false;
+			bool changed = false;
+
+			button.Parent = new Button();
+
+			button.ParentChanging += (_, __) => changing = true;
+			button.ParentChanged += (_, __) =>
+			{
+				if (!changing)
+					Assert.Fail("Attached fired before changing");
+
+				changed = true;
+			};
+
+			Assert.IsFalse(changing);
+			Assert.IsFalse(changed);
+
+			button.ParentOverride = new Button();
+
+			Assert.IsTrue(changing);
+			Assert.IsTrue(changed);
+		}
+
+		[Test]
+		public void ChangingAndChangedBothFireInitially()
+		{
+			LifeCycleButton button = new LifeCycleButton();
+			bool changing = false;
+			bool changed = false;
+
+			button.ParentChanging += (_, __) => changing = true;
+			button.ParentChanged += (_, __) =>
+			{
+				if (!changing)
+					Assert.Fail("Attached fired before changing");
+
+				changed = true;
+			};
+
+			Assert.AreEqual(0, button.changing);
+			Assert.AreEqual(0, button.changed);
+			Assert.IsFalse(changing);
+			Assert.IsFalse(changed);
+
+			button.Parent = new Button();
+
+			Assert.IsTrue(changing);
+			Assert.IsTrue(changed);
+			Assert.AreEqual(1, button.changing);
+			Assert.AreEqual(1, button.changed);
+		}
+
+		[Test]
+		public void ParentOverrideChangingArgsSendCorrectly()
+		{
+			LifeCycleButton button = new LifeCycleButton();
+
+			Assert.IsNull(button.Parent);
+			var firstParent = new Button();
+			button.Parent = firstParent;
+
+			Assert.AreEqual(button.LastParentChangingEventArgs.NewParent, firstParent);
+			Assert.IsNull(button.LastParentChangingEventArgs.OldParent);
+
+			var secondParent = new Button();
+			button.ParentOverride = secondParent;
+			Assert.AreEqual(button.LastParentChangingEventArgs.OldParent, firstParent);
+			Assert.AreEqual(button.LastParentChangingEventArgs.NewParent, secondParent);
+
+			button.ParentOverride = null;
+			Assert.AreEqual(button.LastParentChangingEventArgs.OldParent, secondParent);
+			Assert.AreEqual(button.LastParentChangingEventArgs.NewParent, firstParent);
+		}
+
+		[Test]
+		public void ChangingArgsAreSetCorrectly()
+		{
+			LifeCycleButton button = new LifeCycleButton();
+
+			Assert.IsNull(button.Parent);
+			var firstParent = new Button();
+			button.Parent = firstParent;
+
+			Assert.AreEqual(button.LastParentChangingEventArgs.NewParent, firstParent);
+			Assert.IsNull(button.LastParentChangingEventArgs.OldParent);
+
+			var secondParent = new Button();
+			button.Parent = secondParent;
+			Assert.AreEqual(button.LastParentChangingEventArgs.OldParent, firstParent);
+			Assert.AreEqual(button.LastParentChangingEventArgs.NewParent, secondParent);
+
+			button.Parent = null;
+			Assert.AreEqual(button.LastParentChangingEventArgs.OldParent, secondParent);
+			Assert.AreEqual(button.LastParentChangingEventArgs.NewParent, null);
+
+			Assert.AreEqual(3, button.changing);
+			Assert.AreEqual(3, button.changed);
+		}
+
+		public class LifeCycleButton : Button
+		{
+			public int changing = 0;
+			public int changed = 0;
+			public ParentChangingEventArgs LastParentChangingEventArgs { get; set; }
+
+			protected override void OnParentChanging(ParentChangingEventArgs args)
+			{
+				LastParentChangingEventArgs = args;
+				changing++;
+				base.OnParentChanging(args);
+			}
+
+			protected override void OnParentChanged()
+			{
+				changed++;
+				base.OnParentChanged();
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Expose events that let a user subscribe to when a parent is changing on an Element

### Additions made ###
- Adds Element.ParentChanging
- Adds Element.ParentChanged
- Adds ParentChangingEventArgs

```C#
public class ParentChangingEventArgs
	{
		public Element NewParent { get; }
		public Element OldParent { get; }

		public ParentChangingEventArgs(Element oldParent, Element newParent)
		{
			NewParent = newParent;
			OldParent = oldParent;
		}
	}
```
