### PR TITLE
Call disconnect on shimmed NavPage Handler and fix image loading code that was running on the task pool

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -78,6 +78,7 @@ var packageVersion = GetBuildVariable("packageVersion", "0.1.0-p2");
 var releaseChannelArg = GetBuildVariable("CHANNEL", "Stable");
 var teamProject = GetBuildVariable("TeamProject", GetBuildVariable("SYSTEM_TEAMPROJECT", ""));
 bool isHostedAgent = agentName.StartsWith("Azure Pipelines") || agentName.StartsWith("Hosted Agent");
+var localDotnet = GetBuildVariable("dotnet", "local") == "local";
 
 var vsVersion = GetBuildVariable("VS", "");
 
@@ -171,6 +172,7 @@ Information("NUNIT_TEST_WHERE: {0}", NUNIT_TEST_WHERE);
 Information("TARGET: {0}", target);
 Information("MSBUILD: {0}", MSBuildExe);
 Information("vsVersion: {0}", vsVersion);
+Information("localDotnet: {0}", localDotnet);
 
 
 var releaseChannel = ReleaseChannel.Stable;

--- a/build.cake
+++ b/build.cake
@@ -79,6 +79,8 @@ var releaseChannelArg = GetBuildVariable("CHANNEL", "Stable");
 var teamProject = GetBuildVariable("TeamProject", GetBuildVariable("SYSTEM_TEAMPROJECT", ""));
 bool isHostedAgent = agentName.StartsWith("Azure Pipelines") || agentName.StartsWith("Hosted Agent");
 
+var vsVersion = GetBuildVariable("VS", "");
+
 var MAUI_SLN = "./Microsoft.Maui.sln";
 
 var CONTROLGALLERY_SLN = "./ControlGallery.sln";
@@ -168,6 +170,7 @@ Information("workingDirectory: {0}", workingDirectory);
 Information("NUNIT_TEST_WHERE: {0}", NUNIT_TEST_WHERE);
 Information("TARGET: {0}", target);
 Information("MSBUILD: {0}", MSBuildExe);
+Information("vsVersion: {0}", vsVersion);
 
 
 var releaseChannel = ReleaseChannel.Stable;
@@ -756,7 +759,7 @@ Task("Android100")
     });
 
 Task("VS")
-    .Description("Builds projects necessary so solution compiles on VS")
+    .Description("Builds projects necessary so solution compiles on VS Preview")
     .IsDependentOn("Clean")
     .IsDependentOn("VSMAC")
     .IsDependentOn("VSWINDOWS");
@@ -767,6 +770,17 @@ Task("VS-CG")
     .IsDependentOn("VSMAC")
     .IsDependentOn("VSWINDOWS");
 
+Task("VS-CG-STABLE")
+    .Description("Builds projects necessary so solution compiles on VS")
+    .IsDependentOn("Clean")
+    .IsDependentOn("VSMAC")
+    .IsDependentOn("VSWINDOWS");
+
+Task("VS-STABLE")
+    .Description("Builds projects necessary so solution compiles on VS Stable")
+    .IsDependentOn("Clean")
+    .IsDependentOn("VSMAC")
+    .IsDependentOn("VSWINDOWS");
 
 Task("VSWINDOWS")
     .Description("Builds projects necessary so solution compiles on VS Windows")
@@ -774,15 +788,22 @@ Task("VSWINDOWS")
     .WithCriteria(IsRunningOnWindows())
     .Does(() =>
     {
-        string sln = "Microsoft.Maui.sln";
-        if (target == "VS-CG")
-            sln = "Compatibility.ControlGallery.sln";
+        bool includePrerelease = !target.ToLower().Contains("stable");
 
-        MSBuild(sln,
+        if (target.ToLower().StartsWith("vs-cg"))
+        {
+            MSBuild("Compatibility.ControlGallery.sln",
                 GetMSBuildSettings()
                     .WithRestore());
-
-        StartVisualStudio(sln);
+            StartVisualStudio("Compatibility.ControlGallery.sln", includePrerelease: includePrerelease);
+        }
+        else
+        {
+            MSBuild(@"src\Compatibility\Core\src\Compatibility.csproj",
+                GetMSBuildSettings()
+                    .WithRestore());
+            StartVisualStudio("Microsoft.Maui.sln", includePrerelease: includePrerelease);
+        }
     });
 
 Task("VSMAC")
@@ -1054,20 +1075,21 @@ void RunTests(string unitTestLibrary, NUnit3Settings settings, ICakeContext ctx)
     }
 }
 
