### PR TITLE
Fix the tests after the MainPage changes in #2035

### DIFF
--- a/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DynamicResourceTests.cs
@@ -43,13 +43,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 			label.SetDynamicResource(Label.TextColorProperty, "GreenColor");
 
-			Application.Current.MainPage = new ContentPage
+			Application.Current.LoadPage(new ContentPage
 			{
 				Content = new StackLayout
 				{
 					Children = { label }
 				}
-			};
+			});
 
 			Assert.AreEqual(Colors.Green, label.TextColor);
 		}

--- a/src/Controls/tests/Core.UnitTests/GridTests.cs
+++ b/src/Controls/tests/Core.UnitTests/GridTests.cs
@@ -901,9 +901,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				var id = 0;
 				foreach (var view in _grid.Children.Cast<Label>().OrderBy(o => o.Text))
 				{
-					var expected = $"{id++}: " +
-						$"{Grid.GetColumn(view)}x{Grid.GetRow(view)} " +
-						$"{Grid.GetColumnSpan(view)}x{Grid.GetRowSpan(view)}";
+					var expected = $"{id++}: {Grid.GetColumn(view)}x{Grid.GetRow(view)} {Grid.GetColumnSpan(view)}x{Grid.GetRowSpan(view)}";
 
 					var actual = view.Text;
 

--- a/src/Controls/tests/Core.UnitTests/PageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageTests.cs
@@ -424,7 +424,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var page = new ContentPage();
 
 			Page actual = null;
-			app.MainPage = page;
+			app.LoadPage(page);
 			app.PageAppearing += (sender, args) => actual = args;
 
 			((IPageController)page).SendDisappearing();
@@ -440,7 +440,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var page = new ContentPage();
 
 			Page actual = null;
-			app.MainPage = page;
+			app.LoadPage(page);
 			app.PageDisappearing += (sender, args) => actual = args;
 
 			((IPageController)page).SendAppearing();

--- a/src/Controls/tests/Core.UnitTests/StyleSheets/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleSheets/StyleTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Controls.StyleSheets.UnitTests
 			{
 				Content = new Label()
 			};
-			app.MainPage = page;
+			app.LoadPage(page);
 			Assert.That((page.Content as Label).TextColor, Is.EqualTo(Colors.Red));
 		}
 
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.Controls.StyleSheets.UnitTests
 				Content = new Label()
 			};
 			page.Resources.Add(StyleSheet.FromString("label{ color: red; }"));
-			app.MainPage = page;
+			app.LoadPage(page);
 			Assert.That((page.Content as Label).TextColor, Is.EqualTo(Colors.Red));
 			Assert.That((page.Content as Label).BackgroundColor, Is.EqualTo(Colors.Blue));
 		}
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.Controls.StyleSheets.UnitTests
 				Content = new Label()
 			};
 			page.Resources.Add(StyleSheet.FromString("label{ color: red; }"));
-			app.MainPage = page;
+			app.LoadPage(page);
 			Assert.That((page.Content as Label).TextColor, Is.EqualTo(Colors.Red));
 
 			app.Resources.Add(StyleSheet.FromString("label{ color: white; background-color: blue; }"));
@@ -147,7 +147,7 @@ namespace Microsoft.Maui.Controls.StyleSheets.UnitTests
 				Content = label
 			};
 			page.Resources.Add(StyleSheet.FromString("label{ color: red; }"));
-			app.MainPage = page;
+			app.LoadPage(page);
 			Assert.That((page.Content as Label).TextColor, Is.EqualTo(Colors.Yellow));
 		}
 

--- a/src/Controls/tests/Core.UnitTests/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleTests.cs
@@ -836,7 +836,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 			};
 
-			mockApp.MainPage = new ContentPage { Content = layout };
+			mockApp.LoadPage(new ContentPage { Content = layout });
 			//Assert.That(label0.TextColor, Is.EqualTo(Color.Pink));
 			//Assert.That(label1.TextColor, Is.EqualTo(null));
 
@@ -864,10 +864,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var mockApp = new MockApplication();
 			mockApp.Resources = rd0;
-			mockApp.MainPage = new MyPage()
+			mockApp.LoadPage(new MyPage()
 			{
 				Content = new Button()
-			};
+			});
 
 			Application.Current = mockApp;
 
@@ -892,13 +892,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var mockApp = new MockApplication();
 			mockApp.Resources = rd0;
-			mockApp.MainPage = new ContentPage()
+			mockApp.LoadPage(new ContentPage()
 			{
 				Content = new MyContentView()
 				{
 					Content = new Button()
 				}
-			};
+			});
 
 			Application.Current = mockApp;
 

