### PR TITLE
Fix traits on Checkbox so they are settable

### DIFF
--- a/src/Core/src/Platform/iOS/MauiCheckBox.cs
+++ b/src/Core/src/Platform/iOS/MauiCheckBox.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Maui
 
 		static UIImage? Checked;
 		static UIImage? Unchecked;
+		static UIAccessibilityTrait? s_switchAccessibilityTraits;
+		UIAccessibilityTrait _accessibilityTraits;
 
 		Color? _tintColor;
 		bool _isChecked;
@@ -43,6 +45,8 @@ namespace Microsoft.Maui
 			AdjustsImageWhenHighlighted = false;
 
 			TouchUpInside += OnTouchUpInside;
+			s_switchAccessibilityTraits ??= new UISwitch().AccessibilityTraits;
+			_accessibilityTraits = s_switchAccessibilityTraits.Value;
 		}
 
 		void OnTouchUpInside(object? sender, EventArgs e)
@@ -263,11 +267,10 @@ namespace Microsoft.Maui
 		}
 
 
-		static UIAccessibilityTrait? _uIAccessibilityTraits;
 		public override UIAccessibilityTrait AccessibilityTraits
 		{
-			get => _uIAccessibilityTraits ??= new UISwitch().AccessibilityTraits;
-			set { }
+			get => _accessibilityTraits;
+			set => _accessibilityTraits = value;
 		}
 
 		public override string? AccessibilityValue

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
@@ -1,13 +1,48 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using UIKit;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class CheckBoxHandlerTests
 	{
+		[Fact(DisplayName = "Accessibility Value Sets Correctly")]
+		public async Task AccessibilityValueSetsCorrectly()
+		{
+			var checkboxStub = new CheckBoxStub()
+			{
+				IsChecked = true
+			};
+
+			var onValue = await GetValueAsync(checkboxStub, (handler) => GetNativeCheckBox(handler).AccessibilityValue);
+			checkboxStub.IsChecked = false;
+			var offValue = await GetValueAsync(checkboxStub, (handler) => GetNativeCheckBox(handler).AccessibilityValue);
+
+			Assert.Equal("1", onValue);
+			Assert.Equal("0", offValue);
+		}
+
+		[Fact(DisplayName = "Accessibility Traits Init Correctly")]
+		public async Task AccessibilityTraitsSetWithHeading()
+		{
+			var checkboxStub = new CheckBoxStub()
+			{
+				IsChecked = true,
+				Semantics = new Semantics() { HeadingLevel = SemanticHeadingLevel.Level4 }
+			};
+
+			var traits = await GetValueAsync(checkboxStub, (handler) => GetNativeCheckBox(handler).AccessibilityTraits);
+			var expectedTraits = await InvokeOnMainThreadAsync(() => new UISwitch().AccessibilityTraits);
+
+			Assert.True(traits.HasFlag(expectedTraits));
+			Assert.True(traits.HasFlag(UIAccessibilityTrait.Header));
+		}
+
+
 		MauiCheckBox GetNativeCheckBox(CheckBoxHandler checkBoxHandler) =>
 			(MauiCheckBox)checkBoxHandler.NativeView;
 


### PR DESCRIPTION
### Description of Change ###

Use a locally stored value for the Accessibility Traits so they can gain additional flags

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [x] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
