### PR TITLE
Restore Rectangle parameter for ArrangeChildren

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Others/TemplatePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/TemplatePage.xaml.cs
@@ -9,11 +9,11 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		int count = 0;
-		private void OnCounterClicked(object sender, EventArgs e)
-		{
-			count++;
-			CounterLabel.Text = $"Current count: {count}";
-		}
+		//int count = 0;
+		//private void OnCounterClicked(object sender, EventArgs e)
+		//{
+		//	count++;
+		//	CounterLabel.Text = $"Current count: {count}";
+		//}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Others/TemplatePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/TemplatePage.xaml.cs
@@ -9,11 +9,11 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 		}
 
-		//int count = 0;
-		//private void OnCounterClicked(object sender, EventArgs e)
-		//{
-		//	count++;
-		//	CounterLabel.Text = $"Current count: {count}";
-		//}
+		int count = 0;
+		private void OnCounterClicked(object sender, EventArgs e)
+		{
+			count++;
+			CounterLabel.Text = $"Current count: {count}";
+		}
 	}
 }

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -56,10 +56,10 @@ namespace Microsoft.Maui.Controls.Compatibility
 			return OnMeasure(widthConstraint, heightConstraint);
 		}
 
-		Size ILayoutManager.ArrangeChildren(Size finalSize)
+		Size ILayoutManager.ArrangeChildren(Rectangle bounds)
 		{
-			LayoutChildren(0, 0, finalSize.Width, finalSize.Height);
-			return finalSize;
+			LayoutChildren(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+			return bounds.Size;
 		}
 	}
 

--- a/src/Core/src/Layouts/FlexLayoutManager.cs
+++ b/src/Core/src/Layouts/FlexLayoutManager.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Maui.Layouts
 			FlexLayout = flexLayout;
 		}
 
-		public Size ArrangeChildren(Size finalSize)
+		public Size ArrangeChildren(Rectangle bounds)
 		{
-			FlexLayout.Layout(finalSize.Width, finalSize.Height);
+			FlexLayout.Layout(bounds.Width, bounds.Height);
 
 			foreach (var child in FlexLayout)
 			{
@@ -25,11 +25,11 @@ namespace Microsoft.Maui.Layouts
 					|| double.IsNaN(frame.Width)
 					|| double.IsNaN(frame.Height))
 					throw new Exception("something is deeply wrong");
-				
+				frame = frame.Offset(bounds.Left, bounds.Top);
 				child.Arrange(frame);
 			}
 
-			return finalSize;
+			return bounds.Size;
 		}
 
 		public Size Measure(double widthConstraint, double heightConstraint)

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Maui.Layouts
 			return new Size(_gridStructure.MeasuredGridWidth(), _gridStructure.MeasuredGridHeight());
 		}
 
-		public override Size ArrangeChildren(Size finalSize)
+		public override Size ArrangeChildren(Rectangle bounds)
 		{
-			var structure = _gridStructure ?? new GridStructure(Grid, finalSize.Width, finalSize.Height);
+			var structure = _gridStructure ?? new GridStructure(Grid, bounds.Width, bounds.Height);
 
 			foreach (var view in Grid)
 			{
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Layouts
 					continue;
 				}
 
-				var cell = structure.GetCellBoundsFor(view);
+				var cell = structure.GetCellBoundsFor(view, bounds.Left, bounds.Top);
 
 				view.Arrange(cell);
 			}
@@ -187,7 +187,7 @@ namespace Microsoft.Maui.Layouts
 				}
 			}
 
-			public Rectangle GetCellBoundsFor(IView view)
+			public Rectangle GetCellBoundsFor(IView view, double xOffset, double yOffset)
 			{
 				var firstColumn = _grid.GetColumn(view).Clamp(0, _columns.Length - 1);
 				var lastColumn = firstColumn + _grid.GetColumnSpan(view).Clamp(1, _columns.Length - firstColumn);
@@ -215,7 +215,7 @@ namespace Microsoft.Maui.Layouts
 				// TODO ezhart this isn't correctly accounting for row spacing when spanning multiple rows
 				// (and column spacing is probably wrong, too)
 
-				return new Rectangle(left, top, width, height);
+				return new Rectangle(left + xOffset, top + yOffset, width, height);
 			}
 
 			public double GridHeight()

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -41,21 +41,23 @@ namespace Microsoft.Maui.Layouts
 			return new Size(finalWidth, finalHeight);
 		}
 
