### PR TITLE
Use the correct variable

### DIFF
--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(MauiPlatforms)</TargetFrameworks>
     <RootNamespace>Maui.Controls.Sample</RootNamespace>
     <AssemblyName>Maui.Controls.Sample</AssemblyName>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
### Description of Change ###

I used the wrong variable in this PR:
https://github.com/dotnet/maui/commit/9e9c44a366274304428facc2be8f793bad7fa7b9#diff-927a4f9f9aa2ffefe1877aaf61bba5546e049d4f3b56f5d0f5e527e4653d7d3d

No use using a blank variable...

Related to #1788