### PR TITLE
Horizontal and Vertical Layouts, now use the the X/Y when laying out

### DIFF
--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -44,18 +44,20 @@ namespace Microsoft.Maui.Layouts
 		public override Size ArrangeChildren(Rectangle bounds)
 		{
 			var padding = Stack.Padding;
+			double stackHeight = padding.Top + bounds.Top;
+			double left = padding.Left + bounds.X;
 			var height = bounds.Height - padding.VerticalThickness;
 			double stackWidth = 0;
 
 			if (Stack.FlowDirection == FlowDirection.LeftToRight)
 			{
-				stackWidth = ArrangeLeftToRight(height, padding.Left, padding.Top, Stack.Spacing, Stack);
+				stackWidth = ArrangeLeftToRight(height, left, top, Stack.Spacing, Stack);
 			}
 			else
 			{
 				// We _could_ simply reverse the list of child views when arranging from right to left, 
 				// but this way we avoid extra list and enumerator allocations
-				stackWidth = ArrangeRightToLeft(height, padding.Left, padding.Top, Stack.Spacing, Stack);
+				stackWidth = ArrangeRightToLeft(height, left, top, Stack.Spacing, Stack);
 			}
 
 			return new Size(height, stackWidth);

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Maui.Layouts
 		{
 			var padding = Stack.Padding;
 
-			double stackHeight = padding.Top;
-			double left = padding.Left;
+			double stackHeight = padding.Top + bounds.Top;
+			double left = padding.Left + bounds.X;
 			double width = bounds.Width - padding.HorizontalThickness;
 
 			for (int n = 0; n < Stack.Count; n++)


### PR DESCRIPTION
Previously the arrange ignored the x/y on the rectangle passed in for the bounds.
This fixes that.