### PR TITLE
Swap layout namespaces

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ExampleTemplateCarousel.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ExampleTemplateCarousel.xaml.cs
@@ -4,7 +4,7 @@ using Microsoft.Maui.Controls.Internals;
 namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.CollectionViewGalleries.CarouselViewGalleries
 {
 	[Preserve(AllMembers = true)]
-	public partial class ExampleTemplateCarousel : Grid
+	public partial class ExampleTemplateCarousel : Microsoft.Maui.Controls.Grid
 	{
 		double _initialY = -1;
 		bool _delete;

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/DragAndDropGalleries/DragAndDropBetweenLayouts.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/DragAndDropGalleries/DragAndDropBetweenLayouts.xaml.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.Drag
 		{
 			// e.Cancel = true;
 			var boxView = (sender as Element).Parent as BoxView;
-			var sl = boxView.Parent as StackLayout;
+			var sl = boxView.Parent as Controls.StackLayout;
 			e.Data.Properties.Add("Color", boxView.Background);
 			e.Data.Properties.Add("Source", sl);
 
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.Drag
 
 		private void OnDropCompleted(object sender, DropCompletedEventArgs e)
 		{
-			var sl = (sender as Element).Parent.Parent as StackLayout;
+			var sl = (sender as Element).Parent.Parent as Controls.StackLayout;
 
 			if (sl == SLAllColors)
 				SLRainbow.Background = SolidColorBrush.White;

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/PlatformSpecificsGalleries/ApplicationAndroid.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/PlatformSpecificsGalleries/ApplicationAndroid.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.Plat
 				VerticalOptions = LayoutOptions.StartAndExpand,
 				HorizontalOptions = LayoutOptions.Center,
 			};
-			layout.Children.Add(buttons, yConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent(parent => { return parent.Y; }));
-			layout.Children.Add(entry, yConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent(parent => { return parent.Height - 100; }));
+			layout.Children.Add(buttons, yConstraint: Compatibility.Constraint.RelativeToParent(parent => { return parent.Y; }));
+			layout.Children.Add(entry, yConstraint: Compatibility.Constraint.RelativeToParent(parent => { return parent.Height - 100; }));
 
 			Content = layout;
 			Title = "Application Features";

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla26032.xaml
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla26032.xaml
@@ -2,13 +2,14 @@
 <local:TestContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 				 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
  				 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Compatibility.ControlGallery"
+                 xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 				 x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues.Bugzilla26032">
-	<RelativeLayout>
-		<ListView x:Name="List1"
-				  RelativeLayout.XConstraint="{ConstraintExpression Type=Constant, Constant=0}"
-				  RelativeLayout.YConstraint="{ConstraintExpression Type=Constant, Constant=0}"
-				  RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.5}"
-				  RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.7}"
+    <cmp:RelativeLayout>
+        <ListView x:Name="List1"
+				  cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=Constant, Constant=0}"
+				  cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=Constant, Constant=0}"
+				  cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.5}"
+				  cmp:RelativeLayout.HeightConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.7}"
 				  
 				  ItemTapped="OnItemTapped"
 				  ItemSelected="OnItemSelected"
@@ -21,10 +22,10 @@
 		</ListView>
 
 		<ListView x:Name="List2"
-				  RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.5}"
-				  RelativeLayout.YConstraint="{ConstraintExpression Type=Constant, Constant=0}"
-				  RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.5}"
-				  RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.7}"
+				  cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.5}"
+				  cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=Constant, Constant=0}"
+				  cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.5}"
+				  cmp:RelativeLayout.HeightConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.7}"
 				  
 				  ItemTapped="OnItemTapped"
 				  ItemSelected="OnItemSelected"
@@ -41,11 +42,11 @@
 		</ListView>
 
 		<ScrollView
-				RelativeLayout.XConstraint="{ConstraintExpression Type=Constant, Constant=0}"
-				RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.7}"
-				RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width}"
-				RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.3}">
+				cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=Constant, Constant=0}"
+				cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.7}"
+				cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width}"
+				cmp:RelativeLayout.HeightConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.3}">
 			<Label x:Name="Log" />
 		</ScrollView>
-	</RelativeLayout>
+	</cmp:RelativeLayout>
 </local:TestContentPage>

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32830.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla32830.cs
@@ -62,13 +62,13 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 							TextColor = Colors.White
 						}
 					}
-				}, yConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent(parent => { return parent.Y; }));
+				}, yConstraint: Compatibility.Constraint.RelativeToParent(parent => { return parent.Y; }));
 
 				relativeLayout.Children.Add(new Label
 				{
 					Text = BottomLabel,
 					TextColor = Colors.White
-				}, yConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent(parent => { return parent.Height - 30; }));
+				}, yConstraint: Compatibility.Constraint.RelativeToParent(parent => { return parent.Height - 30; }));
 
 				Content = relativeLayout;
 
@@ -105,13 +105,13 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 								TextColor = Colors.White
 							}
 						}
-				}, yConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent(parent => { return parent.Y; }));
+				}, yConstraint: Compatibility.Constraint.RelativeToParent(parent => { return parent.Y; }));
 
 				relativeLayout.Children.Add(new Label
 				{
 					Text = BottomLabel,
 					TextColor = Colors.White
-				}, yConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent(parent => { return parent.Height - 30; }));
+				}, yConstraint: Compatibility.Constraint.RelativeToParent(parent => { return parent.Height - 30; }));
 
 				Content = relativeLayout;
 			}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla34061.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla34061.cs
@@ -37,10 +37,10 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 			};
 
 			_layout.Children.Add(stack,
-				Microsoft.Maui.Controls.Constraint.Constant(0),
-				Microsoft.Maui.Controls.Constraint.Constant(0),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.Width),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.Height));
+				Compatibility.Constraint.Constant(0),
+				Compatibility.Constraint.Constant(0),
+				Compatibility.Constraint.RelativeToParent(p => p.Width),
+				Compatibility.Constraint.RelativeToParent(p => p.Height));
 
 			Content = _layout;
 		}
@@ -57,10 +57,10 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 
 			_layout.Children.Add(
 				newView,
-				Microsoft.Maui.Controls.Constraint.Constant(0),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.Height / 2),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.Width),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.Height / 2));
+				Compatibility.Constraint.Constant(0),
+				Compatibility.Constraint.RelativeToParent(p => p.Height / 2),
+				Compatibility.Constraint.RelativeToParent(p => p.Width),
+				Compatibility.Constraint.RelativeToParent(p => p.Height / 2));
 		}
 
 		void RemovePopover(View view)

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36788.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla36788.cs
@@ -58,17 +58,17 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 							BackgroundColor = Colors.Blue,
 							Text = longString,
 							LineBreakMode = LineBreakMode.TailTruncation
-						}, Microsoft.Maui.Controls.Constraint.Constant (0)},
+						}, Compatibility.Constraint.Constant (0)},
 						{new Label {
 							BackgroundColor = Colors.Fuchsia,
 							Text = longString,
 							LineBreakMode = LineBreakMode.TailTruncation
-						}, Microsoft.Maui.Controls.Constraint.Constant (0), Microsoft.Maui.Controls.Constraint.Constant (40)},
+						}, Compatibility.Constraint.Constant (0), Compatibility.Constraint.Constant (40)},
 						{new Label {
 							BackgroundColor = Colors.Fuchsia,
 							Text = longString,
 							LineBreakMode = LineBreakMode.TailTruncation
-						}, Microsoft.Maui.Controls.Constraint.Constant (10), Microsoft.Maui.Controls.Constraint.Constant (80)},
+						}, Compatibility.Constraint.Constant (10), Compatibility.Constraint.Constant (80)},
 					}
 				}
 			};
@@ -89,17 +89,17 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 							BackgroundColor = Colors.Blue,
 							Text = longString,
 							LineBreakMode = LineBreakMode.TailTruncation
-						}, Microsoft.Maui.Controls.Constraint.Constant (0)},
+						}, Compatibility.Constraint.Constant (0)},
 						{new Label {
 							BackgroundColor = Colors.Fuchsia,
 							Text = longString,
 							LineBreakMode = LineBreakMode.TailTruncation
-						}, Microsoft.Maui.Controls.Constraint.Constant (0), Microsoft.Maui.Controls.Constraint.Constant (40)},
+						}, Compatibility.Constraint.Constant (0), Compatibility.Constraint.Constant (40)},
 						{new Label {
 							BackgroundColor = Colors.Fuchsia,
 							Text = longString,
 							LineBreakMode = LineBreakMode.TailTruncation
-						}, Microsoft.Maui.Controls.Constraint.Constant (10), Microsoft.Maui.Controls.Constraint.Constant (80)},
+						}, Compatibility.Constraint.Constant (10), Compatibility.Constraint.Constant (80)},
 					}
 				}
 			};

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10024.xaml
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10024.xaml
@@ -3,29 +3,30 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
              mc:Ignorable="d"
              xmlns:controls="clr-namespace:Microsoft.Maui.Controls.Compatibility.ControlGallery"  
              x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues.Issue10024">
-    <AbsoluteLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
-        <AbsoluteLayout.GestureRecognizers>
+    <cmp:AbsoluteLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
+        <cmp:AbsoluteLayout.GestureRecognizers>
             <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped" />
-        </AbsoluteLayout.GestureRecognizers>
+        </cmp:AbsoluteLayout.GestureRecognizers>
 
         <Label Text="Tap anywhere on the screen to show a animated frame and tap outside the new frame to hide it. It show show no visual artifacts while animating" />
 
 
-        <StackLayout x:Name="OpaqueContainer" AbsoluteLayout.LayoutFlags="All" AbsoluteLayout.LayoutBounds="1, 1, 1, 1" BackgroundColor="Black" Opacity="0" IsVisible="false">
+        <StackLayout x:Name="OpaqueContainer" cmp:AbsoluteLayout.LayoutFlags="All" cmp:AbsoluteLayout.LayoutBounds="1, 1, 1, 1" BackgroundColor="Black" Opacity="0" IsVisible="false">
             <StackLayout.GestureRecognizers>
                 <TapGestureRecognizer Tapped="HideInformationFrame" />
             </StackLayout.GestureRecognizers>
         </StackLayout>
 
-        <Frame AbsoluteLayout.LayoutFlags="All" AbsoluteLayout.LayoutBounds=".5, .5, .85, .8" Padding="10, 20, 10, 10" CornerRadius="5" x:Name="InformationFrame" BackgroundColor="White" IsVisible="false" Opacity="0" HasShadow="False" BorderColor="Black">
+        <Frame cmp:AbsoluteLayout.LayoutFlags="All" cmp:AbsoluteLayout.LayoutBounds=".5, .5, .85, .8" Padding="10, 20, 10, 10" CornerRadius="5" x:Name="InformationFrame" BackgroundColor="White" IsVisible="false" Opacity="0" HasShadow="False" BorderColor="Black">
             <StackLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" Spacing="5">
                 <ScrollView VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
                     <StackLayout x:Name="InformationContainer" VerticalOptions="StartAndExpand" HorizontalOptions="FillAndExpand" />
                 </ScrollView>
             </StackLayout>
         </Frame>
-    </AbsoluteLayout>
+    </cmp:AbsoluteLayout>
 </controls:TestContentPage>

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10333.xaml
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue10333.xaml
@@ -2,70 +2,71 @@
 <ContentPage 
   xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+  xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
   x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues.Issue10333"
   Padding="0,50,0,0">
-    <AbsoluteLayout BackgroundColor="Green">
+    <cmp:AbsoluteLayout BackgroundColor="Green">
         <Label Text="If page is visible dimmed with a padding, all is OK. If solid black on the bg, not OK" 
                BackgroundColor="Orange"
-               AbsoluteLayout.LayoutBounds="0, 0, 300, 49" 
+               cmp:AbsoluteLayout.LayoutBounds="0, 0, 300, 49" 
                />
         <Button Text="Can you see this button? Am I dimmed?" 
                 BackgroundColor="Orange"
-                AbsoluteLayout.LayoutBounds="0, 50, 300, 49"
+                cmp:AbsoluteLayout.LayoutBounds="0, 50, 300, 49"
                 />
         <Image Source="avatar.png" 
-               AbsoluteLayout.LayoutBounds="0,100,49,49"
+               cmp:AbsoluteLayout.LayoutBounds="0,100,49,49"
                />
         <BoxView HeightRequest="50" 
                  WidthRequest="300"
                  BackgroundColor="Orange"
-                 AbsoluteLayout.LayoutBounds="0, 150,300,49"
+                 cmp:AbsoluteLayout.LayoutBounds="0, 150,300,49"
                  />
         <WebView Source="https://google.com"
                  HeightRequest="50"
                  WidthRequest="300"
-                 AbsoluteLayout.LayoutBounds="0,200,300,49"
+                 cmp:AbsoluteLayout.LayoutBounds="0,200,300,49"
                  />
         <ImageButton Source="avatar.png"
                      BackgroundColor="Orange"
-                     AbsoluteLayout.LayoutBounds="0,250,300,49"
+                     cmp:AbsoluteLayout.LayoutBounds="0,250,300,49"
                      />
         <CheckBox IsChecked="true" 
                   BackgroundColor="Orange"
-                  AbsoluteLayout.LayoutBounds="0,300,49,49"
+                  cmp:AbsoluteLayout.LayoutBounds="0,300,49,49"
                   />
-        <Slider AbsoluteLayout.LayoutBounds="0,350,300,49" 
+        <Slider cmp:AbsoluteLayout.LayoutBounds="0,350,300,49" 
                 BackgroundColor="Orange"
                 />
         <Stepper BackgroundColor="Orange"
-                 AbsoluteLayout.LayoutBounds="0,400,300,49"
+                 cmp:AbsoluteLayout.LayoutBounds="0,400,300,49"
                  />
         <Switch BackgroundColor="Orange"
-                AbsoluteLayout.LayoutBounds="0,450,300,49"
+                cmp:AbsoluteLayout.LayoutBounds="0,450,300,49"
                 />
         <DatePicker BackgroundColor="Orange"
-                    AbsoluteLayout.LayoutBounds="0,500,300,49"
+                    cmp:AbsoluteLayout.LayoutBounds="0,500,300,49"
                     />
         <TimePicker BackgroundColor="Orange"
-                    AbsoluteLayout.LayoutBounds="0,550,300,49"
+                    cmp:AbsoluteLayout.LayoutBounds="0,550,300,49"
                     />
         <Entry BackgroundColor="Orange"
                Placeholder="Entry..."
-               AbsoluteLayout.LayoutBounds="0,600,300,49"
+               cmp:AbsoluteLayout.LayoutBounds="0,600,300,49"
                />
         <Editor BackgroundColor="Orange"
                Placeholder="Editor..."
-               AbsoluteLayout.LayoutBounds="0,650,300,49"
+               cmp:AbsoluteLayout.LayoutBounds="0,650,300,49"
                />
         <ProgressBar BackgroundColor="Orange"
                      HeightRequest="50"
                      Progress=".5"
-                     AbsoluteLayout.LayoutBounds="0,700,300,49"
+                     cmp:AbsoluteLayout.LayoutBounds="0,700,300,49"
                />
         <Frame BackgroundColor="Black"
                Opacity="0.25"
                InputTransparent="True"
-               AbsoluteLayout.LayoutBounds="0,0,404,836"
+               cmp:AbsoluteLayout.LayoutBounds="0,0,404,836"
                />
-    </AbsoluteLayout>
+    </cmp:AbsoluteLayout>
 </ContentPage>

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1758.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1758.cs
@@ -40,15 +40,15 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 			var layout = new RelativeLayout();
 
 			layout.Children.Add(_list,
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.X),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.Y),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.Width),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(p => p.Height)
+				Compatibility.Constraint.RelativeToParent(p => p.X),
+				Compatibility.Constraint.RelativeToParent(p => p.Y),
+				Compatibility.Constraint.RelativeToParent(p => p.Width),
+				Compatibility.Constraint.RelativeToParent(p => p.Height)
 			);
 
 			layout.Children.Add(_button,
-				Microsoft.Maui.Controls.Constraint.Constant(0),
-				Microsoft.Maui.Controls.Constraint.Constant(300));
+				Compatibility.Constraint.Constant(0),
+				Compatibility.Constraint.Constant(300));
 
 			return layout;
 		}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1760.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1760.cs
@@ -126,9 +126,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 					};
 
 					headerLayout.Children.Add(_headerLabel,
-						Microsoft.Maui.Controls.Constraint.Constant(0),
-						Microsoft.Maui.Controls.Constraint.Constant(0),
-						Microsoft.Maui.Controls.Constraint.RelativeToParent(parent => parent.Width));
+						Compatibility.Constraint.Constant(0),
+						Compatibility.Constraint.Constant(0),
+						Compatibility.Constraint.RelativeToParent(parent => parent.Width));
 
 					Content = new StackLayout
 					{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2634.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2634.cs
@@ -234,16 +234,16 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 				};
 
 				var rl = new RelativeLayout();
-				rl.Children.Add(bvBackground, Microsoft.Maui.Controls.Constraint.Constant(0), Microsoft.Maui.Controls.Constraint.Constant(0),
-					Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) =>
+				rl.Children.Add(bvBackground, Compatibility.Constraint.Constant(0), Compatibility.Constraint.Constant(0),
+					Compatibility.Constraint.RelativeToParent((parent) =>
 					   parent.Width),
-					Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) =>
+					Compatibility.Constraint.RelativeToParent((parent) =>
 					   parent.Height));
 
 				rl.Children.Add(addFrame,
-					Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) => (parent.Width * .25) / 2),
-					Microsoft.Maui.Controls.Constraint.Constant(Device.RuntimePlatform == Device.iOS ? 60 : 40),
-					Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) => parent.Width * .75));
+					Compatibility.Constraint.RelativeToParent((parent) => (parent.Width * .25) / 2),
+					Compatibility.Constraint.Constant(Device.RuntimePlatform == Device.iOS ? 60 : 40),
+					Compatibility.Constraint.RelativeToParent((parent) => parent.Width * .75));
 
 				Content = rl;
 			}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2858.xaml
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue2858.xaml
@@ -2,6 +2,7 @@
 <controls:TestContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 xmlns:controls="clr-namespace:Microsoft.Maui.Controls.Compatibility.ControlGallery;assembly=Microsoft.Maui.Controls.ControlGallery"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
              x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues.Issue2858">
     <ContentPage.Content>
 		<Grid>
@@ -15,20 +16,20 @@
 			<Label Text="Tap the red box below. Then tap the green area outside the box. If 'Success' is visible below, this test has passed."></Label>
 
 			<Label Grid.Row="1" Text="Running..." x:Name="Result"></Label>
-
-			<Grid Grid.Row="2" BackgroundColor="Blue" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" 
+            
+            <cmp:Grid Grid.Row="2" BackgroundColor="Blue" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" 
 				AutomationId="TapGrid">
-				<Grid.GestureRecognizers>
+                <cmp:Grid.GestureRecognizers>
 					<TapGestureRecognizer Tapped="TapGestureRecognizer_OnTapped" />
