### PR TITLE
Fix heading bug and templates semantics

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
@@ -158,6 +158,11 @@
                 TextColor="DodgerBlue"
                 FontSize="14"
                 SemanticProperties.HeadingLevel="Level3"/>
+            <Label
+                Text="Heading 4 with semantic description and hint"
+                SemanticProperties.HeadingLevel="Level4"
+                SemanticProperties.Description="Description"
+                SemanticProperties.Hint="Hint"/>
             <HorizontalStackLayout>
                 <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch"></CheckBox>
                 <CheckBox SemanticProperties.Description="Checkbox on iOS will read as a switch" Color="DodgerBlue"></CheckBox>

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -117,8 +117,6 @@ namespace Microsoft.Maui.Handlers
 
 				if (viewHandler.AccessibilityDelegate != null)
 					nativeView.ImportantForAccessibility = ImportantForAccessibility.Yes;
-				else
-					nativeView.ImportantForAccessibility = ImportantForAccessibility.Auto;
 			}
 		}
 	}

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/App.xaml
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/App.xaml
@@ -7,18 +7,18 @@
     <Application.Resources>
         <ResourceDictionary>
 
-            <Color x:Key="PageBackgroundColor">#512bdf</Color>
-            <Color x:Key="PrimaryTextColor">White</Color>
+            <Color x:Key="PrimaryColor">#512bdf</Color>
+            <Color x:Key="SecondaryColor">White</Color>
 
             <Style TargetType="Label">
-                <Setter Property="TextColor" Value="{DynamicResource PrimaryTextColor}" />
+                <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}" />
                 <Setter Property="FontFamily" Value="OpenSansRegular" />
             </Style>
 
             <Style TargetType="Button">
-                <Setter Property="TextColor" Value="{DynamicResource PrimaryTextColor}" />
+                <Setter Property="TextColor" Value="{DynamicResource SecondaryColor}" />
                 <Setter Property="FontFamily" Value="OpenSansRegular" />
-                <Setter Property="BackgroundColor" Value="#2b0b98" />
+                <Setter Property="BackgroundColor" Value="{DynamicResource PrimaryColor}" />
                 <Setter Property="Padding" Value="14,10" />
             </Style>
 

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml
@@ -14,13 +14,13 @@
 
             <Label Text="Welcome to .NET Multi-platform App UI"
                 Grid.Row="1"
-                SemanticProperties.Hint="Counts the number of times you click"
+                SemanticProperties.HeadingLevel="Level1"
+                SemanticProperties.Description="Welcome to dot net Multi platform App U I"
                 FontSize="16"
                 HorizontalOptions="CenterAndExpand" />
 
             <Label Text="Current count: 0"
                 Grid.Row="2"
-                SemanticProperties.Hint="Counts the number of times you click"
                 FontSize="18"
                 FontAttributes="Bold"
                 x:Name="CounterLabel"
@@ -34,7 +34,7 @@
 
             <Image Grid.Row="4"
                 Source="dotnet_bot.png"
-                SemanticProperties.Description="Cute dotnet bot waving hi to you!"
+                SemanticProperties.Description="Cute dot net bot waving hi to you!"
                 WidthRequest="300"
                 HeightRequest="372"
                 HorizontalOptions="Center" />

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml
@@ -4,7 +4,7 @@
              BackgroundColor="{DynamicResource PageBackgroundColor}">
 
     <ScrollView Padding="{OnPlatform iOS='30,60,30,30', Default='30'}">
-        <Grid RowSpacing="25" RowDefinitions="Auto,Auto,Auto,Auto,*">
+        <Grid Margin="0,50" RowSpacing="25" RowDefinitions="Auto,Auto,Auto,Auto,*">
 
             <Label Text="Hello, World!"
                 Grid.Row="0"

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml
@@ -10,14 +10,14 @@
                 Grid.Row="0"
                 SemanticProperties.HeadingLevel="Level1"
                 FontSize="32"
-                HorizontalOptions="CenterAndExpand" />
+                HorizontalOptions="Center" />
 
             <Label Text="Welcome to .NET Multi-platform App UI"
                 Grid.Row="1"
                 SemanticProperties.HeadingLevel="Level1"
                 SemanticProperties.Description="Welcome to dot net Multi platform App U I"
                 FontSize="16"
-                HorizontalOptions="CenterAndExpand" />
+                HorizontalOptions="Center" />
 
             <Label Text="Current count: 0"
                 Grid.Row="2"

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml
@@ -1,32 +1,37 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MauiApp1.MainPage"
-             BackgroundColor="{DynamicResource PageBackgroundColor}">
+             BackgroundColor="{DynamicResource SecondaryColor}">
 
     <ScrollView Padding="{OnPlatform iOS='30,60,30,30', Default='30'}">
         <Grid Margin="0,50" RowSpacing="25" RowDefinitions="Auto,Auto,Auto,Auto,*">
 
-            <Label Text="Hello, World!"
+            <Label 
+                Text="Hello, World!"
                 Grid.Row="0"
                 SemanticProperties.HeadingLevel="Level1"
                 FontSize="32"
                 HorizontalOptions="Center" />
 
-            <Label Text="Welcome to .NET Multi-platform App UI"
+            <Label 
+                Text="Welcome to .NET Multi-platform App UI"
                 Grid.Row="1"
                 SemanticProperties.HeadingLevel="Level1"
                 SemanticProperties.Description="Welcome to dot net Multi platform App U I"
-                FontSize="16"
+                FontSize="18"
                 HorizontalOptions="Center" />
 
-            <Label Text="Current count: 0"
+            <Label 
+                Text="Current count: 0"
                 Grid.Row="2"
                 FontSize="18"
                 FontAttributes="Bold"
                 x:Name="CounterLabel"
                 HorizontalOptions="Center" />
 
-            <Button Text="Click me"
+            <Button 
+                Text="Click me"
+                FontAttributes="Bold"
                 Grid.Row="3"
                 SemanticProperties.Hint="Counts the number of times you click"
                 Clicked="OnCounterClicked"

--- a/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1/MainPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Essentials;
 
 namespace MauiApp1
 {
@@ -15,6 +16,7 @@ namespace MauiApp1
 		{
 			count++;
 			CounterLabel.Text = $"Current count: {count}";
+			SemanticScreenReader.Announce(CounterLabel.Text);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

* Fixes semantic heading bug 
     - #1902 
     - #1901 

* Fix and update various things in templates sample
     - Fix color contrast issues - now passes accessibility insights checks

          ![inaccessible colors](https://user-images.githubusercontent.com/21988533/129458044-533e8e51-c37d-40b7-b4dc-48a92911a496.PNG)
          ![accessible colors](https://user-images.githubusercontent.com/21988533/129458048-06851634-d3c0-4c41-bbd6-4f26a1a7b8b2.PNG)

     - Add ScreenReaderService `Announce` sample usage
     
          [<img src="https://user-images.githubusercontent.com/21988533/129458027-4b584d6c-774a-49e9-b164-a5c776830cf4.png" width="250"/>](image.png)
     
     - Update misleading semantic properties, and small design improvements
     - CenterAndExpand --> Center (removed functionless AndExpand)
     - Add margin to layout
   
   
