### PR TITLE
Set base viewmapper to work against IViewHandler

### DIFF
--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override void NativeArrange(Rectangle frame)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null || Context == null)
 			{

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class ElementHandler : IElementHandler
 	{
-		public static IPropertyMapper<IElement, ElementHandler> ElementMapper = new PropertyMapper<IElement, ElementHandler>()
+		public static IPropertyMapper<IElement, IElementHandler> ElementMapper = new PropertyMapper<IElement, IElementHandler>()
 		{
 		};
 

--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
-			handler.WrappedNativeView?.UpdateBackground(image);
+			handler.GetWrappedNativeView()?.UpdateBackground(image);
 		}
 
 		public static void MapAspect(ImageHandler handler, IImage image) =>

--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
-			handler.WrappedNativeView?.UpdateBackground(image);
+			handler.GetWrappedNativeView()?.UpdateBackground(image);
 		}
 
 		public static void MapAspect(ImageHandler handler, IImage image) =>

--- a/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.iOS.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
-			handler.WrappedNativeView?.UpdateBackground(image);
+			handler.GetWrappedNativeView()?.UpdateBackground(image);
 		}
 
 		public static void MapAspect(ImageHandler handler, IImage image) =>

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override void NativeArrange(Rectangle frame)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null || Context == null)
 			{

--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
-			handler.WrappedNativeView?.UpdateBackground(label);
+			handler.GetWrappedNativeView()?.UpdateBackground(label);
 		}
 
 		public static void MapText(LabelHandler handler, ILabel label) =>

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
 