-void StartVisualStudio(string sln = "./Microsoft.Maui.sln")
+void StartVisualStudio(string sln = "./Microsoft.Maui.sln", bool includePrerelease = true)
 {
     if(isCIBuild)
         return;
 
+    if (!String.IsNullOrWhiteSpace(vsVersion))
+        includePrerelease = (vsVersion == "preview");
+    
     if(IsRunningOnWindows())
     {
-        StartProcess("powershell",
-            new ProcessSettings
-            {
-                Arguments = new ProcessArgumentBuilder()
-                    .Append("start")
-                    .Append(sln)
-            });
+        var vsLatest = VSWhereLatest(new VSWhereLatestSettings { IncludePrerelease = includePrerelease, });
+        if (vsLatest == null)
+            throw new Exception("Unable to find Visual Studio!");
+
+        StartProcess(vsLatest.CombineWithFilePath("./Common7/IDE/devenv.exe"), sln);
     }
     else
          StartProcess("open", new ProcessSettings{ Arguments = sln });

--- a/build.cake
+++ b/build.cake
@@ -173,8 +173,8 @@ Information("TARGET: {0}", target);
 Information("MSBUILD: {0}", MSBuildExe);
 Information("vsVersion: {0}", vsVersion);
 Information("localDotnet: {0}", localDotnet);
-Information("dotnet: {0}", GetBuildVariable("dotnet"));
-Information("workloads: {0}", GetBuildVariable("workloads"));
+Information("dotnet: {0}", GetBuildVariable("dotnet", ""));
+Information("workloads: {0}", GetBuildVariable("workloads", ""));
 
 
 var releaseChannel = ReleaseChannel.Stable;

--- a/build.cake
+++ b/build.cake
@@ -78,7 +78,7 @@ var packageVersion = GetBuildVariable("packageVersion", "0.1.0-p2");
 var releaseChannelArg = GetBuildVariable("CHANNEL", "Stable");
 var teamProject = GetBuildVariable("TeamProject", GetBuildVariable("SYSTEM_TEAMPROJECT", ""));
 bool isHostedAgent = agentName.StartsWith("Azure Pipelines") || agentName.StartsWith("Hosted Agent");
-var localDotnet = GetBuildVariable("dotnet", "local") == "local";
+var localDotnet = GetBuildVariable("workloads", "local") == "local";
 
 var vsVersion = GetBuildVariable("VS", "");
 
@@ -173,6 +173,8 @@ Information("TARGET: {0}", target);
 Information("MSBUILD: {0}", MSBuildExe);
 Information("vsVersion: {0}", vsVersion);
 Information("localDotnet: {0}", localDotnet);
+Information("dotnet: {0}", GetBuildVariable("dotnet"));
+Information("workloads: {0}", GetBuildVariable("workloads"));
 
 
 var releaseChannel = ReleaseChannel.Stable;

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -2,7 +2,6 @@
 
 var ext = IsRunningOnWindows() ? ".exe" : "";
 var dotnetPath = $"./bin/dotnet/dotnet{ext}";
-var localDotnet = GetBuildVariable("dotnet", "local") == "local";
 
 // Tasks for CI
 
@@ -333,7 +332,7 @@ void RunMSBuildWithLocalDotNet(string sln, Dictionary<string, string> properties
 {
     var name = System.IO.Path.GetFileNameWithoutExtension(sln);
     var binlog = $"{logDirectory}/{name}-{configuration}.binlog";
-
+    
     if(localDotnet)
         SetDotNetEnvironmentVariables();
 
@@ -357,9 +356,11 @@ void RunMSBuildWithLocalDotNet(string sln, Dictionary<string, string> properties
 
         var dotnetBuildSettings = new DotNetCoreBuildSettings
         {
-            ToolPath = dotnetPath,
             MSBuildSettings = msbuildSettings,
         };
+
+        if (localDotnet)
+            dotnetBuildSettings.ToolPath = dotnetPath;
 
         DotNetCoreBuild(sln, dotnetBuildSettings);
     }

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -48,7 +48,7 @@ Task("dotnet-buildtasks")
     .IsDependentOn("dotnet")
     .Does(() =>
     {
-        RunMSBuildWithLocalDotNet("./Microsoft.Maui.BuildTasks-net6.slnf");
+        RunMSBuildWithDotNet("./Microsoft.Maui.BuildTasks-net6.slnf");
     });
 
 Task("dotnet-build")
@@ -58,15 +58,15 @@ Task("dotnet-build")
     {
         if (IsRunningOnWindows())
         {
-            RunMSBuildWithLocalDotNet("./Microsoft.Maui.BuildTasks-net6.slnf", new Dictionary<string, string> {
+            RunMSBuildWithDotNet("./Microsoft.Maui.BuildTasks-net6.slnf", new Dictionary<string, string> {
                 ["BuildForWinUI"] = bool.TrueString,
             });
-            RunMSBuildWithLocalDotNet("./Microsoft.Maui-winui.sln");
+            RunMSBuildWithDotNet("./Microsoft.Maui-winui.sln");
         }
         else
         {
-            RunMSBuildWithLocalDotNet("./Microsoft.Maui.BuildTasks-net6.slnf");
-            RunMSBuildWithLocalDotNet("./Microsoft.Maui-net6.sln");
+            RunMSBuildWithDotNet("./Microsoft.Maui.BuildTasks-net6.slnf");
+            RunMSBuildWithDotNet("./Microsoft.Maui-net6.sln");
         }
     });
 
@@ -75,24 +75,24 @@ Task("dotnet-build-winui")
     .Description("Build the solutions")
     .Does(() =>
     {
-        RunMSBuildWithLocalDotNet("./Microsoft.Maui.BuildTasks-net6.slnf", new Dictionary<string, string> {
+        RunMSBuildWithDotNet("./Microsoft.Maui.BuildTasks-net6.slnf", new Dictionary<string, string> {
             ["BuildForWinUI"] = bool.TrueString,
         });
-        RunMSBuildWithLocalDotNet("./Microsoft.Maui-winui.sln");
+        RunMSBuildWithDotNet("./Microsoft.Maui-winui.sln");
     });
 
 Task("dotnet-build-net6")
     .IsDependentOn("dotnet")
     .Does(() =>
     {
-        RunMSBuildWithLocalDotNet("./Microsoft.Maui.BuildTasks-net6.slnf");
-        RunMSBuildWithLocalDotNet("./Microsoft.Maui-net6.sln");
+        RunMSBuildWithDotNet("./Microsoft.Maui.BuildTasks-net6.slnf");
+        RunMSBuildWithDotNet("./Microsoft.Maui-net6.sln");
     });
 
 Task("dotnet-samples")
     .Does(() =>
     {
-        RunMSBuildWithLocalDotNet("./Microsoft.Maui.Samples-net6.slnf", new Dictionary<string, string> {
+        RunMSBuildWithDotNet("./Microsoft.Maui.Samples-net6.slnf", new Dictionary<string, string> {
             ["UseWorkload"] = bool.TrueString,
         });;
     });
@@ -169,8 +169,8 @@ Task("VS-NET6")
         // VS has trouble building all the references correctly so this makes sure everything is built
         // and we're ready to go right when VS launches
         
-        RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj");
-        RunMSBuildWithLocalDotNet("./src/Core/tests/DeviceTests/Core.DeviceTests.csproj");
+        RunMSBuildWithDotNet("./src/Compatibility/Android.FormsViewGroup/src/Compatibility.Android.FormsViewGroup-net6.csproj");
+        RunMSBuildWithDotNet("./src/Compatibility/Core/src/Compatibility-net6.csproj");
         StartVisualStudioForDotNet6();
     });
 
@@ -230,7 +230,7 @@ Task("VS-ANDROID")
 
         // VS has trouble building all the references correctly so this makes sure everything is built
         // and we're ready to go right when VS launches
-        RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj");
+        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj");
         StartVisualStudioForDotNet6("./Microsoft.Maui.Droid.sln");
     });
 
@@ -240,7 +240,7 @@ Task("SAMPLE-ANDROID")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
-        RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj", deployAndRun: true);
+        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj", deployAndRun: true);
     });
 
 Task("SAMPLE-IOS")
@@ -249,7 +249,7 @@ Task("SAMPLE-IOS")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
-        RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj", deployAndRun: true);
+        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj", deployAndRun: true);
     });
 
 Task("SAMPLE-MAC")