--- a/src/Controls/tests/Core.UnitTests/TestClasses/ApplicationExtensions.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/ApplicationExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	static class ApplicationExtensions
+	{
+		public static Window LoadPage(this Application app, Page page)
+		{
+			app.MainPage = page;
+
+			return ((IApplication)app).CreateWindow(null) as Window;
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -30,27 +30,28 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public void SetMainPage()
 		{
-			var app = new TestApp();
-			app.MainPage = new ContentPage();
+			var app = new Application();
+			app.LoadPage(new ContentPage());
 			ValidateSetup(app);
 		}
 
 		[Test]
 		public void SetMainPageTwice()
 		{
-			var app = new TestApp();
+			var app = new Application();
 			var firstPage = new ContentPage();
 			var secondPage = new ContentPage();
 
-			app.MainPage = firstPage;
-			app.MainPage = secondPage;
+			var wind1 = app.LoadPage(firstPage);
+			var wind2 = app.LoadPage(secondPage);
 
 			ValidateSetup(app, secondPage);
 			Assert.IsNull(firstPage.Parent);
+			Assert.AreEqual(wind1, wind2);
 		}
 
 
-		void ValidateSetup(TestApp app, Page page = null)
+		void ValidateSetup(Application app, Page page = null)
 		{
 			var window = (Window)app.Windows[0];
 			page ??= window.Page;

--- a/src/Controls/tests/Xaml.UnitTests/ApplicationExtensions.cs
+++ b/src/Controls/tests/Xaml.UnitTests/ApplicationExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	static class ApplicationExtensions
+	{
+		public static Window LoadPage(this Application app, Page page)
+		{
+			app.MainPage = page;
+
+			return ((IApplication)app).CreateWindow(null) as Window;
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/AutomationProperties.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/AutomationProperties.xaml.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void AutomationPropertiesIsInAccessibleTree(bool useCompiledXaml)
 			{
 				var layout = new AutomationProperties(useCompiledXaml);
-				Application.Current.MainPage = layout;
+				Application.Current.LoadPage(layout);
 
 				Assert.AreEqual(true, (bool)layout.entry.GetValue(Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty));
 			}
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void AutomationPropertiesLabeledBy(bool useCompiledXaml)
 			{
 				var layout = new AutomationProperties(useCompiledXaml);
-				Application.Current.MainPage = layout;
+				Application.Current.LoadPage(layout);
 
 				Assert.AreEqual(layout.label, (Element)layout.entry.GetValue(Microsoft.Maui.Controls.AutomationProperties.LabeledByProperty));
 			}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz53381.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz53381.xaml.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			{
 				Application.Current = new Bz53381App();
 				var view = new Bz53381(useCompiledXaml);
-				Application.Current.MainPage = new ContentPage { Content = view };
+				Application.Current.LoadPage(new ContentPage { Content = view });
 				var presenter = ((StackLayout)view.InternalChildren[0]).Children[1] as ContentPresenter;
 				Assume.That(presenter, Is.Not.Null);
 				var grid = presenter.Content as Grid;

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz54334.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz54334.xaml.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 					}
 				}
 			};
-			MainPage = new Bz54334(useCompiledXaml);
+			this.LoadPage(new Bz54334(useCompiledXaml));
 			MessagingCenter.Subscribe<ContentPage>(this, "ChangeTheme", (s) =>
 			{
 				ToggleTheme();

--- a/src/Controls/tests/Xaml.UnitTests/StyleTests.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/StyleTests.xaml.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void StylesDerivedFromDynamicStylesThroughStaticResource(bool useCompiledXaml)
 			{
 				var layout = new StyleTests(useCompiledXaml);
-				Application.Current.MainPage = layout;
+				Application.Current.LoadPage(layout);
 
 				var label = layout.labelWithStyleDerivedFromDynamic_StaticResource;
 
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void StylesDerivedFromDynamicStylesThroughDynamicResource(bool useCompiledXaml)
 			{
 				var layout = new StyleTests(useCompiledXaml);
-				Application.Current.MainPage = layout;
+				Application.Current.LoadPage(layout);
 
 				var label = layout.labelWithStyleDerivedFromDynamic_DynamicResource;
 


### PR DESCRIPTION
### Description of Change ###

The failing tests in CI related to the changes in #2035 were obscured by the .net sdk bug. This PR aims to correct that.

The change that broke the tests is really because the order of operations changed. Previously, setting `MainPage` would immediately hook up a `Window` and add it to the children. As a result, there was no need to create a new window in `CreateWindow`. This however caused the method not to fire and could not be used to catch the event.

This PR realises that change, and now makes the tests call `CreateWindow` after stting the `MainPage`. In a real app, this chang does not matter as `CreateWindow` is _always_ called from the native host application. In the tests however, the property is just set and it waits for a window to be created - which will never happen.