### PR TITLE
Add support for JS root components in BlazorWebView

### DIFF
--- a/src/BlazorWebView/samples/BlazorWinFormsApp/Form1.cs
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/Form1.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Windows.Forms;
+using BlazorWinFormsApp.Pages;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView.WindowsForms;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,7 +24,11 @@ namespace BlazorWinFormsApp
             blazorWebView1.HostPage = @"wwwroot\index.html";
             blazorWebView1.Services = serviceCollection.BuildServiceProvider();
             blazorWebView1.RootComponents.Add<Main>("#app");
-        }
+			blazorWebView1.WebViewManagerCreated += (_, e) =>
+			{
+				blazorWebView1.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
+			};
+		}
 
         private void button1_Click(object sender, EventArgs e)
         {

--- a/src/BlazorWebView/samples/BlazorWinFormsApp/Form1.cs
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/Form1.cs
@@ -7,36 +7,34 @@ using BlazorWinFormsApp.Pages;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView.WindowsForms;
 using Microsoft.Extensions.DependencyInjection;
+using WebViewAppShared;
 
 namespace BlazorWinFormsApp
 {
-    public partial class Form1 : Form
-    {
-        private readonly AppState _appState = new();
+	public partial class Form1 : Form
+	{
+		private readonly AppState _appState = new();
 
-        public Form1()
-        {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddBlazorWebView();
-            serviceCollection.AddSingleton<AppState>(_appState);
-            InitializeComponent();
+		public Form1()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddBlazorWebView();
+			serviceCollection.AddSingleton<AppState>(_appState);
+			InitializeComponent();
 
-            blazorWebView1.HostPage = @"wwwroot\index.html";
-            blazorWebView1.Services = serviceCollection.BuildServiceProvider();
-            blazorWebView1.RootComponents.Add<Main>("#app");
-			blazorWebView1.WebViewManagerCreated += (_, e) =>
-			{
-				blazorWebView1.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
-			};
+			blazorWebView1.HostPage = @"wwwroot\index.html";
+			blazorWebView1.Services = serviceCollection.BuildServiceProvider();
+			blazorWebView1.RootComponents.Add<Main>("#app");
+			blazorWebView1.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
 		}
 
-        private void button1_Click(object sender, EventArgs e)
-        {
-            MessageBox.Show(
-                owner: this,
-                text: $"Current counter value is: {_appState.Counter}",
-                caption: "Counter");
-        }
+		private void button1_Click(object sender, EventArgs e)
+		{
+			MessageBox.Show(
+				owner: this,
+				text: $"Current counter value is: {_appState.Counter}",
+				caption: "Counter");
+		}
 
 		private void _webViewActionButton_Click(object sender, EventArgs e)
 		{

--- a/src/BlazorWebView/samples/BlazorWinFormsApp/Pages/MyDynamicComponent.razor
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/Pages/MyDynamicComponent.razor
@@ -1,0 +1,30 @@
+﻿@implements IAsyncDisposable
+
+<div class="dynamic-root-component" style="border: 1px dashed purple">
+    <p>
+        This is a Blazor component.
+    </p>
+    <p>
+        Click count: <strong class="click-count">@clicks</strong>
+        (will increment in steps of <strong class="increment-amount-value">@IncrementAmount</strong>)
+    </p>
+
+    <button class="increment" @onclick="Increment">Increment</button>
+
+</div>
+
+@code {
+    [Parameter] public int IncrementAmount { get; set; } = 7;
+
+    int clicks;
+
+    void Increment()
+    {
+        clicks += IncrementAmount;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Task.Delay(1000);
+    }
+}

--- a/src/BlazorWebView/samples/BlazorWinFormsApp/wwwroot/index.html
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/wwwroot/index.html
@@ -8,6 +8,27 @@
     <base href="/" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="BlazorWinFormsApp.styles.css" rel="stylesheet" />
+    <script>
+        const addedComponents = [];
+        let numAddedComponents = 0;
+
+        var i = 1;
+        async function addDynamicComponent() {
+            let containerElement = document.createElement('div');
+            containerElement.id = `root-container-${++numAddedComponents}`;
+            document.body.appendChild(containerElement);
+            const component = await Blazor.rootComponents.add(containerElement, 'my-dynamic-root-component', { incrementAmount: i });
+            addedComponents.push({ component, containerElement });
+
+            i++;
+        }
+
+        function removeRootComponent() {
+            // Treat it like a FIFO queue
+            const { component, containerElement } = addedComponents.shift();
+            component.dispose();
+        }
+    </script>
 </head>
 
 <body>
@@ -18,6 +39,9 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+
+    <button onclick="addDynamicComponent()">Add dynamic component</button>
+    <button onclick="removeRootComponent()">Remove root component</button>
 
     <script src="_framework/blazor.webview.js"></script>
 </body>

--- a/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml.cs
+++ b/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Windows;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using WebViewAppShared;
 
 namespace BlazorWpfApp
 {
@@ -21,9 +23,11 @@ namespace BlazorWpfApp
             Resources.Add("services", serviceCollection.BuildServiceProvider());
 
             InitializeComponent();
-        }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+			blazorWebView1.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
+		}
+
+		private void Button_Click(object sender, RoutedEventArgs e)
         {
 			MessageBox.Show(
                 owner: this,

--- a/src/BlazorWebView/samples/BlazorWpfApp/wwwroot/index.html
+++ b/src/BlazorWebView/samples/BlazorWpfApp/wwwroot/index.html
@@ -8,6 +8,27 @@
     <base href="/" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="BlazorWpfApp.styles.css" rel="stylesheet" />
+    <script>
+        const addedComponents = [];
+        let numAddedComponents = 0;
+
+        var i = 1;
+        async function addDynamicComponent() {
+            let containerElement = document.createElement('div');
+            containerElement.id = `root-container-${++numAddedComponents}`;
+            document.body.appendChild(containerElement);
+            const component = await Blazor.rootComponents.add(containerElement, 'my-dynamic-root-component', { incrementAmount: i });
+            addedComponents.push({ component, containerElement });
+
+            i++;
+        }
+
+        function removeRootComponent() {
+            // Treat it like a FIFO queue
+            const { component, containerElement } = addedComponents.shift();
+            component.dispose();
+        }
+    </script>
 </head>
 
 <body>
@@ -18,6 +39,9 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+
+    <button onclick="addDynamicComponent()">Add dynamic component</button>
+    <button onclick="removeRootComponent()">Remove root component</button>
 
     <script src="_framework/blazor.webview.js"></script>
 </body>

--- a/src/BlazorWebView/samples/WebViewAppShared/MyDynamicComponent.razor
+++ b/src/BlazorWebView/samples/WebViewAppShared/MyDynamicComponent.razor
@@ -1,6 +1,6 @@
 ﻿@implements IAsyncDisposable
 
-<div class="dynamic-root-component" style="border: 1px dashed purple">
+<div class="my-dynamic-root-component">
     <p>
         This is a Blazor component.
     </p>

--- a/src/BlazorWebView/samples/WebViewAppShared/MyDynamicComponent.razor.css
+++ b/src/BlazorWebView/samples/WebViewAppShared/MyDynamicComponent.razor.css
@@ -1,0 +1,5 @@
+﻿.my-dynamic-root-component {
+    border: 2px dashed blue;
+    padding: 1em;
+    margin: 1em 0;
+}

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -97,6 +97,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			var jsComponents = new JSComponentConfigurationStore();
 			_webviewManager = new AndroidWebKitWebViewManager(this, NativeView, Services!, MauiDispatcher.Instance, mauiAssetFileProvider, jsComponents, hostPageRelativePath);
+
 			if (RootComponents != null)
 			{
 				foreach (var rootComponent in RootComponents)

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -95,8 +95,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			var mauiAssetFileProvider = new AndroidMauiAssetFileProvider(Context.Assets, contentRootDir);
 
-			var jsComponents = new JSComponentConfigurationStore();
-			_webviewManager = new AndroidWebKitWebViewManager(this, NativeView, Services!, MauiDispatcher.Instance, mauiAssetFileProvider, jsComponents, hostPageRelativePath);
+			_webviewManager = new AndroidWebKitWebViewManager(this, NativeView, Services!, MauiDispatcher.Instance, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -1,12 +1,49 @@
 ﻿using System;
-using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
 	public class BlazorWebView : Microsoft.Maui.Controls.View, IBlazorWebView
 	{
+		public BlazorWebView()
+		{
+			RootComponents = new RootComponentsCollection(this);
+		}
+
 		public string? HostPage { get; set; }
 
-		public ObservableCollection<RootComponent> RootComponents { get; } = new();
+		public RootComponentsCollection RootComponents { get; }
+
+		new public BlazorWebViewHandler? Handler
+		{
+			get => base.Handler as BlazorWebViewHandler;
+			set => base.Handler = value;
+		}
+
+		public WebViewManager? WebViewManager { get; internal set; }
+
+		public event EventHandler<WebViewManagerCreatedEventArgs>? WebViewManagerCreated;
+
+		protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+		{
+			base.OnHandlerChanging(args);
+
+			if (Handler != null)
+			{
+				Handler.WebViewManagerCreated -= OnHandlerWebViewManagerCreated;
+			}
+
+			WebViewManager = null;
+
+			var newBlazorWebViewHandler = (BlazorWebViewHandler)args.NewHandler;
+			newBlazorWebViewHandler.WebViewManagerCreated += OnHandlerWebViewManagerCreated;
+		}
+
+		private void OnHandlerWebViewManagerCreated(object? sender, WebViewManagerCreatedEventArgs e)
+		{
+			WebViewManager = e.WebViewManager;
+
+			WebViewManagerCreated?.Invoke(this, e);
+		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -1,49 +1,20 @@
-﻿using System;
-using Microsoft.Maui.Controls;
+﻿using Microsoft.AspNetCore.Components.Web;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
 	public class BlazorWebView : Microsoft.Maui.Controls.View, IBlazorWebView
 	{
+		private readonly JSComponentConfigurationStore _jSComponents = new();
+
 		public BlazorWebView()
 		{
-			RootComponents = new RootComponentsCollection(this);
+			RootComponents = new RootComponentsCollection(_jSComponents);
 		}
+
+		JSComponentConfigurationStore IBlazorWebView.JSComponents => _jSComponents;
 
 		public string? HostPage { get; set; }
 
 		public RootComponentsCollection RootComponents { get; }
-
-		new public BlazorWebViewHandler? Handler
-		{
-			get => base.Handler as BlazorWebViewHandler;
-			set => base.Handler = value;
-		}
-
-		public WebViewManager? WebViewManager { get; internal set; }
-
-		public event EventHandler<WebViewManagerCreatedEventArgs>? WebViewManagerCreated;
-
-		protected override void OnHandlerChanging(HandlerChangingEventArgs args)
-		{
-			base.OnHandlerChanging(args);
-
-			if (Handler != null)
-			{
-				Handler.WebViewManagerCreated -= OnHandlerWebViewManagerCreated;
-			}
-
-			WebViewManager = null;
-
-			var newBlazorWebViewHandler = (BlazorWebViewHandler)args.NewHandler;
-			newBlazorWebViewHandler.WebViewManagerCreated += OnHandlerWebViewManagerCreated;
-		}
-
-		private void OnHandlerWebViewManagerCreated(object? sender, WebViewManagerCreatedEventArgs e)
-		{
-			WebViewManager = e.WebViewManager;
-
-			WebViewManagerCreated?.Invoke(this, e);
-		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.ObjectModel;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 
@@ -41,8 +39,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 #if !NETSTANDARD
 		private string? HostPage { get; set; }
 
-		private ObservableCollection<RootComponent>? _rootComponents;
-		private ObservableCollection<RootComponent>? RootComponents
+		private RootComponentsCollection? _rootComponents;
+		private RootComponentsCollection? RootComponents
 		{
 			get => _rootComponents;
 			set
@@ -96,12 +94,5 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 		}
 #endif
-
-		public event EventHandler<WebViewManagerCreatedEventArgs>? WebViewManagerCreated;
-
-		protected virtual void OnWebViewManagerCreated(WebViewManagerCreatedEventArgs webViewManagerCreatedEventArgs)
-		{
-			WebViewManagerCreated?.Invoke(this, webViewManagerCreatedEventArgs);
-		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
@@ -95,5 +96,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 		}
 #endif
+
+		public event EventHandler<WebViewManagerCreatedEventArgs>? WebViewManagerCreated;
+
+		protected virtual void OnWebViewManagerCreated(WebViewManagerCreatedEventArgs webViewManagerCreatedEventArgs)
+		{
+			WebViewManagerCreated?.Invoke(this, webViewManagerCreatedEventArgs);
+		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Maui;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -7,7 +7,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	{
 		string? HostPage { get; set; }
 		RootComponentsCollection RootComponents { get; }
-		event EventHandler<WebViewManagerCreatedEventArgs>? WebViewManagerCreated;
-		WebViewManager? WebViewManager { get; }
+		JSComponentConfigurationStore JSComponents { get; }
 	}
 }

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.ObjectModel;
 using Microsoft.Maui;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -7,6 +6,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	public interface IBlazorWebView : IView
 	{
 		string? HostPage { get; set; }
-		ObservableCollection<RootComponent> RootComponents { get; }
+		RootComponentsCollection RootComponents { get; }
+		event EventHandler<WebViewManagerCreatedEventArgs>? WebViewManagerCreated;
+		WebViewManager? WebViewManager { get; }
 	}
 }

--- a/src/BlazorWebView/src/Maui/RootComponentsCollection.cs
+++ b/src/BlazorWebView/src/Maui/RootComponentsCollection.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Microsoft.AspNetCore.Components.WebView.Maui
+{
+	public class RootComponentsCollection : ObservableCollection<RootComponent>, IJSComponentConfiguration
+	{
+		private readonly BlazorWebView _blazorWebView;
+
+		public RootComponentsCollection(BlazorWebView blazorWebView)
+		{
+			_blazorWebView = blazorWebView;
+		}
+
+		public JSComponentConfigurationStore JSComponents => _blazorWebView.WebViewManager?.JSComponentConfiguration!;
+	}
+}

--- a/src/BlazorWebView/src/Maui/RootComponentsCollection.cs
+++ b/src/BlazorWebView/src/Maui/RootComponentsCollection.cs
@@ -5,13 +5,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
 	public class RootComponentsCollection : ObservableCollection<RootComponent>, IJSComponentConfiguration
 	{
-		private readonly BlazorWebView _blazorWebView;
+		private readonly JSComponentConfigurationStore _jSComponents;
 
-		public RootComponentsCollection(BlazorWebView blazorWebView)
+		public RootComponentsCollection(JSComponentConfigurationStore jSComponents)
 		{
-			_blazorWebView = blazorWebView;
+			_jSComponents = jSComponents;
 		}
 
-		public JSComponentConfigurationStore JSComponents => _blazorWebView.WebViewManager?.JSComponentConfiguration!;
+		public JSComponentConfigurationStore JSComponents => _jSComponents;
 	}
 }

--- a/src/BlazorWebView/src/Maui/WebViewManagerCreatedEventArgs.cs
+++ b/src/BlazorWebView/src/Maui/WebViewManagerCreatedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.AspNetCore.Components.WebView.Maui
+{
+	public class WebViewManagerCreatedEventArgs
+	{
+		public WebViewManagerCreatedEventArgs(WebViewManager webViewManager)
+		{
+			WebViewManager = webViewManager;
+		}
+
+		public WebViewManager WebViewManager { get; }
+	}
+}

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -62,8 +62,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			// WinUIWebViewManager so that loading static assets is done entirely there.
 			var mauiAssetFileProvider = new NullFileProvider();
 
-			var jsComponents = new JSComponentConfigurationStore();
-			_webviewManager = new WinUIWebViewManager(NativeView, new WinUIWebView2Wrapper(NativeView), Services!, MauiDispatcher.Instance, mauiAssetFileProvider, jsComponents, hostPageRelativePath, contentRootDir);
+			_webviewManager = new WinUIWebViewManager(NativeView, new WinUIWebView2Wrapper(NativeView), Services!, MauiDispatcher.Instance, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath, contentRootDir);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -64,6 +64,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			var jsComponents = new JSComponentConfigurationStore();
 			_webviewManager = new WinUIWebViewManager(NativeView, new WinUIWebView2Wrapper(NativeView), Services!, MauiDispatcher.Instance, mauiAssetFileProvider, jsComponents, hostPageRelativePath, contentRootDir);
+
 			if (RootComponents != null)
 			{
 				foreach (var rootComponent in RootComponents)

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -115,8 +115,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			var mauiAssetFileProvider = new iOSMauiAssetFileProvider(contentRootDir);
 
-			var jsComponents = new JSComponentConfigurationStore();
-			_webviewManager = new IOSWebViewManager(this, NativeView, Services!, MauiDispatcher.Instance, mauiAssetFileProvider, jsComponents, hostPageRelativePath);
+			_webviewManager = new IOSWebViewManager(this, NativeView, Services!, MauiDispatcher.Instance, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -117,6 +117,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			var jsComponents = new JSComponentConfigurationStore();
 			_webviewManager = new IOSWebViewManager(this, NativeView, Services!, MauiDispatcher.Instance, mauiAssetFileProvider, jsComponents, hostPageRelativePath);
+
 			if (RootComponents != null)
 			{
 				foreach (var rootComponent in RootComponents)

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView.WebView2;
 using Microsoft.Extensions.FileProviders;
 using WebView2Control = Microsoft.Web.WebView2.WinForms.WebView2;
@@ -31,7 +30,6 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
         {
             Dispatcher = new WindowsFormsDispatcher(this);
 
-			RootComponents = new RootComponentsCollection(this);
 			RootComponents.CollectionChanged += HandleRootComponentsCollectionChanged;
 
             _webview = new WebView2Control()
@@ -98,13 +96,13 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		private void ResetHostPage() => HostPage = null;
         private bool ShouldSerializeHostPage() => !string.IsNullOrEmpty(HostPage);
 
-        /// <summary>
-        /// A collection of <see cref="RootComponent"/> instances that specify the Blazor <see cref="IComponent"/> types
-        /// to be used directly in the specified <see cref="HostPage"/>.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public RootComponentsCollection RootComponents { get; }
+		/// <summary>
+		/// A collection of <see cref="RootComponent"/> instances that specify the Blazor <see cref="IComponent"/> types
+		/// to be used directly in the specified <see cref="HostPage"/>.
+		/// </summary>
+		[Browsable(false)]
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public RootComponentsCollection RootComponents { get; } = new();
 
         /// <summary>
         /// Gets or sets an <see cref="IServiceProvider"/> containing services to be used by this control and also by application code.
@@ -157,8 +155,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
             var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage);
             var fileProvider = new PhysicalFileProvider(contentRootDir);
 
-			var jsComponents = new JSComponentConfigurationStore();
-			_webviewManager = new WebView2WebViewManager(new WindowsFormsWebView2Wrapper(_webview), Services, Dispatcher, fileProvider, jsComponents, hostPageRelativePath);
+			_webviewManager = new WebView2WebViewManager(new WindowsFormsWebView2Wrapper(_webview), Services, Dispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
 
             foreach (var rootComponent in RootComponents)
             {

--- a/src/BlazorWebView/src/WindowsForms/RootComponentCollectionExtensions.cs
+++ b/src/BlazorWebView/src/WindowsForms/RootComponentCollectionExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 {
@@ -21,7 +20,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
         /// <param name="components">The collection to which the component should be added.</param>
         /// <param name="selector">The selector to which the component will be associated.</param>
         /// <param name="parameters">The optional creation parameters for the component.</param>
-        public static void Add<TComponent>(this ObservableCollection<RootComponent> components, string selector, IDictionary<string, object> parameters = null)
+        public static void Add<TComponent>(this RootComponentsCollection components, string selector, IDictionary<string, object> parameters = null)
             where TComponent : IComponent
         {
             components.Add(new RootComponent(selector, typeof(TComponent), parameters));
@@ -33,7 +32,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
         /// </summary>
         /// <param name="components">The collection from which the component associated with the selector should be removed.</param>
         /// <param name="selector">The selector associated with the component to be removed.</param>
-        public static void Remove(this ObservableCollection<RootComponent> components, string selector)
+        public static void Remove(this RootComponentsCollection components, string selector)
         {
             for (var i = 0; i < components.Count; i++)
             {

--- a/src/BlazorWebView/src/WindowsForms/RootComponentsCollection.cs
+++ b/src/BlazorWebView/src/WindowsForms/RootComponentsCollection.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.ObjectModel;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
+{
+	public class RootComponentsCollection : ObservableCollection<RootComponent>, IJSComponentConfiguration
+	{
+		private readonly BlazorWebView _blazorWebView;
+
+		public RootComponentsCollection(BlazorWebView blazorWebView)
+		{
+			_blazorWebView = blazorWebView;
+		}
+
+		public JSComponentConfigurationStore JSComponents => _blazorWebView.WebViewManager?.JSComponentConfiguration!;
+	}
+}

--- a/src/BlazorWebView/src/WindowsForms/WebViewManagerCreatedEventArgs.cs
+++ b/src/BlazorWebView/src/WindowsForms/WebViewManagerCreatedEventArgs.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Components.WebView.WebView2;
+
+namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
+{
+	public class WebViewManagerCreatedEventArgs
+	{
+		public WebViewManagerCreatedEventArgs(WebView2WebViewManager webViewManager)
+		{
+			WebViewManager = webViewManager;
+		}
+
+		public WebView2WebViewManager WebViewManager { get; }
+	}
+}

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -10,17 +10,16 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView.WebView2;
 using Microsoft.Extensions.FileProviders;
 using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
 
 namespace Microsoft.AspNetCore.Components.WebView.Wpf
 {
-    /// <summary>
-    /// A Windows Presentation Foundation (WPF) control for hosting Blazor web components locally in Windows desktop applications.
-    /// </summary>
-    public class BlazorWebView : Control, IAsyncDisposable
+	/// <summary>
+	/// A Windows Presentation Foundation (WPF) control for hosting Blazor web components locally in Windows desktop applications.
+	/// </summary>
+	public class BlazorWebView : Control, IAsyncDisposable
     {
         #region Dependency property definitions
         /// <summary>
@@ -37,7 +36,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
         /// </summary>
         public static readonly DependencyProperty RootComponentsProperty = DependencyProperty.Register(
             name: nameof(RootComponents),
-            propertyType: typeof(ObservableCollection<RootComponent>),
+            propertyType: typeof(RootComponentsCollection),
             ownerType: typeof(BlazorWebView));
 
         /// <summary>
@@ -60,7 +59,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
         /// </summary>
         public BlazorWebView()
         {
-            SetValue(RootComponentsProperty, new ObservableCollection<RootComponent>());
+            SetValue(RootComponentsProperty, new RootComponentsCollection());
             RootComponents.CollectionChanged += HandleRootComponentsCollectionChanged;
 
             Template = new ControlTemplate
@@ -93,8 +92,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
         /// A collection of <see cref="RootComponent"/> instances that specify the Blazor <see cref="IComponent"/> types
         /// to be used directly in the specified <see cref="HostPage"/>.
         /// </summary>
-        public ObservableCollection<RootComponent> RootComponents =>
-            (ObservableCollection<RootComponent>)GetValue(RootComponentsProperty);
+        public RootComponentsCollection RootComponents =>
+            (RootComponentsCollection)GetValue(RootComponentsProperty);
 
         /// <summary>
         /// Gets or sets an <see cref="IServiceProvider"/> containing services to be used by this control and also by application code.
@@ -157,8 +156,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
             var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage);
             var fileProvider = new PhysicalFileProvider(contentRootDir);
 
-			var jsComponents = new JSComponentConfigurationStore();
-			_webviewManager = new WebView2WebViewManager(new WpfWebView2Wrapper(_webview), Services, WpfDispatcher.Instance, fileProvider, jsComponents, hostPageRelativePath);
+			_webviewManager = new WebView2WebViewManager(new WpfWebView2Wrapper(_webview), Services, WpfDispatcher.Instance, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
             foreach (var rootComponent in RootComponents)
             {
                 // Since the page isn't loaded yet, this will always complete synchronously

--- a/src/BlazorWebView/src/Wpf/RootComponentsCollection.cs
+++ b/src/BlazorWebView/src/Wpf/RootComponentsCollection.cs
@@ -4,7 +4,7 @@
 using System.Collections.ObjectModel;
 using Microsoft.AspNetCore.Components.Web;
 
-namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
+namespace Microsoft.AspNetCore.Components.WebView.Wpf
 {
 	public class RootComponentsCollection : ObservableCollection<RootComponent>, IJSComponentConfiguration
 	{

--- a/src/Controls/samples/Controls.Sample/Pages/Others/BlazorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/BlazorPage.xaml.cs
@@ -34,12 +34,7 @@ namespace Maui.Controls.Sample.Pages
 			};
 			bwv.RootComponents.Add(new RootComponent { Selector = "#app", ComponentType = typeof(Main) });
 
-
-			bwv.WebViewManagerCreated += (_, e) =>
-			{
-				bwv.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
-			};
-
+			bwv.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
 
 			verticalStack.Add(bwv);
 

--- a/src/Controls/samples/Controls.Sample/Pages/Others/BlazorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/BlazorPage.xaml.cs
@@ -2,6 +2,8 @@ using Maui.Controls.Sample.Controls;
 using Maui.Controls.Sample.Pages.Base;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
+using Microsoft.AspNetCore.Components.Web;
+using Maui.Controls.Sample.Pages.Others;
 
 #if NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Components.WebView.Maui;
@@ -31,6 +33,14 @@ namespace Maui.Controls.Sample.Pages
 				HostPage = @"wwwroot/index.html",
 			};
 			bwv.RootComponents.Add(new RootComponent { Selector = "#app", ComponentType = typeof(Main) });
+
+
+			bwv.WebViewManagerCreated += (_, e) =>
+			{
+				bwv.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
+			};
+
+
 			verticalStack.Add(bwv);
 
 			verticalStack.Add(new Label { Text = "Thank you for using Blazor and .NET MAUI!", FontSize = 24, TextColor = Colors.BlanchedAlmond, HorizontalOptions = LayoutOptions.Center });

--- a/src/Controls/samples/Controls.Sample/Pages/Others/MyDynamicComponent.razor
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/MyDynamicComponent.razor
@@ -1,0 +1,23 @@
+﻿<div class="dynamic-root-component" style="border: 1px dashed purple">
+    <p>
+        This is a Blazor component.
+    </p>
+    <p>
+        Click count: <strong class="click-count">@clicks</strong>
+        (will increment in steps of <strong class="increment-amount-value">@IncrementAmount</strong>)
+    </p>
+
+    <button class="increment" @onclick="Increment">Increment</button>
+
+</div>
+
+@code {
+    [Parameter] public int IncrementAmount { get; set; } = 7;
+
+    int clicks;
+
+    void Increment()
+    {
+        clicks += IncrementAmount;
+    }
+}

--- a/src/Controls/samples/Controls.Sample/wwwroot/index.html
+++ b/src/Controls/samples/Controls.Sample/wwwroot/index.html
@@ -7,6 +7,15 @@
     <base href="/" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="Maui.Controls.Sample.styles.css" rel="stylesheet" />
+    <script>
+        var i = 1;
+        function addDynamicComponent() {
+            var z = document.createElement('div');
+            document.body.appendChild(z);
+            Blazor.rootComponents.add(z, 'my-dynamic-root-component', { incrementAmount: i });
+            i++;
+        }
+    </script>
 </head>
 
 <body>
@@ -18,7 +27,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-
+    <button onclick="addDynamicComponent()">Add dynamic component</button>
     <script src="_framework/blazor.webview.js" autostart="false"></script>
 
 </body>


### PR DESCRIPTION
In each of .NET MAUI, WinForms, and WPF you register the dynamic components like so:

```c#
blazorWebView.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
```

And then in JS code you can dynamically add/remove components:

```js
// Add
var component = await Blazor.rootComponents.add(containerElement, 'my-dynamic-root-component', { param1: 'value1' });

// Remove
component.dispose();
```

Fixes #1825
