### PR TITLE
Rename Font Properties

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/ButtonRenderer.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 			else
 			{
 				NativeButton.Typeface = font.ToTypeface();
-				NativeButton.SetTextSize(ComplexUnitType.Sp, (float)font.FontSize);
+				NativeButton.SetTextSize(ComplexUnitType.Sp, (float)font.Size);
 			}
 		}
 

--- a/src/Compatibility/Core/src/Android/AppCompat/RadioButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/RadioButtonRenderer.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			else
 			{
 				Typeface = font.ToTypeface();
-				SetTextSize(ComplexUnitType.Sp, (float)font.FontSize);
+				SetTextSize(ComplexUnitType.Sp, (float)font.Size);
 			}
 		}
 

--- a/src/Compatibility/Core/src/Android/FastRenderers/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/ButtonRenderer.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 			else
 			{
 				Typeface = font.ToTypeface();
-				SetTextSize(ComplexUnitType.Sp, (float)font.FontSize);
+				SetTextSize(ComplexUnitType.Sp, (float)font.Size);
 			}
 		}
 

--- a/src/Compatibility/Core/src/Android/FastRenderers/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/LabelRenderer.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 				_lastTypeface = newTypeface;
 			}
 
-			float newTextSize = (float)f.FontSize;
+			float newTextSize = (float)f.Size;
 			if (newTextSize != _lastTextSize)
 			{
 				SetTextSize(ComplexUnitType.Sp, newTextSize);

--- a/src/Compatibility/Core/src/Android/Renderers/FormattedStringExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormattedStringExtensions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			void Apply(Paint paint)
 			{
 				paint.SetTypeface(Font.ToTypeface());
-				float value = (float)Font.FontSize;
+				float value = (float)Font.Size;
 				paint.TextSize = TypedValue.ApplyDimension(ComplexUnitType.Sp, value, TextView.Resources.DisplayMetrics);
 				if (Forms.IsLollipopOrNewer)
 				{

--- a/src/Compatibility/Core/src/Android/Renderers/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/LabelRenderer.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				_lastTypeface = newTypeface;
 			}
 
-			float newTextSize = (float)f.FontSize;
+			float newTextSize = (float)f.Size;
 			if (newTextSize != _lastTextSize)
 			{
 				_view.SetTextSize(ComplexUnitType.Sp, newTextSize);

--- a/src/Controls/src/Core/FontElement.cs
+++ b/src/Controls/src/Core/FontElement.cs
@@ -46,8 +46,8 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
-				bindable.SetValue(FontFamilyProperty, font.FontFamily);
-				bindable.SetValue(FontSizeProperty, font.FontSize);
+				bindable.SetValue(FontFamilyProperty, font.Family);
+				bindable.SetValue(FontSizeProperty, font.Size);
 				bindable.SetValue(FontAttributesProperty, font.GetFontAttributes());
 			}
 			SetCancelEvents(bindable, false);

--- a/src/Controls/src/Core/FontExtensions.cs
+++ b/src/Controls/src/Core/FontExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 		public static FontAttributes GetFontAttributes(this Font font)
 		{
 			FontAttributes attributes = font.Weight == FontWeight.Bold ? FontAttributes.Bold : FontAttributes.None;
-			if (font.FontSlant != FontSlant.Default)
+			if (font.Slant != FontSlant.Default)
 			{
 				if (attributes == FontAttributes.None)
 					attributes = FontAttributes.Italic;

--- a/src/Controls/src/Core/FontTypeConverter.cs
+++ b/src/Controls/src/Core/FontTypeConverter.cs
@@ -85,13 +85,13 @@ namespace Microsoft.Maui.Controls
 			if (!(value is Font font))
 				throw new NotSupportedException();
 			var parts = new List<string>();
-			if (!string.IsNullOrEmpty(font.FontFamily))
-				parts.Add(font.FontFamily);
+			if (!string.IsNullOrEmpty(font.Family))
+				parts.Add(font.Family);
 			if (font.Weight == FontWeight.Bold)
 				parts.Add("Bold");
-			if (font.FontSlant != FontSlant.Default)
+			if (font.Slant != FontSlant.Default)
 				parts.Add("Italic");
-			parts.Add($"{font.FontSize}");
+			parts.Add($"{font.Size}");
 			return string.Join(", ", parts);
 		}
 	}

--- a/src/Controls/tests/Core.UnitTests/FontUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FontUnitTests.cs
@@ -12,16 +12,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void TestFontForSize()
 		{
 			var font = Font.OfSize("Foo", 12);
-			Assert.AreEqual("Foo", font.FontFamily);
-			Assert.AreEqual(12, font.FontSize);
+			Assert.AreEqual("Foo", font.Family);
+			Assert.AreEqual(12, font.Size);
 		}
 
 		[Test]
 		public void TestFontForSizeDouble()
 		{
 			var font = Font.OfSize("Foo", 12.7);
-			Assert.AreEqual("Foo", font.FontFamily);
-			Assert.AreEqual(12.7, font.FontSize);
+			Assert.AreEqual("Foo", font.Family);
+			Assert.AreEqual(12.7, font.Size);
 		}
 
 		[Test]
@@ -29,22 +29,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var size = Device.GetNamedSize(NamedSize.Large, null, false);
 			var font = Font.OfSize("Foo", size);
-			Assert.AreEqual("Foo", font.FontFamily);
-			Assert.AreEqual(size, font.FontSize);
+			Assert.AreEqual("Foo", font.Family);
+			Assert.AreEqual(size, font.Size);
 		}
 
 		[Test]
 		public void TestSystemFontOfSize()
 		{
 			var font = Font.SystemFontOfSize(12);
-			Assert.AreEqual(null, font.FontFamily);
-			Assert.AreEqual(12, font.FontSize);
+			Assert.AreEqual(null, font.Family);
+			Assert.AreEqual(12, font.Size);
 
 
 			var size = Device.GetNamedSize(NamedSize.Medium, null, false);
 			font = Font.SystemFontOfSize(size);
-			Assert.AreEqual(null, font.FontFamily);
-			Assert.AreEqual(size, font.FontSize);
+			Assert.AreEqual(null, font.Family);
+			Assert.AreEqual(size, font.Size);
 		}
 
 		[TestCase("en-US"), TestCase("tr-TR"), TestCase("fr-FR")]
@@ -53,13 +53,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(culture);
 
 			var font = Font.SystemFontOfSize(12.7);
-			Assert.AreEqual(null, font.FontFamily);
-			Assert.AreEqual(12.7, font.FontSize);
+			Assert.AreEqual(null, font.Family);
+			Assert.AreEqual(12.7, font.Size);
 
 			var size = Device.GetNamedSize(NamedSize.Medium, null, false);
 			font = Font.SystemFontOfSize(size);
-			Assert.AreEqual(null, font.FontFamily);
-			Assert.AreEqual(size, font.FontSize);
+			Assert.AreEqual(null, font.Family);
+			Assert.AreEqual(size, font.Size);
 		}
 
 		[Test]

