### PR TITLE
Fix issues dynamically adding stuff to a FlexLayout

### DIFF
--- a/src/Controls/src/Core/BindableLayout.cs
+++ b/src/Controls/src/Core/BindableLayout.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	// TODO ezhart 2021-07-16 This interface is just here to give Layout and Compatibility.Layout common ground for BindableLayout
 	// once we have the IContainer changes in, we may be able to drop this in favor of simply Core.ILayout
 	// See also IndicatorView.cs 
-	public interface IBindableLayout
+	public interface IBindableLayout 
 	{
 		public IList Children { get; }
 	}
@@ -118,6 +118,66 @@ namespace Microsoft.Maui.Controls
 			newC.EmptyView = GetEmptyView(b);
 			newC.EmptyViewTemplate = GetEmptyViewTemplate(b);
 			newC.EndBatchUpdate();
+		}
+
+		internal static void Add(this IBindableLayout layout, object item)
+		{
+			if (layout is Maui.ILayout mauiLayout && item is IView view)
+			{
+				mauiLayout.Add(view);
+			}
+			else
+			{
+				_ = layout.Children.Add(item);
+			}
+		}
+
+		internal static void Insert(this IBindableLayout layout, object item, int index)
+		{
+			if (layout is Maui.ILayout mauiLayout && item is IView view)
+			{
+				mauiLayout.Insert(index, view);
+			}
+			else
+			{
+				layout.Children.Insert(index, item);
+			}
+		}
+
+		internal static void Remove(this IBindableLayout layout, object item)
+		{
+			if (layout is Maui.ILayout mauiLayout && item is IView view)
+			{
+				_ = mauiLayout.Remove(view);
+			}
+			else
+			{
+				layout.Children.Remove(item);
+			}
+		}
+
+		internal static void RemoveAt(this IBindableLayout layout, int index) 
+		{
+			if (layout is Maui.ILayout mauiLayout)
+			{
+				mauiLayout.RemoveAt(index);
+			}
+			else
+			{
+				layout.Children.RemoveAt(index);
+			}
+		}
+
+		internal static void Clear(this IBindableLayout layout) 
+		{
+			if (layout is Maui.ILayout mauiLayout)
+			{
+				mauiLayout.Clear();
+			}
+			else
+			{
+				layout.Children.Clear();
+			}
 		}
 	}
 
@@ -231,7 +291,7 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			layout.Children.Clear();
+			layout.Clear();
 
 			UpdateEmptyView(layout);
 
@@ -240,7 +300,7 @@ namespace Microsoft.Maui.Controls
 
 			foreach (object item in _itemsSource)
 			{
-				layout.Children.Add(CreateItemView(item, layout));
+				layout.Add(CreateItemView(item, layout));
 			}
 		}
 
@@ -251,11 +311,11 @@ namespace Microsoft.Maui.Controls
 
 			if (!_itemsSource?.GetEnumerator().MoveNext() ?? true)
 			{
-				layout.Children.Add(_currentEmptyView);
+				layout.Add(_currentEmptyView);
 				return;
 			}
 
-			layout.Children.Remove(_currentEmptyView);
+			layout.Remove(_currentEmptyView);
 		}
 
 		View CreateItemView(object item, IBindableLayout layout)
@@ -307,8 +367,8 @@ namespace Microsoft.Maui.Controls
 			}
 
 			e.Apply(
-				insert: (item, index, _) => layout.Children.Insert(index, CreateItemView(item, layout)),
-				removeAt: (item, index) => layout.Children.RemoveAt(index),
+				insert: (item, index, _) => layout.Insert(CreateItemView(item, layout), index),
+				removeAt: (item, index) => layout.RemoveAt(index),
 				reset: CreateChildren);
 
 			// UpdateEmptyView is called from within CreateChildren, therefor skip it for Reset

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -528,5 +528,37 @@ namespace Microsoft.Maui.Controls
 			item.JustifyContent = (Flex.Justify)(FlexJustify)GetValue(JustifyContentProperty);
 			item.Wrap = (Flex.Wrap)(FlexWrap)GetValue(WrapProperty);
 		}
+
+		protected override void OnAdd(int index, IView view)
+		{
+			base.OnAdd(index, view);
+			AddFlexItem(view);
+		}
+
+		protected override void OnInsert(int index, IView view)
+		{
+			base.OnInsert(index, view);
+			AddFlexItem(view);
+		}
+
+		protected override void OnUpdate(int index, IView view, IView oldView)
+		{
+			base.OnUpdate(index, view, oldView);
+			RemoveFlexItem(oldView);
+			AddFlexItem(view);
+		}
+
+		protected override void OnRemove(int index, IView view)
+		{
+			base.OnRemove(index, view);
+			RemoveFlexItem(view);
+		}
+
+		protected override void OnClear()
+		{
+			base.OnClear();
+			ClearLayout();
+			PopulateLayout();
+		}
 	}
 }


### PR DESCRIPTION
Ensure that items added/removed/inserted/cleared to/from/into/from FlexLayout get their corresponding flex information updated.

Ensure that BindableLayout is calling the new layout add/remove/insert/clear methods when dealing with new layouts.

Fixes #2023; fixes #1505; fixes #2138; fixes #2056


