### PR TITLE
Add custom overrides for measurement to legacy BoxView renderers 

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/BoxRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/BoxRenderer.cs
@@ -169,5 +169,44 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			UpdateBackgroundColor();
 		}
+
+		public override SizeRequest GetDesiredSize(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			// Creating a custom override for measuring the BoxView on Android; this reports the same default size that's 
+			// specified in the old OnMeasure method. Normally we'd just do this centrally in the xplat code or override
+			// GetDesiredSize in a BoxViewHandler. But BoxView is a legacy control (replaced by Shapes), so we don't want
+			// to bring that into the new stuff. 
+
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
+			var specWidth = MeasureSpec.GetSize(widthMeasureSpec);
+			var specHeight = MeasureSpec.GetSize(heightMeasureSpec);
+
+			var elementWidthRequest = Element.WidthRequest;
+			var elementHeightRequest = Element.HeightRequest;
+
+			var widthRequest = elementWidthRequest >= 0 ? elementWidthRequest : 40;
+			var heightRequest = elementHeightRequest >= 0 ? elementHeightRequest : 40;
+
+			if (widthMode != MeasureSpecMode.Exactly && widthRequest >= 0)
+			{
+				if (widthMode == MeasureSpecMode.Unspecified || widthRequest <= specWidth)
+				{
+					var deviceWidth = (int)Context.ToPixels(widthRequest);
+					widthMeasureSpec = MeasureSpec.MakeMeasureSpec(deviceWidth, MeasureSpecMode.Exactly);
+				}
+			}
+
+			if (heightMode != MeasureSpecMode.Exactly && heightRequest >= 0)
+			{
+				if (heightMode == MeasureSpecMode.Unspecified || heightRequest <= specHeight)
+				{
+					var deviceheight = (int)Context.ToPixels(heightRequest);
+					heightMeasureSpec = MeasureSpec.MakeMeasureSpec(deviceheight, MeasureSpecMode.Exactly);
+				}
+			}
+
+			return base.GetDesiredSize(widthMeasureSpec, heightMeasureSpec);
+		}
 	}
 }

--- a/src/Compatibility/Core/src/Windows/BoxViewBorderRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/BoxViewBorderRenderer.cs
@@ -105,5 +105,28 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		{
 			Control.CornerRadius = WinUIHelpers.CreateCornerRadius(cornerRadius.TopLeft, cornerRadius.TopRight, cornerRadius.BottomRight, cornerRadius.BottomLeft);
 		}
+
+		static Size DefaultSize = new(40, 40);
+
+		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			// Creating a custom override for measuring the BoxView on Windows; this reports the same default size that's 
+			// specified in the old OnMeasure method. Normally we'd just do this centrally in the xplat code or override
+			// GetDesiredSize in a BoxViewHandler. But BoxView is a legacy control (replaced by Shapes), so we don't want
+			// to bring that into the new stuff. 
+
+			if (Element != null)
+			{
+				var heightRequest = Element.HeightRequest;
+				var widthRequest = Element.WidthRequest;
+
+				heightRequest = heightRequest >= 0 ? heightRequest : 40;
+				widthRequest = widthRequest >= 0 ? widthRequest : 40;
+
+				return new Size(widthRequest, heightRequest);
+			}
+
+			return DefaultSize;
+		}
 	}
 }

--- a/src/Compatibility/Core/src/iOS/Renderers/BoxRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/BoxRenderer.cs
@@ -136,5 +136,30 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			SetNeedsDisplay();
 		}
+
+		static float DefaultWidth = 40;
+		static float DefaultHeight = 40;
+		static SizeF DefaultSize = new SizeF(DefaultWidth, DefaultHeight);
+
+		public override SizeF SizeThatFits(SizeF size)
+		{
+			// Creating a custom override for measuring the BoxView on iOS; this reports the same default size that's 
+			// specified in the old OnMeasure method. Normally we'd just do this centrally in the xplat code or override
+			// GetDesiredSize in a BoxViewHandler. But BoxView is a legacy control (replaced by Shapes), so we don't want
+			// to bring that into the new stuff. 
+
+			if (Element != null)
+			{
+				var heightRequest = Element.HeightRequest;
+				var widthRequest = Element.WidthRequest;
+
+				var height = heightRequest >= 0 ? heightRequest : DefaultHeight;
+				var width = widthRequest >= 0 ? widthRequest : DefaultWidth;
+
+				return new SizeF(width, height);
+			}
+
+			return DefaultSize;
+		}
 	}
 }


### PR DESCRIPTION
Adds custom overrides to the legacy renderers for BoxView to duplicate the old cross-platform behavior (a default size of 40x40). 

Also makes explicitly-sized BoxViews work on Android (previously they failed to appear at all).

Fixes #1922
