### PR TITLE
Add CodeOwners for Blazor Desktop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,3 +40,9 @@
 
 # Core
 /Xamarin.Forms.Core/ @StephaneDelcroix
+
+# Blazor Desktop
+/src/BlazorWebView/                                     @Eilon
+/src/Templates/src/templates/maui-blazor/               @Eilon
+
+


### PR DESCRIPTION
It's just code owners.