### PR TITLE
Ensure CreateWindow is always called

### DIFF
--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -63,55 +63,32 @@ namespace Microsoft.Maui.Controls
 
 		public static Application Current { get; set; }
 
+		Page _pendingMainPage;
+
 		public Page MainPage
 		{
 			get
 			{
 				if (Windows.Count == 0)
-					return null;
+					return _pendingMainPage;
 
 				return Windows[0].Page;
 			}
 			set
 			{
-				if (value == null)
-					throw new ArgumentNullException(nameof(value));
-
 				if (MainPage == value)
 					return;
 
 				OnPropertyChanging();
 
-				var previousPage = MainPage;
-
-				if (previousPage != null)
-					previousPage.Parent = null;
-
 				if (Windows.Count == 0)
 				{
-					// there are no windows, so add a new window
-
-					AddWindow(new Window(value));
+					_pendingMainPage = value;
 				}
 				else
 				{
-					// find the best window and replace the page
-
-					var theWindow = Windows[0];
-					foreach (var window in Windows)
-					{
-						if (window.Page == previousPage)
-						{
-							theWindow = window;
-							break;
-						}
-					}
-
-					theWindow.Page = value;
+					Windows[0].Page = value;
 				}
-
-				if (previousPage != null)
-					previousPage.NavigationProxy.Inner = NavigationProxy;
 
 				OnPropertyChanged();
 			}

--- a/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
@@ -15,8 +15,14 @@ namespace Microsoft.Maui.Controls
 		{
 			var window = CreateWindow(activationState);
 
+			if (_pendingMainPage != null && window.Page != null && window.Page != _pendingMainPage)
+				throw new InvalidOperationException($"Both {nameof(MainPage)} was set and {nameof(Application.CreateWindow)} was overridden to provide a page.");
+
 			if (!_windows.Contains(window))
 				AddWindow(window);
+
+			// clear out the pending main page as this will never be used again
+			_pendingMainPage = null;
 
 			return window;
 		}
@@ -30,6 +36,9 @@ namespace Microsoft.Maui.Controls
 		{
 			if (Windows.Count > 0)
 				return Windows[0];
+
+			if (_pendingMainPage != null)
+				return new Window(_pendingMainPage);
 
 			throw new NotImplementedException($"Either set {nameof(MainPage)} or override {nameof(Application.CreateWindow)}.");
 		}

--- a/src/Controls/tests/Core.UnitTests/ApplicationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ApplicationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void SettingMainPageSetsMainPageAndWindow()
+		public void SettingMainPageSetsMainPageButNotWindow()
 		{
 			var app = new Application();
 			var page = new ContentPage();
@@ -24,8 +24,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			app.MainPage = page;
 
 			Assert.AreEqual(page, app.MainPage);
-			Assert.AreEqual(1, app.Windows.Count);
-			Assert.AreEqual(page, app.Windows[0].Page);
+			Assert.IsEmpty(app.Windows);
 		}
 
 		[Test]
@@ -73,6 +72,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var iapp = app as IApplication;
 
 			Assert.Throws<NotImplementedException>(() => iapp.CreateWindow(null));
+		}
+
+		[Test]
+		public void SettingMainPageAndOverridingCreateWindowWithSamePageIsValid()
+		{
+			var page = new ContentPage();
+			var window = new Window(page);
+
+			var app = new StubApp() { MainWindow = window, MainPage = page };
+			var iapp = app as IApplication;
+
+			var win = iapp.CreateWindow(null);
+
+			Assert.AreEqual(window, win);
+			Assert.AreEqual(window.Page, page);
+			Assert.AreEqual(app.MainPage, page);
+		}
+
+		[Test]
+		public void SettingMainPageAndOverridingCreateWindowThrows()
+		{
+			var window = new Window(new ContentPage());
+
+			var app = new StubApp() { MainWindow = window, MainPage = new ContentPage() };
+			var iapp = app as IApplication;
+
+			Assert.Throws<InvalidOperationException>(() => iapp.CreateWindow(null));
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change ###

This PR adjusts the way `MainPage` and `CreateWindow` work together. Previously, setting `MainPage` would immediately create a new `Window` and add it to the app. This PR makes `MainPage` rather set a pending field until the app is ready, and then calls `CreateWindow` to construct the window.

Separate to this, the `MainPage` is really just a proxy property and should not set `Parent` or the `NavigationProxy`. This is going to be set when the `Window` is created.

### Additions made ###

None.
### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
