### PR TITLE
Add single file analyzer to maui project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,6 +41,9 @@
 
     <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+
+    <IsTestProject Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
+    <EnableSingleFileAnalyzer Condition="'$(IsTestProject)' != 'true'">true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
     <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 
-    <IsTestProject Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
+    <IsTestProject Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.Tests')) or $(MSBuildProjectName.EndsWith('.UnitTests-net6'))">true</IsTestProject>
     <EnableSingleFileAnalyzer Condition="'$(IsTestProject)' != 'true'">true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Microsoft.Maui.TestUtils.DeviceTests.Runners</RootNamespace>
     <AssemblyName>Microsoft.Maui.TestUtils.DeviceTests.Runners</AssemblyName>
     <!--<Nullable>enable</Nullable>-->
+    <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Disclaimer: This PR is not part of the Handler Property Backlog

This analyzer flags code patterns that would make an application have an undesired/unknown behavior when deployed as a single file, since the end result of MAUI apps it's a single file (.apk or .ipa) the relevance of having an analyzer that flags these patterns is important. Enabling the analyzer in the current repo didn't flag any dangerous code pattern usage, but having this analyzer enabled would allow it to not regress from the current state. 

### Additions made ###
- Enables the Single File analyzer, the analyzer is already included as part of the ILLink.RoslynAnalyzer package and it was just turned on.