### PR TITLE
[vs-insertion] Push packs to "shipping" feed

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -307,3 +307,10 @@ stages:
         symbolArtifactPatterns: |
           **/signed/*.nupkg
           **/*.snupkg
+        pushToShippingFeed: true
+        nupkgArtifactName: nuget-signed
+        nupkgArtifactPatterns: |
+          **/signed/*.nupkg
+        msiNupkgArtifactName: vs-msi-nugets
+        archiveSymbols: false
+        createVSPR: false

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -313,5 +313,3 @@ stages:
         nupkgArtifactPatterns: |
           **/signed/*.nupkg
         msiNupkgArtifactName: vs-msi-nugets
-        archiveSymbols: false
-        createVSPR: false

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -308,7 +308,7 @@ stages:
           **/signed/*.nupkg
           **/*.snupkg
         pushToShippingFeed: true
-        nupkgArtifactName: nuget-signed
+        nupkgArtifactName: nuget
         nupkgArtifactPatterns: |
           **/signed/*.nupkg
         msiNupkgArtifactName: vs-msi-nugets


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/134

The .NET 6 packs will now also be pushed to a public xamarin
`net6-maui-shipping` feed during the `VS Insertion` stage, to
help with testing efforts that can't use the `dotnet6` feed.
