### PR TITLE
Insert iOS subviews correctly

### DIFF
--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -102,7 +102,9 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.Subviews[index] = child.ToNative(MauiContext);
+			var existing = NativeView.Subviews[index];
+			existing.RemoveFromSuperview();
+			NativeView.InsertSubview(child.ToNative(MauiContext), index);
 			NativeView.SetNeedsLayout();
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			});
 
 			Assert.Equal(1, children.Count);
-			Assert.Equal(slider.Handler.NativeView, children[0]);
+			Assert.Same(slider.Handler.NativeView, children[0]);
 
 			var count = await InvokeOnMainThreadAsync(() =>
 			{
@@ -90,8 +90,8 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			});
 
 			Assert.Equal(2, children.Count);
-			Assert.Equal(slider.Handler.NativeView, children[0]);
-			Assert.Equal(button.Handler.NativeView, children[1]);
+			Assert.Same(slider.Handler.NativeView, children[0]);
+			Assert.Same(button.Handler.NativeView, children[1]);
 
 			var count = await InvokeOnMainThreadAsync(() =>
 			{
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			});
 
 			Assert.Equal(1, children.Count);
-			Assert.Equal(slider.Handler.NativeView, children[0]);
+			Assert.Same(slider.Handler.NativeView, children[0]);
 
 			children = await InvokeOnMainThreadAsync(() =>
 			{
@@ -128,8 +128,8 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			});
 
 			Assert.Equal(2, children.Count);
-			Assert.Equal(button.Handler.NativeView, children[0]);
-			Assert.Equal(slider.Handler.NativeView, children[1]);
+			Assert.Same(button.Handler.NativeView, children[0]);
+			Assert.Same(slider.Handler.NativeView, children[1]);
 		}
 
 		[Fact]
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			});
 
 			Assert.Equal(1, children.Count);
-			Assert.Equal(slider.Handler.NativeView, children[0]);
+			Assert.Same(slider.Handler.NativeView, children[0]);
 
 			children = await InvokeOnMainThreadAsync(() =>
 			{
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			});
 
 			Assert.Equal(1, children.Count);
-			Assert.Equal(button.Handler.NativeView, children[0]);
+			Assert.Same(button.Handler.NativeView, children[0]);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

UIView.Subviews is a property that returns an array, so using the indexer is only changing the local copy.

### Additions made ###

* tests :)

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
