### PR TITLE
Fix incorrect arithmetic for determining End alignment

### DIFF
--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Layouts
 					break;
 				case LayoutAlignment.End:
 
-					frameX = startX + boundsWidth - endMargin - desiredWidth;
+					frameX = startX + boundsWidth - desiredWidth + startMargin;
 					break;
 			}
 
@@ -150,7 +150,7 @@ namespace Microsoft.Maui.Layouts
 
 				case LayoutAlignment.End:
 
-					frameY = startY + bounds.Height - margin.Bottom - frameworkElement.DesiredSize.Height;
+					frameY = startY + bounds.Height - frameworkElement.DesiredSize.Height + margin.Top;
 					break;
 			}
 

--- a/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
@@ -94,14 +94,14 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			margin = new Thickness(10);
 			yield return new object[] { LayoutAlignment.Start, point, margin, 10, 80 };
 			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 80 };
-			yield return new object[] { LayoutAlignment.End, point, margin, 190, 80 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 210, 80 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 280 };
 
 			// Lopsided margin
 			margin = new Thickness(5, 5, 10, 10);
 			yield return new object[] { LayoutAlignment.Start, point, margin, 5, 85 };
 			yield return new object[] { LayoutAlignment.Center, point, margin, 97.5, 85 };
-			yield return new object[] { LayoutAlignment.End, point, margin, 190, 85 };
+			yield return new object[] { LayoutAlignment.End, point, margin, 205, 85 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 5, 285 };
 
 			// X and Y offsets (e.g., GridLayout columns and rows)
@@ -144,12 +144,12 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		{
 			var widthConstraint = 50;
 			var heightConstraint = 300;
-			var viewSize = new Size(50, 100);
+			var viewSizeIncludingMargins = new Size(50, 100);
 
 			var element = Substitute.For<IView>();
 
 			element.Margin.Returns(margin);
-			element.DesiredSize.Returns(viewSize);
+			element.DesiredSize.Returns(viewSizeIncludingMargins);
 			element.VerticalLayoutAlignment.Returns(layoutAlignment);
 			element.Width.Returns(-1);
 			element.Height.Returns(-1);
@@ -173,14 +173,14 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			// Even margin
 			margin = new Thickness(10);
-			yield return new object[] { LayoutAlignment.Start, point, margin, 190, 80 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 210, 80 };
 			yield return new object[] { LayoutAlignment.Center, point, margin, 100, 80 };
 			yield return new object[] { LayoutAlignment.End, point, margin, 10, 80 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 280 };
 
 			// Lopsided margin
 			margin = new Thickness(5, 5, 10, 10);
-			yield return new object[] { LayoutAlignment.Start, point, margin, 195, 85 };
+			yield return new object[] { LayoutAlignment.Start, point, margin, 210, 85 };
 			yield return new object[] { LayoutAlignment.Center, point, margin, 102.5, 85 };
 			yield return new object[] { LayoutAlignment.End, point, margin, 10, 85 };
 			yield return new object[] { LayoutAlignment.Fill, point, margin, 10, 285 };


### PR DESCRIPTION
End alignment calculations are miscalculating the starting X and Y coordinates by the size of the top and start margins. These changes properly account the for margins.