### PR TITLE
Font AutoScalingEnabled

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/CoreGalleryPages/ButtonCoreGalleryPage.cs
+++ b/src/Compatibility/ControlGallery/src/Core/CoreGalleryPages/ButtonCoreGalleryPage.cs
@@ -81,14 +81,6 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 				}
 			);
 
-			var fontContainer = new ViewContainer<Button>(Test.Button.Font,
-				new Button
-				{
-					Text = "Font",
-					Font = Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Micro, typeof(Button), false), FontWeight.Bold)
-				}
-			);
-
 			var imageContainer = new ViewContainer<Button>(Test.Button.Image,
 				new Button
 				{
@@ -127,7 +119,6 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 			Add(clickedContainer);
 			Add(pressedContainer);
 			Add(commandContainer);
-			Add(fontContainer);
 			Add(imageContainer);
 			Add(textContainer);
 			Add(textColorContainer);

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/ButtonGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/ButtonGallery.cs
@@ -47,16 +47,16 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 					break;
 			}
 
-			var font = Font.OfSize(fontName, Device.GetNamedSize(NamedSize.Medium, typeof(Button), false));
-
 			var themedButton = new Button
 			{
 				Text = "Accent Button",
 				//BackgroundColor = Colors.Accent,
 				TextColor = Colors.White,
 				ClassId = "AccentButton",
-				Font = font
+				FontFamily = fontName,
+				FontSize = Device.GetNamedSize(NamedSize.Medium, typeof(Button), false)
 			};
+
 			var borderButton = new Button
 			{
 				Text = "Border Button",
@@ -78,7 +78,11 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 			var autoLabel = new Label { Text = "Label Text" };
 			AutomationProperties.SetLabeledBy(labeledBy, autoLabel);
 
-			themedButton.Clicked += (sender, args) => themedButton.Font = Font.Default;
+			themedButton.Clicked += (sender, args) =>
+			{
+				themedButton.FontFamily = Font.Default.Family;
+				themedButton.FontSize = Font.Default.Size;
+			};
 
 			alertSingle.Clicked += (sender, args) => DisplayAlert("Foo", "Bar", "Cancel");
 

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/MacOSTestGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/MacOSTestGallery.cs
@@ -325,7 +325,8 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 			{
 				Text = "Click Me On Mac",
 				ImageSource = "bank.png",
-				Font = Font.OfSize("Helvetica", 14),
+				FontFamily = "Helvetica",
+				FontSize = 14,
 				ContentLayout = layout,
 				BackgroundColor = Colors.Black,
 				TextColor = Colors.White

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29363.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29363.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 			Button modal = new Button
 			{
 				Text = "Modal Push Pop Test",
-				Font = Font.SystemFontOfSize(25, FontWeight.Bold),
+				FontAttributes = FontWeight.Bold,
+				FontSize = 25,
 				HorizontalOptions = LayoutOptions.Center
 			};
 			modal.Clicked += async (object sender, EventArgs e) =>

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29363.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29363.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 			Button modal = new Button
 			{
 				Text = "Modal Push Pop Test",
-				FontAttributes = FontWeight.Bold,
+				FontAttributes = FontAttributes.Bold,
 				FontSize = 25,
 				HorizontalOptions = LayoutOptions.Center
 			};

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla58779.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla58779.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 			Button button = new Button
 			{
 				Text = "Click Here",
-				Font = Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Large, typeof(Button), false)),
+				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Button), false),
 				BorderWidth = 1,
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.CenterAndExpand,

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/PlatformQueries.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/PlatformQueries.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests
 			{ ActivityIndicator.IsRunningProperty, Tuple.Create (new[] { "isAnimating" }, false) },
 			{ Button.CornerRadiusProperty, Tuple.Create (new[] { "layer", "cornerRadius" }, false) },
 			{ Button.BorderWidthProperty, Tuple.Create (new[] { "layer", "borderWidth" }, false) },
-			{ Button.FontProperty, Tuple.Create (new[] { "titleLabel", "font" }, false) },
+			{ FontElement.FontProperty, Tuple.Create (new[] { "titleLabel", "font" }, false) },
 			{ Button.TextProperty, Tuple.Create (new[] { "titleLabel", "text" }, false) },
 			{ Button.TextColorProperty, Tuple.Create (new[] { "titleLabel", "textColor" }, false) },
 			{ ImageButton.CornerRadiusProperty, Tuple.Create (new[] { "layer", "cornerRadius" }, false) },

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/PlatformQueries.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/PlatformQueries.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests
 				{ Button.CornerRadiusProperty, Tuple.Create(new[] { "getBackground" }, false) },
 				{ Button.BorderWidthProperty, Tuple.Create(new[] { "getBackground" }, false) },
 				{ Button.ImageSourceProperty, Tuple.Create(new[] { "getBackground" }, false) },
-				{ Button.FontProperty, Tuple.Create(new[] { "getTypeface", "isBold" }, false) },
+				{ FontElement.FontProperty, Tuple.Create(new[] { "getTypeface", "isBold" }, false) },
 				{ Button.TextProperty, Tuple.Create(new[] { "getText" }, false) },
 				{ Button.TextColorProperty, Tuple.Create(new[] { "getCurrentTextColor" }, false) },
 				{ ImageButton.CornerRadiusProperty, Tuple.Create(new[] { "getBackground" }, false) },

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/Tests/ButtonUITests.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/Tests/ButtonUITests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests
 			remote.GoTo();
 
 #if __ANDROID__
-			var isBold = remote.GetProperty<bool> (Button.FontProperty);
+			var isBold = remote.GetProperty<bool> (FontElement.FontProperty);
 			Assert.True (isBold);
 #elif __MACOS__
 			Assert.Inconclusive("needs testing");

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/Tests/ButtonUITests.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/Tests/ButtonUITests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests
 #elif __MACOS__
 			Assert.Inconclusive("needs testing");
 #else
-			var font = remote.GetProperty<Font>(Button.FontProperty);
+			var font = remote.GetProperty<Font>(FontElement.FontProperty);
 			Assert.AreEqual (FontWeight.Bold, font.Weight);
 #endif
 		}

--- a/src/Compatibility/Core/src/Android/AppCompat/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/ButtonRenderer.cs
@@ -5,6 +5,7 @@ using Android.Graphics;
 using Android.Util;
 using Android.Views;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific;
 using AColor = Android.Graphics.Color;
@@ -118,7 +119,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 				UpdateTextColor();
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateEnabled();
-			else if (e.PropertyName == Button.FontProperty.PropertyName)
+			else if (e.PropertyName == FontElement.FontProperty.PropertyName)
 				UpdateFont();
 			else if (e.PropertyName == Button.CharacterSpacingProperty.PropertyName)
 				UpdateCharacterSpacing();
@@ -153,7 +154,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 		void UpdateFont()
 		{
 			Button button = Element;
-			Font font = button.Font;
+			Font font = (button as ITextStyle).Font;
 
 			if (font == Font.Default && _defaultFontSize == 0f)
 				return;

--- a/src/Compatibility/Core/src/Android/AppCompat/RadioButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/RadioButtonRenderer.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				return;
 			}
 
-			Font font = Font.OfSize(Element.FontFamily, Element.FontSize).WithAttributes(Element.FontAttributes);
+			Font font = Element.ToFont();
 
 			if (font == Font.Default && _defaultFontSize == 0f)
 			{
@@ -273,7 +273,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			else
 			{
 				Typeface = font.ToTypeface();
-				SetTextSize(ComplexUnitType.Sp, (float)font.Size);
+				if (font.AutoScalingEnabled)
+					SetTextSize(ComplexUnitType.Sp, (float)font.Size);
+				else
+					SetTextSize(ComplexUnitType.Dip, (float)font.Size);
 			}
 		}
 

--- a/src/Compatibility/Core/src/Android/FastRenderers/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/ButtonRenderer.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 			{
 				UpdateTextColor();
 			}
-			else if (e.PropertyName == Button.FontProperty.PropertyName)
+			else if (e.PropertyName == FontElement.FontProperty.PropertyName)
 			{
 				UpdateFont();
 			}
@@ -316,7 +316,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 				return;
 			}
 
-			Font font = Button.Font;
+			Font font = (Button as ITextStyle).Font;
 
 			if (font == Font.Default && _defaultFontSize == 0f)
 			{

--- a/src/Compatibility/Core/src/Android/Renderers/FormattedStringExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormattedStringExtensions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				float value = (float)Font.Size;
 
 				paint.TextSize = TypedValue.ApplyDimension(
-					Font.EnableScaling ? ComplexUnitType.Sp : ComplexUnitType.Dip, 
+					Font.AutoScalingEnabled ? ComplexUnitType.Sp : ComplexUnitType.Dip, 
 					value, TextView.Resources.DisplayMetrics);
 
 				if (Forms.IsLollipopOrNewer)

--- a/src/Compatibility/Core/src/Android/Renderers/FormattedStringExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormattedStringExtensions.cs
@@ -103,7 +103,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			{
 				paint.SetTypeface(Font.ToTypeface());
 				float value = (float)Font.Size;
-				paint.TextSize = TypedValue.ApplyDimension(ComplexUnitType.Sp, value, TextView.Resources.DisplayMetrics);
+
+				paint.TextSize = TypedValue.ApplyDimension(
+					Font.EnableScaling ? ComplexUnitType.Sp : ComplexUnitType.Dip, 
+					value, TextView.Resources.DisplayMetrics);
+
 				if (Forms.IsLollipopOrNewer)
 				{
 					paint.LetterSpacing = CharacterSpacing;

--- a/src/Compatibility/Core/src/Windows/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ButtonRenderer.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				UpdateTextColor();
 			}
-			else if (e.PropertyName == Button.FontProperty.PropertyName)
+			else if (e.PropertyName == FontElement.FontProperty.PropertyName)
 			{
 				UpdateFont();
 			}
@@ -295,13 +295,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		void UpdateFont()
 		{
-			if (Control == null || Element == null)
+			if (Control == null || Element is not ITextStyle textStyle)
 				return;
 
-			if (Element.Font == Font.Default && !_fontApplied)
+			if (textStyle.Font == Font.Default && !_fontApplied)
 				return;
 
-			Font fontToApply = Element.Font == Font.Default ? Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Medium, Element.GetType(), false)) : Element.Font;
+			Font fontToApply = textStyle.Font == Font.Default ? Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Medium, Element.GetType(), false)) : textStyle.Font;
 
 			Control.ApplyFont(fontToApply);
 			_fontApplied = true;

--- a/src/Compatibility/Core/src/Windows/FontExtensions.cs
+++ b/src/Compatibility/Core/src/Windows/FontExtensions.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			CompatServiceProvider.FontManager.GetFontFamily(Font.OfSize(fontFamily, 0.0));
 
 		internal static void ApplyFont(this Control self, IFontElement element) =>
-			self.UpdateFont(element.AsFont(), CompatServiceProvider.FontManager);
+			self.UpdateFont(element.ToFont(), CompatServiceProvider.FontManager);
 
 		internal static void ApplyFont(this TextBlock self, IFontElement element) =>
-			self.UpdateFont(element.AsFont(), CompatServiceProvider.FontManager);
+			self.UpdateFont(element.ToFont(), CompatServiceProvider.FontManager);
 
 		internal static void ApplyFont(this UI.Xaml.Documents.TextElement self, IFontElement element) =>
-			self.UpdateFont(element.AsFont(), CompatServiceProvider.FontManager);
+			self.UpdateFont(element.ToFont(), CompatServiceProvider.FontManager);
 
 		internal static double GetFontSize(this NamedSize size) => size switch
 		{
@@ -45,8 +45,5 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		internal static bool IsDefault(this IFontElement self) =>
 			self.FontFamily == null && self.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Label), true) && self.FontAttributes == FontAttributes.None;
-
-		static Font AsFont(this IFontElement element) =>
-			Font.OfSize(element.FontFamily, element.FontSize, enableScaling: element.FontScalingEnabled).WithAttributes(element.FontAttributes);
 	}
 }

--- a/src/Compatibility/Core/src/Windows/FontExtensions.cs
+++ b/src/Compatibility/Core/src/Windows/FontExtensions.cs
@@ -47,6 +47,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			self.FontFamily == null && self.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Label), true) && self.FontAttributes == FontAttributes.None;
 
 		static Font AsFont(this IFontElement element) =>
-			Font.OfSize(element.FontFamily, element.FontSize).WithAttributes(element.FontAttributes);
+			Font.OfSize(element.FontFamily, element.FontSize, enableScaling: element.FontScalingEnabled).WithAttributes(element.FontAttributes);
 	}
 }

--- a/src/Compatibility/Core/src/iOS/Extensions/FontExtensions.cs
+++ b/src/Compatibility/Core/src/iOS/Extensions/FontExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			=> CompatServiceProvider.FontManager.GetFont(self);
 
 		internal static UIFont ToUIFont(this IFontElement self)
-			=> CompatServiceProvider.FontManager.GetFont(Font.OfSize(self.FontFamily, self.FontSize).WithAttributes(self.FontAttributes));
+			=> CompatServiceProvider.FontManager.GetFont(Font.OfSize(self.FontFamily, self.FontSize, enableScaling: self.FontScalingEnabled).WithAttributes(self.FontAttributes));
 
 		internal static bool IsDefault(this IFontElement self)
 			=> self.FontFamily == null && self.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Label), true) && self.FontAttributes == FontAttributes.None;

--- a/src/Compatibility/Core/src/iOS/Extensions/FontExtensions.cs
+++ b/src/Compatibility/Core/src/iOS/Extensions/FontExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Controls.Internals;
 using UIKit;
+using Microsoft.Maui.Controls;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {
@@ -9,7 +10,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			=> CompatServiceProvider.FontManager.GetFont(self);
 
 		internal static UIFont ToUIFont(this IFontElement self)
-			=> CompatServiceProvider.FontManager.GetFont(Font.OfSize(self.FontFamily, self.FontSize, enableScaling: self.FontScalingEnabled).WithAttributes(self.FontAttributes));
+			=> CompatServiceProvider.FontManager.GetFont(self.ToFont());
 
 		internal static bool IsDefault(this IFontElement self)
 			=> self.FontFamily == null && self.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Label), true) && self.FontAttributes == FontAttributes.None;

--- a/src/Compatibility/Core/src/iOS/Renderers/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/ButtonRenderer.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			if (e.PropertyName == Button.TextColorProperty.PropertyName)
 				UpdateTextColor();
-			else if (e.PropertyName == Button.FontProperty.PropertyName)
+			else if (e.PropertyName == FontElement.FontProperty.PropertyName)
 				UpdateFont();
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
@@ -25,7 +25,8 @@
                 <Label
                     Text="Font Image Source"
                     Style="{StaticResource Headline}"/>
-                <Image>
+                <Image
+                    Background="Green">
                     <Image.Source>
                         <FontImageSource
                             FontAutoScalingEnable="True"
@@ -37,7 +38,8 @@
                 <Label
                     Text="Font Image Source Scaling Disabled"
                     Style="{StaticResource Headline}"/>
-                <Image>
+                <Image
+                    Background="Green">
                     <Image.Source>
                         <FontImageSource
                             FontAutoScalingEnable="False"

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
@@ -12,7 +12,9 @@
                     Text="UriSource"
                     Style="{StaticResource Headline}"/>
                 <Image 
-                    Source="https://aka.ms/campus.jpg" />
+                    Source="https://aka.ms/campus.jpg"
+                    HeightRequest="200" 
+                    WidthRequest="200"/>
                 <Label
                     Text="FileSource"
                     Style="{StaticResource Headline}"/>
@@ -20,6 +22,30 @@
                     Source="dotnet_bot.png"
                     HeightRequest="200" 
                     WidthRequest="200"/>
