### PR TITLE
Add traits to iOS Checkbox so it reads as Switch

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
@@ -158,7 +158,11 @@
                 TextColor="DodgerBlue"
                 FontSize="14"
                 SemanticProperties.HeadingLevel="Level3"/>
-
+            <HorizontalStackLayout>
+                <Label Text="Checkbox on iOS will read as a switch"></Label>
+                <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch"></CheckBox>
+                <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch" Color="DodgerBlue"></CheckBox>
+            </HorizontalStackLayout>
             <Label
                 Text="Explore SemanticProperties on controls within layouts below"
                 TextColor="RoyalBlue"

--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
@@ -159,7 +159,6 @@
                 FontSize="14"
                 SemanticProperties.HeadingLevel="Level3"/>
             <HorizontalStackLayout>
-                <CheckBox></CheckBox>
                 <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch"></CheckBox>
                 <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch" Color="DodgerBlue"></CheckBox>
             </HorizontalStackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
@@ -159,7 +159,7 @@
                 FontSize="14"
                 SemanticProperties.HeadingLevel="Level3"/>
             <HorizontalStackLayout>
-                <Label Text="Checkbox on iOS will read as a switch"></Label>
+                <Label AutomationProperties.IsInAccessibleTree="False" Text="Checkbox on iOS will read as a switch"></Label>
                 <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch"></CheckBox>
                 <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch" Color="DodgerBlue"></CheckBox>
             </HorizontalStackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
@@ -159,7 +159,7 @@
                 FontSize="14"
                 SemanticProperties.HeadingLevel="Level3"/>
             <HorizontalStackLayout>
-                <Label AutomationProperties.IsInAccessibleTree="False" Text="Checkbox on iOS will read as a switch"></Label>
+                <CheckBox></CheckBox>
                 <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch"></CheckBox>
                 <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch" Color="DodgerBlue"></CheckBox>
             </HorizontalStackLayout>

--- a/src/Core/src/Platform/iOS/MauiCheckBox.cs
+++ b/src/Core/src/Platform/iOS/MauiCheckBox.cs
@@ -261,5 +261,19 @@ namespace Microsoft.Maui
 			SetImage(GetCheckBoximage(), UIControlState.Normal);
 			SetNeedsDisplay();
 		}
+
+
+		static UIAccessibilityTrait? _uIAccessibilityTraits;
+		public override UIAccessibilityTrait AccessibilityTraits
+		{
+			get => _uIAccessibilityTraits ??= new UISwitch().AccessibilityTraits;
+			set { }
+		}
+
+		public override string? AccessibilityValue
+		{
+			get => (IsChecked) ? "1" : "0";
+			set { }
+		}
 	}
 }


### PR DESCRIPTION

### Description of Change ###

iOS doesn't natively have a checkbox so to make the current checkbox more accessible we will treat it semantically like a switch


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [x] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
