### PR TITLE
Handle ContentViews and templated content in new layout system

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/PageContainer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/PageContainer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		{
 			Child.UpdateLayout();
 
-			if (Child.View is PageViewGroup pageViewGroup)
+			if (Child.View is ContentViewGroup pageViewGroup)
 			{
 				// This is a way to handle situations where the root page is shimmed and uses fragments to host other pages (e.g., NavigationPageRenderer)
 				// The old layout system would have set the width/height of the contained Page by now; the xplat layout call would have come

--- a/src/Compatibility/Core/src/Android/VisualElementTracker.cs
+++ b/src/Compatibility/Core/src/Android/VisualElementTracker.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				formsViewGroup.MeasureAndLayout(MeasureSpecFactory.MakeMeasureSpec(width, MeasureSpecMode.Exactly), MeasureSpecFactory.MakeMeasureSpec(height, MeasureSpecMode.Exactly), x, y, x + width, y + height);
 				Performance.Stop(reference, "MeasureAndLayout");
 			}
-			else if ((aview is LayoutViewGroup || aview is PageViewGroup) && width == 0 && height == 0)
+			else if ((aview is LayoutViewGroup || aview is ContentViewGroup) && width == 0 && height == 0)
 			{
 				// Nothing to do here; just chill.
 			}

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -115,7 +115,6 @@ namespace Microsoft.Maui.Controls.Hosting
 					handlers.TryAddCompatibilityRenderer(typeof(ProgressBar), typeof(ProgressBarRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(ScrollView), typeof(ScrollViewRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(ActivityIndicator), typeof(ActivityIndicatorRenderer));
-					handlers.TryAddCompatibilityRenderer(typeof(Frame), typeof(FrameRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(CheckBox), typeof(CheckBoxRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(TabbedPage), typeof(TabbedPageRenderer));
 #if !WINDOWS
@@ -138,7 +137,6 @@ namespace Microsoft.Maui.Controls.Hosting
 					handlers.TryAddCompatibilityRenderer(typeof(SwitchCell), typeof(SwitchCellRenderer));
 
 					// This is for Layouts that currently don't work when assigned to LayoutHandler
-					handlers.TryAddCompatibilityRenderer(typeof(ContentView), typeof(DefaultRenderer));
 
 					DependencyService.Register<Xaml.ResourcesLoader>();
 					DependencyService.Register<NativeBindingService>();

--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -1,10 +1,11 @@
 using System;
 using System.ComponentModel;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls
 {
-	public class ContentPresenter : Compatibility.Layout
+	public class ContentPresenter : Compatibility.Layout, IContentView
 	{
 		public static BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View),
 			typeof(ContentPresenter), null, propertyChanged: OnContentChanged);
@@ -12,7 +13,7 @@ namespace Microsoft.Maui.Controls
 		public ContentPresenter()
 		{
 			SetBinding(ContentProperty, new Binding(ContentProperty.PropertyName, source: RelativeBindingSource.TemplatedParent,
-				converter: new ContentConverter()));
+				converterParameter: this, converter: new ContentConverter()));
 		}
 
 		public View Content
@@ -20,6 +21,9 @@ namespace Microsoft.Maui.Controls
 			get { return (View)GetValue(ContentProperty); }
 			set { SetValue(ContentProperty, value); }
 		}
+
+		object IContentView.Content => Content;
+		IView IContentView.PresentedContent => Content;
 
 		protected override void LayoutChildren(double x, double y, double width, double height)
 		{
@@ -89,6 +93,17 @@ namespace Microsoft.Maui.Controls
 				self.InternalChildren.Add(newView);
 				newView.ParentOverride = await TemplateUtilities.FindTemplatedParentAsync((Element)bindable);
 			}
+		}
+
+		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			return this.MeasureContent(widthConstraint, heightConstraint);
+		}
+
+		Size IContentView.CrossPlatformArrange(Rectangle bounds)
+		{
+			this.ArrangeContent(bounds);
+			return bounds.Size;
 		}
 	}
 }

--- a/src/Controls/src/Core/ContentView.cs
+++ b/src/Controls/src/Core/ContentView.cs
@@ -1,7 +1,10 @@
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty("Content")]
-	public class ContentView : TemplatedView
+	public class ContentView : TemplatedView, IContentView
 	{
 		public static readonly BindableProperty ContentProperty = BindableProperty.Create(nameof(Content), typeof(View), typeof(ContentView), null, propertyChanged: TemplateUtilities.OnContentChanged);
 
@@ -10,6 +13,9 @@ namespace Microsoft.Maui.Controls
 			get { return (View)GetValue(ContentProperty); }
 			set { SetValue(ContentProperty, value); }
 		}
+
+		object IContentView.Content => Content;
+		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? Content;
 
 		protected override void OnBindingContextChanged()
 		{
@@ -35,6 +41,30 @@ namespace Microsoft.Maui.Controls
 			{
 				SetInheritedBindingContext(content, BindingContext);
 			}
+		}
+
+		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+		{
+			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
+			return DesiredSize;
+		}
+
+		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint) 
+		{
+			return this.MeasureContent(widthConstraint, heightConstraint);
+		}
+
+		protected override Size ArrangeOverride(Rectangle bounds)
+		{
+			Frame = this.ComputeFrame(bounds);
+			Handler?.NativeArrange(Frame);
+			return Frame.Size;
+		}
+
+		Size IContentView.CrossPlatformArrange(Rectangle bounds) 
+		{
+			this.ArrangeContent(bounds);
+			return bounds.Size;
 		}
 	}
 }