+                <Label
+                    Text="Font Image Source"
+                    Style="{StaticResource Headline}"/>
+                <Image>
+                    <Image.Source>
+                        <FontImageSource
+                            FontAutoScalingEnable="True"
+                            FontFamily = "Ionicons" 
+                            Glyph = "&#xf30c;">
+                        </FontImageSource>
+                    </Image.Source>
+                </Image>
+                <Label
+                    Text="Font Image Source Scaling Disabled"
+                    Style="{StaticResource Headline}"/>
+                <Image>
+                    <Image.Source>
+                        <FontImageSource
+                            FontAutoScalingEnable="False"
+                            FontFamily = "Ionicons" 
+                            Glyph = "&#xf30c;">
+                        </FontImageSource>
+                    </Image.Source>
+                </Image>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
@@ -29,7 +29,7 @@
                     Background="Green">
                     <Image.Source>
                         <FontImageSource
-                            FontAutoScalingEnable="True"
+                            FontAutoScalingEnabled="True"
                             FontFamily = "Ionicons" 
                             Glyph = "&#xf30c;">
                         </FontImageSource>
@@ -42,7 +42,7 @@
                     Background="Green">
                     <Image.Source>
                         <FontImageSource
-                            FontAutoScalingEnable="False"
+                            FontAutoScalingEnabled="False"
                             FontFamily = "Ionicons" 
                             Glyph = "&#xf30c;">
                         </FontImageSource>

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/FontsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/FontsPage.xaml
@@ -8,6 +8,7 @@
         <ScrollView>
             <VerticalStackLayout
                 Margin="12">
+                <Label Text="EnableScaling disabled" FontScalingEnabled="False"></Label>
                 <Label
                     Text="Font attributes"
                     Style="{StaticResource Headline}"/>

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/FontsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/FontsPage.xaml
@@ -8,7 +8,7 @@
         <ScrollView>
             <VerticalStackLayout
                 Margin="12">
-                <Label Text="EnableScaling disabled" FontScalingEnabled="False"></Label>
+                <Label Text="EnableScaling disabled" FontAutoScalingEnabled="False"></Label>
                 <Label
                     Text="Font attributes"
                     Style="{StaticResource Headline}"/>

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create("BorderWidth", typeof(double), typeof(Button), -1d);
 
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
@@ -193,6 +195,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		public TextTransform TextTransform
 		{
 			get => (TextTransform)GetValue(TextTransformProperty);
@@ -248,6 +256,9 @@ namespace Microsoft.Maui.Controls
 			HandleFontChanged();
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
+			HandleFontChanged();
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create("BorderWidth", typeof(double), typeof(Button), -1d);
 

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty CharacterSpacingProperty = TextElement.CharacterSpacingProperty;
 
-		public static readonly BindableProperty FontProperty = FontElement.FontProperty;
-
 		public static readonly BindableProperty FontFamilyProperty = FontElement.FontFamilyProperty;
 
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
@@ -116,12 +114,6 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return GetValue(CommandParameterProperty); }
 			set { SetValue(CommandParameterProperty, value); }
-		}
-
-		public Font Font
-		{
-			get { return (Font)GetValue(FontProperty); }
-			set { SetValue(FontProperty, value); }
 		}
 
 		public ImageSource ImageSource

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create("BorderWidth", typeof(double), typeof(Button), -1d);
 
@@ -187,10 +187,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		public TextTransform TextTransform
@@ -255,6 +255,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			_font = null;
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 

--- a/src/Controls/src/Core/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
@@ -101,10 +101,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>

--- a/src/Controls/src/Core/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<DatePicker>> _platformConfigurationRegistry;
@@ -99,6 +101,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
 			HandleFontChanged();
 
@@ -112,6 +120,9 @@ namespace Microsoft.Maui.Controls
 			Device.GetNamedSize(NamedSize.Default, (DatePicker)this);
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			HandleFontChanged();
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public new static readonly BindableProperty TextColorProperty = InputView.TextColorProperty;
 
@@ -62,10 +62,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		protected void UpdateAutoSizeOption()

--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			UpdateAutoSizeOption();
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			UpdateAutoSizeOption();
 
 		public event EventHandler Completed;

--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public new static readonly BindableProperty TextColorProperty = InputView.TextColorProperty;
 
 		public new static readonly BindableProperty CharacterSpacingProperty = InputView.CharacterSpacingProperty;
@@ -60,6 +62,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		protected void UpdateAutoSizeOption()
 		{
 			// Null out the Maui font value so it will be recreated next time it's accessed
@@ -71,28 +79,23 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
-		{
+		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
 			UpdateAutoSizeOption();
-		}
 
-		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
-		{
+		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
 			UpdateAutoSizeOption();
-		}
 
-		void IFontElement.OnFontChanged(Font oldValue, Font newValue)
-		{
+		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			UpdateAutoSizeOption();
-		}
 
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, (Editor)this);
 
-		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue)
-		{
+		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			UpdateAutoSizeOption();
-		}
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+			UpdateAutoSizeOption();
 
 		public event EventHandler Completed;
 

--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			UpdateAutoSizeOption();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			UpdateAutoSizeOption();
 
 		public event EventHandler Completed;

--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public new static readonly BindableProperty TextColorProperty = InputView.TextColorProperty;
 

--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			UpdateAutoSizeOption();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			UpdateAutoSizeOption();
 
 		public event EventHandler Completed;

--- a/src/Controls/src/Core/Entry.cs
+++ b/src/Controls/src/Core/Entry.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Entry), true, BindingMode.OneTime);
 

--- a/src/Controls/src/Core/Entry.cs
+++ b/src/Controls/src/Core/Entry.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			 HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Entry.cs
+++ b/src/Controls/src/Core/Entry.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Entry), true, BindingMode.OneTime);
 
 		public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(nameof(CursorPosition), typeof(int), typeof(Entry), 0, validateValue: (b, v) => (int)v >= 0);
@@ -87,6 +89,12 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return (double)GetValue(FontSizeProperty); }
 			set { SetValue(FontSizeProperty, value); }
+		}
+
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
 		}
 
 		public bool IsTextPredictionEnabled
@@ -145,6 +153,9 @@ namespace Microsoft.Maui.Controls
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			 HandleFontChanged();
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+			HandleFontChanged();
 
 		void HandleFontChanged()
 		{

--- a/src/Controls/src/Core/Entry.cs
+++ b/src/Controls/src/Core/Entry.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(Entry), true, BindingMode.OneTime);
 
@@ -91,10 +91,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		public bool IsTextPredictionEnabled

--- a/src/Controls/src/Core/Entry.cs
+++ b/src/Controls/src/Core/Entry.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			 HandleFontChanged();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Entry.cs
+++ b/src/Controls/src/Core/Entry.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			 HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/FontElement.cs
+++ b/src/Controls/src/Core/FontElement.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create("CancelEvents", typeof(bool), typeof(FontElement), false);
 
 		public static readonly BindableProperty FontAutoScalingEnabledProperty =
-			BindableProperty.Create("FontAutoScalingEnable", typeof(bool), typeof(IFontElement), true,
+			BindableProperty.Create("FontAutoScalingEnabled", typeof(bool), typeof(IFontElement), true,
 									propertyChanged: OnFontAutoScalingEnabledChanged);
 
 		static bool GetCancelEvents(BindableObject bindable) => (bool)bindable.GetValue(CancelEventsProperty);
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Controls
 			if (!OnChanged(bindable))
 				return;
 
-			((IFontElement)bindable).OnFontAutoScalingEnableChanged((bool)oldValue, (bool)newValue);
+			((IFontElement)bindable).OnFontAutoScalingEnabledChanged((bool)oldValue, (bool)newValue);
 		}
 	}
 }

--- a/src/Controls/src/Core/FontElement.cs
+++ b/src/Controls/src/Core/FontElement.cs
@@ -24,6 +24,10 @@ namespace Microsoft.Maui.Controls
 		static readonly BindableProperty CancelEventsProperty =
 			BindableProperty.Create("CancelEvents", typeof(bool), typeof(FontElement), false);
 
+		public static readonly BindableProperty FontScalingEnableProperty =
+			BindableProperty.Create("EnableFontScaling", typeof(bool), typeof(IFontElement), true,
+									propertyChanged: OnEnableFontScalingChanged);
+
 		static bool GetCancelEvents(BindableObject bindable) => (bool)bindable.GetValue(CancelEventsProperty);
 		static void SetCancelEvents(BindableObject bindable, bool value)
 		{
@@ -43,12 +47,14 @@ namespace Microsoft.Maui.Controls
 				bindable.ClearValue(FontFamilyProperty);
 				bindable.ClearValue(FontSizeProperty);
 				bindable.ClearValue(FontAttributesProperty);
+				bindable.ClearValue(FontScalingEnableProperty);
 			}
 			else
 			{
 				bindable.SetValue(FontFamilyProperty, font.Family);
 				bindable.SetValue(FontSizeProperty, font.Size);
 				bindable.SetValue(FontAttributesProperty, font.GetFontAttributes());
+				bindable.SetValue(FontScalingEnableProperty, font.EnableScaling);
 			}
 			SetCancelEvents(bindable, false);
 		}
@@ -63,11 +69,12 @@ namespace Microsoft.Maui.Controls
 			var fontSize = (double)bindable.GetValue(FontSizeProperty);
 			var fontAttributes = (FontAttributes)bindable.GetValue(FontAttributesProperty);
 			var fontFamily = (string)newValue;
+			var enableAutoScaling = (bool)bindable.GetValue(FontScalingEnableProperty);
 
 			if (fontFamily != null)
-				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize).WithAttributes(fontAttributes));
+				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
 			else
-				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize).WithAttributes(fontAttributes));
+				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
 
 			SetCancelEvents(bindable, false);
 			((IFontElement)bindable).OnFontFamilyChanged((string)oldValue, (string)newValue);
@@ -83,11 +90,12 @@ namespace Microsoft.Maui.Controls
 			var fontSize = (double)newValue;
 			var fontAttributes = (FontAttributes)bindable.GetValue(FontAttributesProperty);
 			var fontFamily = (string)bindable.GetValue(FontFamilyProperty);
+			var enableAutoScaling = (bool)bindable.GetValue(FontScalingEnableProperty);
 
 			if (fontFamily != null)
-				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize).WithAttributes(fontAttributes));
+				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
 			else
-				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize).WithAttributes(fontAttributes));
+				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
 
 			SetCancelEvents(bindable, false);
 			((IFontElement)bindable).OnFontSizeChanged((double)oldValue, (double)newValue);
@@ -108,14 +116,36 @@ namespace Microsoft.Maui.Controls
 			var fontSize = (double)bindable.GetValue(FontSizeProperty);
 			var fontAttributes = (FontAttributes)newValue;
 			var fontFamily = (string)bindable.GetValue(FontFamilyProperty);
+			var enableAutoScaling = (bool)bindable.GetValue(FontScalingEnableProperty);
 
 			if (fontFamily != null)
-				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize).WithAttributes(fontAttributes));
+				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
 			else
-				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize).WithAttributes(fontAttributes));
+				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
 
 			SetCancelEvents(bindable, false);
 			((IFontElement)bindable).OnFontAttributesChanged((FontAttributes)oldValue, (FontAttributes)newValue);
+		}
+
+		static void OnEnableFontScalingChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (GetCancelEvents(bindable))
+				return;
+
+			SetCancelEvents(bindable, true);
+
+			var fontSize = (double)bindable.GetValue(FontSizeProperty);
+			var fontAttributes = (FontAttributes)bindable.GetValue(FontAttributesProperty);
+			var fontFamily = (string)bindable.GetValue(FontFamilyProperty);
+			var enableAutoScaling = (bool)newValue;
+
+			if (fontFamily != null)
+				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
+			else
+				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
+
+			SetCancelEvents(bindable, false);
+			((IFontElement)bindable).OnFontScalingEnableChanged((double)oldValue, (double)newValue);
 		}
 	}
 }

--- a/src/Controls/src/Core/FontElement.cs
+++ b/src/Controls/src/Core/FontElement.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Controls
 			if (!OnChanged(bindable))
 				return;
 
-			((IFontElement)bindable).OnFontScalingEnableChanged((bool)oldValue, (bool)newValue);
+			((IFontElement)bindable).OnFontAutoScalingEnableChanged((bool)oldValue, (bool)newValue);
 		}
 	}
 }

--- a/src/Controls/src/Core/FontElement.cs
+++ b/src/Controls/src/Core/FontElement.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Controls
 				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
 
 			SetCancelEvents(bindable, false);
-			((IFontElement)bindable).OnFontScalingEnableChanged((double)oldValue, (double)newValue);
+			((IFontElement)bindable).OnFontScalingEnableChanged((bool)oldValue, (bool)newValue);
 		}
 	}
 }

--- a/src/Controls/src/Core/FontElement.cs
+++ b/src/Controls/src/Core/FontElement.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 		static readonly BindableProperty CancelEventsProperty =
 			BindableProperty.Create("CancelEvents", typeof(bool), typeof(FontElement), false);
 
-		public static readonly BindableProperty FontAutoScalingEnableProperty =
+		public static readonly BindableProperty FontAutoScalingEnabledProperty =
 			BindableProperty.Create("FontAutoScalingEnable", typeof(bool), typeof(IFontElement), true,
 									propertyChanged: OnFontAutoScalingEnabledChanged);
 
@@ -47,14 +47,14 @@ namespace Microsoft.Maui.Controls
 				bindable.ClearValue(FontFamilyProperty);
 				bindable.ClearValue(FontSizeProperty);
 				bindable.ClearValue(FontAttributesProperty);
-				bindable.ClearValue(FontAutoScalingEnableProperty);
+				bindable.ClearValue(FontAutoScalingEnabledProperty);
 			}
 			else
 			{
 				bindable.SetValue(FontFamilyProperty, font.Family);
 				bindable.SetValue(FontSizeProperty, font.Size);
 				bindable.SetValue(FontAttributesProperty, font.GetFontAttributes());
-				bindable.SetValue(FontAutoScalingEnableProperty, font.AutoScalingEnabled);
+				bindable.SetValue(FontAutoScalingEnabledProperty, font.AutoScalingEnabled);
 			}
 
 			SetCancelEvents(bindable, false);

--- a/src/Controls/src/Core/FontElement.cs
+++ b/src/Controls/src/Core/FontElement.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Maui.Controls
 		static readonly BindableProperty CancelEventsProperty =
 			BindableProperty.Create("CancelEvents", typeof(bool), typeof(FontElement), false);
 
-		public static readonly BindableProperty FontScalingEnableProperty =
-			BindableProperty.Create("EnableFontScaling", typeof(bool), typeof(IFontElement), true,
-									propertyChanged: OnEnableFontScalingChanged);
+		public static readonly BindableProperty FontAutoScalingEnableProperty =
+			BindableProperty.Create("FontAutoScalingEnable", typeof(bool), typeof(IFontElement), true,
+									propertyChanged: OnFontAutoScalingEnabledChanged);
 
 		static bool GetCancelEvents(BindableObject bindable) => (bool)bindable.GetValue(CancelEventsProperty);
 		static void SetCancelEvents(BindableObject bindable, bool value)
@@ -47,57 +47,46 @@ namespace Microsoft.Maui.Controls
 				bindable.ClearValue(FontFamilyProperty);
 				bindable.ClearValue(FontSizeProperty);
 				bindable.ClearValue(FontAttributesProperty);