-		public override Size ArrangeChildren(Size finalSize)
+		public override Size ArrangeChildren(Rectangle bounds)
 		{
 			var padding = Stack.Padding;
-			var height = finalSize.Height - padding.VerticalThickness;
-			double stackWidth = 0;
+			double top = padding.Top + bounds.Top;
+			double left = padding.Left + bounds.Left;
+			var height = bounds.Height - padding.VerticalThickness;
+			double stackWidth;
 
 			if (Stack.FlowDirection == FlowDirection.LeftToRight)
 			{
-				stackWidth = ArrangeLeftToRight(height, padding.Left, padding.Top, Stack.Spacing, Stack);
+				stackWidth = ArrangeLeftToRight(height, left, top, Stack.Spacing, Stack);
 			}
 			else
 			{
 				// We _could_ simply reverse the list of child views when arranging from right to left, 
 				// but this way we avoid extra list and enumerator allocations
-				stackWidth = ArrangeRightToLeft(height, padding.Left, padding.Top, Stack.Spacing, Stack);
+				stackWidth = ArrangeRightToLeft(height, left, top, Stack.Spacing, Stack);
 			}
 
 			return new Size(height, stackWidth);

--- a/src/Core/src/Layouts/ILayoutManager.cs
+++ b/src/Core/src/Layouts/ILayoutManager.cs
@@ -1,4 +1,3 @@
-using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Layouts
@@ -7,6 +6,6 @@ namespace Microsoft.Maui.Layouts
 	{
 		Size Measure(double widthConstraint, double heightConstraint);
 
-		Size ArrangeChildren(Size finalSize);
+		Size ArrangeChildren(Rectangle bounds);
 	}
 }

--- a/src/Core/src/Layouts/LayoutManager.cs
+++ b/src/Core/src/Layouts/LayoutManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Layouts
 		public ILayout Layout { get; }
 
 		public abstract Size Measure(double widthConstraint, double heightConstraint);
-		public abstract Size ArrangeChildren(Size finalSize);
+		public abstract Size ArrangeChildren(Rectangle bounds);
 
 		public static double ResolveConstraints(double externalConstraint, double explicitLength, double measuredLength)
 		{

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Layouts
@@ -41,13 +40,13 @@ namespace Microsoft.Maui.Layouts
 			return new Size(finalWidth, finalHeight);
 		}
 