--- a/src/Controls/src/Core/Frame.cs
+++ b/src/Controls/src/Core/Frame.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls
 {

--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -6,29 +6,39 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class ContentPage : IContentView, HotReload.IHotReloadableView
 	{
-		IView IContentView.Content => Content;
+		object IContentView.Content => Content;
+		IView IContentView.PresentedContent => Content;
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			if (Content is IView view)
-			{
-				_ = view.Measure(widthConstraint, heightConstraint);
-			}
-
-			return new Size(widthConstraint, heightConstraint);
+			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
+			return DesiredSize;
 		}
 
 		protected override Size ArrangeOverride(Rectangle bounds)
 		{
 			Frame = this.ComputeFrame(bounds);
+			Handler?.NativeArrange(Frame);
+			return Frame.Size;
+		}
 
-			if (Content is IView view)
+		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			var content = (this as IContentView).PresentedContent;
+			var padding = Padding;
+
+			if (content != null)
 			{
-				// TODO ezhart 2021-08-07 When we implement Padding for the ContentPage new layout stuff, the padding will adjust this rectangle
-				_ = view.Arrange(new Rectangle(0, 0, Frame.Width, Frame.Height));
+				_ = content.Measure(widthConstraint - padding.HorizontalThickness, heightConstraint - padding.VerticalThickness);
 			}
 
-			return Frame.Size;
+			return new Size(widthConstraint, heightConstraint);
+		}
+
+		Size IContentView.CrossPlatformArrange(Rectangle bounds)
+		{
+			this.ArrangeContent(bounds);
+			return bounds.Size;
 		}
 
 		protected override void InvalidateMeasureOverride()

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(Switch), typeof(SwitchHandler) },
 			{ typeof(TimePicker), typeof(TimePickerHandler) },
 			{ typeof(Page), typeof(PageHandler) },
+			{ typeof(IContentView), typeof(ContentViewHandler) },
 			{ typeof(Shapes.Ellipse), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Line), typeof(ShapeViewHandler) },
 			{ typeof(Shapes.Path), typeof(ShapeViewHandler) },

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		public ILayoutHandler LayoutHandler => Handler as ILayoutHandler;
 
-		ILayoutManager Maui.ILayout.LayoutManager => this;
 		IList IBindableLayout.Children => _children;
 
 		bool ISafeAreaView.IgnoreSafeArea => false;
@@ -547,6 +546,18 @@ namespace Microsoft.Maui.Controls.Compatibility
 			if (!ShouldLayoutChildren())
 				return bounds.Size;
 
+			UpdateChildrenLayout();
+
+			return Frame.Size;
+		}
+
+		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint) 
+		{
+			return OnMeasure(widthConstraint, heightConstraint).Request;
+		}
+
+		public Size CrossPlatformArrange(Rectangle bounds)
+		{
 			UpdateChildrenLayout();
 
 			return Frame.Size;

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 
 		protected ILayoutManager _layoutManager;
 
-		public ILayoutManager LayoutManager => _layoutManager ??= CreateLayoutManager();
+		ILayoutManager LayoutManager => _layoutManager ??= CreateLayoutManager();
 
 		// The actual backing store for the IViews in the ILayout
 		readonly List<IView> _children = new();
@@ -231,5 +231,15 @@ namespace Microsoft.Maui.Controls
 		}
 
 		IReadOnlyList<IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => Children.Cast<IVisualTreeElement>().ToList().AsReadOnly();
+
+		public Graphics.Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			return LayoutManager.Measure(widthConstraint, heightConstraint);
+		}
+
+		public Graphics.Size CrossPlatformArrange(Graphics.Rectangle bounds)
+		{
+			return LayoutManager.ArrangeChildren(bounds);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			button.Handler = buttonHandler;
 
 			page.Content = button;
-			(page as IView).Measure(expectedSize.Width, expectedSize.Height);
-			(page as IView).Arrange(expectedRect);
+			(page as IContentView).CrossPlatformMeasure(expectedSize.Width, expectedSize.Height);
+			(page as IContentView).CrossPlatformArrange(expectedRect);
 
 			buttonHandler.Received().NativeArrange(expectedRect);
 			Assert.AreEqual(expectedSize, button.Bounds.Size);
@@ -52,11 +52,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			contentPage.Content = stackLayout;
 
 			var rect = new Rectangle(Point.Zero, expectedSize);
-			(contentPage as IView).Measure(expectedSize.Width, expectedSize.Height);
-			(contentPage as IView).Arrange(rect);
 
-			// This simulates the arrange call that happens from the native LayoutViewGroup
-			(grid as IView).Arrange(rect);
+			(contentPage as Microsoft.Maui.IContentView).CrossPlatformMeasure(expectedSize.Width, expectedSize.Height);
+			(contentPage as Microsoft.Maui.IContentView).CrossPlatformArrange(rect);
 
 			Assert.AreEqual(expectedSize, grid.Bounds.Size);
 		}

