### PR TITLE
[workload] add missing Microsoft.Maui.Controls.aar

### DIFF
--- a/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
@@ -13,6 +13,7 @@
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Android.FormsViewGroup/src/bin/$(Configuration)/net6.0-android/ref/Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.dll" />
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Android.FormsViewGroup/src/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.aar" />
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Core/src/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.Compatibility.aar" />
+    <_AndroidFiles Include="$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.aar" />
     <None Include="@(_AndroidFiles)" FullTfm="net6.0-android30.0" Tfm="net6.0-android" Profile="Android" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change ###

Fixes? https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1364884

The `Microsoft.Maui.Controls.aar` file is missing from the workload,
which includes the following Android resources:

    res\anim\enterfromleft.xml
    res\anim\enterfromright.xml
    res\anim\exittoleft.xml
    res\anim\exittoright.xml
    res\values\strings.xml
    res\layout\bottomtablayout.xml
    res\layout\flyoutcontent.xml
    res\layout\shellcontent.xml
    res\layout\shellrootlayout.xml

I don't know what Android resources are needed and which package they
go in. We should actually do an audit and see if any are missing.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No