### PR TITLE
Add shell parameters for passing complex objects

### DIFF
--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Maui.Controls
 		bool IFlowDirectionController.ApplyEffectiveFlowDirectionToChildContainer => true;
 		double IFlowDirectionController.Width => (Parent as VisualElement)?.Width ?? 0;
 
-		internal virtual void ApplyQueryAttributes(IDictionary<string, string> query)
+		internal virtual void ApplyQueryAttributes(ShellRouteParameters query)
 		{
 		}
 
@@ -444,6 +444,6 @@ namespace Microsoft.Maui.Controls
 
 	public interface IQueryAttributable
 	{
-		void ApplyQueryAttributes(IDictionary<string, string> query);
+		void ApplyQueryAttributes(Dictionary<string, object> query);
 	}
 }

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -444,6 +444,6 @@ namespace Microsoft.Maui.Controls
 
 	public interface IQueryAttributable
 	{
-		void ApplyQueryAttributes(Dictionary<string, object> query);
+		void ApplyQueryAttributes(IDictionary<string, object> query);
 	}
 }

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -498,6 +498,16 @@ namespace Microsoft.Maui.Controls
 			return _navigationManager.GoToAsync(state, animate, false);
 		}
 
+		public Task GoToAsync(ShellNavigationState state, IDictionary<string, object> parameters)
+		{
+			return _navigationManager.GoToAsync(state, null, false, parameters: new ShellRouteParameters(parameters));
+		}
+
+		public Task GoToAsync(ShellNavigationState state, bool animate, IDictionary<string, object> parameters)
+		{
+			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(parameters));
+		}
+
 		public void AddLogicalChild(Element element)
 		{
 			if (element == null)

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -64,8 +64,8 @@ namespace Microsoft.Maui.Controls
 			else
 			{
 				result = ContentCache ?? (Page)template.CreateContent(content, this);
-ContentCache = result;
-}
+				ContentCache = result;
+			}
 
 			if (result == null)
 				throw new InvalidOperationException($"No Content found for {nameof(ShellContent)}, Title:{Title}, Route {Route}");

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create(nameof(ContentTemplate), typeof(DataTemplate), typeof(ShellContent), null, BindingMode.OneTime);
 
 		internal static readonly BindableProperty QueryAttributesProperty =
-			BindableProperty.CreateAttached("QueryAttributes", typeof(IDictionary<string, string>), typeof(ShellContent), defaultValue: null, propertyChanged: OnQueryAttributesPropertyChanged);
+			BindableProperty.CreateAttached("QueryAttributes", typeof(ShellRouteParameters), typeof(ShellContent), defaultValue: null, propertyChanged: OnQueryAttributesPropertyChanged);
 
 		public MenuItemCollection MenuItems => (MenuItemCollection)GetValue(MenuItemsProperty);
 
@@ -64,13 +64,13 @@ namespace Microsoft.Maui.Controls
 			else
 			{
 				result = ContentCache ?? (Page)template.CreateContent(content, this);
-				ContentCache = result;
-			}
+ContentCache = result;
+}
 
 			if (result == null)
 				throw new InvalidOperationException($"No Content found for {nameof(ShellContent)}, Title:{Title}, Route {Route}");
 
-			if (GetValue(QueryAttributesProperty) is IDictionary<string, string> delayedQueryParams)
+			if (GetValue(QueryAttributesProperty) is ShellRouteParameters delayedQueryParams)
 				result.SetValue(QueryAttributesProperty, delayedQueryParams);
 
 			return result;
@@ -241,7 +241,7 @@ namespace Microsoft.Maui.Controls
 				}
 		}
 
-		internal override void ApplyQueryAttributes(IDictionary<string, string> query)
+		internal override void ApplyQueryAttributes(ShellRouteParameters query)
 		{
 			base.ApplyQueryAttributes(query);
 			SetValue(QueryAttributesProperty, query);
@@ -252,13 +252,13 @@ namespace Microsoft.Maui.Controls
 
 		static void OnQueryAttributesPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			ApplyQueryAttributes(bindable, newValue as IDictionary<string, string>, oldValue as IDictionary<string, string>);
+			ApplyQueryAttributes(bindable, newValue as ShellRouteParameters, oldValue as ShellRouteParameters);
 		}
 