@@ -258,7 +258,7 @@ Task("SAMPLE-MAC")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
-        RunMSBuildWithLocalDotNet("./src/Controls/samples/Controls.Sample.MacCatalyst/Maui.Controls.Sample.MacCatalyst-net6.csproj", deployAndRun: true);
+        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.MacCatalyst/Maui.Controls.Sample.MacCatalyst-net6.csproj", deployAndRun: true);
     });
 
 
@@ -328,7 +328,7 @@ void StartVisualStudioForDotNet6(string sln = "./Microsoft.Maui-net6.sln")
 
 // NOTE: These methods work as long as the "dotnet" target has already run
 
-void RunMSBuildWithLocalDotNet(string sln, Dictionary<string, string> properties = null, bool deployAndRun = false)
+void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = null, bool deployAndRun = false)
 {
     var name = System.IO.Path.GetFileNameWithoutExtension(sln);
     var binlog = $"{logDirectory}/{name}-{configuration}.binlog";

--- a/src/Compatibility/Core/src/Android/AppCompat/FragmentContainer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/FragmentContainer.cs
@@ -62,8 +62,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 
 				_onCreateCallback?.Invoke(_pageContainer);
 
-				container.Invalidate();
-				container.RequestLayout();
 				return _pageContainer;
 			}
 

