### PR TITLE
Force null text string to empty when updating HTML text

### DIFF
--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui
 
 		public static void UpdateTextHtml(this TextView textView, ILabel label)
 		{
-			var newText = label.Text;
+			var newText = label.Text ?? string.Empty;
 
 			if (NativeVersion.IsAtLeast(24))
 				textView.SetText(Html.FromHtml(newText, FromHtmlOptions.ModeCompact), BufferType.Spannable);


### PR DESCRIPTION
The Android.Text.FromHtml() method doesn't like null text values; this change forces null text values to String.Empty when updating the HTML text for a Controls Label. 

Fixes #2199