-				</Grid.GestureRecognizers>
-			</Grid>
-			<Grid Grid.Row="2" RowSpacing="0" ColumnSpacing="0" InputTransparent="True" CascadeInputTransparent="False"
+				</cmp:Grid.GestureRecognizers>
+			</cmp:Grid>
+            <cmp:Grid Grid.Row="2" RowSpacing="0" ColumnSpacing="0" InputTransparent="True" CascadeInputTransparent="False"
 				Padding="10" BackgroundColor="Green" AutomationId="OuterGrid">
-				<Grid BackgroundColor="Red"  HorizontalOptions="Center" WidthRequest="300" VerticalOptions="Center"
+                <cmp:Grid BackgroundColor="Red"  HorizontalOptions="Center" WidthRequest="300" VerticalOptions="Center"
 					HeightRequest="300" AutomationId="InnerGrid">
 					
-				</Grid>
-			</Grid>
+				</cmp:Grid>
+			</cmp:Grid>
 		</Grid>
     </ContentPage.Content>
 </controls:TestContentPage>

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9451.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9451.cs
@@ -26,10 +26,10 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 			StackLayout.Children.Add(TriggerButton);
 
 			relativeLayout.Children.Add(StackLayout,
-				Microsoft.Maui.Controls.Constraint.Constant(0),
-				Microsoft.Maui.Controls.Constraint.Constant(0),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(x => x.Width / 2),
-				Microsoft.Maui.Controls.Constraint.RelativeToParent(y => y.Height));
+				Compatibility.Constraint.Constant(0),
+				Compatibility.Constraint.Constant(0),
+				Compatibility.Constraint.RelativeToParent(x => x.Width / 2),
+				Compatibility.Constraint.RelativeToParent(y => y.Height));
 
 			Content = relativeLayout;
 		}
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 
 		private void Button_Clicked(object sender, EventArgs e)
 		{
-			RelativeLayout.SetWidthConstraint(StackLayout, Microsoft.Maui.Controls.Constraint.Constant(0.0));
+			RelativeLayout.SetWidthConstraint(StackLayout, Compatibility.Constraint.Constant(0.0));
 		}
 	}
 }

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/ModalActivityIndicatorTest.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/ModalActivityIndicatorTest.cs
@@ -106,11 +106,11 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 						Opacity = .4,
 						BackgroundColor = Color.FromArgb("#ccc")
 					},
-					widthConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) =>
+					widthConstraint: Compatibility.Constraint.RelativeToParent((parent) =>
 					{
 						return parent.Width;
 					}),
-					heightConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) =>
+					heightConstraint: Compatibility.Constraint.RelativeToParent((parent) =>
 					{
 						return parent.Height;
 					})
@@ -139,19 +139,19 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 
 				Children.Add(
 					view: content,
-					widthConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) =>
+					widthConstraint: Compatibility.Constraint.RelativeToParent((parent) =>
 					{
 						return parent.Width / 2;
 					}),
-					heightConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) =>
+					heightConstraint: Compatibility.Constraint.RelativeToParent((parent) =>
 					{
 						return parent.Width / 3;
 					}),
-					xConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) =>
+					xConstraint: Compatibility.Constraint.RelativeToParent((parent) =>
 					{
 						return parent.Width / 4;
 					}),
-					yConstraint: Microsoft.Maui.Controls.Constraint.RelativeToParent((parent) =>
+					yConstraint: Compatibility.Constraint.RelativeToParent((parent) =>
 					{
 						return (parent.Height / 2) - (parent.Width / 6);
 					})

--- a/src/Compatibility/Core/src/Android/AppCompat/NavigationPageRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/NavigationPageRenderer.cs
@@ -1207,7 +1207,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 				var width = (int)ctx.FromPixels(MeasureSpecFactory.GetSize(widthMeasureSpec));
 
 				SizeRequest request = _child.Element.Measure(width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-				Microsoft.Maui.Controls.Layout.LayoutChildIntoBoundingRegion(_child.Element, new Rectangle(0, 0, width, request.Request.Height));
+				Microsoft.Maui.Controls.Compatibility.Layout.LayoutChildIntoBoundingRegion(_child.Element, new Rectangle(0, 0, width, request.Request.Height));
 
 				int widthSpec = MeasureSpecFactory.MakeMeasureSpec((int)ctx.ToPixels(width), MeasureSpecMode.Exactly);
 				int heightSpec = MeasureSpecFactory.MakeMeasureSpec((int)ctx.ToPixels(request.Request.Height), MeasureSpecMode.Exactly);

--- a/src/Compatibility/Core/src/Android/Cells/ViewCellRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Cells/ViewCellRenderer.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				double height = Context.FromPixels(b - t);
 
 				Performance.Start(reference, "Element.Layout");
-				Microsoft.Maui.Controls.Layout.LayoutChildIntoBoundingRegion(_view.Element, new Rectangle(0, 0, width, height));
+				Microsoft.Maui.Controls.Compatibility.Layout.LayoutChildIntoBoundingRegion(_view.Element, new Rectangle(0, 0, width, height));
 				Performance.Stop(reference, "Element.Layout");
 
 				_view.UpdateLayout();

--- a/src/Compatibility/Core/src/Android/CollectionView/IndicatorViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/IndicatorViewRenderer.cs
@@ -292,17 +292,17 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		void UpdateIndicatorTemplate()
 		{
-			if (IndicatorView.IndicatorLayout == null)
+			if (IndicatorView.IndicatorLayout is not VisualElement indicatorLayout)
 				return;
-
-			var renderer = IndicatorView.IndicatorLayout.GetRenderer() ?? Platform.CreateRendererWithContext(IndicatorView.IndicatorLayout, Context);
-			Platform.SetRenderer(IndicatorView.IndicatorLayout, renderer);
+			
+			var renderer = indicatorLayout.GetRenderer() ?? Platform.CreateRendererWithContext(indicatorLayout, Context);
+			Platform.SetRenderer(indicatorLayout, renderer);
 
 			RemoveAllViews();
 			AddView(renderer.View);
 
-			var indicatorLayoutSizeRequest = IndicatorView.IndicatorLayout.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-			IndicatorView.IndicatorLayout.Layout(new Rectangle(0, 0, indicatorLayoutSizeRequest.Request.Width, indicatorLayoutSizeRequest.Request.Height));
+			var indicatorLayoutSizeRequest = indicatorLayout.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+			indicatorLayout.Layout(new Rectangle(0, 0, indicatorLayoutSizeRequest.Request.Width, indicatorLayoutSizeRequest.Request.Height));
 		}
 
 		void UpdateIndicators()

--- a/src/Compatibility/Core/src/Android/FastRenderers/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/FrameRenderer.cs
@@ -260,13 +260,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 				UpdateCornerRadius();
 			else if (e.PropertyName == Frame.BorderColorProperty.PropertyName)
 				UpdateBorderColor();
-			else if (e.Is(Microsoft.Maui.Controls.Layout.IsClippedToBoundsProperty))
+			else if (e.Is(Microsoft.Maui.Controls.Compatibility.Layout.IsClippedToBoundsProperty))
 				UpdateClippedToBounds();
 		}
 
 		void UpdateClippedToBounds()
 		{
-			var shouldClip = Element.IsSet(Microsoft.Maui.Controls.Layout.IsClippedToBoundsProperty)
+			var shouldClip = Element.IsSet(Microsoft.Maui.Controls.Compatibility.Layout.IsClippedToBoundsProperty)
 					? Element.IsClippedToBounds : Element.CornerRadius > 0f;
 
 			this.SetClipToOutline(shouldClip);

--- a/src/Compatibility/Core/src/Android/Renderers/ListViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ListViewRenderer.cs
@@ -542,7 +542,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				var width = (int)ctx.FromPixels(MeasureSpecFactory.GetSize(widthMeasureSpec));
 
 				SizeRequest request = element.Measure(width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-				Microsoft.Maui.Controls.Layout.LayoutChildIntoBoundingRegion(element, new Rectangle(0, 0, width, request.Request.Height));
+				Microsoft.Maui.Controls.Compatibility.Layout.LayoutChildIntoBoundingRegion(element, new Rectangle(0, 0, width, request.Request.Height));
 
 				int widthSpec = MeasureSpecFactory.MakeMeasureSpec((int)ctx.ToPixels(width), MeasureSpecMode.Exactly);
 				int heightSpec = MeasureSpecFactory.MakeMeasureSpec((int)ctx.ToPixels(request.Request.Height), MeasureSpecMode.Exactly);

--- a/src/Compatibility/Core/src/Android/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/Android/VisualElementRenderer.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				SetFocusable();
 			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
 				UpdateInputTransparent();
-			else if (e.PropertyName == Microsoft.Maui.Controls.Layout.CascadeInputTransparentProperty.PropertyName)
+			else if (e.PropertyName == Microsoft.Maui.Controls.Compatibility.Layout.CascadeInputTransparentProperty.PropertyName)
 				UpdateInputTransparentInherited();
 
 			ElementPropertyChanged?.Invoke(this, e);

--- a/src/Compatibility/Core/src/Windows/IndicatorViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/IndicatorViewRenderer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		void UpdateControl()
 		{
 			var control = (Element.IndicatorTemplate != null)
-				? (FrameworkElement)Element.IndicatorLayout.GetOrCreateRenderer()
+				? (FrameworkElement)(Element.IndicatorLayout as VisualElement).GetOrCreateRenderer()
 				: CreateNativeControl();
 
 			SetNativeControl(control);

--- a/src/Compatibility/Core/src/iOS/CollectionView/ItemsViewController.cs
+++ b/src/Compatibility/Core/src/iOS/CollectionView/ItemsViewController.cs
@@ -384,12 +384,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			if (IsHorizontal)
 			{
 				var request = formsElement.Measure(double.PositiveInfinity, CollectionView.Frame.Height, MeasureFlags.IncludeMargins);
-				Controls.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, 0, request.Request.Width, CollectionView.Frame.Height));
+				Controls.Compatibility.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, 0, request.Request.Width, CollectionView.Frame.Height));
 			}
 			else
 			{
 				var request = formsElement.Measure(CollectionView.Frame.Width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-				Controls.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, 0, CollectionView.Frame.Width, request.Request.Height));
+				Controls.Compatibility.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, 0, CollectionView.Frame.Width, request.Request.Height));
 			}
 		}
 

--- a/src/Compatibility/Core/src/iOS/Renderers/IndicatorViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/IndicatorViewRenderer.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			ClearIndicators();
 
 			var control = (Element.IndicatorTemplate != null)
-				? (UIView)Element.IndicatorLayout.GetRenderer()
+				? (UIView)(Element.IndicatorLayout as VisualElement).GetRenderer()
 				: CreateNativeControl();
 
 			SetNativeControl(control);
@@ -156,15 +156,15 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		void UpdateIndicatorTemplate()
 		{
-			if (Element.IndicatorLayout == null)
+			if (Element.IndicatorLayout is not VisualElement indicatorLayout)
 				return;
 
 			ClearIndicators();
-			var control = (UIView)Element.IndicatorLayout.GetRenderer();
+			var control = (UIView)indicatorLayout.GetRenderer();
 			AddSubview(control);
 
-			var indicatorLayoutSizeRequest = Element.IndicatorLayout.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-			Element.IndicatorLayout.Layout(new Rectangle(0, 0, indicatorLayoutSizeRequest.Request.Width, indicatorLayoutSizeRequest.Request.Height));
+			var indicatorLayoutSizeRequest = indicatorLayout.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+			indicatorLayout.Layout(new Rectangle(0, 0, indicatorLayoutSizeRequest.Request.Width, indicatorLayoutSizeRequest.Request.Height));
 		}
 
 		void UIPagerValueChanged(object sender, System.EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/PinchGestureTestPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/PinchGestureTestPage.cs
@@ -82,6 +82,11 @@ namespace Maui.Controls.Sample.Pages
 		double _currentScale = 1;
 	}
 
+	// TODO ezhart 2021-07-19 Okay, we _have_ a StackLayout in the default layouts namespace now, based on V/HStack 
+	// Right now there's a _lot_ of legacy code using sl.Children.Add that won't compile, but that should be fixed
+	// by making IContainer an IList<IView> and redirection Children to the Layout itself. So we're waiting on that change,
+	// since otherwise we have to change a _lot_ of code in Control Gallery
+
 	public class PinchGestureTestPage : BasePage
 	{
 		public PinchGestureTestPage()

--- a/src/Controls/samples/Controls.Sample/Pages/Core/PinchGestureTestPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/PinchGestureTestPage.cs
@@ -82,11 +82,6 @@ namespace Maui.Controls.Sample.Pages
 		double _currentScale = 1;
 	}
 
-	// TODO ezhart 2021-07-19 Okay, we _have_ a StackLayout in the default layouts namespace now, based on V/HStack 
-	// Right now there's a _lot_ of legacy code using sl.Children.Add that won't compile, but that should be fixed
-	// by making IContainer an IList<IView> and redirection Children to the Layout itself. So we're waiting on that change,
-	// since otherwise we have to change a _lot_ of code in Control Gallery
-
 	public class PinchGestureTestPage : BasePage
 	{
 		public PinchGestureTestPage()

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/AbsoluteLayoutPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/AbsoluteLayoutPage.xaml
@@ -3,29 +3,30 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.AbsoluteLayoutPage"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
     Title="AbsoluteLayout">
     <views:BasePage.Content>
-        <AbsoluteLayout>
+        <cmp:AbsoluteLayout>
             <BoxView 
                 Color="Blue"
-                AbsoluteLayout.LayoutBounds="0.5,0,100,25"
-                AbsoluteLayout.LayoutFlags="PositionProportional" />
+                cmp:AbsoluteLayout.LayoutBounds="0.5,0,100,25"
+                cmp:AbsoluteLayout.LayoutFlags="PositionProportional" />
             <BoxView 
                 Color="Green"
-                AbsoluteLayout.LayoutBounds="0,0.5,25,100"
-                AbsoluteLayout.LayoutFlags="PositionProportional" />
+                cmp:AbsoluteLayout.LayoutBounds="0,0.5,25,100"
+                cmp:AbsoluteLayout.LayoutFlags="PositionProportional" />
             <BoxView 
                 Color="Red"
-                AbsoluteLayout.LayoutBounds="1,0.5,25,100"
-                AbsoluteLayout.LayoutFlags="PositionProportional" />
+                cmp:AbsoluteLayout.LayoutBounds="1,0.5,25,100"
+                cmp:AbsoluteLayout.LayoutFlags="PositionProportional" />
             <BoxView 
                 Color="Black"
-                AbsoluteLayout.LayoutBounds="0.5,1,100,25"
-                AbsoluteLayout.LayoutFlags="PositionProportional" />
+                cmp:AbsoluteLayout.LayoutBounds="0.5,1,100,25"
+                cmp:AbsoluteLayout.LayoutFlags="PositionProportional" />
             <Label 
                 Text="Centered text"
-                AbsoluteLayout.LayoutBounds="0.5,0.5,110,25"
-                AbsoluteLayout.LayoutFlags="PositionProportional" />
-        </AbsoluteLayout>
+                cmp:AbsoluteLayout.LayoutBounds="0.5,0.5,110,25"
+                cmp:AbsoluteLayout.LayoutFlags="PositionProportional" />
+        </cmp:AbsoluteLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/RelativeLayoutPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/RelativeLayoutPage.xaml
@@ -3,40 +3,41 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.RelativeLayoutPage"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
     Title="RelativeLayout">
     <views:BasePage.Content>
-        <RelativeLayout>
+        <cmp:RelativeLayout>
             <BoxView 
                 Color="Red"
-                RelativeLayout.XConstraint="{ConstraintExpression Type=Constant, Constant=0}"
-                RelativeLayout.YConstraint="{ConstraintExpression Type=Constant, Constant=0}" />
+                cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=Constant, Constant=0}"
+                cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=Constant, Constant=0}" />
             <BoxView 
                 Color="Green"
-                RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width, Constant=-40}"
-                RelativeLayout.YConstraint="{ConstraintExpression Type=Constant, Constant=0}" />
+                cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Constant=-40}"
+                cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=Constant, Constant=0}" />
             <BoxView 
                 Color="Blue"
-                RelativeLayout.XConstraint="{ConstraintExpression Type=Constant, Constant=0}"
-                RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToParent, Property=Height, Constant=-40}" />
+                cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=Constant, Constant=0}"
+                cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Constant=-40}" />
             <BoxView 
                 Color="Yellow"
-                RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width, Constant=-40}"
-                RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToParent, Property=Height, Constant=-40}" />
+                cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Constant=-40}"
+                cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Constant=-40}" />
             <!-- Centered and 1/3 width and height of parent -->
             <BoxView 
                 x:Name="oneThird"
                 Color="Silver"
-                RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.33}"
-                RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.33}"
-                RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.33}"
-                RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.33}" />
+                cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.33}"
+                cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.33}"
+                cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.33}"
+                cmp:RelativeLayout.HeightConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.33}" />
             <!-- 1/3 width and height of previous -->
             <BoxView 
                 Color="Black"
-                RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToView, ElementName=oneThird, Property=X}"
-                RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToView, ElementName=oneThird, Property=Y}"
-                RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToView, ElementName=oneThird, Property=Width, Factor=0.33}"
-                RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToView, ElementName=oneThird, Property=Height, Factor=0.33}" />
-        </RelativeLayout>
+                cmp:RelativeLayout.XConstraint="{cmp:ConstraintExpression Type=RelativeToView, ElementName=oneThird, Property=X}"
+                cmp:RelativeLayout.YConstraint="{cmp:ConstraintExpression Type=RelativeToView, ElementName=oneThird, Property=Y}"
+                cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToView, ElementName=oneThird, Property=Width, Factor=0.33}"
+                cmp:RelativeLayout.HeightConstraint="{cmp:ConstraintExpression Type=RelativeToView, ElementName=oneThird, Property=Height, Factor=0.33}" />
+        </cmp:RelativeLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
@@ -56,15 +56,15 @@
             Text="Settings" />
     </views:BasePage.ToolbarItems>
     <ScrollView>
-        <Grid
+        <!--<Grid
             RowDefinitions="150, *, Auto"
-            RowSpacing="0">
+            RowSpacing="0">-->
             <!-- HEADER -->
-            <Image
+            <!--<Image
                 Grid.Row="0"
                 Aspect="AspectFill"
-                Source="header_background"/>
-            <Grid
+                Source="header_background"/>-->
+            <!--<Grid
                 RowSpacing="0"
                 Grid.Row="0">
                 <Grid.RowDefinitions>
@@ -78,11 +78,11 @@
                     Grid.Row="1"
                     Text="An open-source framework for building iOS, Android, macOS and Windows apps"
                     Style="{StaticResource SubTitleStyle}"/>
-            </Grid>
+            </Grid>-->
             <!-- SECTIONS -->
             <Grid
                 Grid.Row="1"
