### PR TITLE
Set fewer defaults in MauiAppBuilder

### DIFF
--- a/src/Core/src/Core/BootstrapHostBuilder.cs
+++ b/src/Core/src/Core/BootstrapHostBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -104,12 +105,12 @@ namespace Microsoft.Maui
 			// This is the hosting environment based on configuration we've seen so far.
 			var hostingEnvironment = new HostingEnvironment()
 			{
-				ApplicationName = hostConfiguration[HostDefaults.ApplicationKey],
+				ApplicationName = hostConfiguration[HostDefaults.ApplicationKey] ?? GetDefaultApplicationName(),
 				EnvironmentName = hostConfiguration[HostDefaults.EnvironmentKey] ?? Environments.Production,
 				ContentRootPath = HostingEnvironment.ResolveContentRootPath(hostConfiguration[HostDefaults.ContentRootKey], AppContext.BaseDirectory),
 			};
 
-			hostingEnvironment.ContentRootFileProvider = new PhysicalFileProvider(hostingEnvironment.ContentRootPath);
+			//hostingEnvironment.ContentRootFileProvider = new PhysicalFileProvider(hostingEnvironment.ContentRootPath);
 
 			var hostContext = new HostBuilderContext(Properties)
 			{
@@ -146,6 +147,12 @@ namespace Microsoft.Maui
 			}
 
 			return hostContext;
+		}
+
+		internal static string GetDefaultApplicationName()
+		{
+			var startupAssemblyName = Assembly.GetEntryAssembly()?.GetName()?.Name;
+			return startupAssemblyName ?? "MauiApp";
 		}
 
 		private class HostingEnvironment : IHostEnvironment

--- a/src/Core/src/Core/MauiApp.cs
+++ b/src/Core/src/Core/MauiApp.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui
 		internal MauiApp(IHost host)
 		{
 			_host = host;
-			Logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("TODO: Environment.ApplicationName");
+			Logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(Environment.ApplicationName);
 		}
 
 		/// <summary>
@@ -27,6 +27,11 @@ namespace Microsoft.Maui
 		/// The application's configured <see cref="IConfiguration"/>.
 		/// </summary>
 		public IConfiguration Configuration => _host.Services.GetRequiredService<IConfiguration>();
+
+		/// <summary>
+		/// The application's configured <see cref="IHostEnvironment"/>.
+		/// </summary>
+		public IHostEnvironment Environment => _host.Services.GetRequiredService<IHostEnvironment>();
 
 		/// <summary>
 		/// Allows consumers to be notified of application lifetime events.

--- a/src/Core/tests/UnitTests/Hosting/HostBuilderAppConfigurationTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/HostBuilderAppConfigurationTests.cs
@@ -71,8 +71,6 @@ namespace Microsoft.Maui.UnitTests.Hosting
 					});
 				});
 
-			// TODO: CHECK THIS WORKS!
-
 			builder.Host
 				.ConfigureServices((context, services) =>
 				{


### PR DESCRIPTION
There's a chance that some of the defaults could be problematic on some .NET MAUI platforms, so this change removes some of the defaults until we can fully consider what they should be. For example, removing some default configuration files, usage of env vars, etc.

In this change I copied the default configuration from MS.Ext.Hosting and commented out some lines that I think are not worth the risk for RC1.

This is related to https://github.com/dotnet/maui/issues/2270, where we can fully consider which defaults make sense.