### PR TITLE
Properly account for row/column spacing within spans

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -190,30 +190,32 @@ namespace Microsoft.Maui.Layouts
 			public Rectangle GetCellBoundsFor(IView view, double xOffset, double yOffset)
 			{
 				var firstColumn = _grid.GetColumn(view).Clamp(0, _columns.Length - 1);
-				var lastColumn = firstColumn + _grid.GetColumnSpan(view).Clamp(1, _columns.Length - firstColumn);
+				var columnSpan = _grid.GetColumnSpan(view).Clamp(1, _columns.Length - firstColumn);
+				var lastColumn = firstColumn + columnSpan;
 
 				var firstRow = _grid.GetRow(view).Clamp(0, _rows.Length - 1);
-				var lastRow = firstRow + _grid.GetRowSpan(view).Clamp(1, _rows.Length - firstRow);
+				var rowSpan = _grid.GetRowSpan(view).Clamp(1, _rows.Length - firstRow);
+				var lastRow = firstRow + rowSpan;
 
 				double top = TopEdgeOfRow(firstRow);
 				double left = LeftEdgeOfColumn(firstColumn);
 
 				double width = 0;
+				double height = 0;
 
 				for (int n = firstColumn; n < lastColumn; n++)
 				{
 					width += _columns[n].Size;
 				}
 
-				double height = 0;
-
 				for (int n = firstRow; n < lastRow; n++)
 				{
 					height += _rows[n].Size;
 				}
 
-				// TODO ezhart this isn't correctly accounting for row spacing when spanning multiple rows
-				// (and column spacing is probably wrong, too)
+				// Account for any space between spanned rows/columns
+				width += (columnSpan - 1) * _columnSpacing;
+				height += (rowSpan - 1) * _rowSpacing;
 
 				return new Rectangle(left + xOffset, top + yOffset, width, height);
 			}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -365,6 +365,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(100 + 100 + 10, measure.Height);
 		}
 
+		[Category(GridSpacing)]
 		[Fact(DisplayName = "Column spacing shouldn't affect a single-column grid")]
 		public void SingleColumnIgnoresColumnSpacing()
 		{
@@ -377,6 +378,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view, 0, 0, 100, 100);
 		}
 
+		[Category(GridSpacing)]
 		[Fact(DisplayName = "Two columns should include the column spacing once")]
 		public void TwoColumnsWithSpacing()
 		{
@@ -492,8 +494,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view1, 100, 25, 50, 75);
 		}
 
-		[Category(GridSpan)]
-		[Category(GridSpacing)]
+		[Category(GridSpacing, GridSpan)]
 		[Fact(DisplayName = "Row spanning with row spacing")]
 		public void RowSpanningShouldAccountForSpacing()
 		{
@@ -512,9 +513,15 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(150, measuredSize.Width);
 			Assert.Equal(50 + 50 + 5, measuredSize.Height);
 
-			AssertArranged(view0, 0, 0, 100, 100);
+			// Starts a Y = 0
 			AssertArranged(view1, 100, 0, 50, 50);
+
+			// Starts at the first row's height + the row spacing value, so Y = 50 + 5 = 55
 			AssertArranged(view2, 100, 55, 50, 50);
+
+			// We expect the height for the view spanning the rows to include the space between the rows,
+			// so 50 + 5 + 50 = 105
+			AssertArranged(view0, 0, 0, 100, 105);
 		}
 
 		[Category(GridSpan)]
@@ -558,9 +565,14 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(50 + 50 + 5, measuredSize.Width);
 			Assert.Equal(100 + 50, measuredSize.Height);
 
-			AssertArranged(view0, 0, 0, 100, 100);
+			// Starts a X = 0
 			AssertArranged(view1, 0, 100, 50, 50);
+			// Starts at the first column's width + the column spacing, so X = 50 + 5 = 55
 			AssertArranged(view2, 55, 100, 50, 50);
+
+			// We expect the width for the view spanning the columns to include the space between the columns,
+			// so 50 + 5 + 50 = 105
+			AssertArranged(view0, 0, 0, 105, 100);
 		}
 
 		[Category(GridSpan)]
@@ -1210,6 +1222,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			view.Received().Measure(Arg.Is<double>(100), Arg.Is<double>(100));
 		}
 
+		[Category(GridAbsoluteSizing)]
 		[Fact]
 		public void GridMeasureShouldUseExplicitHeight()
 		{
@@ -1226,6 +1239,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(50, measure.Height);
 		}
 
+		[Category(GridAbsoluteSizing)]
 		[Fact]
 		public void GridMeasureShouldUseExplicitWidth()
 		{


### PR DESCRIPTION
The GridLayoutManager was not properly accounting for RowSpacing/ColumnSpacing when determining the size of cells which span multiple rows/columns. 

Fixes #2021

