### PR TITLE
When measuring legacy layouts (including Frame), inlcude the margins

### DIFF
--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -226,7 +226,8 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			DesiredSize = OnMeasure(widthConstraint, heightConstraint).Request;
+			var sansMargins = OnMeasure(widthConstraint, heightConstraint).Request;
+			DesiredSize = new Size(sansMargins.Width + Margin.HorizontalThickness, sansMargins.Height + Margin.VerticalThickness);
 			return DesiredSize;
 		}
 


### PR DESCRIPTION
When measuring legacy layouts (including Frame), inlcude the margins when measuring for the new system.

Fixes an issue where a Frame with a margin will be laid out with the margin, but without sufficient space to account for the margin (which compresses the contents of the Frame).