-		public override Size ArrangeChildren(Size finalSize) 
+		public override Size ArrangeChildren(Rectangle bounds) 
 		{
 			var padding = Stack.Padding;
 
-			double stackHeight = padding.Top;
-			double left = padding.Left;
-			double width = finalSize.Width - padding.HorizontalThickness;
+			double stackHeight = padding.Top + bounds.Y;
+			double left = padding.Left + bounds.X;
+			double width = bounds.Width - padding.HorizontalThickness;
 
 			for (int n = 0; n < Stack.Count; n++)
 			{

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -66,12 +66,13 @@ namespace Microsoft.Maui.Handlers
 			var deviceIndependentRight = Context.FromPixels(r);
 			var deviceIndependentBottom = Context.FromPixels(b);
 
-			var finalSize = new Size(deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
+			var destination = Rectangle.FromLTRB(0, 0, 
+				deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
 
-			CrossPlatformArrange(finalSize);
+			CrossPlatformArrange(destination);
 		}
 
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
-		internal Func<Size, Size>? CrossPlatformArrange { get; set; }
+		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
 	}
 }

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui
 	public class LayoutPanel : Panel
 	{
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
-		internal Func<Size, Size>? CrossPlatformArrange { get; set; }
+		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
 
 		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
 		{
@@ -38,7 +38,7 @@ namespace Microsoft.Maui
 			var width = finalSize.Width;
 			var height = finalSize.Height;
 
-			var actual = CrossPlatformArrange(new Size(width, height));
+			var actual = CrossPlatformArrange(new Rectangle(0, 0, width, height));
 
 			return new Windows.Foundation.Size(actual.Width, actual.Height);
 		}

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -1,6 +1,8 @@
 using System;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
+using UIKit;
+using ObjCRuntime;
 
 namespace Microsoft.Maui
 {
@@ -25,16 +27,13 @@ namespace Microsoft.Maui
 		{
 			base.LayoutSubviews();
 
-			// TODO ezhart 2021-07-07 This Frame may not make sense if we're applying a transform to this UIView; we should determine the rectangle from Bounds/Center instead
-			Frame = AdjustForSafeArea(Frame);
-
-			var bounds = Frame.ToRectangle();
+			var bounds = AdjustForSafeArea(Bounds).ToRectangle();
 
 			CrossPlatformMeasure?.Invoke(bounds.Width, bounds.Height);
-			CrossPlatformArrange?.Invoke(bounds.Size);
+			CrossPlatformArrange?.Invoke(bounds);
 		}
 
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
-		internal Func<Size, Size>? CrossPlatformArrange { get; set; }
+		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui
 		UIWindow CreateNativeWindow()
 		{
 			var uiWindow = new UIWindow();
-
+			
 			var mauiContext = new MauiContext(Services, uiWindow);
 
 			Services.InvokeLifecycleEvents<iOSLifecycle.OnMauiContextCreated>(del => del(mauiContext));

--- a/src/Core/src/Platform/iOS/MauiView.cs
+++ b/src/Core/src/Platform/iOS/MauiView.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Maui
 			return (bool)(_respondsToSafeArea = RespondsToSelector(new Selector("safeAreaInsets")));
 		}
 
-		protected CGRect AdjustForSafeArea(CGRect frame)
+		protected CGRect AdjustForSafeArea(CGRect bounds)
 		{
 			if (View is not ISafeAreaView sav || sav.IgnoreSafeArea || !RespondsToSafeArea())
 			{
-				return frame;
+				return bounds;
 			}
 			
-			return SafeAreaInsets.InsetRect(frame);
+			return SafeAreaInsets.InsetRect(bounds);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/PageView.cs
+++ b/src/Core/src/Platform/iOS/PageView.cs
@@ -15,9 +15,7 @@ namespace Microsoft.Maui
 		{
 			base.LayoutSubviews();
 
-			Frame = AdjustForSafeArea(Frame);
-
-			var bounds = Frame.ToRectangle();
+			var bounds = AdjustForSafeArea(Bounds).ToRectangle();
 
 			CrossPlatformMeasure?.Invoke(bounds.Width, bounds.Height);
 			CrossPlatformArrange?.Invoke(bounds);

--- a/src/Core/tests/DeviceTests/Stubs/LayoutManagerStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LayoutManagerStub.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class LayoutManagerStub : ILayoutManager
 	{
-		public Size ArrangeChildren(Size finalSize)
+		public Size ArrangeChildren(Rectangle bounds)
 		{
-			return finalSize;
+			return bounds.Size;
 		}
 
 		public Size Measure(double widthConstraint, double heightConstraint)

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -122,11 +122,11 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			grid.GetColumnSpan(view).Returns(colSpan);
 		}
 
-		Size MeasureAndArrange(IGridLayout grid, double widthConstraint = double.PositiveInfinity, double heightConstraint = double.PositiveInfinity)
+		Size MeasureAndArrange(IGridLayout grid, double widthConstraint = double.PositiveInfinity, double heightConstraint = double.PositiveInfinity, double left = 0, double top = 0)
 		{
 			var manager = new GridLayoutManager(grid);
 			var measuredSize = manager.Measure(widthConstraint, heightConstraint);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(new Point(left, top), measuredSize));
 
 			return measuredSize;
 		}
@@ -336,7 +336,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(new Size(measure.Width, measure.Height));
+			manager.ArrangeChildren(new Rectangle(0, 0, measure.Width, measure.Height));
 
 			// Because the auto row has no content, we expect it to have height zero
 			Assert.Equal(100 + 100, measure.Height);
@@ -424,7 +424,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(new Size(measure.Width, measure.Height));
+			manager.ArrangeChildren(new Rectangle(0, 0, measure.Width, measure.Height));
 
 			// Because the auto column has no content, we expect it to have width zero
 			Assert.Equal(100 + 100, measure.Width);
@@ -703,7 +703,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new GridLayoutManager(grid);
 
 			manager.Measure(200, 100);
-			manager.ArrangeChildren(new Size(200, 100));
+			manager.ArrangeChildren(new Rectangle(0, 0, 200, 100));
 
 			// View should be arranged to span both columns (200 points)
 			AssertArranged(view0, 0, 0, 200, 100);
@@ -721,7 +721,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new GridLayoutManager(grid);
 
 			manager.Measure(100, 200);
-			manager.ArrangeChildren(new Size(100, 200));
+			manager.ArrangeChildren(new Rectangle(0, 0, 100, 200));
 
 			// View should be arranged to span both rows (200 points)
 			AssertArranged(view0, 0, 0, 100, 200);
@@ -1095,7 +1095,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(measure);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -1117,7 +1117,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(measure);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -1180,7 +1180,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new GridLayoutManager(grid);
 			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			AssertArranged(grid[0], padding.Left, padding.Top, viewWidth, viewHeight);
 		}
@@ -1211,7 +1211,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		}
 
 		[Fact]
-		public void GridMeasureShouldUseExplicitHeight() 
+		public void GridMeasureShouldUseExplicitHeight()
 		{
 			var grid = CreateGridLayout();
 			var view = CreateTestView(new Size(10, 10));
@@ -1326,6 +1326,22 @@ namespace Microsoft.Maui.UnitTests.Layouts
 				100 * actualRow,
 				100 * actualColSpan,
 				100 * actualRowSpan);
+		}
+
+		[Fact]
+		public void ArrangeRespectsBounds() 
+		{
+			var grid = CreateGridLayout();
+			var view = CreateTestView(new Size(100, 100));
+
+			SubstituteChildren(grid, view);
+			SetLocation(grid, view);
+
+			var measure = MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity, 10, 15);
+
+			var expectedRectangle = new Rectangle(10, 15, measure.Width, measure.Height);
+			
+			view.Received().Arrange(Arg.Is(expectedRectangle));
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new HorizontalStackLayoutManager(stack);
 
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			var expectedRectangle = new Rectangle(0, 0, 100, 100);
 			stack[0].Received().Arrange(Arg.Is(expectedRectangle));
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new HorizontalStackLayoutManager(stack);
 
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			var expectedRectangle0 = new Rectangle(0, 0, 100, 100);
 			stack[0].Received().Arrange(Arg.Is(expectedRectangle0));
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			// We expect that the starting view (0) should be arranged on the left,
 			// and the next rectangle (1) should be on the right
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			// We expect that the starting view (0) should be arranged on the right,
 			// and the next rectangle (1) should be on the left
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measure = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(measure);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measure = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(measure);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -210,9 +210,23 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			AssertArranged(stack[0], padding.Left, padding.Top, viewWidth, viewHeight);
+		}
+
+		[Fact]
+		public void ArrangeRespectsBounds()
+		{
+			var stack = BuildStack(viewCount: 1, viewWidth: 100, viewHeight: 100);
+
+			var manager = new HorizontalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
+			manager.ArrangeChildren(new Rectangle(new Point(10, 15), measuredSize));
+
+			var expectedRectangle0 = new Rectangle(10, 15, 100, 100);
+
+			stack[0].Received().Arrange(Arg.Is(expectedRectangle0));
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new VerticalStackLayoutManager(stack);
 
 			var measuredSize = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			var expectedRectangle = new Rectangle(0, 0, 100, 100);
 			stack[0].Received().Arrange(Arg.Is(expectedRectangle));
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new VerticalStackLayoutManager(stack);
 
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			AssertArranged(stack[0], 0, 0, 100, 100);
 			AssertArranged(stack[1], 0, 100 + spacing, 100, 100);
@@ -88,7 +88,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new VerticalStackLayoutManager(stack);
 			var measure = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(measure);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -110,7 +110,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new VerticalStackLayoutManager(stack);
 			var measure = manager.Measure(100, double.PositiveInfinity);
-			manager.ArrangeChildren(measure);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
 
 			// View is visible, so we expect it to be measured and arranged
 			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			hiddenView.Received().Arrange(Arg.Any<Rectangle>());
 		}
 
