### PR TITLE
Use new overload of UIApplication.Main

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1/Platforms/MacCatalyst/Program.cs
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/Platforms/MacCatalyst/Program.cs
@@ -9,7 +9,7 @@ namespace MauiApp1
 		{
 			// if you want to use a different Application Delegate class from "AppDelegate"
 			// you can specify it here.
-			UIApplication.Main(args, null, "AppDelegate");
+			UIApplication.Main(args, null, typeof(AppDelegate));
 		}
 	}
 }

--- a/src/Templates/src/templates/maui-blazor/MauiApp1/Platforms/iOS/Program.cs
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1/Platforms/iOS/Program.cs
@@ -9,7 +9,7 @@ namespace MauiApp1
 		{
 			// if you want to use a different Application Delegate class from "AppDelegate"
 			// you can specify it here.
-			UIApplication.Main(args, null, "AppDelegate");
+			UIApplication.Main(args, null, typeof(AppDelegate));
 		}
 	}
 }

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/Platforms/MacCatalyst/Program.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/Platforms/MacCatalyst/Program.cs
@@ -9,7 +9,7 @@ namespace MauiApp1
 		{
 			// if you want to use a different Application Delegate class from "AppDelegate"
 			// you can specify it here.
-			UIApplication.Main(args, null, "AppDelegate");
+			UIApplication.Main(args, null, typeof(AppDelegate));
 		}
 	}
 }

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/Platforms/iOS/Program.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/Platforms/iOS/Program.cs
@@ -9,7 +9,7 @@ namespace MauiApp1
 		{
 			// if you want to use a different Application Delegate class from "AppDelegate"
 			// you can specify it here.
-			UIApplication.Main(args, null, "AppDelegate");
+			UIApplication.Main(args, null, typeof(AppDelegate));
 		}
 	}
 }


### PR DESCRIPTION

### Description of Change ###

The string-based overload is deprecated and a `dotnet new maui` is not cool with warnings.