-				bindable.ClearValue(FontScalingEnableProperty);
+				bindable.ClearValue(FontAutoScalingEnableProperty);
 			}
 			else
 			{
 				bindable.SetValue(FontFamilyProperty, font.Family);
 				bindable.SetValue(FontSizeProperty, font.Size);
 				bindable.SetValue(FontAttributesProperty, font.GetFontAttributes());
-				bindable.SetValue(FontScalingEnableProperty, font.EnableScaling);
+				bindable.SetValue(FontAutoScalingEnableProperty, font.AutoScalingEnabled);
 			}
+
 			SetCancelEvents(bindable, false);
+		}
+
+		static bool OnChanged(BindableObject bindable)
+		{
+			if (GetCancelEvents(bindable))
+				return false;
+
+			IFontElement fontElement = (IFontElement)bindable;
+
+			SetCancelEvents(bindable, true);
+			bindable.SetValue(FontProperty, fontElement.ToFont());
+
+			SetCancelEvents(bindable, false);
+			return true;
 		}
 
 		static void OnFontFamilyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (GetCancelEvents(bindable))
+			if (!OnChanged(bindable)) 
 				return;
 
-			SetCancelEvents(bindable, true);
-
-			var fontSize = (double)bindable.GetValue(FontSizeProperty);
-			var fontAttributes = (FontAttributes)bindable.GetValue(FontAttributesProperty);
-			var fontFamily = (string)newValue;
-			var enableAutoScaling = (bool)bindable.GetValue(FontScalingEnableProperty);
-
-			if (fontFamily != null)
-				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
-			else
-				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
-
-			SetCancelEvents(bindable, false);
 			((IFontElement)bindable).OnFontFamilyChanged((string)oldValue, (string)newValue);
 		}
 
 		static void OnFontSizeChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (GetCancelEvents(bindable))
+			if (!OnChanged(bindable))
 				return;
 
-			SetCancelEvents(bindable, true);
-
-			var fontSize = (double)newValue;
-			var fontAttributes = (FontAttributes)bindable.GetValue(FontAttributesProperty);
-			var fontFamily = (string)bindable.GetValue(FontFamilyProperty);
-			var enableAutoScaling = (bool)bindable.GetValue(FontScalingEnableProperty);
-
-			if (fontFamily != null)
-				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
-			else
-				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
-
-			SetCancelEvents(bindable, false);
 			((IFontElement)bindable).OnFontSizeChanged((double)oldValue, (double)newValue);
 		}
 
@@ -108,43 +97,17 @@ namespace Microsoft.Maui.Controls
 
 		static void OnFontAttributesChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (GetCancelEvents(bindable))
+			if (!OnChanged(bindable))
 				return;
 
-			SetCancelEvents(bindable, true);
-
-			var fontSize = (double)bindable.GetValue(FontSizeProperty);
-			var fontAttributes = (FontAttributes)newValue;
-			var fontFamily = (string)bindable.GetValue(FontFamilyProperty);
-			var enableAutoScaling = (bool)bindable.GetValue(FontScalingEnableProperty);
-
-			if (fontFamily != null)
-				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
-			else
-				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
-
-			SetCancelEvents(bindable, false);
 			((IFontElement)bindable).OnFontAttributesChanged((FontAttributes)oldValue, (FontAttributes)newValue);
 		}
 
-		static void OnEnableFontScalingChanged(BindableObject bindable, object oldValue, object newValue)
+		static void OnFontAutoScalingEnabledChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (GetCancelEvents(bindable))
+			if (!OnChanged(bindable))
 				return;
 
-			SetCancelEvents(bindable, true);
-
-			var fontSize = (double)bindable.GetValue(FontSizeProperty);
-			var fontAttributes = (FontAttributes)bindable.GetValue(FontAttributesProperty);
-			var fontFamily = (string)bindable.GetValue(FontFamilyProperty);
-			var enableAutoScaling = (bool)newValue;
-
-			if (fontFamily != null)
-				bindable.SetValue(FontProperty, Font.OfSize(fontFamily, fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
-			else
-				bindable.SetValue(FontProperty, Font.SystemFontOfSize(fontSize, enableScaling: enableAutoScaling).WithAttributes(fontAttributes));
-
-			SetCancelEvents(bindable, false);
 			((IFontElement)bindable).OnFontScalingEnableChanged((bool)oldValue, (bool)newValue);
 		}
 	}

--- a/src/Controls/src/Core/FontExtensions.cs
+++ b/src/Controls/src/Core/FontExtensions.cs
@@ -27,6 +27,6 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public static Font ToFont(this IFontElement element) =>
-			Font.OfSize(element.FontFamily ?? String.Empty, element.FontSize, enableScaling: element.FontAutoScalingEnabled).WithAttributes(element.FontAttributes);
+			Font.OfSize(element.FontFamily, element.FontSize, enableScaling: element.FontAutoScalingEnabled).WithAttributes(element.FontAttributes);
 	}
 }

--- a/src/Controls/src/Core/FontExtensions.cs
+++ b/src/Controls/src/Core/FontExtensions.cs
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 using System;
 using Microsoft.Maui;
+using Microsoft.Maui.Controls.Internals;
+
 namespace Microsoft.Maui.Controls
 {
 	public static class FontExtensions
@@ -23,5 +25,8 @@ namespace Microsoft.Maui.Controls
 			}
 			return attributes;
 		}
+
+		public static Font ToFont(this IFontElement element) =>
+			Font.OfSize(element.FontFamily ?? String.Empty, element.FontSize, enableScaling: element.FontAutoScalingEnabled).WithAttributes(element.FontAttributes);
 	}
 }

--- a/src/Controls/src/Core/FontImageSource.cs
+++ b/src/Controls/src/Core/FontImageSource.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public static readonly BindableProperty FontAutoScalingEnabledProperty =
-			BindableProperty.Create("FontAutoScalingEnable", typeof(bool), typeof(FontImageSource), false,
+			BindableProperty.Create("FontAutoScalingEnabled", typeof(bool), typeof(FontImageSource), false,
 				propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
 		public bool FontAutoScalingEnabled

--- a/src/Controls/src/Core/FontImageSource.cs
+++ b/src/Controls/src/Core/FontImageSource.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create("FontAutoScalingEnable", typeof(bool), typeof(FontImageSource), false,
 				propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
-		public bool FontAutoScalingEnable
+		public bool FontAutoScalingEnabled
 		{
 			get => (bool)GetValue(FontAutoScalingEnabledProperty);
 			set => SetValue(FontAutoScalingEnabledProperty, value);

--- a/src/Controls/src/Core/FontImageSource.cs
+++ b/src/Controls/src/Core/FontImageSource.cs
@@ -43,14 +43,14 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SizeProperty, value);
 		}
 
-		public static readonly BindableProperty FontScalingEnableProperty =
-			BindableProperty.Create("ScalingEnable", typeof(bool), typeof(FontImageSource), false,
+		public static readonly BindableProperty FontAutoScalingEnableProperty =
+			BindableProperty.Create("FontAutoScalingEnable", typeof(bool), typeof(FontImageSource), false,
 				propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
-		public bool FontScalingEnable
+		public bool FontAutoScalingEnable
 		{
-			get => (bool)GetValue(FontScalingEnableProperty);
-			set => SetValue(FontScalingEnableProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnableProperty);
+			set => SetValue(FontAutoScalingEnableProperty, value);
 		}
 	}
 }

--- a/src/Controls/src/Core/FontImageSource.cs
+++ b/src/Controls/src/Core/FontImageSource.cs
@@ -42,5 +42,15 @@ namespace Microsoft.Maui.Controls
 			get => (double)GetValue(SizeProperty);
 			set => SetValue(SizeProperty, value);
 		}
+
+		public static readonly BindableProperty ScalingEnableProperty =
+			BindableProperty.Create("ScalingEnable", typeof(bool), typeof(FontImageSource), false,
+				propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
+
+		public bool ScalingEnable
+		{
+			get => (bool)GetValue(ScalingEnableProperty);
+			set => SetValue(ScalingEnableProperty, value);
+		}
 	}
 }

--- a/src/Controls/src/Core/FontImageSource.cs
+++ b/src/Controls/src/Core/FontImageSource.cs
@@ -43,14 +43,14 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SizeProperty, value);
 		}
 
-		public static readonly BindableProperty FontAutoScalingEnableProperty =
+		public static readonly BindableProperty FontAutoScalingEnabledProperty =
 			BindableProperty.Create("FontAutoScalingEnable", typeof(bool), typeof(FontImageSource), false,
 				propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
 		public bool FontAutoScalingEnable
 		{
-			get => (bool)GetValue(FontAutoScalingEnableProperty);
-			set => SetValue(FontAutoScalingEnableProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 	}
 }

--- a/src/Controls/src/Core/FontImageSource.cs
+++ b/src/Controls/src/Core/FontImageSource.cs
@@ -43,14 +43,14 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SizeProperty, value);
 		}
 
-		public static readonly BindableProperty ScalingEnableProperty =
+		public static readonly BindableProperty FontScalingEnableProperty =
 			BindableProperty.Create("ScalingEnable", typeof(bool), typeof(FontImageSource), false,
 				propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
-		public bool ScalingEnable
+		public bool FontScalingEnable
 		{
-			get => (bool)GetValue(ScalingEnableProperty);
-			set => SetValue(ScalingEnableProperty, value);
+			get => (bool)GetValue(FontScalingEnableProperty);
+			set => SetValue(FontScalingEnableProperty, value);
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Button.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button.Impl.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Maui.Controls
 			(this as IButtonController).SendReleased();
 		}
 
-		Font ITextStyle.Font => Font;
+		Font? _font;
+
+		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Button.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button.Impl.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Maui.Controls
 
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= this.ToFont();
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/DatePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/DatePicker.Impl.cs
@@ -4,6 +4,6 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= this.ToFont();
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/DatePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/DatePicker.Impl.cs
@@ -4,6 +4,6 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Editor.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor.Impl.cs
@@ -4,7 +4,7 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= this.ToFont();
 
 		void IEditor.Completed()
 		{

--- a/src/Controls/src/Core/HandlerImpl/Editor.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor.Impl.cs
@@ -4,7 +4,7 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
 
 		void IEditor.Completed()
 		{

--- a/src/Controls/src/Core/HandlerImpl/Entry.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry.Impl.cs
@@ -4,7 +4,7 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
 
 		void IEntry.Completed()
 		{

--- a/src/Controls/src/Core/HandlerImpl/Entry.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry.Impl.cs
@@ -4,7 +4,7 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= this.ToFont();
 
 		void IEntry.Completed()
 		{

--- a/src/Controls/src/Core/HandlerImpl/Image.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Image.Impl.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Maui.Controls
 
 	public partial class FontImageSource : IFontImageSource
 	{
-		Font IFontImageSource.Font => Font.OfSize(FontFamily, Size);
+		Font IFontImageSource.Font => Font.OfSize(FontFamily, Size, enableScaling: ScalingEnable);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Image.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Image.Impl.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Maui.Controls
 
 	public partial class FontImageSource : IFontImageSource
 	{
-		Font IFontImageSource.Font => Font.OfSize(FontFamily, Size, enableScaling: FontAutoScalingEnable);
+		Font IFontImageSource.Font => Font.OfSize(FontFamily, Size, enableScaling: FontAutoScalingEnabled);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Image.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Image.Impl.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Maui.Controls
 
 	public partial class FontImageSource : IFontImageSource
 	{
-		Font IFontImageSource.Font => Font.OfSize(FontFamily, Size, enableScaling: FontScalingEnable);
+		Font IFontImageSource.Font => Font.OfSize(FontFamily, Size, enableScaling: FontAutoScalingEnable);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Image.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Image.Impl.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Maui.Controls
 
 	public partial class FontImageSource : IFontImageSource
 	{
-		Font IFontImageSource.Font => Font.OfSize(FontFamily, Size, enableScaling: ScalingEnable);
+		Font IFontImageSource.Font => Font.OfSize(FontFamily, Size, enableScaling: FontScalingEnable);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Label.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label.Impl.cs
@@ -4,6 +4,6 @@ namespace Microsoft.Maui.Controls
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= this.ToFont();
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Label.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label.Impl.cs
@@ -4,6 +4,6 @@ namespace Microsoft.Maui.Controls
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Picker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Picker.Impl.cs
@@ -4,7 +4,7 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= this.ToFont();
 
 		int IItemDelegate<string>.GetCount() => Items?.Count ?? ItemsSource?.Count ?? 0;
 

--- a/src/Controls/src/Core/HandlerImpl/Picker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Picker.Impl.cs
@@ -4,7 +4,7 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
 
 		int IItemDelegate<string>.GetCount() => Items?.Count ?? ItemsSource?.Count ?? 0;
 

--- a/src/Controls/src/Core/HandlerImpl/RadioButton.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton.Impl.cs
@@ -2,5 +2,8 @@
 {
 	public partial class RadioButton : IRadioButton
 	{
+		Font? _font;
+
+		Font ITextStyle.Font => _font ??= this.ToFont();
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/SearchBar.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/SearchBar.Impl.cs
@@ -4,7 +4,7 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
 
 		bool ITextInput.IsTextPredictionEnabled => true;
 

--- a/src/Controls/src/Core/HandlerImpl/SearchBar.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/SearchBar.Impl.cs
@@ -4,7 +4,7 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= this.ToFont();
 
 		bool ITextInput.IsTextPredictionEnabled => true;
 

--- a/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
@@ -4,6 +4,6 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= this.ToFont();
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
@@ -4,6 +4,6 @@
 	{
 		Font? _font;
 
-		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize).WithAttributes(FontAttributes);
+		Font ITextStyle.Font => _font ??= Font.OfSize(FontFamily, FontSize, enableScaling: FontScalingEnabled).WithAttributes(FontAttributes);
 	}
 }

--- a/src/Controls/src/Core/IFontElement.cs
+++ b/src/Controls/src/Core/IFontElement.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Internals
 		//note to implementor: but implement these methods explicitly
 		void OnFontFamilyChanged(string oldValue, string newValue);
 		void OnFontSizeChanged(double oldValue, double newValue);
-		void OnFontScalingEnableChanged(bool oldValue, bool newValue);
+		void OnFontAutoScalingEnableChanged(bool oldValue, bool newValue);
 		double FontSizeDefaultValueCreator();
 		void OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue);
 		void OnFontChanged(Font oldValue, Font newValue);

--- a/src/Controls/src/Core/IFontElement.cs
+++ b/src/Controls/src/Core/IFontElement.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Internals
 		[TypeConverter(typeof(FontSizeConverter))]
 		double FontSize { get; }
 
-		bool FontScalingEnabled { get; }
+		bool FontAutoScalingEnabled { get; }
 
 		//note to implementor: but implement these methods explicitly
 		void OnFontFamilyChanged(string oldValue, string newValue);

--- a/src/Controls/src/Core/IFontElement.cs
+++ b/src/Controls/src/Core/IFontElement.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Internals
 		//note to implementor: but implement these methods explicitly
 		void OnFontFamilyChanged(string oldValue, string newValue);
 		void OnFontSizeChanged(double oldValue, double newValue);
-		void OnFontAutoScalingEnableChanged(bool oldValue, bool newValue);
+		void OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue);
 		double FontSizeDefaultValueCreator();
 		void OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue);
 		void OnFontChanged(Font oldValue, Font newValue);

--- a/src/Controls/src/Core/IFontElement.cs
+++ b/src/Controls/src/Core/IFontElement.cs
@@ -12,9 +12,12 @@ namespace Microsoft.Maui.Controls.Internals
 		[TypeConverter(typeof(FontSizeConverter))]
 		double FontSize { get; }
 
+		bool FontScalingEnabled { get; }
+
 		//note to implementor: but implement these methods explicitly
 		void OnFontFamilyChanged(string oldValue, string newValue);
 		void OnFontSizeChanged(double oldValue, double newValue);
+		void OnFontScalingEnableChanged(double oldValue, double newValue);
 		double FontSizeDefaultValueCreator();
 		void OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue);
 		void OnFontChanged(Font oldValue, Font newValue);

--- a/src/Controls/src/Core/IFontElement.cs
+++ b/src/Controls/src/Core/IFontElement.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Internals
 		//note to implementor: but implement these methods explicitly
 		void OnFontFamilyChanged(string oldValue, string newValue);
 		void OnFontSizeChanged(double oldValue, double newValue);
-		void OnFontScalingEnableChanged(double oldValue, double newValue);
+		void OnFontScalingEnableChanged(bool oldValue, bool newValue);
 		double FontSizeDefaultValueCreator();
 		void OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue);
 		void OnFontChanged(Font oldValue, Font newValue);

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
@@ -175,10 +175,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		public double LineHeight

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
 		public static readonly BindableProperty TextDecorationsProperty = DecorableTextElement.TextDecorationsProperty;
@@ -173,6 +175,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		public double LineHeight
 		{
 			get { return (double)GetValue(LineHeightProperty); }
@@ -210,6 +218,9 @@ namespace Microsoft.Maui.Controls
 			HandleFontChanged();
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
+			HandleFontChanged();
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
@@ -74,10 +74,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		public TextTransform TextTransform

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
 		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
@@ -72,6 +74,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		public TextTransform TextTransform
 		{
 			get => (TextTransform)GetValue(TextTransformProperty);
@@ -94,6 +102,9 @@ namespace Microsoft.Maui.Controls
 			Device.GetNamedSize(NamedSize.Default, (Picker)this);
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			HandleFontChanged();
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellToolbarTracker.cs
@@ -678,7 +678,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			public FlyoutIconDrawerDrawable(Context context, Color defaultColor, Drawable icon, string text) : base(context)
 			{
-				TintColor = defaultColor;		
+				TintColor = defaultColor;
 				if (context.TryResolveAttribute(AndroidResource.Attribute.TextSize, out float? value) &&
 					value != null)
 				{

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellToolbarTracker.cs
@@ -27,6 +27,7 @@ using LP = Android.Views.ViewGroup.LayoutParams;
 using Paint = Android.Graphics.Paint;
 using R = Android.Resource;
 using Toolbar = AndroidX.AppCompat.Widget.Toolbar;
+using AndroidResource = Android.Resource;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -377,7 +378,7 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					if (fid == null)
 					{
-						fid = new FlyoutIconDrawerDrawable(MauiContext, tintColor, customIcon, text);
+						fid = new FlyoutIconDrawerDrawable(MauiContext.Context, tintColor, customIcon, text);
 					}
 					else
 					{
@@ -393,7 +394,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (!string.IsNullOrWhiteSpace(text) && icon == null)
 			{
-				icon = new FlyoutIconDrawerDrawable(MauiContext, tintColor, null, text);
+				icon = new FlyoutIconDrawerDrawable(MauiContext.Context, tintColor, null, text);
 			}
 
 			if (icon == null && (_flyoutBehavior == FlyoutBehavior.Flyout || CanNavigateBack))
@@ -675,11 +676,19 @@ namespace Microsoft.Maui.Controls.Platform
 				}
 			}
 
-			public FlyoutIconDrawerDrawable(IMauiContext context, Color defaultColor, Drawable icon, string text) : base(context.Context)
+			public FlyoutIconDrawerDrawable(Context context, Color defaultColor, Drawable icon, string text) : base(context)
 			{
-				var fontManager = context.Services.GetRequiredService<IFontManager>();
-				TintColor = defaultColor;
-				_defaultSize = fontManager.GetFontSize(Font.OfSize("Roboto", 0));
+				TintColor = defaultColor;		
+				if (context.TryResolveAttribute(AndroidResource.Attribute.TextSize, out float? value) &&
+					value != null)
+				{
+					_defaultSize = value.Value;
+				}
+				else
+				{
+					_defaultSize = 50;
+				}
+
 				IconBitmap = icon;
 				Text = text;
 			}

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
 
 		public static readonly BindableProperty CornerRadiusProperty = BorderElement.CornerRadiusProperty;
@@ -133,6 +135,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		public double BorderWidth
 		{
 			get { return (double)GetValue(BorderWidthProperty); }
@@ -195,6 +203,9 @@ namespace Microsoft.Maui.Controls
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		double IFontElement.FontSizeDefaultValueCreator() =>

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		double IFontElement.FontSizeDefaultValueCreator() =>

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
 
@@ -135,10 +135,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		public double BorderWidth
@@ -194,19 +194,25 @@ namespace Microsoft.Maui.Controls
 			=> InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			HandleFontChanged();
 
 		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			HandleFontChanged();
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			HandleFontChanged();
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			HandleFontChanged();
 
 		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+			HandleFontChanged();
+
+		void HandleFontChanged()
+		{
+			_font = null;
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		}
 
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, this);

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontSizeProperty = FontElement.FontSizeProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
 

--- a/src/Controls/src/Core/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
@@ -92,10 +92,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		double IFontElement.FontSizeDefaultValueCreator() =>

--- a/src/Controls/src/Core/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 

--- a/src/Controls/src/Core/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
 		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
@@ -90,6 +92,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, (SearchBar)this);
 
@@ -103,6 +111,9 @@ namespace Microsoft.Maui.Controls
 			HandleFontChanged();
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
+			HandleFontChanged();
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue)
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue)
 		{
 		}
 

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
 

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue)
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue)
 		{
 		}
 

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
 
@@ -185,10 +185,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue)
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue)
 		{
 		}
 