--- a/src/Core/src/Fonts/FontManager.Android.cs
+++ b/src/Core/src/Fonts/FontManager.Android.cs
@@ -31,16 +31,16 @@ namespace Microsoft.Maui
 
 		public Typeface? GetTypeface(Font font)
 		{
-			if (font == Font.Default || (font.Weight == FontWeight.Regular && string.IsNullOrEmpty(font.FontFamily) && font.FontSlant == FontSlant.Default))
+			if (font == Font.Default || (font.Weight == FontWeight.Regular && string.IsNullOrEmpty(font.Family) && font.Slant == FontSlant.Default))
 				return DefaultTypeface;
 
-			return _typefaces.GetOrAdd((font.FontFamily, font.Weight, font.FontSlant != FontSlant.Default), CreateTypeface);
+			return _typefaces.GetOrAdd((font.Family, font.Weight, font.Slant != FontSlant.Default), CreateTypeface);
 		}
 
 		public float GetFontSize(Font font, float defaultFontSize = 0) =>
-			font.FontSize <= 0
+			font.Size <= 0
 				? (defaultFontSize > 0 ? defaultFontSize : 14f)
-				: (float)font.FontSize;
+				: (float)font.Size;
 
 
 		Typeface? GetFromAssets(string fontName)

--- a/src/Core/src/Fonts/FontManager.Windows.cs
+++ b/src/Core/src/Fonts/FontManager.Windows.cs
@@ -39,16 +39,16 @@ namespace Microsoft.Maui
 
 		public FontFamily GetFontFamily(Font font)
 		{
-			if (font.IsDefault || string.IsNullOrWhiteSpace(font.FontFamily))
+			if (font.IsDefault || string.IsNullOrWhiteSpace(font.Family))
 				return DefaultFontFamily;
 
-			return _fonts.GetOrAdd(font.FontFamily, CreateFontFamily);
+			return _fonts.GetOrAdd(font.Family, CreateFontFamily);
 		}
 
 		public double GetFontSize(Font font, double defaultFontSize = 0) =>
