### PR TITLE
Update project templates to work with safe characters

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0",
+      "version": "1.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.2.0",
+      "version": "1.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -110,7 +110,7 @@ Task("dotnet-templates")
         foreach (var template in new [] { "maui", "maui-blazor", "mauilib" })
         {
             var name = template.Replace("-", "") + " Space-Dash";
-            StartProcess(dn, $"new {template} -o ./templatesTest/{name}");
+            StartProcess(dn, $"new {template} -o \"./templatesTest/{name}\"");
 
             RunMSBuildWithDotNet($"./templatesTest/{name}");
         }

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -350,7 +350,7 @@ void StartVisualStudioForDotNet6(string sln = "./Microsoft.Maui-net6.sln")
 void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = null, bool deployAndRun = false)
 {
     var name = System.IO.Path.GetFileNameWithoutExtension(sln);
-    var binlog = $"{logDirectory}/{name}-{configuration}.binlog";
+    var binlog = $"\"{logDirectory}/{name}-{configuration}.binlog\"";
     
     if(localDotnet)
         SetDotNetEnvironmentVariables();

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -109,7 +109,7 @@ Task("dotnet-templates")
 
         foreach (var template in new [] { "maui", "maui-blazor", "mauilib" })
         {
-            var name = template.Replace("-", "");
+            var name = template.Replace("-", "") + " Space-Dash";
             StartProcess(dn, $"new {template} -o ./templatesTest/{name}");
 
             RunMSBuildWithDotNet($"./templatesTest/{name}");

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -11,7 +11,7 @@
       "language": "C#",
       "type": "solution"
     },
-    "sourceName": "MauiApp1",
+    "sourceName": "MauiApp.1",
     "sources": [
       {
         "source": "./",
@@ -37,7 +37,7 @@
         "type": "parameter",
         "description": "Overrides the $(ApplicationId) in the project",
         "datatype": "string",
-        "replaces": "com.companyname.MauiApp1"
+        "replaces": "com.companyname.MauiApp.1"
       },
       "windowsAppSdkVersion": {
         "type": "parameter",

--- a/src/Templates/src/templates/maui-blazor/App.xaml
+++ b/src/Templates/src/templates/maui-blazor/App.xaml
@@ -1,8 +1,8 @@
 ﻿<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:windows="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;assembly=Microsoft.Maui.Controls"
-             xmlns:local="clr-namespace:MauiApp1"
-             x:Class="MauiApp1.App"
+             xmlns:local="clr-namespace:MauiApp._1"
+             x:Class="MauiApp._1.App"
              windows:Application.ImageDirectory="Assets">
     <Application.Resources>
         <ResourceDictionary>

--- a/src/Templates/src/templates/maui-blazor/App.xaml.cs
+++ b/src/Templates/src/templates/maui-blazor/App.xaml.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
 using Application = Microsoft.Maui.Controls.Application;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public partial class App : Application
 	{

--- a/src/Templates/src/templates/maui-blazor/Data/WeatherForecast.cs
+++ b/src/Templates/src/templates/maui-blazor/Data/WeatherForecast.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace MauiApp1.Data
+namespace MauiApp._1.Data
 {
 	public class WeatherForecast
 	{

--- a/src/Templates/src/templates/maui-blazor/Data/WeatherForecastService.cs
+++ b/src/Templates/src/templates/maui-blazor/Data/WeatherForecastService.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace MauiApp1.Data
+namespace MauiApp._1.Data
 {
 	public class WeatherForecastService
 	{

--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml
@@ -1,8 +1,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:b="clr-namespace:Microsoft.AspNetCore.Components.WebView.Maui;assembly=Microsoft.AspNetCore.Components.WebView.Maui"
-             xmlns:local="clr-namespace:MauiApp1"
-             x:Class="MauiApp1.MainPage"
+             xmlns:local="clr-namespace:MauiApp._1"
+             x:Class="MauiApp._1.MainPage"
              BackgroundColor="{DynamicResource PageBackgroundColor}">
 
     <b:BlazorWebView HostPage="wwwroot/index.html">

--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml.cs
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.Maui.Controls;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public partial class MainPage : ContentPage
 	{

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -51,7 +51,6 @@
 
 	<PropertyGroup>
 		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-		<AppxPackageRecipe>bin\$(Configuration)\net6.0-windows10.0.19041\win-x64\MauiApp._1.build.appxrecipe</AppxPackageRecipe>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-ios;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
 		<!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
-		<RootNamespace>MauiApp1</RootNamespace>
+		<RootNamespace>MauiApp._1</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
@@ -13,7 +13,7 @@
 		<ApplicationTitle>MauiApp1</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.MauiApp1</ApplicationId>
+		<ApplicationId>com.companyname.MauiApp._1</ApplicationId>
 
 		<!-- Versions -->
 		<ApplicationVersion>1.0</ApplicationVersion>
@@ -51,8 +51,11 @@
 
 	<PropertyGroup>
 		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-		<AppxPackageRecipe>bin\$(Configuration)\net6.0-windows10.0.19041\win-x64\MauiApp1.build.appxrecipe</AppxPackageRecipe>
+		<AppxPackageRecipe>bin\$(Configuration)\net6.0-windows10.0.19041\win-x64\MauiApp._1.build.appxrecipe</AppxPackageRecipe>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
+	<ItemGroup>
+		<Content Remove="Properties\launchSettings.json" />
+	</ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.sln
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.sln
@@ -1,9 +1,9 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31611.283
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiApp1", "MauiApp1.csproj", "{07CD65EF-6238-4365-AF5D-F6D433967F48}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiApp.1", "MauiApp.1.csproj", "{07CD65EF-6238-4365-AF5D-F6D433967F48}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Templates/src/templates/maui-blazor/MauiProgram.cs
+++ b/src/Templates/src/templates/maui-blazor/MauiProgram.cs
@@ -4,9 +4,9 @@ using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Controls.Hosting;
-using MauiApp1.Data;
+using MauiApp._1.Data;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public static class MauiProgram
 	{

--- a/src/Templates/src/templates/maui-blazor/Pages/FetchData.razor
+++ b/src/Templates/src/templates/maui-blazor/Pages/FetchData.razor
@@ -1,6 +1,6 @@
 ﻿@page "/fetchdata"
 
-@using MauiApp.1.Data
+@using MauiApp._1.Data
 @inject WeatherForecastService ForecastService
 
 <h1>Weather forecast</h1>

--- a/src/Templates/src/templates/maui-blazor/Pages/FetchData.razor
+++ b/src/Templates/src/templates/maui-blazor/Pages/FetchData.razor
@@ -1,6 +1,6 @@
 ﻿@page "/fetchdata"
 
-@using MauiApp1.Data
+@using MauiApp.1.Data
 @inject WeatherForecastService ForecastService
 
 <h1>Weather forecast</h1>

--- a/src/Templates/src/templates/maui-blazor/Platforms/Android/MainActivity.cs
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Android/MainActivity.cs
@@ -2,7 +2,7 @@
 using Android.Content.PM;
 using Microsoft.Maui;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
 	public class MainActivity : MauiAppCompatActivity

--- a/src/Templates/src/templates/maui-blazor/Platforms/Android/MainApplication.cs
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Android/MainApplication.cs
@@ -3,7 +3,7 @@ using Android.App;
 using Android.Runtime;
 using Microsoft.Maui;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	[Application]
 	public class MainApplication : MauiApplication

--- a/src/Templates/src/templates/maui-blazor/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/Templates/src/templates/maui-blazor/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,7 +1,7 @@
 ﻿using Foundation;
 using Microsoft.Maui;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	[Register("AppDelegate")]
 	public class AppDelegate : MauiUIApplicationDelegate

--- a/src/Templates/src/templates/maui-blazor/Platforms/MacCatalyst/Program.cs
+++ b/src/Templates/src/templates/maui-blazor/Platforms/MacCatalyst/Program.cs
@@ -1,6 +1,6 @@
 ﻿using UIKit;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public class Program
 	{

--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/App.xaml
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/App.xaml
@@ -1,8 +1,8 @@
 ﻿<maui:MauiWinUIApplication
-    x:Class="MauiApp1.WinUI.App"
+    x:Class="MauiApp._1.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:maui="using:Microsoft.Maui"
-    xmlns:local="using:MauiApp1.WinUI">
+    xmlns:local="using:MauiApp._1.WinUI">
 
 </maui:MauiWinUIApplication>

--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/App.xaml.cs
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/App.xaml.cs
@@ -5,7 +5,7 @@ using Windows.ApplicationModel;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace MauiApp1.WinUI
+namespace MauiApp._1.WinUI
 {
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.

--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
@@ -12,7 +12,7 @@
     Version="1.0.0.0" />
 
   <Properties>
-    <DisplayName>MauiApp1</DisplayName>
+    <DisplayName>MauiApp.1</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
     <Logo>Assets\appiconStoreLogo.png</Logo>
   </Properties>
@@ -31,8 +31,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="MauiApp1"
-        Description="MauiApp1"
+        DisplayName="MauiApp.1"
+        Description="MauiApp.1"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\appiconMediumTile.png"
         Square44x44Logo="Assets\appiconLogo.png">
@@ -40,7 +40,7 @@
           Wide310x150Logo="Assets\appiconWideTile.png"
           Square71x71Logo="Assets\appiconSmallTile.png"
           Square310x310Logo="Assets\appiconLargeTile.png"
-          ShortName="MauiApp1">
+          ShortName="MauiApp.1">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>

--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/app.manifest
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MauiApp1.WinUI.app"/>
+  <assemblyIdentity version="1.0.0.0" name="MauiApp.1.WinUI.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>

--- a/src/Templates/src/templates/maui-blazor/Platforms/iOS/AppDelegate.cs
+++ b/src/Templates/src/templates/maui-blazor/Platforms/iOS/AppDelegate.cs
@@ -1,7 +1,7 @@
 ﻿using Foundation;
 using Microsoft.Maui;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	[Register("AppDelegate")]
 	public class AppDelegate : MauiUIApplicationDelegate

--- a/src/Templates/src/templates/maui-blazor/Platforms/iOS/Program.cs
+++ b/src/Templates/src/templates/maui-blazor/Platforms/iOS/Program.cs
@@ -1,6 +1,6 @@
 ﻿using UIKit;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public class Program
 	{

--- a/src/Templates/src/templates/maui-blazor/Shared/NavMenu.razor
+++ b/src/Templates/src/templates/maui-blazor/Shared/NavMenu.razor
@@ -1,5 +1,5 @@
 ﻿<div class="top-row pl-4 navbar navbar-dark">
-	<a class="navbar-brand" href="">MauiApp1</a>
+	<a class="navbar-brand" href="">MauiApp.1</a>
 	<button class="navbar-toggler" @onclick="ToggleNavMenu">
 		<span class="navbar-toggler-icon"></span>
 	</button>

--- a/src/Templates/src/templates/maui-blazor/_Imports.razor
+++ b/src/Templates/src/templates/maui-blazor/_Imports.razor
@@ -4,5 +4,5 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
-@using MauiApp1
-@using MauiApp1.Shared
+@using MauiApp.1
+@using MauiApp.1.Shared

--- a/src/Templates/src/templates/maui-blazor/_Imports.razor
+++ b/src/Templates/src/templates/maui-blazor/_Imports.razor
@@ -4,5 +4,5 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
-@using MauiApp.1
-@using MauiApp.1.Shared
+@using MauiApp._1
+@using MauiApp._1.Shared

--- a/src/Templates/src/templates/maui-blazor/wwwroot/index.html
+++ b/src/Templates/src/templates/maui-blazor/wwwroot/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>MauiApp1</title>
+    <title>MauiApp.1</title>
     <base href="/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="css/app.css" rel="stylesheet" />

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -11,7 +11,7 @@
       "language": "C#",
       "type": "solution"
     },
-    "sourceName": "MauiApp1",
+    "sourceName": "MauiApp.1",
     "sources": [
       {
         "source": "./",
@@ -37,7 +37,7 @@
         "type": "parameter",
         "description": "Overrides the $(ApplicationId) in the project",
         "datatype": "string",
-        "replaces": "com.companyname.MauiApp1"
+        "replaces": "com.companyname.MauiApp.1"
       },
       "windowsAppSdkVersion": {
         "type": "parameter",

--- a/src/Templates/src/templates/maui-mobile/App.xaml
+++ b/src/Templates/src/templates/maui-mobile/App.xaml
@@ -1,8 +1,8 @@
 ﻿<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:windows="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;assembly=Microsoft.Maui.Controls"
-             xmlns:local="clr-namespace:MauiApp1"
-             x:Class="MauiApp1.App"
+             xmlns:local="clr-namespace:MauiApp._1"
+             x:Class="MauiApp._1.App"
              windows:Application.ImageDirectory="Assets">
     <Application.Resources>
         <ResourceDictionary>

--- a/src/Templates/src/templates/maui-mobile/App.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/App.xaml.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
 using Application = Microsoft.Maui.Controls.Application;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public partial class App : Application
 	{

--- a/src/Templates/src/templates/maui-mobile/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/MainPage.xaml
@@ -1,6 +1,6 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MauiApp1.MainPage"
+             x:Class="MauiApp._1.MainPage"
              BackgroundColor="{DynamicResource SecondaryColor}">
 
     <ScrollView Padding="{OnPlatform iOS='30,60,30,30', Default='30'}">

--- a/src/Templates/src/templates/maui-mobile/MainPage.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/MainPage.xaml.cs
@@ -2,7 +2,7 @@
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Essentials;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public partial class MainPage : ContentPage
 	{

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-ios;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
 		<!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
-		<RootNamespace>MauiApp1</RootNamespace>
+		<RootNamespace>MauiApp._1</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
@@ -13,7 +13,7 @@
 		<ApplicationTitle>MauiApp1</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.MauiApp1</ApplicationId>
+		<ApplicationId>com.companyname.MauiApp._1</ApplicationId>
 
 		<!-- Versions -->
 		<ApplicationVersion>1.0</ApplicationVersion>
@@ -51,11 +51,8 @@
 
 	<PropertyGroup>
 		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-		<AppxPackageRecipe>bin\$(Configuration)\net6.0-windows10.0.19041\win-x64\MauiApp1.build.appxrecipe</AppxPackageRecipe>
+		<AppxPackageRecipe>bin\$(Configuration)\net6.0-windows10.0.19041\win-x64\MauiApp._1.build.appxrecipe</AppxPackageRecipe>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
-	<ItemGroup>
-		<Content Remove="Properties\launchSettings.json" />
-	</ItemGroup>
 
 </Project>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -51,7 +51,6 @@
 
 	<PropertyGroup>
 		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-		<AppxPackageRecipe>bin\$(Configuration)\net6.0-windows10.0.19041\win-x64\MauiApp._1.build.appxrecipe</AppxPackageRecipe>
 		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.sln
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.sln
@@ -1,9 +1,9 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31611.283
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiApp1", "MauiApp1.csproj", "{07CD65EF-6238-4365-AF5D-F6D433967F48}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiApp.1", "MauiApp.1.csproj", "{07CD65EF-6238-4365-AF5D-F6D433967F48}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Templates/src/templates/maui-mobile/MauiProgram.cs
+++ b/src/Templates/src/templates/maui-mobile/MauiProgram.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Controls.Hosting;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public static class MauiProgram
 	{

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/MainActivity.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/MainActivity.cs
@@ -2,7 +2,7 @@
 using Android.Content.PM;
 using Microsoft.Maui;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
 	public class MainActivity : MauiAppCompatActivity

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/MainApplication.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/MainApplication.cs
@@ -3,7 +3,7 @@ using Android.App;
 using Android.Runtime;
 using Microsoft.Maui;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	[Application]
 	public class MainApplication : MauiApplication

--- a/src/Templates/src/templates/maui-mobile/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,7 +1,7 @@
 ﻿using Foundation;
 using Microsoft.Maui;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	[Register("AppDelegate")]
 	public class AppDelegate : MauiUIApplicationDelegate

--- a/src/Templates/src/templates/maui-mobile/Platforms/MacCatalyst/Program.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/MacCatalyst/Program.cs
@@ -1,6 +1,6 @@
 ﻿using UIKit;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public class Program
 	{

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/App.xaml
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/App.xaml
@@ -1,8 +1,8 @@
 ﻿<maui:MauiWinUIApplication
-    x:Class="MauiApp1.WinUI.App"
+    x:Class="MauiApp._1.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:maui="using:Microsoft.Maui"
-    xmlns:local="using:MauiApp1.WinUI">
+    xmlns:local="using:MauiApp._1.WinUI">
 
 </maui:MauiWinUIApplication>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/App.xaml.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/App.xaml.cs
@@ -5,7 +5,7 @@ using Windows.ApplicationModel;
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace MauiApp1.WinUI
+namespace MauiApp._1.WinUI
 {
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
@@ -12,7 +12,7 @@
     Version="1.0.0.0" />
 
   <Properties>
-    <DisplayName>MauiApp1</DisplayName>
+    <DisplayName>MauiApp.1</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
     <Logo>Assets\appiconStoreLogo.png</Logo>
   </Properties>
@@ -31,8 +31,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="MauiApp1"
-        Description="MauiApp1"
+        DisplayName="MauiApp.1"
+        Description="MauiApp.1"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\appiconMediumTile.png"
         Square44x44Logo="Assets\appiconLogo.png">
@@ -40,7 +40,7 @@
           Wide310x150Logo="Assets\appiconWideTile.png"
           Square71x71Logo="Assets\appiconSmallTile.png"
           Square310x310Logo="Assets\appiconLargeTile.png"
-          ShortName="MauiApp1">
+          ShortName="MauiApp.1">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/app.manifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MauiApp1.WinUI.app"/>
+  <assemblyIdentity version="1.0.0.0" name="MauiApp.1.WinUI.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>

--- a/src/Templates/src/templates/maui-mobile/Platforms/iOS/AppDelegate.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/iOS/AppDelegate.cs
@@ -1,7 +1,7 @@
 ﻿using Foundation;
 using Microsoft.Maui;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	[Register("AppDelegate")]
 	public class AppDelegate : MauiUIApplicationDelegate

--- a/src/Templates/src/templates/maui-mobile/Platforms/iOS/Program.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/iOS/Program.cs
@@ -1,6 +1,6 @@
 ﻿using UIKit;
 
-namespace MauiApp1
+namespace MauiApp._1
 {
 	public class Program
 	{


### PR DESCRIPTION
Fixes #2176

To learn more about the seemingly-odd `MauiApp.1` and `MauiApp._1` stuff you'll now see, read here: https://github.com/dotnet/templating/wiki/Naming-and-default-value-forms

TL;DR: The template engine is clever enough to understand different substitution patterns (rather than just blanket search & replace), so if you follow certain conventions, the template engine will use the correct substitution you need for cases where there are restricted character sets, such as C# namespaces and class names.

@vlada-shubina - I've also tagged you here as a reviewer because it seems like you're the expert on this. Thank you in advance if you're able to review this!