### PR TITLE
Implement Safe Area handling for iOS

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Maui.Controls
 
 			if (Content is IView view)
 			{
-				_ = view.Arrange(Frame);
+				// TODO ezhart 2021-08-07 When we implement Padding for the ContentPage new layout stuff, the padding will adjust this rectangle
+				_ = view.Arrange(new Rectangle(0, 0, Frame.Width, Frame.Height));
 			}
 
 			return Frame.Size;

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 			return OnMeasure(widthConstraint, heightConstraint);
 		}
 
-		Size ILayoutManager.ArrangeChildren(Rectangle childBounds)
+		Size ILayoutManager.ArrangeChildren(Size finalSize)
 		{
-			LayoutChildren(childBounds.X, childBounds.Y, childBounds.Width, childBounds.Height);
-			return childBounds.Size;
+			LayoutChildren(0, 0, finalSize.Width, finalSize.Height);
+			return finalSize;
 		}
 	}
 

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Maui.Controls.Compatibility
 		ILayoutManager Maui.ILayout.LayoutManager => this;
 		IList IBindableLayout.Children => _children;
 
+		bool ISafeAreaView.IgnoreSafeArea => false;
+
 		protected override void OnChildAdded(Element child)
 		{
 			base.OnChildAdded(child);

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Children))]
-	public abstract class Layout : View, Microsoft.Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement
+	public abstract class Layout : View, Microsoft.Maui.ILayout, IList<IView>, IBindableLayout, IPaddingElement, IVisualTreeElement, ISafeAreaView
 	{
 		ReadOnlyCastingList<Element, IView> _logicalChildren;
 
@@ -72,6 +72,8 @@ namespace Microsoft.Maui.Controls
 			get => (Thickness)GetValue(PaddingElement.PaddingProperty);
 			set => SetValue(PaddingElement.PaddingProperty, value);
 		}
+		
+		public bool IgnoreSafeArea { get; set; }
 
 		protected abstract ILayoutManager CreateLayoutManager();
 

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -7,11 +7,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
-	public partial class Page : VisualElement, ILayout, IPageController, IElementConfiguration<Page>, IPaddingElement
+	public partial class Page : VisualElement, ILayout, IPageController, IElementConfiguration<Page>, IPaddingElement, ISafeAreaView
 	{
 		public const string BusySetSignalName = "Microsoft.Maui.Controls.BusySet";
 
@@ -146,6 +147,8 @@ namespace Microsoft.Maui.Controls
 
 		internal override IReadOnlyList<Element> LogicalChildrenInternal =>
 			_logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(InternalChildren));
+
+		bool ISafeAreaView.IgnoreSafeArea => !On<PlatformConfiguration.iOS>().UsingSafeArea();
 
 		public event EventHandler LayoutChanged;
 

--- a/src/Core/src/Core/ILayout.cs
+++ b/src/Core/src/Core/ILayout.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui
 	/// Provides the base properties and methods for all Layout elements.
 	/// Use Layout elements to position and size child elements in .NET MAUI applications.
 	/// </summary>
-	public interface ILayout : IView, IContainer
+	public interface ILayout : IView, IContainer, ISafeAreaView
 	{
 		/// <summary>
 		/// Gets the Layout Handler.

--- a/src/Core/src/Handlers/Page/PageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.iOS.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
+			NativeView.View = view;
 			NativeView.CrossPlatformArrange = VirtualView.Arrange;
 		}
 

--- a/src/Core/src/Layouts/FlexLayoutManager.cs
+++ b/src/Core/src/Layouts/FlexLayoutManager.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Maui.Layouts
 			FlexLayout = flexLayout;
 		}
 
-		public Size ArrangeChildren(Rectangle childBounds)
+		public Size ArrangeChildren(Size finalSize)
 		{
-			FlexLayout.Layout(childBounds.Width, childBounds.Height);
+			FlexLayout.Layout(finalSize.Width, finalSize.Height);
 
 			foreach (var child in FlexLayout)
 			{
@@ -25,11 +25,11 @@ namespace Microsoft.Maui.Layouts
 					|| double.IsNaN(frame.Width)
 					|| double.IsNaN(frame.Height))
 					throw new Exception("something is deeply wrong");
-				frame = frame.Offset(childBounds.X, childBounds.Y);
+				
 				child.Arrange(frame);
 			}
 
-			return childBounds.Size;
+			return finalSize;
 		}
 
 		public Size Measure(double widthConstraint, double heightConstraint)

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Maui.Layouts
 			return new Size(_gridStructure.MeasuredGridWidth(), _gridStructure.MeasuredGridHeight());
 		}
 
