### PR TITLE
[android] update to latest AndroidX packages

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -1,52 +1,48 @@
 <Project>
-  <PropertyGroup>
-    <!-- Uncomment to use preview packages -->
-    <!-- <_AndroidXVersion>-net6preview03.4680155</_AndroidXVersion> -->
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference
         Update="Xamarin.AndroidX.AppCompat.AppCompatResources"
-        Version="1.2.0.7$(_AndroidXVersion)"
+        Version="1.3.1.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Browser"
-        Version="1.3.0.5$(_AndroidXVersion)"
+        Version="1.3.0.6"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Legacy.Support.V4"
-        Version="1.0.0.7$(_AndroidXVersion)"
+        Version="1.0.0.8"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Lifecycle.LiveData"
-        Version="2.3.1$(_AndroidXVersion)"
+        Version="2.3.1.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.UI"
-        Version="2.3.5$(_AndroidXVersion)"
+        Version="2.3.5.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Fragment"
-        Version="2.3.5$(_AndroidXVersion)"
+        Version="2.3.5.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Runtime"
-        Version="2.3.5$(_AndroidXVersion)"
+        Version="2.3.5.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Common"
-        Version="2.3.5$(_AndroidXVersion)"
+        Version="2.3.5.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.MediaRouter"
-        Version="1.2.2.1$(_AndroidXVersion)"
+        Version="1.2.4.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Palette"
-        Version="1.0.0.7$(_AndroidXVersion)"
+        Version="1.0.0.8"
     />
     <PackageReference
         Update="Xamarin.AndroidX.RecyclerView"
-        Version="1.2.0$(_AndroidXVersion)"
+        Version="1.2.1.1"
     />
     <PackageReference
         Update="Xamarin.Build.Download"
@@ -54,7 +50,7 @@
     />
     <PackageReference
         Update="Xamarin.Google.Android.Material"
-        Version="1.3.0.1$(_AndroidXVersion)"
+        Version="1.4.0.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Migration"

--- a/src/Compatibility/Core/src/Android/AppCompat/TabbedPageRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/TabbedPageRenderer.cs
@@ -12,6 +12,7 @@ using AndroidX.Fragment.App;
 using AndroidX.ViewPager.Widget;
 using Google.Android.Material.BottomNavigation;
 using Google.Android.Material.BottomSheet;
+using Google.Android.Material.Navigation;
 using Google.Android.Material.Tabs;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
@@ -29,7 +30,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 #pragma warning disable CS0618 // Type or member is obsolete
 		TabLayout.IOnTabSelectedListener,
 #pragma warning restore CS0618 // Type or member is obsolete
