### PR TITLE
Remove extra quotes from binlog name

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -365,7 +365,7 @@ void StartVisualStudioForDotNet6(string sln = "./Microsoft.Maui-net6.sln")
 void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = null, bool deployAndRun = false)
 {
     var name = System.IO.Path.GetFileNameWithoutExtension(sln);
-    var binlog = $"\"{logDirectory}/{name}-{configuration}.binlog\"";
+    var binlog = $"{logDirectory}/{name}-{configuration}.binlog";
     
     if(localDotnet)
         SetDotNetEnvironmentVariables();


### PR DESCRIPTION
This isn't needed now that we updated from Cake 1.0.0 to 1.2.0

Part of https://github.com/dotnet/maui/issues/2372