--- a/src/Core/src/Core/IContentView.cs
+++ b/src/Core/src/Core/IContentView.cs
@@ -22,8 +22,19 @@ namespace Microsoft.Maui
 		/// </summary>
 		Thickness Padding { get; }
 
-		// TODO ezhart Document this
+		/// <summary>
+		/// Measures the desired size of the IContentView within the given constraints.
+		/// </summary>
+		/// <param name="widthConstraint">The width limit for measuring the IContentView.</param>
+		/// <param name="heightConstraint">The height limit for measuring the IContentView.</param>
+		/// <returns>The desired size of the IContentView.</returns>
 		Size CrossPlatformMeasure(double widthConstraint, double heightConstraint);
+
+		/// <summary>
+		/// Arranges the content of the IContentView within the given bounds.
+		/// </summary>
+		/// <param name="bounds">The bounds in which the IContentView's content should be arranged.</param>
+		/// <returns>The actual size of the arranged IContentView.</returns>
 		Size CrossPlatformArrange(Rectangle bounds);
 	}
 }

--- a/src/Core/src/Core/IContentView.cs
+++ b/src/Core/src/Core/IContentView.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Maui
 	public interface IContentView : IView
 	{
 		/// <summary>
-		/// Gets the content of this view.
+		/// Gets the raw content of this view.
 		/// </summary>
 		object? Content { get; }
 
 		/// <summary>
-		/// Gets the content of this view it will be rendered in the user interface.
+		/// Gets the content of this view as it will be rendered in the user interface, including any transformations or applied templates.
 		/// </summary>
 		IView? PresentedContent { get; }
 

--- a/src/Core/src/Core/IContentView.cs
+++ b/src/Core/src/Core/IContentView.cs
@@ -1,3 +1,5 @@
+using Microsoft.Maui.Graphics;
+
 namespace Microsoft.Maui
 {
 	/// <summary>
@@ -6,8 +8,22 @@ namespace Microsoft.Maui
 	public interface IContentView : IView
 	{
 		/// <summary>
-		/// Gets the view that contains the actual contents of this view.
+		/// Gets the content of this view.
 		/// </summary>
-		IView? Content { get; }
+		object? Content { get; }
+
+		/// <summary>
+		/// Gets the content of this view it will be rendered in the user interface.
+		/// </summary>
+		IView? PresentedContent { get; }
+
+		/// <summary>
+		/// The space between the outer edge of the IContentViews's content area and its content.
+		/// </summary>
+		Thickness Padding { get; }
+
+		// TODO ezhart Document this
+		Size CrossPlatformMeasure(double widthConstraint, double heightConstraint);
+		Size CrossPlatformArrange(Rectangle bounds);
 	}
 }

--- a/src/Core/src/Core/ILayout.cs
+++ b/src/Core/src/Core/ILayout.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Layouts;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui
 {
@@ -13,9 +14,8 @@ namespace Microsoft.Maui
 		/// </summary>
 		Thickness Padding { get; }
 
-		/// <summary>
-		/// The LayoutManager responsible for laying out the children of this ILayout
-		/// </summary>
-		ILayoutManager LayoutManager { get; }
+		// TODO ezhart Document this
+		Size CrossPlatformMeasure(double widthConstraint, double heightConstraint);
+		Size CrossPlatformArrange(Rectangle bounds);
 	}
 }

--- a/src/Core/src/Core/ILayout.cs
+++ b/src/Core/src/Core/ILayout.cs
@@ -14,8 +14,19 @@ namespace Microsoft.Maui
 		/// </summary>
 		Thickness Padding { get; }
 
-		// TODO ezhart Document this
+		/// <summary>
+		/// Measures the desired size of the ILayout within the given constraints.
+		/// </summary>
+		/// <param name="widthConstraint">The width limit for measuring the ILayout.</param>
+		/// <param name="heightConstraint">The height limit for measuring the ILayout.</param>
+		/// <returns>The desired size of the ILayout.</returns>
 		Size CrossPlatformMeasure(double widthConstraint, double heightConstraint);
