### PR TITLE
Remove test cloud if def for now

### DIFF
--- a/src/Compatibility/ControlGallery/src/Android/FormsAppCompatActivity.cs
+++ b/src/Compatibility/ControlGallery/src/Android/FormsAppCompatActivity.cs
@@ -56,13 +56,12 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Android
 			Microsoft.Maui.Controls.Compatibility.Forms.Init(this, bundle);
 			FormsMaps.Init(this, bundle);
 
-#if ENABLE_TEST_CLOUD
 			ViewHandler.ViewMapper
 				.Add(nameof(IView.AutomationId), (h, v) =>
 				{
-					h.NativeView.ContentDescription = v.AutomationId;
+					if (h.NativeView is global::Android.Views.View nativeView)
+						nativeView.ContentDescription = v.AutomationId;
 				});
-#endif
 
 			//FormsMaterial.Init(this, bundle);
 			AndroidAppLinks.Init(this);


### PR DESCRIPTION
### Description of Change ###

A while back I added an if/def so that ContentDescription will only get set when we are producing APKs for Xamarin.UITest

I've removed that if/def for now because we need to rethink a few things before we start submitting APKS up to Xamarin.UITest and for now this will get our build back to green