--- a/src/Controls/src/Core/Shell/SearchHandler.cs
+++ b/src/Controls/src/Core/Shell/SearchHandler.cs
@@ -132,6 +132,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty PlaceholderProperty = PlaceholderElement.PlaceholderProperty;
 
 		public static readonly BindableProperty PlaceholderColorProperty = PlaceholderElement.PlaceholderColorProperty;
@@ -183,11 +185,21 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue)
 		{
 		}
 
 		void IFontElement.OnFontSizeChanged(double oldValue, double newValue)
+		{
+		}
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue)
 		{
 		}
 

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty LineHeightProperty = LineHeightElement.LineHeightProperty;
 

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) { }
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) { }
 
 		internal override void ValidateGesture(IGestureRecognizer gesture)
 		{

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty LineHeightProperty = LineHeightElement.LineHeightProperty;
 
 		public FontAttributes FontAttributes
@@ -95,6 +97,12 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return (double)GetValue(FontElement.FontSizeProperty); }
 			set { SetValue(FontElement.FontSizeProperty, value); }
+		}
+
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
 		}
 
 		public TextDecorations TextDecorations
@@ -145,6 +153,8 @@ namespace Microsoft.Maui.Controls
 		void ITextElement.OnTextTransformChanged(TextTransform oldValue, TextTransform newValue)
 		{
 		}
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) { }
 
 		internal override void ValidateGesture(IGestureRecognizer gesture)
 		{

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) { }
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) { }
 
 		internal override void ValidateGesture(IGestureRecognizer gesture)
 		{

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) { }
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) { }
 
 		internal override void ValidateGesture(IGestureRecognizer gesture)
 		{

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty LineHeightProperty = LineHeightElement.LineHeightProperty;
 
@@ -99,10 +99,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontElement.FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		public TextDecorations TextDecorations

--- a/src/Controls/src/Core/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
 
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
@@ -78,10 +78,10 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
-		public bool FontScalingEnabled
+		public bool FontAutoScalingEnabled
 		{
-			get => (bool)GetValue(FontScalingEnabledProperty);
-			set => SetValue(FontScalingEnabledProperty, value);
+			get => (bool)GetValue(FontAutoScalingEnabledProperty);
+			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
 		public TextTransform TextTransform
@@ -94,22 +94,29 @@ namespace Microsoft.Maui.Controls
 			=> TextTransformUtilites.GetTransformedText(source, textTransform);
 
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			HandleFontChanged();
 
 		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			HandleFontChanged();
 
 		void IFontElement.OnFontChanged(Font oldValue, Font newValue) =>
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			HandleFontChanged();
 
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			Device.GetNamedSize(NamedSize.Default, (TimePicker)this);
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
-			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+			HandleFontChanged();
 
 		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+			HandleFontChanged();
+
+		void HandleFontChanged()
+		{
+			// Null out the Maui font value so it will be recreated next time it's accessed
+			_font = null;
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		}
 
 		public IPlatformElementConfiguration<T, TimePicker> On<T>() where T : IConfigPlatform
 		{

--- a/src/Controls/src/Core/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
-		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
+		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		public IPlatformElementConfiguration<T, TimePicker> On<T>() where T : IConfigPlatform

--- a/src/Controls/src/Core/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
-		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnableProperty;
+		public static readonly BindableProperty FontAutoScalingEnabledProperty = FontElement.FontAutoScalingEnabledProperty;
 
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 

--- a/src/Controls/src/Core/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/src/Core/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Maui.Controls
 
 		public static readonly BindableProperty FontAttributesProperty = FontElement.FontAttributesProperty;
 
+		public static readonly BindableProperty FontScalingEnabledProperty = FontElement.FontScalingEnableProperty;
+
 		public static readonly BindableProperty TextTransformProperty = TextElement.TextTransformProperty;
 
 		readonly Lazy<PlatformConfigurationRegistry<TimePicker>> _platformConfigurationRegistry;
@@ -76,6 +78,12 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(FontSizeProperty, value); }
 		}
 
+		public bool FontScalingEnabled
+		{
+			get => (bool)GetValue(FontScalingEnabledProperty);
+			set => SetValue(FontScalingEnabledProperty, value);
+		}
+
 		public TextTransform TextTransform
 		{
 			get => (TextTransform)GetValue(TextTransformProperty);
@@ -98,6 +106,9 @@ namespace Microsoft.Maui.Controls
 			Device.GetNamedSize(NamedSize.Default, (TimePicker)this);
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
+			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+
+		void IFontElement.OnFontScalingEnableChanged(double oldValue, double newValue) =>
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 
 		public IPlatformElementConfiguration<T, TimePicker> On<T>() where T : IConfigPlatform

--- a/src/Controls/src/Core/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.Controls
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
 			HandleFontChanged();
 
-		void IFontElement.OnFontScalingEnableChanged(bool oldValue, bool newValue) =>
+		void IFontElement.OnFontAutoScalingEnableChanged(bool oldValue, bool newValue) =>
 			HandleFontChanged();
 
 		void HandleFontChanged()

--- a/src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var button = new Button();
 
 			button.FontSize = 1000;
-			Assert.AreEqual((button as ITextStyle), Font.SystemFontOfSize(1000));
+			Assert.AreEqual((button as ITextStyle).Font, Font.SystemFontOfSize(1000));
 		}
 
 		[Test]
@@ -194,7 +194,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var button = new Button();
 
 			button.FontAttributes = FontAttributes.Italic | FontAttributes.Bold;
-			Assert.AreEqual((button as ITextStyle), Font.SystemFontOfSize(button.FontSize, FontWeight.Bold, FontSlant.Italic));
+			Assert.AreEqual((button as ITextStyle).Font, Font.SystemFontOfSize(button.FontSize, FontWeight.Bold, FontSlant.Italic));
 		}
 
 		[Test]

--- a/src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					firedAttributesChanged = true;
 			};
 
-			button.Font = Font.OfSize("Testing123", Device.GetNamedSize(size, typeof(Label), true)).WithAttributes(attributes);
+			button.SetValue(FontElement.FontProperty, Font.OfSize("Testing123", Device.GetNamedSize(size, typeof(Label), true)).WithAttributes(attributes));
 
 			Assert.AreEqual(Device.GetNamedSize(size, typeof(Label), true), button.FontSize);
 			Assert.AreEqual(attributes, button.FontAttributes);
@@ -176,7 +176,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var button = new Button();
 
 			button.FontFamily = "CrazyFont";
-			Assert.AreEqual(button.Font, Font.OfSize("CrazyFont", button.FontSize));
+			Assert.AreEqual((button as ITextStyle).Font, Font.OfSize("CrazyFont", button.FontSize));
 		}
 
 		[Test]
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var button = new Button();
 
 			button.FontSize = 1000;
-			Assert.AreEqual(button.Font, Font.SystemFontOfSize(1000));
+			Assert.AreEqual((button as ITextStyle), Font.SystemFontOfSize(1000));
 		}
 
 		[Test]
@@ -194,7 +194,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var button = new Button();
 
 			button.FontAttributes = FontAttributes.Italic | FontAttributes.Bold;
-			Assert.AreEqual(button.Font, Font.SystemFontOfSize(button.FontSize, FontWeight.Bold, FontSlant.Italic));
+			Assert.AreEqual((button as ITextStyle), Font.SystemFontOfSize(button.FontSize, FontWeight.Bold, FontSlant.Italic));
 		}
 
 		[Test]

--- a/src/Controls/tests/Core.UnitTests/NotifiedPropertiesTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NotifiedPropertiesTests.cs
@@ -77,7 +77,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			new PropertyTestCase<ActivityIndicator, Color> ("Color", v => v.Color, (v, o) => v.Color = o, () => null, new Color (0, 1, 0)),
 			new PropertyTestCase<Button, string> ("Text", v => v.Text, (v, o) => v.Text = o, () => null, "Foo"),
 			new PropertyTestCase<Button, Color> ("TextColor", v => v.TextColor, (v, o) => v.TextColor = o, () => null, new Color (0, 1, 0)),
-			new PropertyTestCase<Button, Font> ("Font", v => v.Font, (v, o) => v.Font = o, () => default (Font), Font.SystemFontOfSize (20)),
 			new PropertyTestCase<Button, double> ("BorderWidth", v => v.BorderWidth, (v, o) => v.BorderWidth = o, () => -1d, 16d),
 			new PropertyTestCase<Button, int> ("CornerRadius", v => v.CornerRadius, (v, o) => v.CornerRadius = o, () => -1, 12),
 			new PropertyTestCase<Button, Color> ("BorderColor", v => v.BorderColor, (v, o) => v.BorderColor = o, () => null, new Color (0, 1, 0)),

--- a/src/Core/src/Core/IRadioButton.cs
+++ b/src/Core/src/Core/IRadioButton.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Represents a View that provides a toggled value.
 	/// </summary>
-	public interface IRadioButton : IView
+	public interface IRadioButton : IView, ITextStyle
 	{
 		/// <summary>
 		/// Gets or sets a Boolean value that indicates whether this RadioButton is checked.

--- a/src/Core/src/Fonts/FontManager.Android.cs
+++ b/src/Core/src/Fonts/FontManager.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using Android.Graphics;
+using Android.Util;
 using Microsoft.Extensions.Logging;
 using AApplication = Android.App.Application;
 
@@ -37,10 +38,21 @@ namespace Microsoft.Maui
 			return _typefaces.GetOrAdd((font.Family, font.Weight, font.Slant != FontSlant.Default), CreateTypeface);
 		}
 
-		public float GetFontSize(Font font, float defaultFontSize = 0) =>
-			font.Size <= 0
+		public FontSize GetFontSize(Font font, float defaultFontSize = 0)
+		{
+			var size = font.Size <= 0
 				? (defaultFontSize > 0 ? defaultFontSize : 14f)
 				: (float)font.Size;
+
+			ComplexUnitType units;
+
+			if (font.EnableScaling)
+				units = ComplexUnitType.Sp;
+			else
+				units = ComplexUnitType.Dip;
+
+			return new FontSize(size, units);
+		}
 
 
 		Typeface? GetFromAssets(string fontName)

--- a/src/Core/src/Fonts/FontManager.Android.cs
+++ b/src/Core/src/Fonts/FontManager.Android.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui
 
 			ComplexUnitType units;
 
