### PR TITLE
Fix Failing Android API 30 Device Tests (only on CI)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "pwsh"
       ]
+    },
+    "microsoft.dotnet.xharness.cli": {
+      "version": "1.0.0-prerelease.21404.1",
+      "commands": [
+        "xharness"
+      ]
     }
   }
 }

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -81,7 +81,7 @@ Setup(context =>
 			else
 				DEVICE_ARCH = "arm64-v8a";
 		}
-		sdk = api >= 24 ? "google_apis_playstore" : "google_apis";
+		var sdk = api >= 24 ? "google_apis_playstore" : "google_apis";
 		DEVICE_ID = $"system-images;android-{api};{sdk};{DEVICE_ARCH}";
 
 		// we are not using a virtual device, so quit

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -81,7 +81,8 @@ Setup(context =>
 			else
 				DEVICE_ARCH = "arm64-v8a";
 		}
-		DEVICE_ID = $"system-images;android-{api};google_apis;{DEVICE_ARCH}";
+		sdk = api >= 24 ? "google_apis_playstore" : "google_apis";
+		DEVICE_ID = $"system-images;android-{api};{sdk};{DEVICE_ARCH}";
 
 		// we are not using a virtual device, so quit
 		if (!emulator)

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -20,9 +20,6 @@ steps:
   - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
     displayName: 'Build the MSBuild Tasks'
 
-  - pwsh: $(DotNet.Path) tool update microsoft.dotnet.xharness.cli --version $(XHARNESS_VERSION)
-    displayName: 'Install XHarness'
-
   - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
     displayName: $(Agent.JobName)
 

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -25,11 +25,13 @@ stages:
                 clean: all
               displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
               pool:
-                # name: ${{ parameters.androidVmPool }}
-                # vmImage: ${{ parameters.androidVmImage }}
-                vmImage: macOS-latest
+                name: ${{ parameters.androidVmPool }}
+                vmImage: ${{ parameters.androidVmImage }}
               variables:
-                ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
+                ${{ if ge(24, api) }}:
+                  ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
+                ${{ if lt(24, api) }}:
+                  ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
                 REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
               steps:
                 - template: device-tests-steps.yml

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -28,9 +28,9 @@ stages:
                 name: ${{ parameters.androidVmPool }}
                 vmImage: ${{ parameters.androidVmImage }}
               variables:
-                ${{ if ge(24, api) }}:
+                ${{ if ge(api, 24) }}:
                   ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
-                ${{ if lt(24, api) }}:
+                ${{ if lt(api, 24) }}:
                   ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
                 REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
               steps:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -25,8 +25,9 @@ stages:
                 clean: all
               displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
               pool:
-                name: ${{ parameters.androidVmPool }}
-                vmImage: ${{ parameters.androidVmImage }}
+                # name: ${{ parameters.androidVmPool }}
+                # vmImage: ${{ parameters.androidVmImage }}
+                vmImage: macOS-latest
               variables:
                 ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
                 REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -7,8 +7,6 @@ variables:
   value: true
 - name: DOTNET_VERSION
   value: 5.0.201
-- name: XHARNESS_VERSION
-  value: 1.0.0-prerelease.21404.1
 - name: LocBranchPrefix
   value: 'loc-hb'
 - name: LocBranch

--- a/src/Core/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Core/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -5,4 +5,35 @@
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+	<queries>
+		<!-- Email -->
+		<intent>
+			<action android:name="android.intent.action.SENDTO" />
+			<data android:scheme="mailto" />
+		</intent>
+		<!-- Browser -->
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="http" />
+		</intent>
+		<!-- Browser -->
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="https" />
+		</intent>
+		<!-- Sms -->
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="smsto" />
+		</intent>
+		<!-- PhoneDialer -->
+		<intent>
+			<action android:name="android.intent.action.DIAL" />
+			<data android:scheme="tel" />
+		</intent>
+		<!-- MediaPicker -->
+		<intent>
+			<action android:name="android.media.action.IMAGE_CAPTURE" />
+		</intent>
+	</queries>
 </manifest>

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -179,7 +179,7 @@
       Inputs="$(_Inputs)"
       Outputs="$(DotNetPacksDirectory).stamp">
     <Exec
-        Command="&quot;$(DotNetToolPath)&quot; workload install @(_WorkloadIds, ' ') --skip-manifest-update --verbosity diag --temp-dir $(DotNetTempDirectory)"
+        Command="&quot;$(DotNetToolPath)&quot; workload install %(_WorkloadIds.Identity) --skip-manifest-update --verbosity diag --temp-dir $(DotNetTempDirectory)"
         WorkingDirectory="$(MauiRootDirectory)"
     />
     <Touch Files="$(DotNetPacksDirectory).stamp" AlwaysCreate="true" />

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21372.1" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.21404.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

With API 30, Android requires that all checks need to be listed for security/privacy reasons.

Prior to net6.0, the tests actually targets only API 29, which got around this new feature.

### Additions made ###

 * added the `<queries>` that the tests may use.

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