+
+		/// <summary>
+		/// Arranges the children of the ILayout within the given bounds.
+		/// </summary>
+		/// <param name="bounds">The bounds in which the ILayout's children should be arranged.</param>
+		/// <returns>The actual size of the arranged ILayout.</returns>
 		Size CrossPlatformArrange(Rectangle bounds);
 	}
 }

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ContentViewHandler : ViewHandler<IContentView, ContentViewGroup>
+	{
+		protected override ContentViewGroup CreateNativeView()
+		{
+			if (VirtualView == null)
+			{
+				throw new InvalidOperationException($"{nameof(VirtualView)} must be set to create a ContentViewGroup");
+			}
+
+			var viewGroup = new ContentViewGroup(Context)
+			{
+				CrossPlatformMeasure = VirtualView.CrossPlatformMeasure,
+				CrossPlatformArrange = VirtualView.CrossPlatformArrange
+			};
+
+			return viewGroup;
+		}
+
+		public override void SetVirtualView(IView view)
+		{
+			base.SetVirtualView(view);
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+
+			NativeView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
+			NativeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
+		}
+
+		void UpdateContent()
+		{
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+
+			NativeView.RemoveAllViews();
+
+			if (VirtualView.PresentedContent is IView view)
+				NativeView.AddView(view.ToNative(MauiContext));
+		}
+
+		public static void MapContent(ContentViewHandler handler, IContentView page)
+		{
+			handler.UpdateContent();
+		}
+
+		protected override void DisconnectHandler(ContentViewGroup nativeView)
+		{
+			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
+			nativeView.RemoveAllViews();
+			base.DisconnectHandler(nativeView);
+		}
+	}
+}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Standard.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ContentViewHandler : ViewHandler<IContentView, object>
+	{
+		protected override object CreateNativeView() => throw new NotImplementedException();
+
+		public static void MapContent(ContentViewHandler handler, IContentView page)
+		{
+		}
+	}
+}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Windows.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Maui.Handlers
+{
+    public partial class ContentViewHandler : ViewHandler<IContentView, ContentPanel>
+    {
+        public override void SetVirtualView(IView view)
+        {
+            base.SetVirtualView(view);
+
+            _ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+            _ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+
+            NativeView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
+            NativeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
+        }
+
+        void UpdateContent()
+        {
+            _ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+            _ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+            _ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
+            NativeView.Children.Clear();
+
+            if (VirtualView.PresentedContent is IView view)
+                NativeView.Children.Add(view.ToNative(MauiContext));
+        }
+
+        protected override ContentPanel CreateNativeView()
+        {
+            if (VirtualView == null)
+            {
+                throw new InvalidOperationException($"{nameof(VirtualView)} must be set to create a LayoutView");
+            }
+
+            var view = new ContentPanel
+			{
+                CrossPlatformMeasure = VirtualView.CrossPlatformMeasure,
+                CrossPlatformArrange = VirtualView.CrossPlatformArrange
+            };
+
+            return view;
+        }
+
+        public static void MapContent(ContentViewHandler handler, IContentView page)
+        {
+            handler.UpdateContent();
+        }
+    }
+}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
@@ -1,0 +1,33 @@
+﻿#nullable enable
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ContentViewHandler
+	{
+		public static IPropertyMapper<IContentView, ContentViewHandler> ContentViewMapper = new PropertyMapper<IContentView, ContentViewHandler>(ViewMapper)
+		{
+			[nameof(IContentView.Content)] = MapContent,
+		};
+
+		public static CommandMapper<IPicker, PickerHandler> ContentViewCommandMapper = new(ViewCommandMapper)
+		{
+#if __IOS__
+			[nameof(IView.Frame)] = MapFrame,
+#endif
+		};
+
+		public ContentViewHandler() : base(ContentViewMapper, ContentViewCommandMapper)
+		{
+
+		}
+
+		protected ContentViewHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null)
+			: base(mapper, commandMapper ?? ViewCommandMapper)
+		{
+		}
+
+		public ContentViewHandler(IPropertyMapper? mapper = null) : base(mapper ?? ContentViewMapper)
+		{
+
+		}
+	}
+}

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using NativeView = UIKit.UIView;
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial class ContentViewHandler : ViewHandler<IContentView, ContentView>
+	{
+		protected override ContentView CreateNativeView()
+		{
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} must be set to create a {nameof(ContentView)}");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} cannot be null");
+
+			return new ContentView
+			{
+				CrossPlatformMeasure = VirtualView.CrossPlatformMeasure,
+				CrossPlatformArrange = VirtualView.CrossPlatformArrange
+			};
+		}
+
+		public override void SetVirtualView(IView view)
+		{
+			base.SetVirtualView(view);
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+
+			NativeView.View = view;
+			NativeView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
+			NativeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
+		}
+
+		void UpdateContent()
+		{
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
+			//Cleanup the old view when reused
+			var oldChildren = NativeView.Subviews.ToList();
+			oldChildren.ForEach(x => x.RemoveFromSuperview());
+
+			if (VirtualView.PresentedContent is IView view)
+				NativeView.AddSubview(view.ToNative(MauiContext));
+		}
+
+		public static void MapContent(ContentViewHandler handler, IContentView page)
+		{
+			handler.UpdateContent();
+		}
+
+		public static void MapFrame(ContentViewHandler handler, IContentView view)
+		{
+			ViewHandler.MapFrame(handler, view, null);
+
+			// TODO MAUI: Currently the background layer frame is tied to the layout system
+			// which needs to be investigated more
+			handler.NativeView?.UpdateBackgroundLayerFrame();
+		}
+	}
+}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Maui.Handlers
 
 			var viewGroup = new LayoutViewGroup(Context!)
 			{
-				CrossPlatformMeasure = VirtualView.LayoutManager.Measure,
-				CrossPlatformArrange = VirtualView.LayoutManager.ArrangeChildren
+				CrossPlatformMeasure = VirtualView.CrossPlatformMeasure,
+				CrossPlatformArrange = VirtualView.CrossPlatformArrange
 			};
 
 			return viewGroup;
