### PR TITLE
Register Concrete Types against Image Source Services

### DIFF
--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -69,9 +69,23 @@ namespace Microsoft.Maui.Controls.Hosting
 		}
 
 
+		static IAppHostBuilder ConfigureImageSourceHandlers(this IAppHostBuilder builder)
+		{
+			builder.ConfigureImageSources(services =>
+			{
+				 services.AddService<FileImageSource>(svcs => new FileImageSourceService(svcs.GetService<IImageSourceServiceConfiguration>(), svcs.CreateLogger<FileImageSourceService>()));
+				 services.AddService<FontImageSource>(svcs => new FontImageSourceService(svcs.GetRequiredService<IFontManager>(), svcs.CreateLogger<FontImageSourceService>()));
+				 services.AddService<StreamImageSource>(svcs => new StreamImageSourceService(svcs.CreateLogger<StreamImageSourceService>()));
+				 services.AddService<UriImageSource>(svcs => new UriImageSourceService(svcs.CreateLogger<UriImageSourceService>()));
+			 });
+
+			return builder;
+		}
+
 		static IAppHostBuilder SetupDefaults(this IAppHostBuilder builder)
 		{
 			builder.ConfigureCompatibilityLifecycleEvents();
+			builder.ConfigureImageSourceHandlers();
 			builder
 				.ConfigureMauiHandlers(handlers =>
 				{

--- a/src/Core/src/Hosting/ImageSources/ImageSourceServiceProvider.cs
+++ b/src/Core/src/Hosting/ImageSources/ImageSourceServiceProvider.cs
@@ -22,11 +22,19 @@ namespace Microsoft.Maui.Hosting
 
 		public IServiceProvider HostServiceProvider { get; }
 
-		public IImageSourceService? GetImageSourceService(Type imageSource) =>
+		public IImageSourceService? GetImageSourceService(Type imageSource) => 
 			(IImageSourceService?)GetService(GetImageSourceServiceType(imageSource));
 
 		public Type GetImageSourceServiceType(Type imageSource) =>
-			_serviceCache.GetOrAdd(imageSource, type => ImageSourceServiceType.MakeGenericType(GetImageSourceType(type)));
+			_serviceCache.GetOrAdd(imageSource, type =>
+			{
+				var genericConcreteType = ImageSourceServiceType.MakeGenericType(type);
+
+				if (genericConcreteType != null && GetServiceDescriptor(genericConcreteType) != null)
+					return genericConcreteType;
+
+				return ImageSourceServiceType.MakeGenericType(GetImageSourceType(type));
+			});
 
 		public Type GetImageSourceType(Type imageSource) =>
 			_imageSourceCache.GetOrAdd(imageSource, CreateImageSourceTypeCacheEntry);

--- a/src/Core/src/Hosting/ImageSources/ImageSourceServiceProvider.cs
+++ b/src/Core/src/Hosting/ImageSources/ImageSourceServiceProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Hosting
 
 		public IServiceProvider HostServiceProvider { get; }
 
-		public IImageSourceService? GetImageSourceService(Type imageSource) => 
+		public IImageSourceService? GetImageSourceService(Type imageSource) =>
 			(IImageSourceService?)GetService(GetImageSourceServiceType(imageSource));
 
 		public Type GetImageSourceServiceType(Type imageSource) =>

--- a/src/Core/src/ImageSources/IImageSourceService.cs
+++ b/src/Core/src/ImageSources/IImageSourceService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui
 #endif
 	}
 
-	public interface IImageSourceService<T> : IImageSourceService
+	public interface IImageSourceService<in T> : IImageSourceService
 		where T : IImageSource
 	{
 	}

--- a/src/Core/tests/UnitTests/ImageSource/ImageSourceServiceTests.cs
+++ b/src/Core/tests/UnitTests/ImageSource/ImageSourceServiceTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.UnitTests.ImageSource
+{
+	[Category(TestCategory.Core, TestCategory.ImageSource)]
+	public class ImageSourceServiceTests
+	{
+		[Fact]
+		public void ResolvesToConcreteTypeOverInterface()
+		{
+			var provider = CreateImageSourceServiceProvider(services =>
+			{
+				services.AddService<IStreamImageSource, StreamImageSourceService>();
+				services.AddService<MultipleInterfacesImageSourceStub, UriImageSourceService>();
+			});
+
+			var service = provider.GetRequiredImageSourceService(new MultipleInterfacesImageSourceStub());
+			Assert.IsType<UriImageSourceService>(service);
+		}
+
+		private IImageSourceServiceProvider CreateImageSourceServiceProvider(Action<IImageSourceServiceCollection> configure)
+		{
+
+			var host = new AppHostBuilder()
+				.UseMauiServiceProviderFactory(true)
+				.ConfigureImageSources(configure)
+				.Build();
+
+			var services = host.Services;
+
+			var provider = services.GetRequiredService<IImageSourceServiceProvider>();
+
+			return provider;
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/TestCategory.cs
+++ b/src/Core/tests/UnitTests/TestCategory.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Maui.UnitTests
 		public const string PropertyMapping = "PropertyMapping";
 		public const string Lifecycle = "Lifecycle";
 		public const string Hosting = "Hosting";
+		public const string ImageSource = "ImageSource";
 	}
 }

--- a/src/Core/tests/UnitTests/TestClasses/ImageSourceStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ImageSourceStub.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.UnitTests
 {
@@ -20,4 +24,50 @@ namespace Microsoft.Maui.UnitTests
 
 		public string Glyph { get; set; }
 	}
+
+	class MultipleInterfacesImageSourceStub : ImageSourceStub, IUriImageSource, IStreamImageSource
+	{
+		public MultipleInterfacesImageSourceStub()
+		{
+		}
+
+		public Func<CancellationToken, Task<Stream>> Stream { get; set; }
+
+		public Uri Uri { get; set; }
+
+		public TimeSpan CacheValidity { get; set; }
+
+		public bool CachingEnabled { get; set; }
+
+		public Task<Stream> GetStreamAsync(CancellationToken cancellationToken = default) =>
+			Stream?.Invoke(cancellationToken);
+	}
+
+	class StreamImageSourceStub : ImageSourceStub, IStreamImageSource
+	{
+		public StreamImageSourceStub()
+		{
+		}
+
+		public StreamImageSourceStub(Stream stream)
+		{
+			Stream = token => Task.FromResult(stream);
+		}
+
+		public StreamImageSourceStub(Func<CancellationToken, Task<Stream>> stream)
+		{
+			Stream = stream;
+		}
+
+		public StreamImageSourceStub(Func<Stream> stream)
+		{
+			Stream = token => Task.FromResult(stream());
+		}
+
+		public Func<CancellationToken, Task<Stream>> Stream { get; set; }
+
+		public Task<Stream> GetStreamAsync(CancellationToken cancellationToken = default) =>
+			Stream?.Invoke(cancellationToken);
+	}
+
 }


### PR DESCRIPTION
### Description of Change ###

Currently inside `Maui.Core` ImageSourceServices are registered against interfaces 

```C#
builder.ConfigureImageSources(services =>
{
	services.AddService<IFileImageSource>(svcs => new FileImageSourceService(svcs.GetService<IImageSourceServiceConfiguration>(), svcs.CreateLogger<FileImageSourceService>()));
	services.AddService<IFontImageSource>(svcs => new FontImageSourceService(svcs.GetRequiredService<IFontManager>(), svcs.CreateLogger<FontImageSourceService>()));
	services.AddService<IStreamImageSource>(svcs => new StreamImageSourceService(svcs.CreateLogger<StreamImageSourceService>()));
	services.AddService<IUriImageSource>(svcs => new UriImageSourceService(svcs.CreateLogger<UriImageSourceService>()));
});
```

Inside Controls the `UriImageSource` implements both `IStreamImageSource` and `IUriImageSource`

```C#
	public partial class UriImageSource : IUriImageSource, IStreamImageSource
```

On Android this is currently causing a concrete `UriImageSource` to return the `StreamImageSourceService`

Interestingly enough, if you try to test for this inside the controls unit tests it always returns the correct `ImageSourceService` because `net6.0-android` seems to return the interfaces in a different order than `net6.0`

- added behavior to the `ImageSourceServiceProvider` so it first checks for any concrete registrations before going to interfaces
- Added concrete registrations for all of our controls implementations of sources. I figure this avoids some extra reflection as well
- Made `IImageSourceService<in T>` contravariant so that you can register concrete types against these interfaces

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