-			handler.WrappedNativeView?.UpdateBackground(label);
+			handler.GetWrappedNativeView()?.UpdateBackground(label);
 		}
 
 		public static void MapText(LabelHandler handler, ILabel label)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null)
 			{

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -21,67 +21,64 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		static partial void MappingFrame(ViewHandler handler, IView view)
+		static partial void MappingFrame(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateAnchorX(view);
-			((NativeView?)handler.WrappedNativeView)?.UpdateAnchorY(view);
+			handler.GetWrappedNativeView()?.UpdateAnchorX(view);
+			handler.GetWrappedNativeView()?.UpdateAnchorY(view);
 		}
 
-		public static void MapTranslationX(ViewHandler handler, IView view)
+		public static void MapTranslationX(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateTranslationX(view);
+			handler.GetWrappedNativeView()?.UpdateTranslationX(view);
 		}
 
-		public static void MapTranslationY(ViewHandler handler, IView view)
+		public static void MapTranslationY(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateTranslationY(view);
+			handler.GetWrappedNativeView()?.UpdateTranslationY(view);
 		}
 
-		public static void MapScale(ViewHandler handler, IView view)
+		public static void MapScale(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateScale(view);
+			handler.GetWrappedNativeView()?.UpdateScale(view);
 		}
 
-		public static void MapScaleX(ViewHandler handler, IView view)
+		public static void MapScaleX(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateScaleX(view);
+			handler.GetWrappedNativeView()?.UpdateScaleX(view);
 		}
 
-		public static void MapScaleY(ViewHandler handler, IView view)
+		public static void MapScaleY(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateScaleY(view);
+			handler.GetWrappedNativeView()?.UpdateScaleY(view);
 		}
 
-		public static void MapRotation(ViewHandler handler, IView view)
+		public static void MapRotation(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateRotation(view);
+			handler.GetWrappedNativeView()?.UpdateRotation(view);
 		}
 
-		public static void MapRotationX(ViewHandler handler, IView view)
+		public static void MapRotationX(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateRotationX(view);
+			handler.GetWrappedNativeView()?.UpdateRotationX(view);
 		}
 
-		public static void MapRotationY(ViewHandler handler, IView view)
+		public static void MapRotationY(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateRotationY(view);
+			handler.GetWrappedNativeView()?.UpdateRotationY(view);
 		}
 
-		public static void MapAnchorX(ViewHandler handler, IView view)
+		public static void MapAnchorX(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateAnchorX(view);
+			handler.GetWrappedNativeView()?.UpdateAnchorX(view);
 		}
 
-		public static void MapAnchorY(ViewHandler handler, IView view)
+		public static void MapAnchorY(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateAnchorY(view);
+			handler.GetWrappedNativeView()?.UpdateAnchorY(view);
 		}
 
-		static partial void MappingSemantics(ViewHandler handler, IView view)
+		static partial void MappingSemantics(IViewHandler handler, IView view)
 		{
-			if (handler.NativeView == null)
-				return;
-
 			if (view.Semantics != null &&
 				handler is ViewHandler viewHandler &&
 				viewHandler.AccessibilityDelegate == null)

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -77,11 +77,12 @@ namespace Microsoft.Maui.Handlers
 
 		static partial void MappingSemantics(IViewHandler handler, IView view)
 		{
-			var accessibilityDelegate = ViewCompat.GetAccessibilityDelegate(handler.NativeView as View)
-				as MauiAccessibilityDelegateCompat;
+			if (handler.NativeView == null)
+				return;
 
-			if (view.Semantics != null &&
-				accessibilityDelegate == null)
+			var accessibilityDelegate = ViewCompat.GetAccessibilityDelegate(handler.NativeView as View) as MauiAccessibilityDelegateCompat;
+
+			if (view.Semantics != null && accessibilityDelegate == null)
 			{
 				if (handler.NativeView is not NativeView nativeView)
 					return;

--- a/src/Core/src/Handlers/View/ViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Standard.cs
@@ -2,24 +2,24 @@
 {
 	public partial class ViewHandler
 	{
-		public static void MapTranslationX(ViewHandler handler, IView view) { }
+		public static void MapTranslationX(IViewHandler handler, IView view) { }
 
-		public static void MapTranslationY(ViewHandler handler, IView view) { }
+		public static void MapTranslationY(IViewHandler handler, IView view) { }
 
-		public static void MapScale(ViewHandler handler, IView view) { }
+		public static void MapScale(IViewHandler handler, IView view) { }
 
-		public static void MapScaleX(ViewHandler handler, IView view) { }
+		public static void MapScaleX(IViewHandler handler, IView view) { }
 
-		public static void MapScaleY(ViewHandler handler, IView view) { }
+		public static void MapScaleY(IViewHandler handler, IView view) { }
 
-		public static void MapRotation(ViewHandler handler, IView view) { }
+		public static void MapRotation(IViewHandler handler, IView view) { }
 
-		public static void MapRotationX(ViewHandler handler, IView view) { }
+		public static void MapRotationX(IViewHandler handler, IView view) { }
 
-		public static void MapRotationY(ViewHandler handler, IView view) { }
+		public static void MapRotationY(IViewHandler handler, IView view) { }
 
-		public static void MapAnchorX(ViewHandler handler, IView view) { }
+		public static void MapAnchorX(IViewHandler handler, IView view) { }
 
-		public static void MapAnchorY(ViewHandler handler, IView view) { }
+		public static void MapAnchorY(IViewHandler handler, IView view) { }
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -5,54 +5,54 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ViewHandler
 	{
-		public static void MapTranslationX(ViewHandler handler, IView view) 
+		public static void MapTranslationX(IViewHandler handler, IView view) 
 		{ 
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view);
+			handler.GetWrappedNativeView()?.UpdateTransformation(view);
 		}
 
-		public static void MapTranslationY(ViewHandler handler, IView view) 
+		public static void MapTranslationY(IViewHandler handler, IView view) 
 		{ 
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view);
+			handler.GetWrappedNativeView()?.UpdateTransformation(view);
 		}
 
-		public static void MapScale(ViewHandler handler, IView view) 
+		public static void MapScale(IViewHandler handler, IView view) 
 		{ 
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view);
+			handler.GetWrappedNativeView()?.UpdateTransformation(view);
 		}
 
-		public static void MapScaleX(ViewHandler handler, IView view)
+		public static void MapScaleX(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view);
+			handler.GetWrappedNativeView()?.UpdateTransformation(view);
 		}
 
-		public static void MapScaleY(ViewHandler handler, IView view)
+		public static void MapScaleY(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view);
+			handler.GetWrappedNativeView()?.UpdateTransformation(view);
 		}
 
-		public static void MapRotation(ViewHandler handler, IView view) 
+		public static void MapRotation(IViewHandler handler, IView view) 
 		{ 
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view); 
+			handler.GetWrappedNativeView()?.UpdateTransformation(view); 
 		}
 
-		public static void MapRotationX(ViewHandler handler, IView view) 
+		public static void MapRotationX(IViewHandler handler, IView view) 
 		{ 
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view);
+			handler.GetWrappedNativeView()?.UpdateTransformation(view);
 		}
 
-		public static void MapRotationY(ViewHandler handler, IView view) 
+		public static void MapRotationY(IViewHandler handler, IView view) 
 		{ 
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view); 
+			handler.GetWrappedNativeView()?.UpdateTransformation(view); 
 		}
 
-		public static void MapAnchorX(ViewHandler handler, IView view) 
+		public static void MapAnchorX(IViewHandler handler, IView view) 
 		{ 
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view); 
+			handler.GetWrappedNativeView()?.UpdateTransformation(view); 
 		}
 