--- a/src/Compatibility/Core/src/Android/AppCompat/FragmentContainer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/FragmentContainer.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 
 				_onCreateCallback?.Invoke(_pageContainer);
 
+				container.Invalidate();
+				container.RequestLayout();
 				return _pageContainer;
 			}
 
@@ -74,7 +76,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 			{
 				if (_visualElementRenderer != null)
 				{
-					if (_visualElementRenderer.View.Handle != IntPtr.Zero)
+					if (_visualElementRenderer.View.IsAlive())
 					{
 						_visualElementRenderer.View.RemoveFromParent();
 					}

--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -41,8 +41,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				{
 					if (mauiView.Handler == null && newvalue is IVisualElementRenderer ver)
 						mauiView.Handler = new RendererToHandlerShim(ver);
-					else if (mauiView.Handler != null && newvalue == null)
-						mauiView.Handler = null;
 				}
 
 			});

--- a/src/Compatibility/Core/src/Android/RendererPool.cs
+++ b/src/Compatibility/Core/src/Android/RendererPool.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					if (renderer == null)
 						continue;
 
-					if (renderer.View.IsDisposed())
+					if (!renderer.View.IsAlive())
 						continue;
 
 					if (renderer.View.Parent != _parent.View)

--- a/src/Compatibility/Core/src/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.cs
@@ -116,17 +116,8 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		protected override void DisconnectHandler(NativeView nativeView)
 		{
-			if (VisualElementRenderer != null)
-			{
-				SetRenderer(
-					VisualElementRenderer.Element,
-					null);
-
-				VisualElementRenderer.SetElement(null);
-			}
-
+			VisualElementRenderer?.Dispose();
 			base.DisconnectHandler(nativeView);
-			base.VirtualView.Handler = null;
 		}
 
 		public override void SetVirtualView(IView view)

--- a/src/Compatibility/Core/src/Windows/Platform.cs
+++ b/src/Compatibility/Core/src/Windows/Platform.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				{
 					if (view.Handler == null && newvalue is IVisualElementRenderer ver)
 						view.Handler = new RendererToHandlerShim(ver);
-					else if (newvalue == null && view.Handler != null)
-						view.Handler = null;
 				}
 			});
 

--- a/src/Compatibility/Core/src/iOS/Platform.cs
+++ b/src/Compatibility/Core/src/iOS/Platform.cs
@@ -34,8 +34,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				{
 					if (mauiView.Handler == null && newvalue is IVisualElementRenderer ver)
 						mauiView.Handler = new RendererToHandlerShim(ver);
-					else if (mauiView.Handler != null && newvalue == null)
-						mauiView.Handler = null;
 				}
 			});
 

--- a/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls
 			try
 			{
 				// If a handler is getting changed before the end of this method
-				// Something is wired up correctly
+				// Something is wired up incorrectly
 				if (_previousHandler != null)
 					throw new InvalidOperationException("Handler is already being set elsewhere");
 

--- a/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls
 		{
 			EffectControlProvider = (Handler != null) ? this : null;
 			HandlerChanged?.Invoke(this, EventArgs.Empty);
+
 			OnHandlerChanged();
 		}
 
@@ -38,21 +39,33 @@ namespace Microsoft.Maui.Controls
 			OnHandlerChanging(args);
 		}
 
+		IElementHandler _previousHandler;
 		void SetHandler(IElementHandler newHandler)
 		{
 			if (newHandler == _handler)
 				return;
 
-			var previousHandler = _handler;
+			try
+			{
+				if (_previousHandler != null)
+					throw new InvalidOperationException("Handler is already being set elsewhere");
 
-			OnHandlerChangingCore(new HandlerChangingEventArgs(previousHandler, newHandler));
+				_previousHandler = _handler;
 
-			_handler = newHandler;
+				OnHandlerChangingCore(new HandlerChangingEventArgs(_previousHandler, newHandler));
 
-			if (_handler?.VirtualView != this)
-				_handler?.SetVirtualView(this);
+				_handler = newHandler;
+				_previousHandler?.DisconnectHandler();
 
-			OnHandlerChangedCore();
+				if (_handler?.VirtualView != this)
+					_handler?.SetVirtualView(this);
+
+				OnHandlerChangedCore();
+			}
+			finally
+			{
+				_previousHandler = null;
+			}
 		}
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)

