### PR TITLE
Make scoped CSS work in the main project

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -48,7 +48,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="EnsureBundles" BeforeTargets="CoreCompile" DependsOnTargets="BundleScopedCssFiles" />
+  <Target Name="EnsureBundles" BeforeTargets="CoreCompile" DependsOnTargets="_ResolveBundlingConfiguration;BundleScopedCssFiles" />
 
   <Target Name="_FixUpMauiReference"
     BeforeTargets="ComputeReferencedProjectsPublishAssets"


### PR DESCRIPTION
It already works in RCLs from an earlier fix, but this fixes it to work in the main project.