-		ViewPager.IOnPageChangeListener, IManageFragments, BottomNavigationView.IOnNavigationItemSelectedListener
+		ViewPager.IOnPageChangeListener, IManageFragments, NavigationBarView.IOnItemSelectedListener
 	{
 		Drawable _backgroundDrawable;
 		Drawable _wrappedBackgroundDrawable;
@@ -193,7 +194,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 
 				if (_bottomNavigationView != null)
 				{
-					_bottomNavigationView.SetOnNavigationItemSelectedListener(null);
+					_bottomNavigationView.SetOnItemSelectedListener(null);
 					_bottomNavigationView.Dispose();
 					_bottomNavigationView = null;
 				}
@@ -262,7 +263,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 						if (_bottomNavigationView != null)
 						{
 							_relativeLayout.RemoveView(_bottomNavigationView);
-							_bottomNavigationView.SetOnNavigationItemSelectedListener(null);
+							_bottomNavigationView.SetOnItemSelectedListener(null);
 						}
 
 						var bottomNavigationViewLayoutParams = new AWidget.RelativeLayout.LayoutParams(
@@ -462,7 +463,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 				else
 				{
 					SetupBottomNavigationView(e);
-					bottomNavigationView.SetOnNavigationItemSelectedListener(this);
+					bottomNavigationView.SetOnItemSelectedListener(this);
 				}
 
 				UpdateIgnoreContainerAreas();

--- a/src/Compatibility/Core/src/Android/CollectionView/SelectableItemsViewAdapter.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/SelectableItemsViewAdapter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			for (int i = 0; i < _currentViewHolders.Count; i++)
 			{
-				if (_currentViewHolders[i].AdapterPosition == position)
+				if (_currentViewHolders[i].BindingAdapterPosition == position)
 				{
 					_currentViewHolders[i].IsSelected = true;
 					return;

--- a/src/Compatibility/Core/src/Android/CollectionView/SelectableViewHolder.cs
+++ b/src/Compatibility/Core/src/Android/CollectionView/SelectableViewHolder.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		{
 			if (_isSelectionEnabled)
 			{
-				OnViewHolderClicked(AdapterPosition);
+				OnViewHolderClicked(BindingAdapterPosition);
 			}
 		}
 

--- a/src/Compatibility/Core/src/Android/Renderers/ShellItemRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ShellItemRenderer.cs
@@ -9,6 +9,7 @@ using Android.Views;
 using Android.Widget;
 using Google.Android.Material.BottomNavigation;
 using Google.Android.Material.BottomSheet;
+using Google.Android.Material.Navigation;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using AColor = Android.Graphics.Color;
@@ -19,16 +20,16 @@ using Orientation = Android.Widget.Orientation;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
-	public class ShellItemRenderer : ShellItemRendererBase, BottomNavigationView.IOnNavigationItemSelectedListener, IAppearanceObserver
+	public class ShellItemRenderer : ShellItemRendererBase, NavigationBarView.IOnItemSelectedListener, IAppearanceObserver
 	{
-		#region IOnNavigationItemSelectedListener
+		#region IOnItemSelectedListener
 
-		bool BottomNavigationView.IOnNavigationItemSelectedListener.OnNavigationItemSelected(IMenuItem item)
+		bool NavigationBarView.IOnItemSelectedListener.OnNavigationItemSelected(IMenuItem item)
 		{
 			return OnItemSelected(item);
 		}
 
-		#endregion IOnNavigationItemSelectedListener
+		#endregion IOnItemSelectedListener
 
 		#region IAppearanceObserver
 
@@ -65,7 +66,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			_navigationArea = _outerLayout.FindViewById<FrameLayout>(Resource.Id.bottomtab_navarea);
 
 			_bottomView.SetBackgroundColor(Colors.White.ToAndroid());
-			_bottomView.SetOnNavigationItemSelectedListener(this);
+			_bottomView.SetOnItemSelectedListener(this);
 
 			if (ShellItem == null)
 				throw new InvalidOperationException("Active Shell Item not set. Have you added any Shell Items to your Shell?");
@@ -104,7 +105,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			if (_bottomView != null)
 			{
-				_bottomView?.SetOnNavigationItemSelectedListener(null);
+				_bottomView?.SetOnItemSelectedListener(null);
 				_bottomView?.Background?.Dispose();
 				_bottomView?.Dispose();
 			}

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellItemView.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellItemView.cs
@@ -9,6 +9,7 @@ using Android.Views;
 using Android.Widget;
 using Google.Android.Material.BottomNavigation;
 using Google.Android.Material.BottomSheet;
+using Google.Android.Material.Navigation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
@@ -20,16 +21,16 @@ using Orientation = Android.Widget.Orientation;
 
 namespace Microsoft.Maui.Controls.Platform
 {
-	public class ShellItemView : ShellItemViewBase, BottomNavigationView.IOnNavigationItemSelectedListener, IAppearanceObserver
+	public class ShellItemView : ShellItemViewBase, NavigationBarView.IOnItemSelectedListener, IAppearanceObserver
 	{
-		#region IOnNavigationItemSelectedListener
+		#region IOnItemSelectedListener
 
-		bool BottomNavigationView.IOnNavigationItemSelectedListener.OnNavigationItemSelected(IMenuItem item)
+		bool NavigationBarView.IOnItemSelectedListener.OnNavigationItemSelected(IMenuItem item)
 		{
 			return OnItemSelected(item);
 		}
 
-		#endregion IOnNavigationItemSelectedListener
+		#endregion IOnItemSelectedListener
 
 		#region IAppearanceObserver
 
@@ -67,7 +68,7 @@ namespace Microsoft.Maui.Controls.Platform
 			_navigationArea = _outerLayout.FindViewById<FrameLayout>(Resource.Id.bottomtab_navarea);
 
 			_bottomView.SetBackgroundColor(Colors.White.ToNative());
-			_bottomView.SetOnNavigationItemSelectedListener(this);
+			_bottomView.SetOnItemSelectedListener(this);
 
 			if (ShellItem == null)
 				throw new InvalidOperationException("Active Shell Item not set. Have you added any Shell Items to your Shell?");
@@ -106,7 +107,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (_bottomView != null)
 			{
-				_bottomView?.SetOnNavigationItemSelectedListener(null);
+				_bottomView?.SetOnItemSelectedListener(null);
 				_bottomView?.Background?.Dispose();
 				_bottomView?.Dispose();
 			}


### PR DESCRIPTION
### Description of Change ###

Fixes: https://github.com/dotnet/maui/issues/1904

This partially reverts d2d7176c.

There are a few API changes in the updates.

1. `AdapterPosition` is obsolete. Use `BindingAdapterPosition` instead.

2. `IOnNavigationItemSelectedListener` is obsolete use
   `IOnItemSelectedListener` instead.

https://stackoverflow.com/questions/67641594/bottomnavigation-view-onnavigationitemselectedlistener-is-deprecated

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No