### PR TITLE
[Android] Don't clip layout children

### DIFF
--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Maui.Handlers
 	{
 		public LayoutViewGroup(Context context) : base(context)
 		{
+			//Maui layouts should not impose clipping on their children
+			SetClipChildren(false);
 		}
 
 		public LayoutViewGroup(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)


### PR DESCRIPTION
### Description of Change ###

When adding items to a Layout they are being clipped to the frame of the layout and don't allow to overlap for example other previous layout.

fixes #2331 

Check the LayoutUpdatesPage

When clearing the shapes and adding a a new one it should overlap the Update button, right now we can't see it because of the Elevation of the button

![image](https://user-images.githubusercontent.com/1235097/131529207-4881cdff-4b42-4320-8d50-a0513808f894.png)

But if you change the Update button to label, you can check it 

![image](https://user-images.githubusercontent.com/1235097/131529738-096a3765-fc08-404d-aea7-5c5b755a50cf.png)


### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
