### PR TITLE
[workoad] include missing dependencies in the workload

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -56,6 +56,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.Binder" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
@@ -76,11 +80,79 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Composite" Version="6.0.0-rc.2.21420.12" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.0-rc.2.21420.26" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.Configuration" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.EventLog" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Logging.EventSource" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Options" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Authorization" Version="6.0.0-rc.2.21420.26" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>51deae0b18ab779e227b31688a6157441027ea15</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components" Version="6.0.0-rc.2.21420.26" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>51deae0b18ab779e227b31688a6157441027ea15</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.Analyzers" Version="6.0.0-rc.2.21420.26" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>51deae0b18ab779e227b31688a6157441027ea15</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.Forms" Version="6.0.0-rc.2.21420.26" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>51deae0b18ab779e227b31688a6157441027ea15</Sha>
     </Dependency>
@@ -89,6 +161,10 @@
       <Sha>51deae0b18ab779e227b31688a6157441027ea15</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.2.21420.26" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>51deae0b18ab779e227b31688a6157441027ea15</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Metadata" Version="6.0.0-rc.2.21420.26" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>51deae0b18ab779e227b31688a6157441027ea15</Sha>
     </Dependency>
@@ -101,6 +177,30 @@
       <Sha>139cb9518e7bdd2219a552b5e23ac412f09000a4</Sha>
     </Dependency>
     <Dependency Name="System.CodeDom" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Pipelines" Version="6.0.0-rc.2.21420.12" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encodings.Web" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Json" Version="6.0.0-rc.2.21420.29" CoherentParentDependency="Microsoft.AspNetCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>91406a13fb953d6ba8a6e274e8a6f6d240ac9436</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,32 +1,61 @@
 <Project>
-  <!--Package versions-->
   <PropertyGroup>
+    <!-- dotnet/installer -->
     <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-rc.2.21423.2</MicrosoftDotnetSdkInternalPackageVersion>
+    <!-- dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>6.0.0-rc.2.21420.29</MicrosoftNETCoreAppRefPackageVersion>
+    <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>31.0.100-rc.2.12</MicrosoftAndroidSdkWindowsPackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>15.0.100-rc.1.521</MicrosoftMacCatalystSdkPackageVersion>
+    <!-- xamarin/xamarin-macios -->
     <MicrosoftiOSSdkPackageVersion>15.0.100-rc.1.521</MicrosoftiOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>15.0.100-rc.1.521</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>15.0.100-rc.1.521</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>12.0.100-rc.1.521</MicrosoftmacOSSdkPackageVersion>
-    <MicrosoftExtensionsPrimitivesPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsPrimitivesPackageVersion>
-    <MicrosoftExtensionsHostingAbstractionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsHostingAbstractionsPackageVersion>
-    <MicrosoftExtensionsHostingPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsHostingPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>15.0.100-rc.1.521</MicrosofttvOSSdkPackageVersion>
+    <!-- Everything else -->
+    <MicrosoftAspNetCoreAppRuntimewinx64Version>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreAppRuntimewinx64Version>
+    <MicrosoftAspNetCoreAuthorizationPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreAuthorizationPackageVersion>
+    <MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreComponentsAnalyzersPackageVersion>
+    <MicrosoftAspNetCoreComponentsFormsPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreComponentsFormsPackageVersion>
+    <MicrosoftAspNetCoreComponentsPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreComponentsPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
+    <MicrosoftAspNetCoreMetadataPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreMetadataPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
     <MicrosoftExtensionsDependencyInjectionPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersCompositePackageVersion>6.0.0-rc.2.21420.12</MicrosoftExtensionsFileProvidersCompositePackageVersion>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>6.0.0-rc.2.21420.26</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
