### PR TITLE
Add exception handling for GatherXmlnsDefinitionAttributes Assembly Loading

### DIFF
--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -352,11 +352,22 @@ namespace Microsoft.Maui.Controls.Xaml
 			s_xmlnsDefinitions = new List<XmlnsDefinitionAttribute>();
 
 			foreach (var assembly in assemblies)
-				foreach (XmlnsDefinitionAttribute attribute in assembly.GetCustomAttributes(typeof(XmlnsDefinitionAttribute)))
+			{
+				try
 				{
-					s_xmlnsDefinitions.Add(attribute);
-					attribute.AssemblyName = attribute.AssemblyName ?? assembly.FullName;
+					foreach (XmlnsDefinitionAttribute attribute in assembly.GetCustomAttributes(typeof(XmlnsDefinitionAttribute)))
+					{
+						s_xmlnsDefinitions.Add(attribute);
+						attribute.AssemblyName = attribute.AssemblyName ?? assembly.FullName;
+					}
 				}
+				catch (Exception ex)
+				{
+					// If we can't load the custom attribute for whatever reason from the assembly,
+					// We can ignore it and keep going.
+					System.Diagnostics.Debug.WriteLine($"Failed to parse Assembly Attribute: {ex.ToString()}");
+				}
+			}
 		}
 
 		public static Type GetElementType(XmlType xmlType, IXmlLineInfo xmlInfo, Assembly currentAssembly,


### PR DESCRIPTION
When calling XamlParser.GatherXmlnsDefinitionAttributes, we call the current app domain for all the current assemblies, then iterate over them to get a custom attribute of `XmlnsDefinitionAttribute`. There could be times, however, when checking for that attribute that it fails to load the assembly for whatever. That assembly could be fine in other contexts, but not when loaded here.

This was first spotted during the injection of XAML Hot Reload assemblies. There was a bug where we were injecting too many assemblies, some of which were already loaded as part of the app and not needed to be reloaded again. Depending on when the app loaded, if our assemblies were already injected or not, this code could be called and throw an exception when it was trying to load one of these assemblies.

That bug should be fixed, but if that assembly _was_ used elsewhere, it would have been valid in other contexts and still would have been thrown here. If we catch the exception and continue, we should still be able to continue running the app fine.
