### PR TITLE
Fix template ApplicationTitle variable to have correct substitution

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -10,7 +10,7 @@
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 
 		<!-- Display name -->
-		<ApplicationTitle>MauiApp1</ApplicationTitle>
+		<ApplicationTitle>MauiApp.1</ApplicationTitle>
 
 		<!-- App Identifier -->
 		<ApplicationId>com.companyname.MauiApp._1</ApplicationId>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -10,7 +10,7 @@
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 
 		<!-- Display name -->
-		<ApplicationTitle>MauiApp1</ApplicationTitle>
+		<ApplicationTitle>MauiApp.1</ApplicationTitle>
 
 		<!-- App Identifier -->
 		<ApplicationId>com.companyname.MauiApp._1</ApplicationId>


### PR DESCRIPTION
Apparently I missed this in my earlier template fix. This change makes sure that the `<ApplicationTitle>` in the CSPROJ gets substituted with the user-specified app-name. Otherwise every app in the world will have the UI title `MauiApp1` by default 😁 