### PR TITLE
Add the new dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,6 @@
     <MicrosoftExtensionsLoggingConsolePackageVersion>6.0.0-rc.1.21417.1</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingDebugPackageVersion>6.0.0-rc.1.21417.1</MicrosoftExtensionsLoggingDebugPackageVersion>
     <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>6.0.0-rc.1.21417.1</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>6.0.0-rc.1.21403.6</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftAspNetCoreAuthorizationPackageVersion>6.0.0-rc.1.21417.2</MicrosoftAspNetCoreAuthorizationPackageVersion>
     <MicrosoftAspNetCoreComponentsWebViewPackageVersion>6.0.0-rc.1.21417.2</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
     <MicrosoftAspNetCoreComponentsWebPackageVersion>6.0.0-rc.1.21417.2</MicrosoftAspNetCoreComponentsWebPackageVersion>

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -31,7 +31,7 @@
       <_TemplateJsonFileWithContent
           Include="@(_TemplateJsonFile)"
           Contents="$([System.IO.File]::ReadAllText('%(FullPath)')
-              .Replace('MICROSOFT_EXTENSIONS_VERSION_VALUE', '$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion)')
+              .Replace('MICROSOFT_EXTENSIONS_VERSION_VALUE', '$(MicrosoftExtensionsPrimitivesPackageVersion)')
               .Replace('WINDOWSAPPSDK_VERSION_VALUE', '$(_MicrosoftWindowsAppSdkVersion)'))" />
     </ItemGroup>
     <WriteLinesToFile

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -31,7 +31,6 @@
       <_TemplateJsonFileWithContent
           Include="@(_TemplateJsonFile)"
           Contents="$([System.IO.File]::ReadAllText('%(FullPath)')
-              .Replace('MICROSOFT_EXTENSIONS_VERSION_VALUE', '$(MicrosoftExtensionsPrimitivesPackageVersion)')
               .Replace('WINDOWSAPPSDK_VERSION_VALUE', '$(_MicrosoftWindowsAppSdkVersion)'))" />
     </ItemGroup>
     <WriteLinesToFile

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -31,12 +31,6 @@
         "datatype": "string",
         "replaces": "com.companyname.MauiApp1"
       },
-      "microsoftExtensionsVersion": {
-        "type": "parameter",
-        "dataType": "string",
-        "replaces": "MICROSOFT_EXTENSIONS_VERSION",
-        "defaultValue": "MICROSOFT_EXTENSIONS_VERSION_VALUE"
-      },
       "windowsAppSdkVersion": {
         "type": "parameter",
         "dataType": "string",

--- a/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
+++ b/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
@@ -22,20 +22,20 @@
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration)/lib/netstandard2.0/Microsoft.Extensions.Configuration.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Configuration.Abstractions.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Configuration.Abstractions.xml" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.dll" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.xml" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.Abstractions.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection)/lib/net6.0/Microsoft.Extensions.DependencyInjection.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection)/lib/net6.0/Microsoft.Extensions.DependencyInjection.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection_Abstractions)/lib/net6.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection_Abstractions)/lib/net6.0/Microsoft.Extensions.DependencyInjection.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.Hosting.Abstractions.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.Hosting.Abstractions.xml" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting)/lib/netstandard2.1/Microsoft.Extensions.Hosting.dll" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting)/lib/netstandard2.1/Microsoft.Extensions.Hosting.xml" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.dll" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.xml" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.xml" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Primitives)/lib/netstandard2.0/Microsoft.Extensions.Primitives.dll" />
-    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Primitives)/lib/netstandard2.0/Microsoft.Extensions.Primitives.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting)/lib/net6.0/Microsoft.Extensions.Hosting.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting)/lib/net6.0/Microsoft.Extensions.Hosting.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/net6.0/Microsoft.Extensions.FileProviders.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/net6.0/Microsoft.Extensions.FileProviders.Abstractions.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/net6.0/Microsoft.Extensions.Logging.Abstractions.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/net6.0/Microsoft.Extensions.Logging.Abstractions.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Primitives)/lib/net6.0/Microsoft.Extensions.Primitives.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Primitives)/lib/net6.0/Microsoft.Extensions.Primitives.xml" />
     <None Include="@(_ExtensionsFiles)" FullTfm="@(_TargetPlatform->'%(FullTfm)')" Tfm="@(_TargetPlatform->'%(Tfm)')" Profile="@(_TargetPlatform->'%(Profile)')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/net6.0/%(FileName)%(Extension)" />
     <_PackageFiles Include="@(None)" PackagePath="lib/net6.0" TargetPath="lib/net6.0" />

--- a/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
+++ b/src/Workload/Microsoft.Maui.Extensions/Microsoft.Maui.Extensions.csproj
@@ -9,14 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration"          GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection"    GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"   GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"   GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Extensions.Primitives"             GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" GeneratePathProperty="true" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration)/lib/netstandard2.0/Microsoft.Extensions.Configuration.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration)/lib/netstandard2.0/Microsoft.Extensions.Configuration.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Configuration_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Configuration.Abstractions.dll" />
@@ -27,6 +28,8 @@
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_DependencyInjection_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.DependencyInjection.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.Hosting.Abstractions.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting_Abstractions)/lib/netstandard2.1/Microsoft.Extensions.Hosting.Abstractions.xml" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting)/lib/netstandard2.1/Microsoft.Extensions.Hosting.dll" />
+    <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Hosting)/lib/netstandard2.1/Microsoft.Extensions.Hosting.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.dll" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_FileProviders_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.xml" />
     <_ExtensionsFiles Include="$(PkgMicrosoft_Extensions_Logging_Abstractions)/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll" />


### PR DESCRIPTION
### Description of Change ###

Core now depends on `Microsoft.Extensions.Hosting`, so this is needed in the workloads.

### Additions made ###

* Add `Microsoft.Extensions.Hosting` to the workload

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