-		public override Size ArrangeChildren(Rectangle childBounds)
+		public override Size ArrangeChildren(Size finalSize)
 		{
-			var structure = _gridStructure ?? new GridStructure(Grid, childBounds.Width, childBounds.Height);
+			var structure = _gridStructure ?? new GridStructure(Grid, finalSize.Width, finalSize.Height);
 
 			foreach (var view in Grid)
 			{

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -41,10 +41,10 @@ namespace Microsoft.Maui.Layouts
 			return new Size(finalWidth, finalHeight);
 		}
 
-		public override Size ArrangeChildren(Rectangle bounds)
+		public override Size ArrangeChildren(Size finalSize)
 		{
 			var padding = Stack.Padding;
-			var height = bounds.Height - padding.VerticalThickness;
+			var height = finalSize.Height - padding.VerticalThickness;
 			double stackWidth = 0;
 
 			if (Stack.FlowDirection == FlowDirection.LeftToRight)

--- a/src/Core/src/Layouts/ILayoutManager.cs
+++ b/src/Core/src/Layouts/ILayoutManager.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Maui.Layouts
 	public interface ILayoutManager
 	{
 		Size Measure(double widthConstraint, double heightConstraint);
-		Size ArrangeChildren(Rectangle childBounds);
+
+		Size ArrangeChildren(Size finalSize);
 	}
 }

--- a/src/Core/src/Layouts/LayoutManager.cs
+++ b/src/Core/src/Layouts/LayoutManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Layouts
 		public ILayout Layout { get; }
 
 		public abstract Size Measure(double widthConstraint, double heightConstraint);
-		public abstract Size ArrangeChildren(Rectangle childBounds);
+		public abstract Size ArrangeChildren(Size finalSize);
 
 		public static double ResolveConstraints(double externalConstraint, double explicitLength, double measuredLength)
 		{

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Maui.Layouts
 			return new Size(finalWidth, finalHeight);
 		}
 
-		public override Size ArrangeChildren(Rectangle bounds) 
+		public override Size ArrangeChildren(Size finalSize) 
 		{
 			var padding = Stack.Padding;
 
 			double stackHeight = padding.Top;
 			double left = padding.Left;
-			double width = bounds.Width - padding.HorizontalThickness;
+			double width = finalSize.Width - padding.HorizontalThickness;
 
 			for (int n = 0; n < Stack.Count; n++)
 			{

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -66,13 +66,12 @@ namespace Microsoft.Maui.Handlers
 			var deviceIndependentRight = Context.FromPixels(r);
 			var deviceIndependentBottom = Context.FromPixels(b);
 
-			var destination = Rectangle.FromLTRB(deviceIndependentLeft, deviceIndependentTop,
-				deviceIndependentRight, deviceIndependentBottom);
+			var finalSize = new Size(deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
 
-			CrossPlatformArrange(destination);
+			CrossPlatformArrange(finalSize);
 		}
 
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
-		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
+		internal Func<Size, Size>? CrossPlatformArrange { get; set; }
 	}
 }

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui
 	public class LayoutPanel : Panel
 	{
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
-		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
+		internal Func<Size, Size>? CrossPlatformArrange { get; set; }
 
 		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
 		{
@@ -38,7 +38,7 @@ namespace Microsoft.Maui
 			var width = finalSize.Width;
 			var height = finalSize.Height;
 
-			var actual = CrossPlatformArrange(new Rectangle(0, 0, width, height));
+			var actual = CrossPlatformArrange(new Size(width, height));
 
 			return new Windows.Foundation.Size(actual.Width, actual.Height);
 		}

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -1,13 +1,10 @@
 using System;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Handlers;
-using ObjCRuntime;
-using UIKit;
 
 namespace Microsoft.Maui
 {
-	public class LayoutView : UIView
+	public class LayoutView : MauiView
 	{
 		public override CGSize SizeThatFits(CGSize size)
 		{
@@ -24,90 +21,20 @@ namespace Microsoft.Maui
 			return crossPlatformSize.ToCGSize();
 		}
 
-		public IView? View { get; set; }
-
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();
 
 			// TODO ezhart 2021-07-07 This Frame may not make sense if we're applying a transform to this UIView; we should determine the rectangle from Bounds/Center instead
+			Frame = AdjustForSafeArea(Frame);
+
 			var bounds = Frame.ToRectangle();
-			if (View is ISafeAreaView sav && !sav.IgnoreSafeArea && RespondsToSafeArea())
-			{
-				var safe = SafeAreaInsets;
-				bounds.X += safe.Left;
-				bounds.Y += safe.Top;
-				bounds.Height -= safe.Top + safe.Bottom;
-				bounds.Width -= safe.Left + safe.Right;
-			}
 
 			CrossPlatformMeasure?.Invoke(bounds.Width, bounds.Height);
-			CrossPlatformArrange?.Invoke(bounds);
-		}
-
-		static bool? respondsToSafeArea;
-
-		bool RespondsToSafeArea()
-		{
-			if (respondsToSafeArea.HasValue)
-				return respondsToSafeArea.Value;
-			return (bool)(respondsToSafeArea = this.RespondsToSelector(new Selector("safeAreaInsets")));
+			CrossPlatformArrange?.Invoke(bounds.Size);
 		}
 
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
-		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
-	}
-
-	public class PageView : UIView
-	{
-		public override CGSize SizeThatFits(CGSize size)
-		{
-			return size;
-		}
-
-		public override void LayoutSubviews()
-		{
-			base.LayoutSubviews();
-
-			var width = Frame.Width;
-			var height = Frame.Height;
-
-			CrossPlatformMeasure?.Invoke(width, height);
-			CrossPlatformArrange?.Invoke(Frame.ToRectangle());
-		}
-
-		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
-		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
-	}
-
-	public class PageViewController : ContainerViewController
-	{
-		public PageViewController(IView page, IMauiContext mauiContext)
-		{
-			CurrentView = page;
-			Context = mauiContext;
-
-			LoadFirstView(page);
-		}
-
-		protected override UIView CreateNativeView(IElement view)
-		{
-			return new PageView
-			{
-				CrossPlatformArrange = ((IView)view).Arrange,
-				CrossPlatformMeasure = ((IView)view).Measure
-			};
-		}
-
-		public override void TraitCollectionDidChange(UITraitCollection? previousTraitCollection)
-		{
-			if (CurrentView?.Handler is ElementHandler handler)
-			{
-				var application = handler.GetRequiredService<IApplication>();
-				application?.ThemeChanged();
-			}
-
-			base.TraitCollectionDidChange(previousTraitCollection);
-		}
+		internal Func<Size, Size>? CrossPlatformArrange { get; set; }
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -1,0 +1,30 @@
+﻿using CoreGraphics;
+using ObjCRuntime;
+using UIKit;
+
+namespace Microsoft.Maui
+{
+	public abstract class MauiView : UIView 
+	{
+		static bool? _respondsToSafeArea;
+
+		public IView? View { get; set; }
+
+		bool RespondsToSafeArea()
+		{
+			if (_respondsToSafeArea.HasValue)
+				return _respondsToSafeArea.Value;
+			return (bool)(_respondsToSafeArea = RespondsToSelector(new Selector("safeAreaInsets")));
+		}
+
+		protected CGRect AdjustForSafeArea(CGRect frame)
+		{
+			if (View is not ISafeAreaView sav || sav.IgnoreSafeArea || !RespondsToSafeArea())
+			{
+				return frame;
+			}
+			
+			return SafeAreaInsets.InsetRect(frame);
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/PageView.cs
+++ b/src/Core/src/Platform/iOS/PageView.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using CoreGraphics;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
+{
+	public class PageView : MauiView
+	{
+		public override CGSize SizeThatFits(CGSize size)
+		{
+			return size;
+		}
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+
+			Frame = AdjustForSafeArea(Frame);
+
+			var bounds = Frame.ToRectangle();
+
+			CrossPlatformMeasure?.Invoke(bounds.Width, bounds.Height);
+			CrossPlatformArrange?.Invoke(bounds);
+		}
+
+		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
+		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
+	}
+}

--- a/src/Core/src/Platform/iOS/PageViewController.cs
+++ b/src/Core/src/Platform/iOS/PageViewController.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Maui.Handlers;
+using UIKit;
+
+namespace Microsoft.Maui
+{
+	public class PageViewController : ContainerViewController
+	{
+		public PageViewController(IView page, IMauiContext mauiContext)
+		{
+			CurrentView = page;
+			Context = mauiContext;
+
+			LoadFirstView(page);
+		}
+
+		protected override UIView CreateNativeView(IElement view)
+		{
+			return new PageView
+			{
+				CrossPlatformArrange = ((IView)view).Arrange,
+				CrossPlatformMeasure = ((IView)view).Measure
+			};
+		}
+
+		public override void TraitCollectionDidChange(UITraitCollection? previousTraitCollection)
+		{
+			if (CurrentView?.Handler is ElementHandler handler)
+			{
+				var application = handler.GetRequiredService<IApplication>();
+				application?.ThemeChanged();
+			}
+
+			base.TraitCollectionDidChange(previousTraitCollection);
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Stubs/LayoutManagerStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LayoutManagerStub.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class LayoutManagerStub : ILayoutManager
 	{
-		public Size ArrangeChildren(Rectangle childBounds)
+		public Size ArrangeChildren(Size finalSize)
 		{
-			return childBounds.Size;
+			return finalSize;
 		}
 
 		public Size Measure(double widthConstraint, double heightConstraint)

--- a/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public ILayoutManager LayoutManager => _layoutManager ??= new LayoutManagerStub();
 
+		public bool IgnoreSafeArea => false;
+
 		public IView this[int index] { get => _children[index]; set => _children[index] = value; }
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		{
 			var manager = new GridLayoutManager(grid);
 			var measuredSize = manager.Measure(widthConstraint, heightConstraint);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			return measuredSize;
 		}
@@ -336,7 +336,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(0, 0, measure.Width, measure.Height));
+			manager.ArrangeChildren(new Size(measure.Width, measure.Height));
 
 			// Because the auto row has no content, we expect it to have height zero
 			Assert.Equal(100 + 100, measure.Height);
@@ -424,7 +424,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(0, 0, measure.Width, measure.Height));
+			manager.ArrangeChildren(new Size(measure.Width, measure.Height));
 
 			// Because the auto column has no content, we expect it to have width zero
 			Assert.Equal(100 + 100, measure.Width);
@@ -703,7 +703,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new GridLayoutManager(grid);
 
 			manager.Measure(200, 100);
-			manager.ArrangeChildren(new Rectangle(0, 0, 200, 100));
+			manager.ArrangeChildren(new Size(200, 100));
 
 			// View should be arranged to span both columns (200 points)
 			AssertArranged(view0, 0, 0, 200, 100);
@@ -721,7 +721,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new GridLayoutManager(grid);
 
 			manager.Measure(100, 200);
-			manager.ArrangeChildren(new Rectangle(0, 0, 100, 200));
+			manager.ArrangeChildren(new Size(100, 200));
 
 			// View should be arranged to span both rows (200 points)
 			AssertArranged(view0, 0, 0, 100, 200);
@@ -1095,7 +1095,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
+			manager.ArrangeChildren(measure);
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -1117,7 +1117,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
+			manager.ArrangeChildren(measure);
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -1180,7 +1180,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			AssertArranged(grid[0], padding.Left, padding.Top, viewWidth, viewHeight);
 		}

--- a/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new HorizontalStackLayoutManager(stack);
 
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			var expectedRectangle = new Rectangle(0, 0, 100, 100);
 			stack[0].Received().Arrange(Arg.Is(expectedRectangle));
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new HorizontalStackLayoutManager(stack);
 
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			var expectedRectangle0 = new Rectangle(0, 0, 100, 100);
 			stack[0].Received().Arrange(Arg.Is(expectedRectangle0));
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			// We expect that the starting view (0) should be arranged on the left,
 			// and the next rectangle (1) should be on the right
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			// We expect that the starting view (0) should be arranged on the right,
 			// and the next rectangle (1) should be on the left
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measure = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
+			manager.ArrangeChildren(measure);
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measure = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
+			manager.ArrangeChildren(measure);
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -210,7 +210,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			AssertArranged(stack[0], padding.Left, padding.Top, viewWidth, viewHeight);
 		}

--- a/src/Core/tests/UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new VerticalStackLayoutManager(stack);
 
 			var measuredSize = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			var expectedRectangle = new Rectangle(0, 0, 100, 100);
 			stack[0].Received().Arrange(Arg.Is(expectedRectangle));
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new VerticalStackLayoutManager(stack);
 
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			AssertArranged(stack[0], 0, 0, 100, 100);
 			AssertArranged(stack[1], 0, 100 + spacing, 100, 100);
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new VerticalStackLayoutManager(stack);
 			var measure = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
+			manager.ArrangeChildren(measure);
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -110,7 +110,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new VerticalStackLayoutManager(stack);
 			var measure = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
+			manager.ArrangeChildren(measure);
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -168,7 +168,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new VerticalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
+			manager.ArrangeChildren(measuredSize);
 
 			AssertArranged(stack[0], padding.Left, padding.Top, viewWidth, viewHeight);
 		}


### PR DESCRIPTION
Adds the ISafeAreaView interface to ILayout (and to Page in Controls).

Page implements ISafeAreaView.IgnoreSafeArea via the `UseSafeArea` platform specific. 

Handle safe area offset checking for LayoutView and PageView.

Also fixes incorrect parameter type for ILayoutManager.ArrangeChildren (Rectangle -> Size).

| IgnoreSafeArea=False | IgnoreSafeArea=True |
| :-: | :-: |
| ![stayinsafearea](https://user-images.githubusercontent.com/538025/128617493-68282c88-5336-4199-b947-1e15120cf1d2.png) | ![ignore](https://user-images.githubusercontent.com/538025/128617500-2add1bc9-3e9e-4b8d-a2b6-c53261be7230.png) |
| ![safearea](https://user-images.githubusercontent.com/538025/128617524-81484b9b-6faf-4edb-a98f-0bd159bba5e5.png) | ![ignoresafearea](https://user-images.githubusercontent.com/538025/128617527-59614f20-0da0-4e17-a7b1-c56ccf8fa433.png) |