--- a/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Maui.Controls
 
 			try
 			{
+				// If a handler is getting changed before the end of this method
+				// Something is wired up correctly
 				if (_previousHandler != null)
 					throw new InvalidOperationException("Handler is already being set elsewhere");
 
@@ -55,6 +57,8 @@ namespace Microsoft.Maui.Controls
 				OnHandlerChangingCore(new HandlerChangingEventArgs(_previousHandler, newHandler));
 
 				_handler = newHandler;
+
+				// Disconnect the handler after the changing event fire
 				_previousHandler?.DisconnectHandler();
 
 				if (_handler?.VirtualView != this)

--- a/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element.Impl.cs
@@ -58,9 +58,6 @@ namespace Microsoft.Maui.Controls
 
 				_handler = newHandler;
 
-				// Disconnect the handler after the changing event fire
-				_previousHandler?.DisconnectHandler();
-
 				if (_handler?.VirtualView != this)
 					_handler?.SetVirtualView(this);
 

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
@@ -58,11 +58,8 @@ namespace Microsoft.Maui.Controls
 		Task<IView> INavigationView.PopAsync() =>
 			(this as INavigationView).PopAsync(true);
 
-		async Task<IView> INavigationView.PopAsync(bool animated)
-		{
-			var thing = await this.PopAsync(animated);
-			return thing;
-		}
+		async Task<IView> INavigationView.PopAsync(bool animated) => 
+			await this.PopAsync(animated);
 
 		Task<IView> INavigationView.PopModalAsync()
 		{
@@ -97,8 +94,7 @@ namespace Microsoft.Maui.Controls
 			throw new NotImplementedException();
 		}
 
-		IView Content =>
-			this.CurrentPage;
+		IView Content => this.CurrentPage;
 
 		IReadOnlyList<IView> INavigationView.ModalStack => throw new NotImplementedException();
 

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
@@ -50,6 +50,22 @@ namespace Microsoft.Maui.Controls
 			return Frame.Size;
 		}
 
