### PR TITLE
Ensure no references to Xamarin.Forms in a .NET Maui app

### DIFF
--- a/.nuspec/Microsoft.Maui.Core.targets
+++ b/.nuspec/Microsoft.Maui.Core.targets
@@ -21,7 +21,7 @@
       <_MauiXamarinFormsReferencePath Include="@(ReferencePath)" Condition="'%(Filename)%(Extension)' == 'Xamarin.Forms.Platform.dll'" />
       <_MauiXamarinFormsReferencePath Include="@(ReferencePath)" Condition="'%(Filename)%(Extension)' == 'Xamarin.Forms.Xaml.dll'" />
     </ItemGroup>
-    <Error Text="Xamarin.Forms was referenced in the project. .NET MAUI is not binary compatible with Xamarin.Forms. Make sure that all references are updated."
+    <Error Text="Xamarin.Forms was referenced in the project either directly or via a transitive dependency. .NET MAUI is not binary compatible with Xamarin.Forms. Make sure that all packages are updated, making sure to check dependencies as well as transitive dependencies."
            Condition="'@(_MauiXamarinFormsReferencePath->Count())' &gt; '0'" />
   </Target>
 

--- a/.nuspec/Microsoft.Maui.Core.targets
+++ b/.nuspec/Microsoft.Maui.Core.targets
@@ -1,4 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <Target Name="_RemoveIncompatibleXamlFiles" BeforeTargets="BeforeBuild" Condition="'$(MauiRemoveIncompatibleXaml)' != 'false' and $(TargetFramework.Contains('-windows')) == true and '$(SingleProject)' != 'true'">
     <!-- assume all xaml files in a non-WinExe are MAUI xaml, so remove WinUI xaml -->
     <ItemGroup Condition=" '$(OutputType)' != 'WinExe' ">
@@ -11,4 +12,17 @@
       <Compile Remove="**\*.xaml" />
     </ItemGroup>
   </Target>
+
+  <Target Name="MauiEnsureNoXamarinFormsReferences"
+          AfterTargets="ResolveReferences"
+          Condition="'$(MauiDisableXamarinFormsValidation)' != 'True'">
+    <ItemGroup>
+      <_MauiXamarinFormsReferencePath Include="@(ReferencePath)" Condition="'%(Filename)%(Extension)' == 'Xamarin.Forms.Core.dll'" />
+      <_MauiXamarinFormsReferencePath Include="@(ReferencePath)" Condition="'%(Filename)%(Extension)' == 'Xamarin.Forms.Platform.dll'" />
+      <_MauiXamarinFormsReferencePath Include="@(ReferencePath)" Condition="'%(Filename)%(Extension)' == 'Xamarin.Forms.Xaml.dll'" />
+    </ItemGroup>
+    <Error Text="Xamarin.Forms was referenced in the project. .NET MAUI is not binary compatible with Xamarin.Forms. Make sure that all references are updated."
+           Condition="'@(_MauiXamarinFormsReferencePath->Count())' &gt; '0'" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
### Description of Change ###

Technically this scenario is possible. They are independent UI frameworks. However, this is almost certainly not what you were trying to do. If you install a package that referenced Xamarin.Forms you probably are trying to use it in a .NET Maui app and there is no integration.

Fixes #1621