### PR TITLE
Call cross-platform measure in LayoutView.LayoutSubviews

### DIFF
--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Maui
 				bounds.Height -= safe.Top + safe.Bottom;
 				bounds.Width -= safe.Left + safe.Right;
 			}
-
+			
+			CrossPlatformMeasure?.Invoke(bounds.Width, bounds.Height);
 			CrossPlatformArrange?.Invoke(bounds);
 		}
 


### PR DESCRIPTION
Call cross-platform measure in LayoutSubviews. In some situations SizeThatFits will not be called, and the cross-platform measurement code still needs to run.