### PR TITLE
Hook up the new layouts to LogicalChildren

### DIFF
--- a/src/Compatibility/Core/src/Android/VisualElementPackager.cs
+++ b/src/Compatibility/Core/src/Android/VisualElementPackager.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			var sameChildrenTypes = false;
 
-			ReadOnlyCollection<Element> newChildren = null, oldChildren = null;
+			IReadOnlyList<Element> newChildren = null, oldChildren = null;
 
 			RendererPool pool = null;
 

--- a/src/Compatibility/Core/src/Windows/PageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/PageRenderer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Windows.UI.ViewManagement;
 using Microsoft.UI.Xaml;

--- a/src/Compatibility/Core/src/Windows/PageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/PageRenderer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				if (Element != null)
 				{
-					ReadOnlyCollection<Element> children = ((IElementController)Element).LogicalChildren;
+					IReadOnlyList<Element> children = ((IElementController)Element).LogicalChildren;
 					for (var i = 0; i < children.Count; i++)
 					{
 						var visualChild = children[i] as VisualElement;

--- a/src/Compatibility/Core/src/Windows/VisualElementPackager.cs
+++ b/src/Compatibility/Core/src/Windows/VisualElementPackager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.UI.Xaml.Controls;
 
@@ -79,7 +80,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			_renderer.Element.ChildRemoved += OnChildRemoved;
 			_renderer.Element.ChildrenReordered += OnChildrenReordered;
 
-			ReadOnlyCollection<Element> children = ElementController.LogicalChildren;
+			IReadOnlyList<Element> children = ElementController.LogicalChildren;
 			for (var i = 0; i < children.Count; i++)
 			{
 				var view = children[i] as VisualElement;

--- a/src/Compatibility/Core/src/iOS/CollectionView/ItemsViewController.cs
+++ b/src/Compatibility/Core/src/iOS/CollectionView/ItemsViewController.cs
@@ -502,7 +502,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			_emptyUIView.Tag = EmptyTag;
 			CollectionView.AddSubview(_emptyUIView);
 
-			if (!ItemsView.LogicalChildren.Contains(_emptyViewFormsElement))
+			if (ItemsView.LogicalChildren.IndexOf(_emptyViewFormsElement) == -1)
 			{
 				ItemsView.AddLogicalChild(_emptyViewFormsElement);
 			}
@@ -547,7 +547,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			_emptyUIView.Frame = frame;
 
-			if (_emptyViewFormsElement != null && ItemsView.LogicalChildren.Contains(_emptyViewFormsElement))
+			if (_emptyViewFormsElement != null && ItemsView.LogicalChildren.IndexOf(_emptyViewFormsElement) != -1)
 				_emptyViewFormsElement.Layout(frame.ToRectangle());
 		}
 

--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal
+		internal override IReadOnlyList<Element> LogicalChildrenInternal
 		{
 			get { return _logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(InternalChildren)); }
 		}

--- a/src/Controls/src/Core/BindableObjectExtensions.cs
+++ b/src/Controls/src/Core/BindableObjectExtensions.cs
@@ -6,21 +6,21 @@ namespace Microsoft.Maui.Controls
 {
 	public static class BindableObjectExtensions
 	{
-		internal static void PropagateBindingContext<T>(this BindableObject self, IList<T> children)
+		internal static void PropagateBindingContext<T>(this BindableObject self, IEnumerable<T> children)
 		{
 			PropagateBindingContext(self, children, BindableObject.SetInheritedBindingContext);
 		}
 
-		internal static void PropagateBindingContext<T>(this BindableObject self, IList<T> children, Action<BindableObject, object> setChildBindingContext)
+		internal static void PropagateBindingContext<T>(this BindableObject self, IEnumerable<T> children, Action<BindableObject, object> setChildBindingContext)
 		{
-			if (children == null || children.Count == 0)
+			if (children == null)
 				return;
 
 			var bc = self.BindingContext;
 
-			for (var i = 0; i < children.Count; i++)
+			foreach (var child in children)
 			{
-				var bo = children[i] as BindableObject;
+				var bo = child as BindableObject;
 				if (bo == null)
 					continue;
 

--- a/src/Controls/src/Core/Cells/ViewCell.cs
+++ b/src/Controls/src/Core/Cells/ViewCell.cs
@@ -43,6 +43,6 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildren ?? base.LogicalChildrenInternal;
+		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren ?? base.LogicalChildrenInternal;
 	}
 }

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Controls
 
 		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => EmptyChildren;
 
-		IReadOnlyList<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
+		IReadOnlyCollection<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
 
 		internal IReadOnlyList<Element> LogicalChildren => LogicalChildrenInternal;
 

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Controls
 
 		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => EmptyChildren;
 
-		IReadOnlyCollection<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
+		IReadOnlyList<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
 
 		internal IReadOnlyList<Element> LogicalChildren => LogicalChildrenInternal;
 

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal virtual ReadOnlyCollection<Element> LogicalChildrenInternal => EmptyChildren;
+		internal virtual IReadOnlyList<Element> LogicalChildrenInternal => EmptyChildren;
+
 		internal IEnumerable<Element> AllChildren
 		{
 			get
@@ -128,9 +129,8 @@ namespace Microsoft.Maui.Controls
 
 		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => EmptyChildren;
 
-
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public ReadOnlyCollection<Element> LogicalChildren => LogicalChildrenInternal;
+		public IReadOnlyList<Element> LogicalChildren => LogicalChildrenInternal;
 
 		internal bool Owned { get; set; }
 
@@ -404,7 +404,7 @@ namespace Microsoft.Maui.Controls
 
 			while (queue.Count > 0)
 			{
-				ReadOnlyCollection<Element> children = queue.Dequeue().LogicalChildrenInternal;
+				IReadOnlyList<Element> children = queue.Dequeue().LogicalChildrenInternal;
 				for (var i = 0; i < children.Count; i++)
 				{
 					Element child = children[i];
@@ -506,7 +506,7 @@ namespace Microsoft.Maui.Controls
 
 			while (queue.Count > 0)
 			{
-				ReadOnlyCollection<Element> children = queue.Dequeue().LogicalChildrenInternal;
+				IReadOnlyList<Element> children = queue.Dequeue().LogicalChildrenInternal;
 				for (var i = 0; i < children.Count; i++)
 				{
 					var child = children[i] as VisualElement;

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -129,8 +129,9 @@ namespace Microsoft.Maui.Controls
 
 		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => EmptyChildren;
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public IReadOnlyList<Element> LogicalChildren => LogicalChildrenInternal;
+		IReadOnlyList<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
+
+		internal IReadOnlyList<Element> LogicalChildren => LogicalChildrenInternal;
 
 		internal bool Owned { get; set; }
 

--- a/src/Controls/src/Core/HandlerImpl/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window.Impl.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.Controls
 
 		internal ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal =>
+		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
 			_logicalChildren ??= new ReadOnlyCollection<Element>(InternalChildren);
 
 		internal AlertManager AlertManager { get; }

--- a/src/Controls/src/Core/IElementController.cs
+++ b/src/Controls/src/Core/IElementController.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 
 		void SetValueFromRenderer(BindableProperty property, object value);
 		void SetValueFromRenderer(BindablePropertyKey propertyKey, object value);
-		ReadOnlyCollection<Element> LogicalChildren { get; }
+		IReadOnlyList<Element> LogicalChildren { get; }
 		Element RealParent { get; }
 		IEnumerable<Element> Descendants();
 	}

--- a/src/Controls/src/Core/IElementController.cs
+++ b/src/Controls/src/Core/IElementController.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 
 		void SetValueFromRenderer(BindableProperty property, object value);
 		void SetValueFromRenderer(BindablePropertyKey propertyKey, object value);
-		IReadOnlyCollection<Element> LogicalChildren { get; }
+		IReadOnlyList<Element> LogicalChildren { get; }
 		Element RealParent { get; }
 		IEnumerable<Element> Descendants();
 	}

--- a/src/Controls/src/Core/IElementController.cs
+++ b/src/Controls/src/Core/IElementController.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 
 		void SetValueFromRenderer(BindableProperty property, object value);
 		void SetValueFromRenderer(BindablePropertyKey propertyKey, object value);
-		IReadOnlyList<Element> LogicalChildren { get; }
+		IReadOnlyCollection<Element> LogicalChildren { get; }
 		Element RealParent { get; }
 		IEnumerable<Element> Descendants();
 	}

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -121,13 +121,7 @@ namespace Microsoft.Maui.Controls
 			VisualDiagnostics.OnChildRemoved(this, element, oldLogicalIndex);
 		}
 
-#if NETSTANDARD1_0
-		ReadOnlyCollection<Element> _readOnlyLogicalChildren;
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _readOnlyLogicalChildren ?? 
-			(_readOnlyLogicalChildren = new ReadOnlyCollection<Element>(_logicalChildren));
-#else
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildren.AsReadOnly();
-#endif
+		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren.AsReadOnly();
 
 		internal static readonly BindableProperty InternalItemsLayoutProperty =
 			BindableProperty.Create(nameof(ItemsLayout), typeof(IItemsLayout), typeof(ItemsView),

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		internal ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(InternalChildren));
+		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(InternalChildren));
 
 		public event EventHandler LayoutChanged;
 
@@ -336,7 +336,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		internal virtual void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger)
 		{
-			ReadOnlyCollection<Element> children = LogicalChildrenInternal;
+			IReadOnlyList<Element> children = LogicalChildrenInternal;
 			int count = children.Count;
 			for (var index = 0; index < count; index++)
 			{

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls
@@ -10,7 +8,10 @@ namespace Microsoft.Maui.Controls
 	[ContentProperty(nameof(Children))]
 	public abstract class Layout : View, Microsoft.Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement
 	{
+		ReadOnlyCastingList<Element, IView> _logicalChildren;
+
 		protected ILayoutManager _layoutManager;
+
 		public ILayoutManager LayoutManager => _layoutManager ??= CreateLayoutManager();
 
 		// The actual backing store for the IViews in the ILayout
@@ -21,7 +22,10 @@ namespace Microsoft.Maui.Controls
 
 		public ILayoutHandler LayoutHandler => Handler as ILayoutHandler;
 		IList IBindableLayout.Children => _children;
-		
+
+		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
+			_logicalChildren ??= new ReadOnlyCastingList<Element, IView>(_children);
+
 		public int Count => _children.Count;
 
 		public bool IsReadOnly => ((ICollection<IView>)_children).IsReadOnly;
@@ -58,7 +62,7 @@ namespace Microsoft.Maui.Controls
 				child.InvalidateMeasure();
 			}
 		}
-		
+
 		public virtual void Add(IView child)
 		{
 			if (child == null)

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal =>
+		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
 			_logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(InternalChildren));
 
 		public event EventHandler LayoutChanged;

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -589,7 +589,7 @@ namespace Microsoft.Maui.Controls
 
 		ObservableCollection<Element> _logicalChildren = new ObservableCollection<Element>();
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal =>
+		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
 			new ReadOnlyCollection<Element>(_logicalChildren);
 
 		public Shell()

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Controls
 		public ShellContent() => ((INotifyCollectionChanged)MenuItems).CollectionChanged += MenuItemsCollectionChanged;
 
 		internal bool IsVisibleContent => Parent is ShellSection shellSection && shellSection.IsVisibleSection && shellSection.CurrentItem == this;
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
+		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
 
 		internal override void SendDisappearing()
 		{

--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Maui.Controls
 
 		internal bool IsVisibleItem => Parent is Shell shell && shell?.CurrentItem == this;
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(_children));
+		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(_children));
 
 		internal void SendStructureChanged()
 		{

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Maui.Controls
 
 		public IReadOnlyList<Page> Stack => _navStack;
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
+		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
 
 		internal Page DisplayedPage
 		{

--- a/src/Controls/src/Core/TemplateUtilities.cs
+++ b/src/Controls/src/Core/TemplateUtilities.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.Controls
 
 				while (queue.Count > 0)
 				{
-					ReadOnlyCollection<Element> children = queue.Dequeue().LogicalChildrenInternal;
+					IReadOnlyList<Element> children = queue.Dequeue().LogicalChildrenInternal;
 					for (var i = 0; i < children.Count; i++)
 					{
 						Element child = children[i];

--- a/src/Controls/tests/Core.UnitTests/ElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ElementTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			get { return internalChildren; }
 		}
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal
+		internal override IReadOnlyList<Element> LogicalChildrenInternal
 		{
 			get { return new ReadOnlyCollection<Element>(internalChildren); }
 		}


### PR DESCRIPTION
### Description of Change ###

Make sure that we link the `LogicalChildren` with the new layouts. This makes the binding context propagation and styles and more work.

