### PR TITLE
Allow .NET MAUI Community Toolkit to Access Internal APIs

### DIFF
--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -16,4 +16,8 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Core.UnitTests")]
 [assembly: InternalsVisibleTo("Comet")]
 [assembly: InternalsVisibleTo("Comet.Tests")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
 [assembly: InternalsVisibleTo("Reloadify-emit")]

--- a/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
+++ b/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
@@ -5,3 +5,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsUWP")]
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsShared")]
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsiOS")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]


### PR DESCRIPTION
### Description of Change ###

### Additions made ###
Adds `InternalsVisibleTo` for the .NET MAUI Community Toolkit libraries

```csharp
[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
```