-                Margin="12">
+                Margin="0">
                 <CollectionView 
                     x:Name="HomeSections"
                     BackgroundColor="Transparent"
@@ -100,8 +100,8 @@
                     </CollectionView.ItemsLayout>
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
-                            <Frame
-                               Style="{StaticResource SectionItemContainerStyle}">
+                            <!--<Frame
+                               Style="{StaticResource SectionItemContainerStyle}">-->
                                 <Grid
                                    RowSpacing="0"
                                    RowDefinitions="Auto, *">
@@ -113,16 +113,16 @@
                                        Text="{Binding Description}"
                                        Style="{StaticResource GalleryItemDescriptionStyle}"/>
                                 </Grid>
-                            </Frame>
+                            <!--</Frame>-->
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>
             </Grid>
             <!-- FOOTER -->
-            <Label
+            <!--<Label
                 Grid.Row="2"
                 Text="Microsoft Corporation © 2021"
-                Style="{StaticResource FooterStyle}" />
-        </Grid>
+                Style="{StaticResource FooterStyle}" />-->
+        <!--</Grid>-->
     </ScrollView>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
@@ -56,15 +56,15 @@
             Text="Settings" />
     </views:BasePage.ToolbarItems>
     <ScrollView>
-        <!--<Grid
+        <Grid
             RowDefinitions="150, *, Auto"
-            RowSpacing="0">-->
+            RowSpacing="0">
             <!-- HEADER -->
-            <!--<Image
+            <Image
                 Grid.Row="0"
                 Aspect="AspectFill"
-                Source="header_background"/>-->
-            <!--<Grid
+                Source="header_background"/>
+            <Grid
                 RowSpacing="0"
                 Grid.Row="0">
                 <Grid.RowDefinitions>
@@ -78,11 +78,11 @@
                     Grid.Row="1"
                     Text="An open-source framework for building iOS, Android, macOS and Windows apps"
                     Style="{StaticResource SubTitleStyle}"/>
-            </Grid>-->
+            </Grid>
             <!-- SECTIONS -->
             <Grid
                 Grid.Row="1"
-                Margin="0">
+                Margin="12">
                 <CollectionView 
                     x:Name="HomeSections"
                     BackgroundColor="Transparent"
@@ -100,8 +100,8 @@
                     </CollectionView.ItemsLayout>
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
-                            <!--<Frame
-                               Style="{StaticResource SectionItemContainerStyle}">-->
+                            <Frame
+                               Style="{StaticResource SectionItemContainerStyle}">
                                 <Grid
                                    RowSpacing="0"
                                    RowDefinitions="Auto, *">
@@ -113,16 +113,16 @@
                                        Text="{Binding Description}"
                                        Style="{StaticResource GalleryItemDescriptionStyle}"/>
                                 </Grid>
-                            <!--</Frame>-->
+                            </Frame>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>
             </Grid>
             <!-- FOOTER -->
-            <!--<Label
+            <Label
                 Grid.Row="2"
                 Text="Microsoft Corporation © 2021"
-                Style="{StaticResource FooterStyle}" />-->
-        <!--</Grid>-->
+                Style="{StaticResource FooterStyle}" />
+        </Grid>
     </ScrollView>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml
@@ -5,18 +5,18 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="Gallery">
     <views:BasePage.Content>
-        <ScrollView 
-            Padding="{OnPlatform iOS='30,60,30,30', Default='30'}">
-            <VerticalStackLayout
+        <!--<ScrollView 
+            Padding="{OnPlatform iOS='30,60,30,30', Default='30'}">-->
+            <StackLayout Orientation="Vertical"
                 Margin="12">
-                <Label 
+                <!--<Label 
                     Text="Welcome to .NET MAUI!"
                     TextColor="{AppThemeBinding Light={StaticResource LightAccentColor}, Dark={StaticResource DarkAccentColor}}"
                     SemanticProperties.HeadingLevel="Level1"
                     FontSize="32"
-                    HorizontalOptions="CenterAndExpand" />
+                    HorizontalOptions="CenterAndExpand" />-->
                 <Label 
-                    Text="Click the button. You know you want to!" 
+                    Text="Click" 
                     FontSize="18"
                     x:Name="CounterLabel"
                     HorizontalOptions="CenterAndExpand" />
@@ -24,7 +24,7 @@
                     Text="Click Me!" 
                     Clicked="OnButtonClicked"
                     SemanticProperties.Hint="Counts the number of times you click"/>
-                <Label
+                <!--<Label
                     Text="Entry" 
                     TextColor="{DynamicResource PrimaryTextColor}"  />
                 <Entry 
@@ -49,8 +49,8 @@
                     HorizontalOptions="Center"
                     HeightRequest="150"
                     WidthRequest="150"
-                    Margin="48, 0" />
-            </VerticalStackLayout>
-        </ScrollView>
+                    Margin="48, 0" />-->
+            </StackLayout>
+        <!--</ScrollView>-->
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml
@@ -5,18 +5,18 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="Gallery">
     <views:BasePage.Content>
-        <!--<ScrollView 
-            Padding="{OnPlatform iOS='30,60,30,30', Default='30'}">-->
-            <StackLayout Orientation="Vertical"
+        <ScrollView 
+            Padding="{OnPlatform iOS='30,60,30,30', Default='30'}">
+            <VerticalStackLayout
                 Margin="12">
-                <!--<Label 
+                <Label 
                     Text="Welcome to .NET MAUI!"
                     TextColor="{AppThemeBinding Light={StaticResource LightAccentColor}, Dark={StaticResource DarkAccentColor}}"
                     SemanticProperties.HeadingLevel="Level1"
                     FontSize="32"
-                    HorizontalOptions="CenterAndExpand" />-->
+                    HorizontalOptions="CenterAndExpand" />
                 <Label 
-                    Text="Click" 
+                    Text="Click the button. You know you want to!" 
                     FontSize="18"
                     x:Name="CounterLabel"
                     HorizontalOptions="CenterAndExpand" />
@@ -24,7 +24,7 @@
                     Text="Click Me!" 
                     Clicked="OnButtonClicked"
                     SemanticProperties.Hint="Counts the number of times you click"/>
-                <!--<Label
+                <Label
                     Text="Entry" 
                     TextColor="{DynamicResource PrimaryTextColor}"  />
                 <Entry 
@@ -49,8 +49,8 @@
                     HorizontalOptions="Center"
                     HeightRequest="150"
                     WidthRequest="150"
-                    Margin="48, 0" />-->
-            </StackLayout>
-        <!--</ScrollView>-->
+                    Margin="48, 0" />
+            </VerticalStackLayout>
+        </ScrollView>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml.cs
@@ -11,12 +11,13 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		async void OnButtonClicked(object sender, EventArgs e)
+		//async 
+		void OnButtonClicked(object sender, EventArgs e)
 		{
 			_counter++;
 			string message = $"You clicked {_counter} times!";
 			CounterLabel.Text = message;
-			await DisplayAlert("Alert", message, "Ok");
+			//await DisplayAlert("Alert", message, "Ok");
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/TempPage.xaml.cs
@@ -11,13 +11,12 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		//async 
-		void OnButtonClicked(object sender, EventArgs e)
+		async void OnButtonClicked(object sender, EventArgs e)
 		{
 			_counter++;
 			string message = $"You clicked {_counter} times!";
 			CounterLabel.Text = message;
-			//await DisplayAlert("Alert", message, "Ok");
+			await DisplayAlert("Alert", message, "Ok");
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -104,7 +104,7 @@ namespace Maui.Controls.Sample
 #if WINDOWS
 							PageType.Main => typeof(TempPage),
 #else
-							PageType.Main => typeof(CustomNavigationPage),
+							PageType.Main => typeof(TempPage),
 #endif
 							PageType.Blazor =>
 #if NET6_0_OR_GREATER

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -104,7 +104,7 @@ namespace Maui.Controls.Sample
 #if WINDOWS
 							PageType.Main => typeof(TempPage),
 #else
-							PageType.Main => typeof(TempPage),
+							PageType.Main => typeof(CustomNavigationPage),
 #endif
 							PageType.Blazor =>
 #if NET6_0_OR_GREATER

--- a/src/Controls/src/Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/BoundsTypeConverter.cs
@@ -33,21 +33,21 @@ namespace Microsoft.Maui.Controls.XamlC
 			if (!hasW && xywh.Length == 4 && string.Compare("AutoSize", xywh[2].Trim(), StringComparison.OrdinalIgnoreCase) == 0)
 			{
 				hasW = true;
-				w = AbsoluteLayout.AutoSize;
+				w = Compatibility.AbsoluteLayout.AutoSize;
 			}
 
 			if (!hasH && xywh.Length == 4 && string.Compare("AutoSize", xywh[3].Trim(), StringComparison.OrdinalIgnoreCase) == 0)
 			{
 				hasH = true;
-				h = AbsoluteLayout.AutoSize;
+				h = Compatibility.AbsoluteLayout.AutoSize;
 			}
 
 			if (hasX && hasY && xywh.Length == 2)
 			{
 				hasW = true;
-				w = AbsoluteLayout.AutoSize;
+				w = Compatibility.AbsoluteLayout.AutoSize;
 				hasH = true;
-				h = AbsoluteLayout.AutoSize;
+				h = Compatibility.AbsoluteLayout.AutoSize;
 			}
 
 			if (!hasX || !hasY || !hasW || !hasH)

--- a/src/Controls/src/Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.XamlC
 			double size;
 
 			if (string.IsNullOrEmpty(value) || !double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out size))
-				throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(Constraint));
+				throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(Compatibility.Constraint));
 
 			yield return Create(Ldc_R8, size);
 			yield return Create(Call, module.ImportMethodReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Compatibility", "Constraint"),

--- a/src/Controls/src/Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/ConstraintTypeConverter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.XamlC
 				throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(Constraint));
 
 			yield return Create(Ldc_R8, size);
-			yield return Create(Call, module.ImportMethodReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "Constraint"),
+			yield return Create(Call, module.ImportMethodReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls.Compatibility", "Constraint"),
 																   methodName: "Constant",
 																   parameterTypes: new[] { ("mscorlib", "System", "Double") },
 																   isStatic: true));