-		public static void MapAnchorY(ViewHandler handler, IView view) 
+		public static void MapAnchorY(IViewHandler handler, IView view) 
 		{ 
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view); 
+			handler.GetWrappedNativeView()?.UpdateTransformation(view); 
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class ViewHandler : ElementHandler, IViewHandler
 	{
-		public static IPropertyMapper<IView, ViewHandler> ViewMapper = new PropertyMapper<IView, ViewHandler>(ElementHandler.ElementMapper)
+		public static IPropertyMapper<IView, IViewHandler> ViewMapper = new PropertyMapper<IView, IViewHandler>(ElementHandler.ElementMapper)
 		{
 			[nameof(IView.AutomationId)] = MapAutomationId,
 			[nameof(IView.Clip)] = MapClip,
@@ -87,8 +87,6 @@ namespace Microsoft.Maui.Handlers
 
 		object? IViewHandler.ContainerView => ContainerView;
 
-		protected NativeView? WrappedNativeView => ContainerView ?? NativeView;
-
 		public new NativeView? NativeView
 		{
 			get => (NativeView?)base.NativeView;
@@ -132,47 +130,47 @@ namespace Microsoft.Maui.Handlers
 		}
 #endif
 
-		public static void MapWidth(ViewHandler handler, IView view)
+		public static void MapWidth(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateWidth(view);
 		}
 
-		public static void MapHeight(ViewHandler handler, IView view)
+		public static void MapHeight(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateHeight(view);
 		}
 
-		public static void MapMinimumHeight(ViewHandler handler, IView view)
+		public static void MapMinimumHeight(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateMinimumHeight(view);
 		}
 
-		public static void MapMaximumHeight(ViewHandler handler, IView view)
+		public static void MapMaximumHeight(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateMaximumHeight(view);
 		}
 
-		public static void MapMinimumWidth(ViewHandler handler, IView view)
+		public static void MapMinimumWidth(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateMinimumWidth(view);
 		}
 
-		public static void MapMaximumWidth(ViewHandler handler, IView view)
+		public static void MapMaximumWidth(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateMaximumWidth(view);
 		}
 
-		public static void MapIsEnabled(ViewHandler handler, IView view)
+		public static void MapIsEnabled(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateIsEnabled(view);
 		}
 
-		public static void MapVisibility(ViewHandler handler, IView view)
+		public static void MapVisibility(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateVisibility(view);
 		}
 
-		public static void MapBackground(ViewHandler handler, IView view)
+		public static void MapBackground(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateBackground(view);
 		}
@@ -182,47 +180,47 @@ namespace Microsoft.Maui.Handlers
 			((NativeView?)handler.NativeView)?.UpdateFlowDirection(view);
 		}
 
-		public static void MapOpacity(ViewHandler handler, IView view)
+		public static void MapOpacity(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateOpacity(view);
 		}
 
-		public static void MapAutomationId(ViewHandler handler, IView view)
+		public static void MapAutomationId(IViewHandler handler, IView view)
 		{
 			((NativeView?)handler.NativeView)?.UpdateAutomationId(view);
 		}
 
-		public static void MapClip(ViewHandler handler, IView view)
+		public static void MapClip(IViewHandler handler, IView view)
 		{
 #if WINDOWS
 			((NativeView?)handler.NativeView)?.UpdateClip(view);
 #else
-			((NativeView?)handler.WrappedNativeView)?.UpdateClip(view);
+			handler.GetWrappedNativeView()?.UpdateClip(view);
 #endif
 		}
 
-		static partial void MappingSemantics(ViewHandler handler, IView view);
+		static partial void MappingSemantics(IViewHandler handler, IView view);
 
-		public static void MapSemantics(ViewHandler handler, IView view)
+		public static void MapSemantics(IViewHandler handler, IView view)
 		{
 			MappingSemantics(handler, view);
 			((NativeView?)handler.NativeView)?.UpdateSemantics(view);
 		}
 
-		public static void MapInvalidateMeasure(ViewHandler handler, IView view, object? args)
+		public static void MapInvalidateMeasure(IViewHandler handler, IView view, object? args)
 		{
-			handler.NativeView?.InvalidateMeasure(view);
+			(handler.NativeView as NativeView)?.InvalidateMeasure(view);
 		}
 
-		public static void MapContainerView(ViewHandler handler, IView view)
+		public static void MapContainerView(IViewHandler handler, IView view)
 		{
 			if (handler is ViewHandler viewHandler)
 				handler.HasContainer = viewHandler.NeedsContainer;
 		}
 
-		static partial void MappingFrame(ViewHandler handler, IView view);
+		static partial void MappingFrame(IViewHandler handler, IView view);
 
-		public static void MapFrame(ViewHandler handler, IView view, object? args)
+		public static void MapFrame(IViewHandler handler, IView view, object? args)
 		{
 			MappingFrame(handler, view);
 #if WINDOWS

--- a/src/Core/src/Handlers/View/ViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.iOS.cs
@@ -4,64 +4,64 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ViewHandler
 	{
-		static partial void MappingFrame(ViewHandler handler, IView view)
+		static partial void MappingFrame(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapTranslationX(ViewHandler handler, IView view)
+		public static void MapTranslationX(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapTranslationY(ViewHandler handler, IView view)
+		public static void MapTranslationY(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapScale(ViewHandler handler, IView view)
+		public static void MapScale(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapScaleX(ViewHandler handler, IView view)
+		public static void MapScaleX(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapScaleY(ViewHandler handler, IView view)
+		public static void MapScaleY(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapRotation(ViewHandler handler, IView view)
+		public static void MapRotation(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapRotationX(ViewHandler handler, IView view)
+		public static void MapRotationX(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapRotationY(ViewHandler handler, IView view)
+		public static void MapRotationY(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapAnchorX(ViewHandler handler, IView view)
+		public static void MapAnchorX(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapAnchorY(ViewHandler handler, IView view)
+		public static void MapAnchorY(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
 		}
 
-		internal static void UpdateTransformation(ViewHandler handler, IView view)
+		internal static void UpdateTransformation(IViewHandler handler, IView view)
 		{
-			((NativeView?)handler.WrappedNativeView)?.UpdateTransformation(view);
+			handler.GetWrappedNativeView()?.UpdateTransformation(view);
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
@@ -9,11 +9,8 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ViewHandler<TVirtualView, TNativeView> : INativeViewHandler
 	{
-		View? INativeViewHandler.NativeView => WrappedNativeView;
+		View? INativeViewHandler.NativeView => this.GetWrappedNativeView();
 		View? INativeViewHandler.ContainerView => ContainerView;
-
-		protected new View? WrappedNativeView =>
-			(View?)base.WrappedNativeView;
 
 		public new WrapperView? ContainerView
 		{
@@ -25,7 +22,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override void NativeArrange(Rectangle frame)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null || MauiContext == null || Context == null)
 			{
@@ -48,7 +45,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null || VirtualView == null || Context == null)
 			{

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -8,11 +8,8 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class ViewHandler<TVirtualView, TNativeView> : INativeViewHandler
 	{
-		FrameworkElement? INativeViewHandler.NativeView => WrappedNativeView;
+		FrameworkElement? INativeViewHandler.NativeView => this.GetWrappedNativeView();
 		FrameworkElement? INativeViewHandler.ContainerView => ContainerView;
-
-		protected new FrameworkElement? WrappedNativeView =>
-			(FrameworkElement?)base.WrappedNativeView;
 
 		public new Border? ContainerView
 		{
@@ -22,7 +19,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override void NativeArrange(Rectangle rect)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null)
 				return;
@@ -35,7 +32,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null)
 				return Size.Zero;

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
@@ -6,11 +6,8 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ViewHandler<TVirtualView, TNativeView> : INativeViewHandler
 	{
-		UIView? INativeViewHandler.NativeView => WrappedNativeView;
+		UIView? INativeViewHandler.NativeView => this.GetWrappedNativeView();
 		UIView? INativeViewHandler.ContainerView => ContainerView;
-
-		protected new UIView? WrappedNativeView =>
-			(UIView?)base.WrappedNativeView;
 
 		public new WrapperView? ContainerView
 		{
@@ -22,7 +19,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override void NativeArrange(Rectangle rect)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null)
 				return;
@@ -40,7 +37,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var nativeView = WrappedNativeView;
+			var nativeView = this.GetWrappedNativeView();
 
 			if (nativeView == null)
 			{

--- a/src/Core/src/Platform/ViewHandlerExtensions.cs
+++ b/src/Core/src/Platform/ViewHandlerExtensions.cs
@@ -1,0 +1,18 @@
+﻿#if __IOS__ || MACCATALYST
+using NativeView = UIKit.UIView;
+#elif __ANDROID__
+using NativeView = Android.Views.View;
+#elif WINDOWS
+using NativeView = Microsoft.UI.Xaml.FrameworkElement;
+#elif NETSTANDARD
+using NativeView = System.Object;
+#endif
+
+namespace Microsoft.Maui
+{
+	public static class ViewHandlerExtensions
+	{
+		public static NativeView? GetWrappedNativeView(this IViewHandler viewHandler) =>
+			(NativeView?)(viewHandler.ContainerView ?? viewHandler.NativeView);
+	}
+}


### PR DESCRIPTION
### Description of Change ###

ViewHandler.ViewMapper was changed to `<IView, ViewHandler>`

This means all handlers that want to use this mapper are required to inherit from ViewHandler. 

This PR changes the base mapper to `<IView, IViewHandler>` so someone can reuse the ViewHandler Mapper without inheriting from our implementation

I also moved `WrappedNativeView` out to an extension method because it's a behavior that generally applies to `IViewHandler`