-		IStackLayout BuildPaddedStack(Thickness padding, double viewWidth, double viewHeight) 
+		IStackLayout BuildPaddedStack(Thickness padding, double viewWidth, double viewHeight)
 		{
 			var stack = BuildStack(1, viewWidth, viewHeight);
 			stack.Padding.Returns(padding);
@@ -168,9 +168,23 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			var manager = new VerticalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-			manager.ArrangeChildren(measuredSize);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measuredSize));
 
 			AssertArranged(stack[0], padding.Left, padding.Top, viewWidth, viewHeight);
+		}
+
+		[Fact]
+		public void ArrangeRespectsBounds()
+		{
+			var stack = BuildStack(viewCount: 1, viewWidth: 100, viewHeight: 100);
+
+			var manager = new VerticalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
+			manager.ArrangeChildren(new Rectangle(new Point(10, 15), measuredSize));
+
+			var expectedRectangle0 = new Rectangle(10, 15, 100, 100);
+
+			stack[0].Received().Arrange(Arg.Is(expectedRectangle0));
 		}
 	}
 }


### PR DESCRIPTION
Reinstate the Rectangle parameter for ILayoutManager.ArrangeChildren; zero out bounds parameters for CrossPlatformArrange calls on Windows/Android. 

Also adds implementations for non-zero origins when arranging GridLayout, FlexLayout. Adds unit tests for non-zero origins for layout managers.