### PR TITLE
Fix some Layout update bugs

### DIFF
--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Maui.Controls
 				VisualDiagnostics.OnChildAdded(this, element);
 			}
 
-			AddToHandler(index, child);
+			InsertIntoHandler(index, child);
 		}
 
 		public virtual bool Remove(IView child)

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -96,15 +96,16 @@ namespace Microsoft.Maui.Controls
 			if (child == null)
 				return;
 
+			var index = _children.Count;
 			_children.Add(child);
 
 			if (child is Element element)
 			{
 				element.Parent = this;
-				VisualDiagnostics.OnChildAdded(this, element, _children.Count - 1);
+				VisualDiagnostics.OnChildAdded(this, element, index);
 			}
 
-			AddToHandler(_children.Count, child);
+			AddToHandler(index, child);
 		}
 
 		public void Clear()

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Controls
 			if (child is Element element)
 			{
 				element.Parent = this;
-				VisualDiagnostics.OnChildAdded(this, element);
+				VisualDiagnostics.OnChildAdded(this, element, _children.Count - 1);
 			}
 
 			AddToHandler(_children.Count, child);
@@ -109,10 +109,13 @@ namespace Microsoft.Maui.Controls
 
 		public void Clear()
 		{
-			foreach (var child in this)
+			for (var index = Count - 1; index >= 0; index--)
 			{
-				if (child is Element element)
+				if (this[index] is Element element)
+				{
 					element.Parent = null;
+					VisualDiagnostics.OnChildRemoved(this, element, index);
+				}
 			}
 
 			_children.Clear();

--- a/src/Controls/src/Core/Xaml/Diagnostics/VisualDiagnostics.cs
+++ b/src/Controls/src/Core/Xaml/Diagnostics/VisualDiagnostics.cs
@@ -4,11 +4,10 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 {
-	public class VisualDiagnostics
+	public static class VisualDiagnostics
 	{
 		static ConditionalWeakTable<object, XamlSourceInfo> sourceInfos = new ConditionalWeakTable<object, XamlSourceInfo>();
 
@@ -19,7 +18,11 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 				sourceInfos.Add(target, new XamlSourceInfo(uri, lineNumber, linePosition));
 		}
 
-		internal static void OnChildAdded(Element parent, Element child)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static XamlSourceInfo GetXamlSourceInfo(object obj) =>
+			sourceInfos.TryGetValue(obj, out var sourceinfo) ? sourceinfo : null;
+
+		public static void OnChildAdded(Element parent, Element child)
 		{
 			if (!DebuggerHelper.DebuggerIsAttached)
 				return;
@@ -28,19 +31,35 @@ namespace Microsoft.Maui.Controls.Xaml.Diagnostics
 				return;
 
 			var index = (parent as IVisualTreeElement)?.GetVisualChildren().IndexOf(child) ?? -1;
-			VisualTreeChanged?.Invoke(parent, new VisualTreeChangeEventArgs(parent, child, index, VisualTreeChangeType.Add));
+
+			OnChildAdded(parent, child, index);
 		}
 
-		internal static void OnChildRemoved(Element parent, Element child, int oldLogicalIndex)
+		public static void OnChildAdded(Element parent, Element child, int newLogicalIndex)
 		{
 			if (!DebuggerHelper.DebuggerIsAttached)
 				return;
 
-			VisualTreeChanged?.Invoke(parent, new VisualTreeChangeEventArgs(parent, child, oldLogicalIndex, VisualTreeChangeType.Remove));
+			if (child is null)
+				return;
+
+			OnVisualTreeChanged(new VisualTreeChangeEventArgs(parent, child, newLogicalIndex, VisualTreeChangeType.Add));
+		}
+
+		public static void OnChildRemoved(Element parent, Element child, int oldLogicalIndex)
+		{
+			if (!DebuggerHelper.DebuggerIsAttached)
+				return;
+
+			OnVisualTreeChanged(new VisualTreeChangeEventArgs(parent, child, oldLogicalIndex, VisualTreeChangeType.Remove));
 		}
 
 		public static event EventHandler<VisualTreeChangeEventArgs> VisualTreeChanged;
-		public static XamlSourceInfo GetXamlSourceInfo(object obj) => sourceInfos.TryGetValue(obj, out var sourceinfo) ? sourceinfo : null;
+
+		static void OnVisualTreeChanged(VisualTreeChangeEventArgs e)
+		{
+			VisualTreeChanged?.Invoke(e.Parent, e);
+		}
 	}
 
 	public enum VisualTreeChangeType

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutTests.cs
@@ -1,4 +1,8 @@
-﻿using NUnit.Framework;
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Handlers;
+using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 {
@@ -45,6 +49,117 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 
 			Assert.Null(child0.Parent);
 			Assert.Null(child1.Parent);
+		}
+
+		[TestCase(typeof(VerticalStackLayout))]
+		[TestCase(typeof(HorizontalStackLayout))]
+		[TestCase(typeof(Grid))]
+		[TestCase(typeof(StackLayout))]
+		public void AddCallsCorrectHandlerMethod(Type TLayout)
+		{
+			var events = new List<(string Name, LayoutHandlerUpdate? Args)>();
+
+			var layout = CreateLayout(TLayout);
+			layout.Handler = CreateLayoutHandler((n, h, l, a) => events.Add((n, a)));
+
+			events.Clear();
+
+			var child0 = new Button();
+
+			layout.Add(child0);
+
+			Assert.AreEqual(1, events.Count);
+			var (name, args) = events[0];
+			Assert.AreEqual(nameof(ILayoutHandler.Add), name);
+			Assert.AreEqual(0, args!.Index);
+			Assert.AreEqual(child0, args!.View);
+		}
+
+		[TestCase(typeof(VerticalStackLayout))]
+		[TestCase(typeof(HorizontalStackLayout))]
+		[TestCase(typeof(Grid))]
+		[TestCase(typeof(StackLayout))]
+		public void RemoveCallsCorrectHandlerMethod(Type TLayout)
+		{
+			var events = new List<(string Name, LayoutHandlerUpdate? Args)>();
+
+			var layout = CreateLayout(TLayout);
+			layout.Handler = CreateLayoutHandler((n, h, l, a) => events.Add((n, a)));
+
+			var child0 = new Button();
+			layout.Add(child0);
+
+			events.Clear();
+
+			layout.Remove(child0);
+
+			Assert.AreEqual(1, events.Count);
+			var (name, args) = events[0];
+			Assert.AreEqual(nameof(ILayoutHandler.Remove), name);
+			Assert.AreEqual(0, args!.Index);
+			Assert.AreEqual(child0, args!.View);
+		}
+
+		[TestCase(typeof(VerticalStackLayout))]
+		[TestCase(typeof(HorizontalStackLayout))]
+		[TestCase(typeof(Grid))]
+		[TestCase(typeof(StackLayout))]
+		public void InsertCallsCorrectHandlerMethod(Type TLayout)
+		{
+			var events = new List<(string Name, LayoutHandlerUpdate? Args)>();
+
+			var layout = CreateLayout(TLayout);
+			layout.Handler = CreateLayoutHandler((n, h, l, a) => events.Add((n, a)));
+
+			var child0 = new Button();
+			var child1 = new Button();
+			var child2 = new Button();
+
+			layout.Add(child0);
+			layout.Add(child2);
+
+			events.Clear();
+
+			layout.Insert(1, child1);
+
+			Assert.AreEqual(1, events.Count);
+			var (name, args) = events[0];
+			Assert.AreEqual(nameof(ILayoutHandler.Insert), name);
+			Assert.AreEqual(1, args!.Index);
+			Assert.AreEqual(child1, args!.View);
+		}
+
+		Layout CreateLayout(Type TLayout)
+		{
+			var layout = (Layout)Activator.CreateInstance(TLayout)!;
+			layout.IsPlatformEnabled = true;
+			return layout;
+		}
+
+		LayoutHandler CreateLayoutHandler(Action<string, ILayoutHandler, Maui.ILayout, LayoutHandlerUpdate?>? action)
+		{
+			var handler = new NonThrowingLayoutHandler(
+				LayoutHandler.LayoutMapper,
+				new CommandMapper<Maui.ILayout, ILayoutHandler>(LayoutHandler.LayoutCommandMapper)
+				{
+					[nameof(ILayoutHandler.Add)] = (h, l, a) => action?.Invoke(nameof(ILayoutHandler.Add), h, l, (LayoutHandlerUpdate?)a),
+					[nameof(ILayoutHandler.Remove)] = (h, l, a) => action?.Invoke(nameof(ILayoutHandler.Remove), h, l, (LayoutHandlerUpdate?)a),
+					[nameof(ILayoutHandler.Clear)] = (h, l, a) => action?.Invoke(nameof(ILayoutHandler.Clear), h, l, (LayoutHandlerUpdate?)a),
+					[nameof(ILayoutHandler.Insert)] = (h, l, a) => action?.Invoke(nameof(ILayoutHandler.Insert), h, l, (LayoutHandlerUpdate?)a),
+					[nameof(ILayoutHandler.Update)] = (h, l, a) => action?.Invoke(nameof(ILayoutHandler.Update), h, l, (LayoutHandlerUpdate?)a),
+				});
+
+			return handler;
+		}
+
+		class NonThrowingLayoutHandler : LayoutHandler
+		{
+			public NonThrowingLayoutHandler(PropertyMapper? mapper = null, CommandMapper? commandMapper = null)
+				: base(mapper, commandMapper)
+			{
+			}
+
+			protected override object CreateNativeView() => new object();
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualTreeHelperTests.cs
@@ -1,31 +1,50 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Xaml.Diagnostics;
-using Microsoft.Maui.Graphics;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	[TestFixture]
-	public class VisualTreeHelperTests : BaseTestFixture
+	public class VisualTreeHelperTests : BaseTestFixture, IDisposable
 	{
+		readonly List<(Element? Parent, VisualTreeChangeEventArgs Args)> _treeEvents = new();
+
+		public VisualTreeHelperTests()
+		{
+			VisualDiagnostics.VisualTreeChanged += OnVisualTreeChanged;
+		}
+
+		public void Dispose()
+		{
+			VisualDiagnostics.VisualTreeChanged -= OnVisualTreeChanged;
+		}
+
+		public Action<Element?, VisualTreeChangeEventArgs>? VisualTreeChanged { get; set; }
+
+		void OnVisualTreeChanged(object? sender, VisualTreeChangeEventArgs e)
+		{
+			_treeEvents.Add((sender as Element, e));
+			VisualTreeChanged?.Invoke(sender as Element, e);
+		}
+
 		[TestCase(typeof(VerticalStackLayout))]
 		[TestCase(typeof(HorizontalStackLayout))]
 		[TestCase(typeof(Grid))]
 		[TestCase(typeof(StackLayout))]
 		public void LayoutChildren(Type TLayout)
 		{
-			var layout = (Layout)Activator.CreateInstance(TLayout);
-			layout.IsPlatformEnabled = true;
+			var layout = CreateLayout(TLayout)!;
+
 			var label = new Label();
 			var button = new Button();
 			layout.Children.Add(label);
 			layout.Children.Add(button);
+
 			var visualChildren = (layout as IVisualTreeElement).GetVisualChildren();
+
 			Assert.AreEqual(layout.Children.Count, visualChildren.Count);
 			Assert.AreEqual(label, visualChildren[0]);
 			Assert.AreEqual(button, visualChildren[1]);
@@ -34,13 +53,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public async Task ModalChildren()
 		{
-			var app = new Application();
-			var iapp = app as IApplication;
-			var page = new ContentPage();
-			app.MainPage = page;
-			var window = (Window)iapp.CreateWindow(null);
+			CreateNewApp(out _, out var window, out var page);
+
 			var modalPage = new ContentPage();
+
 			await window.Navigation.PushModalAsync(modalPage);
+
 			var windowChildren = (window as IVisualTreeElement).GetVisualChildren();
 			var modalParent = (modalPage as IVisualTreeElement).GetVisualParent();
 
@@ -56,62 +74,268 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			if (!DebuggerHelper.DebuggerIsAttached)
 				return;
 
-			var app = new Application();
-			var iapp = app as IApplication;
-			var page = new ContentPage();
-			app.MainPage = page;
-			var window = (Window)iapp.CreateWindow(null);
+			CreateNewApp(out _, out var window, out _);
+
 			var modalPage = new ContentPage();
-			VisualDiagnostics.VisualTreeChanged += OnVisualTreeChanged;
-			VisualTreeChangeEventArgs lastArgs = null;
 
 			await window.Navigation.PushModalAsync(modalPage);
-			Assert.AreEqual(window, lastArgs.Parent);
-			Assert.AreEqual(modalPage, lastArgs.Child);
-			Assert.AreEqual(1, lastArgs.ChildIndex);
-			lastArgs = null;
+
+			Assert.AreEqual(1, _treeEvents.Count);
+			var (parent, args) = _treeEvents[0];
+
+			Assert.AreEqual(window, parent);
+			Assert.AreEqual(window, args.Parent);
+			Assert.AreEqual(modalPage, args.Child);
+			Assert.AreEqual(1, args.ChildIndex);
+			Assert.AreEqual(VisualTreeChangeType.Add, args.ChangeType);
+
+			_treeEvents.Clear();
 
 			await window.Navigation.PopModalAsync();
-			Assert.AreEqual(window, lastArgs.Parent);
-			Assert.AreEqual(modalPage, lastArgs.Child);
-			Assert.AreEqual(1, lastArgs.ChildIndex);
 
-			void OnVisualTreeChanged(object s, VisualTreeChangeEventArgs e)
-			{
-				lastArgs = e;
-			}
+			Assert.AreEqual(1, _treeEvents.Count);
+			(parent, args) = _treeEvents[0];
+
+			Assert.AreEqual(window, parent);
+			Assert.AreEqual(window, args.Parent);
+			Assert.AreEqual(modalPage, args.Child);
+			Assert.AreEqual(1, args.ChildIndex);
+			Assert.AreEqual(VisualTreeChangeType.Remove, args.ChangeType);
 		}
 
 		[Test]
 		public void ApplicationChildren()
 		{
-			var app = new Application();
-			var iapp = app as IApplication;
-			var page = new ContentPage();
+			CreateNewApp(out var app, out var window, out var page);
 
-			app.MainPage = page;
+			var appChildren = ((IVisualTreeElement)app).GetVisualChildren();
+			var windowChildren = ((IVisualTreeElement)window).GetVisualChildren();
+			var pageChildren = ((IVisualTreeElement)page).GetVisualChildren();
 
-			var window = iapp.CreateWindow(null);
-
-			var appChildren = (app as IVisualTreeElement).GetVisualChildren();
-			var windowChildren = (window as IVisualTreeElement).GetVisualChildren();
-			Assert.Greater(appChildren.Count, 0);
-			Assert.IsTrue(appChildren[0] is IWindow);
-			Assert.AreEqual(windowChildren.Count, 1);
+			Assert.AreEqual(1, appChildren.Count);
+			Assert.AreEqual(window, appChildren[0]);
+			Assert.AreEqual(1, windowChildren.Count);
+			Assert.AreEqual(page, windowChildren[0]);
+			Assert.AreEqual(0, pageChildren.Count);
 		}
 
 		[Test]
 		public void VisualElementParent()
 		{
-			var app = new Application();
-			var iapp = app as IApplication;
-			var page = new ContentPage();
-			app.MainPage = page;
-			var window = iapp.CreateWindow(null);
-			var appParent = (app as IVisualTreeElement).GetVisualParent();
-			var windowParent = (window as IVisualTreeElement).GetVisualParent();
+			CreateNewApp(out var app, out var window, out var page);
+
+			var appParent = ((IVisualTreeElement)app).GetVisualParent();
+			var windowParent = ((IVisualTreeElement)window).GetVisualParent();
+			var pageParent = ((IVisualTreeElement)page).GetVisualParent();
+
 			Assert.IsNull(appParent);
-			Assert.IsNotNull(windowParent);
+			Assert.AreEqual(app, windowParent);
+			Assert.AreEqual(window, pageParent);
+		}
+
+		[Test]
+		public async Task AddPageContentFiresVisualTreeChanged()
+		{
+			if (!DebuggerHelper.DebuggerIsAttached)
+				return;
+
+			CreateNewApp(out _, out _, out var page);
+			var button = new Button();
+
+			page.Content = button;
+
+			Assert.AreEqual(1, _treeEvents.Count);
+
+			var (parent, args) = _treeEvents[0];
+			Assert.AreEqual(page, parent);
+			Assert.AreEqual(page, args.Parent);
+			Assert.AreEqual(button, args.Child);
+			Assert.AreEqual(0, args.ChildIndex);
+			Assert.AreEqual(VisualTreeChangeType.Add, args.ChangeType);
+		}
+
+		[Test]
+		public async Task RemovePageContentFiresVisualTreeChanged()
+		{
+			if (!DebuggerHelper.DebuggerIsAttached)
+				return;
+
+			CreateNewApp(out _, out _, out var page);
+			var button = new Button();
+			page.Content = button;
+			_treeEvents.Clear();
+
+			page.Content = null;
+
+			Assert.AreEqual(1, _treeEvents.Count);
+
+			var (parent, args) = _treeEvents[0];
+			Assert.AreEqual(page, parent);
+			Assert.AreEqual(page, args.Parent);
+			Assert.AreEqual(button, args.Child);
+			Assert.AreEqual(0, args.ChildIndex);
+			Assert.AreEqual(VisualTreeChangeType.Remove, args.ChangeType);
+		}
+
+		[TestCase(typeof(VerticalStackLayout))]
+		[TestCase(typeof(HorizontalStackLayout))]
+		[TestCase(typeof(Grid))]
+		[TestCase(typeof(StackLayout))]
+		public void AddLayoutChildFiresVisualTreeChanged(Type TLayout)
+		{
+			if (!DebuggerHelper.DebuggerIsAttached)
+				return;
+
+			CreateNewApp(out _, out _, out var page);
+
+			var layout = CreateLayout(TLayout)!;
+			page.Content = layout;
+			_treeEvents.Clear();
+
+			var button1 = new Button();
+			var button2 = new Button();
+			var button3 = new Button();
+			var buttons = new[] { button1, button2, button3 };
+
+			for (var i = 0; i < buttons.Length; i++)
+			{
+				var button = buttons[i];
+				layout.Add(button);
+
+				Assert.AreEqual(i + 1, _treeEvents.Count);
+
+				var (parent, args) = _treeEvents[i];
+				Assert.AreEqual(layout, parent);
+				Assert.AreEqual(layout, args.Parent);
+				Assert.AreEqual(button, args.Child);
+				Assert.AreEqual(i, args.ChildIndex);
+				Assert.AreEqual(VisualTreeChangeType.Add, args.ChangeType);
+			}
+		}
+
+		[TestCase(typeof(VerticalStackLayout))]
+		[TestCase(typeof(HorizontalStackLayout))]
+		[TestCase(typeof(Grid))]
+		[TestCase(typeof(StackLayout))]
+		public void InsertLayoutChildFiresVisualTreeChanged(Type TLayout)
+		{
+			if (!DebuggerHelper.DebuggerIsAttached)
+				return;
+
+			CreateNewApp(out _, out _, out var page);
+
+			var layout = CreateLayout(TLayout)!;
+			page.Content = layout;
+			layout.Add(new Button());
+			layout.Add(new Button());
+			layout.Add(new Button());
+			_treeEvents.Clear();
+
+			var button = new Button();
+			layout.Insert(2, button);
+
+			Assert.AreEqual(1, _treeEvents.Count);
+
+			var (parent, args) = _treeEvents[0];
+			Assert.AreEqual(layout, parent);
+			Assert.AreEqual(layout, args.Parent);
+			Assert.AreEqual(button, args.Child);
+			Assert.AreEqual(2, args.ChildIndex);
+			Assert.AreEqual(VisualTreeChangeType.Add, args.ChangeType);
+		}
+
+		[TestCase(typeof(VerticalStackLayout))]
+		[TestCase(typeof(HorizontalStackLayout))]
+		[TestCase(typeof(Grid))]
+		[TestCase(typeof(StackLayout))]
+		public void RemoveLayoutChildFiresVisualTreeChanged(Type TLayout)
+		{
+			if (!DebuggerHelper.DebuggerIsAttached)
+				return;
+
+			CreateNewApp(out _, out _, out var page);
+
+			var layout = CreateLayout(TLayout)!;
+			page.Content = layout;
+
+			var button = new Button();
+			layout.Add(button);
+			_treeEvents.Clear();
+
+			layout.Remove(button);
+
+			Assert.AreEqual(1, _treeEvents.Count);
+
+			var (parent, args) = _treeEvents[0];
+			Assert.AreEqual(layout, parent);
+			Assert.AreEqual(layout, args.Parent);
+			Assert.AreEqual(button, args.Child);
+			Assert.AreEqual(0, args.ChildIndex);
+			Assert.AreEqual(VisualTreeChangeType.Remove, args.ChangeType);
+		}
+
+		[TestCase(typeof(VerticalStackLayout))]
+		[TestCase(typeof(HorizontalStackLayout))]
+		[TestCase(typeof(Grid))]
+		[TestCase(typeof(StackLayout))]
+		public void ClearLayoutChildrenFiresVisualTreeChanged(Type TLayout)
+		{
+			if (!DebuggerHelper.DebuggerIsAttached)
+				return;
+
+			CreateNewApp(out _, out _, out var page);
+
+			var layout = CreateLayout(TLayout);
+			page.Content = layout;
+
+			var button1 = new Button();
+			var button2 = new Button();
+			var button3 = new Button();
+			var buttons = new[] { button1, button2, button3 };
+
+			layout.Add(button1);
+			layout.Add(button2);
+			layout.Add(button3);
+			_treeEvents.Clear();
+
+			layout.Clear();
+
+			Assert.AreEqual(3, _treeEvents.Count);
+
+			for (var i = _treeEvents.Count - 1; i >= 0; i--)
+			{
+				var (parent, args) = _treeEvents[_treeEvents.Count - 1 - i];
+
+				Assert.AreEqual(layout, parent);
+				Assert.AreEqual(layout, args.Parent);
+				Assert.AreEqual(buttons[i], args.Child);
+				Assert.AreEqual(i, args.ChildIndex);
+				Assert.AreEqual(VisualTreeChangeType.Remove, args.ChangeType);
+			}
+		}
+
+		Layout CreateLayout(Type TLayout)
+		{
+			var layout = (Layout)Activator.CreateInstance(TLayout)!;
+			layout.IsPlatformEnabled = true;
+
+			return layout;
+		}
+
+		void CreateNewApp(out Application app, out Window window, out ContentPage page)
+		{
+			page = new ContentPage();
+
+			app = new Application
+			{
+				MainPage = page
+			};
+
+			var iapp = app as IApplication;
+
+			window = (Window)iapp.CreateWindow(null!);
+
+			_treeEvents.Clear();
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Microsoft.Maui.Handlers;
+using AView = Android.Views.View;
 
 namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 {
@@ -6,7 +8,19 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 	{
 		double GetNativeChildCount(LayoutHandler layoutHandler)
 		{
-			return (layoutHandler.NativeView as LayoutViewGroup).ChildCount;
+			return layoutHandler.NativeView.ChildCount;
+		}
+
+		IReadOnlyList<AView> GetNativeChildren(LayoutHandler layoutHandler)
+		{
+			var views = new List<AView>();
+
+			for (int i = 0; i < layoutHandler.NativeView.ChildCount; i++)
+			{
+				views.Add(layoutHandler.NativeView.GetChildAt(i));
+			}
+
+			return views;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -36,6 +36,14 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			var handler = await CreateHandlerAsync(layout);
 
+			var children = await InvokeOnMainThreadAsync(() =>
+			{
+				return GetNativeChildren(handler);
+			});
+
+			Assert.Equal(1, children.Count);
+			Assert.Equal(slider.Handler.NativeView, children[0]);
+
 			var count = await InvokeOnMainThreadAsync(() =>
 			{
 				handler.Remove(slider);
@@ -69,20 +77,22 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			var layout = new LayoutStub();
 			var slider = new SliderStub();
 			var button = new ButtonStub();
-			
+
 			layout.Add(slider);
 			layout.Add(button);
 
 			var handler = await CreateHandlerAsync(layout);
 
-			var count = await InvokeOnMainThreadAsync(() =>
+			var children = await InvokeOnMainThreadAsync(() =>
 			{
-				return GetNativeChildCount(handler);
+				return GetNativeChildren(handler);
 			});
 
-			Assert.Equal(2, count);
+			Assert.Equal(2, children.Count);
+			Assert.Equal(slider.Handler.NativeView, children[0]);
+			Assert.Equal(button.Handler.NativeView, children[1]);
 
-			count = await InvokeOnMainThreadAsync(() =>
+			var count = await InvokeOnMainThreadAsync(() =>
 			{
 				handler.Clear();
 				return GetNativeChildCount(handler);
@@ -99,23 +109,26 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			var button = new ButtonStub();
 
 			layout.Add(slider);
-			
+
 			var handler = await CreateHandlerAsync(layout);
 
-			var count = await InvokeOnMainThreadAsync(() =>
+			var children = await InvokeOnMainThreadAsync(() =>
 			{
-				return GetNativeChildCount(handler);
+				return GetNativeChildren(handler);
 			});
 
-			Assert.Equal(1, count);
+			Assert.Equal(1, children.Count);
+			Assert.Equal(slider.Handler.NativeView, children[0]);
 
-			count = await InvokeOnMainThreadAsync(() =>
+			children = await InvokeOnMainThreadAsync(() =>
 			{
 				handler.Insert(0, button);
-				return GetNativeChildCount(handler);
+				return GetNativeChildren(handler);
 			});
 
-			Assert.Equal(2, count);
+			Assert.Equal(2, children.Count);
+			Assert.Equal(button.Handler.NativeView, children[0]);
+			Assert.Equal(slider.Handler.NativeView, children[1]);
 		}
 
 		[Fact]
@@ -129,20 +142,22 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			var handler = await CreateHandlerAsync(layout);
 
-			var count = await InvokeOnMainThreadAsync(() =>
+			var children = await InvokeOnMainThreadAsync(() =>
 			{
-				return GetNativeChildCount(handler);
+				return GetNativeChildren(handler);
 			});
 
-			Assert.Equal(1, count);
+			Assert.Equal(1, children.Count);
+			Assert.Equal(slider.Handler.NativeView, children[0]);
 
-			count = await InvokeOnMainThreadAsync(() =>
+			children = await InvokeOnMainThreadAsync(() =>
 			{
 				handler.Update(0, button);
-				return GetNativeChildCount(handler);
+				return GetNativeChildren(handler);
 			});
 
-			Assert.Equal(1, count);
+			Assert.Equal(1, children.Count);
+			Assert.Equal(button.Handler.NativeView, children[0]);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.Maui.Handlers;
 using UIKit;
 
@@ -7,7 +8,12 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 	{
 		double GetNativeChildCount(LayoutHandler layoutHandler)
 		{
-			return (layoutHandler.NativeView as UIView).Subviews.Length;
+			return layoutHandler.NativeView.Subviews.Length;
+		}
+
+		IReadOnlyList<UIView> GetNativeChildren(LayoutHandler layoutHandler)
+		{
+			return layoutHandler.NativeView.Subviews;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This PR ensures that clearing a layout using `Clear()` calls `VisualDiagnostics.OnChildRemoved` for each item. It also make sure to use the Insert operation when inserting views.

 - Fixes #2196
 - Fixes #2198

### Additions made ###

More tests.

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
