### PR TITLE
Navigation Events

### DIFF
--- a/src/Compatibility/Core/src/Windows/NavigationPageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/NavigationPageRenderer.cs
@@ -460,7 +460,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		void PushExistingNavigationStack()
 		{
-			foreach (var page in Element.Pages)
+			INavigationPageController navigationPageController = Element;
+			foreach (var page in navigationPageController.Pages)
 			{
 				SetPage(page, false, false);
 			}

--- a/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		IPageController PageController => Element as IPageController;
 
 		NavigationPage NavPage => Element as NavigationPage;
+		INavigationPageController NavPageController => NavPage;
 
 		public VisualElement Element { get; private set; }
 
@@ -237,7 +238,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
 			// If there is already stuff on the stack we need to push it
-			navPage.Pages.ForEach(async p => await PushPageAsync(p, false));
+			NavPageController.Pages.ForEach(async p => await PushPageAsync(p, false));
 
 			_tracker = new VisualElementTracker(this);
 
@@ -1218,7 +1219,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 					return;
 
 				var currentChild = this.Child;
-				var firstPage = n.NavPage.Pages.FirstOrDefault();
+				var firstPage = n.NavPageController.Pages.FirstOrDefault();
 
 
 				if (n._parentFlyoutPage == null)

--- a/src/Controls/src/Core/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage.cs
@@ -40,12 +40,19 @@ namespace Microsoft.Maui.Controls
 				if (value.RealParent != null)
 					throw new InvalidOperationException("Detail must not already have a parent.");
 
+				var previousDetail = _detail;
+				// TODO MAUI refine this to fire earlier
+				_detail?.SendNavigatingFrom(new NavigatingFromEventArgs());
+
 				OnPropertyChanging();
 				if (_detail != null)
 					InternalChildren.Remove(_detail);
 				_detail = value;
 				InternalChildren.Add(_detail);
 				OnPropertyChanged();
+
+				previousDetail?.SendNavigatedFrom(new NavigatedFromEventArgs(_detail));
+				_detail?.SendNavigatedTo(new NavigatedToEventArgs(previousDetail));
 			}
 		}
 
@@ -78,12 +85,18 @@ namespace Microsoft.Maui.Controls
 				if (value.RealParent != null)
 					throw new InvalidOperationException("Flyout must not already have a parent.");
 
+				// TODO MAUI refine this to fire earlier
+				var previousFlyout = value;
+
 				OnPropertyChanging();
 				if (_flyout != null)
 					InternalChildren.Remove(_flyout);
 				_flyout = value;
 				InternalChildren.Add(_flyout);
 				OnPropertyChanged();
+
+				previousFlyout?.SendNavigatedFrom(new NavigatedFromEventArgs(_flyout));
+				_flyout.SendNavigatedTo(new NavigatedToEventArgs(previousFlyout));
 			}
 		}
 

--- a/src/Controls/src/Core/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage.cs
@@ -86,7 +86,9 @@ namespace Microsoft.Maui.Controls
 					throw new InvalidOperationException("Flyout must not already have a parent.");
 
 				// TODO MAUI refine this to fire earlier
-				var previousFlyout = value;
+				var previousFlyout = _flyout;
+				// TODO MAUI refine this to fire earlier
+				_flyout?.SendNavigatingFrom(new NavigatingFromEventArgs());
 
 				OnPropertyChanging();
 				if (_flyout != null)

--- a/src/Controls/src/Core/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Controls
 				OnPropertyChanged();
 
 				previousFlyout?.SendNavigatedFrom(new NavigatedFromEventArgs(_flyout));
