### PR TITLE
Fix logic for concatenating hints in Android

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -131,8 +131,13 @@ namespace Microsoft.Maui.Handlers
 			if (!string.IsNullOrEmpty(desc))
 			{
 				// Edit Text fields won't read anything for the content description
-				if (host is EditText)
-					newText = $"{desc}, {((EditText)host).Text}";
+				if (host is EditText et)
+				{
+					if (!string.IsNullOrEmpty(et.Text))
+						newText = $"{desc}, {et.Text}";
+					else
+						newText = $"{desc}";
+				}
 				else
 					newContentDescription = desc;
 			}
@@ -150,10 +155,25 @@ namespace Microsoft.Maui.Handlers
 				}
 				else
 				{
-					if (host is TextView tv)
+					if (host is EditText et)
 					{
-						newText = newText ?? tv.Text;
+						newText = newText ?? et.Text;
 						newText = $"{newText}, {hint}";
+					}
+					else if (host is TextView tv)
+					{
+						if (newContentDescription != null)
+						{
+							newText = $"{newContentDescription}, {hint}";
+						}
+						else if (!string.IsNullOrEmpty(tv.Text))
+						{
+							newText = $"{tv.Text}, {hint}";
+						}
+						else
+						{
+							newText = $"{hint}";
+						}
 					}
 					else
 					{
@@ -171,10 +191,10 @@ namespace Microsoft.Maui.Handlers
 				}
 			}
 
-			if (!String.IsNullOrWhiteSpace(newContentDescription))
+			if (!string.IsNullOrWhiteSpace(newContentDescription))
 				info.ContentDescription = newContentDescription;
 
-			if (!String.IsNullOrWhiteSpace(newText))
+			if (!string.IsNullOrWhiteSpace(newText))
 				info.Text = newText;
 		}
 


### PR DESCRIPTION
### Description of Change ###

This copies over the work done here
https://github.com/xamarin/XamarinCommunityToolkit/pull/1381

The logic for concatenating the EditText for Pre API 26 needed to be fixed

In general adding Hints will have degraded experience on Pre API 26 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [x] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
