### PR TITLE
Fix Cake VS-WINUI target

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -185,7 +185,7 @@ Task("VS-WINUI")
             }
         }.WithRestore().WithProperty("BuildForWinUI", "true");
 
-        MSBuild("./Microsoft.Maui.BuildTasks-net6.sln", msbuildSettings);
+        MSBuild("./Microsoft.Maui.BuildTasks-net6.slnf", msbuildSettings);
 
         msbuildSettings = new MSBuildSettings
         {


### PR DESCRIPTION
Small typo in the WINUI target. On my machine it's broken without the fix (can't find the solution), and works with the fix (to use the solution _filter_ file).