@@ -29,8 +29,8 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.CrossPlatformMeasure = VirtualView.LayoutManager.Measure;
-			NativeView.CrossPlatformArrange = VirtualView.LayoutManager.ArrangeChildren;
+			NativeView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
+			NativeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
 
 			NativeView.RemoveAllViews();
 			foreach (var child in VirtualView)

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.CrossPlatformMeasure = VirtualView.LayoutManager.Measure;
-			NativeView.CrossPlatformArrange = VirtualView.LayoutManager.ArrangeChildren;
+			NativeView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
+			NativeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
 
 			NativeView.Children.Clear();
 			foreach (var child in VirtualView)
@@ -76,8 +76,8 @@ namespace Microsoft.Maui.Handlers
 
 			var view = new LayoutPanel
 			{
-				CrossPlatformMeasure = VirtualView.LayoutManager.Measure,
-				CrossPlatformArrange = VirtualView.LayoutManager.ArrangeChildren,
+				CrossPlatformMeasure = VirtualView.CrossPlatformMeasure,
+				CrossPlatformArrange = VirtualView.CrossPlatformArrange,
 			};
 
 			return view;

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Maui.Handlers
 
 			var view = new LayoutView
 			{
-				CrossPlatformMeasure = VirtualView.LayoutManager.Measure,
-				CrossPlatformArrange = VirtualView.LayoutManager.ArrangeChildren,
+				CrossPlatformMeasure = VirtualView.CrossPlatformMeasure,
+				CrossPlatformArrange = VirtualView.CrossPlatformArrange,
 			};
 
 			return view;
@@ -31,8 +31,8 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			NativeView.View = view;
-			NativeView.CrossPlatformMeasure = VirtualView.LayoutManager.Measure;
-			NativeView.CrossPlatformArrange = VirtualView.LayoutManager.ArrangeChildren;
+			NativeView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
+			NativeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
 
 			// Remove any previous children 
 			var oldChildren = NativeView.Subviews;

