### PR TITLE
MS.Ext.FileProviders.Abstractions is still used

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -15,6 +15,7 @@
     <MicrosoftExtensionsLoggingPackageVersion>$(_MicrosoftHostingVersion)</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>$(_MicrosoftHostingVersion)</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingDebugPackageVersion>$(_MicrosoftHostingVersion)</MicrosoftExtensionsLoggingDebugPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>$(_MicrosoftHostingVersion)</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
   </PropertyGroup>
    <!-- Microsoft.Maui.Graphics related Packages -->
   <PropertyGroup>
@@ -63,6 +64,10 @@
     <PackageReference
         Update="Microsoft.Extensions.DependencyInjection.Abstractions"
         Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)"
+    />
+    <PackageReference
+        Update="Microsoft.Extensions.FileProviders.Abstractions"
+        Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)"
     />
     <PackageReference
         Update="Microsoft.Extensions.Hosting.Abstractions"

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -72,6 +72,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d90f6b6c86be7001dc839e147ab229dfd1c7d20d</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0-rc.1.21401.3" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d90f6b6c86be7001dc839e147ab229dfd1c7d20d</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Authorization" Version="6.0.0-rc.1.21403.6" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>408d4106ea802eff805fb3c8729aeb0bb88c0aaa</Sha>

--- a/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
+++ b/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"    GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"   GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"   GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Primitives"             GeneratePathProperty="true" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration)/lib/netstandard2.0/Microsoft.Extensions.Configuration.dll" />
@@ -26,6 +27,8 @@
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.Hosting.Abstractions.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.Hosting.Abstractions.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Primitives)/lib/netstandard2.0/Microsoft.Extensions.Primitives.dll" />


### PR DESCRIPTION

### Description of Change ###

The IFileProvider type is used by IHostEnvironment which is a base type that is referenced via the builder

Part undo of 61c33ca61ea2a971703f66dd6586b0b47230a52d which removed the Embedded AND the Abstractions. Probably missed due to transitive dependencies in the projects.