### PR TITLE
BlazorWebView: Don't override GetDesiredSize to avoid iOS/MacCatalyst crash

### DIFF
--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -71,24 +71,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			_webviewManager?.MessageReceivedInternal(uri, message);
 		}
 
-		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
-		{
-			SetDesiredSize(widthConstraint, heightConstraint);
-
-			return base.GetDesiredSize(widthConstraint, heightConstraint);
-		}
-
-		void SetDesiredSize(double width, double height)
-		{
-			if (NativeView != null)
-			{
-				var x = NativeView.Frame.X;
-				var y = NativeView.Frame.Y;
-
-				NativeView.Frame = new RectangleF(x, y, width, height);
-			}
-		}
-
 		protected override void DisconnectHandler(WKWebView nativeView)
 		{
 			//nativeView.StopLoading();


### PR DESCRIPTION
On iOS and MacCatalyst in some scenarios the BlazorWebView would insta-crash with this stack:

```
Name: CALayerInvalidGeometry Reason: CALayer position contains NaN: [1019.5 nan]. Layer: <CALayer:0x600003addec0; position = CGPoint (1019.5 393.5); bounds = CGRect (0 0; 3 7); delegate = <_UIScrollViewScrollIndicator: 0x7fd63285ae70; frame = (1018 390; 3 7); alpha = 0; autoresize = LM; gestureRecognizers = <NSArray: 0x6000030cb2d0>; layer = <CALayer: 0x600003addec0>>; sublayers = (<CALayer: 0x600003addda0>); opaque = YES; allowsGroupOpacity = YES; opacity = 0; zPosition = 1000>
   at ObjCRuntime.Runtime.ThrowNSException(IntPtr ns_exception) in Xamarin.iOS.dll:token 0x60019a5+0xb
   at ObjCRuntime.Runtime.throw_ns_exception(IntPtr exc) in Xamarin.iOS.dll:token 0x6001945+0x0
   at UIKit.UIView.set_Frame(CGRect value) in Xamarin.iOS.dll:token 0x6011b3d+0x1d
   at Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.SetDesiredSize(Double width, Double height) in /Users/eilonlipton/GitHub/maui/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs:line 88
   at Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetDesiredSize(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs:line 76
   at Microsoft.Maui.Layouts.LayoutExtensions.ComputeDesiredSize(IFrameworkElement frameworkElement, Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Core/src/Layouts/LayoutExtensions.cs:line 25
   at Microsoft.Maui.Controls.VisualElement.MeasureOverride(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 99
   at Microsoft.Maui.Controls.VisualElement.Microsoft.Maui.IFrameworkElement.Measure(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 92
   at Microsoft.Maui.Layouts.VerticalStackLayoutManager.Measure(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Core/src/Layouts/VerticalStackLayoutManager.cs:line 29
   at Microsoft.Maui.LayoutView.SizeThatFits(CGSize size) in /Users/eilonlipton/GitHub/maui/src/Core/src/Platform/iOS/LayoutView.cs:line 22
   at Microsoft.Maui.Handlers.ViewHandler`2[[Microsoft.Maui.ILayout, Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[Microsoft.Maui.LayoutView, Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]].GetDesiredSize(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs:line 54
   at Microsoft.Maui.Layouts.LayoutExtensions.ComputeDesiredSize(IFrameworkElement frameworkElement, Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Core/src/Layouts/LayoutExtensions.cs:line 25
   at Microsoft.Maui.Controls.VisualElement.MeasureOverride(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 99
   at Microsoft.Maui.Controls.VisualElement.Microsoft.Maui.IFrameworkElement.Measure(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 92
   at Microsoft.Maui.Controls.ContentPage.MeasureOverride(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs:line 17
   at Microsoft.Maui.Controls.VisualElement.Microsoft.Maui.IFrameworkElement.Measure(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 92
   at Microsoft.Maui.PageView.LayoutSubviews() in /Users/eilonlipton/GitHub/maui/src/Core/src/Platform/iOS/LayoutView.cs:line 74
--- End of stack trace from previous location ---
   at UIKit.UIView.set_Frame(CGRect value) in Xamarin.iOS.dll:token 0x6011b3d+0x1d
   at Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.SetDesiredSize(Double width, Double height) in /Users/eilonlipton/GitHub/maui/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs:line 88
   at Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetDesiredSize(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs:line 76
   at Microsoft.Maui.Layouts.LayoutExtensions.ComputeDesiredSize(IFrameworkElement frameworkElement, Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Core/src/Layouts/LayoutExtensions.cs:line 25
   at Microsoft.Maui.Controls.VisualElement.MeasureOverride(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 99
   at Microsoft.Maui.Controls.VisualElement.Microsoft.Maui.IFrameworkElement.Measure(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 92
   at Microsoft.Maui.Layouts.VerticalStackLayoutManager.Measure(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Core/src/Layouts/VerticalStackLayoutManager.cs:line 29
   at Microsoft.Maui.LayoutView.SizeThatFits(CGSize size) in /Users/eilonlipton/GitHub/maui/src/Core/src/Platform/iOS/LayoutView.cs:line 22
   at Microsoft.Maui.Handlers.ViewHandler`2[[Microsoft.Maui.ILayout, Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[Microsoft.Maui.LayoutView, Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]].GetDesiredSize(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs:line 54
   at Microsoft.Maui.Layouts.LayoutExtensions.ComputeDesiredSize(IFrameworkElement frameworkElement, Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Core/src/Layouts/LayoutExtensions.cs:line 25
   at Microsoft.Maui.Controls.VisualElement.MeasureOverride(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 99
   at Microsoft.Maui.Controls.VisualElement.Microsoft.Maui.IFrameworkElement.Measure(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 92
   at Microsoft.Maui.Controls.ContentPage.MeasureOverride(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs:line 17
   at Microsoft.Maui.Controls.VisualElement.Microsoft.Maui.IFrameworkElement.Measure(Double widthConstraint, Double heightConstraint) in /Users/eilonlipton/GitHub/maui/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs:line 92
   at Microsoft.Maui.PageView.LayoutSubviews() in /Users/eilonlipton/GitHub/maui/src/Core/src/Platform/iOS/LayoutView.cs:line 74
--- End of stack trace from previous location ---
   at UIKit.UIApplication.Main(String[] args, Type principalClass, Type delegateClass) in Xamarin.iOS.dll:token 0x6010d4d+0x4d
   at Maui.Controls.Sample.iOS.Application.Main(String[] args) in /Users/eilonlipton/GitHub/maui/src/Controls/samples/Controls.Sample.iOS/Main.cs:line 7
```

And it turns out that BlazorWebView (on iOS only) was doing some GetDesiredSize logic that seems totally different from every other control. I'm not even sure where this code came from. I see that the regular WebView does some "size" code but it's quite different, and uses legacy renderers:

* WebView iOS renderer `GetDesiredSize` implementation:
   * https://github.com/dotnet/maui/blob/dfaa0424bb22a69545311bdeb964d589f23d10d4/src/Compatibility/Core/src/iOS/Renderers/WkWebViewRenderer.cs#L77-L80
* Calls this extension method:
   * https://github.com/dotnet/maui/blob/dfaa0424bb22a69545311bdeb964d589f23d10d4/src/Compatibility/Core/src/iOS/Extensions/UIViewExtensions.cs#L56

I removed the sizing code and everything seems to work in all cases now.