--- a/src/Core/src/Handlers/Page/PageHandler.Android.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Android.cs
@@ -1,65 +1,14 @@
-﻿using System;
-using Android.Views;
+﻿using Android.Views;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class PageHandler : ViewHandler<IView, PageViewGroup>
+	public partial class PageHandler : ContentViewHandler
 	{
 		//Graphics.Color? DefaultBackgroundColor;
 
-		protected override PageViewGroup CreateNativeView()
+		public static void MapTitle(PageHandler handler, IContentView page)
 		{
-			if (VirtualView == null)
-			{
-				throw new InvalidOperationException($"{nameof(VirtualView)} must be set to create a PageViewGroup");
-			}
-
-			var viewGroup = new PageViewGroup(Context)
-			{
-				CrossPlatformMeasure = VirtualView.Measure,
-				CrossPlatformArrange = VirtualView.Arrange
-			};
-
-			return viewGroup;
-		}
-
-		public override void SetVirtualView(IView view)
-		{
-			base.SetVirtualView(view);
-			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
-			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
-
-			NativeView.CrossPlatformMeasure = VirtualView.Measure;
-			NativeView.CrossPlatformArrange = VirtualView.Arrange;
-		}
-
-		void UpdateContent()
-		{
-			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
-			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
-
-			NativeView.RemoveAllViews();
-
-			if (VirtualView is IContentView cv && cv.Content is IView view)
-				NativeView.AddView(view.ToNative(MauiContext));
-		}
-
-		public static void MapTitle(PageHandler handler, IView page)
-		{
-		}
-
-		public static void MapContent(PageHandler handler, IView page)
-		{
-			handler.UpdateContent();
-		}
-
-		protected override void DisconnectHandler(PageViewGroup nativeView)
-		{
-			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
-			nativeView.RemoveAllViews();
-			base.DisconnectHandler(nativeView);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Page/PageHandler.Standard.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Standard.cs
@@ -2,14 +2,9 @@
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class PageHandler : ViewHandler<IView, object>
+	public partial class PageHandler : ContentViewHandler
 	{
-		protected override object CreateNativeView() => throw new NotImplementedException();
-
-		public static void MapTitle(PageHandler handler, IView page)
-		{
-		}
-		public static void MapContent(PageHandler handler, IView page)
+		public static void MapTitle(PageHandler handler, IContentView page)
 		{
 		}
 	}

--- a/src/Core/src/Handlers/Page/PageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Windows.cs
@@ -4,54 +4,10 @@ using System.Text;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class PageHandler : ViewHandler<IView, PagePanel>
+	public partial class PageHandler : ContentViewHandler
 	{
-		public override void SetVirtualView(IView view)
+		public static void MapTitle(PageHandler handler, IContentView page)
 		{
-			base.SetVirtualView(view);
-
-			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
-			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
-
-			NativeView.CrossPlatformMeasure = VirtualView.Measure;
-			NativeView.CrossPlatformArrange = VirtualView.Arrange;
-		}
-
-		void UpdateContent()
-		{
-			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
-			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
-			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-
-			NativeView.Children.Clear();
-
-			if (VirtualView is IContentView cv && cv.Content is IView view)
-				NativeView.Children.Add(view.ToNative(MauiContext));
-		}
-
-		protected override PagePanel CreateNativeView()
-		{
-			if (VirtualView == null)
-			{
-				throw new InvalidOperationException($"{nameof(VirtualView)} must be set to create a LayoutView");
-			}
-
-			var view = new PagePanel
-			{
-				CrossPlatformMeasure = VirtualView.Measure,
-				CrossPlatformArrange = VirtualView.Arrange
-			};
-
-			return view;
-		}
-
-		public static void MapTitle(PageHandler handler, IView page)
-		{
-		}
-
-		public static void MapContent(PageHandler handler, IView page)
-		{
-			handler.UpdateContent();
 		}
 	}
 }

--- a/src/Core/src/Handlers/Page/PageHandler.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.cs
@@ -1,19 +1,16 @@
 ﻿#nullable enable
 namespace Microsoft.Maui.Handlers
 {
-	public partial class PageHandler : IViewHandler
+	public partial class PageHandler : ContentViewHandler
 	{
-		public static IPropertyMapper<IView, PageHandler> PageMapper = new PropertyMapper<IView, PageHandler>(ViewMapper)
+		public static IPropertyMapper<IContentView, PageHandler> PageMapper = new PropertyMapper<IContentView, PageHandler>(ContentViewMapper)
 		{
-			[nameof(ITitledElement.Title)] = MapTitle,
-			[nameof(IContentView.Content)] = MapContent,
+			[nameof(ITitledElement.Title)] = MapTitle
 		};
 
-		public static CommandMapper<IPicker, PickerHandler> PageCommandMapper = new(ViewCommandMapper)
+		public static CommandMapper<IPicker, PickerHandler> PageCommandMapper = new(ContentViewCommandMapper)
 		{
-#if __IOS__
-			[nameof(IView.Frame)] = MapFrame,
-#endif
+
 		};
 
 		public PageHandler() : base(PageMapper, PageCommandMapper)

--- a/src/Core/src/Handlers/Page/PageHandler.iOS.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.iOS.cs
@@ -5,66 +5,33 @@ using NativeView = UIKit.UIView;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class PageHandler : ViewHandler<IView, PageView>, INativeViewHandler
+	public partial class PageHandler : ContentViewHandler, INativeViewHandler
 	{
 		PageViewController? _pageViewController;
 		UIViewController? INativeViewHandler.ViewController => _pageViewController;
 
-		protected override PageView CreateNativeView()
+		protected override ContentView CreateNativeView()
 		{
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} must be set to create a LayoutView");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} cannot be null");
 
 			_pageViewController = new PageViewController(VirtualView, this.MauiContext);
 
-			if (_pageViewController.CurrentNativeView is PageView pv)
+			if (_pageViewController.CurrentNativeView is ContentView pv)
 				return pv;
 
-			throw new InvalidOperationException($"PageViewController.View must be a PageView");
+			throw new InvalidOperationException($"PageViewController.View must be a {nameof(ContentView)}");
 		}
 
-		public override void SetVirtualView(IView view)
+		public static void MapTitle(PageHandler handler, IContentView page)
 		{
-			base.SetVirtualView(view);
-			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
-			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
-
-			NativeView.View = view;
-			NativeView.CrossPlatformArrange = VirtualView.Arrange;
-		}
-
-		void UpdateContent()
-		{
-			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
-			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
-			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-
-			//Cleanup the old view when reused
-			var oldChildren = NativeView.Subviews.ToList();
-			oldChildren.ForEach(x => x.RemoveFromSuperview());
-
-			if (VirtualView is IContentView cv && cv.Content is IView view)
-				NativeView.AddSubview(view.ToNative(MauiContext));
-		}
-
-		public static void MapTitle(PageHandler handler, IView page)
-		{
-			if (handler._pageViewController != null && page is ITitledElement titled)
-				handler._pageViewController.Title = titled.Title;
-		}
-
-		public static void MapContent(PageHandler handler, IView page)
-		{
-			handler.UpdateContent();
-		}
-
-		public static void MapFrame(PageHandler handler, IView view)
-		{
-			ViewHandler.MapFrame(handler, view, null);
-
-			// TODO MAUI: Currently the background layer frame is tied to the layout system
-			// which needs to be investigated more
-			handler.NativeView?.UpdateBackgroundLayerFrame();
+			if (handler is INativeViewHandler invh && invh.ViewController != null)
+			{
+				if (page is ITitledElement titled)
+				{
+					invh.ViewController.Title = titled.Title;
+				}
+			}
 		}
 	}
 }

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapContent(ScrollViewHandler handler, IScrollView scrollView)
 		{
-			if (handler.NativeView == null || handler.MauiContext == null || scrollView.Content == null)
+			if (handler.NativeView == null || handler.MauiContext == null || scrollView.PresentedContent == null)
 				return;
 
-			handler.NativeView.SetContent(scrollView.Content.ToNative(handler.MauiContext));
+			handler.NativeView.SetContent(scrollView.PresentedContent.ToNative(handler.MauiContext));
 		}
 
 		public static void MapHorizontalScrollBarVisibility(ScrollViewHandler handler, IScrollView scrollView)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Handlers
 			if (handler.NativeView == null || handler.MauiContext == null || scrollView.Content == null)
 				return;
 
