### PR TITLE
Try a workaround for #1935

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,9 +11,9 @@
     <BuildForAndroid Condition="'$(SolutionFileName)' == 'Microsoft.Maui.Droid.sln' AND '$(Packing)' == ''">true</BuildForAndroid>
     <BuildForNet6 Condition="'$(Packing)' == 'true' OR $(MSBuildProjectFile.Contains('SingleProject')) OR $(MSBuildProjectFile.Contains('Profiling')) OR $(MSBuildProjectFile.Contains('net6')) OR $(SolutionFileName.Contains('net6')) OR '$(BuildForWinUI)' == 'true' OR '$(BuildForAndroid)' == 'true'">true</BuildForNet6>
     <MauiPlatforms>net6.0-ios;net6.0-maccatalyst;net6.0-android</MauiPlatforms>
-    <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362;net6.0-windows10.0.19041</WindowsTargetFramework>
-    <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);$(WindowsTargetFramework)</MauiPlatforms>
-    <MauiPlatforms Condition="'$(BuildForWinUI)' == 'true'">$(WindowsTargetFramework)</MauiPlatforms>
+    <WindowsMauiPlatforms Condition="'$(WindowsMauiPlatforms)' == ''">net6.0-windows10.0.18362;net6.0-windows10.0.19041</WindowsMauiPlatforms>
+    <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);$(WindowsMauiPlatforms)</MauiPlatforms>
+    <MauiPlatforms Condition="'$(BuildForWinUI)' == 'true'">$(WindowsMauiPlatforms)</MauiPlatforms>
     <MauiPlatforms Condition="'$(BuildForAndroid)' == 'true'">net6.0-android</MauiPlatforms>
 
     <!-- Work around the IDE not properly handling the NU1703 warning -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <BuildForAndroid Condition="'$(SolutionFileName)' == 'Microsoft.Maui.Droid.sln' AND '$(Packing)' == ''">true</BuildForAndroid>
     <BuildForNet6 Condition="'$(Packing)' == 'true' OR $(MSBuildProjectFile.Contains('SingleProject')) OR $(MSBuildProjectFile.Contains('Profiling')) OR $(MSBuildProjectFile.Contains('net6')) OR $(SolutionFileName.Contains('net6')) OR '$(BuildForWinUI)' == 'true' OR '$(BuildForAndroid)' == 'true'">true</BuildForNet6>
     <MauiPlatforms>net6.0-ios;net6.0-maccatalyst;net6.0-android</MauiPlatforms>
-    <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362</WindowsTargetFramework>
+    <WindowsTargetFramework Condition="'$(WindowsTargetFramework)' == ''">net6.0-windows10.0.18362;net6.0-windows10.0.19041</WindowsTargetFramework>
     <MauiPlatforms Condition="'$(Packing)' == 'true'">$(MauiPlatforms);$(WindowsTargetFramework)</MauiPlatforms>
     <MauiPlatforms Condition="'$(BuildForWinUI)' == 'true'">$(WindowsTargetFramework)</MauiPlatforms>
     <MauiPlatforms Condition="'$(BuildForAndroid)' == 'true'">net6.0-android</MauiPlatforms>

--- a/src/Compatibility/ControlGallery/src/WinUI/Compatibility.ControlGallery.WinUI.csproj
+++ b/src/Compatibility/ControlGallery/src/WinUI/Compatibility.ControlGallery.WinUI.csproj
@@ -3,7 +3,7 @@
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\..\..\..\..\eng\Environment.Build.props" />
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT'">
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.18362.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041</TargetFramework>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/Compatibility/Core/tests/WinUI/Compatibility.Windows.UnitTests.csproj
+++ b/src/Compatibility/Core/tests/WinUI/Compatibility.Windows.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT'">
-    <TargetFramework>net6.0-windows10.0.18362.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041</TargetFramework>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Maui.Controls.Compatibility.UAP.UnitTests</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>

--- a/src/Controls/samples/Controls.Sample.WinUI/Maui.Controls.Sample.WinUI.csproj
+++ b/src/Controls/samples/Controls.Sample.WinUI/Maui.Controls.Sample.WinUI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>Maui.Controls.Sample.WinUI</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
+++ b/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Xamarin.AndroidX.Browser" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(WindowsTargetFramework)' ">
+  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">
     <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" />
     <PackageReference Include="Microsoft.ProjectReunion" />
     <PackageReference Include="Microsoft.ProjectReunion.Foundation" />

--- a/src/Workload/Shared/Frameworks.targets
+++ b/src/Workload/Shared/Frameworks.targets
@@ -38,9 +38,9 @@
     />
     <_TargetPlatform
         Condition=" '$(MauiPlatformName)' == 'win' "
-        Include="$(WindowsTargetFramework)"
+        Include="net6.0-windows10.0.18362"
         FullTfm="%(Identity)"
-        Tfm="$(WindowsTargetFramework)"
+        Tfm="net6.0-windows10.0.18362"
         Profile="Windows"
     />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

If you build the library for 18362 AND 19041, then no matter what the app head is, it will have it.

Not a perfect solution, but one that should work for now until we properly resolve #1935