-			if (font.EnableScaling)
+			if (font.AutoScalingEnabled)
 				units = ComplexUnitType.Sp;
 			else
 				units = ComplexUnitType.Dip;

--- a/src/Core/src/Fonts/FontManager.Android.cs
+++ b/src/Core/src/Fonts/FontManager.Android.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui
 			"fonts/",
 		};
 
-		readonly ConcurrentDictionary<(string fontFamilyName, FontWeight weight, bool italic), Typeface?> _typefaces = new();
+		readonly ConcurrentDictionary<(string? fontFamilyName, FontWeight weight, bool italic), Typeface?> _typefaces = new();
 		readonly IFontRegistrar _fontRegistrar;
 		readonly ILogger<FontManager>? _logger;
 
@@ -114,7 +114,7 @@ namespace Microsoft.Maui
 			return name != null && (name.Contains(".ttf#") || name.Contains(".otf#"));
 		}
 
-		Typeface? CreateTypeface((string fontFamilyName, FontWeight weight, bool italic) fontData)
+		Typeface? CreateTypeface((string? fontFamilyName, FontWeight weight, bool italic) fontData)
 		{
 			var (fontFamily, weight, italic) = fontData;
 			fontFamily ??= string.Empty;

--- a/src/Core/src/Fonts/FontManager.iOS.cs
+++ b/src/Core/src/Fonts/FontManager.iOS.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Maui
 
 			UIFont ApplyScaling(Font font, UIFont uiFont)
 			{
-				if (font.EnableScaling)
+				if (font.AutoScalingEnabled)
 					return UIFontMetrics.DefaultMetrics.GetScaledFont(uiFont);
 
 				return uiFont;

--- a/src/Core/src/Fonts/FontManager.iOS.cs
+++ b/src/Core/src/Fonts/FontManager.iOS.cs
@@ -160,7 +160,6 @@ namespace Microsoft.Maui
 
 			return ApplyScaling(font, UIFont.SystemFontOfSize(size));
 
-
 			UIFont ApplyScaling(Font font, UIFont uiFont)
 			{
 				if (font.AutoScalingEnabled)

--- a/src/Core/src/Fonts/FontManager.iOS.cs
+++ b/src/Core/src/Fonts/FontManager.iOS.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui
 		public UIFont GetFont(Font font, double defaultFontSize = 0) =>
 			GetFont(font, defaultFontSize, CreateFont);
 
-		public double GetFontSize(Font font, double defaultFontSize = 0) =>
+		double GetFontSize(Font font, double defaultFontSize = 0) =>
 			font.Size <= 0
 				? (defaultFontSize > 0 ? (float)defaultFontSize : DefaultFont.PointSize)
 				: (nfloat)font.Size;
@@ -114,13 +114,13 @@ namespace Microsoft.Maui
 
 						result = UIFont.FromDescriptor(descriptor, size);
 						if (result != null)
-							return result;
+							return ApplyScaling(font, result);
 					}
 
 					var cleansedFont = CleanseFontName(family);
 					result = UIFont.FromName(cleansedFont, size);
 					if (result != null)
-						return result;
+						return ApplyScaling(font, result);
 
 					if (family.StartsWith(".SFUI", StringComparison.InvariantCultureIgnoreCase))
 					{
@@ -133,17 +133,17 @@ namespace Microsoft.Maui
 						{
 							result = UIFont.SystemFontOfSize(size, uIFontWeight);
 							if (result != null)
-								return result;
+								return ApplyScaling(font, result);
 						}
 
 						result = UIFont.SystemFontOfSize(size, UIFontWeight.Regular);
 						if (result != null)
-							return result;
+							return ApplyScaling(font, result);
 					}
 
 					result = UIFont.FromName(family, size);
 					if (result != null)
-						return result;
+						return ApplyScaling(font, result);
 				}
 				catch (Exception ex)
 				{
@@ -155,10 +155,19 @@ namespace Microsoft.Maui
 			{
 				var defaultFont = UIFont.SystemFontOfSize(size);
 				var descriptor = defaultFont.FontDescriptor.CreateWithAttributes(GetFontAttributes(font));
-				return UIFont.FromDescriptor(descriptor, size);
+				return ApplyScaling(font, UIFont.FromDescriptor(descriptor, size));
 			}
 
-			return UIFont.SystemFontOfSize(size);
+			return ApplyScaling(font, UIFont.SystemFontOfSize(size));
+
+
+			UIFont ApplyScaling(Font font, UIFont uiFont)
+			{
+				if (font.EnableScaling)
+					return UIFontMetrics.DefaultMetrics.GetScaledFont(uiFont);
+
+				return uiFont;
+			}
 		}
 
 		string? CleanseFontName(string fontName)

--- a/src/Core/src/Fonts/FontSize.Android.cs
+++ b/src/Core/src/Fonts/FontSize.Android.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.Util;
+
+namespace Microsoft.Maui
+{
+	public struct FontSize
+	{
+		public FontSize(float value, ComplexUnitType unit)
+		{
+			Value = value;
+			Unit = unit;
+		}
+
+		public float Value { get; set; }
+		public ComplexUnitType Unit { get; set; }
+	}
+}

--- a/src/Core/src/Fonts/FontSize.Android.cs
+++ b/src/Core/src/Fonts/FontSize.Android.cs
@@ -5,7 +5,7 @@ using Android.Util;
 
 namespace Microsoft.Maui
 {
-	public struct FontSize
+	public readonly struct FontSize
 	{
 		public FontSize(float value, ComplexUnitType unit)
 		{
@@ -13,7 +13,7 @@ namespace Microsoft.Maui
 			Unit = unit;
 		}
 
-		public float Value { get; set; }
-		public ComplexUnitType Unit { get; set; }
+		public float Value { get; }
+		public ComplexUnitType Unit { get; }
 	}
 }

--- a/src/Core/src/Fonts/IFontManager.Android.cs
+++ b/src/Core/src/Fonts/IFontManager.Android.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Maui
 
 		Typeface? GetTypeface(Font font);
 
-		float GetFontSize(Font font, float defaultFontSize = 0);
+		FontSize GetFontSize(Font font, float defaultFontSize = 0);
 	}
 }

--- a/src/Core/src/Fonts/IFontManager.iOS.cs
+++ b/src/Core/src/Fonts/IFontManager.iOS.cs
@@ -8,7 +8,5 @@ namespace Microsoft.Maui
 		UIFont DefaultFont { get; }
 
 		UIFont GetFont(Font font, double defaultFontSize = 0);
-
-		double GetFontSize(Font font, double defaultFontSize = 0);
 	}
 }

--- a/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Android.cs
+++ b/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Android.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Maui
 
 			var glyph = imageSource.Glyph;
 
-			var sp = FontManager.GetFontSize(imageSource.Font);
-			var textSize = TypedValue.ApplyDimension(ComplexUnitType.Dip, sp, context.Resources?.DisplayMetrics);
+			var size = FontManager.GetFontSize(imageSource.Font);
+			var textSize = TypedValue.ApplyDimension(size.Unit, size.Value, context.Resources?.DisplayMetrics);
 			var typeface = FontManager.GetTypeface(imageSource.Font);
 			var color = (imageSource.Color ?? Graphics.Colors.White).ToNative();
 

--- a/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
+++ b/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Maui
 				// There's really no perfect solution to handle font families with fallbacks (comma-separated)	
 				// So if the font family has fallbacks, only one is taken, because CanvasTextFormat	
 				// only supports one font family
-				var source = imageSource.Font.Family;
+				var source = imageSource.Font.Family ?? String.Empty;
 
 				foreach (var family in allFamilies)
 				{

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -121,6 +121,9 @@ namespace Microsoft.Maui
 			}
 		}
 
+		public static bool TryResolveAttribute(this Context context, int id, out float? value) =>
+			context.Theme.TryResolveAttribute(id, out value);
+
 		public static bool TryResolveAttribute(this Context context, int id)
 		{
 			return context.Theme.TryResolveAttribute(id);

--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Maui
 			var tf = fontManager.GetTypeface(font);
 			textView.Typeface = tf;
 
-			var sp = fontManager.GetFontSize(font);
-			textView.SetTextSize(ComplexUnitType.Sp, sp);
+			var fontSize = fontManager.GetFontSize(font);
+			textView.SetTextSize(fontSize.Unit, fontSize.Value);
 		}
 
 		public static void UpdateCharacterSpacing(this TextView textView, ITextStyle textStyle) =>

--- a/src/Core/src/Platform/Android/ThemeExtensions.cs
+++ b/src/Core/src/Platform/Android/ThemeExtensions.cs
@@ -30,5 +30,20 @@ namespace Microsoft.Maui
 			value = null;
 			return false;
 		}
+
+		public static bool TryResolveAttribute(this Resources.Theme? theme, int id, out float? value)
+		{
+			using (var tv = new Android.Util.TypedValue())
+			{
+				if (theme != null && theme.ResolveAttribute(id, tv, resolveRefs: true))
+				{
+					value = tv.Data;
+					return true;
+				}
+			}
+
+			value = null;
+			return false;
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/ControlExtensions.cs
+++ b/src/Core/src/Platform/Windows/ControlExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui
 			nativeControl.FontFamily = fontManager.GetFontFamily(font);
 			nativeControl.FontStyle = font.ToFontStyle();
 			nativeControl.FontWeight = font.ToFontWeight();
+			nativeControl.IsTextScaleFactorEnabled = font.EnableScaling;
 		}
 
 		public static void UpdateIsEnabled(this Control nativeControl, bool isEnabled) =>

--- a/src/Core/src/Platform/Windows/ControlExtensions.cs
+++ b/src/Core/src/Platform/Windows/ControlExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui
 			nativeControl.FontFamily = fontManager.GetFontFamily(font);
 			nativeControl.FontStyle = font.ToFontStyle();
 			nativeControl.FontWeight = font.ToFontWeight();
-			nativeControl.IsTextScaleFactorEnabled = font.EnableScaling;
+			nativeControl.IsTextScaleFactorEnabled = font.AutoScalingEnabled;
 		}
 
 		public static void UpdateIsEnabled(this Control nativeControl, bool isEnabled) =>

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui
 			nativeControl.FontFamily = fontManager.GetFontFamily(font);
 			nativeControl.FontStyle = font.ToFontStyle();
 			nativeControl.FontWeight = font.ToFontWeight();
-			nativeControl.IsTextScaleFactorEnabled = font.EnableScaling;
+			nativeControl.IsTextScaleFactorEnabled = font.AutoScalingEnabled;
 		}
 
 		public static void UpdateFont(this TextBlock nativeControl, IText text, IFontManager fontManager) =>

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui
 			nativeControl.FontFamily = fontManager.GetFontFamily(font);
 			nativeControl.FontStyle = font.ToFontStyle();
 			nativeControl.FontWeight = font.ToFontWeight();
+			nativeControl.IsTextScaleFactorEnabled = font.EnableScaling;
 		}
 
 		public static void UpdateFont(this TextBlock nativeControl, IText text, IFontManager fontManager) =>

--- a/src/Core/src/Platform/Windows/TextBoxExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBoxExtensions.cs
@@ -78,14 +78,6 @@ namespace Microsoft.Maui
 		public static void UpdateFont(this MauiTextBox nativeControl, IText text, IFontManager fontManager) =>
 			nativeControl.UpdateFont(text.Font, fontManager);
 
-		public static void UpdateFont(this MauiTextBox nativeControl, Font font, IFontManager fontManager)
-		{
-			nativeControl.FontSize = fontManager.GetFontSize(font);
-			nativeControl.FontFamily = fontManager.GetFontFamily(font);
-			nativeControl.FontStyle = font.ToFontStyle();
-			nativeControl.FontWeight = font.ToFontWeight();
-		}
-
 		public static void UpdateIsReadOnly(this MauiTextBox textBox, IEditor editor)
 		{
 			textBox.IsReadOnly = editor.IsReadOnly;

--- a/src/Core/src/Platform/Windows/TextElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextElementExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui
 			nativeControl.FontFamily = fontManager.GetFontFamily(font);
 			nativeControl.FontStyle = font.ToFontStyle();
 			nativeControl.FontWeight = font.ToFontWeight();
-			nativeControl.IsTextScaleFactorEnabled = font.EnableScaling;
+			nativeControl.IsTextScaleFactorEnabled = font.AutoScalingEnabled;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/TextElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextElementExtensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui
 			nativeControl.FontFamily = fontManager.GetFontFamily(font);
 			nativeControl.FontStyle = font.ToFontStyle();
 			nativeControl.FontWeight = font.ToFontWeight();
+			nativeControl.IsTextScaleFactorEnabled = font.EnableScaling;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/TextViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextViewExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Maui
 
 		public static void UpdateFont(this UITextView textView, ITextStyle textStyle, IFontManager fontManager)
 		{
-			var uiFont = fontManager.GetFont(textStyle.Font, UIFont.LabelFontSize);
+			var font = textStyle.Font;
+			var uiFont = fontManager.GetFont(font, UIFont.LabelFontSize);
 			textView.Font = uiFont;
 		}
 

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -23,6 +23,13 @@ namespace Microsoft.Maui
 			private set => _weight = value;
 		}
 
+		bool _disableScaling;
+		public bool EnableScaling
+		{
+			get => !_disableScaling;
+			set => _disableScaling = !value;
+		}
+
 		public Font WithSize(double size)
 		{
 			return new Font { Family = Family, Size = size, Slant = Slant, Weight = Weight };
@@ -43,21 +50,25 @@ namespace Microsoft.Maui
 			return new Font { Family = Family, Size = Size, Slant = fontSlant, Weight = weight };
 		}
 
