### PR TITLE
Convert Controls ScrollTo element request to position request before sending to handler

### DIFF
--- a/src/Controls/src/Core/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView.cs
@@ -363,7 +363,19 @@ namespace Microsoft.Maui.Controls
 			CheckTaskCompletionSource();
 			ScrollToRequested?.Invoke(this, e);
 
-			Handler?.Invoke(nameof(IScrollView.RequestScrollTo), e.ToRequest());
+			Handler?.Invoke(nameof(IScrollView.RequestScrollTo), ConvertRequestMode(e).ToRequest());
+		}
+
+		ScrollToRequestedEventArgs ConvertRequestMode(ScrollToRequestedEventArgs args) 
+		{
+			if (args.Mode == ScrollToMode.Element && args.Element is VisualElement visualElement)
+			{
+				var point = GetScrollPositionForElement(visualElement, args.Position);
+				var result = new ScrollToRequestedEventArgs(point.X, point.Y, args.ShouldAnimate);
+				return result;
+			}
+
+			return args;
 		}
 	}
 }


### PR DESCRIPTION
Controls ScrollTo Element requests were being converted to Core ScrollToRequests without first converting them to Position requests. This change forces that conversion before sending them to the handler.

Fixes #2214

