### PR TITLE
Remove left over Platform Effect from WinUI compatibility

### DIFF
--- a/src/Compatibility/Core/src/Windows/PlatformEffect.cs
+++ b/src/Compatibility/Core/src/Windows/PlatformEffect.cs
@@ -1,8 +1,0 @@
-using Microsoft.UI.Xaml;
-
-namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
-{
-	public abstract class PlatformEffect : PlatformEffect<FrameworkElement, FrameworkElement>
-	{
-	}
-}


### PR DESCRIPTION
### Description of Change ###

PlatformEffects were all deleted from compatibility but this one for some reason survived
