### PR TITLE
[Android] Fix Horizontal Scrollbar Visibility

### DIFF
--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui
 		ScrollOrientation _scrollOrientation = ScrollOrientation.Vertical;
 		ScrollBarVisibility _defaultHorizontalScrollVisibility = 0;
 		ScrollBarVisibility _defaultVerticalScrollVisibility = 0;
+		ScrollBarVisibility _horizontalScrollVisibility = 0;
 
 		internal float LastX { get; set; }
 		internal float LastY { get; set; }
@@ -44,6 +45,7 @@ namespace Microsoft.Maui
 
 		public void SetHorizontalScrollBarVisibility(ScrollBarVisibility scrollBarVisibility)
 		{
+			_horizontalScrollVisibility = scrollBarVisibility;
 			if (_hScrollView == null)
 			{
 				return;
@@ -92,6 +94,7 @@ namespace Microsoft.Maui
 					_hScrollView = new MauiHorizontalScrollView(Context, this);
 					_hScrollView.HorizontalFadingEdgeEnabled = HorizontalFadingEdgeEnabled;
 					_hScrollView.SetFadingEdgeLength(HorizontalFadingEdgeLength);
+					SetHorizontalScrollBarVisibility(_horizontalScrollVisibility);
 				}
 
 				_hScrollView.IsBidirectional = _isBidirectional = orientation == ScrollOrientation.Both;

--- a/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ScrollView/ScrollViewHandlerTests.Android.cs
@@ -45,5 +45,25 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.True(result, $"Expected (but did not find) a {nameof(AppCompatEditText)} child of the {nameof(NestedScrollView)}.");
 		}
+
+		[Fact]
+		public async Task HorizontalVisibilityInitializesCorrectly()
+		{
+			bool result = await InvokeOnMainThreadAsync(() =>
+			{
+				var scrollView = new ScrollViewStub()
+				{
+					Orientation = ScrollOrientation.Horizontal,
+					HorizontalScrollBarVisibility = ScrollBarVisibility.Never
+				};
+
+				var scrollViewHandler = CreateHandler(scrollView);
+
+
+				return ((MauiHorizontalScrollView)scrollViewHandler.NativeView.GetChildAt(0)).HorizontalScrollBarEnabled;
+			});
+
+			Assert.False(result, $"Expected HorizontalScrollBarEnabled to be false.");
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

The handler is currently applying the horizontal visibility property before the orientation property is set. This means that the HorizontalScrollView hasn't been created so the property never gets applied

This PR keeps track of the setting and then applies it once the horizontal scroll view is initialized

- fixes #2202
### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
