### PR TITLE
Windows - Added PointerReleasedEvent to match functionality

### DIFF
--- a/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.Handlers
 		static UI.Xaml.Media.Brush? DefaultBackground;
 
 		PointerEventHandler? _pointerPressedHandler;
+		PointerEventHandler? _pointerReleasedHandler;
 
 		protected override MauiButton CreateNativeView() 
 			=> new MauiButton();
@@ -24,9 +25,11 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiButton nativeView)
 		{
 			_pointerPressedHandler = new PointerEventHandler(OnPointerPressed);
+			_pointerReleasedHandler = new PointerEventHandler(OnPointerReleased);
 
 			nativeView.Click += OnClick;
 			nativeView.AddHandler(UI.Xaml.UIElement.PointerPressedEvent, _pointerPressedHandler, true);
+			nativeView.AddHandler(UI.Xaml.UIElement.PointerReleasedEvent, _pointerReleasedHandler, true);
 
 			base.ConnectHandler(nativeView);
 		}
@@ -35,8 +38,10 @@ namespace Microsoft.Maui.Handlers
 		{
 			nativeView.Click -= OnClick;
 			nativeView.RemoveHandler(UI.Xaml.UIElement.PointerPressedEvent, _pointerPressedHandler);
+			nativeView.RemoveHandler(UI.Xaml.UIElement.PointerReleasedEvent, _pointerReleasedHandler);
 
 			_pointerPressedHandler = null;
+			_pointerReleasedHandler = null;
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -83,6 +88,11 @@ namespace Microsoft.Maui.Handlers
 		void OnPointerPressed(object sender, PointerRoutedEventArgs e)
 		{
 			VirtualView?.Pressed();
+		}
+
+		void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+		{
+			VirtualView?.Released();
 		}
 	}
 }


### PR DESCRIPTION
## Description of Change ###

When walking through the code I noticed that Windows did not implement an OnReleased event handler like iOS and Android. By implementing the PointerReleasedEvent this will match functionality on the other platforms. This does not have anything in the backlog, but I wanted to submit it anyways.

Implements #

### Additions made ###
* Adds OnReleased for Windows on Button

### PR Checklist ###

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
