### PR TITLE
[workload] use **FromWorkload** for targeting/runtime pack versions

### DIFF
--- a/src/Controls/samples/Directory.Build.props
+++ b/src/Controls/samples/Directory.Build.props
@@ -4,13 +4,5 @@
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />
-  <!--
-    We don't want to use cached Microsoft.Maui.* runtime packs.
-    This can be removed when we get: https://github.com/dotnet/sdk/issues/14044
-  -->
-  <PropertyGroup Condition=" '$(UseMaui)' == 'true' ">
-    <RestoreNoCache>true</RestoreNoCache>
-    <RestorePackagesPath>$(MauiRootDirectory)packages/</RestorePackagesPath>
-  </PropertyGroup>
   <Import Project="Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
 </Project>

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -89,16 +89,6 @@
     />
     <Delete Files="$(_NuGetConfig)" />
 
-    <!--
-      HACK: temporarily put runtime packs in 'library-packs', until they can be resolved from 'packs'
-      See: https://github.com/dotnet/sdk/issues/14044
-    -->
-    <ItemGroup>
-      <_RuntimePacks Include="$(PackageOutputPath)/*.Runtime.*.nupkg" />
-      <_RuntimePacks Include="$(PackageOutputPath)/Microsoft.Maui.Extensions.*.nupkg" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_RuntimePacks)" DestinationFolder="$(MSBuildExtensionsPath)../../library-packs" SkipUnchangedFiles="true" />
-
   </Target>
 
   <!-- Eventually replaced by eng/Version.targets -->

--- a/src/Essentials/samples/Directory.Build.props
+++ b/src/Essentials/samples/Directory.Build.props
@@ -4,13 +4,5 @@
     <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
   </PropertyGroup>
   <Import Project="../../../Directory.Build.props" />
-  <!--
-    We don't want to use cached Microsoft.Maui.* runtime packs.
-    This can be removed when we get: https://github.com/dotnet/sdk/issues/14044
-  -->
-  <PropertyGroup Condition=" '$(UseMaui)' == 'true' ">
-    <RestoreNoCache>true</RestoreNoCache>
-    <RestorePackagesPath>$(MauiRootDirectory)packages/</RestorePackagesPath>
-  </PropertyGroup>
   <Import Project="Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />
 </Project>

--- a/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Controls.Sdk/Sdk/BundledVersions.in.targets
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
+    <_MauiRuntimePackVersion>$(MicrosoftMauiSdkVersion)</_MauiRuntimePackVersion>
+    <_MauiRuntimePackVersion Condition=" '$(_MauiRuntimePackVersion)' == '' ">**FromWorkload**</_MauiRuntimePackVersion>
     <MicrosoftMauiSdkVersion Condition=" '$(MicrosoftMauiSdkVersion)' == '' ">@VERSION@</MicrosoftMauiSdkVersion>
     <!-- $(_MauiPlatformName) is used as RIDs as well as a suffix to targeting pack names -->
     <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">win</_MauiPlatformName>
@@ -15,10 +17,10 @@
         Include="Microsoft.Maui.Extensions"
         TargetFramework="net6.0"
         RuntimeFrameworkName="Microsoft.Maui.Extensions"
-        DefaultRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
-        LatestRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
+        DefaultRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
+        LatestRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
         TargetingPackName="Microsoft.Maui.Extensions"
-        TargetingPackVersion="$(MicrosoftMauiSdkVersion)"
+        TargetingPackVersion="$(_MauiRuntimePackVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Extensions"
         RuntimePackRuntimeIdentifiers="any"
     />
@@ -27,10 +29,10 @@
         Include="Microsoft.Maui.Core"
         TargetFramework="net6.0"
         RuntimeFrameworkName="Microsoft.Maui.Core"
-        DefaultRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
-        LatestRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
+        DefaultRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
+        LatestRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
         TargetingPackName="Microsoft.Maui.Core.Ref.$(_MauiPlatformName)"
-        TargetingPackVersion="$(MicrosoftMauiSdkVersion)"
+        TargetingPackVersion="$(_MauiRuntimePackVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Core.Runtime.**RID**"
         RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"
@@ -40,10 +42,10 @@
         Include="Microsoft.Maui.Controls"
         TargetFramework="net6.0"
         RuntimeFrameworkName="Microsoft.Maui.Controls"
-        DefaultRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
-        LatestRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
+        DefaultRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
+        LatestRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
         TargetingPackName="Microsoft.Maui.Controls.Ref.$(_MauiPlatformName)"
-        TargetingPackVersion="$(MicrosoftMauiSdkVersion)"
+        TargetingPackVersion="$(_MauiRuntimePackVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Controls.Runtime.**RID**"
         RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"
@@ -53,10 +55,10 @@
         Include="Microsoft.Maui.Essentials"
         TargetFramework="net6.0"
         RuntimeFrameworkName="Microsoft.Maui.Essentials"
-        DefaultRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
-        LatestRuntimeFrameworkVersion="$(MicrosoftMauiSdkVersion)"
+        DefaultRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
+        LatestRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
         TargetingPackName="Microsoft.Maui.Essentials.Ref.$(_MauiPlatformName)"
-        TargetingPackVersion="$(MicrosoftMauiSdkVersion)"
+        TargetingPackVersion="$(_MauiRuntimePackVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Essentials.Runtime.**RID**"
         RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"

--- a/src/Workload/Shared/FrameworkList.targets
+++ b/src/Workload/Shared/FrameworkList.targets
@@ -49,10 +49,4 @@
     </ItemGroup>
   </Target>
 
-  <!--
-    HACK: temporarily put runtime packs in 'library-packs', until they can be resolved from 'packs'
-    See: https://github.com/dotnet/sdk/issues/14044
-  -->
-  <Import Condition=" !$(MSBuildProjectName.Contains('.Ref')) " Project="LibraryPacks.targets" />
-
 </Project>


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/dotnet/sdk/pull/19596

If we use the version number string of `**FromWorkload**`, then our
runtime packages don't need to be resolved from a NuGet feed. They can
be resolved from the `dotnet/packs` directory.

This completely eliminates the need for a `NuGet.config` file for
projects when you have the `maui` workload installed.

One caveat for dotnet/maui is we have a `$(MicrosoftMauiSdkVersion)`.
We'll need to use `**FromWorkload**` in some places, and the actual
number when declaring `@(PackageReference)`.

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No
