### PR TITLE
[Android] Show entire search bar by default and make it not collapse

### DIFF
--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Handlers
 		protected override SearchView CreateNativeView()
 		{
 			var searchView = new SearchView(Context);
+			searchView.SetIconifiedByDefault(false);
 
 			_editText = searchView.GetFirstChildOfType<EditText>();
 


### PR DESCRIPTION
Make entire search bar be visible (and therefore more accessible!) by default, not expandable/collapsible

## Before
https://user-images.githubusercontent.com/21988533/131734939-8b0e7a72-46c6-4f56-8781-1d30a32c91d4.mp4

## After
![Screenshot (Sep 1, 2021 3_48_41 PM)](https://user-images.githubusercontent.com/21988533/131735159-b6e7d0e7-b306-44fb-ab80-9beb3a7e3619.png)