--- a/src/Controls/src/Core/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout.cs
@@ -1,34 +1,43 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls
 {
+	// TODO ezhart 2021-07-16 This interface is just here to give Layout and Compatibility.Layout common ground for BindableLayout
+	// once we have the IContainer changes in, we may be able to drop this in favor of simply Core.ILayout
+	// See also IndicatorView.cs 
+	public interface IBindableLayout 
+	{
+		public IList Children { get; }
+	}
+
 	public static class BindableLayout
 	{
 		public static readonly BindableProperty ItemsSourceProperty =
-			BindableProperty.CreateAttached("ItemsSource", typeof(IEnumerable), typeof(Layout<View>), default(IEnumerable),
+			BindableProperty.CreateAttached("ItemsSource", typeof(IEnumerable), typeof(IBindableLayout), default(IEnumerable),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemsSource = (IEnumerable)n; });
 
 		public static readonly BindableProperty ItemTemplateProperty =
-			BindableProperty.CreateAttached("ItemTemplate", typeof(DataTemplate), typeof(Layout<View>), default(DataTemplate),
+			BindableProperty.CreateAttached("ItemTemplate", typeof(DataTemplate), typeof(IBindableLayout), default(DataTemplate),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplate = (DataTemplate)n; });
 
 		public static readonly BindableProperty ItemTemplateSelectorProperty =
-			BindableProperty.CreateAttached("ItemTemplateSelector", typeof(DataTemplateSelector), typeof(Layout<View>), default(DataTemplateSelector),
+			BindableProperty.CreateAttached("ItemTemplateSelector", typeof(DataTemplateSelector), typeof(IBindableLayout), default(DataTemplateSelector),
 				propertyChanged: (b, o, n) => { GetBindableLayoutController(b).ItemTemplateSelector = (DataTemplateSelector)n; });
 
 		static readonly BindableProperty BindableLayoutControllerProperty =
-			 BindableProperty.CreateAttached("BindableLayoutController", typeof(BindableLayoutController), typeof(Layout<View>), default(BindableLayoutController),
-				 defaultValueCreator: (b) => new BindableLayoutController((Layout<View>)b),
+			 BindableProperty.CreateAttached("BindableLayoutController", typeof(BindableLayoutController), typeof(IBindableLayout), default(BindableLayoutController),
+				 defaultValueCreator: (b) => new BindableLayoutController((IBindableLayout)b),
 				 propertyChanged: (b, o, n) => OnControllerChanged(b, (BindableLayoutController)o, (BindableLayoutController)n));
 
 		public static readonly BindableProperty EmptyViewProperty =
-			BindableProperty.Create("EmptyView", typeof(object), typeof(Layout<View>), null, propertyChanged: (b, o, n) => { GetBindableLayoutController(b).EmptyView = n; });
+			BindableProperty.Create("EmptyView", typeof(object), typeof(IBindableLayout), null, propertyChanged: (b, o, n) => { GetBindableLayoutController(b).EmptyView = n; });
 
 		public static readonly BindableProperty EmptyViewTemplateProperty =
-			BindableProperty.Create("EmptyViewTemplate", typeof(DataTemplate), typeof(Layout<View>), null, propertyChanged: (b, o, n) => { GetBindableLayoutController(b).EmptyViewTemplate = (DataTemplate)n; });
+			BindableProperty.Create("EmptyViewTemplate", typeof(DataTemplate), typeof(IBindableLayout), null, propertyChanged: (b, o, n) => { GetBindableLayoutController(b).EmptyViewTemplate = (DataTemplate)n; });
 
 		public static void SetItemsSource(BindableObject b, IEnumerable value)
 		{
@@ -114,7 +123,7 @@ namespace Microsoft.Maui.Controls
 
 	class BindableLayoutController
 	{
-		readonly WeakReference<Layout<View>> _layoutWeakReference;
+		readonly WeakReference<IBindableLayout> _layoutWeakReference;
 		IEnumerable _itemsSource;
 		DataTemplate _itemTemplate;
 		DataTemplateSelector _itemTemplateSelector;
@@ -130,9 +139,9 @@ namespace Microsoft.Maui.Controls
 		public object EmptyView { get => _emptyView; set => SetEmptyView(value); }
 		public DataTemplate EmptyViewTemplate { get => _emptyViewTemplate; set => SetEmptyViewTemplate(value); }
 
-		public BindableLayoutController(Layout<View> layout)
+		public BindableLayoutController(IBindableLayout layout)
 		{
-			_layoutWeakReference = new WeakReference<Layout<View>>(layout);
+			_layoutWeakReference = new WeakReference<IBindableLayout>(layout);
 		}
 
 		internal void StartBatchUpdate()
@@ -217,7 +226,7 @@ namespace Microsoft.Maui.Controls
 
 		void CreateChildren()
 		{
-			if (!_layoutWeakReference.TryGetTarget(out Layout<View> layout))
+			if (!_layoutWeakReference.TryGetTarget(out IBindableLayout layout))
 			{
 				return;
 			}
@@ -235,7 +244,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		void UpdateEmptyView(Layout<View> layout)
+		void UpdateEmptyView(IBindableLayout layout)
 		{
 			if (_currentEmptyView == null)
 				return;
@@ -249,9 +258,9 @@ namespace Microsoft.Maui.Controls
 			layout.Children.Remove(_currentEmptyView);
 		}
 
-		View CreateItemView(object item, Layout<View> layout)
+		View CreateItemView(object item, IBindableLayout layout)
 		{
-			return CreateItemView(item, _itemTemplate ?? _itemTemplateSelector?.SelectTemplate(item, layout));
+			return CreateItemView(item, _itemTemplate ?? _itemTemplateSelector?.SelectTemplate(item, layout as BindableObject));
 		}
 
 		View CreateItemView(object item, DataTemplate dataTemplate)
@@ -270,7 +279,7 @@ namespace Microsoft.Maui.Controls
 
 		View CreateEmptyView(object emptyView, DataTemplate dataTemplate)
 		{
-			if (!_layoutWeakReference.TryGetTarget(out Layout<View> layout))
+			if (!_layoutWeakReference.TryGetTarget(out IBindableLayout layout))
 			{
 				return null;
 			}
@@ -278,7 +287,7 @@ namespace Microsoft.Maui.Controls
 			if (dataTemplate != null)
 			{
 				var view = (View)dataTemplate.CreateContent();
-				view.BindingContext = layout.BindingContext;
+				view.BindingContext = (layout as BindableObject).BindingContext;
 				return view;
 			}
 
@@ -292,7 +301,7 @@ namespace Microsoft.Maui.Controls
 
 		void ItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (!_layoutWeakReference.TryGetTarget(out Layout<View> layout))
+			if (!_layoutWeakReference.TryGetTarget(out IBindableLayout layout))
 			{
 				return;
 			}

--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -4,7 +4,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
-	public class ContentPresenter : Layout
+	public class ContentPresenter : Compatibility.Layout
 	{
 		public static BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View),
 			typeof(ContentPresenter), null, propertyChanged: OnContentChanged);

--- a/src/Controls/src/Core/HandlerImpl/Layout.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout.Impl.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	public abstract partial class Layout<T> 
 	{

--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -56,10 +56,12 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
-			Layout(this.ComputeFrame(bounds));
+			var frame = this.ComputeFrame(bounds);
 
 			// Force a native arrange call; otherwise, the native bookkeeping won't be done and things won't lay out correctly
-			Handler?.NativeArrange(Frame);
+			Handler?.NativeArrange(frame);
+
+			Layout(frame);
 
 			return Frame.Size;
 		}

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (this.ActualWidth > request.Width)
 				request.Width = this.ActualWidth;
 
-			Layout.LayoutChildIntoBoundingRegion(_content, new Rectangle(0, 0, request.Width, request.Height));
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(_content, new Rectangle(0, 0, request.Width, request.Height));
 			Clip = new RectangleGeometry { Rect = new WRect(0, 0, request.Width, request.Height) };
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFooterView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFooterView.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnShellFooterViewSizeChanged(object sender, SizeChangedEventArgs e)
 		{
-			if (Element is Layout layout)
+			if (Element is Compatibility.Layout layout)
 				layout.ForceLayout();
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellHeaderView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellHeaderView.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void OnShellHeaderViewSizeChanged(object sender, SizeChangedEventArgs e)
 		{
-			if (Element is Layout layout)
+			if (Element is Compatibility.Layout layout)
 				layout.ForceLayout();
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ViewToHandlerConverter.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ViewToHandlerConverter.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.Platform
 						// If the view is a layout (stacklayout, grid, etc) we need to trigger a layout pass
 						// with all the controls in a consistent native state (i.e., loaded) so they'll actually
 						// have Bounds set
-						(_view as Layout)?.ForceLayout();
+						(_view as Compatibility.Layout)?.ForceLayout();
 						InvalidateMeasure();
 					};
 				}
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Controls.Platform
 			protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
 			{
 				_view.IsInNativeLayout = true;
-				Layout.LayoutChildIntoBoundingRegion(_view, new Rectangle(0, 0, finalSize.Width, finalSize.Height));
+				Compatibility.Layout.LayoutChildIntoBoundingRegion(_view, new Rectangle(0, 0, finalSize.Width, finalSize.Height));
 
 				if (_view.Width <= 0 || _view.Height <= 0)
 				{

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(GraphicsView), typeof(GraphicsViewHandler) },
 			{ typeof(Image), typeof(ImageHandler) },
 			{ typeof(Label), typeof(LabelHandler) },
-			{ typeof(Layout2.Layout), typeof(LayoutHandler) },
+			{ typeof(Layout), typeof(LayoutHandler) },
 			{ typeof(Picker), typeof(PickerHandler) },
 			{ typeof(ProgressBar), typeof(ProgressBarHandler) },
 			{ typeof(ScrollView), typeof(ScrollViewHandler) },

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(Shapes.Polygon), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Polyline), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Rectangle), typeof(ShapeViewHandler) },
-			{ typeof(Layout), typeof(LayoutHandler) },
 			{ typeof(Window), typeof(WindowHandler) },
 			//{ typeof(NavigationPage), typeof(NavigationPageHandler) },
 		};

--- a/src/Controls/src/Core/IndicatorStackLayout.cs
+++ b/src/Controls/src/Core/IndicatorStackLayout.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
-	internal class IndicatorStackLayout : StackLayout
+	internal class IndicatorStackLayout : Compatibility.StackLayout
 	{
 		IndicatorView _indicatorView;
 		public IndicatorStackLayout(IndicatorView indicatorView)

--- a/src/Controls/src/Core/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(IndicatorView), null, propertyChanged: (bindable, oldValue, newValue)
 			=> ((IndicatorView)bindable).ResetItemsSource((IEnumerable)oldValue));
 
-		static readonly BindableProperty IndicatorLayoutProperty = BindableProperty.Create(nameof(IndicatorLayout), typeof(Layout<View>), typeof(IndicatorView), null, propertyChanged: TemplateUtilities.OnContentChanged);
+		static readonly BindableProperty IndicatorLayoutProperty = BindableProperty.Create(nameof(IndicatorLayout), typeof(IBindableLayout), typeof(IndicatorView), null, propertyChanged: TemplateUtilities.OnContentChanged);
 
 		public IndicatorView()
 		{
@@ -47,9 +47,9 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(IndicatorsShapeProperty, value); }
 		}
 
-		public Layout<View> IndicatorLayout
+		public IBindableLayout IndicatorLayout
 		{
-			get => (Layout<View>)GetValue(IndicatorLayoutProperty);
+			get => (IBindableLayout)GetValue(IndicatorLayoutProperty);
 			set => SetValue(IndicatorLayoutProperty, value);
 		}
 

--- a/src/Controls/src/Core/Internals/ProfilePage.cs
+++ b/src/Controls/src/Core/Internals/ProfilePage.cs
@@ -100,11 +100,11 @@ namespace Microsoft.Maui.Controls.Internals
 			var scrollView = new ScrollView();
 			var label = new Label();
 
-			var controls = new Grid();
+			var controls = new Compatibility.Grid();
 			var buttonA = new Button() { Text = "0s", HeightRequest = 62 };
 			controls.Children.AddHorizontal(new[] { buttonA });
 
-			var grid = new Grid
+			var grid = new Compatibility.Grid
 			{
 				RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -9,10 +9,10 @@ using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[ContentProperty(nameof(Children))]
-	public abstract partial class Layout<T> : Layout, Microsoft.Maui.ILayout, ILayoutManager, IViewContainer<T> where T : View
+	public abstract class Layout<T> : Layout, Microsoft.Maui.ILayout, ILayoutManager, IBindableLayout, IViewContainer<T> where T : View
 	{
 		readonly ElementCollection<T> _children;
 
@@ -23,6 +23,7 @@ namespace Microsoft.Maui.Controls
 		public ILayoutHandler LayoutHandler => Handler as ILayoutHandler;
 
 		ILayoutManager Maui.ILayout.LayoutManager => this;
+		IList IBindableLayout.Children => _children;
 
 		protected override void OnChildAdded(Element child)
 		{

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -12,7 +12,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls.Compatibility
 {
 	[ContentProperty(nameof(Children))]
-	public abstract class Layout<T> : Layout, Microsoft.Maui.ILayout, ILayoutManager, IBindableLayout, IViewContainer<T> where T : View
+	public abstract partial class Layout<T> : Layout, Microsoft.Maui.ILayout, ILayoutManager, IBindableLayout, IViewContainer<T> where T : View
 	{
 		readonly ElementCollection<T> _children;
 

--- a/src/Controls/src/Core/Layout/FlexExtensions.cs
+++ b/src/Controls/src/Core/Layout/FlexExtensions.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Maui.Graphics;
+using Flex = Microsoft.Maui.Layouts.Flex;
+using Microsoft.Maui.Layouts;
+
+namespace Microsoft.Maui.Controls
+{
+	static class FlexExtensions
+	{
+		public static int IndexOf(this Flex.Item parent, Flex.Item child)
+		{
+			var index = -1;
+			foreach (var it in parent)
+			{
+				index++;
+				if (it == child)
+					return index;
+			}
+			return -1;
+		}
+
+		public static void Remove(this Flex.Item parent, Flex.Item child)
+		{
+			var index = parent.IndexOf(child);
+			if (index < 0)
+				return;
+			parent.RemoveAt((uint)index);
+		}
+
+		public static Rectangle GetFrame(this Flex.Item item)
+		{
+			return new Rectangle(item.Frame[0], item.Frame[1], item.Frame[2], item.Frame[3]);
+		}
+
+		public static Size GetConstraints(this Flex.Item item)
+		{
+			var widthConstraint = -1d;
+			var heightConstraint = -1d;
+			var parent = item.Parent;
+			do
+			{
+				if (parent == null)
+					break;
+				if (widthConstraint < 0 && !float.IsNaN(parent.Width))
+					widthConstraint = (double)parent.Width;
+				if (heightConstraint < 0 && !float.IsNaN(parent.Height))
+					heightConstraint = (double)parent.Height;
+				parent = parent.Parent;
+			} while (widthConstraint < 0 || heightConstraint < 0);
+			return new Size(widthConstraint, heightConstraint);
+		}
+
+		public static Flex.Basis ToFlexBasis(this FlexBasis basis)
+		{
+			if (basis.IsAuto)
+				return Flex.Basis.Auto;
+			if (basis.IsRelative)
+				return new Flex.Basis(basis.Length, isRelative: true);
+			return new Flex.Basis(basis.Length, isRelative: false);
+		}
+	}
+}

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -5,8 +5,7 @@ using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Layouts;
 using Flex = Microsoft.Maui.Layouts.Flex;
 
-// This is a temporary namespace until we rename everything and move the legacy layouts
-namespace Microsoft.Maui.Controls.Layout2
+namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Children))]
 	public class FlexLayout : Layout, IFlexLayout
@@ -425,7 +424,7 @@ namespace Microsoft.Maui.Controls.Layout2
 			// TODO ezhart The Core layout interfaces don't have the padding property yet; when that's available, we should add a check for it here
 			if (view is FlexLayout && view is Controls.Layout layout)
 			{
-				var (pleft, ptop, pright, pbottom) = (Thickness)layout.GetValue(Controls.Layout.PaddingProperty);
+				var (pleft, ptop, pright, pbottom) = (Thickness)layout.GetValue(Compatibility.Layout.PaddingProperty);
 				item.PaddingLeft = (float)pleft;
 				item.PaddingTop = (float)ptop;
 				item.PaddingRight = (float)pright;

--- a/src/Controls/src/Core/Layout/GridLayout.cs
+++ b/src/Controls/src/Core/Layout/GridLayout.cs
@@ -4,8 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.Maui.Layouts;
 
-// This is a temporary namespace until we rename everything and move the legacy layouts
-namespace Microsoft.Maui.Controls.Layout2
+namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Children))]
 	public class GridLayout : Layout, IGridLayout
@@ -13,7 +12,7 @@ namespace Microsoft.Maui.Controls.Layout2
 		readonly Dictionary<IView, GridInfo> _viewInfo = new();
 
 		public static readonly BindableProperty ColumnDefinitionsProperty = BindableProperty.Create("ColumnDefinitions",
-			typeof(ColumnDefinitionCollection), typeof(Grid), null, validateValue: (bindable, value) => value != null,
+			typeof(ColumnDefinitionCollection), typeof(GridLayout), null, validateValue: (bindable, value) => value != null,
 			propertyChanged: UpdateSizeChangedHandlers, defaultValueCreator: bindable =>
 			{
 				var colDef = new ColumnDefinitionCollection();
@@ -22,7 +21,7 @@ namespace Microsoft.Maui.Controls.Layout2
 			});
 
 		public static readonly BindableProperty RowDefinitionsProperty = BindableProperty.Create("RowDefinitions",
-			typeof(RowDefinitionCollection), typeof(Grid), null, validateValue: (bindable, value) => value != null,
+			typeof(RowDefinitionCollection), typeof(GridLayout), null, validateValue: (bindable, value) => value != null,
 			propertyChanged: UpdateSizeChangedHandlers, defaultValueCreator: bindable =>
 			{
 				var rowDef = new RowDefinitionCollection();

--- a/src/Controls/src/Core/Layout/GridLayout.cs
+++ b/src/Controls/src/Core/Layout/GridLayout.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls

--- a/src/Controls/src/Core/Layout/HorizontalStackLayout.cs
+++ b/src/Controls/src/Core/Layout/HorizontalStackLayout.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Children))]
-	public class HorizontalStackLayout : StackLayout
+	public class HorizontalStackLayout : StackBase
 	{
 		protected override ILayoutManager CreateLayoutManager() => new HorizontalStackLayoutManager(this);
 	}

--- a/src/Controls/src/Core/Layout/HorizontalStackLayout.cs
+++ b/src/Controls/src/Core/Layout/HorizontalStackLayout.cs
@@ -1,13 +1,9 @@
-using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Layouts;
-
 
 namespace Microsoft.Maui.Controls
 {
-	// Don't panic, Layout2.StackLayout is the temporary name for the abstract base class until
-	// we rename everything and move the legacy layouts
 	[ContentProperty(nameof(Children))]
-	public class HorizontalStackLayout : Layout2.StackLayout
+	public class HorizontalStackLayout : StackLayout
 	{
 		protected override ILayoutManager CreateLayoutManager() => new HorizontalStackLayoutManager(this);
 	}

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -4,11 +4,10 @@ using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
-// This is a temporary namespace until we rename everything and move the legacy layouts
-namespace Microsoft.Maui.Controls.Layout2
+namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Children))]
-	public abstract class Layout : View, Microsoft.Maui.ILayout, IList<IView>, IPaddingElement
+	public abstract class Layout : View, Microsoft.Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement
 	{
 		ILayoutManager _layoutManager;
 		public ILayoutManager LayoutManager => _layoutManager ??= CreateLayoutManager();
@@ -20,7 +19,8 @@ namespace Microsoft.Maui.Controls.Layout2
 		public IList<IView> Children => this;
 
 		public ILayoutHandler LayoutHandler => Handler as ILayoutHandler;
-
+		IList IBindableLayout.Children => _children;
+		
 		public int Count => _children.Count;
 
 		public bool IsReadOnly => ((ICollection<IView>)_children).IsReadOnly;

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Children))]
 	public abstract class Layout : View, Microsoft.Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement
 	{
-		ILayoutManager _layoutManager;
+		protected ILayoutManager _layoutManager;
 		public ILayoutManager LayoutManager => _layoutManager ??= CreateLayoutManager();
 
 		// The actual backing store for the IViews in the ILayout

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Maui.Controls
 
 		public IView this[int index] { get => _children[index]; set => _children[index] = value; }
 
+		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
+
 		public Thickness Padding
 		{
 			get => (Thickness)GetValue(PaddingElement.PaddingProperty);

--- a/src/Controls/src/Core/Layout/Shims.cs
+++ b/src/Controls/src/Core/Layout/Shims.cs
@@ -1,8 +1,8 @@
 ﻿namespace Microsoft.Maui.Controls
 {
 	public class Grid : GridLayout { }
-
 	public class RelativeLayout : Compatibility.RelativeLayout { }
 	public class AbsoluteLayout : Compatibility.AbsoluteLayout { }
+	public sealed class Constraint : Compatibility.Constraint { }
 	public class ConstraintExpression : Compatibility.ConstraintExpression { }
 }

--- a/src/Controls/src/Core/Layout/Shims.cs
+++ b/src/Controls/src/Core/Layout/Shims.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	public class Grid : GridLayout { }
+
+	public class RelativeLayout : Compatibility.RelativeLayout { }
+	public class AbsoluteLayout : Compatibility.AbsoluteLayout { }
+	public class ConstraintExpression : Compatibility.ConstraintExpression { }
+}

--- a/src/Controls/src/Core/Layout/Shims.cs
+++ b/src/Controls/src/Core/Layout/Shims.cs
@@ -1,8 +1,4 @@
 ﻿namespace Microsoft.Maui.Controls
 {
 	public class Grid : GridLayout { }
-	public class RelativeLayout : Compatibility.RelativeLayout { }
-	public class AbsoluteLayout : Compatibility.AbsoluteLayout { }
-	public sealed class Constraint : Compatibility.Constraint { }
-	public class ConstraintExpression : Compatibility.ConstraintExpression { }
 }

--- a/src/Controls/src/Core/Layout/StackLayout.cs
+++ b/src/Controls/src/Core/Layout/StackLayout.cs
@@ -1,5 +1,4 @@
-﻿// This is a temporary namespace until we rename everything and move the legacy layouts
-namespace Microsoft.Maui.Controls.Layout2
+﻿namespace Microsoft.Maui.Controls
 {
 	public abstract class StackLayout : Layout, IStackLayout
 	{

--- a/src/Controls/src/Core/Layout/StackLayout.cs
+++ b/src/Controls/src/Core/Layout/StackLayout.cs
@@ -1,14 +1,46 @@
-﻿namespace Microsoft.Maui.Controls
+﻿using Microsoft.Maui.Layouts;
+
+namespace Microsoft.Maui.Controls
 {
-	public abstract class StackLayout : Layout, IStackLayout
+	public abstract class StackBase : Layout, IStackLayout
 	{
-		public static readonly BindableProperty SpacingProperty = BindableProperty.Create(nameof(Spacing), typeof(double), typeof(StackLayout), 0d,
-					propertyChanged: (bindable, oldvalue, newvalue) => ((IFrameworkElement)bindable).InvalidateMeasure());
+		public static readonly BindableProperty SpacingProperty = BindableProperty.Create(nameof(Spacing), typeof(double), typeof(StackBase), 0d,
+				propertyChanged: (bindable, oldvalue, newvalue) => ((IFrameworkElement)bindable).InvalidateMeasure());
 
 		public double Spacing
 		{
 			get { return (double)GetValue(SpacingProperty); }
 			set { SetValue(SpacingProperty, value); }
+		}
+	}
+
+	public class StackLayout : StackBase, IStackLayout 
+	{
+		public static readonly BindableProperty OrientationProperty = BindableProperty.Create(nameof(Orientation), typeof(StackOrientation), typeof(StackLayout), StackOrientation.Vertical,
+			propertyChanged: OrientationChanged);
+
+		public StackOrientation Orientation
+		{
+			get { return (StackOrientation)GetValue(OrientationProperty); }
+			set { SetValue(OrientationProperty, value); }
+		}
+
+		static void OrientationChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var layout = (StackLayout)bindable;
+
+			// Clear out the current layout manager; when the layout system needs it again, it'll call CreateLayoutManager
+			layout._layoutManager = null;
+			layout.InvalidateMeasure();
+		}
+
+		protected override ILayoutManager CreateLayoutManager()
+		{
+			return Orientation switch
+			{
+				StackOrientation.Horizontal => new HorizontalStackLayoutManager(this),
+				_ => new VerticalStackLayoutManager(this),
+			};
 		}
 	}
 }

--- a/src/Controls/src/Core/Layout/VerticalStackLayout.cs
+++ b/src/Controls/src/Core/Layout/VerticalStackLayout.cs
@@ -1,12 +1,9 @@
 using Microsoft.Maui.Layouts;
 
-
 namespace Microsoft.Maui.Controls
 {
-	// Don't panic, Layout2.StackLayout is the temporary name for the abstract base class until
-	// we rename everything and move the legacy layout
 	[ContentProperty(nameof(Children))]
-	public class VerticalStackLayout : Layout2.StackLayout
+	public class VerticalStackLayout : StackLayout
 	{
 		protected override ILayoutManager CreateLayoutManager() => new VerticalStackLayoutManager(this);
 	}

--- a/src/Controls/src/Core/Layout/VerticalStackLayout.cs
+++ b/src/Controls/src/Core/Layout/VerticalStackLayout.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Children))]
-	public class VerticalStackLayout : StackLayout
+	public class VerticalStackLayout : StackBase
 	{
 		protected override ILayoutManager CreateLayoutManager() => new VerticalStackLayoutManager(this);
 	}

--- a/src/Controls/src/Core/LegacyLayouts/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/AbsoluteLayout.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[ContentProperty(nameof(Children))]
 	public class AbsoluteLayout : Layout<View>, IElementConfiguration<AbsoluteLayout>

--- a/src/Controls/src/Core/LegacyLayouts/BoundsTypeConverter.cs
+++ b/src/Controls/src/Core/LegacyLayouts/BoundsTypeConverter.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 using System.Globalization;
 using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[Xaml.ProvideCompiled("Microsoft.Maui.Controls.XamlC.BoundsTypeConverter")]
 	[Xaml.TypeConversion(typeof(Rectangle))]

