### PR TITLE
Don't copy the System.*.dll to .nuspec as this is no longer needed in .nuspec

### DIFF
--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
@@ -79,7 +79,7 @@
 
 	<Target Name="_CopyToNuspecDir" AfterTargets="Build">
 		<ItemGroup>
-			<_CopyItems Include="$(TargetDir)*.dll" />
+			<_CopyItems Include="$(TargetDir)*.dll" Exclude="$(TargetDir)System.*.dll" />
 		</ItemGroup>
 		<Copy SourceFiles="@(_CopyItems)" DestinationFolder="..\..\..\..\.nuspec\" ContinueOnError="true" Retries="0" />
 	</Target>


### PR DESCRIPTION
### Description of Change ###

The System.*.dll is no longer needed when building on the Mac with the IDE since that is using .NET Core.