-		public static Font OfSize(string name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default) =>
-			new() { Family = name, Size = size, Weight = weight, Slant = fontSlant };
+		public static Font OfSize(string name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
+			new() { Family = name, Size = size, Weight = weight, Slant = fontSlant, EnableScaling = enableScaling };
 
-		public static Font SystemFontOfSize(double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default) =>
-			new() { Size = size, Weight = weight, Slant = fontSlant };
+		public static Font SystemFontOfSize(double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
+			new() { Size = size, Weight = weight, Slant = fontSlant, EnableScaling = enableScaling };
 
-		public static Font SystemFontOfWeight(FontWeight weight, FontSlant fontSlant = FontSlant.Default)
+		public static Font SystemFontOfWeight(FontWeight weight, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true)
 		{
-			var result = new Font { Weight = weight, Slant = fontSlant };
+			var result = new Font { Weight = weight, Slant = fontSlant, EnableScaling = enableScaling };
 			return result;
 		}
 
 		bool Equals(Font other)
 		{
-			return string.Equals(Family, other.Family) && Size.Equals(other.Size) && Weight == other.Weight && Slant == other.Slant;
+			return string.Equals(Family, other.Family)
+				&& Size.Equals(other.Size)
+				&& Weight == other.Weight
+				&& Slant == other.Slant
+				&& EnableScaling == other.EnableScaling;
 		}
 
 		public override bool Equals(object? obj)
@@ -73,7 +84,7 @@ namespace Microsoft.Maui
 			return Equals((Font)obj);
 		}
 
-		public override int GetHashCode() => (Family, Size, Weight, Slant).GetHashCode();
+		public override int GetHashCode() => (Family, Size, Weight, Slant, EnableScaling).GetHashCode();
 
 		public static bool operator ==(Font left, Font right)
 		{

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui
 
 
 		readonly bool _disableScaling;
-		public bool EnableScaling
+		public bool AutoScalingEnabled
 		{
 			get => !_disableScaling;
 		}
@@ -46,22 +46,22 @@ namespace Microsoft.Maui
 
 		public Font WithSize(double size)
 		{
-			return new Font(Family, size, Slant, Weight, EnableScaling);
+			return new Font(Family, size, Slant, Weight, AutoScalingEnabled);
 		}
 
 		public Font WithSlant(FontSlant fontSlant)
 		{
-			return new Font(Family, Size, fontSlant, Weight, EnableScaling);
+			return new Font(Family, Size, fontSlant, Weight, AutoScalingEnabled);
 		}
 
 		public Font WithWeight(FontWeight weight)
 		{
-			return new Font(Family, Size, Slant, weight, EnableScaling);
+			return new Font(Family, Size, Slant, weight, AutoScalingEnabled);
 		}
 
 		public Font WithWeight(FontWeight weight, FontSlant fontSlant)
 		{
-			return new Font(Family, Size, fontSlant, weight, EnableScaling);
+			return new Font(Family, Size, fontSlant, weight, AutoScalingEnabled);
 		}
 
 		public static Font OfSize(string name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
@@ -79,7 +79,7 @@ namespace Microsoft.Maui
 				&& Size.Equals(other.Size)
 				&& Weight == other.Weight
 				&& Slant == other.Slant
-				&& EnableScaling == other.EnableScaling;
+				&& AutoScalingEnabled == other.AutoScalingEnabled;
 		}
 
 		public override bool Equals(object? obj)
@@ -95,7 +95,7 @@ namespace Microsoft.Maui
 			return Equals((Font)obj);
 		}
 
-		public override int GetHashCode() => (Family, Size, Weight, Slant, EnableScaling).GetHashCode();
+		public override int GetHashCode() => (Family, Size, Weight, Slant, AutoScalingEnabled).GetHashCode();
 
 		public static bool operator ==(Font left, Font right)
 		{

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui
 			get => !_disableScaling;
 		}
 
-		public Font WithScaling(bool enabled)
+		public Font WithAutoScaling(bool enabled)
 		{
 			return new Font(Family, Size, Slant, Weight, enabled);
 		}

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -3,64 +3,75 @@ using System;
 
 namespace Microsoft.Maui
 {
-	public struct Font
+	public readonly struct Font
 	{
-		public string Family { get; private set; }
+		public string Family { get; }
 
-		public double Size { get; private set; }
+		public double Size { get; }
 
-		public FontSlant Slant { get; private set; }
+		public FontSlant Slant { get; }
 
 		public bool IsDefault => Family == null && Size == 0 && Slant == FontSlant.Default && Weight == FontWeight.Regular;
 
 		static Font _default = default(Font).WithWeight(FontWeight.Regular);
 		public static Font Default => _default;
 
-		FontWeight _weight;
+		readonly FontWeight _weight;
+
 		public FontWeight Weight
 		{
 			get => _weight <= 0 ? FontWeight.Regular : _weight;
-			private set => _weight = value;
 		}
 
-		bool _disableScaling;
+		private Font(string family, double size, FontSlant slant, FontWeight weight, bool enableScaling) : this()
+		{
+			Family = family;
+			Size = size;
+			Slant = slant;
+			_weight = weight;
+			_disableScaling = !enableScaling;
+		}
+
+
+		readonly bool _disableScaling;
 		public bool EnableScaling
 		{
 			get => !_disableScaling;
-			set => _disableScaling = !value;
+		}
+
+		public Font WithScaling(bool enabled)
+		{
+			return new Font(Family, Size, Slant, Weight, enabled);
 		}
 
 		public Font WithSize(double size)
 		{
-			return new Font { Family = Family, Size = size, Slant = Slant, Weight = Weight };
+			return new Font(Family, size, Slant, Weight, EnableScaling);
 		}
 
 		public Font WithSlant(FontSlant fontSlant)
 		{
-			return new Font { Family = Family, Size = Size, Slant = fontSlant, Weight = Weight };
+			return new Font(Family, Size, fontSlant, Weight, EnableScaling);
 		}
 
 		public Font WithWeight(FontWeight weight)
 		{
-			return new Font { Family = Family, Size = Size, Slant = Slant, Weight = weight };
+			return new Font(Family, Size, Slant, weight, EnableScaling);
 		}
 
 		public Font WithWeight(FontWeight weight, FontSlant fontSlant)
 		{
-			return new Font { Family = Family, Size = Size, Slant = fontSlant, Weight = weight };
+			return new Font(Family, Size, fontSlant, weight, EnableScaling);
 		}
 
 		public static Font OfSize(string name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
-			new() { Family = name, Size = size, Weight = weight, Slant = fontSlant, EnableScaling = enableScaling };
+			new(name, size, fontSlant, weight, enableScaling);
 
 		public static Font SystemFontOfSize(double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
-			new() { Size = size, Weight = weight, Slant = fontSlant, EnableScaling = enableScaling };
+			new(String.Empty, size, fontSlant, weight, enableScaling);
 
-		public static Font SystemFontOfWeight(FontWeight weight, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true)
-		{
-			var result = new Font { Weight = weight, Slant = fontSlant, EnableScaling = enableScaling };
-			return result;
-		}
+		public static Font SystemFontOfWeight(FontWeight weight, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
+			new(String.Empty, default(double), fontSlant, weight, enableScaling);
 
 		bool Equals(Font other)
 		{

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -108,6 +108,6 @@ namespace Microsoft.Maui
 		}
 
 		public override string ToString()
-			=> $"Family: {Family}, Size: {Size}, Weight: {Weight}, Slant: {Slant}";
+			=> $"Family: {Family}, Size: {Size}, Weight: {Weight}, Slant: {Slant}, AutoScalingEnabled: {AutoScalingEnabled}";
 	}
 }

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui
 {
 	public readonly struct Font
 	{
-		public string Family { get; }
+		public string? Family { get; }
 
 		public double Size { get; }
 
@@ -23,7 +23,7 @@ namespace Microsoft.Maui
 			get => _weight <= 0 ? FontWeight.Regular : _weight;
 		}
 
-		private Font(string family, double size, FontSlant slant, FontWeight weight, bool enableScaling) : this()
+		private Font(string? family, double size, FontSlant slant, FontWeight weight, bool enableScaling) : this()
 		{
 			Family = family;
 			Size = size;
@@ -64,14 +64,14 @@ namespace Microsoft.Maui
 			return new Font(Family, Size, fontSlant, weight, AutoScalingEnabled);
 		}
 
-		public static Font OfSize(string name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
+		public static Font OfSize(string? name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
 			new(name, size, fontSlant, weight, enableScaling);
 
 		public static Font SystemFontOfSize(double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
-			new(String.Empty, size, fontSlant, weight, enableScaling);
+			new(null, size, fontSlant, weight, enableScaling);
 
 		public static Font SystemFontOfWeight(FontWeight weight, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
-			new(String.Empty, default(double), fontSlant, weight, enableScaling);
+			new(null, default(double), fontSlant, weight, enableScaling);
 
 		bool Equals(Font other)
 		{

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Microsoft.Maui
 {
-	public readonly struct Font
+	public readonly struct Font : IEquatable<Font>
 	{
 		public string? Family { get; }
 
@@ -109,5 +109,10 @@ namespace Microsoft.Maui
 
 		public override string ToString()
 			=> $"Family: {Family}, Size: {Size}, Weight: {Weight}, Slant: {Slant}, AutoScalingEnabled: {AutoScalingEnabled}";
+
+		bool IEquatable<Font>.Equals(Font other)
+		{
+			return Equals(other);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.Android.cs
@@ -37,33 +37,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
 		}
 
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("monospace")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var button = new ButtonStub
-			{
-				Text = "Test",
-				Font = Font.OfSize(family, 10)
-			};
-
-			var handler = await CreateHandlerAsync(button);
-			var nativeButton = GetNativeButton(handler);
-
-			var fontManager = handler.Services.GetRequiredService<IFontManager>();
-
-			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
-
-			Assert.Equal(nativeFont, nativeButton.Typeface);
-
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultTypeface, nativeButton.Typeface);
-			else
-				Assert.NotEqual(fontManager.DefaultTypeface, nativeButton.Typeface);
-		}
-
 		[Fact(DisplayName = "Button Padding Initializing")]
 		public async Task PaddingInitializesCorrectly()
 		{
@@ -126,18 +99,6 @@ namespace Microsoft.Maui.DeviceTests
 				GetNativeButton(CreateHandler(button)).PerformClick();
 			});
 		}
-
-		double GetNativeUnscaledFontSize(ButtonHandler buttonHandler)
-		{
-			var textView = GetNativeButton(buttonHandler);
-			return textView.TextSize / textView.Resources.DisplayMetrics.Density;
-		}
-
-		bool GetNativeIsBold(ButtonHandler buttonHandler) =>
-			GetNativeButton(buttonHandler).Typeface.GetFontWeight() == FontWeight.Bold;
-
-		bool GetNativeIsItalic(ButtonHandler buttonHandler) =>
-			GetNativeButton(buttonHandler).Typeface.IsItalic;
 
 		double GetNativeCharacterSpacing(ButtonHandler buttonHandler)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.cs
@@ -60,38 +60,5 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.True(clicked);
 		}
-
-		[Theory(DisplayName = "Font Size Initializes Correctly")]
-		[InlineData(1)]
-		[InlineData(10)]
-		[InlineData(20)]
-		[InlineData(100)]
-		public async Task FontSizeInitializesCorrectly(int fontSize)
-		{
-			var button = new ButtonStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", fontSize)
-			};
-
-			await ValidatePropertyInitValue(button, () => button.Font.Size, GetNativeUnscaledFontSize, button.Font.Size);
-		}
-
-		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
-		[InlineData(FontWeight.Regular, false, false)]
-		[InlineData(FontWeight.Bold, true, false)]
-		[InlineData(FontWeight.Regular, false, true)]
-		[InlineData(FontWeight.Bold, true, true)]
-		public async Task FontAttributesInitializeCorrectly(FontWeight weight, bool isBold, bool isItalic)
-		{
-			var button = new ButtonStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", 10, weight, isItalic ? FontSlant.Italic : FontSlant.Default)
-			};
-
-			await ValidatePropertyInitValue(button, () => button.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(button, () => button.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
-		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
@@ -35,31 +35,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
 		}
 
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("Times New Roman")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var button = new ButtonStub
-			{
-				Text = "Test",
-				Font = Font.OfSize(family, 10)
-			};
-
-			var (services, nativeFont) = await GetValueAsync(button, handler => (handler.Services, GetNativeButton(handler).Font));
-
-			var fontManager = services.GetRequiredService<IFontManager>();
-
-			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
-
-			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-			else
-				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-		}
-
 		[Fact(DisplayName = "Button Padding Initializing")]
 		public async Task PaddingInitializesCorrectly()
 		{
@@ -120,15 +95,6 @@ namespace Microsoft.Maui.DeviceTests
 				GetNativeButton(CreateHandler(button)).SendActionForControlEvents(UIControlEvent.TouchUpInside);
 			});
 		}
-
-		double GetNativeUnscaledFontSize(ButtonHandler buttonHandler) =>
-			GetNativeButton(buttonHandler).TitleLabel.Font.PointSize;
-
-		bool GetNativeIsBold(ButtonHandler buttonHandler) =>
-			GetNativeButton(buttonHandler).TitleLabel.Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Bold);
-
-		bool GetNativeIsItalic(ButtonHandler buttonHandler) =>
-			GetNativeButton(buttonHandler).TitleLabel.Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
 
 		double GetNativeCharacterSpacing(ButtonHandler buttonHandler)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Android.cs
@@ -90,33 +90,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
 		}
 
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("monospace")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var datePicker = new DatePickerStub()
-			{
-				Date = DateTime.Today,
-				Font = Font.OfSize(family, 10)
-			};
-
-			var handler = await CreateHandlerAsync(datePicker);
-			var nativeDatePicker = GetNativeDatePicker(handler);
-
-			var fontManager = handler.Services.GetRequiredService<IFontManager>();
-
-			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
-
-			Assert.Equal(nativeFont, nativeDatePicker.Typeface);
-
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultTypeface, nativeDatePicker.Typeface);
-			else
-				Assert.NotEqual(fontManager.DefaultTypeface, nativeDatePicker.Typeface);
-		}
-
 		MauiDatePicker GetNativeDatePicker(DatePickerHandler datePickerHandler) =>
 			datePickerHandler.NativeView;
 
@@ -155,12 +128,6 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var mauiDatePicker = GetNativeDatePicker(datePickerHandler);
 			return mauiDatePicker.LetterSpacing;
-		}
-
-		double GetNativeUnscaledFontSize(DatePickerHandler datePickerHandler)
-		{
-			var mauiDatePicker = GetNativeDatePicker(datePickerHandler);
-			return mauiDatePicker.TextSize / mauiDatePicker.Resources.DisplayMetrics.Density;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.cs
@@ -43,21 +43,5 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAsync(datePicker);
 		}
-
-		[Theory(DisplayName = "Font Size Initializes Correctly")]
-		[InlineData(1)]
-		[InlineData(10)]
-		[InlineData(20)]
-		[InlineData(100)]
-		public async Task FontSizeInitializesCorrectly(int fontSize)
-		{
-			var datePicker = new DatePickerStub()
-			{
-				Date = DateTime.Today,
-				Font = Font.OfSize("Arial", fontSize)
-			};
-
-			await ValidatePropertyInitValue(datePicker, () => datePicker.Font.Size, GetNativeUnscaledFontSize, datePicker.Font.Size);
-		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.iOS.cs
@@ -87,32 +87,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
 		}
 
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("Times New Roman")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var datePicker = new DatePickerStub()
-			{
-				Date = DateTime.Today,
-				Font = Font.OfSize(family, 10)
-			};
-
-			var handler = await CreateHandlerAsync(datePicker);
-			var nativeFont = await GetValueAsync(datePicker, handler => GetNativeDatePicker(handler).Font);
-
-			var fontManager = handler.Services.GetRequiredService<IFontManager>();
-
-			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
-
-			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-			else
-				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-		}
-
 		MauiDatePicker GetNativeDatePicker(DatePickerHandler datePickerHandler) =>
 			datePickerHandler.NativeView;
 

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -39,33 +39,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
 		}
 
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("monospace")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var editor = new EditorStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize(family, 10)
-			};
-
-			var handler = await CreateHandlerAsync(editor);
-			var nativeEditor = GetNativeEditor(handler);
-
-			var fontManager = handler.Services.GetRequiredService<IFontManager>();
-
-			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
-
-			Assert.Equal(nativeFont, nativeEditor.Typeface);
-
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultTypeface, nativeEditor.Typeface);
-			else
-				Assert.NotEqual(fontManager.DefaultTypeface, nativeEditor.Typeface);
-		}
-
 		AppCompatEditText GetNativeEditor(EditorHandler editorHandler) =>
 			(AppCompatEditText)editorHandler.NativeView;
 
@@ -95,12 +68,6 @@ namespace Microsoft.Maui.DeviceTests
 			}
 
 			return -1;
-		}
-
-		double GetNativeUnscaledFontSize(EditorHandler editorHandler)
-		{
-			var textView = GetNativeEditor(editorHandler);
-			return textView.TextSize / textView.Resources.DisplayMetrics.Density;
 		}
 
 		Color GetNativeTextColor(EditorHandler editorHandler)

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -245,22 +245,6 @@ namespace Microsoft.Maui.DeviceTests
 				unsetValue);
 		}
 
