### PR TITLE
Simplify layout further

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Maui.Graphics;
 using Microsoft.Maui.HotReload;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls
 {
@@ -22,8 +23,13 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
-			// Update the other stuff on this page (basically the content)
-			Layout(bounds);
+			Frame = this.ComputeFrame(bounds);
+
+			if (Content is IFrameworkElement frameworkElement)
+			{
+				_ = frameworkElement.Arrange(Frame);
+			}
+
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
@@ -40,8 +40,13 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
-			// Update the Bounds (Frame) for this page
-			Layout(bounds);
+			Frame = this.ComputeFrame(bounds);
+
+			if (Content is IFrameworkElement frameworkElement)
+			{
+				_ = frameworkElement.Arrange(Frame);
+			}
+
 			return Frame.Size;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -41,29 +41,14 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			// We call OnSizeRequest so that the content gets measured appropriately
-			// and then use the standard GetDesiredSize from the handler so the ScrollView's
-			// backing control gets measured. 
-
-			// TODO ezhart 2021-07-14 Verify that we've got the naming correct on this after we resolve the OnSizeRequest obsolete stuff
-#pragma warning disable CS0618 // Type or member is obsolete
-			var request = OnSizeRequest(widthConstraint, heightConstraint);
-#pragma warning restore CS0618 // Type or member is obsolete
-
 			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
+
+			if (Content is IFrameworkElement frameworkElement)
+			{
+				_ = frameworkElement.Measure(widthConstraint, heightConstraint);
+			}
+
 			return DesiredSize;
-		}
-
-		protected override Size ArrangeOverride(Rectangle bounds)
-		{
-			var frame = this.ComputeFrame(bounds);
-
-			// Force a native arrange call; otherwise, the native bookkeeping won't be done and things won't lay out correctly
-			Handler?.NativeArrange(frame);
-
-			Layout(frame);
-
-			return Frame.Size;
 		}
 	}
 }


### PR DESCRIPTION
Trying to keep the backward-compatibility with the "layout" things that Page.cs is doing is causing more problems than it's solving. Bypass that completely for the new layout system. 

If it turns out we need that stuff, I'll add it back in manually in a way that's compatible.