+		IElementHandler _previousHandler;
+		protected override void OnHandlerChanged()
+		{
+			// Because the navigation handler is shimmed we disconnect from it so it disposes
+			_previousHandler?.DisconnectHandler();
+			_previousHandler = null;
+			base.OnHandlerChanged();
+		}
+
+		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
+		{
+			base.OnHandlerChangingCore(args);
+
+			_previousHandler = args.OldHandler;
+		}
+
 		void INavigationView.InsertPageBefore(IView page, IView before)
 		{
 			throw new NotImplementedException();

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage.Impl.cs
@@ -54,7 +54,9 @@ namespace Microsoft.Maui.Controls
 		protected override void OnHandlerChanged()
 		{
 			// Because the navigation handler is shimmed we disconnect from it so it disposes
-			_previousHandler?.DisconnectHandler();
+			if (_previousHandler?.VirtualView == this)
+				_previousHandler?.DisconnectHandler();
+
 			_previousHandler = null;
 			base.OnHandlerChanged();
 		}

--- a/src/Controls/src/Core/Platform/Android/BottomNavigationViewUtils.cs
+++ b/src/Controls/src/Core/Platform/Android/BottomNavigationViewUtils.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 					image.ImageTintList = ColorStateList.ValueOf(Colors.Black.MultiplyAlpha(0.6f).ToNative());
 
-					ShellImagePart shellImagePart = new ShellImagePart()
+					ImageSourceLoader shellImagePart = new ImageSourceLoader()
 					{
 						Source = shellContent.icon
 					};
@@ -175,7 +175,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 					var services = mauiContext.Services;
 					var provider = services.GetRequiredService<IImageSourceServiceProvider>();
-					image.UpdateSourceAsync(new ShellImagePart() { Source = shellContent.icon }, provider)
+					image.UpdateSourceAsync(new ImageSourceLoader() { Source = shellContent.icon }, provider)
 						.FireAndForget(e => Internals.Log.Warning("MenuItem", $"{e}"));
 
 					innerLayout.AddView(image);

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal static void UpdateMenuItemIcon(IMauiContext mauiContext, IMenuItem menuItem, ToolbarItem toolBarItem, Color tintColor)
 		{
-			ShellImagePart.LoadImage(toolBarItem, mauiContext, result =>
+			ImageSourceLoader.LoadImage(toolBarItem, mauiContext, result =>
 			{
 				var baseDrawable = result.Value;
 				if (menuItem == null || !menuItem.IsAlive())

--- a/src/Controls/src/Core/Platform/Android/ImageSourceLoader.cs
+++ b/src/Controls/src/Core/Platform/Android/ImageSourceLoader.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Controls.Platform
 {
-	class ShellImagePart : IImageSourcePart
+	class ImageSourceLoader : IImageSourcePart
 	{
 		public IImageSource Source
 		{
@@ -54,20 +54,26 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void LoadImage(IImageSource source, IMauiContext mauiContext, Action<IImageSourceServiceResult<Drawable>> finished = null)
 		{
-			GetImageAsync(source, mauiContext)
-						.FireAndForget(e => Internals.Log.Warning(nameof(ShellImagePart), $"{e}"), finished);
+			LoadImageResult(GetImageAsync(source, mauiContext), finished)
+						.FireAndForget(e => Internals.Log.Warning(nameof(ImageSourceLoader), $"{e}"));
 		}
 
 		public static void LoadImage(IImageSourcePart part, IMauiContext mauiContext, Action<IImageSourceServiceResult<Drawable>> finished = null)
 		{
-			GetImageAsync(part.Source, mauiContext)
-						.FireAndForget(e => Internals.Log.Warning(nameof(ShellImagePart), $"{e}"), finished);
+			LoadImageResult(GetImageAsync(part.Source, mauiContext), finished)
+						.FireAndForget(e => Internals.Log.Warning(nameof(ImageSourceLoader), $"{e}"));
 		}
 
 		public void LoadImage(ImageView view, Action<IImageSourceServiceResult<Drawable>> finished = null)
 		{
-			LoadImageAsync(view)
-						.FireAndForget(e => Internals.Log.Warning(nameof(ShellImagePart), $"{e}"), finished);
+			LoadImageResult(LoadImageAsync(view), finished)
+						.FireAndForget(e => Internals.Log.Warning(nameof(ImageSourceLoader), $"{e}"));
+		}
+
+		static async Task LoadImageResult(Task<IImageSourceServiceResult<Drawable>> task, Action<IImageSourceServiceResult<Drawable>> finished = null)
+		{
+			var result = await task;
+			finished?.Invoke(result);
 		}
 
 		public Task<IImageSourceServiceResult<Drawable>> LoadImageAsync(ImageView view)
@@ -79,7 +85,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static Task<IImageSourceServiceResult<Drawable>> LoadImageAsync(ImageView imageView, IMauiContext mauiContext, IImageSource imageSource)
 		{
-			var part = new ShellImagePart()
+			var part = new ImageSourceLoader()
 			{
 				MauiContext = mauiContext,
 				Source = imageSource,

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellFlyoutTemplatedContentView.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellFlyoutTemplatedContentView.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls.Platform
 		int _actionBarHeight;
 		int _flyoutHeight;
 		int _flyoutWidth;
-		ShellImagePart _shellFlyoutBackgroundImagePart;
+		ImageSourceLoader _shellFlyoutBackgroundImagePart;
 
 		protected IMauiContext MauiContext => _shellContext.Shell.Handler.MauiContext;
 
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls.Platform
 		public ShellFlyoutTemplatedContentView(IShellContext shellContext)
 		{
 			_shellContext = shellContext;
-			_shellFlyoutBackgroundImagePart = new ShellImagePart();
+			_shellFlyoutBackgroundImagePart = new ImageSourceLoader();
 			LoadView(shellContext);
 		}
 

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellItemView.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellItemView.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Maui.Controls.Platform
 					var provider = services.GetRequiredService<IImageSourceServiceProvider>();
 					var icon = shellContent.Icon;
 
-					var imageLoad = new ShellImagePart() { Source = shellContent.Icon, MauiContext = MauiContext };
+					var imageLoad = new ImageSourceLoader() { Source = shellContent.Icon, MauiContext = MauiContext };
 
 					imageLoad.LoadImage(image,
 						(result) =>

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellSearchView.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellSearchView.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (bindable.GetValue(property) is ImageSource image)
 				AutomationPropertiesProvider.SetContentDescription(result, image, null, null);
 
-			new ShellImagePart()
+			new ImageSourceLoader()
 			{
 				Source = (ImageSource)bindable.GetValue(property),
 				MauiContext = MauiContext

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellToolbarTracker.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Maui.Controls.Platform
 				if (fid?.IconBitmapSource == image)
 					customIcon = fid.IconBitmap;
 				else
-					customIcon = (await ShellImagePart.GetImageAsync(image, MauiContext))?.Value;
+					customIcon = (await ImageSourceLoader.GetImageAsync(image, MauiContext))?.Value;
 
 				if (customIcon != null)
 				{
@@ -477,7 +477,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		protected virtual void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
 		{
-			ShellImagePart.LoadImage(toolBarItem.IconImageSource, MauiContext, finished =>
+			ImageSourceLoader.LoadImage(toolBarItem.IconImageSource, MauiContext, finished =>
 			{
 				var baseDrawable = finished.Value;
 				if (baseDrawable != null)

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -66,6 +66,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(3, button.changed);
 		}
 
+		[Test]
+		public void DisconnectCalledOnPreviousHandler()
+		{
+			LifeCycleButton button = new LifeCycleButton();
+
+			Assert.IsNull(button.Handler);
+			var firstHandler = new HandlerStub();
+			button.Handler = firstHandler;
+			var secondHandler = new HandlerStub();
+			button.Handler = secondHandler;
+
+			Assert.AreEqual(1, firstHandler.ConnectHandlerCount);
+			Assert.AreEqual(1, firstHandler.DisconnectHandlerCount);
+			Assert.AreEqual(1, secondHandler.ConnectHandlerCount);
+			Assert.AreEqual(0, secondHandler.DisconnectHandlerCount);
+		}
+
 		public class LifeCycleButton : Button
 		{
 			public int changing = 0;

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -66,23 +66,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(3, button.changed);
 		}
 
-		[Test]
-		public void DisconnectCalledOnPreviousHandler()
-		{
-			LifeCycleButton button = new LifeCycleButton();
-
-			Assert.IsNull(button.Handler);
-			var firstHandler = new HandlerStub();
-			button.Handler = firstHandler;
-			var secondHandler = new HandlerStub();
-			button.Handler = secondHandler;
-
-			Assert.AreEqual(1, firstHandler.ConnectHandlerCount);
-			Assert.AreEqual(1, firstHandler.DisconnectHandlerCount);
-			Assert.AreEqual(1, secondHandler.ConnectHandlerCount);
-			Assert.AreEqual(0, secondHandler.DisconnectHandlerCount);
-		}
-
 		public class LifeCycleButton : Button
 		{
 			public int changing = 0;

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -98,11 +98,11 @@ namespace Microsoft.Maui.Handlers
 
 		private protected abstract void OnDisconnectHandler(object nativeView);
 
-		void DisconnectHandle(object nativeView)
+		void DisconnectHandler(object nativeView)
 		{
 			OnDisconnectHandler(nativeView);
 
-			if (VirtualView != null)
+			if (VirtualView != null && VirtualView.Handler == this)
 				VirtualView.Handler = null;
 
 			VirtualView = null;
@@ -111,7 +111,14 @@ namespace Microsoft.Maui.Handlers
 		void IElementHandler.DisconnectHandler()
 		{
 			if (NativeView != null && VirtualView != null)
-				DisconnectHandle(NativeView);
+			{
+				// We set the NativeView to null so no one outside of this handler tries to access
+				// NativeView. NativeView access should be isolated to the instance passed into
+				// DisconnectHandler
+				var oldNativeView = NativeView;
+				NativeView = null;
+				DisconnectHandler(oldNativeView);
+			}
 		}
 	}
 }

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -101,7 +101,8 @@ namespace Microsoft.Maui.Handlers
 		void DisconnectHandler(object nativeView)
 		{
 			OnDisconnectHandler(nativeView);
-
+			
+			// VirtualView has already been changed over to a new handler
 			if (VirtualView != null && VirtualView.Handler == this)
 				VirtualView.Handler = null;
 

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -39,10 +39,11 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			var oldVirtualView = VirtualView;
-			if (oldVirtualView?.Handler != null)
-				oldVirtualView.Handler = null;
 
 			bool setupNativeView = oldVirtualView == null;
+
+			if (oldVirtualView?.Handler != null)
+				oldVirtualView.Handler = null;
 
 			VirtualView = view;
 			NativeView ??= CreateNativeElement();

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -39,11 +39,10 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			var oldVirtualView = VirtualView;
-
-			bool setupNativeView = oldVirtualView == null;
-
 			if (oldVirtualView?.Handler != null)
 				oldVirtualView.Handler = null;
+
+			bool setupNativeView = oldVirtualView == null;
 
 			VirtualView = view;
 			NativeView ??= CreateNativeElement();

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -59,9 +59,15 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
+
+		void Clear(LayoutViewGroup nativeView)
+		{
+			nativeView.RemoveAllViews();
+		}
+
 		public void Clear()
 		{
-			NativeView?.RemoveAllViews();
+			Clear(NativeView);
 		}
 
 		public void Insert(int index, IView child)
@@ -86,7 +92,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(LayoutViewGroup nativeView)
 		{
 			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
-			Clear();
+			Clear(nativeView);
 			base.DisconnectHandler(nativeView);
 		}
 	}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		public void Clear()
+		void Clear(UIView nativeView)
 		{
 			if (NativeView == null)
 			{
@@ -79,6 +79,11 @@ namespace Microsoft.Maui.Handlers
 			{
 				subView.RemoveFromSuperview();
 			}
+		}
+
+		public void Clear()
+		{
+			Clear(NativeView);
 		}
 
 		public void Insert(int index, IView child)
@@ -103,7 +108,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(LayoutView nativeView)
 		{
 			base.DisconnectHandler(nativeView);
-			Clear();
+			Clear(nativeView);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -69,12 +69,12 @@ namespace Microsoft.Maui.Handlers
 
 		void Clear(UIView nativeView)
 		{
-			if (NativeView == null)
+			if (nativeView == null)
 			{
 				return;
 			}
 
-			var subViews = NativeView.Subviews;
+			var subViews = nativeView.Subviews;
 
 			foreach (var subView in subViews)
 			{

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -1,5 +1,6 @@
 using System;
 using NativeView = UIKit.UIView;
+using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {

--- a/src/Core/src/Handlers/Page/PageHandler.Android.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Android.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(PageViewGroup nativeView)
 		{
 			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
-			NativeView?.RemoveAllViews();
+			nativeView.RemoveAllViews();
 			base.DisconnectHandler(nativeView);
 		}
 	}

--- a/src/Core/src/TaskExtensions.cs
+++ b/src/Core/src/TaskExtensions.cs
@@ -10,9 +10,7 @@ namespace Microsoft.Maui
 	{
 		public static async void FireAndForget<TResult>(
 			   this Task<TResult> task,
-			   Action<Exception>? errorCallback = null,
-			   Action<TResult?>? finishedCallBack = null
-			   )
+			   Action<Exception>? errorCallback = null)
 		{
 			TResult? result = default;
 			try
@@ -22,21 +20,15 @@ namespace Microsoft.Maui
 			catch (Exception exc)
 			{
 				errorCallback?.Invoke(exc);
-			}
-			finally
-			{
-				try
-				{
-					finishedCallBack?.Invoke(result);
-				}
-				catch (Exception fe) { errorCallback?.Invoke(fe); }
+#if DEBUG
+				throw;
+#endif
 			}
 		}
 
 		public static async void FireAndForget(
 			this Task task,
-			Action<Exception>? errorCallback = null,
-			Action? finishedCallBack = null
+			Action<Exception>? errorCallback = null
 			)
 		{
 			try
@@ -46,14 +38,9 @@ namespace Microsoft.Maui
 			catch (Exception ex)
 			{
 				errorCallback?.Invoke(ex);
-			}
-			finally
-			{
-				try
-				{
-					finishedCallBack?.Invoke();
-				}
-				catch (Exception fe) { errorCallback?.Invoke(fe); }
+#if DEBUG
+				throw;
+#endif
 			}
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
@@ -6,9 +6,14 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 {
 	public partial class LayoutHandlerTests
 	{
-		double GetNativeChildCount(LayoutHandler layoutHandler)
+		double GetNativeChildCount(IElementHandler layoutHandler)
 		{
-			return ((layoutHandler as IElementHandler).NativeView as LayoutViewGroup).ChildCount;
+			return GetNativeChildCount(layoutHandler.NativeView as LayoutViewGroup);
+		}
+
+		double GetNativeChildCount(object nativeView)
+		{
+			return (nativeView as LayoutViewGroup).ChildCount;
 		}
 
 		IReadOnlyList<AView> GetNativeChildren(LayoutHandler layoutHandler)

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 	{
 		double GetNativeChildCount(LayoutHandler layoutHandler)
 		{
-			return layoutHandler.NativeView.ChildCount;
+			return ((layoutHandler as IElementHandler).NativeView as LayoutViewGroup).ChildCount;
 		}
 
 		IReadOnlyList<AView> GetNativeChildren(LayoutHandler layoutHandler)

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -64,8 +64,9 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			var count = await InvokeOnMainThreadAsync(() =>
 			{
+				var nativeView = layout.Handler.NativeView;
 				layout.Handler.DisconnectHandler();
-				return GetNativeChildCount(handler);
+				return GetNativeChildCount(nativeView);
 			});
 
 			Assert.Equal(0, count);

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 	{
 		double GetNativeChildCount(LayoutHandler layoutHandler)
 		{
-			return layoutHandler.NativeView.Subviews.Length;
+			return ((layoutHandler as IElementHandler).NativeView as UIView).Subviews.Length;
 		}
 
 		IReadOnlyList<UIView> GetNativeChildren(LayoutHandler layoutHandler)

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
@@ -8,7 +8,12 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 	{
 		double GetNativeChildCount(LayoutHandler layoutHandler)
 		{
-			return ((layoutHandler as IElementHandler).NativeView as UIView).Subviews.Length;
+			return GetNativeChildCount((layoutHandler as IElementHandler).NativeView as UIView);
+		}
+
+		double GetNativeChildCount(object nativeView)
+		{
+			return (nativeView as UIView).Subviews.Length;
 		}
 
 		IReadOnlyList<UIView> GetNativeChildren(LayoutHandler layoutHandler)


### PR DESCRIPTION
### Description of Change ###

This PR fixes a smattering of issues related to navigation on android

- NavigationPage currently uses shimmed renderers so we need to call disconnect on it after it's been removed so that the underlying IVER disposes and doesn't overlap the newly set Renderer
- Fixes some issues related to FireAndForget where the continuation was firing on a task pool thread and causing everything to crash
- Fixed up some cake scripts so it's easier to build with global workloads
- I tried to setup a generalized place to call disconnect but the current call ordering makes that very difficult for scenarios where you want to swap out a virtual view on a handler and you don't want to call disconnect on that handler. We probably need to rework the handler/virtualview dance a bit so things can happen all in one place better. 