-		[Theory(DisplayName = "Font Size Initializes Correctly")]
-		[InlineData(1)]
-		[InlineData(10)]
-		[InlineData(20)]
-		[InlineData(100)]
-		public async Task FontSizeInitializesCorrectly(int fontSize)
-		{
-			var editor = new EditorStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", fontSize)
-			};
-
-			await ValidatePropertyInitValue(editor, () => editor.Font.Size, GetNativeUnscaledFontSize, editor.Font.Size);
-		}
-
 		[Theory(DisplayName = "Validates Numeric Keyboard")]
 		[InlineData(nameof(Keyboard.Chat), false)]
 		[InlineData(nameof(Keyboard.Default), false)]

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -36,32 +36,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
 		}
 
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("Times New Roman")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var editor = new EditorStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize(family, 10)
-			};
-
-			var handler = await CreateHandlerAsync(editor);
-			var nativeFont = await GetValueAsync(editor, handler => GetNativeEditor(handler).Font);
-
-			var fontManager = handler.Services.GetRequiredService<IFontManager>();
-
-			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
-
-			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-			else
-				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-		}
-
 		MauiTextView GetNativeEditor(EditorHandler editorHandler) =>
 			editorHandler.NativeView;
 

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -15,33 +15,6 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EntryHandlerTests
 	{
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("monospace")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var entry = new EntryStub
-			{
-				Text = "Test",
-				Font = Font.OfSize(family, 10)
-			};
-
-			var handler = await CreateHandlerAsync(entry);
-			var nativeEntry = GetNativeEntry(handler);
-
-			var fontManager = handler.Services.GetRequiredService<IFontManager>();
-
-			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
-
-			Assert.Equal(nativeFont, nativeEntry.Typeface);
-
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultTypeface, nativeEntry.Typeface);
-			else
-				Assert.NotEqual(fontManager.DefaultTypeface, nativeEntry.Typeface);
-		}
-
 		[Fact(DisplayName = "ReturnType Initializes Correctly")]
 		public async Task ReturnTypeInitializesCorrectly()
 		{
@@ -202,18 +175,6 @@ namespace Microsoft.Maui.DeviceTests
 
 			return inputTypes.HasFlag(InputTypes.ClassText) && inputTypes.HasFlag(InputTypes.TextFlagCapSentences) && !inputTypes.HasFlag(InputTypes.TextFlagNoSuggestions);
 		}
-
-		double GetNativeUnscaledFontSize(EntryHandler entryHandler)
-		{
-			var textView = GetNativeEntry(entryHandler);
-			return textView.TextSize / textView.Resources.DisplayMetrics.Density;
-		}
-
-		bool GetNativeIsBold(EntryHandler entryHandler) =>
-			GetNativeEntry(entryHandler).Typeface.GetFontWeight() == FontWeight.Bold;
-
-		bool GetNativeIsItalic(EntryHandler entryHandler) =>
-			GetNativeEntry(entryHandler).Typeface.IsItalic;
 
 		Android.Views.TextAlignment GetNativeHorizontalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -174,39 +174,6 @@ namespace Microsoft.Maui.DeviceTests
 				unsetValue);
 		}
 
-		[Theory(DisplayName = "Font Size Initializes Correctly")]
-		[InlineData(1)]
-		[InlineData(10)]
-		[InlineData(20)]
-		[InlineData(100)]
-		public async Task FontSizeInitializesCorrectly(int fontSize)
-		{
-			var entry = new EntryStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", fontSize)
-			};
-
-			await ValidatePropertyInitValue(entry, () => entry.Font.Size, GetNativeUnscaledFontSize, entry.Font.Size);
-		}
-
-		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
-		[InlineData(FontWeight.Regular, false, false)]
-		[InlineData(FontWeight.Bold, true, false)]
-		[InlineData(FontWeight.Regular, false, true)]
-		[InlineData(FontWeight.Bold, true, true)]
-		public async Task FontAttributesInitializeCorrectly(FontWeight weight, bool isBold, bool isItalic)
-		{
-			var entry = new EntryStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", 10, weight, isItalic ? FontSlant.Italic : FontSlant.Default)
-			};
-
-			await ValidatePropertyInitValue(entry, () => entry.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(entry, () => entry.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
-		}
-
 		[Theory(DisplayName = "Validates clear button visibility.")]
 		[InlineData(ClearButtonVisibility.WhileEditing, true)]
 		[InlineData(ClearButtonVisibility.Never, false)]

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -10,31 +10,6 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EntryHandlerTests
 	{
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("Times New Roman")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var entry = new EntryStub
-			{
-				Text = "Test",
-				Font = Font.OfSize(family, 10)
-			};
-
-			var (services, nativeFont) = await GetValueAsync(entry, handler => (handler.Services, GetNativeEntry(handler).Font));
-
-			var fontManager = services.GetRequiredService<IFontManager>();
-
-			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
-
-			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-			else
-				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-		}
-
 		[Fact(DisplayName = "Horizontal TextAlignment Initializes Correctly")]
 		public async Task HorizontalTextAlignmentInitializesCorrectly()
 		{
@@ -196,15 +171,6 @@ namespace Microsoft.Maui.DeviceTests
 				nativeEntry.AutocorrectionType == UITextAutocorrectionType.Yes &&
 				nativeEntry.SpellCheckingType == UITextSpellCheckingType.No;
 		}
-
-		double GetNativeUnscaledFontSize(EntryHandler entryHandler) =>
-			GetNativeEntry(entryHandler).Font.PointSize;
-
-		bool GetNativeIsBold(EntryHandler entryHandler) =>
-			GetNativeEntry(entryHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Bold);
-
-		bool GetNativeIsItalic(EntryHandler entryHandler) =>
-			GetNativeEntry(entryHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
 
 		bool GetNativeClearButtonVisibility(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ClearButtonMode == UITextFieldViewMode.WhileEditing;

--- a/src/Core/tests/DeviceTests/Handlers/Fonts/FontTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Fonts/FontTests.Android.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected TextView GetNativeTextView(THandler handler) =>
 			GetNativeTextView(handler as ElementHandler);
-		
+
 		protected TextView GetNativeTextView(ElementHandler handler)
 		{
 			switch (handler.NativeView)
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.DeviceTests
 				case SearchView sv:
 					return sv.GetFirstChildOfType<EditText>();
 				default:
-					Assert.False(false, $"I don't know how to get the TextView from here {handler}");
+					Assert.True(false, $"I don't know how to get the TextView from here {handler.NativeView}");
 					return null;
 
 			}

--- a/src/Core/tests/DeviceTests/Handlers/Fonts/FontTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Fonts/FontTests.Android.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using Android.Graphics;
+using Android.Widget;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Handlers;
+using Xunit;
+using SearchView = AndroidX.AppCompat.Widget.SearchView;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class HandlerTestBase<THandler, TStub>
+	{
+		[Theory(DisplayName = "Font Family Initializes Correctly")]
+		[InlineData(null)]
+		[InlineData("monospace")]
+		[InlineData("Dokdo")]
+		public async Task FontFamilyInitializesCorrectly(string family)
+		{
+			var view = new TStub();
+			if (view is not ITextStyle)
+				return;
+
+			view.GetType().GetProperty("Font").SetValue(view, Font.OfSize(family, 10));
+			var handler = (await CreateHandlerAsync(view)) as ElementHandler;
+
+			Typeface nativeTypeFace = GetNativeTextView(handler).Typeface;
+
+			var fontManager = handler.Services.GetRequiredService<IFontManager>();
+
+			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
+
+			Assert.Equal(nativeFont, nativeTypeFace);
+
+			if (string.IsNullOrEmpty(family))
+				Assert.Equal(fontManager.DefaultTypeface, nativeTypeFace);
+			else
+				Assert.NotEqual(fontManager.DefaultTypeface, nativeTypeFace);
+		}
+
+		protected double GetNativeUnscaledFontSize(THandler handler, bool autoScalingEnabled)
+		{
+			var textView = GetNativeTextView(handler);
+
+			var scaleFactor = textView.Resources.DisplayMetrics.Density;
+
+			if (autoScalingEnabled)
+				scaleFactor = scaleFactor * textView.Context.Resources.Configuration.FontScale;
+
+			double returnValue = textView.TextSize / scaleFactor;
+
+			return returnValue;
+		}
+
+		protected TextView GetNativeTextView(THandler handler) =>
+			GetNativeTextView(handler as ElementHandler);
+		
+		protected TextView GetNativeTextView(ElementHandler handler)
+		{
+			switch (handler.NativeView)
+			{
+				case TextView tv:
+					return tv;
+				case SearchView sv:
+					return sv.GetFirstChildOfType<EditText>();
+				default:
+					Assert.False(false, $"I don't know how to get the TextView from here {handler}");
+					return null;
+
+			}
+		}
+
+		protected bool GetNativeIsBold(THandler handler) =>
+			GetNativeTextView(handler).Typeface.GetFontWeight() == FontWeight.Bold;
+
+		protected bool GetNativeIsItalic(THandler handler) =>
+			GetNativeTextView(handler).Typeface.IsItalic;
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Fonts/FontTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Fonts/FontTests.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class HandlerTestBase<THandler, TStub>
+	{
+		[Theory(DisplayName = "Font Size Initializes Correctly")]
+		[InlineData(1)]
+		[InlineData(10)]
+		[InlineData(20)]
+		[InlineData(100)]
+		public async Task FontSizeInitializesCorrectly(int fontSize)
+		{
+			var view = new TStub();
+			if (view is not ITextStyle textStyle)
+				return;
+
+			view.GetType().GetProperty("Font").SetValue(view, Font.OfSize("Arial", fontSize, enableScaling: false));
+			await ValidatePropertyInitValue(view, () => textStyle.Font.Size, (h) => GetNativeUnscaledFontSize(h, false), textStyle.Font.Size);
+		}
+
+		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
+		[InlineData(FontWeight.Regular, false, false)]
+		[InlineData(FontWeight.Bold, true, false)]
+		[InlineData(FontWeight.Regular, false, true)]
+		[InlineData(FontWeight.Bold, true, true)]
+		public async Task FontAttributesInitializeCorrectly(FontWeight weight, bool isBold, bool isItalic)
+		{
+			var view = new TStub();
+			if (view is not ITextStyle textStyle)
+				return;
+
+			view.GetType().GetProperty("Font").SetValue(view, Font.OfSize("Arial", 10, weight, isItalic ? FontSlant.Italic : FontSlant.Default));
+
+			await ValidatePropertyInitValue(view, () => textStyle.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
+			await ValidatePropertyInitValue(view, () => textStyle.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
+		}
+
+		[Theory(DisplayName = "Auto Scaling Enabled Initializes Correctly")]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task FontAutoScalingEnabledInitializesCorrectly(bool enableAutoScaling)
+		{
+			var view = new TStub();
+			if (view is not ITextStyle textStyle)
+				return;
+
+			view.GetType().GetProperty("Font").SetValue(view, Font.OfSize(null, 10, enableScaling: enableAutoScaling));
+			await ValidatePropertyInitValue(view, () => textStyle.Font.Size, (h) => GetNativeUnscaledFontSize(h, enableAutoScaling), textStyle.Font.Size);
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Fonts/FontTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Fonts/FontTests.iOS.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Handlers;
+using UIKit;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class HandlerTestBase<THandler, TStub>
+	{
+		[Theory(DisplayName = "Font Family Initializes Correctly")]
+		[InlineData(null)]
+		[InlineData("Times New Roman")]
+		[InlineData("Dokdo")]
+		public async Task FontFamilyInitializesCorrectly(string family)
+		{
+			var view = new TStub();
+			if (view is not ITextStyle)
+				return;
+
+			view.GetType().GetProperty("Font").SetValue(view, Font.OfSize(family, 10));
+
+			var handler = await CreateHandlerAsync(view);
+			var nativeFont = await GetValueAsync(view, handler => GetNativeFont(handler));
+
+			var fontManager = (handler as ElementHandler).Services.GetRequiredService<IFontManager>();
+
+			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
+
+			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
+			if (string.IsNullOrEmpty(family))
+				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
+			else
+				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
+		}
+
+		protected bool GetNativeIsBold(THandler handler) =>
+			GetNativeFont(handler).FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Bold);
+
+		protected bool GetNativeIsItalic(THandler handler) =>
+			GetNativeFont(handler).FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
+
+		protected double GetNativeUnscaledFontSize(THandler handler, bool autoScalingEnabled)
+		{
+			var returnValue = GetNativeFont(handler).PointSize;
+
+			if(autoScalingEnabled)
+			{
+				var scale = UIFontMetrics.DefaultMetrics.GetScaledValue(1);
+				returnValue = returnValue / scale;
+			}
+
+			return returnValue;
+		}
+
+		protected UIFont GetNativeFont(THandler handler) =>
+			GetNativeFont(handler as ElementHandler);
+		
+		protected UIFont GetNativeFont(ElementHandler handler)
+		{
+			switch (handler.NativeView)
+			{
+				case UITextField tf:
+					return tf.Font;
+				case UIButton button:
+					return button.TitleLabel.Font;
+				case UILabel label:
+					return label.Font;
+				case UISearchBar searchBar:
+					return searchBar.FindDescendantView<UITextField>().Font;
+				default:
+					Assert.False(false, $"I don't know how to get the UIFont from here {handler}");
+					return null;
+
+			}
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
@@ -15,33 +15,6 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class LabelHandlerTests
 	{
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("monospace")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var label = new LabelStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize(family, 10)
-			};
-
-			var handler = await CreateHandlerAsync(label);
-			var nativeLabel = GetNativeLabel(handler);
-
-			var fontManager = handler.Services.GetRequiredService<IFontManager>();
-
-			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
-
-			Assert.Equal(nativeFont, nativeLabel.Typeface);
-
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultTypeface, nativeLabel.Typeface);
-			else
-				Assert.NotEqual(fontManager.DefaultTypeface, nativeLabel.Typeface);
-		}
-
 		[Fact(DisplayName = "Horizontal TextAlignment Initializes Correctly")]
 		public async Task HorizontalTextAlignmentInitializesCorrectly()
 		{
@@ -131,18 +104,6 @@ namespace Microsoft.Maui.DeviceTests
 
 		Color GetNativeTextColor(LabelHandler labelHandler) =>
 			((uint)GetNativeLabel(labelHandler).CurrentTextColor).ToColor();
-
-		double GetNativeUnscaledFontSize(LabelHandler labelHandler)
-		{
-			var textView = GetNativeLabel(labelHandler);
-			return textView.TextSize / textView.Resources.DisplayMetrics.Density;
-		}
-
-		bool GetNativeIsBold(LabelHandler labelHandler) =>
-			GetNativeLabel(labelHandler).Typeface.GetFontWeight() == FontWeight.Bold;
-
-		bool GetNativeIsItalic(LabelHandler labelHandler) =>
-			GetNativeLabel(labelHandler).Typeface.IsItalic;
 
 		(GravityFlags gravity, ATextAlignemnt alignment) GetNativeHorizontalTextAlignment(LabelHandler labelHandler)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.cs
@@ -58,39 +58,6 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAsync(label);
 		}
 
-		[Theory(DisplayName = "Font Size Initializes Correctly")]
-		[InlineData(1)]
-		[InlineData(10)]
-		[InlineData(20)]
-		[InlineData(100)]
-		public async Task FontSizeInitializesCorrectly(int fontSize)
-		{
-			var label = new LabelStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", fontSize)
-			};
-
-			await ValidatePropertyInitValue(label, () => label.Font.Size, GetNativeUnscaledFontSize, label.Font.Size);
-		}
-
-		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
-		[InlineData(FontWeight.Regular, false, false)]
-		[InlineData(FontWeight.Bold, true, false)]
-		[InlineData(FontWeight.Regular, false, true)]
-		[InlineData(FontWeight.Bold, true, true)]
-		public async Task FontAttributesInitializeCorrectly(FontWeight weight, bool isBold, bool isItalic)
-		{
-			var label = new LabelStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", 10, weight, isItalic ? FontSlant.Italic : FontSlant.Default)
-			};
-
-			await ValidatePropertyInitValue(label, () => label.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(label, () => label.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
-		}
-
 		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
 		public async Task CharacterSpacingInitializesCorrectly()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
@@ -13,31 +13,6 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class LabelHandlerTests
 	{
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("Times New Roman")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var label = new LabelStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize(family, 10)
-			};
-
-			var (services, nativeFont) = await GetValueAsync(label, handler => (handler.Services, GetNativeLabel(handler).Font));
-
-			var fontManager = services.GetRequiredService<IFontManager>();
-
-			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
-
-			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-			else
-				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-		}
-
 		[Fact(DisplayName = "Horizontal TextAlignment Updates Correctly")]
 		public async Task HorizontalTextAlignmentInitializesCorrectly()
 		{
@@ -209,15 +184,6 @@ namespace Microsoft.Maui.DeviceTests
 
 		Color GetNativeTextColor(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).TextColor.ToColor();
-
-		double GetNativeUnscaledFontSize(LabelHandler labelHandler) =>
-			GetNativeLabel(labelHandler).Font.PointSize;
-
-		bool GetNativeIsBold(LabelHandler labelHandler) =>
-			GetNativeLabel(labelHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Bold);
-
-		bool GetNativeIsItalic(LabelHandler labelHandler) =>
-			GetNativeLabel(labelHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
 
 		int GetNativeMaxLines(LabelHandler labelHandler) =>
  			(int)GetNativeLabel(labelHandler).Lines;

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
@@ -88,18 +88,6 @@ namespace Microsoft.Maui.DeviceTests
 			return -1;
 		}
 
-		double GetNativeUnscaledFontSize(PickerHandler pickerHandler)
-		{
-			var mauiPicker = GetNativePicker(pickerHandler);
-			return mauiPicker.TextSize / mauiPicker.Resources.DisplayMetrics.Density;
-		}
-
-		bool GetNativeIsBold(PickerHandler pickerHandler) =>
-			GetNativePicker(pickerHandler).Typeface.GetFontWeight() == FontWeight.Bold;
-
-		bool GetNativeIsItalic(PickerHandler pickerHandler) =>
-			GetNativePicker(pickerHandler).Typeface.IsItalic;
-
 		ATextAlignment GetNativeHorizontalTextAlignment(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).TextAlignment;
 

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.cs
@@ -9,59 +9,6 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Picker)]
 	public partial class PickerHandlerTests : HandlerTestBase<PickerHandler, PickerStub>
 	{
-		[Theory(DisplayName = "Font Size Initializes Correctly")]
-		[InlineData(1)]
-		[InlineData(10)]
-		[InlineData(20)]
-		[InlineData(100)]
-		public async Task FontSizeInitializesCorrectly(int fontSize)
-		{
-			var items = new List<string>
-			{
-				"Item 1",
-				"Item 2",
-				"Item 3"
-			};
-
-			var picker = new PickerStub()
-			{
-				Title = "Select an Item",
-				Font = Font.OfSize("Arial", fontSize)
-			};
-
-			picker.ItemsSource = items;
-			picker.SelectedIndex = 0;
-
-			await ValidatePropertyInitValue(picker, () => picker.Font.Size, GetNativeUnscaledFontSize, picker.Font.Size);
-		}
-
-		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
-		[InlineData(FontWeight.Regular, false, false)]
-		[InlineData(FontWeight.Bold, true, false)]
-		[InlineData(FontWeight.Regular, false, true)]
-		[InlineData(FontWeight.Bold, true, true)]
-		public async Task FontAttributesInitializeCorrectly(FontWeight weight, bool isBold, bool isItalic)
-		{
-			var items = new List<string>
-			{
-				"Item 1",
-				"Item 2",
-				"Item 3"
-			};
-
-			var picker = new PickerStub()
-			{
-				Title = "Select an Item",
-				Font = Font.OfSize("Arial", 10, weight, isItalic ? FontSlant.Italic : FontSlant.Default)
-			};
-
-			picker.ItemsSource = items;
-			picker.SelectedIndex = 0;
-
-			await ValidatePropertyInitValue(picker, () => picker.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(picker, () => picker.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
-		}
-
 		[Theory(DisplayName = "Updating Font Does Not Affect HorizontalTextAlignment")]
 		[InlineData(10, 20)]
 		[InlineData(20, 10)]

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -66,15 +66,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, selectedIndex);
 		}
 
-		double GetNativeUnscaledFontSize(PickerHandler pickerHandler) =>
-			GetNativePicker(pickerHandler).Font.PointSize;
-
-		bool GetNativeIsBold(PickerHandler pickerHandler) =>
-			GetNativePicker(pickerHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Bold);
-
-		bool GetNativeIsItalic(PickerHandler pickerHandler) =>
-			GetNativePicker(pickerHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
-
 		UITextAlignment GetNativeHorizontalTextAlignment(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).TextAlignment;
 

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -122,39 +122,6 @@ namespace Microsoft.Maui.DeviceTests
 			return editText.TextAlignment;
 		}
 
-		double GetNativeUnscaledFontSize(SearchBarHandler searchBarHandler)
-		{
-			var searchView = GetNativeSearchBar(searchBarHandler);
-			var editText = searchView.GetChildrenOfType<EditText>().FirstOrDefault();
-
-			if (editText == null)
-				return -1;
-
-			return editText.TextSize / editText.Resources.DisplayMetrics.Density;
-		}
-
-		bool GetNativeIsBold(SearchBarHandler searchBarHandler)
-		{
-			var searchView = GetNativeSearchBar(searchBarHandler);
-			var editText = searchView.GetChildrenOfType<EditText>().FirstOrDefault();
-
-			if (editText == null)
-				return false;
-
-			return editText.Typeface.GetFontWeight() == FontWeight.Bold;
-		}
-
-		bool GetNativeIsItalic(SearchBarHandler searchBarHandler)
-		{
-			var searchView = GetNativeSearchBar(searchBarHandler);
-			var editText = searchView.GetChildrenOfType<EditText>().FirstOrDefault();
-
-			if (editText == null)
-				return false;
-
-			return editText.Typeface.IsItalic;
-		}
-
 		Task ValidateHasColor(ISearchBar searchBar, Color color, Action action = null)
 		{
 			return InvokeOnMainThreadAsync(() =>

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -78,39 +78,6 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(searchBar, () => searchBar.Placeholder, GetNativePlaceholder, searchBar.Placeholder);
 		}
 
-		[Theory(DisplayName = "Font Size Initializes Correctly")]
-		[InlineData(1)]
-		[InlineData(10)]
-		[InlineData(20)]
-		[InlineData(100)]
-		public async Task FontSizeInitializesCorrectly(int fontSize)
-		{
-			var searchBar = new SearchBarStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", fontSize)
-			};
-
-			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.Size, GetNativeUnscaledFontSize, searchBar.Font.Size);
-		}
-
-		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
-		[InlineData(FontWeight.Regular, false, false)]
-		[InlineData(FontWeight.Bold, true, false)]
-		[InlineData(FontWeight.Regular, false, true)]
-		[InlineData(FontWeight.Bold, true, true)]
-		public async Task FontAttributesInitializeCorrectly(FontWeight weight, bool isBold, bool isItalic)
-		{
-			var searchBar = new SearchBarStub()
-			{
-				Text = "Test",
-				Font = Font.OfSize("Arial", 10, weight, isItalic ? FontSlant.Italic : FontSlant.Default),
-			};
-
-			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(searchBar, () => searchBar.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
-		}
-
 		[Theory(DisplayName = "MaxLength Initializes Correctly")]
 		[InlineData(2)]
 		[InlineData(5)]

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -111,28 +111,6 @@ namespace Microsoft.Maui.DeviceTests
 			return textField.Font.PointSize;
 		}
 
-		bool GetNativeIsBold(SearchBarHandler searchBarHandler)
-		{
-			var uiSearchBar = GetNativeSearchBar(searchBarHandler);
-			var textField = uiSearchBar.FindDescendantView<UITextField>();
-
-			if (textField == null)
-				return false;
-
-			return textField.Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Bold);
-		}
-
-		bool GetNativeIsItalic(SearchBarHandler searchBarHandler)
-		{
-			var uiSearchBar = GetNativeSearchBar(searchBarHandler);
-			var textField = uiSearchBar.FindDescendantView<UITextField>();
-
-			if (textField == null)
-				return false;
-
-			return textField.Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
-		}
-
 		Task ValidateHasColor(ISearchBar searchBar, Color color, Action action = null)
 		{
 			return InvokeOnMainThreadAsync(() =>

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.Android.cs
@@ -37,33 +37,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
 		}
 
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("monospace")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var timePicker = new TimePickerStub()
-			{
-				Time = TimeSpan.FromHours(7),
-				Font = Font.OfSize(family, 10)
-			};
-
-			var handler = await CreateHandlerAsync(timePicker);
-			var nativeEntry = GetNativeTimePicker(handler);
-
-			var fontManager = handler.Services.GetRequiredService<IFontManager>();
-
-			var nativeFont = fontManager.GetTypeface(Font.OfSize(family, 0.0));
-
-			Assert.Equal(nativeFont, nativeEntry.Typeface);
-
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultTypeface, nativeEntry.Typeface);
-			else
-				Assert.NotEqual(fontManager.DefaultTypeface, nativeEntry.Typeface);
-		}
-
 		MauiTimePicker GetNativeTimePicker(TimePickerHandler timePickerHandler) =>
 			(MauiTimePicker)timePickerHandler.NativeView;
 
@@ -99,17 +72,5 @@ namespace Microsoft.Maui.DeviceTests
 			AColor currentTextColor = new AColor(currentTextColorInt);
 			return currentTextColor.ToColor();
 		}
-
-		double GetNativeUnscaledFontSize(TimePickerHandler timePickerHandler)
-		{
-			var mauiTimePicker = GetNativeTimePicker(timePickerHandler);
-			return mauiTimePicker.TextSize / mauiTimePicker.Resources.DisplayMetrics.Density;
-		}
-
-		bool GetNativeIsBold(TimePickerHandler timePickerHandler) =>
-			GetNativeTimePicker(timePickerHandler).Typeface.GetFontWeight() == FontWeight.Bold;
-
-		bool GetNativeIsItalic(TimePickerHandler timePickerHandler) =>
-			GetNativeTimePicker(timePickerHandler).Typeface.IsItalic;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.cs
@@ -23,39 +23,6 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateTime(timePicker, () => timePicker.Time = time);
 		}
 
-		[Theory(DisplayName = "Font Size Initializes Correctly")]
-		[InlineData(1)]
-		[InlineData(10)]
-		[InlineData(20)]
-		[InlineData(100)]
-		public async Task FontSizeInitializesCorrectly(int fontSize)
-		{
-			var timePicker = new TimePickerStub()
-			{
-				Time = new TimeSpan(17, 0, 0),
-				Font = Font.OfSize("Arial", fontSize)
-			};
-
-			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.Size, GetNativeUnscaledFontSize, timePicker.Font.Size);
-		}
-
-		[Theory(DisplayName = "Font Attributes Initialize Correctly")]
-		[InlineData(FontWeight.Regular, false, false)]
-		[InlineData(FontWeight.Bold, true, false)]
-		[InlineData(FontWeight.Regular, false, true)]
-		[InlineData(FontWeight.Bold, true, true)]
-		public async Task FontAttributesInitializeCorrectly(FontWeight weight, bool isBold, bool isItalic)
-		{
-			var timePicker = new TimePickerStub()
-			{
-				Time = new TimeSpan(17, 0, 0),
-				Font = Font.OfSize("Arial", 10, weight, isItalic ? FontSlant.Italic : FontSlant.Default)
-			};
-
-			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.Weight == FontWeight.Bold, GetNativeIsBold, isBold);
-			await ValidatePropertyInitValue(timePicker, () => timePicker.Font.Slant == FontSlant.Italic, GetNativeIsItalic, isItalic);
-		}
-
 		[Fact(DisplayName = "Null Text Color Doesn't Crash")]
 		public async Task NullTextColorDoesntCrash()
 		{

--- a/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TimePicker/TimePickerHandlerTests.iOS.cs
@@ -35,31 +35,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
 		}
 
