### PR TITLE
Add timeouts and continueOnError for macOS builds

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -165,9 +165,6 @@ stages:
                 platform: ${{ BuildPlatform.name }}
             - pwsh: ./build.ps1 --target=dotnet-pack --configuration="Release" --verbosity=diagnostic
               displayName: 'Pack .NET Maui'
-              ${{ if eq(BuildPlatform.name, 'macOS') }}:
-                timeoutInMinutes: 20
-                continueOnError: true
             - task: CopyFiles@2
               condition: always()
               displayName: 'Copy files to staging'

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -128,8 +128,13 @@ stages:
                 displayName: 'Install .NET'
               - pwsh: ./build.ps1 --target=dotnet-build --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET Maui'
+                ${{ if eq(BuildPlatform.name, 'macOS') }}:
+                  timeoutInMinutes: 15
+                  continueOnError: true
               - pwsh: ./build.ps1 --target=dotnet-test --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Run Unit Tests'
+                ${{ if eq(BuildPlatform.name, 'macOS') }}:
+                  continueOnError: true
               - task: PublishTestResults@2
                 condition: always()
                 inputs:
@@ -160,6 +165,9 @@ stages:
                 platform: ${{ BuildPlatform.name }}
             - pwsh: ./build.ps1 --target=dotnet-pack --configuration="Release" --verbosity=diagnostic
               displayName: 'Pack .NET Maui'
+              ${{ if eq(BuildPlatform.name, 'macOS') }}:
+                timeoutInMinutes: 20
+                continueOnError: true
             - task: CopyFiles@2
               condition: always()
               displayName: 'Copy files to staging'
@@ -218,6 +226,8 @@ stages:
                 displayName: 'Install .NET (Local Workloads)'
               - pwsh: ./build.ps1 --target=dotnet-samples --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET 6 Samples'
+                timeoutInMinutes: 20
+                continueOnError: true
               - task: PublishBuildArtifacts@1
                 condition: always()
                 displayName: publish artifacts


### PR DESCRIPTION
macOS builds are hanging for hours and blocking up our current build process

Attempted workarounds so far haven't yielded anything

https://github.com/dotnet/maui/pull/2089
This might be caused by the following issue
https://github.com/dotnet/msbuild/issues/6753

We'll continue to work on a better fix inside #2089 but for the time being we are just going to rely on our windows pipelines for validation