### PR TITLE
Add `OnNativeMessage` back for Lifecycle on Windows

### DIFF
--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -200,6 +200,7 @@ namespace Maui.Controls.Sample
 #elif WINDOWS
 					// Log everything in this one
 					events.AddWindows(windows => windows
+						.OnNativeMessage((a, b) => LogEvent(nameof(WindowsLifecycle.OnNativeMessage)))
 						.OnActivated((a, b) => LogEvent(nameof(WindowsLifecycle.OnActivated)))
 						.OnClosed((a, b) => LogEvent(nameof(WindowsLifecycle.OnClosed)))
 						.OnLaunched((a, b) => LogEvent(nameof(WindowsLifecycle.OnLaunched)))

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
@@ -9,6 +9,7 @@
 		public static IWindowsLifecycleBuilder OnVisibilityChanged(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnVisibilityChanged del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnWindowCreated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnWindowCreated del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnResumed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnResumed del) => lifecycle.OnEvent(del);
+		public static IWindowsLifecycleBuilder OnNativeMessage(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnNativeMessage del) => lifecycle.OnEvent(del);
 
 		internal static IWindowsLifecycleBuilder OnMauiContextCreated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnMauiContextCreated del) => lifecycle.OnEvent(del);
 	}


### PR DESCRIPTION
This used to work, and went missing (bad merge?).

It's still possible to use with something like:

```csharp
lifecycle.AddEvent<WindowsLifecycle.OnNativeMessage>(nameof(WindowsLifecycle.OnNativeMessage), (window, b) =>
  {
	  System.Diagnostics.Debug.WriteLine(b.MessageId);
  });
```

But it should exist with the other extension methods to make life easier.