### PR TITLE
Create convenience methods for adding behavior to a mapper

### DIFF
--- a/src/Core/src/PropertyMapperExtensions.cs
+++ b/src/Core/src/PropertyMapperExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui
 
 			void newMethod(TViewHandler handler, TVirtualView view)
 			{
-				previousMethod(handler, view);
+				previousMethod?.Invoke(handler, view);
 				method(handler, view);
 			}
 
@@ -28,7 +28,7 @@ namespace Microsoft.Maui
 			void newMethod(TViewHandler handler, TVirtualView view)
 			{
 				method(handler, view);
-				previousMethod(handler, view);
+				previousMethod?.Invoke(handler, view);
 			}
 
 			propertyMapper[key] = newMethod;

--- a/src/Core/src/PropertyMapperExtensions.cs
+++ b/src/Core/src/PropertyMapperExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Microsoft.Maui
+{
+	public static class PropertyMapperExtensions
+	{
+		public static void AppendToMapping<TVirtualView, TViewHandler>(this PropertyMapper<TVirtualView, TViewHandler> propertyMapper,
+			string key, Action<TViewHandler, TVirtualView> method)
+			where TVirtualView : IElement where TViewHandler : IElementHandler
+		{
+			var previousMethod = propertyMapper[key];
+
+			void newMethod(TViewHandler handler, TVirtualView view)
+			{
+				previousMethod(handler, view);
+				method(handler, view);
+			}
+
+			propertyMapper[key] = newMethod;
+		}
+
+		public static void PrependToMapping<TVirtualView, TViewHandler>(this PropertyMapper<TVirtualView, TViewHandler> propertyMapper,
+			string key, Action<TViewHandler, TVirtualView> method)
+			where TVirtualView : IElement where TViewHandler : IElementHandler
+		{
+			var previousMethod = propertyMapper[key];
+
+			void newMethod(TViewHandler handler, TVirtualView view)
+			{
+				method(handler, view);
+				previousMethod(handler, view);
+			}
+
+			propertyMapper[key] = newMethod;
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/PropertyMapperExtensionTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperExtensionTests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Microsoft.Maui.UnitTests
+{
+	[Category(TestCategory.Core, TestCategory.PropertyMapping)]
+	public class PropertyMapperExtensionTests
+	{
+		[Fact]
+		public void AddAfterMapping()
+		{
+			string log = string.Empty;
+
+			var msg1 = "original mapping should have run";
+			var msg2 = "and also this one";
+
+			var mapper1 = new PropertyMapper<IView, IViewHandler>
+			{
+				[nameof(IView.Background)] = (r, v) => log += msg1
+			};
+
+			mapper1.AppendToMapping(nameof(IView.Background), (h, v) => log += msg2);
+
+			mapper1.UpdateProperties(null, new Button());
+
+			Assert.Contains(msg1, log);
+			Assert.Contains(msg2, log);
+
+			var originalIndex = log.IndexOf(msg1);
+			var additionalIndex = log.IndexOf(msg2);
+
+			Assert.True(originalIndex < additionalIndex);
+		}
+
+		[Fact]
+		public void AddBeforeMapping()
+		{
+			string log = string.Empty;
+
+			var msg1 = "original mapping should have run";
+			var msg2 = "and also this one";
+
+			var mapper1 = new PropertyMapper<IView, IViewHandler>
+			{
+				[nameof(IView.Background)] = (r, v) => log += msg1
+			};
+
+			mapper1.PrependToMapping(nameof(IView.Background), (h, v) => log += msg2);
+
+			mapper1.UpdateProperties(null, new Button());
+
+			Assert.Contains(msg1, log);
+			Assert.Contains(msg2, log);
+
+			var originalIndex = log.IndexOf(msg1);
+			var additionalIndex = log.IndexOf(msg2);
+
+			Assert.True(additionalIndex < originalIndex);
+		}
+	}
+}


### PR DESCRIPTION
Convenience extension methods for adding extra behavior before/after an existing mapping.

Adds two extensions:
`propertyMapper.AppendToMapping(string key, Action<TViewHandler, TVirtualView> method)`
`propertyMapper.PrependToMapping(string key, Action<TViewHandler, TVirtualView> method)`

Given a mapper like 
```
var mapper = new PropertyMapper<IView, IViewHandler>
{
	[nameof(IView.Background)] = (r, v) => Debug.WriteLine("Original behavior")
};
```

We can do this
```
mapper.AppendToMapping(nameof(IView.Background), (h, v) => Debug.WriteLine("Additional behavior"));
```

And the output when the Background property updates would be 
```
Original behavior
Additional behavior
```

Prepend works the other way around - the new behavior runs first.