### PR TITLE
[ci] Pass SkiaSharp extras to symbol archiving

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -307,3 +307,5 @@ stages:
         symbolArtifactPatterns: |
           **/signed/*.nupkg
           **/*.snupkg
+          **/additional-assets.zip
+        createVSPR: false

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -308,4 +308,3 @@ stages:
           **/signed/*.nupkg
           **/*.snupkg
           **/additional-assets.zip
-        createVSPR: false


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_queries/edit/1394568

The missing symbols for Windows C++ SkiaSharp files are now being
uploaded as a MAUI build artifact thanks to commit b80186d4.  We should
be able to fix the remaining SymbolCheck issues by archiving them.