### PR TITLE
Fix cake to launch vs2022

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -141,7 +141,7 @@ Task("VS-WINUI")
 
         MSBuild(sln, msbuildSettings);
 
-        var vsLatest = VSWhereLatest(new VSWhereLatestSettings { IncludePrerelease = true, Version = "[\"16.0\",\"17.0\"]"});
+        var vsLatest = VSWhereLatest(new VSWhereLatestSettings { IncludePrerelease = true, Version = "[\"17.0\",\"19.0\"]"});
 
         if (vsLatest == null)
             throw new Exception("Unable to find Visual Studio!");


### PR DESCRIPTION
The latest builds of WinUI require VS 2022. This updates the cake script to launch VS 2022 instead of VS 2019