+    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
+    <MicrosoftExtensionsHostingAbstractionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsHostingAbstractionsPackageVersion>
+    <MicrosoftExtensionsHostingPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsHostingPackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsLoggingConfigurationPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsLoggingConfigurationPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingDebugPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsLoggingDebugPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebViewPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreComponentsWebViewPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebPackageVersion>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreComponentsWebPackageVersion>
+    <MicrosoftExtensionsLoggingEventLogPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsLoggingEventLogPackageVersion>
+    <MicrosoftExtensionsLoggingEventSourcePackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsLoggingEventSourcePackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsPrimitivesPackageVersion>6.0.0-rc.2.21420.29</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftJSInteropPackageVersion>6.0.0-rc.2.21420.26</MicrosoftJSInteropPackageVersion>
-    <MicrosoftAspNetCoreAppRuntimewinx64Version>6.0.0-rc.2.21420.26</MicrosoftAspNetCoreAppRuntimewinx64Version>
     <MicrosoftWindowsDesktopAppRuntimewinx64Version>6.0.0-rc.2.21419.14</MicrosoftWindowsDesktopAppRuntimewinx64Version>
     <SystemCodeDomPackageVersion>6.0.0-rc.2.21420.29</SystemCodeDomPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>6.0.0-rc.2.21420.29</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>6.0.0-rc.2.21420.29</SystemDiagnosticsEventLogPackageVersion>
+    <SystemIOPipelinesPackageVersion>6.0.0-rc.2.21420.12</SystemIOPipelinesPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>6.0.0-rc.2.21420.29</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemTextEncodingsWebPackageVersion>6.0.0-rc.2.21420.29</SystemTextEncodingsWebPackageVersion>
+    <SystemTextJsonPackageVersion>6.0.0-rc.2.21420.29</SystemTextJsonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Trim all characters after first `-` or `+` is encountered. -->

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -107,12 +107,26 @@ Task("dotnet-templates")
 
         CleanDirectories("./templatesTest/");
 
+        // Create empty Directory.Build.props/targets
+        EnsureDirectoryExists(Directory("./templatesTest/"));
+        FileWriteText(File("./templatesTest/Directory.Build.props"), "<Project/>");
+        FileWriteText(File("./templatesTest/Directory.Build.targets"), "<Project/>");
+
+        // Create an empty NuGet.config
+        StartProcess(dn, "new nugetconfig -o ./templatesTest/");
+        var properties = new Dictionary<string, string> {
+            // Properties that ensure we don't use cached packages, and *only* the empty NuGet.config
+            { "RestoreNoCache", "true" },
+            { "RestorePackagesPath", MakeAbsolute(File("./templatesTest/packages")).FullPath },
+            { "RestoreConfigFile", MakeAbsolute(File("./templatesTest/nuget.config")).FullPath },
+        };
+
         foreach (var template in new [] { "maui", "maui-blazor", "mauilib" })
         {
             var name = template.Replace("-", "");
             StartProcess(dn, $"new {template} -o ./templatesTest/{name}");
 
-            RunMSBuildWithDotNet($"./templatesTest/{name}");
+            RunMSBuildWithDotNet($"./templatesTest/{name}", properties);
         }
     });
 

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -63,7 +63,7 @@
       <_VersionsToReplace Update="@(_VersionsToReplace)" PropertyName="%(Identity)" />
       <!-- Microsoft.Maui.Graphics.* have custom property names -->
       <_VersionsToReplace Include="MicrosoftMauiGraphicsVersion" PropertyName="_MicrosoftMauiGraphics" />
-      <_VersionsToReplace Include="MicrosoftMauiGraphicsWin2DVersion" PropertyName="_MicrosoftMauiGraphicsWin2D" />
+      <_VersionsToReplace Include="MicrosoftMauiGraphicsWin2DWinUIDesktopPackageVersion" PropertyName="_MicrosoftMauiGraphicsWin2D" />
     </ItemGroup>
     <ReplaceText
         Input="WorkloadManifest.in.json"

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -18,7 +18,65 @@
   </ItemGroup>
 
   <Target Name="_GenerateWorkloadManifest" BeforeTargets="Build;AssignTargetPaths" DependsOnTargets="SetVersions" Inputs="$(MSBuildProjectFile);WorkloadManifest.in.json" Outputs="$(IntermediateOutputPath)WorkloadManifest.json">
