### PR TITLE
Only run all device tests on DevDiv

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -52,7 +52,7 @@ stages:
 
   - template: common/device-tests.yml
     parameters:
-      ${{ if or(parameters.BuildEverything, ne(variables['Build.Reason'], 'PullRequest')) }}:
+      ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off
         iosVersions: [ 'latest', '14.5', '13.7', '12.4', '11.4' ]


### PR DESCRIPTION
### Description of Change ###

Public has seriously limited bots, and not necessary to build everything twice.