-			handler.NativeView.Content = scrollView.Content.ToNative(handler.MauiContext);
+			handler.NativeView.Content = scrollView.PresentedContent?.ToNative(handler.MauiContext);
 		}
 
 		public static void MapHorizontalScrollBarVisibility(ScrollViewHandler handler, IScrollView scrollView)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -67,10 +67,10 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapContent(ScrollViewHandler handler, IScrollView scrollView)
 		{
-			if (handler.NativeView == null || handler.MauiContext == null || scrollView.Content == null)
+			if (handler.NativeView == null || handler.MauiContext == null || scrollView.PresentedContent == null)
 				return;
 
-			handler.NativeView.UpdateContent(scrollView.Content.ToNative(handler.MauiContext));
+			handler.NativeView.UpdateContent(scrollView.PresentedContent.ToNative(handler.MauiContext));
 		}
 
 		public static void MapContentSize(ScrollViewHandler handler, IScrollView scrollView)

--- a/src/Core/src/HotReload/HotReloadExtensions.cs
+++ b/src/Core/src/HotReload/HotReloadExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.HotReload
 
 			if (view is IContentView p)
 			{
-				CheckHandlers(p.Content);
+				CheckHandlers(p.PresentedContent);
 			}
 
 			if (view is IContainer layout)

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -149,5 +149,36 @@ namespace Microsoft.Maui.Layouts
 
 			return frameY;
 		}