-			font.FontSize <= 0
+			font.Size <= 0
 				? (defaultFontSize > 0 ? defaultFontSize : DefaultFontSize)
-				: font.FontSize;
+				: font.Size;
 
 		FontFamily CreateFontFamily(string fontFamily)
 		{

--- a/src/Core/src/Fonts/FontManager.iOS.cs
+++ b/src/Core/src/Fonts/FontManager.iOS.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Maui
 			GetFont(font, defaultFontSize, CreateFont);
 
 		public double GetFontSize(Font font, double defaultFontSize = 0) =>
-			font.FontSize <= 0
+			font.Size <= 0
 				? (defaultFontSize > 0 ? (float)defaultFontSize : DefaultFont.PointSize)
-				: (nfloat)font.FontSize;
+				: (nfloat)font.Size;
 
 		static float GetWeightConstant(FontWeight self)
 		{
@@ -59,7 +59,7 @@ namespace Microsoft.Maui
 		UIFont GetFont(Font font, double defaultFont, Func<Font, UIFont> factory)
 		{
 			var size = GetFontSize(font, defaultFont);
-			if (size != font.FontSize)
+			if (size != font.Size)
 				font = font.WithSize(size);
 			return _fonts.GetOrAdd(font, factory);
 		}
@@ -81,10 +81,10 @@ namespace Microsoft.Maui
 				a.Traits = new UIFontTraits
 				{
 					Weight = GetWeightConstant(font.Weight),
-					Slant = font.FontSlant == FontSlant.Oblique ? 30.0f : 0.0f
+					Slant = font.Slant == FontSlant.Oblique ? 30.0f : 0.0f
 				};
 			}
-			if (font.FontSlant == FontSlant.Italic)
+			if (font.Slant == FontSlant.Italic)
 				traits |= UIFontDescriptorSymbolicTraits.Italic;
 
 			a.Traits.SymbolicTrait = traits;
@@ -93,12 +93,12 @@ namespace Microsoft.Maui
 
 		UIFont CreateFont(Font font)
 		{
-			var family = font.FontFamily;
-			var size = (nfloat)font.FontSize;
+			var family = font.Family;
+			var size = (nfloat)font.Size;
 
 			var hasAttributes =
 				font.Weight != FontWeight.Regular ||
-				font.FontSlant != FontSlant.Default;
+				font.Slant != FontSlant.Default;
 
 			if (family != null && family != DefaultFont.FamilyName)
 			{

--- a/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
+++ b/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui
 			var dpi = scale * BaseLogicalDpi;
 
 			var fontFamily = GetFontSource(imageSource);
-			var fontSize = (float)imageSource.Font.FontSize;
+			var fontSize = (float)imageSource.Font.Size;
 			var color = (imageSource.Color ?? Colors.White).ToWindowsColor();
 
 			var textFormat = new CanvasTextFormat
@@ -102,7 +102,7 @@ namespace Microsoft.Maui
 				// There's really no perfect solution to handle font families with fallbacks (comma-separated)	
 				// So if the font family has fallbacks, only one is taken, because CanvasTextFormat	
 				// only supports one font family
-				var source = imageSource.Font.FontFamily;
+				var source = imageSource.Font.Family;
 
 				foreach (var family in allFamilies)
 				{

--- a/src/Core/src/Platform/Windows/FontExtensions.cs
+++ b/src/Core/src/Platform/Windows/FontExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui
 	public static class FontExtensions
 	{
 		public static FontStyle ToFontStyle(this Font fontAttributes) =>
-				fontAttributes.FontSlant switch
+				fontAttributes.Slant switch
 				{
 					FontSlant.Italic => FontStyle.Italic,
 					FontSlant.Oblique => FontStyle.Oblique,

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui
 {
 	public struct Font
 	{
-		public string FontFamily { get; private set; }
+		public string Family { get; private set; }
 
-		public double FontSize { get; private set; }
+		public double Size { get; private set; }
 
-		public FontSlant FontSlant { get; private set; }
+		public FontSlant Slant { get; private set; }
 
-		public bool IsDefault => FontFamily == null && FontSize == 0 && FontSlant == FontSlant.Default && Weight == FontWeight.Regular;
+		public bool IsDefault => Family == null && Size == 0 && Slant == FontSlant.Default && Weight == FontWeight.Regular;
 
 		static Font _default = default(Font).WithWeight(FontWeight.Regular);
 		public static Font Default => _default;
@@ -25,39 +25,39 @@ namespace Microsoft.Maui
 
 		public Font WithSize(double size)
 		{
-			return new Font { FontFamily = FontFamily, FontSize = size, FontSlant = FontSlant, Weight = Weight };
+			return new Font { Family = Family, Size = size, Slant = Slant, Weight = Weight };
 		}
 
 		public Font WithSlant(FontSlant fontSlant)
 		{
-			return new Font { FontFamily = FontFamily, FontSize = FontSize, FontSlant = fontSlant, Weight = Weight };
+			return new Font { Family = Family, Size = Size, Slant = fontSlant, Weight = Weight };
 		}
 
 		public Font WithWeight(FontWeight weight)
 		{
-			return new Font { FontFamily = FontFamily, FontSize = FontSize, FontSlant = FontSlant, Weight = weight };
+			return new Font { Family = Family, Size = Size, Slant = Slant, Weight = weight };
 		}
 
 		public Font WithWeight(FontWeight weight, FontSlant fontSlant)
 		{
-			return new Font { FontFamily = FontFamily, FontSize = FontSize, FontSlant = fontSlant, Weight = weight };
+			return new Font { Family = Family, Size = Size, Slant = fontSlant, Weight = weight };
 		}
 
 		public static Font OfSize(string name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default) =>
-			new() { FontFamily = name, FontSize = size, Weight = weight, FontSlant = fontSlant };
+			new() { Family = name, Size = size, Weight = weight, Slant = fontSlant };
 
 		public static Font SystemFontOfSize(double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default) =>
-			new() { FontSize = size, Weight = weight, FontSlant = fontSlant };
+			new() { Size = size, Weight = weight, Slant = fontSlant };
 
 		public static Font SystemFontOfWeight(FontWeight weight, FontSlant fontSlant = FontSlant.Default)
 		{
-			var result = new Font { Weight = weight, FontSlant = fontSlant };
+			var result = new Font { Weight = weight, Slant = fontSlant };
 			return result;
 		}
 
 		bool Equals(Font other)
 		{
-			return string.Equals(FontFamily, other.FontFamily) && FontSize.Equals(other.FontSize) && Weight == other.Weight && FontSlant == other.FontSlant;
+			return string.Equals(Family, other.Family) && Size.Equals(other.Size) && Weight == other.Weight && Slant == other.Slant;
 		}
 
 		public override bool Equals(object? obj)
@@ -73,7 +73,7 @@ namespace Microsoft.Maui
 			return Equals((Font)obj);
 		}
 
-		public override int GetHashCode() => (FontFamily, FontSize, Weight, FontSlant).GetHashCode();
+		public override int GetHashCode() => (Family, Size, Weight, Slant).GetHashCode();
 
 		public static bool operator ==(Font left, Font right)
 		{
@@ -86,6 +86,6 @@ namespace Microsoft.Maui
 		}
 
 		public override string ToString()
-			=> $"FontFamily: {FontFamily}, FontSize: {FontSize}, Weight: {Weight}, FontSlant: {FontSlant}";
+			=> $"Family: {Family}, Size: {Size}, Weight: {Weight}, Slant: {Slant}";
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.DeviceTests
 				Font = Font.OfSize("Arial", fontSize)
 			};
 
-			await ValidatePropertyInitValue(button, () => button.Font.FontSize, GetNativeUnscaledFontSize, button.Font.FontSize);
+			await ValidatePropertyInitValue(button, () => button.Font.Size, GetNativeUnscaledFontSize, button.Font.Size);
 		}
 
 		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await ValidatePropertyInitValue(button, () => button.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(button, () => button.Font.FontSlant == FontSlant.Italic, GetNativeIsItalic, isItalic);
+			await ValidatePropertyInitValue(button, () => button.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.DeviceTests
 				Font = Font.OfSize("Arial", fontSize)
 			};
 
-			await ValidatePropertyInitValue(datePicker, () => datePicker.Font.FontSize, GetNativeUnscaledFontSize, datePicker.Font.FontSize);
+			await ValidatePropertyInitValue(datePicker, () => datePicker.Font.Size, GetNativeUnscaledFontSize, datePicker.Font.Size);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Maui.DeviceTests
 				Font = Font.OfSize("Arial", fontSize)
 			};
 
-			await ValidatePropertyInitValue(editor, () => editor.Font.FontSize, GetNativeUnscaledFontSize, editor.Font.FontSize);
+			await ValidatePropertyInitValue(editor, () => editor.Font.Size, GetNativeUnscaledFontSize, editor.Font.Size);
 		}
 
 		[Theory(DisplayName = "Validates Numeric Keyboard")]

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Maui.DeviceTests
 				Font = Font.OfSize("Arial", fontSize)
 			};
 
-			await ValidatePropertyInitValue(entry, () => entry.Font.FontSize, GetNativeUnscaledFontSize, entry.Font.FontSize);
+			await ValidatePropertyInitValue(entry, () => entry.Font.Size, GetNativeUnscaledFontSize, entry.Font.Size);
 		}
 
 		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
@@ -204,7 +204,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await ValidatePropertyInitValue(entry, () => entry.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(entry, () => entry.Font.FontSlant == FontSlant.Italic, GetNativeIsItalic, isItalic);
+			await ValidatePropertyInitValue(entry, () => entry.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
 		}
 
 		[Theory(DisplayName = "Validates clear button visibility.")]

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.DeviceTests
 				Font = Font.OfSize("Arial", fontSize)
 			};
 
-			await ValidatePropertyInitValue(label, () => label.Font.FontSize, GetNativeUnscaledFontSize, label.Font.FontSize);
+			await ValidatePropertyInitValue(label, () => label.Font.Size, GetNativeUnscaledFontSize, label.Font.Size);
 		}
 
 		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await ValidatePropertyInitValue(label, () => label.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(label, () => label.Font.FontSlant == FontSlant.Italic, GetNativeIsItalic, isItalic);
+			await ValidatePropertyInitValue(label, () => label.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
 		}
 
 		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.DeviceTests
 			picker.ItemsSource = items;
 			picker.SelectedIndex = 0;
 
-			await ValidatePropertyInitValue(picker, () => picker.Font.FontSize, GetNativeUnscaledFontSize, picker.Font.FontSize);
+			await ValidatePropertyInitValue(picker, () => picker.Font.Size, GetNativeUnscaledFontSize, picker.Font.Size);
 		}
 
 		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.DeviceTests
 			picker.SelectedIndex = 0;
 
 			await ValidatePropertyInitValue(picker, () => picker.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(picker, () => picker.Font.FontSlant == FontSlant.Italic, GetNativeIsItalic, isItalic);
+			await ValidatePropertyInitValue(picker, () => picker.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
 		}
 
 		[Theory(DisplayName = "Updating Font Does Not Affect HorizontalTextAlignment")]

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.DeviceTests
 				Font = Font.OfSize("Arial", fontSize)
 			};
 
-			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.FontSize, GetNativeUnscaledFontSize, searchBar.Font.FontSize);
+			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.Size, GetNativeUnscaledFontSize, searchBar.Font.Size);
 		}
 
 		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.FontSlant == FontSlant.Italic, GetNativeIsItalic, isItalic);
+			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
 		}
 
 		[Theory(DisplayName = "MaxLength Initializes Correctly")]

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.DeviceTests
 				Font = Font.OfSize("Arial", fontSize)
 			};
 
-			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.FontSize, GetNativeUnscaledFontSize, timePicker.Font.FontSize);
+			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.Size, GetNativeUnscaledFontSize, timePicker.Font.Size);
 		}
 
 		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.FontSlant == FontSlant.Italic, GetNativeIsItalic, isItalic);
+			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
 		}
 
 		[Fact(DisplayName = "Null Text Color Doesn't Crash")]


### PR DESCRIPTION
### Description of Change ###

Rename the `Font` properties to not be repetitive.

Renamed properties:
 - FontFamily => Family
 - FontSize => Size
 - FontSlant => Slant

Weight was already Font-free.

Might be worth merging this before #1683 