-		[Theory(DisplayName = "Font Family Initializes Correctly")]
-		[InlineData(null)]
-		[InlineData("Times New Roman")]
-		[InlineData("Dokdo")]
-		public async Task FontFamilyInitializesCorrectly(string family)
-		{
-			var timePicker = new TimePickerStub
-			{
-				Time = TimeSpan.FromHours(8),
-				Font = Font.OfSize(family, 10)
-			};
-
-			var (services, nativeFont) = await GetValueAsync(timePicker, handler => (handler.Services, GetNativeTimePicker(handler).Font));
-
-			var fontManager = services.GetRequiredService<IFontManager>();
-
-			var expectedNativeFont = fontManager.GetFont(Font.OfSize(family, 0.0));
-
-			Assert.Equal(expectedNativeFont.FamilyName, nativeFont.FamilyName);
-			if (string.IsNullOrEmpty(family))
-				Assert.Equal(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-			else
-				Assert.NotEqual(fontManager.DefaultFont.FamilyName, nativeFont.FamilyName);
-		}
-
 		MauiTimePicker GetNativeTimePicker(TimePickerHandler timePickerHandler) =>
 			(MauiTimePicker)timePickerHandler.NativeView;
 
@@ -86,14 +61,5 @@ namespace Microsoft.Maui.DeviceTests
 			var mauiTimePicker = GetNativeTimePicker(timePickerHandler);
 			return mauiTimePicker.AttributedText.GetCharacterSpacing();
 		}
-
-		double GetNativeUnscaledFontSize(TimePickerHandler timePickerHandler) =>
-			GetNativeTimePicker(timePickerHandler).Font.PointSize;
-
-		bool GetNativeIsBold(TimePickerHandler timePickerHandler) =>
-			GetNativeTimePicker(timePickerHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Bold);
-
-		bool GetNativeIsItalic(TimePickerHandler timePickerHandler) =>
-			GetNativeTimePicker(timePickerHandler).Font.FontDescriptor.SymbolicTraits.HasFlag(UIFontDescriptorSymbolicTraits.Italic);
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implements #1683

For Android/WinUI the default behavior here doesn't change. 

This now means that fonts on iOS will auto scale based on the dynamic font sizing settings on the device

![image](https://user-images.githubusercontent.com/5375137/126825428-91414543-ab52-4dee-bb91-f4c11590ec95.png)


### Additions made ###
- Adds Font.AutoScalingEnabled
- Adds Button.FontAutoScalingEnabled
- Adds DatePicker.FontAutoScalingEnabled
- Adds Editor.FontAutoScalingEnabled
- Adds Entry.FontAutoScalingEnabled
- Adds FontElement.FontAutoScalingEnabled
- Adds Label.FontAutoScalingEnabled
- Adds Picker.FontAutoScalingEnabled
- Adds RadioButton.FontAutoScalingEnabled
- Adds SearchBar.FontAutoScalingEnabled
- Adds Span.FontAutoScalingEnabled
- Adds TimePicker.FontAutoScalingEnabled
- Adds FontImageSource.FontAutoScalingEnabled

- (Android) Adds 
```C#
	public struct FontSize
	{
		public FontSize(float value, ComplexUnitType unit)
		{
			Value = value;
			Unit = unit;
		}

		public float Value { get; set; }
		public ComplexUnitType Unit { get; set; }
	}
```
- (Android) Changes `float IFontManager.GetSize` => `FontSize IFontManager.GetSize`

### Removed ###
- Button.Font (to make Button consistent with all the other controls)
- (iOS) IFontManager.GetSize  Nothing outside of FontManager is currently using this so I just removed it for now
