### PR TITLE
AppxPackageRecipe prop no longer needed

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.csproj
@@ -20,7 +20,7 @@
 		<AndroidVersionCode>1</AndroidVersionCode>
 
 		<!-- Required for C# Hot Reload -->
-		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
+		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">False</UseInterpreter>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-blazor/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.csproj
@@ -50,7 +50,6 @@
 	</ItemGroup>
 
 	<PropertyGroup>
-		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-blazor/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.csproj
@@ -51,7 +51,6 @@
 
 	<PropertyGroup>
 		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-		<AppxPackageRecipe>bin\$(Configuration)\net6.0-windows10.0.19041\win-x64\MauiApp1.build.appxrecipe</AppxPackageRecipe>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
@@ -50,7 +50,6 @@
 	</ItemGroup>
 
 	<PropertyGroup>
-		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
@@ -51,7 +51,6 @@
 
 	<PropertyGroup>
 		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-		<AppxPackageRecipe>bin\$(Configuration)\net6.0-windows10.0.19041\win-x64\MauiApp1.build.appxrecipe</AppxPackageRecipe>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
@@ -20,7 +20,7 @@
 		<AndroidVersionCode>1</AndroidVersionCode>
 
 		<!-- Required for C# Hot Reload -->
-		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
+		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">False</UseInterpreter>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Updated Single Project MSIX VSIX fixes the problem this workaround initially addressed, and now this work around causes issues itself, so removing.