-		static void ApplyQueryAttributes(object content, IDictionary<string, string> query, IDictionary<string, string> oldQuery)
+		static void ApplyQueryAttributes(object content, ShellRouteParameters query, ShellRouteParameters oldQuery)
 		{
-			query = query ?? new Dictionary<string, string>();
-			oldQuery = oldQuery ?? new Dictionary<string, string>();
+			query = query ?? new ShellRouteParameters();
+			oldQuery = oldQuery ?? new ShellRouteParameters();
 
 			if (content is IQueryAttributable attributable)
 				attributable.ApplyQueryAttributes(query);
@@ -286,10 +286,10 @@ namespace Microsoft.Maui.Controls
 
 					if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
 					{
-						if (prop.PropertyType == typeof(String))
+						if (prop.PropertyType == typeof(string))
 						{
 							if (value != null)
-								value = global::System.Net.WebUtility.UrlDecode(value);
+								value = global::System.Net.WebUtility.UrlDecode((string)value);
 
 							prop.SetValue(content, value);
 						}

--- a/src/Controls/src/Core/Shell/ShellNavigationParameters.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationParameters.cs
@@ -16,5 +16,6 @@ namespace Microsoft.Maui.Controls
 		public bool PopAllPagesNotSpecifiedOnTargetState { get; set; }
 		// This is used to service Navigation.PushAsync style APIs where the user doesn't use routes at all
 		public Page PagePushing { get; set; }
+		public ShellRouteParameters Parameters { get; set; }
 	}
 }

--- a/src/Controls/src/Core/Shell/ShellRouteParameters.cs
+++ b/src/Controls/src/Core/Shell/ShellRouteParameters.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Maui.Controls
+{
+	internal class ShellRouteParameters : Dictionary<string, object>
+	{
+		public ShellRouteParameters()
+		{
+		}
+
+		public ShellRouteParameters(ShellRouteParameters shellRouteParams) : base(shellRouteParams)
+		{
+		}
+
+		public ShellRouteParameters(IDictionary<string, object> shellRouteParams) : base(shellRouteParams)
+		{
+		}
+
+		public ShellRouteParameters(int count)
+			: base(count)
+		{
+		}
+
+		internal void Merge(IDictionary<string, string> input)
+		{
+			if (input == null || input.Count == 0)
+				return;
+
+			foreach (var item in input)
+				Add(item.Key, item.Value);
+		}
+	}
+
+
+	internal static class ShellParameterExtensions
+	{
+		public static void Deconstruct(this KeyValuePair<string, object> tuple, out string key, out object value)
+		{
+			key = tuple.Key;
+			value = tuple.Value;
+		}
+	}
+}

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Maui.Controls
 			return (ShellSection)(ShellContent)page;
 		}
 
-		async Task PrepareCurrentStackForBeingReplaced(NavigationRequest request, IDictionary<string, string> queryData, bool? animate, List<string> globalRoutes, bool isRelativePopping)
+		async Task PrepareCurrentStackForBeingReplaced(NavigationRequest request, ShellRouteParameters queryData, bool? animate, List<string> globalRoutes, bool isRelativePopping)
 		{
 			string route = "";
 			List<Page> navStack = null;
@@ -468,7 +468,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		Page GetOrCreateFromRoute(string route, IDictionary<string, string> queryData, bool isLast, bool isPopping)
+		Page GetOrCreateFromRoute(string route, ShellRouteParameters queryData, bool isLast, bool isPopping)
 		{
 			var content = Routing.GetOrCreateContent(route) as Page;
 			if (content == null)
@@ -480,7 +480,7 @@ namespace Microsoft.Maui.Controls
 			return content;
 		}
 
-		internal async Task GoToAsync(NavigationRequest request, IDictionary<string, string> queryData, bool? animate, bool isRelativePopping)
+		internal async Task GoToAsync(NavigationRequest request, ShellRouteParameters queryData, bool? animate, bool isRelativePopping)
 		{
 			List<string> globalRoutes = request.Request.GlobalRoutes;
 			if (globalRoutes == null || globalRoutes.Count == 0)

--- a/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[QueryProperty("DoubleQueryParameter", "DoubleQueryParameter")]
 		[QueryProperty("SomeQueryParameter", "SomeQueryParameter")]
 		[QueryProperty("CancelNavigationOnBackButtonPressed", "CancelNavigationOnBackButtonPressed")]
+		[QueryProperty("ComplexObject", "ComplexObject")]
 		public class ShellTestPage : ContentPage
 		{
 			public string CancelNavigationOnBackButtonPressed { get; set; }
@@ -100,6 +101,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 
 			public double DoubleQueryParameter
+			{
+				get;
+				set;
+			}
+
+			public object ComplexObject
 			{
 				get;
 				set;


### PR DESCRIPTION
### Description of Change ###

Add a method to `GotoAsync` that allows users to pass complex objects via Shell

https://github.com/xamarin/Xamarin.Forms/pull/12465

### Additions made ###
 - Shell.GoToAsync(ShellNavigationState state, IDictionary<string,object> parameters)
 - Shell.GoToAsync(ShellNavigationState state, bool animated, IDictionary<string,object> parameters)

### Testing Procedure ###

When you navigate with Shell you can pass `IDictionary<string,object>` in the method, just like:

`await Shell.Current.GoToAsync("//myAwesomeUri", new Dictionary { {"My key", someObj} });`