-				_flyout.SendNavigatedTo(new NavigatedToEventArgs(previousFlyout));
+				_flyout?.SendNavigatedTo(new NavigatedToEventArgs(previousFlyout));
 			}
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -14,28 +14,28 @@ namespace Microsoft.Maui.Controls
 		internal void SendNavigatedTo(NavigatedToEventArgs args)
 		{
 			NavigatedTo?.Invoke(this, args);
-			OnNavigatedTo();
+			OnNavigatedTo(args);
 		}
 
 		internal void SendNavigatingFrom(NavigatingFromEventArgs args)
 		{
 			NavigatingFrom?.Invoke(this, args);
-			OnNavigatingFrom();
+			OnNavigatingFrom(args);
 		}
 
 		internal void SendNavigatedFrom(NavigatedFromEventArgs args)
 		{
 			NavigatedFrom?.Invoke(this, args);
-			OnNavigatedFrom();
+			OnNavigatedFrom(args);
 		}
 
 		public event EventHandler<NavigatedToEventArgs> NavigatedTo;
 		public event EventHandler<NavigatingFromEventArgs> NavigatingFrom;
 		public event EventHandler<NavigatedFromEventArgs> NavigatedFrom;
 
-		protected virtual void OnNavigatedTo() { }
-		protected virtual void OnNavigatingFrom() { }
-		protected virtual void OnNavigatedFrom() { }
+		protected virtual void OnNavigatedTo(NavigatedToEventArgs args) { }
+		protected virtual void OnNavigatingFrom(NavigatingFromEventArgs args) { }
+		protected virtual void OnNavigatedFrom(NavigatedFromEventArgs args) { }
 	}
 
 	public sealed class NavigatingFromEventArgs : EventArgs

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Controls
 			PreviousPage = previousPage;
 		}
 
-		public Page PreviousPage { get; }
+		internal Page PreviousPage { get; }
 	}
 
 	public sealed class NavigatedFromEventArgs : EventArgs
@@ -60,6 +60,6 @@ namespace Microsoft.Maui.Controls
 			DestinationPage = destinationPage;
 		}
 
-		public Page DestinationPage { get; }
+		internal Page DestinationPage { get; }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -14,21 +14,28 @@ namespace Microsoft.Maui.Controls
 		internal void SendNavigatedTo(NavigatedToEventArgs args)
 		{
 			NavigatedTo?.Invoke(this, args);
+			OnNavigatedTo();
 		}
 
 		internal void SendNavigatingFrom(NavigatingFromEventArgs args)
 		{
 			NavigatingFrom?.Invoke(this, args);
+			OnNavigatingFrom();
 		}
 
 		internal void SendNavigatedFrom(NavigatedFromEventArgs args)
 		{
 			NavigatedFrom?.Invoke(this, args);
+			OnNavigatedFrom();
 		}
 
 		public event EventHandler<NavigatedToEventArgs> NavigatedTo;
 		public event EventHandler<NavigatingFromEventArgs> NavigatingFrom;
 		public event EventHandler<NavigatedFromEventArgs> NavigatedFrom;
+
+		protected virtual void OnNavigatedTo() { }
+		protected virtual void OnNavigatingFrom() { }
+		protected virtual void OnNavigatedFrom() { }
 	}
 
 	public sealed class NavigatingFromEventArgs : EventArgs

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Controls.Internals;
+﻿using System;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -9,5 +10,49 @@ namespace Microsoft.Maui.Controls
 
 		// TODO ezhart super sus
 		public Thickness Margin => Thickness.Zero;
+
+		internal void SendNavigatedTo(NavigatedToEventArgs args)
+		{
+			NavigatedTo?.Invoke(this, args);
+		}
+
+		internal void SendNavigatingFrom(NavigatingFromEventArgs args)
+		{
+			NavigatingFrom?.Invoke(this, args);
+		}
+
+		internal void SendNavigatedFrom(NavigatedFromEventArgs args)
+		{
+			NavigatedFrom?.Invoke(this, args);
+		}
+
+		public event EventHandler<NavigatedToEventArgs> NavigatedTo;
+		public event EventHandler<NavigatingFromEventArgs> NavigatingFrom;
+		public event EventHandler<NavigatedFromEventArgs> NavigatedFrom;
+	}
+
+	public sealed class NavigatingFromEventArgs : EventArgs
+	{
+
+	}
+
+	public sealed class NavigatedToEventArgs : EventArgs
+	{
+		internal NavigatedToEventArgs(Page previousPage)
+		{
+			PreviousPage = previousPage;
+		}
+
+		public Page PreviousPage { get; }
+	}
+
+	public sealed class NavigatedFromEventArgs : EventArgs
+	{
+		internal NavigatedFromEventArgs(Page destinationPage)
+		{
+			DestinationPage = destinationPage;
+		}
+
+		public Page DestinationPage { get; }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/View.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/View.Impl.cs
@@ -26,11 +26,5 @@ namespace Microsoft.Maui.Controls
 
 			base.OnHandlerChangingCore(args);
 		}
