### PR TITLE
Apply Accessibility traits to controls that have TapGestureRecognizers

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/PageRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/PageRenderer.cs
@@ -72,8 +72,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			}
 
 			UpdateBackground(false);
-
-			Clickable = true;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -64,6 +64,20 @@ namespace Maui.Controls.Sample.Pages
 				Text = "Tap Gesture Gallery"
 			};
 			vertical.Add(changeColorBoxView);
+
+
+			vertical.Add(new Button()
+			{
+				Text = "Toggle Single Tap Gesture",
+				Command = new Command(() =>
+				{
+					if (singleTapLabel.GestureRecognizers.Count > 0)
+						singleTapLabel.GestureRecognizers.RemoveAt(0);
+					else
+						singleTapLabel.GestureRecognizers.Add(singleTapGesture);
+				})
+			});
+
 			Content = vertical;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/View.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/View.Android.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	{
 		partial void HandlerChangedPartial()
 		{
-			this.ApplyControlsAccessibilityDelegateIfNeeded();
+			this.AddOrRemoveControlsAccessibilityDelegate();
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/View.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/View.Android.cs
@@ -1,0 +1,35 @@
+﻿#nullable enable
+
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibility;
+using Microsoft.Maui.Controls.Platform;
+using NativeView = Android.Views.View;
+
+namespace Microsoft.Maui.Controls
+{
+	public partial class View
+	{
+		partial void HandlerChangedPartial()
+		{
+			this.ApplyControlsAccessibilityDelegateIfNeeded();
+		}
+	}
+
+	class ControlsAccessibilityDelegate : AccessibilityDelegateCompatWrapper
+	{
+		public IViewHandler Handler { get; }
+
+		public ControlsAccessibilityDelegate(AccessibilityDelegateCompat? originalDelegate, IViewHandler viewHandler) : base(originalDelegate)
+		{
+			Handler = viewHandler;
+		}
+
+		public override void OnInitializeAccessibilityNodeInfo(NativeView? host, AccessibilityNodeInfoCompat? info)
+		{
+			base.OnInitializeAccessibilityNodeInfo(host, info);
+
+			if (Handler?.NativeView is NativeView nativeView && Handler?.VirtualView is View v)
+				v.UpdateSemanticNodeInfo(info);
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/View.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/View.Android.cs
@@ -1,9 +1,6 @@
 ﻿#nullable enable
 
-using AndroidX.Core.View;
-using AndroidX.Core.View.Accessibility;
 using Microsoft.Maui.Controls.Platform;
-using NativeView = Android.Views.View;
 
 namespace Microsoft.Maui.Controls
 {
@@ -12,24 +9,6 @@ namespace Microsoft.Maui.Controls
 		partial void HandlerChangedPartial()
 		{
 			this.ApplyControlsAccessibilityDelegateIfNeeded();
-		}
-	}
-
-	class ControlsAccessibilityDelegate : AccessibilityDelegateCompatWrapper
-	{
-		public IViewHandler Handler { get; }
-
-		public ControlsAccessibilityDelegate(AccessibilityDelegateCompat? originalDelegate, IViewHandler viewHandler) : base(originalDelegate)
-		{
-			Handler = viewHandler;
-		}
-
-		public override void OnInitializeAccessibilityNodeInfo(NativeView? host, AccessibilityNodeInfoCompat? info)
-		{
-			base.OnInitializeAccessibilityNodeInfo(host, info);
-
-			if (Handler?.NativeView is NativeView nativeView && Handler?.VirtualView is View v)
-				v.UpdateSemanticNodeInfo(info);
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/View.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/View.Impl.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class View
 	{
+		partial void HandlerChangedPartial();
 		GestureManager? _gestureManager;
 		private protected override void OnHandlerChangedCore()
 		{
@@ -17,6 +18,8 @@ namespace Microsoft.Maui.Controls
 
 			if (Handler != null)
 				_gestureManager = new GestureManager(Handler);
+
+			HandlerChangedPartial();
 		}
 
 		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)

--- a/src/Controls/src/Core/Platform/Android/ControlsAccessibilityDelegate.cs
+++ b/src/Controls/src/Core/Platform/Android/ControlsAccessibilityDelegate.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibility;
+using Microsoft.Maui.Controls.Platform;
+using NativeView = Android.Views.View;
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	public class ControlsAccessibilityDelegate : AccessibilityDelegateCompatWrapper
+	{
+		public IViewHandler Handler { get; }
+
+		public ControlsAccessibilityDelegate(AccessibilityDelegateCompat? originalDelegate, IViewHandler viewHandler) 
+			: base(originalDelegate)
+		{
+			Handler = viewHandler;
+		}
+
+		public override void OnInitializeAccessibilityNodeInfo(NativeView? host, AccessibilityNodeInfoCompat? info)
+		{
+			base.OnInitializeAccessibilityNodeInfo(host, info);
+
+			if (Handler?.NativeView is NativeView nativeView && Handler?.VirtualView is View v)
+				v.UpdateSemanticNodeInfo(info);
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/Android/ControlsAccessibilityDelegate.cs
+++ b/src/Controls/src/Core/Platform/Android/ControlsAccessibilityDelegate.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			base.OnInitializeAccessibilityNodeInfo(host, info);
 
-			if (Handler?.NativeView is NativeView nativeView && Handler?.VirtualView is View v)
+			if (Handler?.VirtualView is View v)
 				v.UpdateSemanticNodeInfo(info);
 		}
 	}

--- a/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
@@ -13,16 +13,16 @@ namespace Microsoft.Maui.Controls.Platform
 			if (info == null)
 				return;
 
-			if(virtualView.TapGestureRecognizerNeedsDelegate())
+			if (virtualView.TapGestureRecognizerNeedsDelegate())
 				info.AddAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick);
 		}
 
-		internal static void ApplyControlsAccessibilityDelegateIfNeeded(this View virtualView)
+		internal static void AddOrRemoveControlsAccessibilityDelegate(this View virtualView)
 		{
 			if (virtualView?.Handler?.NativeView is not AView view)
 				return;
 
-			bool needsDelegate = virtualView.TapGestureRecognizerNeedsDelegate();
+			bool needsDelegate = virtualView.ControlsAccessibilityDelegateNeeded();
 			var currentDelegate = ViewCompat.GetAccessibilityDelegate(view);
 
 			if (needsDelegate)

--- a/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
@@ -6,7 +6,7 @@ using AView = Android.Views.View;
 
 namespace Microsoft.Maui.Controls.Platform
 {
-	public static class SemanticExtensions
+	public static partial class SemanticExtensions
 	{
 		public static void UpdateSemanticNodeInfo(this View virtualView, AccessibilityNodeInfoCompat? info)
 		{
@@ -15,19 +15,6 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if(virtualView.TapGestureRecognizerNeedsDelegate())
 				info.AddAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick);
-		}
-
-		static bool TapGestureRecognizerNeedsDelegate(this View virtualView)
-		{
-			foreach (var gesture in virtualView.GestureRecognizers)
-			{
-				//Accessibility can't handle Tap Recognizers with > 1 tap
-				if (gesture is TapGestureRecognizer tgr && tgr.NumberOfTapsRequired == 1)
-				{
-					return true;
-				}
-			}
-			return false;
 		}
 
 		internal static void ApplyControlsAccessibilityDelegateIfNeeded(this View virtualView)

--- a/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
@@ -1,11 +1,7 @@
 ﻿#nullable enable
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using AndroidX.Core.View;
 using AndroidX.Core.View.Accessibility;
-using Microsoft.Maui.Handlers;
 using AView = Android.Views.View;
 
 namespace Microsoft.Maui.Controls.Platform

--- a/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/SemanticExtensions.cs
@@ -1,0 +1,69 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibility;
+using Microsoft.Maui.Handlers;
+using AView = Android.Views.View;
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	public static class SemanticExtensions
+	{
+		public static void UpdateSemanticNodeInfo(this View virtualView, AccessibilityNodeInfoCompat? info)
+		{
+			if (info == null)
+				return;
+
+			if(virtualView.TapGestureRecognizerNeedsDelegate())
+				info.AddAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ActionClick);
+		}
+
+		static bool TapGestureRecognizerNeedsDelegate(this View virtualView)
+		{
+			foreach (var gesture in virtualView.GestureRecognizers)
+			{
+				//Accessibility can't handle Tap Recognizers with > 1 tap
+				if (gesture is TapGestureRecognizer tgr && tgr.NumberOfTapsRequired == 1)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		internal static void ApplyControlsAccessibilityDelegateIfNeeded(this View virtualView)
+		{
+			if (virtualView?.Handler?.NativeView is not AView view)
+				return;
+
+			bool needsDelegate = virtualView.TapGestureRecognizerNeedsDelegate();
+			var currentDelegate = ViewCompat.GetAccessibilityDelegate(view);
+
+			if (needsDelegate)
+			{
+				if (currentDelegate is ControlsAccessibilityDelegate)
+					return;
+
+				// This means the current delegate didn't come from our code at all so we just exit and assume
+				// the user wants full control of the delegate
+				// If the user is inheriting from AccessibilityDelegateCompatWrapper then we will continue wrapping
+				if (currentDelegate != null && currentDelegate is not AccessibilityDelegateCompatWrapper)
+					return;
+
+				var controlsDelegate = new ControlsAccessibilityDelegate(currentDelegate, virtualView.Handler);
+				ViewCompat.SetAccessibilityDelegate(view, controlsDelegate);
+			}
+			else if (currentDelegate != null)
+			{
+				if (currentDelegate is ControlsAccessibilityDelegate cad)
+				{
+					ViewCompat.SetAccessibilityDelegate(view, cad.WrappedDelegate);
+					return;
+				}
+			}
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Android.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_tapAndPanAndSwipeDetector.IsValueCreated)
 				_tapAndPanAndSwipeDetector.Value.UpdateLongPressSettings();
 
-			View?.ApplyControlsAccessibilityDelegateIfNeeded();
+			View?.AddOrRemoveControlsAccessibilityDelegate();
 		}
 
 		void UpdateDragAndDrop()

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Android.cs
@@ -150,15 +150,12 @@ namespace Microsoft.Maui.Controls.Platform
 			if (View == null)
 				return;
 
-			AView? nativeView = (_handler?.NativeView as AView);
-
-			if (nativeView == null)
+			if (_handler?.NativeView is not AView nativeView)
 				return;
 
 			if (View.GestureRecognizers.Count == 0)
 			{
 				nativeView.Touch -= OnNativeViewTouched;
-
 			}
 			else
 			{
@@ -211,6 +208,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (_tapAndPanAndSwipeDetector.IsValueCreated)
 				_tapAndPanAndSwipeDetector.Value.UpdateLongPressSettings();
+
+			View?.ApplyControlsAccessibilityDelegateIfNeeded();
 		}
 
 		void UpdateDragAndDrop()

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (ElementGestureRecognizers == null)
 				return;
-			
+
 #if __MOBILE__
 			if (_shouldReceiveTouch == null)
 			{
@@ -582,24 +582,20 @@ namespace Microsoft.Maui.Controls.Platform
 			bool dragFound = false;
 			bool dropFound = false;
 #endif
+			if (_nativeView != null &&
+				_handler.VirtualView is View v &&
+				v.TapGestureRecognizerNeedsDelegate() &&
+				(_nativeView.AccessibilityTraits & UIAccessibilityTrait.Button) != UIAccessibilityTrait.Button)
+			{
+				_nativeView.AccessibilityTraits |= UIAccessibilityTrait.Button;
+				_addedFlags |= UIAccessibilityTrait.Button;
+				_defaultAccessibilityRespondsToUserInteraction = _nativeView.AccessibilityRespondsToUserInteraction;
+				_nativeView.AccessibilityRespondsToUserInteraction = true;
+			}
+
 			for (int i = 0; i < ElementGestureRecognizers.Count; i++)
 			{
 				IGestureRecognizer recognizer = ElementGestureRecognizers[i];
-				
-				// If the user adds a TapGestureRecognizer that activates as a single click then
-				// we tell Voice Over to treat that element as a button. If the users
-				// wants to add any other gestures then they'll need to add custom actions themselves
-				// and describe the actions.
-				if (_nativeView != null && 
-					recognizer is TapGestureRecognizer tpr && 
-					tpr.NumberOfTapsRequired == 1 &&
-					(_nativeView.AccessibilityTraits & UIAccessibilityTrait.Button) != UIAccessibilityTrait.Button)
-				{
-					_nativeView.AccessibilityTraits |= UIAccessibilityTrait.Button;
-					_addedFlags |= UIAccessibilityTrait.Button;
-					_defaultAccessibilityRespondsToUserInteraction = _nativeView.AccessibilityRespondsToUserInteraction;
-					_nativeView.AccessibilityRespondsToUserInteraction = true;
-				}
 
 				if (_gestureRecognizers.ContainsKey(recognizer))
 					continue;

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 		bool _disposed;
 		NativeView? _nativeView;
+		UIAccessibilityTrait _addedFlags;
+		bool? _defaultAccessibilityRespondsToUserInteraction;
 
 		double _previousScale = 1.0;
 #if __MOBILE__
@@ -554,22 +556,20 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			if (ElementGestureRecognizers == null)
 				return;
-
+			
 #if __MOBILE__
 			if (_shouldReceiveTouch == null)
 			{
 				// Cache this so we don't create a new UITouchEventArgs instance for every recognizer
 				_shouldReceiveTouch = ShouldReceiveTouch;
 			}
-#endif
 
-#if __MOBILE__
 			UIDragInteraction? uIDragInteraction = null;
 			UIDropInteraction? uIDropInteraction = null;
 
-			if (_dragAndDropDelegate != null && _handler.NativeView != null)
+			if (_dragAndDropDelegate != null && _nativeView != null)
 			{
-				foreach (var interaction in _handler.NativeView.Interactions)
+				foreach (var interaction in _nativeView.Interactions)
 				{
 					if (interaction is UIDragInteraction uIDrag && uIDrag.Delegate == _dragAndDropDelegate)
 						uIDragInteraction = uIDrag;
@@ -585,6 +585,22 @@ namespace Microsoft.Maui.Controls.Platform
 			for (int i = 0; i < ElementGestureRecognizers.Count; i++)
 			{
 				IGestureRecognizer recognizer = ElementGestureRecognizers[i];
+				
+				// If the user adds a TapGestureRecognizer that activates as a single click then
+				// we tell Voice Over to treat that element as a button. If the users
+				// wants to add any other gestures then they'll need to add custom actions themselves
+				// and describe the actions.
+				if (_nativeView != null && 
+					recognizer is TapGestureRecognizer tpr && 
+					tpr.NumberOfTapsRequired == 1 &&
+					(_nativeView.AccessibilityTraits & UIAccessibilityTrait.Button) != UIAccessibilityTrait.Button)
+				{
+					_nativeView.AccessibilityTraits |= UIAccessibilityTrait.Button;
+					_addedFlags |= UIAccessibilityTrait.Button;
+					_defaultAccessibilityRespondsToUserInteraction = _nativeView.AccessibilityRespondsToUserInteraction;
+					_nativeView.AccessibilityRespondsToUserInteraction = true;
+				}
+
 				if (_gestureRecognizers.ContainsKey(recognizer))
 					continue;
 
@@ -682,6 +698,16 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void ModelGestureRecognizersOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{
+			if (_nativeView != null)
+			{
+				_nativeView.AccessibilityTraits &= ~_addedFlags;
+
+				if (_defaultAccessibilityRespondsToUserInteraction != null)
+					_nativeView.AccessibilityRespondsToUserInteraction = _defaultAccessibilityRespondsToUserInteraction.Value;
+			}
+
+			_addedFlags = UIAccessibilityTrait.None;
+			_defaultAccessibilityRespondsToUserInteraction = null;
 			LoadRecognizers();
 		}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_nativeView == null)
 				throw new ArgumentNullException(nameof(handler.NativeView));
 
-			_collectionChangedHandler = ModelGestureRecognizersOnCollectionChanged;
+			_collectionChangedHandler = GestureRecognizersOnCollectionChanged;
 
 			// In XF this was called inside ViewDidLoad
 			if (_handler.VirtualView is View view)
@@ -692,7 +692,7 @@ namespace Microsoft.Maui.Controls.Platform
 		}
 #endif
 
-		void ModelGestureRecognizersOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
+		void GestureRecognizersOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{
 			if (_nativeView != null)
 			{

--- a/src/Controls/src/Core/Platform/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/SemanticExtensions.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	public static partial class SemanticExtensions
 	{
+		internal static bool ControlsAccessibilityDelegateNeeded(this View virtualView)
+			=> virtualView.TapGestureRecognizerNeedsDelegate();
+
 		internal static bool TapGestureRecognizerNeedsDelegate(this View virtualView)
 		{
 			foreach (var gesture in virtualView.GestureRecognizers)

--- a/src/Controls/src/Core/Platform/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/SemanticExtensions.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	public static partial class SemanticExtensions
+	{
+		internal static bool TapGestureRecognizerNeedsDelegate(this View virtualView)
+		{
+			foreach (var gesture in virtualView.GestureRecognizers)
+			{
+				//Accessibility can't handle Tap Recognizers with > 1 tap
+				if (gesture is TapGestureRecognizer tgr && tgr.NumberOfTapsRequired == 1)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -1,7 +1,7 @@
 using Microsoft.Maui.Graphics;
 #if __IOS__ || MACCATALYST
 using NativeView = UIKit.UIView;
-#elif MONOANDROID
+#elif __ANDROID__
 using NativeView = Android.Views.View;
 #elif WINDOWS
 using NativeView = Microsoft.UI.Xaml.FrameworkElement;

--- a/src/Core/src/Platform/Android/AccessibilityDelegateCompatWrapper.cs
+++ b/src/Core/src/Platform/Android/AccessibilityDelegateCompatWrapper.cs
@@ -1,0 +1,65 @@
+﻿using Android.Views.Accessibility;
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibility;
+using NativeView = Android.Views.View;
+
+namespace Microsoft.Maui
+{
+	public class AccessibilityDelegateCompatWrapper : AccessibilityDelegateCompat
+	{
+		readonly AccessibilityDelegateCompat _originalDelegate;
+		public AccessibilityDelegateCompat? WrappedDelegate
+		{
+			get
+			{
+				if (_originalDelegate == s_blankDelegate)
+					return null;
+
+				return _originalDelegate;
+			}
+		}
+
+		static AccessibilityDelegateCompat? s_blankDelegate;
+		static AccessibilityDelegateCompat BlankDelegate => s_blankDelegate ??= new AccessibilityDelegateCompat();
+
+		public AccessibilityDelegateCompatWrapper(AccessibilityDelegateCompat? originalDelegate)
+		{
+			_originalDelegate = originalDelegate ?? BlankDelegate;
+		}
+
+		public override void OnInitializeAccessibilityNodeInfo(NativeView? host, AccessibilityNodeInfoCompat? info)
+		{
+			_originalDelegate.OnInitializeAccessibilityNodeInfo(host, info);
+		}
+
+		public override void SendAccessibilityEvent(NativeView host, int eventType)
+		{
+			_originalDelegate.SendAccessibilityEvent(host, eventType);
+		}
+
+		public override void SendAccessibilityEventUnchecked(NativeView host, AccessibilityEvent e)
+		{
+			_originalDelegate.SendAccessibilityEventUnchecked(host, e);
+		}
+
+		public override bool DispatchPopulateAccessibilityEvent(NativeView host, AccessibilityEvent e)
+		{
+			return _originalDelegate.DispatchPopulateAccessibilityEvent(host, e);
+		}
+
+		public override void OnPopulateAccessibilityEvent(NativeView host, AccessibilityEvent e)
+		{
+			_originalDelegate.OnPopulateAccessibilityEvent(host, e);
+		}
+
+		public override void OnInitializeAccessibilityEvent(NativeView host, AccessibilityEvent e)
+		{
+			_originalDelegate.OnInitializeAccessibilityEvent(host, e);
+		}
+
+		public override bool OnRequestSendAccessibilityEvent(Android.Views.ViewGroup host, NativeView child, AccessibilityEvent e)
+		{
+			return _originalDelegate.OnRequestSendAccessibilityEvent(host, child, e);
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/AccessibilityDelegateCompatWrapper.cs
+++ b/src/Core/src/Platform/Android/AccessibilityDelegateCompatWrapper.cs
@@ -25,9 +25,6 @@ namespace Microsoft.Maui
 		static AccessibilityDelegateCompat? s_blankDelegate;
 		static AccessibilityDelegateCompat BlankDelegate => s_blankDelegate ??= new AccessibilityDelegateCompat();
 
-		public static AccessibilityDelegateCompatWrapper Wrap(NativeView nativeView) =>
-			new AccessibilityDelegateCompatWrapper(ViewCompat.GetAccessibilityDelegate(nativeView));
-
 		public AccessibilityDelegateCompatWrapper(AccessibilityDelegateCompat? originalDelegate)
 		{
 			_originalDelegate = originalDelegate ?? BlankDelegate;

--- a/src/Core/src/Platform/Android/AccessibilityDelegateCompatWrapper.cs
+++ b/src/Core/src/Platform/Android/AccessibilityDelegateCompatWrapper.cs
@@ -5,6 +5,9 @@ using NativeView = Android.Views.View;
 
 namespace Microsoft.Maui
 {
+	// This allows you to take an existing delegate and wrap it if you want to retain
+	// the behavior of the Accessibility Delegate that's already assigned.
+	// We use this inside controls if we want to add additional accessibility delegate behavior
 	public class AccessibilityDelegateCompatWrapper : AccessibilityDelegateCompat
 	{
 		readonly AccessibilityDelegateCompat _originalDelegate;
@@ -21,6 +24,9 @@ namespace Microsoft.Maui
 
 		static AccessibilityDelegateCompat? s_blankDelegate;
 		static AccessibilityDelegateCompat BlankDelegate => s_blankDelegate ??= new AccessibilityDelegateCompat();
+
+		public static AccessibilityDelegateCompatWrapper Wrap(NativeView nativeView) =>
+			new AccessibilityDelegateCompatWrapper(ViewCompat.GetAccessibilityDelegate(nativeView));
 
 		public AccessibilityDelegateCompatWrapper(AccessibilityDelegateCompat? originalDelegate)
 		{

--- a/src/Core/src/Platform/Android/MauiAccessibilityDelegateCompat.cs
+++ b/src/Core/src/Platform/Android/MauiAccessibilityDelegateCompat.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Android.Views.Accessibility;
 using AndroidX.Core.View;
 using AndroidX.Core.View.Accessibility;
 using Microsoft.Maui.Handlers;
@@ -9,64 +8,6 @@ using NativeView = Android.Views.View;
 
 namespace Microsoft.Maui
 {
-	public class AccessibilityDelegateCompatWrapper : AccessibilityDelegateCompat
-	{
-		readonly AccessibilityDelegateCompat _originalDelegate;
-		public AccessibilityDelegateCompat? WrappedDelegate
-		{
-			get
-			{
-				if (_originalDelegate == s_blankDelegate)
-					return null;
-
-				return _originalDelegate;
-			}
-		}
-
-		static AccessibilityDelegateCompat? s_blankDelegate;
-		static AccessibilityDelegateCompat BlankDelegate => s_blankDelegate ??= new AccessibilityDelegateCompat();
-
-		public AccessibilityDelegateCompatWrapper(AccessibilityDelegateCompat? originalDelegate)
-		{
-			_originalDelegate = originalDelegate ?? BlankDelegate;
-		}
-
-		public override void OnInitializeAccessibilityNodeInfo(NativeView? host, AccessibilityNodeInfoCompat? info)
-		{
-			_originalDelegate.OnInitializeAccessibilityNodeInfo(host, info);
-		}
-
-		public override void SendAccessibilityEvent(NativeView host, int eventType)
-		{
-			_originalDelegate.SendAccessibilityEvent(host, eventType);
-		}
-
-		public override void SendAccessibilityEventUnchecked(NativeView host, AccessibilityEvent e)
-		{
-			_originalDelegate.SendAccessibilityEventUnchecked(host, e);
-		}
-
-		public override bool DispatchPopulateAccessibilityEvent(NativeView host, AccessibilityEvent e)
-		{
-			return _originalDelegate.DispatchPopulateAccessibilityEvent(host, e);
-		}
-
-		public override void OnPopulateAccessibilityEvent(NativeView host, AccessibilityEvent e)
-		{
-			_originalDelegate.OnPopulateAccessibilityEvent(host, e);
-		}
-
-		public override void OnInitializeAccessibilityEvent(NativeView host, AccessibilityEvent e)
-		{
-			_originalDelegate.OnInitializeAccessibilityEvent(host, e);
-		}
-
-		public override bool OnRequestSendAccessibilityEvent(Android.Views.ViewGroup host, NativeView child, AccessibilityEvent e)
-		{
-			return _originalDelegate.OnRequestSendAccessibilityEvent(host, child, e);
-		}
-	}
-
 	public class MauiAccessibilityDelegateCompat : AccessibilityDelegateCompatWrapper
 	{
 		public IViewHandler? Handler { get; set; }

--- a/src/Core/src/Platform/Android/MauiAccessibilityDelegateCompat.cs
+++ b/src/Core/src/Platform/Android/MauiAccessibilityDelegateCompat.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.Views.Accessibility;
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibility;
+using Microsoft.Maui.Handlers;
+using NativeView = Android.Views.View;
+
+namespace Microsoft.Maui
+{
+	public class AccessibilityDelegateCompatWrapper : AccessibilityDelegateCompat
+	{
+		readonly AccessibilityDelegateCompat _originalDelegate;
+		public AccessibilityDelegateCompat? WrappedDelegate
+		{
+			get
+			{
+				if (_originalDelegate == s_blankDelegate)
+					return null;
+
+				return _originalDelegate;
+			}
+		}
+
+		static AccessibilityDelegateCompat? s_blankDelegate;
+		static AccessibilityDelegateCompat BlankDelegate => s_blankDelegate ??= new AccessibilityDelegateCompat();
+
+		public AccessibilityDelegateCompatWrapper(AccessibilityDelegateCompat? originalDelegate)
+		{
+			_originalDelegate = originalDelegate ?? BlankDelegate;
+		}
+
+		public override void OnInitializeAccessibilityNodeInfo(NativeView? host, AccessibilityNodeInfoCompat? info)
+		{
+			_originalDelegate.OnInitializeAccessibilityNodeInfo(host, info);
+		}
+
+		public override void SendAccessibilityEvent(NativeView host, int eventType)
+		{
+			_originalDelegate.SendAccessibilityEvent(host, eventType);
+		}
+
+		public override void SendAccessibilityEventUnchecked(NativeView host, AccessibilityEvent e)
+		{
+			_originalDelegate.SendAccessibilityEventUnchecked(host, e);
+		}
+
+		public override bool DispatchPopulateAccessibilityEvent(NativeView host, AccessibilityEvent e)
+		{
+			return _originalDelegate.DispatchPopulateAccessibilityEvent(host, e);
+		}
+
+		public override void OnPopulateAccessibilityEvent(NativeView host, AccessibilityEvent e)
+		{
+			_originalDelegate.OnPopulateAccessibilityEvent(host, e);
+		}
+
+		public override void OnInitializeAccessibilityEvent(NativeView host, AccessibilityEvent e)
+		{
+			_originalDelegate.OnInitializeAccessibilityEvent(host, e);
+		}
+
+		public override bool OnRequestSendAccessibilityEvent(Android.Views.ViewGroup host, NativeView child, AccessibilityEvent e)
+		{
+			return _originalDelegate.OnRequestSendAccessibilityEvent(host, child, e);
+		}
+	}
+
+	public class MauiAccessibilityDelegateCompat : AccessibilityDelegateCompatWrapper
+	{
+		public IViewHandler? Handler { get; set; }
+
+		public MauiAccessibilityDelegateCompat() : this(null)
+		{
+		}
+
+		public MauiAccessibilityDelegateCompat(AccessibilityDelegateCompat? originalDelegate) : base(originalDelegate)
+		{
+		}
+
+		public override void OnInitializeAccessibilityNodeInfo(NativeView? host, AccessibilityNodeInfoCompat? info)
+		{
+			base.OnInitializeAccessibilityNodeInfo(host, info);
+
+			if (Handler?.NativeView is NativeView nativeView && Handler?.VirtualView != null)
+				nativeView.UpdateSemanticNodeInfo(Handler.VirtualView, info);
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/SemanticExtensions.cs
+++ b/src/Core/src/Platform/Android/SemanticExtensions.cs
@@ -2,6 +2,10 @@
 using Android.Text;
 using Android.Views;
 using Android.Views.Accessibility;
+using Android.Widget;
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibility;
+using Microsoft.Maui.Platform;
 
 namespace Microsoft.Maui
 {
@@ -13,6 +17,100 @@ namespace Microsoft.Maui
 				throw new NullReferenceException("Can't access view from a null handler");
 
 			view.SendAccessibilityEvent(EventTypes.ViewFocused);
+		}
+
+		public static void UpdateSemanticNodeInfo(this View nativeView, IView virtualView, AccessibilityNodeInfoCompat? info)
+		{
+			if (info == null)
+				return;
+
+			var semantics = virtualView?.Semantics;
+
+			if (semantics == null)
+				return;
+
+			string? newText = null;
+			string? newContentDescription = null;
+
+			var desc = semantics.Description;
+			if (!string.IsNullOrEmpty(desc))
+			{
+				// Edit Text fields won't read anything for the content description
+				if (nativeView is EditText et)
+				{
+					if (!string.IsNullOrEmpty(et.Text))
+						newText = $"{desc}, {et.Text}";
+					else
+						newText = $"{desc}";
+				}
+				else
+					newContentDescription = desc;
+			}
+
+			var hint = semantics.Hint;
+			if (!string.IsNullOrEmpty(hint))
+			{
+				// info HintText won't read anything back when using TalkBack pre API 26
+				if (NativeVersion.IsAtLeast(26))
+				{
+					info.HintText = hint;
+
+					if (nativeView is EditText)
+						info.ShowingHintText = false;
+				}
+				else
+				{
+					if (nativeView is EditText et)
+					{
+						newText = newText ?? et.Text;
+						newText = $"{newText}, {hint}";
+					}
+					else if (nativeView is TextView tv)
+					{
+						if (newContentDescription != null)
+						{
+							newText = $"{newContentDescription}, {hint}";
+						}
+						else if (!string.IsNullOrEmpty(tv.Text))
+						{
+							newText = $"{tv.Text}, {hint}";
+						}
+						else
+						{
+							newText = $"{hint}";
+						}
+					}
+					else
+					{
+						if (newContentDescription != null)
+						{
+							newText = $"{newContentDescription}, {hint}";
+						}
+						else
+						{
+							newText = $"{hint}";
+						}
+					}
+
+					newContentDescription = null;
+				}
+			}
+
+			if (!string.IsNullOrWhiteSpace(newContentDescription))
+				info.ContentDescription = newContentDescription;
+
+			if (!string.IsNullOrWhiteSpace(newText))
+				info.Text = newText;
+		}
+
+		public static void UpdateSemantics(this View nativeView, IView view)
+		{
+			var semantics = view.Semantics;
+
+			if (semantics == null)
+				return;
+
+			ViewCompat.SetAccessibilityHeading(nativeView, semantics.IsHeading);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -92,16 +92,6 @@ namespace Microsoft.Maui
 			nativeView.SetTag(AutomationTagId, view.AutomationId);
 		}
 
-		public static void UpdateSemantics(this AView nativeView, IView view)
-		{
-			var semantics = view.Semantics;
-
-			if (semantics == null)
-				return;
-
-			ViewCompat.SetAccessibilityHeading(nativeView, semantics.IsHeading);
-		}
-
 		public static void InvalidateMeasure(this AView nativeView, IView view)
 		{
 			nativeView.RequestLayout();

--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -16,5 +16,25 @@ namespace Microsoft.Maui
 
 			UIAccessibility.PostNotification(UIAccessibilityPostNotification.LayoutChanged, nativeView);
 		}
+
+		public static void UpdateSemantics(this UIView nativeView, IView view)
+		{
+			var semantics = view.Semantics;
+
+			if (semantics == null)
+				return;
+
+			nativeView.AccessibilityLabel = semantics.Description;
+			nativeView.AccessibilityHint = semantics.Hint;
+
+			// UIControl elements automatically have IsAccessibilityElement set to true
+			if (nativeView is not UIControl && (!string.IsNullOrWhiteSpace(semantics.Hint) || !string.IsNullOrWhiteSpace(semantics.Description)))
+				nativeView.IsAccessibilityElement = true;
+
+			if (semantics.IsHeading)
+				nativeView.AccessibilityTraits |= UIAccessibilityTrait.Header;
+			else
+				nativeView.AccessibilityTraits &= ~UIAccessibilityTrait.Header;
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -100,26 +100,6 @@ namespace Microsoft.Maui
 				wrapper.Clip = view.Clip;
 		}
 
-		public static void UpdateSemantics(this UIView nativeView, IView view)
-		{
-			var semantics = view.Semantics;
-
-			if (semantics == null)
-				return;
-
-			nativeView.AccessibilityLabel = semantics.Description;
-			nativeView.AccessibilityHint = semantics.Hint;
-
-			// UIControl elements automatically have IsAccessibilityElement set to true
-			if (nativeView is not UIControl && (!string.IsNullOrWhiteSpace(semantics.Hint) || !string.IsNullOrWhiteSpace(semantics.Description)))
-				nativeView.IsAccessibilityElement = true;
-
-			if (semantics.IsHeading)
-				nativeView.AccessibilityTraits |= UIAccessibilityTrait.Header;
-			else
-				nativeView.AccessibilityTraits &= ~UIAccessibilityTrait.Header;
-		}
-
 		public static T? FindDescendantView<T>(this UIView view) where T : UIView
 		{
 			var queue = new Queue<UIView>();


### PR DESCRIPTION
### Description of Change ###

If users attach a touch gesture recognizer that will activate with a single touch then we add accessibility traits that will inform readers that the element is clickable.

Move all the semantic processing logic to extension methods to allow users to reuse if they need to

Make the MauiAccessibilityDelegate public for reuse

Adds an `AccessibilityDelegateCompatWrapper` that wraps an already assigned AccessibilityDelegateCompat. This allows you to easily retain the behavior of the current delegate and then add on to it

Alternative PR to 
https://github.com/dotnet/maui/pull/1861

### Additions made ###
```C#
// Contains logic for adding accessibility info if you're using a touch gesture
public class ControlsAccessibilityDelegate : AccessibilityDelegateCompatWrapper
```

```C#
// Allows users to call our code as an extension if they want to reuse any of our logic
// from their own custom code
namespace Microsoft.Maui.Controls.Platform
{
	public static class SemanticExtensions
	{
		public static void UpdateSemanticNodeInfo(this View virtualView, AccessibilityNodeInfoCompat? info)
```

```C#
// This allows you to take the existing delegate and wrap it if you want to retain
// the behavior of the Accessibility Delegate that's already assigned to the control
// We use this inside controls if we want to add additional accessibility delegate behavior
namespace Microsoft.Maui
{
	public class AccessibilityDelegateCompatWrapper : AccessibilityDelegateCompat
	{
		public AccessibilityDelegateCompatWrapper(AccessibilityDelegateCompat? originalDelegate)
		{
			_originalDelegate = originalDelegate ?? BlankDelegate;
		}
```

```C#
// Made our delegate public if users want to reuse it
public class MauiAccessibilityDelegateCompat : AccessibilityDelegateCompatWrapper
```

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [x] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
