### PR TITLE
Make StaticWebAssets not fail in RCLs referenced by MAUI projects

### DIFF
--- a/src/BlazorWebView/samples/MauiRazorClassLibrarySample/MauiRazorClassLibrarySample.csproj
+++ b/src/BlazorWebView/samples/MauiRazorClassLibrarySample/MauiRazorClassLibrarySample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -105,4 +105,19 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_FixUpMauiReference"
+    BeforeTargets="ComputeReferencedProjectsPublishAssets"
+    AfterTargets="LoadStaticWebAssetsBuildManifest">
+
+    <ItemGroup>
+      <_MauiManifestsToUpdate Include="@(StaticWebAssetManifest)" Condition="'%(ManifestType)' == 'Publish'" />
+      <_MauiManifestsToUpdate>
+        <AdditionalPublishPropertiesToRemove>@(_MauiManifestsToUpdate->'%(AdditionalPublishPropertiesToRemove)');TargetFramework</AdditionalPublishPropertiesToRemove>
+      </_MauiManifestsToUpdate>
+
+      <StaticWebAssetManifest Remove="@(_MauiManifestsToUpdate)" />
+      <StaticWebAssetManifest Include="@(_MauiManifestsToUpdate)" />
+    </ItemGroup>
+
+  </Target>
 </Project>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -112,7 +112,7 @@
     <ItemGroup>
       <_MauiManifestsToUpdate Include="@(StaticWebAssetManifest)" Condition="'%(ManifestType)' == 'Publish'" />
       <_MauiManifestsToUpdate>
-        <AdditionalPublishPropertiesToRemove>@(_MauiManifestsToUpdate->'%(AdditionalPublishPropertiesToRemove)');TargetFramework</AdditionalPublishPropertiesToRemove>
+       <AdditionalPublishPropertiesToRemove Condition="$([System.String]::Copy('%(_MauiManifestsToUpdate.AdditionalPublishProperties)').Contains('TargetFramework')) == 'false'">@(_MauiManifestsToUpdate->'%(AdditionalPublishPropertiesToRemove)');TargetFramework</AdditionalPublishPropertiesToRemove>      
       </_MauiManifestsToUpdate>
 
       <StaticWebAssetManifest Remove="@(_MauiManifestsToUpdate)" />


### PR DESCRIPTION
The fix is to prevent a wrong TFM being flowed to the "inner build" of iOS/Android/MacCatalyst MAUI projects so that a referenced RCL is built only with its actual TFM and not the referencing project's TFM.

NOTE: The fix as of right now just makes the project build, but it doesn't produce a working project. We believe that once we get a new SDK in this repo, it will all come together.