--- a/src/Controls/src/Core/LegacyLayouts/Constraint.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Constraint.cs
@@ -7,11 +7,11 @@ using Microsoft.Maui.Controls.Internals;
 namespace Microsoft.Maui.Controls.Compatibility
 {
 	[System.ComponentModel.TypeConverter(typeof(ConstraintTypeConverter))]
-	public sealed class Constraint
+	public class Constraint
 	{
 		Func<RelativeLayout, double> _measureFunc;
 
-		Constraint()
+		public Constraint()
 		{
 		}
 

--- a/src/Controls/src/Core/LegacyLayouts/Constraint.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Constraint.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 using System.Linq.Expressions;
 using Microsoft.Maui.Controls.Internals;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[System.ComponentModel.TypeConverter(typeof(ConstraintTypeConverter))]
 	public sealed class Constraint

--- a/src/Controls/src/Core/LegacyLayouts/ConstraintExpression.cs
+++ b/src/Controls/src/Core/LegacyLayouts/ConstraintExpression.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Xaml;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	public class ConstraintExpression : IMarkupExtension<Constraint>
 	{

--- a/src/Controls/src/Core/LegacyLayouts/ConstraintTypeConverter.cs
+++ b/src/Controls/src/Core/LegacyLayouts/ConstraintTypeConverter.cs
@@ -2,7 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Globalization;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[Xaml.ProvideCompiled("Microsoft.Maui.Controls.XamlC.ConstraintTypeConverter")]
 	[Xaml.TypeConversion(typeof(Constraint))]

--- a/src/Controls/src/Core/LegacyLayouts/FlexLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/FlexLayout.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 using Flex = Microsoft.Maui.Layouts.Flex;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[ContentProperty(nameof(Children))]
 	public class FlexLayout : Layout<View>
@@ -470,61 +470,6 @@ namespace Microsoft.Maui.Controls
 			_root.Width = !double.IsPositiveInfinity((width)) ? (float)width : 0;
 			_root.Height = !double.IsPositiveInfinity((height)) ? (float)height : 0;
 			_root.Layout();
-		}
-	}
-
-	static class FlexExtensions
-	{
-		public static int IndexOf(this Flex.Item parent, Flex.Item child)
-		{
-			var index = -1;
-			foreach (var it in parent)
-			{
-				index++;
-				if (it == child)
-					return index;
-			}
-			return -1;
-		}
-
-		public static void Remove(this Flex.Item parent, Flex.Item child)
-		{
-			var index = parent.IndexOf(child);
-			if (index < 0)
-				return;
-			parent.RemoveAt((uint)index);
-		}
-
-		public static Rectangle GetFrame(this Flex.Item item)
-		{
-			return new Rectangle(item.Frame[0], item.Frame[1], item.Frame[2], item.Frame[3]);
-		}
-
-		public static Size GetConstraints(this Flex.Item item)
-		{
-			var widthConstraint = -1d;
-			var heightConstraint = -1d;
-			var parent = item.Parent;
-			do
-			{
-				if (parent == null)
-					break;
-				if (widthConstraint < 0 && !float.IsNaN(parent.Width))
-					widthConstraint = (double)parent.Width;
-				if (heightConstraint < 0 && !float.IsNaN(parent.Height))
-					heightConstraint = (double)parent.Height;
-				parent = parent.Parent;
-			} while (widthConstraint < 0 || heightConstraint < 0);
-			return new Size(widthConstraint, heightConstraint);
-		}
-
-		public static Flex.Basis ToFlexBasis(this FlexBasis basis)
-		{
-			if (basis.IsAuto)
-				return Flex.Basis.Auto;
-			if (basis.IsRelative)
-				return new Flex.Basis(basis.Length, isRelative: true);
-			return new Flex.Basis(basis.Length, isRelative: false);
 		}
 	}
 }

--- a/src/Controls/src/Core/LegacyLayouts/Grid.cs
+++ b/src/Controls/src/Core/LegacyLayouts/Grid.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Microsoft.Maui.Controls.Internals;
 
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[ContentProperty(nameof(Children))]
 	public partial class Grid : Layout<View>, IGridController, IElementConfiguration<Grid>, IGridLayout

--- a/src/Controls/src/Core/LegacyLayouts/GridCalc.cs
+++ b/src/Controls/src/Core/LegacyLayouts/GridCalc.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	public partial class Grid
 	{

--- a/src/Controls/src/Core/LegacyLayouts/RelativeLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/RelativeLayout.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[ContentProperty(nameof(Children))]
 	public class RelativeLayout : Layout<View>, IElementConfiguration<RelativeLayout>

--- a/src/Controls/src/Core/LegacyLayouts/StackLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/StackLayout.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.Controls
+namespace Microsoft.Maui.Controls.Compatibility
 {
 	[ContentProperty(nameof(Children))]
 	public class StackLayout : Layout<View>, IElementConfiguration<StackLayout>, IFrameworkElement

--- a/src/Controls/src/Core/MergedStyle.cs
+++ b/src/Controls/src/Core/MergedStyle.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 	{
 		////If the base type is one of these, stop registering dynamic resources further
 		////The last one (typeof(Element)) is a safety guard as we might be creating VisualElement directly in internal code
-		static readonly IList<Type> s_stopAtTypes = new List<Type> { typeof(View), typeof(Layout<>), typeof(VisualElement), typeof(NavigableElement), typeof(Element) };
+		static readonly IList<Type> s_stopAtTypes = new List<Type> { typeof(View), typeof(Compatibility.Layout<>), typeof(VisualElement), typeof(NavigableElement), typeof(Element) };
 
 		IList<BindableProperty> _classStyleProperties;
 

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -261,9 +261,9 @@ namespace Microsoft.Maui.Controls
 
 				var page = child as Page;
 				if (page != null && page.IgnoresContainerArea)
-					Maui.Controls.Layout.LayoutChildIntoBoundingRegion(child, originalArea);
+					Maui.Controls.Compatibility.Layout.LayoutChildIntoBoundingRegion(child, originalArea);
 				else
-					Maui.Controls.Layout.LayoutChildIntoBoundingRegion(child, area);
+					Maui.Controls.Compatibility.Layout.LayoutChildIntoBoundingRegion(child, area);
 			}
 		}
 

--- a/src/Controls/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Core/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.StyleSheets;
+using Compatibility = Microsoft.Maui.Controls.Compatibility;
 
 [assembly: InternalsVisibleTo("iOSUnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility.ControlGallery")]
@@ -78,7 +79,8 @@ using Microsoft.Maui.Controls.StyleSheets;
 [assembly: StyleProperty("text-transform", typeof(ITextElement), nameof(TextElement.TextTransformProperty), Inherited = true)]
 [assembly: StyleProperty("color", typeof(ProgressBar), nameof(ProgressBar.ProgressColorProperty))]
 [assembly: StyleProperty("color", typeof(Switch), nameof(Switch.OnColorProperty))]
-[assembly: StyleProperty("column-gap", typeof(Grid), nameof(Grid.ColumnSpacingProperty))]
+[assembly: StyleProperty("column-gap", typeof(Compatibility.Grid), nameof(Compatibility.Grid.ColumnSpacingProperty))]
+[assembly: StyleProperty("column-gap", typeof(GridLayout), nameof(GridLayout.ColumnSpacingProperty))]
 [assembly: StyleProperty("direction", typeof(VisualElement), nameof(VisualElement.FlowDirectionProperty), Inherited = true)]
 [assembly: StyleProperty("font-family", typeof(IFontElement), nameof(FontElement.FontFamilyProperty), Inherited = true)]
 [assembly: StyleProperty("font-size", typeof(IFontElement), nameof(FontElement.FontSizeProperty), Inherited = true)]
@@ -98,7 +100,8 @@ using Microsoft.Maui.Controls.StyleSheets;
 [assembly: StyleProperty("padding-top", typeof(IPaddingElement), nameof(PaddingElement.PaddingTopProperty), PropertyOwnerType = typeof(PaddingElement))]
 [assembly: StyleProperty("padding-right", typeof(IPaddingElement), nameof(PaddingElement.PaddingRightProperty), PropertyOwnerType = typeof(PaddingElement))]
 [assembly: StyleProperty("padding-bottom", typeof(IPaddingElement), nameof(PaddingElement.PaddingBottomProperty), PropertyOwnerType = typeof(PaddingElement))]
-[assembly: StyleProperty("row-gap", typeof(Grid), nameof(Grid.RowSpacingProperty))]
+[assembly: StyleProperty("row-gap", typeof(Compatibility.Grid), nameof(Compatibility.Grid.RowSpacingProperty))]
+[assembly: StyleProperty("row-gap", typeof(GridLayout), nameof(GridLayout.RowSpacingProperty))]
 [assembly: StyleProperty("text-align", typeof(ITextAlignmentElement), nameof(TextAlignmentElement.HorizontalTextAlignmentProperty), Inherited = true)]
 [assembly: StyleProperty("text-decoration", typeof(IDecorableTextElement), nameof(DecorableTextElement.TextDecorationsProperty))]
 [assembly: StyleProperty("transform", typeof(VisualElement), nameof(VisualElement.TransformProperty))]
@@ -122,6 +125,19 @@ using Microsoft.Maui.Controls.StyleSheets;
 [assembly: StyleProperty("order", typeof(VisualElement), nameof(FlexLayout.OrderProperty), PropertyOwnerType = typeof(FlexLayout))]
 [assembly: StyleProperty("position", typeof(FlexLayout), nameof(FlexLayout.PositionProperty))]
 
+// compatibility flex
+[assembly: StyleProperty("align-content", typeof(Compatibility.FlexLayout), nameof(Compatibility.FlexLayout.AlignContentProperty))]
+[assembly: StyleProperty("align-items", typeof(Compatibility.FlexLayout), nameof(Compatibility.FlexLayout.AlignItemsProperty))]
+[assembly: StyleProperty("align-self", typeof(VisualElement), nameof(Compatibility.FlexLayout.AlignSelfProperty), PropertyOwnerType = typeof(Compatibility.FlexLayout))]
+[assembly: StyleProperty("flex-direction", typeof(Compatibility.FlexLayout), nameof(Compatibility.FlexLayout.DirectionProperty))]
+[assembly: StyleProperty("flex-basis", typeof(VisualElement), nameof(Compatibility.FlexLayout.BasisProperty), PropertyOwnerType = typeof(Compatibility.FlexLayout))]
+[assembly: StyleProperty("flex-grow", typeof(VisualElement), nameof(Compatibility.FlexLayout.GrowProperty), PropertyOwnerType = typeof(Compatibility.FlexLayout))]
+[assembly: StyleProperty("flex-shrink", typeof(VisualElement), nameof(Compatibility.FlexLayout.ShrinkProperty), PropertyOwnerType = typeof(Compatibility.FlexLayout))]
+[assembly: StyleProperty("flex-wrap", typeof(VisualElement), nameof(Compatibility.FlexLayout.WrapProperty), PropertyOwnerType = typeof(Compatibility.FlexLayout))]
+[assembly: StyleProperty("justify-content", typeof(Compatibility.FlexLayout), nameof(Compatibility.FlexLayout.JustifyContentProperty))]
+[assembly: StyleProperty("order", typeof(VisualElement), nameof(Compatibility.FlexLayout.OrderProperty), PropertyOwnerType = typeof(Compatibility.FlexLayout))]
+[assembly: StyleProperty("position", typeof(Compatibility.FlexLayout), nameof(Compatibility.FlexLayout.PositionProperty))]
+
 //xf specific
 [assembly: StyleProperty("-xf-placeholder", typeof(IPlaceholderElement), nameof(PlaceholderElement.PlaceholderProperty))]
 [assembly: StyleProperty("-xf-placeholder-color", typeof(IPlaceholderElement), nameof(PlaceholderElement.PlaceholderColorProperty))]
@@ -134,8 +150,15 @@ using Microsoft.Maui.Controls.StyleSheets;
 [assembly: StyleProperty("-xf-min-track-color", typeof(Slider), nameof(Slider.MinimumTrackColorProperty))]
 [assembly: StyleProperty("-xf-max-track-color", typeof(Slider), nameof(Slider.MaximumTrackColorProperty))]
 [assembly: StyleProperty("-xf-thumb-color", typeof(Slider), nameof(Slider.ThumbColorProperty))]
-[assembly: StyleProperty("-xf-spacing", typeof(StackLayout), nameof(StackLayout.SpacingProperty))]
-[assembly: StyleProperty("-xf-orientation", typeof(StackLayout), nameof(StackLayout.OrientationProperty))]
+[assembly: StyleProperty("-xf-spacing", typeof(Compatibility.StackLayout), nameof(Compatibility.StackLayout.SpacingProperty))]
+[assembly: StyleProperty("-xf-orientation", typeof(Compatibility.StackLayout), nameof(Compatibility.StackLayout.OrientationProperty))]
+
+// TODO ezhart 2021-07-16 When we fix #1634, we'll need to enable this so the CSS applies 
+//[assembly: StyleProperty("-xf-spacing", typeof(StackLayout), nameof(StackLayout.SpacingProperty))]
+
+// TODO ezhart 2021-07-16 When we create the new composed StackLayout, we'll need to ensure we have this enabled 
+//[assembly: StyleProperty("-xf-orientation", typeof(StackLayout), nameof(StackLayout.OrientationProperty))]
+
 [assembly: StyleProperty("-xf-visual", typeof(VisualElement), nameof(VisualElement.VisualProperty))]
 [assembly: StyleProperty("-xf-vertical-text-alignment", typeof(Label), nameof(TextAlignmentElement.VerticalTextAlignmentProperty))]
 [assembly: StyleProperty("-xf-thumb-color", typeof(Switch), nameof(Switch.ThumbColorProperty))]

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Maui.Controls
 				{
 					MessagingCenter.Subscribe<RadioButton, RadioButtonGroupSelectionChanged>(this,
 						RadioButtonGroup.GroupSelectionChangedMessage, HandleRadioButtonGroupSelectionChanged);
-					MessagingCenter.Subscribe<Layout<View>, RadioButtonGroupValueChanged>(this,
+					MessagingCenter.Subscribe<Compatibility.Layout<View>, RadioButtonGroupValueChanged>(this,
 						RadioButtonGroup.GroupValueChangedMessage, HandleRadioButtonGroupValueChanged);
 				}
 
@@ -405,7 +405,7 @@ namespace Microsoft.Maui.Controls
 				if (!string.IsNullOrEmpty(oldGroupName))
 				{
 					MessagingCenter.Unsubscribe<RadioButton, RadioButtonGroupSelectionChanged>(this, RadioButtonGroup.GroupSelectionChangedMessage);
-					MessagingCenter.Unsubscribe<Layout<View>, RadioButtonGroupValueChanged>(this, RadioButtonGroup.GroupValueChangedMessage);
+					MessagingCenter.Unsubscribe<Compatibility.Layout<View>, RadioButtonGroupValueChanged>(this, RadioButtonGroup.GroupValueChangedMessage);
 				}
 			}
 		}
@@ -425,7 +425,7 @@ namespace Microsoft.Maui.Controls
 			IsChecked = false;
 		}
 