-
-		void IView.NavigatedTo() { }
-
-		void IView.NavigatingFrom() { }
-
-		void IView.NavigatedFrom() { }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/View.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/View.Impl.cs
@@ -26,5 +26,11 @@ namespace Microsoft.Maui.Controls
 
 			base.OnHandlerChangingCore(args);
 		}
+
+		void IView.NavigatedTo() { }
+
+		void IView.NavigatingFrom() { }
+
+		void IView.NavigatedFrom() { }
 	}
 }

--- a/src/Controls/src/Core/MultiPage.cs
+++ b/src/Controls/src/Core/MultiPage.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Controls
 				OnCurrentPageChanged();
 
 				previousPage?.SendNavigatedFrom(new NavigatedFromEventArgs(_current));
-				_current.SendNavigatedTo(new NavigatedToEventArgs(previousPage));
+				_current?.SendNavigatedTo(new NavigatedToEventArgs(previousPage));
 			}
 		}
 

--- a/src/Controls/src/Core/MultiPage.cs
+++ b/src/Controls/src/Core/MultiPage.cs
@@ -76,10 +76,18 @@ namespace Microsoft.Maui.Controls
 				if (_current == value)
 					return;
 
+				var previousPage = value;
 				OnPropertyChanging();
+
+				// TODO MAUI refine this to fire earlier
+				_current?.SendNavigatingFrom(new NavigatingFromEventArgs());
+
 				_current = value;
 				OnPropertyChanged();
 				OnCurrentPageChanged();
+
+				previousPage?.SendNavigatedFrom(new NavigatedFromEventArgs(_current));
+				_current.SendNavigatedTo(new NavigatedToEventArgs(previousPage));
 			}
 		}
 

--- a/src/Controls/src/Core/MultiPage.cs
+++ b/src/Controls/src/Core/MultiPage.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls
 				if (_current == value)
 					return;
 
-				var previousPage = value;
+				var previousPage = _current;
 				OnPropertyChanging();
 
 				// TODO MAUI refine this to fire earlier

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -310,9 +310,10 @@ namespace Microsoft.Maui.Controls
 			}
 
 			var page = (Page)InternalChildren.Last();
+			var previousPage = CurrentPage;
 			SendNavigating();
 			var removedPage = await RemoveAsyncInner(page, animated, fast, requestedFromHandler);
-			SendNavigated();
+			SendNavigated(previousPage);
 			return removedPage;
 		}
 
@@ -358,18 +359,15 @@ namespace Microsoft.Maui.Controls
 			return page;
 		}
 
-		Page _previousPage;
-		void SendNavigated()
+		void SendNavigated(Page previousPage)
 		{
-			_previousPage?.SendNavigatedFrom(new NavigatedFromEventArgs(CurrentPage));
-			CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(_previousPage));
-			_previousPage = null;
+			previousPage?.SendNavigatedFrom(new NavigatedFromEventArgs(CurrentPage));
+			CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(previousPage));
 		}
 
 		void SendNavigating()
 		{
 			CurrentPage?.SendNavigatingFrom(new NavigatingFromEventArgs());
-			_previousPage = CurrentPage;
 		}
 
 
@@ -427,6 +425,7 @@ namespace Microsoft.Maui.Controls
 			if (NavigationPageController.StackDepth == 1)
 				return;
 
+			var previousPage = CurrentPage;
 			SendNavigating();
 			FireDisappearing(CurrentPage);
 			FireAppearing((Page)InternalChildren[0]);
@@ -449,7 +448,7 @@ namespace Microsoft.Maui.Controls
 			}
 
 			PoppedToRoot?.Invoke(this, new PoppedToRootEventArgs(RootPage, childrenToRemove.OfType<Page>().ToList()));
