### PR TITLE
Download additional SkiaSharp symbols

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -20,6 +20,11 @@
   <PropertyGroup>
     <_XamarinAndroidGlideVersion>4.11.0.1</_XamarinAndroidGlideVersion>
   </PropertyGroup>
+  <!-- SkiaSharp related Packages -->
+  <PropertyGroup>
+    <_SkiaSharpVersion>2.88.0-preview.127</_SkiaSharpVersion>
+    <_SkiaSharpNativeAssetsVersion>0.0.0-commit.d5187387149d680645e1dbefbb726c50bfab46e9.127</_SkiaSharpNativeAssetsVersion>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0-ios' Or '$(TargetFramework)' == 'net6.0-maccatalyst'">
     <!-- Debugger workaround -->
     <MtouchExtraArgs>$(MtouchExtraArgs) --setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs>

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -174,6 +174,22 @@ Task("dotnet-pack")
             DiagnosticOutput = true,
             ArgumentCustomization = args => args.Append($"./eng/package.ps1 -configuration \"{configuration}\"")
         });
+
+        // Download some additional symbols that need to be archived along with the maui symbols:
+        //  - _NativeAssets.windows
+        //     - libSkiaSharp.pdb
+        //     - libHarfBuzzSharp.pdb
+        var assetsDir = "./artifacts/additional-assets";
+        var nativeAssetsVersion = XmlPeek("./eng/Microsoft.Extensions.targets", "/Project/PropertyGroup/_SkiaSharpNativeAssetsVersion");
+        NuGetInstall("_NativeAssets.windows", new NuGetInstallSettings
+        {
+            Version = nativeAssetsVersion,
+            ExcludeVersion  = true,
+            OutputDirectory = assetsDir,
+            Source = new[] { "https://aka.ms/skiasharp-eap/index.json" },
+        });
+        foreach (var nupkg in GetFiles($"{assetsDir}/**/*.nupkg"))
+            DeleteFile(nupkg);
     });
 
 Task("dotnet-build-test")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -190,6 +190,7 @@ Task("dotnet-pack")
         });
         foreach (var nupkg in GetFiles($"{assetsDir}/**/*.nupkg"))
             DeleteFile(nupkg);
+        Zip(assetsDir, $"{assetsDir}.zip");
     });
 
 Task("dotnet-build-test")

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -166,6 +166,7 @@ stages:
               inputs:
                 Contents: |
                   artifacts/**/*.*nupkg
+                  artifacts/**/*.zip
                   artifacts/vs-workload.props
                   eng/automation/SignList.xml
                 TargetFolder: $(build.artifactstagingdirectory)

--- a/src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems
+++ b/src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems
@@ -5,11 +5,11 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2-preview.127" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.7.0" PrivateAssets="all" />
-    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.127" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.0-preview.127" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.0-preview.127" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.0-preview.127" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.0-preview.127" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="SkiaSharp" Version="$(_SkiaSharpVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="$(_SkiaSharpVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="$(_SkiaSharpVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="$(_SkiaSharpVersion)" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="$(_SkiaSharpVersion)" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Svg.Skia" Version="0.4.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Svg.Custom" Version="0.4.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Svg.Picture" Version="0.4.1" GeneratePathProperty="true" PrivateAssets="all" />


### PR DESCRIPTION
### Description of Change ###

Currently, we do not include the native libSkiaSharp.dll symbols in the nugets and workload because they are over 50MB. However, we do still need these symbols to be associated with this build.

This PR will download from the public feed for now, however, once we get symbols out on nuget.org (somehow) this can either pull from there or not be needed.

### Additions made ###

Just an additional step that downloads the native artifacts and includes it in the artifacts.
