### PR TITLE
Fix if statement check used to null out handler

### DIFF
--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == view)
 				return;
 
-			if (VirtualView?.Handler != null && VirtualView.Handler != this)
+			if (VirtualView?.Handler != null && VirtualView.Handler == this)
 				VirtualView.Handler = null;
 
 			bool setupNativeView = VirtualView == null;

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -38,10 +38,11 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == view)
 				return;
 
-			if (VirtualView?.Handler != null && VirtualView.Handler == this)
-				VirtualView.Handler = null;
+			var oldVirtualView = VirtualView;
+			if (oldVirtualView?.Handler != null)
+				oldVirtualView.Handler = null;
 
-			bool setupNativeView = VirtualView == null;
+			bool setupNativeView = oldVirtualView == null;
 
 			VirtualView = view;
 			NativeView ??= CreateNativeElement();

--- a/src/Core/tests/UnitTests/AbstractViewHandlerTests.cs
+++ b/src/Core/tests/UnitTests/AbstractViewHandlerTests.cs
@@ -89,5 +89,17 @@ namespace Microsoft.Maui.UnitTests
 
 			Assert.IsType<FooService>(foo);
 		}
+
+		[Fact]
+		public void SettingVirtualViewOnHandlerRemovesHandlerFromPreviousVirtualView()
+		{
+			HandlerStub handlerStub = new HandlerStub();
+			var button1 = new Maui.Controls.Button();
+			var button2 = new Maui.Controls.Button();
+			handlerStub.SetVirtualView(button1);
+			handlerStub.SetVirtualView(button2);
+
+			Assert.Null(button1.Handler);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

The logic to null out the handler on a `VirtualView` when moving a handler to a new `VirtualView` is incorrect