### PR TITLE
ZStackLayout

### DIFF
--- a/src/Controls/src/Core/Layout/ZStackLayout.cs
+++ b/src/Controls/src/Core/Layout/ZStackLayout.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Maui.Layouts;
+
+namespace Microsoft.Maui.Controls
+{
+	[ContentProperty(nameof(Children))]
+	public class ZStackLayout : StackBase
+	{
+		protected override ILayoutManager CreateLayoutManager() => new ZStackLayoutManager(this);
+	}
+}

--- a/src/Core/src/Layouts/ZStackLayoutManager.cs
+++ b/src/Core/src/Layouts/ZStackLayoutManager.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Layouts
+{
+	public class ZStackLayoutManager : StackLayoutManager 
+	{
+		public ZStackLayoutManager(IStackLayout stackLayout) : base(stackLayout)
+		{
+		}
+
+		public override Size Measure(double widthConstraint, double heightConstraint)
+		{
+			var padding = Stack.Padding;
+
+			double measuredHeight = 0;
+			double measuredWidth = 0;
+
+			for (int n = 0; n < Stack.Count; n++)
+			{
+				var child = Stack[n];
+
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
+				var measure = child.Measure(double.PositiveInfinity, double.PositiveInfinity);
+				measuredHeight = Math.Max(measuredHeight, measure.Height);
+				measuredWidth = Math.Max(measuredWidth, measure.Width);
+			}
+
+			measuredHeight += padding.VerticalThickness;
+			measuredWidth += padding.HorizontalThickness;
+
+			var finalHeight = ResolveConstraints(heightConstraint, Stack.Height, measuredHeight);
+			var finalWidth = ResolveConstraints(widthConstraint, Stack.Width, measuredWidth);
+
+			return new Size(finalWidth, finalHeight);
+		}
+
+		public override Size ArrangeChildren(Rectangle bounds)
+		{
+			var padding = Stack.Padding;
+
+			double stackHeight = padding.Top + bounds.Y;
+			double left = padding.Left + bounds.X;
+			double width = bounds.Width - padding.HorizontalThickness;
+			double height = bounds.Height - padding.VerticalThickness;
+
+			for (int n = 0; n < Stack.Count; n++)
+			{
+				var child = Stack[n];
+
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
+				var destination = new Rectangle(left, stackHeight, width, height);
+				child.Arrange(destination);
+			}
+
+			return new Size(width, height);
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/Layouts/ZStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/ZStackLayoutManagerTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+using Microsoft.Maui.UnitTests;
+using Microsoft.Maui.UnitTests.Layouts;
+using NSubstitute;
+using Xunit;
+using static Microsoft.Maui.UnitTests.Layouts.LayoutTestHelpers;
+
+namespace Microsoft.Maui.UnitTests.Layouts
+{
+	[Category(TestCategory.Core, TestCategory.Layout)]
+	public class ZStackLayoutManagerTests : StackLayoutManagerTests
+	{
+		[Fact]
+		public void MeasureWidthEqualsWidestChild()
+		{
+			var expectedWidth = 200;
+
+			var view = LayoutTestHelpers.CreateTestView(new Size(100, 100));
+			var viewNarrow = LayoutTestHelpers.CreateTestView(new Size(50, 100));
+			var viewWide = LayoutTestHelpers.CreateTestView(new Size(expectedWidth, 100));
+
+			var stack = CreateTestLayout(new List<IView>() { view, viewNarrow, viewWide });
+
+			var manager = new ZStackLayoutManager(stack);
+			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			Assert.Equal(expectedWidth, measure.Width);
+		}
+
+		[Fact]
+		public void MeasureHeightEqualsTallestChild()
+		{
+			var expectedHeight = 200;
+
+			var view = LayoutTestHelpers.CreateTestView(new Size(100, 100));
+			var viewShort = LayoutTestHelpers.CreateTestView(new Size(100, 50));
+			var viewTall = LayoutTestHelpers.CreateTestView(new Size(100, expectedHeight));
+
+			var stack = CreateTestLayout(new List<IView>() { view, viewTall, viewShort });
+
+			var manager = new ZStackLayoutManager(stack);
+			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			Assert.Equal(expectedHeight, measure.Height);
+		}
+
+		[Fact]
+		public void IgnoresCollapsedViews()
+		{
+			var view = LayoutTestHelpers.CreateTestView(new Size(100, 100));
+			var collapsedView = LayoutTestHelpers.CreateTestView(new Size(200, 200));
+			collapsedView.Visibility.Returns(Visibility.Collapsed);
+
+			var stack = CreateTestLayout(new List<IView>() { view, collapsedView });
+
+			var manager = new ZStackLayoutManager(stack);
+			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
+
+			// View is visible, so we expect it to be measured and arranged
+			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
+			view.Received().Arrange(Arg.Any<Rectangle>());
+
+			// View is collapsed, so we expect it not to be measured or arranged
+			collapsedView.DidNotReceive().Measure(Arg.Any<double>(), Arg.Any<double>());
+			collapsedView.DidNotReceive().Arrange(Arg.Any<Rectangle>());
+		}
+
+		[Fact]
+		public void DoesNotIgnoreHiddenViews()
+		{
+			var view = LayoutTestHelpers.CreateTestView(new Size(100, 100));
+			var hiddenView = LayoutTestHelpers.CreateTestView(new Size(100, 100));
+			hiddenView.Visibility.Returns(Visibility.Hidden);
+
+			var stack = CreateTestLayout(new List<IView>() { view, hiddenView });
+
+			var manager = new ZStackLayoutManager(stack);
+			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			manager.ArrangeChildren(new Rectangle(Point.Zero, measure));
+
+			// View is visible, so we expect it to be measured and arranged
+			view.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
+			view.Received().Arrange(Arg.Any<Rectangle>());
+
+			// View is hidden, so we expect it to be measured and arranged (since it'll need to take up space)
+			hiddenView.Received().Measure(Arg.Any<double>(), Arg.Any<double>());
+			hiddenView.Received().Arrange(Arg.Any<Rectangle>());
+		}
+
+		[Fact]
+		public void ArrangeRespectsBounds()
+		{
+			var stack = BuildStack(viewCount: 1, viewWidth: 100, viewHeight: 100);
+
+			var manager = new ZStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
+			manager.ArrangeChildren(new Rectangle(new Point(10, 15), measuredSize));
+
+			var expectedRectangle0 = new Rectangle(10, 15, 100, 100);
+
+			stack[0].Received().Arrange(Arg.Is(expectedRectangle0));
+		}
+	}
+}


### PR DESCRIPTION
Variation of StackLayout which arranges its children atop one another in order. 

Works just like a VerticalStackLayout or HorizontalStackLayout, except along the Z-axis. All children are laid out at the origin; the arrangement area's width is determined by the widest child and the height is determined by the tallest child. 

Provides a lower-complexity alternative to using a GridLayout to stack Views along the z-axis (e.g., in order to use an Image as a background for another View).

Example usage:

```
<ZStackLayout>
	<Image Source="dotnet_bot.png" WidthRequest="300" HeightRequest="372" HorizontalOptions="Center" />

	<Label Text="Text over the image, aligned to top" FontAttributes="Bold" FontSize="15" TextColor="White" HorizontalOptions="Center" VerticalOptions="Start"/>
	<Label Text="Text right in the middle" FontAttributes="Bold" FontSize="20" TextColor="LightGreen" HorizontalOptions="Center" VerticalOptions="Center"/>
	<Label Text="This is an easy way to do captions" FontAttributes="Bold" FontSize="16" TextColor="Red" HorizontalOptions="Center" VerticalOptions="End"/>
</ZStackLayout>
```
Results in: 
![image](https://user-images.githubusercontent.com/538025/129497410-8e2700b5-6ba3-407c-aa6d-0f26c4c60452.png)


The Spacing property currently has no effect; if we later introduce a z-index property, it will likely be applied to that.