-		void HandleRadioButtonGroupValueChanged(Layout<View> layout, RadioButtonGroupValueChanged args)
+		void HandleRadioButtonGroupValueChanged(Compatibility.Layout<View> layout, RadioButtonGroupValueChanged args)
 		{
 			if (IsChecked || string.IsNullOrEmpty(GroupName) || GroupName != args.GroupName || Value != args.Value || !MatchesScope(args))
 			{
@@ -456,7 +456,7 @@ namespace Microsoft.Maui.Controls
 				MarginProperty, OpacityProperty, RotationProperty, ScaleProperty, ScaleXProperty, ScaleYProperty,
 				TranslationYProperty, TranslationXProperty, VerticalOptionsProperty);
 
-			var grid = new Grid
+			var grid = new Compatibility.Grid
 			{
 				RowSpacing = 0,
 				ColumnDefinitions = new ColumnDefinitionCollection {

--- a/src/Controls/src/Core/RadioButtonGroup.cs
+++ b/src/Controls/src/Core/RadioButtonGroup.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Maui.Controls
 		internal const string GroupValueChangedMessage = "RadioButtonGroupValueChanged";
 
 		static readonly BindableProperty RadioButtonGroupControllerProperty =
-			BindableProperty.CreateAttached("RadioButtonGroupController", typeof(RadioButtonGroupController), typeof(Layout<View>), default(RadioButtonGroupController),
-			defaultValueCreator: (b) => new RadioButtonGroupController((Layout<View>)b),
+			BindableProperty.CreateAttached("RadioButtonGroupController", typeof(RadioButtonGroupController), typeof(Compatibility.Layout<View>), default(RadioButtonGroupController),
+			defaultValueCreator: (b) => new RadioButtonGroupController((Compatibility.Layout<View>)b),
 			propertyChanged: (b, o, n) => OnControllerChanged(b, (RadioButtonGroupController)o, (RadioButtonGroupController)n));
 
 		static RadioButtonGroupController GetRadioButtonGroupController(BindableObject b)
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public static readonly BindableProperty GroupNameProperty =
-			BindableProperty.Create("GroupName", typeof(string), typeof(Layout<View>), null,
+			BindableProperty.Create("GroupName", typeof(string), typeof(Compatibility.Layout<View>), null,
 			propertyChanged: (b, o, n) => { GetRadioButtonGroupController(b).GroupName = (string)n; });
 
 		public static string GetGroupName(BindableObject b)
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public static readonly BindableProperty SelectedValueProperty =
-			BindableProperty.Create("SelectedValue", typeof(object), typeof(Layout<View>), null,
+			BindableProperty.Create("SelectedValue", typeof(object), typeof(Compatibility.Layout<View>), null,
 			defaultBindingMode: BindingMode.TwoWay,
 			propertyChanged: (b, o, n) => { GetRadioButtonGroupController(b).SelectedValue = n; });
 

--- a/src/Controls/src/Core/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButtonGroupController.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls
 {
 	internal class RadioButtonGroupController
 	{
-		readonly Layout<View> _layout;
+		readonly Compatibility.Layout<View> _layout;
 
 		string _groupName;
 		private object _selectedValue;
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 		public string GroupName { get => _groupName; set => SetGroupName(value); }
 		public object SelectedValue { get => _selectedValue; set => SetSelectedValue(value); }
 
-		public RadioButtonGroupController(Layout<View> layout)
+		public RadioButtonGroupController(Compatibility.Layout<View> layout)
 		{
 			if (layout is null)
 			{
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		void UpdateGroupNames(Layout<View> layout, string name, string oldName = null)
+		void UpdateGroupNames(Compatibility.Layout<View> layout, string name, string oldName = null)
 		{
 			foreach (var descendant in layout.Descendants())
 			{

--- a/src/Controls/src/Core/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView.cs
@@ -8,7 +8,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Content))]
-	public class ScrollView : Compatibility.Layout, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController
+	public partial class ScrollView : Compatibility.Layout, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController
 	{
 		#region IScrollViewController
 

--- a/src/Controls/src/Core/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView.cs
@@ -8,7 +8,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Content))]
-	public partial class ScrollView : Layout, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController
+	public class ScrollView : Compatibility.Layout, IScrollViewController, IElementConfiguration<ScrollView>, IFlowDirectionController
 	{
 		#region IScrollViewController
 

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		static void UpdateFlyoutItemStyles(Grid flyoutItemCell, IStyleSelectable source)
+		static void UpdateFlyoutItemStyles(Compatibility.Grid flyoutItemCell, IStyleSelectable source)
 		{
 			List<string> bindableObjectStyle = new List<string>() {
 				DefaultFlyoutItemLabelStyle,
@@ -455,7 +455,7 @@ namespace Microsoft.Maui.Controls
 		{
 			return new DataTemplate(() =>
 			{
-				var grid = new Grid();
+				var grid = new Compatibility.Grid();
 				if (Device.RuntimePlatform == Device.UWP)
 					grid.ColumnSpacing = grid.RowSpacing = 0;
 
@@ -477,7 +477,7 @@ namespace Microsoft.Maui.Controls
 					Class = DefaultFlyoutItemImageStyle,
 				};
 
-				var defaultGridClass = new Style(typeof(Grid))
+				var defaultGridClass = new Style(typeof(Compatibility.Grid))
 				{
 					Class = DefaultFlyoutItemLayoutStyle,
 				};
@@ -520,9 +520,9 @@ namespace Microsoft.Maui.Controls
 				defaultGridClass.Setters.Add(new Setter { Property = VisualStateManager.VisualStateGroupsProperty, Value = groups });
 
 				if (Device.RuntimePlatform == Device.Android)
-					defaultGridClass.Setters.Add(new Setter { Property = Grid.HeightRequestProperty, Value = 50 });
+					defaultGridClass.Setters.Add(new Setter { Property = Compatibility.Grid.HeightRequestProperty, Value = 50 });
 				else
-					defaultGridClass.Setters.Add(new Setter { Property = Grid.HeightRequestProperty, Value = 44 });
+					defaultGridClass.Setters.Add(new Setter { Property = Compatibility.Grid.HeightRequestProperty, Value = 44 });
 
 
 				ColumnDefinitionCollection columnDefinitions = new ColumnDefinitionCollection();
@@ -535,7 +535,7 @@ namespace Microsoft.Maui.Controls
 					columnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
 				columnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star });
-				defaultGridClass.Setters.Add(new Setter { Property = Grid.ColumnDefinitionsProperty, Value = columnDefinitions });
+				defaultGridClass.Setters.Add(new Setter { Property = Compatibility.Grid.ColumnDefinitionsProperty, Value = columnDefinitions });
 
 				var image = new Image();
 
@@ -596,7 +596,7 @@ namespace Microsoft.Maui.Controls
 
 				grid.BindingContextChanged += (sender, __) =>
 				{
-					if (sender is Grid g)
+					if (sender is Compatibility.Grid g)
 					{
 						var bo = g.BindingContext as BindableObject;
 						var styleClassSource = Shell.GetBindableObjectWithFlyoutItemTemplate(bo) as IStyleSelectable;

--- a/src/Controls/src/Core/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView.cs
@@ -5,7 +5,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
-	public class TemplatedView : Layout, IControlTemplated
+	public class TemplatedView : Compatibility.Layout, IControlTemplated
 	{
 		public static readonly BindableProperty ControlTemplateProperty = BindableProperty.Create(nameof(ControlTemplate), typeof(ControlTemplate), typeof(TemplatedView), null,
 			propertyChanged: TemplateUtilities.OnControlTemplateChanged);

--- a/src/Controls/tests/Core.UnitTests/AbsoluteLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AbsoluteLayoutTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
 

--- a/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableLayoutTests.cs
@@ -9,6 +9,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+	
 	[TestFixture]
 	public class BindableLayoutTests : BaseTestFixture
 	{
@@ -385,7 +387,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		// Checks if for every item in the items source there's a corresponding view
-		static bool IsLayoutWithItemsSource(IEnumerable itemsSource, Layout layout)
+		static bool IsLayoutWithItemsSource(IEnumerable itemsSource, Compatibility.Layout layout)
 		{
 			if (itemsSource == null)
 			{

--- a/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindableObjectUnitTests.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[System.ComponentModel.TypeConverter(typeof(ToBarConverter))]
 	internal class Bar
 	{

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -12,6 +12,8 @@ using DescriptionAttribute = NUnit.Framework.DescriptionAttribute;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class BindingUnitTests
 		: BindingBaseUnitTests

--- a/src/Controls/tests/Core.UnitTests/ContentViewUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ContentViewUnitTest.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class ContentViewUnitTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/ContraintTypeConverterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ContraintTypeConverterTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Controls.Compatibility;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests

--- a/src/Controls/tests/Core.UnitTests/ContraintTypeConverterTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ContraintTypeConverterTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using Constraint = Microsoft.Maui.Controls.Compatibility.Constraint;
+
 	[TestFixture]
 	public class ContraintTypeConverterTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/ControlTemplateTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ControlTemplateTests.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class ControlTemplateTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutAlignContentTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutAlignContentTests.cs
@@ -5,6 +5,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using FlexLayout = Microsoft.Maui.Controls.Compatibility.FlexLayout;
+
 	[TestFixture]
 	public class FlexLayoutAlignContentTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutAlignItemsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutAlignItemsTests.cs
@@ -10,6 +10,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using FlexLayout = Microsoft.Maui.Controls.Compatibility.FlexLayout;
+
 	[TestFixture]
 	public class FlexLayoutAlignItemsTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutAlignSelfTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutAlignSelfTests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using FlexLayout = Microsoft.Maui.Controls.Compatibility.FlexLayout;
+
 	[TestFixture]
 	public class FlexLayoutAlignSelfTest : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutFlexDirectionTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutFlexDirectionTests.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using FlexLayout = Microsoft.Maui.Controls.Compatibility.FlexLayout;
+
 	[TestFixture]
 	public class FlexLayoutFlexDirectionTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutMarginTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutMarginTests.cs
@@ -9,6 +9,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using FlexLayout = Microsoft.Maui.Controls.Compatibility.FlexLayout;
+
 	public class FlexLayoutMarginTests : BaseTestFixture
 	{
 		[Test]

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using FlexLayout = Microsoft.Maui.Controls.Compatibility.FlexLayout;
+
 	[TestFixture]
 	public class FlexLayoutTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			double totalWidth = 0;
 			foreach (var view in layout.Children)
 			{
-				totalWidth += view.Bounds.Width;
+				totalWidth += view.Frame.Width;
 			}
 
 			Assert.AreEqual(layoutSize.Width, totalWidth, 2);
@@ -143,7 +143,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Layout(new Rectangle(0, 0, layoutSize.Width, layoutSize.Height));
 
 			foreach (var view in layout.Children)
-				Assert.That(view.Bounds.Width, Is.EqualTo(100));
+				Assert.That(view.Frame.Width, Is.EqualTo(100));
 
 			layout.Children.Remove(label3);
 
@@ -310,11 +310,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.That(layout.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 600)));
 			Assert.That(header.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 50)));
 			Assert.That(inner.Bounds, Is.EqualTo(new Rectangle(0, 50, 300, 500)));
-			Assert.That(inner.Children[0].Bounds, Is.EqualTo(new Rectangle(5, 5, 50, 490)));
-			Assert.That(inner.Children[1].Bounds, Is.EqualTo(new Rectangle(65, 5, 50, 490)));
-			Assert.That(inner.Children[2].Bounds, Is.EqualTo(new Rectangle(125, 5, 50, 490)));
-			Assert.That(inner.Children[3].Bounds, Is.EqualTo(new Rectangle(185, 5, 50, 490)));
-			Assert.That(inner.Children[4].Bounds, Is.EqualTo(new Rectangle(245, 5, 50, 490)));
+			Assert.That(inner.Children[0].Frame, Is.EqualTo(new Rectangle(5, 5, 50, 490)));
+			Assert.That(inner.Children[1].Frame, Is.EqualTo(new Rectangle(65, 5, 50, 490)));
+			Assert.That(inner.Children[2].Frame, Is.EqualTo(new Rectangle(125, 5, 50, 490)));
+			Assert.That(inner.Children[3].Frame, Is.EqualTo(new Rectangle(185, 5, 50, 490)));
+			Assert.That(inner.Children[4].Frame, Is.EqualTo(new Rectangle(245, 5, 50, 490)));
 
 			Assert.That(footer.Bounds, Is.EqualTo(new Rectangle(0, 550, 300, 50)));
 		}
@@ -480,7 +480,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				FlexLayout.SetGrow(box, 1f);
 			}
 
-			Assert.That(layout.Children[2].Bounds, Is.EqualTo(new Rectangle(0, 200, 300, 100)));
+			Assert.That(layout.Children[2].Frame, Is.EqualTo(new Rectangle(0, 200, 300, 100)));
 		}
 
 		[Test]
@@ -514,8 +514,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 
 			layout.Layout(new Rectangle(0, 0, 500, 300));
-			Assert.That(layout.Children[0].Bounds, Is.EqualTo(new Rectangle(20, 10, 100, 20)));
-			Assert.That(layout.Children[2].Bounds, Is.EqualTo(new Rectangle(380, 10, 100, 20)));
+			Assert.That(layout.Children[0].Frame, Is.EqualTo(new Rectangle(20, 10, 100, 20)));
+			Assert.That(layout.Children[2].Frame, Is.EqualTo(new Rectangle(380, 10, 100, 20)));
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/FlexOrderTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexOrderTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using FlexLayout = Microsoft.Maui.Controls.Compatibility.FlexLayout;
+
 	[TestFixture]
 	public class FlexOrderTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/GridTests.cs
+++ b/src/Controls/tests/Core.UnitTests/GridTests.cs
@@ -9,6 +9,8 @@ using NUnit.Framework.Constraints;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using Grid = Microsoft.Maui.Controls.Compatibility.Grid;
+
 	[TestFixture]
 	public class GridTests : BaseTestFixture
 	{
@@ -1921,10 +1923,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var view = new View();
 			var grid = new Grid();
 			Assert.AreEqual(0, grid.Children.Count);
-			(grid as Layout<View>).Children.Add(view);
+			(grid as Compatibility.Layout<View>).Children.Add(view);
 			Assert.AreEqual(1, grid.Children.Count);
-			Assert.AreEqual(1, (grid as Layout<View>).Children.Count);
-			Assert.AreSame(view, (grid as Layout<View>).Children.First());
+			Assert.AreEqual(1, (grid as Compatibility.Layout<View>).Children.Count);
+			Assert.AreSame(view, (grid as Compatibility.Layout<View>).Children.First());
 			Assert.AreSame(view, grid.Children.First());
 		}
 

--- a/src/Controls/tests/Core.UnitTests/GridTests.cs
+++ b/src/Controls/tests/Core.UnitTests/GridTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework.Constraints;
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	using Grid = Microsoft.Maui.Controls.Compatibility.Grid;
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
 
 	[TestFixture]
 	public class GridTests : BaseTestFixture

--- a/src/Controls/tests/Core.UnitTests/GroupViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/GroupViewUnitTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
-	internal class NaiveLayout : Layout<View>
+	internal class NaiveLayout : Compatibility.Layout<View>
 	{
 		protected override void LayoutChildren(double x, double y, double width, double height)
 		{

--- a/src/Controls/tests/Core.UnitTests/LayoutChildIntoBoundingRegionTests.cs
+++ b/src/Controls/tests/Core.UnitTests/LayoutChildIntoBoundingRegionTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -100,7 +100,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -162,7 +162,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -192,7 +192,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -222,7 +222,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -252,7 +252,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -282,7 +282,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -312,7 +312,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -342,7 +342,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -372,7 +372,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -402,7 +402,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -432,7 +432,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -463,7 +463,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -494,7 +494,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -524,7 +524,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -554,7 +554,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -584,7 +584,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -614,7 +614,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -644,7 +644,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -674,7 +674,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -704,7 +704,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -734,7 +734,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -764,7 +764,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;
@@ -794,7 +794,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Children.Add(view);
 			var region = new Rectangle(Region_X, Region_Y, Region_Width, Region_Height);
 
-			Layout.LayoutChildIntoBoundingRegion(view, region);
+			Compatibility.Layout.LayoutChildIntoBoundingRegion(view, region);
 
 			var target = view.Bounds;
 			var thickness = margin * 2;

--- a/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Microsoft.Maui.Controls.Layout2;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
@@ -9,6 +9,9 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+	using Grid = Microsoft.Maui.Controls.Compatibility.Grid;
+
 	public class LayoutCompatTests : BaseTestFixture
 	{
 		[Test]

--- a/src/Controls/tests/Core.UnitTests/MarginTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MarginTests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	public class MarginTests : BaseTestFixture
 	{
 		[SetUp]

--- a/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MultiBindingTests.cs
@@ -12,6 +12,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using Grid = Microsoft.Maui.Controls.Compatibility.Grid;
+
 	[TestFixture]
 	public class MultiBindingTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/NotifiedPropertiesTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NotifiedPropertiesTests.cs
@@ -7,6 +7,9 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+	using Grid = Microsoft.Maui.Controls.Compatibility.Grid;
+
 	[TestFixture]
 	public class NotifiedPropertiesTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RadioButtonTests.cs
@@ -2,6 +2,9 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+	using Grid = Microsoft.Maui.Controls.Compatibility.Grid;
+
 	[TestFixture]
 	public class RadioButtonTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/RelativeLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/RelativeLayoutTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;

--- a/src/Controls/tests/Core.UnitTests/ScrollViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ScrollViewUnitTests.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class ScrollViewUnitTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/ShellFlyoutItemTemplateTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellFlyoutItemTemplateTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using Grid = Microsoft.Maui.Controls.Compatibility.Grid;
+
 	[TestFixture]
 	public class ShellFlyoutItemTemplateTests : ShellTestBase
 	{

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class ShellTests : ShellTestBase
 	{

--- a/src/Controls/tests/Core.UnitTests/StackLayoutUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StackLayoutUnitTests.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class StackLayoutUnitTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/StackLayoutUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StackLayoutUnitTests.cs
@@ -232,9 +232,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			stack.Layout(new Rectangle(0, 0, 200, 200));
 
-			Assert.AreEqual(new Rectangle(0, 0, 20, 30), stack.Children[0].Bounds);
-			Assert.AreEqual(new Rectangle(90, 36, 20, 30), stack.Children[1].Bounds);
-			Assert.AreEqual(new Rectangle(180, 72, 20, 30), stack.Children[2].Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 20, 30), stack.Children[0].Frame);
+			Assert.AreEqual(new Rectangle(90, 36, 20, 30), stack.Children[1].Frame);
+			Assert.AreEqual(new Rectangle(180, 72, 20, 30), stack.Children[2].Frame);
 		}
 
 		[Test]
@@ -274,9 +274,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			stack.Layout(new Rectangle(0, 0, 100, 250));
 
-			Assert.That(stack.Children.ToArray()[0].Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
-			Assert.That(stack.Children.ToArray()[1].Bounds, Is.EqualTo(new Rectangle(0, 110, 100, 100)));
-			Assert.That(stack.Children.ToArray()[2].Bounds, Is.EqualTo(new Rectangle(0, 220, 100, 30)));
+			Assert.That(stack.Children.ToArray()[0].Frame, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(stack.Children.ToArray()[1].Frame, Is.EqualTo(new Rectangle(0, 110, 100, 100)));
+			Assert.That(stack.Children.ToArray()[2].Frame, Is.EqualTo(new Rectangle(0, 220, 100, 30)));
 		}
 
 		[Test]
@@ -296,9 +296,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			stack.Layout(new Rectangle(0, 0, 250, 100));
 
-			Assert.That(stack.Children.ToArray()[0].Bounds, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
-			Assert.That(stack.Children.ToArray()[1].Bounds, Is.EqualTo(new Rectangle(110, 0, 100, 100)));
-			Assert.That(stack.Children.ToArray()[2].Bounds, Is.EqualTo(new Rectangle(220, 0, 30, 100)));
+			Assert.That(stack.Children.ToArray()[0].Frame, Is.EqualTo(new Rectangle(0, 0, 100, 100)));
+			Assert.That(stack.Children.ToArray()[1].Frame, Is.EqualTo(new Rectangle(110, 0, 100, 100)));
+			Assert.That(stack.Children.ToArray()[2].Frame, Is.EqualTo(new Rectangle(220, 0, 30, 100)));
 		}
 
 		[Test]

--- a/src/Controls/tests/Core.UnitTests/StyleSheets/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleSheets/StyleTests.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.StyleSheets.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class StyleTests
 	{

--- a/src/Controls/tests/Core.UnitTests/TitleViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TitleViewUnitTests.cs
@@ -5,6 +5,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class TitleViewUnitTests : BaseTestFixture
 	{

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -12,6 +12,8 @@ using DescriptionAttribute = NUnit.Framework.DescriptionAttribute;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class TypedBindingUnitTests : BindingBaseUnitTests
 	{

--- a/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/BindingsCompiler.xaml
@@ -4,10 +4,10 @@
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
 		xmlns:sys="clr-namespace:System;assembly=mscorlib"
-
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.BindingsCompiler" >
-	<StackLayout>
-		<StackLayout x:DataType="local:MockViewModel">
+	<cmp:StackLayout>
+        <cmp:StackLayout x:DataType="local:MockViewModel">
 			<Label Text="{Binding Text}" x:Name="label0" />
 			<Label Text="{Binding Path=Text}" x:Name="label1" />
 			<Label Text="{Binding Model.Text}" x:Name="label2" />
@@ -21,7 +21,7 @@
             <Label Text="{Binding Text, Mode=OneTime}" x:Name="label8" />
 			<Label Text="{Binding StructModel.Text, Mode=TwoWay}" x:Name="label9" />
 			<Label Text="{Binding StructModel.Model.Text, Mode=TwoWay}" x:Name="label10" />
-		</StackLayout>
+		</cmp:StackLayout>
 		<Label Text="{Binding Text}" x:Name="labelWithUncompiledBinding" />
-	</StackLayout>
+	</cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml
@@ -2,11 +2,12 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.CompiledTypeConverter"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 RectangleP="0,1,2,4"
 			 RectangleBP="4,8,16,32"
 			 BackgroundColor="Pink"
 			 List="Foo, Bar">
 	<Label x:Name="label"
 		HorizontalOptions="EndAndExpand"
-		RelativeLayout.XConstraint="2" Margin="2,3"/>
+		cmp:RelativeLayout.XConstraint="2" Margin="2,3"/>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				Assert.AreEqual(new Rectangle(4, 8, 16, 32), p.RectangleBP);
 				Assert.AreEqual(Colors.Pink, p.BackgroundColor);
 				Assert.AreEqual(LayoutOptions.EndAndExpand, p.label.GetValue(View.HorizontalOptionsProperty));
-				var xConstraint = RelativeLayout.GetXConstraint(p.label);
+				var xConstraint = Microsoft.Maui.Controls.Compatibility.RelativeLayout.GetXConstraint(p.label);
 				Assert.AreEqual(2, xConstraint.Compute(null));
 				Assert.AreEqual(new Thickness(2, 3), p.label.Margin);
 				Assert.AreEqual(2, p.List.Count);

--- a/src/Controls/tests/Xaml.UnitTests/ConstraintExpression.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/ConstraintExpression.xaml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.ConstraintExpression" >
-	<RelativeLayout x:Name="relativeLayout">
+	<cmp:RelativeLayout x:Name="relativeLayout">
 		<Label x:Name="constantConstraint"
-			   RelativeLayout.WidthConstraint="{ConstraintExpression Type=Constant, Constant=42}" />
+			   cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=Constant, Constant=42}" />
 		<Label x:Name="constraintRelativeToParent"
-			   RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent, Constant=2, Factor=.5, Property=Width}" />
+			   cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToParent, Constant=2, Factor=.5, Property=Width}" />
 		<Label x:Name="foo" />
 		<Label x:Name="constraintRelativeToView"
-			   RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToView, Constant=2, Factor=.5, Property=Width, ElementName=foo}" />
-	</RelativeLayout>
+			   cmp:RelativeLayout.WidthConstraint="{cmp:ConstraintExpression Type=RelativeToView, Constant=2, Factor=.5, Property=Width, ElementName=foo}" />
+	</cmp:RelativeLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/ConstraintExpression.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/ConstraintExpression.xaml.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			{
 				var layout = new ConstraintExpression(useCompiledXaml);
 				var label = layout.constantConstraint;
-				var constraint = RelativeLayout.GetWidthConstraint(label);
+				var constraint = Microsoft.Maui.Controls.Compatibility.RelativeLayout.GetWidthConstraint(label);
 				Assert.NotNull(constraint);
 				Assert.AreEqual(42, constraint.Compute(null));
 			}
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				var layout = new ConstraintExpression(useCompiledXaml);
 				layout.relativeLayout.Layout(new Rectangle(0, 0, 200, 200));
 				var label = layout.constraintRelativeToParent;
-				var constraint = RelativeLayout.GetWidthConstraint(label);
+				var constraint = Microsoft.Maui.Controls.Compatibility.RelativeLayout.GetWidthConstraint(label);
 				Assert.NotNull(constraint);
 				Assert.AreEqual(102, constraint.Compute(layout.relativeLayout));
 			}
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				layout.foo.Layout(new Rectangle(5, 5, 190, 25));
 
 				var label = layout.constraintRelativeToView;
-				var constraint = RelativeLayout.GetWidthConstraint(label);
+				var constraint = Microsoft.Maui.Controls.Compatibility.RelativeLayout.GetWidthConstraint(label);
 				Assert.NotNull(constraint);
 				Assert.AreEqual(97, constraint.Compute(layout.relativeLayout));
 			}

--- a/src/Controls/tests/Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class DesignTimeLoaderTests
 	{

--- a/src/Controls/tests/Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -471,6 +471,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 			var xaml = @"
 				<ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
+					xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
 					xmlns:local=""clr-namespace:MissingNamespace;assembly=MissingAssembly"">
 					<ContentPage.Resources>
 						<StyleSheet>
@@ -481,16 +482,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 							]]>
 						</StyleSheet>
 					</ContentPage.Resources>
-					<StackLayout>
+					<cmp:StackLayout>
 						<Button />
 						<MyCustomButton />
-					</StackLayout>
+					</cmp:StackLayout>
 				</ContentPage>";
 
 			var page = (ContentPage)XamlLoader.Create(xaml, true);
 
-			var button = ((StackLayout)page.Content).Children[0];
-			var myButton = ((StackLayout)page.Content).Children[1];
+			var button = ((Compatibility.StackLayout)page.Content).Children[0];
+			var myButton = ((Compatibility.StackLayout)page.Content).Children[1];
 
 			Assert.That(button.BackgroundColor, Is.EqualTo(Colors.Red));
 			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Colors.Red));

--- a/src/Controls/tests/Xaml.UnitTests/InlineCSS.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/InlineCSS.xaml
@@ -2,6 +2,7 @@
 <ContentPage 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
     x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.InlineCSS">
     <ContentPage.Resources>
         <StyleSheet>
@@ -17,8 +18,8 @@ label {
             ]]>
         </StyleSheet>
     </ContentPage.Resources>
-    <StackLayout x:Name="stack">
+    <cmp:StackLayout x:Name="stack">
         <Label x:Name="label"/>
         <Button x:Name="button"/>
-    </StackLayout>
+    </cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz24910.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz24910.xaml
@@ -2,13 +2,14 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Bz24910" >
-	<StackLayout>
+	<cmp:StackLayout>
 		<local:Bz24910Control x:Name="control0" Text="CustomButton" NullableInt="1" NullableDouble="2.2" />
 		<local:Bz24910Control x:Name="control1" Text="CustomButton" NullableDouble="2"  />
 		<local:Bz24910Control x:Name="control2" Text="CustomButton" NullableInt="{x:Null}" />
 		<local:Bz24910Control x:Name="control3" Text="CustomButton" NullableInt="{Binding .}" />
 		<Label x:Name="control4" local:Bz24910Control.AttachedNullableInt="3" />
 		<local:Bz24910Control x:Name="control5" Text="CustomButton" NullableIntProp="5" />
-	</StackLayout>
+	</cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz27863.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz27863.xaml
@@ -2,15 +2,16 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Bz27863">
 	<ContentPage.Resources>
 		<ResourceDictionary>
 			<local:ReverseConverter x:Key="reverseConverter"/>
 			<DataTemplate x:Key="SimpleMessageTemplate">
 				<ViewCell>
-					<StackLayout >
+					<cmp:StackLayout >
 						<Label Text="{Binding Converter={StaticResource reverseConverter}}" />
-					</StackLayout>
+					</cmp:StackLayout>
 				</ViewCell>
 			</DataTemplate>
 			<ListView x:Key="listview"

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz27863.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz27863.xaml.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				var template = listview.ItemTemplate;
 				var cell = template.CreateContent() as ViewCell;
 				cell.BindingContext = "Foo";
-				Assert.AreEqual("ooF", ((Label)((StackLayout)cell.View).Children[0]).Text);
+				Assert.AreEqual("ooF", ((Label)((Compatibility.StackLayout)cell.View).Children[0]).Text);
 			}
 		}
 	}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz28545.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz28545.xaml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Bz28545">
 	<ContentPage.Resources>
 		<ResourceDictionary>
 			<Style x:Key="TitleLabel" TargetType="Label">
-				<Setter Property="AbsoluteLayout.LayoutBounds" Value="1,1,AutoSize,AutoSize" />
-				<Setter Property="AbsoluteLayout.LayoutFlags" Value="PositionProportional" />
+				<Setter Property="cmp:AbsoluteLayout.LayoutBounds" Value="1,1,AutoSize,AutoSize" />
+                <Setter Property="cmp:AbsoluteLayout.LayoutFlags" Value="PositionProportional" />
 				<Setter Property="TextColor" Value="Pink" />
 			</Style>
 		</ResourceDictionary>
 	</ContentPage.Resources>
-	<AbsoluteLayout>
+	<cmp:AbsoluteLayout>
 		<Label x:Name="label"
 			   Style="{StaticResource TitleLabel}" />
-	</AbsoluteLayout>
+	</cmp:AbsoluteLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz28545.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz28545.xaml.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	using AbsoluteLayout = Microsoft.Maui.Controls.Compatibility.AbsoluteLayout;
+
 	public partial class Bz28545 : ContentPage
 	{
 		public Bz28545()

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh11334.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh11334.xaml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage
         xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh11334">
-    <StackLayout x:Name="stack">
+    <cmp:StackLayout x:Name="stack">
         <Label x:Name="label" Text="Welcome to Microsoft.Maui.Controls!!!!" 
            HorizontalOptions="Start"
            VerticalOptions="CenterAndExpand" />
-        <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
+        <cmp:StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
             <Button Margin="5" Text="Remove" Clicked="Remove" />
             <Button Margin="5" Text="Add" Clicked="Add" />
-        </StackLayout>
-    </StackLayout>
+        </cmp:StackLayout>
+    </cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh11335.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh11335.xaml
@@ -2,14 +2,15 @@
 <ContentPage
         xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
         x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh11335">
-    <StackLayout x:Name="stack">
+    <cmp:StackLayout x:Name="stack">
         <Label x:Name="label" Text="Welcome to Microsoft.Maui.Controls!!!!" 
            HorizontalOptions="Start"
            VerticalOptions="CenterAndExpand" />
-        <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
+        <cmp:StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
             <Button Margin="5" Text="Remove" Clicked="Remove" />
             <Button Margin="5" Text="Add" Clicked="Add" />
-        </StackLayout>
-    </StackLayout>
+        </cmp:StackLayout>
+    </cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh11551.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh11551.xaml
@@ -3,14 +3,15 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:mg="clr-namespace:Microsoft.Maui.Graphics;assembly=Microsoft.Maui.Graphics"
+    xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 	x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh11551">
     <ContentPage.Resources>
-		<mg:Rectangle x:Key="rect" Height="22" Width="{x:Static AbsoluteLayout.AutoSize}" X="1" Y="0.5"/>
+		<mg:Rectangle x:Key="rect" Height="22" Width="{x:Static cmp:AbsoluteLayout.AutoSize}" X="1" Y="0.5"/>
     </ContentPage.Resources>
     <Label x:Name="label">
 		<Label.Style>
 			<Style TargetType="Label">
-				<Setter Property="AbsoluteLayout.LayoutBounds" Value="{DynamicResource rect}"/>
+				<Setter Property="cmp:AbsoluteLayout.LayoutBounds" Value="{DynamicResource rect}"/>
 			</Style>
 		</Label.Style>
     </Label>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh11551.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh11551.xaml.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	using AbsoluteLayout = Microsoft.Maui.Controls.Compatibility.AbsoluteLayout;
+
 	public partial class Gh11551 : ContentPage
 	{
 		public Gh11551() => InitializeComponent();

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh3260.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh3260.xaml.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
-	public abstract class Gh3260MyGLayout<T> : Layout<T> where T : View
+	public abstract class Gh3260MyGLayout<T> : Controls.Compatibility.Layout<T> where T : View
 	{
 		protected override void LayoutChildren(double x, double y, double width, double height)
 		{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh4227.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh4227.xaml
@@ -2,11 +2,12 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh4227"
 			 x:DataType="local:IGh4227Level1">
-	<StackLayout>
+	<cmp:StackLayout>
 		<Label x:Name="label0" Text="{Binding Level0}"/>
 		<Label x:Name="label1" Text="{Binding Level1}"/>
-	</StackLayout>
+	</cmp:StackLayout>
 </ContentPage>
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh5510.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh5510.xaml
@@ -3,9 +3,10 @@
         xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
         x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh5510"
         x:DataType="local:Gh5510VM">
-   <StackLayout>
+   <cmp:StackLayout>
         <Label Text="Name"/>
         <Entry Text="{Binding Name}" TextColor="Red" x:Name="entry">
             <Entry.Triggers>
@@ -15,5 +16,5 @@
             </Entry.Triggers>
         </Entry>
         <Button Text="Clear error"/>
-    </StackLayout>
+    </cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh6648.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh6648.xaml
@@ -2,14 +2,15 @@
 <ContentPage
         xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"    
         x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh6648"
         x:DataType="Label">
     <ContentPage.Content>
-        <StackLayout>
+        <cmp:StackLayout>
             <Label Text="{Binding Text}" />
-            <StackLayout x:DataType="{x:Null}" x:Name="stack" >
+            <cmp:StackLayout x:DataType="{x:Null}" x:Name="stack" >
                 <Label Text="{Binding foo}" x:Name="label" />
-            </StackLayout>
-       </StackLayout>
+            </cmp:StackLayout>
+       </cmp:StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh7837.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh7837.xaml
@@ -2,15 +2,16 @@
 <ContentPage
         xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
         xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
         x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh7837">
     <ContentPage.BindingContext>
         <local:Gh7837VM />
     </ContentPage.BindingContext>
-    <StackLayout>
+    <cmp:StackLayout>
         <Label x:Name="label0" Text="{Binding .[42]}" />
         <Label x:Name="label1" Text="{Binding .[foo]}" />
         <Label x:Name="label2" Text="{Binding .[42]}" x:DataType="local:Gh7837VM" />
         <Label x:Name="label3" Text="{Binding .[foo]}" x:DataType="local:Gh7837VM" />
-    </StackLayout>
+    </cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh8221.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh8221.xaml
@@ -3,10 +3,11 @@
         xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
         x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh8221"
         x:DataType="local:Gh8221VM">
-    <StackLayout>
+    <cmp:StackLayout>
         <Label Text="{Binding Data[EntryOne]}" x:Name="entryone"/>
         <Label Text="{Binding Data[EntryTwo]}" x:Name="entrytwo"/>
-    </StackLayout>
+    </cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1493.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1493.cs
@@ -34,8 +34,9 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 						<View 
 							xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
 							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-							RelativeLayout.HeightConstraint=""{ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.25}""
-							RelativeLayout.WidthConstraint=""{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.6}""/>";
+							xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
+							cmp:RelativeLayout.HeightConstraint=""{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.25}""
+							cmp:RelativeLayout.WidthConstraint=""{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.6}""/>";
 			View view = new View();
 			view.LoadFromXaml(xaml);
 			Assert.DoesNotThrow(() => view.LoadFromXaml(xaml));

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1545.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1545.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		{
 			string xaml = @"<ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 						 xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+						 xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
+						 xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
 						 x:Class=""Microsoft.Maui.Controls.ControlGallery.Issue1545"">
 							<ContentPage.Resources>
 							<ResourceDictionary>
@@ -66,9 +68,9 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 							<ListView.ItemTemplate>
 								<DataTemplate>
 									<ViewCell>
-									<StackLayout>
+									<cmp:StackLayout>
 										<Label Text=""{Binding}"" BackgroundColor=""{StaticResource color}""/>
-									</StackLayout>
+									</cmp:StackLayout>
 									</ViewCell>
 								</DataTemplate>
 							</ListView.ItemTemplate>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1545.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1545.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class Issue1545
 	{

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1549.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1549.cs
@@ -135,6 +135,7 @@ xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 			var xaml = @"<local:BaseView 
 	xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
 	xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"" 
+	xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
   	xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
 	Padding=""0,40,0,0"">
     <local:BaseView.Resources>
@@ -153,10 +154,10 @@ xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 			<DataTemplate> 
 				<ViewCell >
 				<ViewCell.View>
-					<Grid  VerticalOptions=""FillAndExpand"" HorizontalOptions=""FillAndExpand""  >			
+					<cmp:Grid  VerticalOptions=""FillAndExpand"" HorizontalOptions=""FillAndExpand""  >			
 					<Label  IsVisible=""{Binding IsLocked}""  Text=""Show Is Locked""  />
 					<Label  IsVisible=""{Binding IsLocked, Converter={StaticResource cnvInvert}}"" Text=""Show Is Not locked"" />
-				</Grid>
+				</cmp:Grid>
 				</ViewCell.View>
 				</ViewCell>
 			</DataTemplate>
@@ -182,8 +183,8 @@ xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 			var cell2 = (ViewCell)lst.TemplatedItems.GetOrCreateContent(2, items[2]);
 			var cell3 = (ViewCell)lst.TemplatedItems.GetOrCreateContent(3, items[3]);
 
-			var label00 = (cell0.View as Grid).Children[0] as Label;
-			var label01 = (cell0.View as Grid).Children[1] as Label;
+			var label00 = (cell0.View as Compatibility.Grid).Children[0] as Label;
+			var label01 = (cell0.View as Compatibility.Grid).Children[1] as Label;
 
 			Assert.AreEqual("Show Is Locked", label00.Text);
 			Assert.AreEqual("Show Is Not locked", label01.Text);

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue1794.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue1794.cs
@@ -1,5 +1,4 @@
 using System;
-
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
@@ -13,6 +12,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			var xaml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
 				<ContentPage xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 						 xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+						 xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
 						 xmlns:local=""clr-namespace:Microsoft.Maui.ControlsFormsXamlSample;assembly=Microsoft.Maui.ControlsFormsXamlSample""
 						 xmlns:constants=""clr-namespace:Microsoft.Maui.ControlsFormsSample;assembly=Microsoft.Maui.ControlsFormsXamlSample""
 						 x:Class=""UxDemoAppXF.Layouts.Menu""
@@ -26,23 +26,23 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 						<ListView.ItemTemplate>
 							<DataTemplate>
 								<ViewCell>
-									<RelativeLayout>
+									<cmp:RelativeLayout>
 										<Label x:Name=""LinkText""
 													 Text=""{Binding Name}""
-													 RelativeLayout.XConstraint=
-														""{ConstraintExpression  Type=RelativeToParent, 
+													 cmp:RelativeLayout.XConstraint=
+														""{cmp:ConstraintExpression  Type=RelativeToParent, 
 																										Property=Width, 
 																										Factor=0.5}""/>
 										<Image x:Name=""LinkImage"" 
 													 Source=""{Binding ImageSource}""
-													 RelativeLayout.XConstraint=
-														""{ConstraintExpression  Type=RelativeToView,
+													 cmp:RelativeLayout.XConstraint=
+														""{cmp:ConstraintExpression  Type=RelativeToView,
 																				Property=Width, 
 																				ElementName=LinkText,
 																				Constant=5}""/>
 									 
 				 
-									</RelativeLayout>
+									</cmp:RelativeLayout>
 								</ViewCell>
 							</DataTemplate>
 						</ListView.ItemTemplate>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Issue3090.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Issue3090.xaml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Issue3090">
-	<AbsoluteLayout >
-		<Label AbsoluteLayout.LayoutBounds="0, 0, 1, 1" />
-	</AbsoluteLayout>
+	<cmp:AbsoluteLayout >
+		<Label cmp:AbsoluteLayout.LayoutBounds="0, 0, 1, 1" />
+	</cmp:AbsoluteLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/TestCases.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/TestCases.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.ConstrainedExecution;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using NUnit.Framework;
 
@@ -51,19 +52,20 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 			xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
 			xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests""
+			xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
 			Title=""Home"">
 				<local:TestCases.InnerView>
 					<Label x:Name=""innerView""/>
 				</local:TestCases.InnerView>
 				<ContentPage.Content>
-					<Grid RowSpacing=""9"" ColumnSpacing=""6"" Padding=""6,9"" VerticalOptions=""Fill"" HorizontalOptions=""Fill"" BackgroundColor=""Red"">
-						<Grid.Children>
+					<cmp:Grid RowSpacing=""9"" ColumnSpacing=""6"" Padding=""6,9"" VerticalOptions=""Fill"" HorizontalOptions=""Fill"" BackgroundColor=""Red"">
+						<cmp:Grid.Children>
 							<Label x:Name=""label0""/>
 							<Label x:Name=""label1""/>
 							<Label x:Name=""label2""/>
 							<Label x:Name=""label3""/>
-						</Grid.Children>
-					</Grid>
+						</cmp:Grid.Children>
+					</cmp:Grid>
 				</ContentPage.Content>
 			</ContentPage>";
 			var contentPage = new ContentPage().LoadFromXaml(xaml);
@@ -103,18 +105,19 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				<ContentPage
 					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 					xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+					xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
 					Title=""People"">
 
-					<StackLayout Spacing=""0"">
+					<cmp:StackLayout Spacing=""0"">
 						<SearchBar x:Name=""searchBar""/>
 						<ListView ItemsSource=""{Binding Path=.}"" RowHeight=""42"" x:Name=""listview"">
 							<ListView.ItemTemplate>
 								<DataTemplate>
 									<ViewCell>
 										<ViewCell.View>
-											<StackLayout Orientation=""Horizontal"" HorizontalOptions=""FillAndExpand"" VerticalOptions=""CenterAndExpand"" BackgroundColor=""#fff4f4f4"">
+											<cmp:StackLayout Orientation=""Horizontal"" HorizontalOptions=""FillAndExpand"" VerticalOptions=""CenterAndExpand"" BackgroundColor=""#fff4f4f4"">
 												<BoxView WidthRequest=""10""/>
-												<Grid WidthRequest=""42"" HeightRequest=""32"" VerticalOptions=""CenterAndExpand"" HorizontalOptions=""Start"">
+												<cmp:Grid WidthRequest=""42"" HeightRequest=""32"" VerticalOptions=""CenterAndExpand"" HorizontalOptions=""Start"">
 													<Image WidthRequest=""32"" HeightRequest=""32"" Aspect=""AspectFill"" HorizontalOptions=""FillAndExpand"" Source=""Images/icone_nopic_members_42.png""/>
 													<!--<Image WidthRequest=""32"" HeightRequest=""32"" Aspect=""AspectFill"" HorizontalOptions=""FillAndExpand"">
 														<Image.Source>
@@ -122,16 +125,16 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 														</Image.Source>
 													</Image>-->
 													<Image Source=""Images/cropcircle.png"" HorizontalOptions=""FillAndExpand"" VerticalOptions=""FillAndExpand"" WidthRequest=""32"" HeightRequest=""32"" Aspect=""Fill""/>
-												</Grid>
+												</cmp:Grid>
 												<Label Text=""{Binding FirstName}"" VerticalOptions=""CenterAndExpand""/>
 												<Label Text=""{Binding LastName}"" FontFamily=""HelveticaNeue-Bold"" FontSize=""Medium"" VerticalOptions=""CenterAndExpand"" />
-											</StackLayout>
+											</cmp:StackLayout>
 										</ViewCell.View>
 									</ViewCell>
 								</DataTemplate>
 							</ListView.ItemTemplate>
 						</ListView>
-					</StackLayout>
+					</cmp:StackLayout>
 				</ContentPage>";
 			var page = new ContentPage().LoadFromXaml(xaml);
 			var model = new List<object> {
@@ -187,6 +190,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 						<ContentPage 
 							xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
 							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+							xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
 							xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"">
 							<Label x:Name=""label"" Text=""{Binding Converter={x:Static local:ReverseConverter.Instance}, Mode=TwoWay}""/>
 						</ContentPage>";
@@ -207,8 +211,9 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 						<View 
 							xmlns=""http://schemas.microsoft.com/dotnet/2021/maui"" 
 							xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
-							RelativeLayout.HeightConstraint=""{ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.25}""
-							RelativeLayout.WidthConstraint=""{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.6}""/>";
+							xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
+							cmp:RelativeLayout.HeightConstraint=""{cmp:ConstraintExpression Type=RelativeToParent, Property=Height, Factor=0.25}""
+							cmp:RelativeLayout.WidthConstraint=""{cmp:ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.6}""/>";
 			View view = new View();
 			view.LoadFromXaml(xaml);
 			Assert.DoesNotThrow(() => view.LoadFromXaml(xaml));

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported002.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported002.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Unreported002">
 	<Label x:Name="label"
-		   AbsoluteLayout.LayoutBounds="0.5,0.5,1,AutoSize" />
+		   cmp:AbsoluteLayout.LayoutBounds="0.5,0.5,1,AutoSize" />
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported002.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported002.xaml.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	using AbsoluteLayout = Microsoft.Maui.Controls.Compatibility.AbsoluteLayout;
+
 	public partial class Unreported002 : ContentPage
 	{
 		public Unreported002()

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported005.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported005.xaml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 		xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
 		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Unreported005">
-	<RelativeLayout>
+	<cmp:RelativeLayout>
 		<Label x:Name="before" />
 		<Button x:Name="after"
-				RelativeLayout.XConstraint="{local:Unreported005RelativeToViewHorizontal ElementName=before, Constant=105}" />
+				cmp:RelativeLayout.XConstraint="{local:Unreported005RelativeToViewHorizontal ElementName=before, Constant=105}" />
     
-	</RelativeLayout>
+	</cmp:RelativeLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported005.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported005.xaml.cs
@@ -3,6 +3,9 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	using Constraint = Microsoft.Maui.Controls.Compatibility.Constraint;
+	using RelativeLayout = Microsoft.Maui.Controls.Compatibility.RelativeLayout;
+
 	public abstract class Unreported005RelativeToView : IMarkupExtension
 	{
 		protected Unreported005RelativeToView()

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported006.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported006.xaml
@@ -3,9 +3,10 @@
 		xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Unreported006">
 	<local:Unreported006.GenericProperty>
-		<StackLayout/>
+		<cmp:StackLayout/>
 	</local:Unreported006.GenericProperty>
 	<ContentPage.Content>
 	</ContentPage.Content>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported006.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported006.xaml.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			{
 				var page = new Unreported006();
 				Assert.NotNull(page.GenericProperty);
-				Assert.That(page.GenericProperty, Is.TypeOf<StackLayout>());
+				Assert.That(page.GenericProperty, Is.TypeOf<Compatibility.StackLayout>());
 			}
 		}
 	}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported006.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported006.xaml.cs
@@ -14,14 +14,14 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			//this stub will be replaced at compile time
 		}
 
-		public Layout<View> GenericProperty
+		public Controls.Compatibility.Layout<View> GenericProperty
 		{
-			get { return (Layout<View>)GetValue(GenericPropertyProperty); }
+			get { return (Controls.Compatibility.Layout<View>)GetValue(GenericPropertyProperty); }
 			set { SetValue(GenericPropertyProperty, value); }
 		}
 
 		public static readonly BindableProperty GenericPropertyProperty =
-			BindableProperty.Create(nameof(GenericProperty), typeof(Layout<View>), typeof(Unreported006));
+			BindableProperty.Create(nameof(GenericProperty), typeof(Controls.Compatibility.Layout<View>), typeof(Unreported006));
 
 		[TestFixture]
 		class Tests

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported007.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported007.xaml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Unreported007">
 
 	<Label Text="Foo" x:Name="label">
-		<RelativeLayout.XConstraint>
-			<OnPlatform x:TypeArguments="Constraint">
-				<On Platform="iOS" Value="{ConstraintExpression Type=Constant,Constant=3}" />
-				<On Platform="Android" Value="{ConstraintExpression Type=Constant,Constant=6}" />
+		<cmp:RelativeLayout.XConstraint>
+			<OnPlatform x:TypeArguments="cmp:Constraint">
+                <On Platform="iOS" Value="{cmp:ConstraintExpression Type=Constant,Constant=3}" />
+                <On Platform="Android" Value="{cmp:ConstraintExpression Type=Constant,Constant=6}" />
 			</OnPlatform>
-		</RelativeLayout.XConstraint>
+		</cmp:RelativeLayout.XConstraint>
 	</Label>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported007.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported007.xaml.cs
@@ -6,6 +6,9 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	using RelativeLayout = Microsoft.Maui.Controls.Compatibility.RelativeLayout;
+	using Constraint = Microsoft.Maui.Controls.Compatibility.Constraint;
+
 	public partial class Unreported007 : ContentPage
 	{
 		public Unreported007()

--- a/src/Controls/tests/Xaml.UnitTests/LoaderTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/LoaderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ConstrainedExecution;
 using Microsoft.Maui.Controls.Build.Tasks;
 using Microsoft.Maui.Controls.Core.UnitTests;
 using Mono.Cecil;
@@ -195,16 +196,17 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 		public void TestBindingPath()
 		{
 			var xaml = @"
-				<StackLayout 
+				<cmp:StackLayout 
 				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
+				xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
 				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
-					<StackLayout.Children>
+					<cmp:StackLayout.Children>
 						<Label x:Name=""label0"" Text=""{Binding text}""/>
 						<Label x:Name=""label1"" Text=""{Binding Path=text}""/>
-					</StackLayout.Children>
-				</StackLayout>";
+					</cmp:StackLayout.Children>
+				</cmp:StackLayout>";
 
-			var stacklayout = new StackLayout();
+			var stacklayout = new Compatibility.StackLayout();
 			stacklayout.LoadFromXaml(xaml);
 
 			var label0 = stacklayout.FindByName<Label>("label0");
@@ -231,6 +233,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				<ContentPage 
 				xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
 				xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+				xmlns:cmp=""clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls""
 				xmlns:local=""clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;assembly=Microsoft.Maui.Controls.Xaml.UnitTests"">
 					<ContentPage.Resources>
 						<ResourceDictionary>
@@ -238,12 +241,12 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 						</ResourceDictionary>
 					</ContentPage.Resources>
 					<ContentPage.Content>
-						<StackLayout Orientation=""Vertical"">
-							<StackLayout.Children>
+						<cmp:StackLayout Orientation=""Vertical"">
+							<cmp:StackLayout.Children>
 								<Label x:Name=""label0"" Text=""{Binding Text, Converter={StaticResource reverseConverter}}""/>
 								<Label x:Name=""label1"" Text=""{Binding Text, Mode=TwoWay}""/>
-							</StackLayout.Children>
-						</StackLayout>
+							</cmp:StackLayout.Children>
+						</cmp:StackLayout>
 					</ContentPage.Content>
 				</ContentPage>";
 

--- a/src/Controls/tests/Xaml.UnitTests/NameScopeTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/NameScopeTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 					<Label />
 				</StackLayout>";
 
-			var layout = new StackLayout().LoadFromXaml(xaml);
+			var layout = new Controls.Compatibility.StackLayout().LoadFromXaml(xaml);
 
 			Assert.IsNotNull(Maui.Controls.Internals.NameScope.GetNameScope(layout));
 			Assert.That(Maui.Controls.Internals.NameScope.GetNameScope(layout), Is.TypeOf<Maui.Controls.Internals.NameScope>());

--- a/src/Controls/tests/Xaml.UnitTests/NativeViewsAndBindings.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/NativeViewsAndBindings.xaml
@@ -3,11 +3,12 @@
 		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		xmlns:ios="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;targetPlatform=iOS"
 		xmlns:android="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests;targetPlatform=Android"
+        xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 		x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.NativeViewsAndBindings">
-	<StackLayout>
+	<cmp:StackLayout>
 		<ContentView x:Name="view0">
 			<ios:MockUIView Foo="foo" Bar="42" Baz="{Binding Baz}" View.HorizontalOptions="End" View.VerticalOptions="{Binding VerticalOption}" />
 			<android:MockAndroidView Foo="foo" Bar="42" Baz="{Binding Baz}" View.HorizontalOptions="End" View.VerticalOptions="{Binding VerticalOption}" />
 		</ContentView>
-	</StackLayout>
+	</cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/SetValue.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/SetValue.xaml
@@ -13,7 +13,7 @@
 			<Color x:Key="purple">Purple</Color>
 		</ResourceDictionary>
 	</ContentPage.Resources>
-	<StackLayout>
+	<cmp:StackLayout>
 		<Label x:Name="label0" Text="Foo"/>
 		<Label x:Name="label1" Text="{Binding Path=labeltext}"/>
 		<Button x:Name="button0" Clicked="onButtonClicked" />
@@ -29,24 +29,24 @@
 		<ContentView x:Name="contentview1">
 			<Label x:Name="label4"/>
 		</ContentView>
-		<StackLayout x:Name="stack0">
-			<StackLayout.Children>
+        <cmp:StackLayout x:Name="stack0">
+            <cmp:StackLayout.Children>
 				<Label x:Name="label5"/>
 				<Label x:Name="label6"/>
-			</StackLayout.Children>
-		</StackLayout>
-		<StackLayout x:Name="stack1">
+			</cmp:StackLayout.Children>
+		</cmp:StackLayout>
+        <cmp:StackLayout x:Name="stack1">
 			<Label x:Name="label7"/>
 			<Label x:Name="label8"/>
-		</StackLayout>
-		<StackLayout x:Name="stack2">
-			<StackLayout.Children>
+		</cmp:StackLayout>
+        <cmp:StackLayout x:Name="stack2">
+            <cmp:StackLayout.Children>
 				<Label x:Name="label9"/>
-			</StackLayout.Children>
-		</StackLayout>
-		<StackLayout x:Name="stack3">
+			</cmp:StackLayout.Children>
+		</cmp:StackLayout>
+        <cmp:StackLayout x:Name="stack3">
 			<Label x:Name="label10"/>
-		</StackLayout>
+		</cmp:StackLayout>
 		<Label x:Name="label11" Text="{Binding labeltext}"/>
 		<ListView x:Name="listView">
 			<ListView.ItemsSource>
@@ -75,9 +75,9 @@
 		<ContentView x:Name="content0">
 			<local:ConvertibleToView/>
 		</ContentView>
-		<StackLayout x:Name="stack4">
+        <cmp:StackLayout x:Name="stack4">
 			<local:ConvertibleToView/>
-		</StackLayout>
+		</cmp:StackLayout>
 		<ContentView x:Name="contentview2">
 			<ContentView.Content>
 				<Label />
@@ -98,5 +98,5 @@
 			</local:MockViewWithValues.Bar>
 		</local:MockViewWithValues>
 		<local:MockViewWithValues x:Name="implicit3" Foo="Foo" />
-	</StackLayout>
+	</cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/SetValue.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/SetValue.xaml
@@ -3,6 +3,7 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+    xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 	xmlns:d="ignoreme"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d"
@@ -70,7 +71,7 @@
 				<ColumnDefinition/>
 			</Grid.ColumnDefinitions>
 		</Grid>
-		<Label x:Name="label14" AbsoluteLayout.LayoutFlags="PositionProportional,WidthProportional" />
+		<Label x:Name="label14" cmp:AbsoluteLayout.LayoutFlags="PositionProportional,WidthProportional" />
 		<ContentView x:Name="content0">
 			<local:ConvertibleToView/>
 		</ContentView>

--- a/src/Controls/tests/Xaml.UnitTests/SetValue.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/SetValue.xaml.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
+	using AbsoluteLayout = Microsoft.Maui.Controls.Compatibility.AbsoluteLayout;
+
 	public class ConvertibleToView
 	{
 		public static implicit operator View(ConvertibleToView source)

--- a/src/Controls/tests/Xaml.UnitTests/StyleSheet.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/StyleSheet.xaml
@@ -2,11 +2,12 @@
 <ContentPage 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+    xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
     x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.StyleSheet">
     <ContentPage.Resources>
         <StyleSheet Source="css/foo.css" />
     </ContentPage.Resources>
-    <StackLayout>
+    <cmp:StackLayout>
         <Label x:Name="label0" />
-    </StackLayout>
+    </cmp:StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/XamlC/MethodReferenceExtensionsTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/XamlC/MethodReferenceExtensionsTests.cs
@@ -54,17 +54,17 @@ namespace Microsoft.Maui.Controls.XamlcUnitTests
 		public void GenericGetter()
 		{
 			TypeReference declaringTypeReference;
-			var type = module.ImportReference(typeof(StackLayout));
+			var type = module.ImportReference(typeof(Compatibility.StackLayout));
 			var property = type.GetProperty(pd => pd.Name == "Children", out declaringTypeReference);
-			Assert.AreEqual("System.Collections.Generic.IList`1<T> Microsoft.Maui.Controls.Layout`1::Children()", property.FullName);
-			Assert.AreEqual("Microsoft.Maui.Controls.Layout`1<Microsoft.Maui.Controls.View>", declaringTypeReference.FullName);
+			Assert.AreEqual("System.Collections.Generic.IList`1<T> Microsoft.Maui.Controls.Compatibility.Layout`1::Children()", property.FullName);
+			Assert.AreEqual("Microsoft.Maui.Controls.Compatibility.Layout`1<Microsoft.Maui.Controls.View>", declaringTypeReference.FullName);
 			var propertyGetter = property.GetMethod;
-			Assert.AreEqual("System.Collections.Generic.IList`1<T> Microsoft.Maui.Controls.Layout`1::get_Children()", propertyGetter.FullName);
+			Assert.AreEqual("System.Collections.Generic.IList`1<T> Microsoft.Maui.Controls.Compatibility.Layout`1::get_Children()", propertyGetter.FullName);
 			var propertyGetterRef = module.ImportReference(propertyGetter);
-			Assert.AreEqual("System.Collections.Generic.IList`1<T> Microsoft.Maui.Controls.Layout`1::get_Children()", propertyGetterRef.FullName);
+			Assert.AreEqual("System.Collections.Generic.IList`1<T> Microsoft.Maui.Controls.Compatibility.Layout`1::get_Children()", propertyGetterRef.FullName);
 
 			propertyGetterRef = module.ImportReference(propertyGetterRef.ResolveGenericParameters(declaringTypeReference, module));
-			Assert.AreEqual("System.Collections.Generic.IList`1<T> Microsoft.Maui.Controls.Layout`1<Microsoft.Maui.Controls.View>::get_Children()", propertyGetterRef.FullName);
+			Assert.AreEqual("System.Collections.Generic.IList`1<T> Microsoft.Maui.Controls.Compatibility.Layout`1<Microsoft.Maui.Controls.View>::get_Children()", propertyGetterRef.FullName);
 			var returnType = propertyGetterRef.ReturnType.ResolveGenericParameters(declaringTypeReference);
 			Assert.AreEqual("System.Collections.Generic.IList`1<Microsoft.Maui.Controls.View>", returnType.FullName);
 		}

--- a/src/Controls/tests/Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls.XamlcUnitTests
 		[TestCase(typeof(OnPlatform<string>), typeof(BindableObject), ExpectedResult = false)]
 		[TestCase(typeof(OnPlatform<string>), typeof(BindingBase), ExpectedResult = false)]
 		[TestCase(typeof(OnPlatform<FontAttributes>), typeof(BindableObject), ExpectedResult = false)]
-		[TestCase(typeof(StackLayout), typeof(Layout<View>), ExpectedResult = true)]
+		[TestCase(typeof(StackLayout), typeof(Controls.Compatibility.Layout<View>), ExpectedResult = true)]
 		[TestCase(typeof(StackLayout), typeof(View), ExpectedResult = true)]
 		[TestCase(typeof(Foo<string>), typeof(Foo), ExpectedResult = true)]
 		[TestCase(typeof(Bar<string>), typeof(Foo), ExpectedResult = true)]

--- a/src/Controls/tests/Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Maui.Controls
 }
 namespace Microsoft.Maui.Controls.XamlcUnitTests
 {
+	using Constraint = Microsoft.Maui.Controls.Compatibility.Constraint;
+	using ConstraintExpression = Microsoft.Maui.Controls.Compatibility.ConstraintExpression;
+	using StackLayout = Microsoft.Maui.Controls.Compatibility.StackLayout;
+
 	[TestFixture]
 	public class TypeReferenceExtensionsTests
 	{

--- a/src/Core/src/Core/IStackLayout.cs
+++ b/src/Core/src/Core/IStackLayout.cs
@@ -6,7 +6,7 @@
 	public interface IStackLayout : ILayout
 	{
 		/// <summary>
-		/// Identifies the Spacing between childs.
+		/// Specifies the amount of space between children.
 		/// </summary>
 		double Spacing { get; }
 	}


### PR DESCRIPTION
Move legacy layouts to Microsoft.Maui.Controls.Compatibility; new layouts move to Microsoft.Maui.Controls.

Also adds a StackLayout type to the new layouts which is built out of VerticalStackLayout and HorizontalStackLayout.