### PR TITLE
Add additional exact measure call for Android Labels with LayoutAlignment.Fill

### DIFF
--- a/src/Controls/tests/Core.UnitTests/GridTests.cs
+++ b/src/Controls/tests/Core.UnitTests/GridTests.cs
@@ -901,9 +901,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				var id = 0;
 				foreach (var view in _grid.Children.Cast<Label>().OrderBy(o => o.Text))
 				{
-					var expected = $"{id++}: " +
-						$"{Grid.GetColumn(view)}x{Grid.GetRow(view)} " +
-						$"{Grid.GetColumnSpan(view)}x{Grid.GetRowSpan(view)}";
+					var expected = $"{id++}: {Grid.GetColumn(view)}x{Grid.GetRow(view)} {Grid.GetColumnSpan(view)}x{Grid.GetRowSpan(view)}";
 
 					var actual = view.Text;
 

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -1,3 +1,4 @@
+using Android.Views;
 using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Graphics;
 
@@ -10,6 +11,30 @@ namespace Microsoft.Maui.Handlers
 		static float? LineSpacingMultDefault { get; set; }
 
 		protected override AppCompatTextView CreateNativeView() => new AppCompatTextView(Context);
+
+		public override void NativeArrange(Rectangle frame)
+		{
+			var nativeView = WrappedNativeView;
+
+			if (nativeView == null || Context == null)
+			{
+				return;
+			}
+
+			if (frame.Width < 0 || frame.Height < 0)
+			{
+				return;
+			}
+
+			// Depending on our layout situation, the TextView may need an additional measurement pass at the final size
+			// in order to properly handle any TextAlignment properties.
+			if (NeedsExactMeasure())
+			{
+				nativeView.Measure(MakeMeasureSpecExact(frame.Width), MakeMeasureSpecExact(frame.Height));
+			}
+
+			base.NativeArrange(frame);
+		}
 
 		void SetupDefaults(AppCompatTextView nativeView)
 		{
@@ -79,6 +104,34 @@ namespace Microsoft.Maui.Handlers
 		public static void MapLineHeight(LabelHandler handler, ILabel label)
 		{
 			handler.NativeView?.UpdateLineHeight(label);
+		}
+
+		bool NeedsExactMeasure() 
+		{
+			if (VirtualView.VerticalLayoutAlignment != Primitives.LayoutAlignment.Fill
+				&& VirtualView.HorizontalLayoutAlignment != Primitives.LayoutAlignment.Fill)
+			{
+				// Layout Alignments of Start, Center, and End will be laying out the TextView at its measured size,
+				// so we won't need another pass with MeasureSpecMode.Exactly
+				return false;
+			}
+
+			if (VirtualView.Width >= 0 && VirtualView.Height >= 0)
+			{
+				// If the Width and Height are both explicit, then we've already done MeasureSpecMode.Exactly in 
+				// both dimensions; no need to do it again
+				return false;
+			}
+
+			// We're going to need a second measurement pass so TextView can properly handle alignments
+			return true;
+		}
+
+		int MakeMeasureSpecExact(double size)
+		{
+			// Convert to a native size to create the spec for measuring
+			var deviceSize = (int)Context!.ToPixels(size);
+			return MeasureSpecMode.Exactly.MakeMeasureSpec(deviceSize);
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
@@ -26,17 +26,16 @@ namespace Microsoft.Maui.Handlers
 		{
 			var nativeView = WrappedNativeView;
 
-			if (nativeView == null)
+			if (nativeView == null || Context == null)
+			{
 				return;
+			}
 
 			if (frame.Width < 0 || frame.Height < 0)
 			{
 				// This is a legacy layout value from Controls, nothing is actually laying out yet so we just ignore it
 				return;
 			}
-
-			if (Context == null)
-				return;
 
 			var left = Context.ToPixels(frame.Left);
 			var top = Context.ToPixels(frame.Top);

--- a/src/Core/src/Platform/Android/MeasureSpecExtensions.cs
+++ b/src/Core/src/Platform/Android/MeasureSpecExtensions.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Maui
 			return MeasureSpec.GetMode(measureSpec);
 		}
 
-		// Need a method to extract mode, so we can see if the viewgroup is calling measure twice with different modes
-
 		public static int MakeMeasureSpec(this MeasureSpecMode mode, int size)
 		{
 			return size + (int)mode;


### PR DESCRIPTION
On Android, TextViews without explicit sizes being laid out with LayoutAlignment.Fill don't have enough information at measurement time to handle their TextAlignment. 

This change adds a check for this condition and adds an exact measure call to give the native control the information necessary to handle its alignment during final layout. 

Fixes #2019
Fixes #1509