-    <ReplaceText Input="WorkloadManifest.in.json" Output="$(IntermediateOutputPath)WorkloadManifest.json" OldValue="@VERSION@" NewValue="$(PackageReferenceVersion)" />
+    <ItemGroup>
+      <_VersionsToReplace Include="MicrosoftAspNetCoreAuthorizationPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsAnalyzersPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsFormsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsWebPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsWebViewPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAspNetCoreMetadataPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsConfigurationAbstractionsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsConfigurationBinderPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsConfigurationCommandLinePackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsConfigurationFileExtensionsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsConfigurationJsonPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsConfigurationPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsConfigurationUserSecretsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsDependencyInjectionPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsFileProvidersAbstractionsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsFileProvidersCompositePackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsFileProvidersEmbeddedPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsFileProvidersPhysicalPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsFileSystemGlobbingPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsHostingAbstractionsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsHostingPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsLoggingAbstractionsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsLoggingConfigurationPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsLoggingConsolePackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsLoggingDebugPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsLoggingEventLogPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsLoggingEventSourcePackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsLoggingPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsOptionsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftExtensionsPrimitivesPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftJSInteropPackageVersion" />
+      <_VersionsToReplace Include="SystemDiagnosticsDiagnosticSourcePackageVersion" />
+      <_VersionsToReplace Include="SystemDiagnosticsEventLogPackageVersion" />
+      <_VersionsToReplace Include="SystemIOPipelinesPackageVersion" />
+      <_VersionsToReplace Include="SystemRuntimeCompilerServicesUnsafePackageVersion" />
+      <_VersionsToReplace Include="SystemTextEncodingsWebPackageVersion" />
+      <_VersionsToReplace Include="SystemTextJsonPackageVersion" />
+      <_VersionsToReplace Update="@(_VersionsToReplace)" PropertyName="%(Identity)" />
+      <!-- Microsoft.Maui.Graphics.* have custom property names -->
+      <_VersionsToReplace Include="MicrosoftMauiGraphicsVersion" PropertyName="_MicrosoftMauiGraphics" />
+      <_VersionsToReplace Include="MicrosoftMauiGraphicsWin2DVersion" PropertyName="_MicrosoftMauiGraphicsWin2D" />
+    </ItemGroup>
+    <ReplaceText
+        Input="WorkloadManifest.in.json"
+        Output="$(IntermediateOutputPath)WorkloadManifest.json"
+        OldValue="@VERSION@"
+        NewValue="$(PackageReferenceVersion)"
+    />
+    <ReplaceText
+        Input="$(IntermediateOutputPath)WorkloadManifest.json"
+        Output="$(IntermediateOutputPath)WorkloadManifest.json"
+        OldValue="@%(_VersionsToReplace.Identity)@"
+        NewValue="$(%(_VersionsToReplace.PropertyName))"
+    />
     <ItemGroup>
       <None Include="$(IntermediateOutputPath)WorkloadManifest.json" Link="WorkloadManifest.json" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="data" Visible="false" />
       <FileWrites Include="$(IntermediateOutputPath)WorkloadManifest.json" />

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -427,7 +427,7 @@
     },
     "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop": {
       "kind": "library",
-      "version": "@MicrosoftMauiGraphicsWin2DVersion@"
+      "version": "@MicrosoftMauiGraphicsWin2DWinUIDesktopPackageVersion@"
     },
     "System.Diagnostics.EventLog": {
       "kind": "library",

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -26,7 +26,6 @@
       "abstract": true,
       "description": ".NET MAUI SDK Core Packages",
       "packs": [
-          "Microsoft.AspNetCore.Components.WebView.Maui",
           "Microsoft.Maui.Dependencies",
           "Microsoft.Maui.Controls.Sdk",
           "Microsoft.Maui.Extensions",
@@ -37,13 +36,63 @@
           "Microsoft.Maui.Controls.Ref.any",
           "Microsoft.Maui.Controls.Runtime.any",
           "Microsoft.Maui.Essentials.Ref.any",
-          "Microsoft.Maui.Essentials.Runtime.any"
+          "Microsoft.Maui.Essentials.Runtime.any",
+          "Microsoft.Extensions.Configuration",
+          "Microsoft.Extensions.Configuration.Abstractions",
+          "Microsoft.Extensions.Configuration.Binder",
+          "Microsoft.Extensions.Configuration.CommandLine",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables",
+          "Microsoft.Extensions.Configuration.FileExtensions",
+          "Microsoft.Extensions.Configuration.Json",
+          "Microsoft.Extensions.Configuration.UserSecrets",
+          "Microsoft.Extensions.DependencyInjection",
+          "Microsoft.Extensions.DependencyInjection.Abstractions",
+          "Microsoft.Extensions.FileProviders.Abstractions",
+          "Microsoft.Extensions.FileProviders.Physical",
+          "Microsoft.Extensions.FileSystemGlobbing",
+          "Microsoft.Extensions.Hosting",
+          "Microsoft.Extensions.Hosting.Abstractions",
+          "Microsoft.Extensions.Logging",
+          "Microsoft.Extensions.Logging.Abstractions",
+          "Microsoft.Extensions.Logging.Console",
+          "Microsoft.Extensions.Logging.Configuration",
+          "Microsoft.Extensions.Logging.Debug",
+          "Microsoft.Extensions.Logging.EventLog",
+          "Microsoft.Extensions.Logging.EventSource",
+          "Microsoft.Extensions.Primitives",
+          "Microsoft.Extensions.Options",
+          "Microsoft.Extensions.Options.ConfigurationExtensions",
+          "Microsoft.Maui.Graphics",
+          "System.Diagnostics.DiagnosticSource",
+          "System.Diagnostics.EventLog",
+          "System.Runtime.CompilerServices.Unsafe",
+          "System.Text.Encodings.Web",
+          "System.Text.Json"
+      ]
+    },
+    "maui-blazor": {
+      "abstract": true,
+      "description": ".NET MAUI SDK Blazor Packages",
+      "extends": [ "maui-core" ],
+      "packs": [
+          "Microsoft.AspNetCore.Components.WebView.Maui",
+          "Microsoft.AspNetCore.Authorization",
+          "Microsoft.AspNetCore.Components",
+          "Microsoft.AspNetCore.Components.Analyzers",
+          "Microsoft.AspNetCore.Components.Forms",
+          "Microsoft.AspNetCore.Components.Web",
+          "Microsoft.AspNetCore.Components.WebView",
+          "Microsoft.AspNetCore.Metadata",
+          "Microsoft.Extensions.FileProviders.Composite",
+          "Microsoft.Extensions.FileProviders.Embedded",
+          "Microsoft.JSInterop",
+          "System.IO.Pipelines"
       ]
     },
     "maui-android": {
       "description": ".NET MAUI SDK for Android",
       "extends": [ 
-        "maui-core",
+        "maui-blazor",
         "android"
       ],
       "packs": [
@@ -58,7 +107,7 @@
     "maui-maccatalyst": {
       "description": ".NET MAUI SDK for Mac Catalyst",
       "extends": [ 
-        "maui-core",
+        "maui-blazor",
         "maccatalyst"
       ],
       "packs": [
@@ -73,7 +122,7 @@
     "maui-ios": {
       "description": ".NET MAUI SDK for iOS",
       "extends": [ 
-        "maui-core",
+        "maui-blazor",
         "ios"
       ],
       "packs": [
@@ -87,14 +136,15 @@
     },
     "maui-windows": {
       "description": ".NET MAUI SDK for Windows",
-      "extends": [ "maui-core" ],
+      "extends": [ "maui-blazor" ],
       "packs": [
           "Microsoft.Maui.Core.Ref.win",
           "Microsoft.Maui.Core.Runtime.win",
           "Microsoft.Maui.Controls.Ref.win",
           "Microsoft.Maui.Controls.Runtime.win",
           "Microsoft.Maui.Essentials.Ref.win",
-          "Microsoft.Maui.Essentials.Runtime.win"
+          "Microsoft.Maui.Essentials.Runtime.win",
+          "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop"
       ]
     }
   },
@@ -230,6 +280,178 @@
     "Microsoft.Maui.Extensions": {
       "kind": "library",
       "version": "@VERSION@"
+    },
+    "Microsoft.AspNetCore.Authorization": {
+      "kind": "library",
+      "version": "@MicrosoftAspNetCoreAuthorizationPackageVersion@"
+    },
+    "Microsoft.AspNetCore.Components": {
+      "kind": "library",
+      "version": "@MicrosoftAspNetCoreComponentsPackageVersion@"
+    },
+    "Microsoft.AspNetCore.Components.Analyzers": {
+      "kind": "library",
+      "version": "@MicrosoftAspNetCoreComponentsAnalyzersPackageVersion@"
+    },
+    "Microsoft.AspNetCore.Components.Forms": {
+      "kind": "library",
+      "version": "@MicrosoftAspNetCoreComponentsFormsPackageVersion@"
+    },
+    "Microsoft.AspNetCore.Components.Web": {
+      "kind": "library",
+      "version": "@MicrosoftAspNetCoreComponentsWebPackageVersion@"
+    },
+    "Microsoft.AspNetCore.Components.WebView": {
+      "kind": "library",
+      "version": "@MicrosoftAspNetCoreComponentsWebViewPackageVersion@"
+    },
+    "Microsoft.AspNetCore.Metadata": {
+      "kind": "library",
+      "version": "@MicrosoftAspNetCoreMetadataPackageVersion@"
+    },
+    "Microsoft.Extensions.Configuration": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsConfigurationPackageVersion@"
+    },
+    "Microsoft.Extensions.Configuration.Abstractions": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsConfigurationAbstractionsPackageVersion@"
+    },
+    "Microsoft.Extensions.Configuration.Binder": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsConfigurationAbstractionsPackageVersion@"
+    },
+    "Microsoft.Extensions.Configuration.CommandLine": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsConfigurationCommandLinePackageVersion@"
+    },
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion@"
+    },
+    "Microsoft.Extensions.Configuration.FileExtensions": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsConfigurationFileExtensionsPackageVersion@"
+    },
+    "Microsoft.Extensions.Configuration.Json": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsConfigurationJsonPackageVersion@"
+    },
+    "Microsoft.Extensions.Configuration.UserSecrets": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsConfigurationUserSecretsPackageVersion@"
+    },
+    "Microsoft.Extensions.DependencyInjection": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsDependencyInjectionPackageVersion@"
+    },
+    "Microsoft.Extensions.DependencyInjection.Abstractions": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion@"
+    },
+    "Microsoft.Extensions.FileProviders.Abstractions": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsFileProvidersAbstractionsPackageVersion@"
+    },
+    "Microsoft.Extensions.FileProviders.Composite": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsFileProvidersCompositePackageVersion@"
+    },
+    "Microsoft.Extensions.FileProviders.Embedded": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsFileProvidersEmbeddedPackageVersion@"
+    },
+    "Microsoft.Extensions.FileProviders.Physical": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsFileProvidersPhysicalPackageVersion@"
+    },
+    "Microsoft.Extensions.FileSystemGlobbing": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsFileSystemGlobbingPackageVersion@"
+    },
+    "Microsoft.Extensions.Hosting": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsHostingPackageVersion@"
+    },
+    "Microsoft.Extensions.Hosting.Abstractions": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsHostingAbstractionsPackageVersion@"
+    },
+    "Microsoft.Extensions.Logging": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsLoggingPackageVersion@"
+    },
+    "Microsoft.Extensions.Logging.Abstractions": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsLoggingAbstractionsPackageVersion@"
+    },
+    "Microsoft.Extensions.Logging.Configuration": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsLoggingConfigurationPackageVersion@"
+    },
+    "Microsoft.Extensions.Logging.Console": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsLoggingConsolePackageVersion@"
+    },
+    "Microsoft.Extensions.Logging.Debug": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsLoggingDebugPackageVersion@"
+    },
+    "Microsoft.Extensions.Logging.EventLog": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsLoggingEventLogPackageVersion@"
+    },
+    "Microsoft.Extensions.Logging.EventSource": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsLoggingEventSourcePackageVersion@"
+    },
+    "Microsoft.Extensions.Options": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsOptionsPackageVersion@"
+    },
+    "Microsoft.Extensions.Options.ConfigurationExtensions": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion@"
+    },
+    "Microsoft.Extensions.Primitives": {
+      "kind": "library",
+      "version": "@MicrosoftExtensionsPrimitivesPackageVersion@"
+    },
+    "Microsoft.JSInterop": {
+      "kind": "library",
+      "version": "@MicrosoftJSInteropPackageVersion@"
+    },
+    "Microsoft.Maui.Graphics": {
+      "kind": "library",
+      "version": "@MicrosoftMauiGraphicsVersion@"
+    },
+    "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop": {
+      "kind": "library",
+      "version": "@MicrosoftMauiGraphicsWin2DVersion@"
+    },
+    "System.Diagnostics.EventLog": {
+      "kind": "library",
+      "version": "@SystemDiagnosticsEventLogPackageVersion@"
+    },
+    "System.Diagnostics.DiagnosticSource": {
+      "kind": "library",
+      "version": "@SystemDiagnosticsDiagnosticSourcePackageVersion@"
+    },
+    "System.IO.Pipelines": {
+      "kind": "library",
+      "version": "@SystemIOPipelinesPackageVersion@"
+    },
+    "System.Runtime.CompilerServices.Unsafe": {
+      "kind": "library",
+      "version": "@SystemRuntimeCompilerServicesUnsafePackageVersion@"
+    },
+    "System.Text.Encodings.Web": {
+      "kind": "library",
+      "version": "@SystemTextEncodingsWebPackageVersion@"
+    },
+    "System.Text.Json": {
+      "kind": "library",
+      "version": "@SystemTextJsonPackageVersion@"
     },
     "Microsoft.Maui.Controls.Sdk": {
       "kind": "sdk",

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -319,7 +319,7 @@
     },
     "Microsoft.Extensions.Configuration.Binder": {
       "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationAbstractionsPackageVersion@"
+      "version": "@MicrosoftExtensionsConfigurationBinderPackageVersion@"
     },
     "Microsoft.Extensions.Configuration.CommandLine": {
       "kind": "library",


### PR DESCRIPTION
### Description of Change ###

I found that using .NET 6 rc.1/rc.2 builds, if you do:

* `dotnet new maui`
* `dotnet build`

You'll get build errors unless you add the `dotnet6` feed to a
`nuget.config`:

    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />

We should put these packages *inside* the workload as `library-packs`,
so this is not needed. I had to start tracking various versions of
packages through Maestro for us to be able to do this.

To further help delimit what packs are for what, I created an abstract
`maui-blazor` workload. This is a way for us to know which packs are
only needed for Blazor. These packs are still installed by default for
all .NET MAUI workloads like `maui-desktop`, `maui-mobile`, etc., but
this gives us flexibility down the road.

To verify this won't break going forward, let's use an empty
`nuget.config` before building the templates.

`dotnet new nugetconfig` outputs:

    <?xml version="1.0" encoding="utf-8"?>
    <configuration>
      <packageSources>
        <!--To inherit the global NuGet package sources remove the <clear/> line below -->
        <clear />
        <add key="nuget" value="https://api.nuget.org/v3/index.json" />
      </packageSources>
    </configuration>

We should be able to build apps with only the packs the workload
installed or NuGet.org.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No
