### PR TITLE
[workload] include Design/Microsoft.Maui.Controls.Xaml.DesignTools.dll

### DIFF
--- a/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
@@ -20,13 +20,17 @@
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Compatibility/Core/src/bin/$(Configuration)/%(Tfm)/ref/Microsoft.Maui.Controls.Compatibility.dll')" />
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/%(Tfm)/ref/Microsoft.Maui.Controls.dll')" />
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Xaml/bin/$(Configuration)/%(Tfm)/ref/Microsoft.Maui.Controls.Xaml.dll')" />
-    <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="ref/%(FullTfm)/%(FileName)%(Extension)" />
-    <_PackageFiles Include="@(None)" PackagePath="ref/%(FullTfm)" TargetPath="ref/%(FullTfm)" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core.Design/bin/$(Configuration)/net472/Microsoft.Maui.Controls.DesignTools.dll')" SubFolder="/Design" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Xaml.Design/bin/$(Configuration)/net472/Microsoft.Maui.Controls.Xaml.DesignTools.dll')" SubFolder="/Design" />
+    <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="ref/%(FullTfm)%(SubFolder)/%(FileName)%(Extension)" />
+    <_PackageFiles Include="@(None)" PackagePath="ref/%(FullTfm)%(SubFolder)" TargetPath="ref/%(FullTfm)%(SubFolder)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(MauiPlatformName)' == '' ">
     <ProjectReference Include="../../../src/Controls/src/Core/Controls.Core-net6.csproj" />
     <ProjectReference Include="../../../src/Controls/src/Xaml/Controls.Xaml-net6.csproj" />
+    <ProjectReference Include="../../../src/Controls/src/Core.Design/Controls.Core.Design-net6.csproj" />
+    <ProjectReference Include="../../../src/Controls/src/Xaml.Design/Controls.Xaml.Design-net6.csproj" />
     <ProjectReference Include="../../../src/Compatibility/Core/src/Compatibility-net6.csproj" />
     <ProjectReference Include="../../../src/Compatibility/Android.FormsViewGroup/src/Compatibility.Android.FormsViewGroup-net6.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Fixes: https://github.com/dotnet/maui/issues/1699

This adds the missing "design" assembly in our various
`Microsoft.Maui.Controls.Ref.*` packs, such as:

    > 7z l .\artifacts\Microsoft.Maui.Controls.Ref.android.0.0.1-alpha1.nupkg
       Date      Time    Attr         Size   Compressed  Name
    ------------------- ----- ------------ ------------  ------------------------
    2021-07-16 11:05:26 .....          529          296  _rels\.rels
    2021-07-16 11:05:26 .....          799          421  Microsoft.Maui.Controls.Ref.android.nuspec
    2021-07-16 15:38:00 .....        10752         3894  ref\net6.0-android30.0\Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.dll
    2021-07-16 15:37:56 .....         2259         2258  ref\net6.0-android30.0\Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.aar
    2021-07-16 15:38:22 .....         7010         5676  ref\net6.0-android30.0\Microsoft.Maui.Controls.Compatibility.aar
    2021-07-16 15:38:22 .....       361472       111051  ref\net6.0-android30.0\Microsoft.Maui.Controls.Compatibility.dll
    2021-07-16 15:38:14 .....       676352       216556  ref\net6.0-android30.0\Microsoft.Maui.Controls.dll
    2021-07-16 15:38:18 .....       215552        62234  ref\net6.0-android30.0\Microsoft.Maui.Controls.Xaml.dll
    2021-07-16 16:05:14 .....        11264         2657  ref\net6.0-android30.0\Design\Microsoft.Maui.Controls.DesignTools.dll
    2021-07-16 15:37:56 .....         4608         1544  ref\net6.0-android30.0\Design\Microsoft.Maui.Controls.Xaml.DesignTools.dll
    2021-07-16 16:05:26 .....         1581          290  data\FrameworkList.xml
    2021-07-16 11:05:26 .....          591          223  [Content_Types].xml
    2021-07-16 11:05:26 .....          662          396  package\services\metadata\core-properties\b8f1a5e1756847dca0c02a1e31dd6a34.psmdcp
    ------------------- ----- ------------ ------------  ------------------------
    2021-07-16 16:05:26            1293431       407496  13 files

I don't know how to verify this location is correct, but it seems to
mirror what we had in .NET MAUI Preview 5:

https://www.nuget.org/api/v2/package/Microsoft.Maui.Controls/6.0.100-preview.5.794

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No