### PR TITLE
Update OutputType to WinExe on -windows

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp1.csproj
@@ -49,9 +49,11 @@
 		<PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="WINDOWSAPPSDK_VERSION" NoWarn="NU1701" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
+	<PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
+		<OutputType>WinExe</OutputType>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	</PropertyGroup>
+
 	<ItemGroup>
 		<Content Remove="Properties\launchSettings.json" />
 	</ItemGroup>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
@@ -49,8 +49,9 @@
 		<PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="WINDOWSAPPSDK_VERSION" NoWarn="NU1701" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
+	<PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
+		<OutputType>WinExe</OutputType>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp1.csproj
@@ -20,7 +20,7 @@
 		<AndroidVersionCode>1</AndroidVersionCode>
 
 		<!-- Required for C# Hot Reload -->
-		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">False</UseInterpreter>
+		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This happens in the sdk targets/props but not quite early enough to influence the `EnableWin32Codegen` property which causes `[STAThreadAttribute]` to be generated in the Windows app.


Also: For non-blazor projects, interpreter is fine
Blazor android projects (and possibly iOS?) will require this runtime fix: dotnet/runtime#58467
So, enabling interpreter again on non-blazor templates
