### PR TITLE
Run page's content measurement through handler/native control

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (Content is IFrameworkElement frameworkElement)
 			{
-				frameworkElement.Measure(widthConstraint, heightConstraint);
+				_ = frameworkElement.Handler?.GetDesiredSize(widthConstraint, heightConstraint);
 			}
 
 			return new Size(widthConstraint, heightConstraint);

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
@@ -29,7 +29,10 @@ namespace Microsoft.Maui.Handlers
 			// We set Center and Bounds rather than Frame because Frame is undefined if the CALayer's transform is 
 			// anything other than the identity (https://developer.apple.com/documentation/uikit/uiview/1622459-transform)
 			nativeView.Center = new CoreGraphics.CGPoint(rect.Center.X, rect.Center.Y);
-			nativeView.Bounds = new CoreGraphics.CGRect(0, 0, rect.Width, rect.Height);
+
+			// The position of Bounds is usually (0,0), but in some cases (e.g., UIScrollView) it's the content offset.
+			// So just leave it a whatever value iOS thinks it should be.
+			nativeView.Bounds = new CoreGraphics.CGRect(nativeView.Bounds.X, nativeView.Bounds.Y, rect.Width, rect.Height);
 
 			nativeView.UpdateBackgroundLayerFrame();
 		}


### PR DESCRIPTION
ContentPage is calling measure on content layouts directly, which prevents them from running the measurement via the native control. In some cases, this prevents internal bookkeeping necessary for the control to properly update/redraw.

This change fixes that issue, and fixes an issue with updates on iOS which can cause a UIScrollView's ContentOffset to reset to zero when updating other controls in the layout.

Fixes #1269.