### PR TITLE
[CI] Only wait 30 minutes for VS insertion task

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -410,3 +410,4 @@ stages:
     - template: vs-insertion/stage/v1.yml@xamarin-templates
       parameters:
         dependsOn: nuget_signing
+        approvalTimeoutInMinutes: 30


### PR DESCRIPTION
Commit 41a42d1 added a new stage for releases that will wait for up to
two days for approval before timing out.  In most cases, this will cause
the `maui-release` and `maui-nightly` release definitions to wait the
full two days before they trigger automatically.  This is only avoided
if someone approves or rejects the `VS Insertion` stage in the pipeline
before the default timeout occurs.

We can reduce the timeout to 30 minutes to speed up the majority of post
build efforts, as the `VS Insertion` stage can still be re-ran after it
is rejected.