### PR TITLE
[templates] use android:targetSdkVersion="31"

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>


### PR DESCRIPTION
### Description of Change ###

Building `dotnet new maui` currently hits the warning:

    warning XA4211: AndroidManifest.xml //uses-sdk/@android:targetSdkVersion '30' is less than $(TargetFrmeworkVersion (Android API level 31) is higher than the targetSdkVersion (30). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.

Let's update the templates to use 31.

I don't think we should do this for every project in dotnet/maui yet,
because "legacy" Xamarin.Android is used for some .NET MAUI
development and 31 isn't supported there yet.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No