+
+		public static Size MeasureContent(this IContentView contentView, double widthConstraint, double heightConstraint) 
+		{
+			var content = contentView.PresentedContent;
+			var padding = contentView.Padding;
+
+			var contentSize = Size.Zero;
+
+			if (content != null)
+			{
+				contentSize = content.Measure(widthConstraint - padding.HorizontalThickness,
+					heightConstraint - padding.VerticalThickness);
+			}
+
+			return new Size(contentSize.Width + padding.HorizontalThickness, contentSize.Height + padding.VerticalThickness);
+		}
+
+		public static void ArrangeContent(this IContentView contentView, Rectangle bounds) 
+		{
+			if (contentView.PresentedContent == null)
+			{
+				return;
+			}
+
+			var padding = contentView.Padding;
+
+			var targetBounds = new Rectangle(bounds.Left + padding.Left, bounds.Top + padding.Top,
+				bounds.Width - padding.HorizontalThickness, bounds.Height - padding.VerticalThickness);
+
+			_ = contentView.PresentedContent.Arrange(targetBounds);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -3,29 +3,30 @@ using Android.Content;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Handlers
 {
-	// TODO ezhart At this point, PageViewGroup is almost exactly a clone of LayoutViewGroup; we may be able to drop this class entirely
-	public class PageViewGroup : ViewGroup
+	// TODO ezhart At this point, this is almost exactly a clone of LayoutViewGroup; we may be able to drop this class entirely
+	public class ContentViewGroup : ViewGroup
 	{
-		public PageViewGroup(Context context) : base(context)
+		public ContentViewGroup(Context context) : base(context)
 		{
 		}
 
-		public PageViewGroup(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+		public ContentViewGroup(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
 		{
 		}
 
-		public PageViewGroup(Context context, IAttributeSet attrs) : base(context, attrs)
+		public ContentViewGroup(Context context, IAttributeSet attrs) : base(context, attrs)
 		{
 		}
 
-		public PageViewGroup(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
+		public ContentViewGroup(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
 		{
 		}
 
-		public PageViewGroup(Context context, IAttributeSet attrs, int defStyleAttr, int defStyleRes) : base(context, attrs, defStyleAttr, defStyleRes)
+		public ContentViewGroup(Context context, IAttributeSet attrs, int defStyleAttr, int defStyleRes) : base(context, attrs, defStyleAttr, defStyleRes)
 		{
 		}
 
@@ -65,8 +66,8 @@ namespace Microsoft.Maui.Handlers
 			var deviceIndependentRight = Context.FromPixels(r);
 			var deviceIndependentBottom = Context.FromPixels(b);
 
-			var destination = Graphics.Rectangle.FromLTRB(deviceIndependentLeft, deviceIndependentTop,
-				deviceIndependentRight, deviceIndependentBottom);
+			var destination = Rectangle.FromLTRB(0, 0,
+				deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
 
 			CrossPlatformArrange(destination);
 		}

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -5,7 +5,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui
 {
-	public class PagePanel : Panel
+	public class ContentPanel : Panel
 	{
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
 		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
@@ -17,9 +17,9 @@ namespace Microsoft.Maui
 				return base.MeasureOverride(availableSize);
 			}
 
-			CrossPlatformMeasure(availableSize.Width, availableSize.Height);
+			var measure = CrossPlatformMeasure(availableSize.Width, availableSize.Height);
 
-			return availableSize;
+			return measure.ToNative();
 		}
 
 		protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)

--- a/src/Core/src/Platform/Windows/SizeExtensions.cs
+++ b/src/Core/src/Platform/Windows/SizeExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
+{
+	public static class SizeExtensions 
+	{ 
+		public static Windows.Foundation.Size ToNative(this Size size) => new Windows.Foundation.Size(size.Width, size.Height);
+	}
+}

--- a/src/Core/src/Platform/Windows/Styles/MauiButtonStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/MauiButtonStyle.xaml
@@ -9,8 +9,8 @@
         <Setter Property="BorderBrush" Value="{ThemeResource ButtonBorderBrush}"/>
         <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}"/>
         <Setter Property="Padding" Value="{StaticResource ButtonPadding}"/>
-        <Setter Property="HorizontalAlignment" Value="Left"/>
-        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="VerticalAlignment" Value="Stretch"/>
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
         <Setter Property="FontWeight" Value="Normal"/>
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -4,11 +4,21 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui
 {
-	public class PageView : MauiView
+	public class ContentView : MauiView
 	{
 		public override CGSize SizeThatFits(CGSize size)
 		{
-			return size;
+			if (CrossPlatformMeasure == null)
+			{
+				return base.SizeThatFits(size);
+			}
+
+			var width = size.Width;
+			var height = size.Height;
+
+			var crossPlatformSize = CrossPlatformMeasure(width, height);
+
+			return crossPlatformSize.ToCGSize();
 		}
 
 		public override void LayoutSubviews()

--- a/src/Core/src/Platform/iOS/PageViewController.cs
+++ b/src/Core/src/Platform/iOS/PageViewController.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Maui
 
 		protected override UIView CreateNativeView(IElement view)
 		{
-			return new PageView
+			return new ContentView
 			{
-				CrossPlatformArrange = ((IView)view).Arrange,
-				CrossPlatformMeasure = ((IView)view).Measure
+				CrossPlatformArrange = ((IContentView)view).CrossPlatformArrange,
+				CrossPlatformMeasure = ((IContentView)view).CrossPlatformMeasure
 			};
 		}
 

--- a/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
@@ -63,11 +63,21 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 			return _children.GetEnumerator();
 		}
 
+		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			return LayoutManager.Measure(widthConstraint, heightConstraint);
+		}
+
+		public Size CrossPlatformArrange(Rectangle bounds)
+		{
+			return LayoutManager.ArrangeChildren(bounds);
+		}
+
 		public Thickness Padding { get; set; }
 		public int Count => _children.Count;
 		public bool IsReadOnly => _children.IsReadOnly;
 
-		public ILayoutManager LayoutManager => _layoutManager ??= new LayoutManagerStub();
+		ILayoutManager LayoutManager => _layoutManager ??= new LayoutManagerStub();
 
 		public bool IgnoreSafeArea => false;
 

--- a/src/Core/tests/DeviceTests/Stubs/PageStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/PageStub.cs
@@ -9,8 +9,21 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		private IView _content;
 		private string _title;
 
-		public IView Content { get => _content; set => this.SetProperty(ref _content, value); }
+		public object Content { get => _content; set => this.SetProperty(ref _content, (IView)value); }
+		public IView PresentedContent => _content;
+
+		public Thickness Padding { get; set; }
 
 		public string Title { get => _title; set => this.SetProperty(ref _title, value); }
+
+		public Size CrossPlatformArrange(Rectangle bounds)
+		{
+			return bounds.Size;
+		}
+
+		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			return new Size(widthConstraint, heightConstraint);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/ScrollViewStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ScrollViewStub.cs
@@ -4,13 +4,15 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public partial class ScrollViewStub : StubBase, IScrollView
 	{
-		public IView Content { get; set; }
+		public object Content { get; set; }
 		public ScrollBarVisibility HorizontalScrollBarVisibility { get; set; }
 		public ScrollBarVisibility VerticalScrollBarVisibility { get; set; }
 		public ScrollOrientation Orientation { get; set; }
 		public Size ContentSize { get; set; }
 		public double HorizontalOffset { get; set; }
 		public double VerticalOffset { get; set; }
+		public Thickness Padding { get; set; }
+		public IView PresentedContent => Content as IView;
 
 		public void RequestScrollTo(double horizontalOffset, double verticalOffset, bool instant)
 		{
@@ -20,6 +22,16 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public void ScrollFinished()
 		{
 			throw new System.NotImplementedException();
+		}
+
+		public Size CrossPlatformArrange(Rectangle bounds)
+		{
+			return bounds.Size;
+		}
+
+		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			return new Size(widthConstraint, heightConstraint);
 		}
 	}
 }


### PR DESCRIPTION
Fleshes out the API for IContentView from the Core perspective; makes content controls work with the handler architecture and new layouts.

Also makes the `Padding` property work with ScrollView and ContentPage.

Note - this does _not_ make Frame work; that's a separate branch that's still in progress (based on this work).

Fixes: #1302

Changes:

`PageViewGroup` -> `ContentViewGroup`
`PagePanel` -> `ContentPanel`
`PageView` -> `ContentView`

`ContentPresenter` now implements `IContentView`
`ContentView` now implements `IContentView`

`ILayout` changes: 
	Removed `ILayoutManager`
	Added `Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)`
	Added `Size CrossPlatformArrange(Rectangle bounds)`

`IContentView` now has the following members:

`object? Content { get; }`
`IView? PresentedContent { get; }`
`Thickness Padding { get; }`
`Size CrossPlatformMeasure(double widthConstraint, double heightConstraint);`
`Size CrossPlatformArrange(Rectangle bounds);`

`ContentConverter` no longer binds text and font properties unless the template actually has legit ancestors to which to bind those properties.