### PR TITLE
[build] fix local 'dotnet cake' builds

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,6 @@
 <Project>
 
+  <Import Condition="'$(SampleProject)' == 'true' or '$(CI)' != 'true' " Project="eng\Versions.dev.targets" />
   <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true'" Project="eng\Git.Build.targets" />
   <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true' " Project="eng\Versions.targets" />
   <Import Project="eng\AndroidX.targets" />

--- a/eng/Versions.dev.targets
+++ b/eng/Versions.dev.targets
@@ -1,0 +1,9 @@
+<!-- This file is an alternative to Versions.targets, when building locally and not for CI -->
+<Project>
+  <Target Name="SetVersions">
+    <PropertyGroup>
+      <PackageReferenceVersion>$(PackageVersion)</PackageReferenceVersion>
+      <VSComponentVersion>$(PackageVersion)</VSComponentVersion>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -91,9 +91,6 @@
 
   </Target>
 
-  <!-- Eventually replaced by eng/Version.targets -->
-  <Target Name="SetVersions" />
-
   <PropertyGroup>
     <!-- These files should invalidate ./bin/dotnet completely -->
     <_Inputs>

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -25,9 +25,6 @@
     <BeforePack>_UpdateTemplateVersions</BeforePack>
   </PropertyGroup>
 
-  <!-- Eventually replaced by eng/Version.targets -->
-  <Target Name="SetVersions" />
-
   <Target Name="_UpdateTemplateVersions" DependsOnTargets="SetVersions">
     <ItemGroup>
       <_TemplateJsonFile Include="templates\*\.template.config\template.json" />

--- a/src/Workload/Microsoft.Maui.Controls.Sdk/Microsoft.Maui.Controls.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Sdk/Microsoft.Maui.Controls.Sdk.csproj
@@ -42,9 +42,6 @@
 
   <Import Project="$(MauiRootDirectory)eng/ReplaceText.targets" />
 
-  <!-- Eventually replaced by eng/Version.targets -->
-  <Target Name="SetVersions" />
-
   <Target Name="_GenerateBundledVersions"
       BeforeTargets="Build;AssignTargetPaths"
       DependsOnTargets="SetVersions"

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -17,9 +17,6 @@
     <ProjectReference Include="../Microsoft.Maui.*/*.csproj" />
   </ItemGroup>
 
-  <!-- Eventually replaced by eng/Version.targets -->
-  <Target Name="SetVersions" />
-
   <Target Name="_GenerateWorkloadManifest" BeforeTargets="Build;AssignTargetPaths" DependsOnTargets="SetVersions" Inputs="$(MSBuildProjectFile);WorkloadManifest.in.json" Outputs="$(IntermediateOutputPath)WorkloadManifest.json">
     <ReplaceText Input="WorkloadManifest.in.json" Output="$(IntermediateOutputPath)WorkloadManifest.json" OldValue="@VERSION@" NewValue="$(PackageReferenceVersion)" />
     <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

I found `dotnet cake` fails with:

    C:\src\maui\src\Workload\Microsoft.Maui.Controls.Sdk\Microsoft.Maui.Controls.Sdk.csproj(53,5):
    error MSB4044: The "ReplaceText" task was not given a value for the required parameter "NewValue".

This is happening because `$(CI)` is not set, and
`$(PackageReferenceVersion)` is blank.

To solve this issue going forward:

* Make a `eng/Versions.dev.targets` as a local replacement for
  `eng/Versions.targets`.
* Create a `SetVersions` target so we don't need to declare the empty
  one anymore in several files.
* Set `$(PackageReferenceVersion)` and `$(VSComponentVersion)` to the
  default `$(PackageVersion)` value that comes from
  `Directory.Build.props`.

Now when I run `dotnet cake`, it is successful.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No
