### PR TITLE
[Android] Only set click listener if the item is indeed clickable

### DIFF
--- a/src/Compatibility/Core/src/Android/CollectionView/ItemsViewAdapter.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/ItemsViewAdapter.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					break;
 			}
 		}
+		protected virtual bool IsSelectionEnabled(ViewGroup parent, int viewType) => true;
 
 		public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
 		{
@@ -82,12 +83,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			if (viewType == ItemViewType.TextItem)
 			{
 				var view = new TextView(context);
-				return new TextViewHolder(view);
+				return new TextViewHolder(view, IsSelectionEnabled(parent, viewType));
 			}
 
 			var itemContentView = _createItemContentView.Invoke(ItemsView, context);
 
-			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate);
+			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate, IsSelectionEnabled(parent, viewType));
 		}
 
 		public override int ItemCount => ItemsSource.Count;

--- a/src/Compatibility/Core/src/Android/CollectionView/SelectableViewHolder.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/SelectableViewHolder.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		protected SelectableViewHolder(global::Android.Views.View itemView, bool isSelectionEnabled = true) : base(itemView)
 		{
-			itemView.SetOnClickListener(this);
+			if (isSelectionEnabled)
+				itemView.SetOnClickListener(this);
+
 			_isSelectionEnabled = isSelectionEnabled;
 		}
 

--- a/src/Compatibility/Core/src/Android/CollectionView/TextViewHolder.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/TextViewHolder.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public TextViewHolder(TextView itemView, bool isSelectionEnabled = true) : base(itemView, isSelectionEnabled)
 		{
 			TextView = itemView;
-			TextView.Clickable = true;
+			TextView.Clickable = isSelectionEnabled;
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/CarouselViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/CarouselViewPage.xaml
@@ -26,6 +26,9 @@
                                 VerticalOptions="Center"
                                 FontSize="Large"
                                 Text="{Binding}"/>
+                            <Grid.GestureRecognizers>
+                                <TapGestureRecognizer NumberOfTapsRequired="1" Tapped="TapGestureRecognizer_Tapped"></TapGestureRecognizer>
+                            </Grid.GestureRecognizers>
                         </Grid>
                     </DataTemplate>
                 </CarouselView.ItemTemplate>

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/CarouselViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/CarouselViewPage.xaml.cs
@@ -1,10 +1,18 @@
-﻿namespace Maui.Controls.Sample.Pages
+﻿using System;
+
+namespace Maui.Controls.Sample.Pages
 {
 	public partial class CarouselViewPage
 	{
 		public CarouselViewPage()
 		{
 			InitializeComponent();
+		}
+
+
+		private async void TapGestureRecognizer_Tapped(object sender, EventArgs e)
+		{
+			await DisplayAlert("Item", "Tapped", "Successfully");
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 		}
 
+		protected virtual bool IsSelectionEnabled(ViewGroup parent, int viewType) => true;
+
 		public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
 		{
 			var context = parent.Context;
@@ -83,12 +85,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (viewType == ItemViewType.TextItem)
 			{
 				var view = new TextView(context);
-				return new TextViewHolder(view);
+				return new TextViewHolder(view, IsSelectionEnabled(parent, viewType));
 			}
 
 			var itemContentView = _createItemContentView.Invoke(ItemsView, context);
 
-			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate);
+			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate, IsSelectionEnabled(parent, viewType));
 		}
 
 		public override int ItemCount => ItemsSource.Count;

--- a/src/Controls/src/Core/Handlers/Items/Android/SelectableViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SelectableViewHolder.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected SelectableViewHolder(global::Android.Views.View itemView, bool isSelectionEnabled = true) : base(itemView)
 		{
-			itemView.SetOnClickListener(this);
+			if (isSelectionEnabled)
+				itemView.SetOnClickListener(this);
+
 			_isSelectionEnabled = isSelectionEnabled;
 		}
 

--- a/src/Controls/src/Core/Handlers/Items/Android/TextViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TextViewHolder.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		public TextViewHolder(TextView itemView, bool isSelectionEnabled = true) : base(itemView, isSelectionEnabled)
 		{
 			TextView = itemView;
-			TextView.Clickable = true;
+			TextView.Clickable = isSelectionEnabled;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

If a user is using Gesture Recognizers to trigger Tap events on CarV or ColV those gestures won't trigger if you turn an accessibility reader on because the SelectableViewHolder currently is setup to intercept all click events. 

This fix currently only addresses Carousel View but I want to vet the idea before going much further. 

The main problem here is that CarouselView doesn't have an "ItemClicked" event. 

Currently when using a CarouselView with `TalkBack on` the experience is as follows
- when you select the CarouselView it reads out information about the item and then says "Double Tap To Activate". It says this because the ItemView has a click listener attached to it.
- User double clicks and nothing happens because there's currently no xplat API that this event will propagate up to

Users that are using CollectionView can utilize the "ItemSelected" event to workaround this but if they opt for using a TapGesture then the control will no longer be accessible. 

Even if we add an "ItemClicked" event I'm wondering if my fixes in this PR are still applicable. If a `SelectableViewHolder` has `isSelectionEnabled` set to `false` it seems like it shouldn't attach the click listener otherwise Talk Back is going to indicate to users that the view has some sort of useful click action.

## FYI

I've modified the samples here to demonstrate the issue but currently CarouselView on android causes an infinite layout loop so you won't really be able to test this on MAUI https://github.com/dotnet/maui/issues/1882

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
