### PR TITLE
Layout indexer parents

### DIFF
--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -26,7 +26,33 @@ namespace Microsoft.Maui.Controls
 
 		public bool IsReadOnly => ((ICollection<IView>)_children).IsReadOnly;
 
-		public IView this[int index] { get => _children[index]; set => _children[index] = value; }
+		public IView this[int index]
+		{
+			get => _children[index]; 
+			set
+			{
+				var old = _children[index];
+
+				if (old == value)
+				{
+					return;
+				}
+
+				if (old is Element oldElement)
+				{
+					oldElement.Parent = null;
+				}
+
+				_children[index] = value;
+
+				if (value is Element newElement)
+				{
+					newElement.Parent = this;
+				}
+
+				InvalidateMeasure();
+			}
+		}
 
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -43,12 +43,16 @@ namespace Microsoft.Maui.Controls
 					oldElement.Parent = null;
 				}
 
+				LayoutHandler?.Remove(old);
+
 				_children[index] = value;
 
 				if (value is Element newElement)
 				{
 					newElement.Parent = this;
 				}
+
+				LayoutHandler?.Add(value);
 
 				InvalidateMeasure();
 			}

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutTests.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
+{
+	[TestFixture, Category("Layout")]
+	public class LayoutTests : BaseTestFixture 
+	{
+		[Test]
+		public void UsingIndexUpdatesParent() 
+		{
+			var layout = new VerticalStackLayout();
+
+			var child0 = new Button();
+			var child1 = new Button();
+
+			Assert.Null(child0.Parent);
+			Assert.Null(child1.Parent);
+
+			layout.Add(child0);
+
+			Assert.AreEqual(layout, child0.Parent);
+			Assert.Null(child1.Parent);
+
+			layout[0] = child1;
+
+			Assert.Null(child0.Parent);
+			Assert.AreEqual(layout, child1.Parent);
+		}
+	}
+}


### PR DESCRIPTION
Make sure that changing the children of a Layout via the indexer also updates the Parent values for the children.