-			SendNavigated();
+			SendNavigated(previousPage);
 		}
 
 		void FireDisappearing(Page page)
@@ -469,6 +468,7 @@ namespace Microsoft.Maui.Controls
 			if (InternalChildren.Contains(page))
 				return;
 
+			var previousPage = CurrentPage;
 			SendNavigating();
 			FireDisappearing(CurrentPage);
 			FireAppearing(page);
@@ -486,7 +486,7 @@ namespace Microsoft.Maui.Controls
 					await args.Task;
 			}
 
-			SendNavigated();
+			SendNavigated(previousPage);
 			Pushed?.Invoke(this, args);
 		}
 

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -87,8 +87,7 @@ namespace Microsoft.Maui.Controls
 			return (Page)InternalChildren[InternalChildren.Count - depth - 1];
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public IEnumerable<Page> Pages => InternalChildren.Cast<Page>();
+		IEnumerable<Page> INavigationPageController.Pages => InternalChildren.Cast<Page>();
 
 		int INavigationPageController.StackDepth
 		{
@@ -298,6 +297,10 @@ namespace Microsoft.Maui.Controls
 			remove => _insertPageBeforeRequested -= value;
 		}
 
+		internal void InitialNativeNavigationStackLoaded()
+		{
+			SendNavigated(null);
+		}
 
 		internal async Task<Page> PopAsyncInner(
 			bool animated,

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Standard.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Standard.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -11,12 +12,16 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public Task<Page> PopModalAsync(bool animated)
 		{
-			throw new NotImplementedException();
+			if (ModalStack.Count == 0)
+				throw new InvalidOperationException();
+			
+			return Task.FromResult(_navModel.PopModal());
 		}
 
 		public Task PushModalAsync(Page modal, bool animated)
 		{
-			throw new NotImplementedException();
+			_navModel.PushModal(modal);
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Controls
 						var page = section.Navigation.ModalStack[i];
 						RegisterImplicitPageRoute(page);
 
-						if (page is NavigationPage np)
+						if (page is INavigationPageController np)
 						{
 							foreach (var npPages in np.Pages)
 							{

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -890,7 +890,7 @@ namespace Microsoft.Maui.Controls
 			OnNavigated(args);
 
 			_previousPage?.SendNavigatedFrom(new NavigatedFromEventArgs(CurrentPage));
-			CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(_previousPage));
+			CurrentPage?.SendNavigatedTo(new NavigatedToEventArgs(_previousPage));
 			_previousPage = null;
 		}
 
@@ -902,7 +902,7 @@ namespace Microsoft.Maui.Controls
 			if (!args.Cancelled)
 			{
 				_previousPage = CurrentPage;
-				CurrentPage.SendNavigatingFrom(new NavigatingFromEventArgs());
+				CurrentPage?.SendNavigatingFrom(new NavigatingFromEventArgs());
 			}
 		}
 

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -592,15 +592,8 @@ namespace Microsoft.Maui.Controls
 		public Shell()
 		{
 			_navigationManager = new ShellNavigationManager(this);
-			_navigationManager.Navigated += (_, args) =>
-			{
-				SendNavigated(args);
-			};
-
-			_navigationManager.Navigating += (_, args) =>
-			{
-				SendNavigating(args);
-			};
+			_navigationManager.Navigated += (_, args) => SendNavigated(args);
+			_navigationManager.Navigating += (_, args) => SendNavigating(args);
 
 			_flyoutManager = new ShellFlyoutItemsManager(this);
 			Navigation = new NavigationImpl(this);

--- a/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
@@ -1,0 +1,222 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	[TestFixture]
+	public class PageLifeCycleTests : BaseTestFixture
+	{
+		[Test]
+		public void NavigationPageInitialPage()
+		{
+			var lcPage = new LCPage();
+			NavigationPage navigationPage = new NavigationPage(lcPage);
+			navigationPage.InitialNativeNavigationStackLoaded();
+			Assert.IsNull(lcPage.NavigatingFromArgs);
+			Assert.IsNull(lcPage.NavigatedFromArgs);
+			Assert.NotNull(lcPage.NavigatedToArgs);
+			Assert.IsNull(lcPage.NavigatedToArgs.PreviousPage);
+		}
+
+		[Test]
+		public async Task NavigationPagePushPage()
+		{
+			var previousPage = new LCPage();
+			var lcPage = new LCPage();
+			NavigationPage navigationPage = new NavigationPage(previousPage);
+			await navigationPage.PushAsync(lcPage);
+
+			Assert.IsNotNull(previousPage.NavigatingFromArgs);
+			Assert.AreEqual(previousPage, lcPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(lcPage, previousPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		[Test]
+		public async Task NavigationPagePopPage()
+		{
+			var firstPage = new LCPage();
+			var poppedPage = new LCPage();
+
+			NavigationPage navigationPage = new NavigationPage(firstPage);
+			await navigationPage.PushAsync(poppedPage);
+			await navigationPage.PopAsync();
+
+			Assert.IsNotNull(poppedPage.NavigatingFromArgs);
+			Assert.AreEqual(poppedPage, firstPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(firstPage, poppedPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		[Test]
+		public async Task NavigationPagePopToRoot()
+		{
+			var firstPage = new LCPage();
+			var poppedPage = new LCPage();
+
+			NavigationPage navigationPage = new NavigationPage(firstPage);
+			await navigationPage.PushAsync(new ContentPage());
+			await navigationPage.PushAsync(new ContentPage());
+			await navigationPage.PushAsync(poppedPage);
+			await navigationPage.PopToRootAsync();
+
+			Assert.IsNotNull(poppedPage.NavigatingFromArgs);
+			Assert.AreEqual(poppedPage, firstPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(firstPage, poppedPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		[Test]
+		public async Task TabbedPageBasicSelectionChanged()
+		{
+			var firstPage = new LCPage() { Title = "First Page" };
+			var secondPage = new LCPage() { Title = "Second Page" };
+			var tabbedPage = new TabbedPage() { Children = { firstPage, secondPage } };
+
+			tabbedPage.CurrentPage = secondPage;
+			Assert.IsNotNull(firstPage.NavigatingFromArgs);
+			Assert.AreEqual(firstPage, secondPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(secondPage, firstPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		[Test]
+		public void TabbedPageInitialPage()
+		{
+			var firstPage = new LCPage() { Title = "First Page" };
+			var secondPage = new LCPage() { Title = "Second Page" };
+			var tabbedPage = new TabbedPage() { Children = { firstPage, secondPage } };
+			Assert.IsNull(firstPage.NavigatingFromArgs);
+			Assert.IsNull(firstPage.NavigatedFromArgs);
+			Assert.NotNull(firstPage.NavigatedToArgs);
+			Assert.IsNull(firstPage.NavigatedToArgs.PreviousPage);
+		}
+
+		[Test]
+		public async Task FlyoutPageFlyoutChanged()
+		{
+			var firstPage = new LCPage() { Title = "First Page" };
+			var secondPage = new LCPage() { Title = "Second Page" };
+			var flyoutPage = new FlyoutPage() { Flyout = firstPage };
+			flyoutPage.Flyout = secondPage;
+
+			Assert.IsNotNull(firstPage.NavigatingFromArgs);
+			Assert.AreEqual(firstPage, secondPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(secondPage, firstPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		[Test]
+		public async Task FlyoutPageDetailChanged()
+		{
+			var firstPage = new LCPage() { Title = "First Page" };
+			var secondPage = new LCPage() { Title = "Second Page" };
+			var flyoutPage = new FlyoutPage() { Detail = firstPage };
+			flyoutPage.Detail = secondPage;
+
+			Assert.IsNotNull(firstPage.NavigatingFromArgs);
+			Assert.AreEqual(firstPage, secondPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(secondPage, firstPage.NavigatedFromArgs.DestinationPage);
+		}
+
+
+
+		[Test]
+		public async Task PushModalPage()
+		{
+			var previousPage = new LCPage();
+			var lcPage = new LCPage();
+			var window = new Window(previousPage);
+
+			await window.Navigation.PushModalAsync(lcPage);
+
+			Assert.IsNotNull(previousPage.NavigatingFromArgs);
+			Assert.AreEqual(previousPage, lcPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(lcPage, previousPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		[Test]
+		public async Task PopModalPage()
+		{
+			var firstPage = new LCPage();
+			var poppedPage = new LCPage();
+
+			var window = new Window(firstPage);
+			await window.Navigation.PushModalAsync(poppedPage);
+			await window.Navigation.PopModalAsync();
+
+			Assert.IsNotNull(poppedPage.NavigatingFromArgs);
+			Assert.AreEqual(poppedPage, firstPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(firstPage, poppedPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		[Test]
+		public async Task PopToAModalPage()
+		{
+			var firstPage = new LCPage();
+			var firstModalPage = new LCPage();
+			var secondModalPage = new LCPage();
+
+			var window = new Window(firstPage);
+			await window.Navigation.PushModalAsync(firstModalPage);
+			await window.Navigation.PushModalAsync(secondModalPage);
+
+			firstModalPage.ClearNavigationArgs();
+			secondModalPage.ClearNavigationArgs();
+
+			await window.Navigation.PopModalAsync();
+
+			Assert.IsNotNull(secondModalPage.NavigatingFromArgs);
+			Assert.AreEqual(secondModalPage, firstModalPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(firstModalPage, secondModalPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		[Test]
+		public async Task PushSecondModalPage()
+		{
+			var firstPage = new LCPage();
+			var firstModalPage = new LCPage();
+			var secondModalPage = new LCPage();
+
+			var window = new Window(firstPage);
+			await window.Navigation.PushModalAsync(firstModalPage);
+
+			firstModalPage.ClearNavigationArgs();
+			secondModalPage.ClearNavigationArgs();
+
+			await window.Navigation.PushModalAsync(secondModalPage);
+
+			Assert.IsNotNull(firstModalPage.NavigatingFromArgs);
+			Assert.AreEqual(firstModalPage, secondModalPage.NavigatedToArgs.PreviousPage);
+			Assert.AreEqual(secondModalPage, firstModalPage.NavigatedFromArgs.DestinationPage);
+		}
+
+		class LCPage : ContentPage
+		{
+			public NavigatedFromEventArgs NavigatedFromArgs { get; private set; }
+			public NavigatingFromEventArgs NavigatingFromArgs { get; private set; }
+			public NavigatedToEventArgs NavigatedToArgs { get; private set; }
+
+
+			public void ClearNavigationArgs()
+			{
+				NavigatedFromArgs = null;
+				NavigatingFromArgs = null;
+				NavigatedToArgs = null;
+			}
+
+			protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+			{
+				base.OnNavigatedFrom(args);
+				NavigatedFromArgs = args;
+			}
+
+			protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
+			{
+				base.OnNavigatingFrom(args);
+				NavigatingFromArgs = args;
+			}
+
+			protected override void OnNavigatedTo(NavigatedToEventArgs args)
+			{
+				base.OnNavigatedTo(args);
+				NavigatedToArgs = args;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Some timing fixes that need to happen
https://github.com/dotnet/maui/issues/1817

#### NavigationPage
- Fires for pushed page and previouspage
- Fires for popped page and landed on page
- PopToRoot fires for root page and currently visible page

#### TabbedPage
- fires for tab you are currently on and tab you navigated to

#### ModalPage
- Fires for top level window page when the first modal page is pushed
- Fires for top level window page when the last modal page is popped
- Fires for previous modal page and next modal page when pushing a second modal page


### Additions made ###
```C#
public class Page
{
	public event EventHandler<NavigatedToEventArgs> NavigatedTo;
	public event EventHandler<NavigatingFromEventArgs> NavigatingFrom;
	public event EventHandler<NavigatedFromEventArgs> NavigatedFrom;		
	protected virtual void OnNavigatedTo(NavigatedToEventArgs args) { }
	protected virtual void OnNavigatingFrom(NavigatingFromEventArgs args) { }
	protected virtual void OnNavigatedFrom(NavigatedFromEventArgs args) { }
}
```

```C#
public sealed class NavigatingFromEventArgs : EventArgs
{

}

public sealed class NavigatedToEventArgs : EventArgs
{
}

public sealed class NavigatedFromEventArgs : EventArgs
{
}
```