### PR TITLE
Make Spacing a bindable property on the base StackLayout class

### DIFF
--- a/src/Controls/src/Core/Layout/StackLayout.cs
+++ b/src/Controls/src/Core/Layout/StackLayout.cs
@@ -3,6 +3,13 @@ namespace Microsoft.Maui.Controls.Layout2
 {
 	public abstract class StackLayout : Layout, IStackLayout
 	{
-		public int Spacing { get; set; }
+		public static readonly BindableProperty SpacingProperty = BindableProperty.Create(nameof(Spacing), typeof(double), typeof(StackLayout), 0d,
+					propertyChanged: (bindable, oldvalue, newvalue) => ((IFrameworkElement)bindable).InvalidateMeasure());
+
+		public double Spacing
+		{
+			get { return (double)GetValue(SpacingProperty); }
+			set { SetValue(SpacingProperty, value); }
+		}
 	}
 }

--- a/src/Core/src/Core/IStackLayout.cs
+++ b/src/Core/src/Core/IStackLayout.cs
@@ -8,6 +8,6 @@
 		/// <summary>
 		/// Identifies the Spacing between childs.
 		/// </summary>
-		int Spacing { get; }
+		double Spacing { get; }
 	}
 }

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Layouts
 			}
 		}
 
-		static Size Measure(double heightConstraint, int spacing, IReadOnlyList<IView> views)
+		static Size Measure(double heightConstraint, double spacing, IReadOnlyList<IView> views)
 		{
 			double totalRequestedWidth = 0;
 			double requestedHeight = 0;
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Layouts
 			return new Size(totalRequestedWidth, requestedHeight);
 		}
 
-		static void ArrangeLeftToRight(double height, int spacing, IReadOnlyList<IView> views)
+		static void ArrangeLeftToRight(double height, double spacing, IReadOnlyList<IView> views)
 		{
 			double xPosition = 0;
 
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.Layouts
 			}
 		}
 
-		static void ArrangeRightToLeft(double height, int spacing, IReadOnlyList<IView> views)
+		static void ArrangeRightToLeft(double height, double spacing, IReadOnlyList<IView> views)
 		{
 			double xPostition = 0;
 
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Layouts
 			}
 		}
 
-		static double ArrangeChild(IView child, double height, int spacing, double x)
+		static double ArrangeChild(IView child, double height, double spacing, double x)
 		{
 			var destination = new Rectangle(x, 0, child.DesiredSize.Width, height);
 			child.Frame = child.ComputeFrame(destination);

--- a/src/Core/src/Layouts/StackLayoutManager.cs
+++ b/src/Core/src/Layouts/StackLayoutManager.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Layouts
 
 		public IStackLayout Stack { get; }
 
-		protected static int MeasureSpacing(int spacing, int childCount)
+		protected static double MeasureSpacing(double spacing, int childCount)
 		{
 			return childCount > 1 ? (childCount - 1) * spacing : 0;
 		}

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Layouts
 
 		public override void ArrangeChildren(Rectangle bounds) => Arrange(bounds.Width, Stack.Spacing, Stack.Children);
 
-		static Size Measure(double widthConstraint, int spacing, IReadOnlyList<IView> views)
+		static Size Measure(double widthConstraint, double spacing, IReadOnlyList<IView> views)
 		{
 			double totalRequestedHeight = 0;
 			double requestedWidth = 0;
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Layouts
 			return new Size(requestedWidth, totalRequestedHeight);
 		}
 
-		static void Arrange(double width, int spacing, IEnumerable<IView> views)
+		static void Arrange(double width, double spacing, IEnumerable<IView> views)
 		{
 			double stackHeight = 0;
 


### PR DESCRIPTION
Fixes #1600
Fixes #1634

This also changes Spacing on `IStackLayout` from an `int` to a `double` to be more consistent with other platforms. 
