### PR TITLE
[Android] Wire up text for SearchBar and Editor

### DIFF
--- a/src/Core/src/Core/Extensions/ITextInputExtensions.cs
+++ b/src/Core/src/Core/Extensions/ITextInputExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+namespace Microsoft.Maui
+{
+	public static class ITextInputExtensions
+	{
+		public static void UpdateText(this ITextInput textInput, string? text)
+		{
+			// Even though <null> is technically different to "", it has no
+			// functional difference to apps. Thus, hide it.
+			var mauiText = textInput.Text ?? string.Empty;
+			var nativeText = text ?? string.Empty;
+			if (mauiText != nativeText)
+				textInput.Text = nativeText;
+		}
+
+#if __ANDROID__
+		public static void UpdateText(this ITextInput textInput, Android.Text.TextChangedEventArgs e)
+		{
+			if (e.BeforeCount == 0 && e.AfterCount == 0)
+				return;
+
+			if (e.Text is Java.Lang.ICharSequence cs)
+				textInput.UpdateText(cs.ToString());
+			else if (e.Text != null)
+				textInput.UpdateText(String.Concat(e.Text));
+			else
+				textInput.UpdateText((string?)null);
+		}
+#endif
+	}
+}

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			FocusChangeListener.Handler = this;
 
+			nativeView.TextChanged += OnTextChanged;
 			nativeView.OnFocusChangeListener = FocusChangeListener;
 		}
 
@@ -41,13 +42,15 @@ namespace Microsoft.Maui.Handlers
 		{
 			nativeView.OnFocusChangeListener = null;
 
+			nativeView.TextChanged -= OnTextChanged;
 			FocusChangeListener.Handler = null;
 		}
 
+		void OnTextChanged(object? sender, Android.Text.TextChangedEventArgs e) =>
+			VirtualView.UpdateText(e);
+
 		void SetupDefaults(AppCompatEditText nativeView)
 		{
-
-
 			DefaultTextColors = nativeView.TextColors;
 			DefaultPlaceholderTextColors = nativeView.HintTextColors;
 			DefaultBackground = nativeView.Background;

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.Changed += OnChanged;
 			nativeView.ShouldChangeText += OnShouldChangeText;
 			nativeView.Ended += OnEnded;
+			nativeView.TextPropertySet += OnTextPropertySet;
 		}
 
 		protected override void DisconnectHandler(MauiTextView nativeView)
@@ -34,6 +35,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.Changed -= OnChanged;
 			nativeView.ShouldChangeText -= OnShouldChangeText;
 			nativeView.Ended -= OnEnded;
+			nativeView.TextPropertySet -= OnTextPropertySet;
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint) =>
@@ -128,14 +130,15 @@ namespace Microsoft.Maui.Handlers
 
 		void OnEnded(object? sender, EventArgs eventArgs)
 		{
-			if (VirtualView == null || NativeView == null)
-				return;
-
-			VirtualView.UpdateText(NativeView.Text);
-
 			// TODO: Update IsFocused property
 			VirtualView.Completed();
 		}
+
+		private void OnTextPropertySet(object sender, EventArgs e)
+		{
+			VirtualView.UpdateText(NativeView.Text);
+		}
+
 
 		public static void MapKeyboard(EditorHandler handler, IEditor editor)
 		{

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Maui.Handlers
 			VirtualView.Completed();
 		}
 
-		private void OnTextPropertySet(object sender, EventArgs e)
+		private void OnTextPropertySet(object? sender, EventArgs e)
 		{
 			VirtualView.UpdateText(NativeView.Text);
 		}

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -131,8 +131,7 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null || NativeView == null)
 				return;
 
-			if (NativeView.Text != VirtualView.Text)
-				VirtualView.Text = NativeView.Text ?? string.Empty;
+			VirtualView.UpdateText(NativeView.Text);
 
 			// TODO: Update IsFocused property
 			VirtualView.Completed();

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -173,12 +173,7 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null || NativeView == null)
 				return;
 
-			// Even though <null> is technically different to "", it has no
-			// functional difference to apps. Thus, hide it.
-			var mauiText = VirtualView!.Text ?? string.Empty;
-			var nativeText = NativeView.Text ?? string.Empty;
-			if (mauiText != nativeText)
-				VirtualView.Text = nativeText;
+			VirtualView.UpdateText(NativeView.Text);
 		}
 
 		bool OnShouldChangeCharacters(UITextField textField, NSRange range, string replacementString)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class SearchBarHandler : ViewHandler<ISearchBar, SearchView>
 	{
-		QueryTextListener QueryListener { get; } = new QueryTextListener();
-
 		static Drawable? DefaultBackground;
 		static ColorStateList? DefaultPlaceholderTextColors { get; set; }
 
@@ -28,16 +26,14 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void ConnectHandler(SearchView nativeView)
 		{
-			QueryListener.Handler = this;
-
-			nativeView.SetOnQueryTextListener(QueryListener);
+			nativeView.QueryTextChange += OnQueryTextChange;
+			nativeView.QueryTextSubmit += OnQueryTextSubmit;
 		}
 
 		protected override void DisconnectHandler(SearchView nativeView)
 		{
-			nativeView.SetOnQueryTextListener(null);
-
-			QueryListener.Handler = null;
+			nativeView.QueryTextChange -= OnQueryTextChange;
+			nativeView.QueryTextSubmit -= OnQueryTextSubmit;
 		}
 
 		void SetupDefaults(SearchView nativeView)
@@ -104,23 +100,16 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateCancelButtonColor(searchBar);
 		}
 
-		public class QueryTextListener : Java.Lang.Object, IOnQueryTextListener
+
+		void OnQueryTextSubmit(object? sender, QueryTextSubmitEventArgs e)
 		{
-			public SearchBarHandler? Handler { get; set; }
+			VirtualView.SearchButtonPressed();
+		}
 
-			public bool OnQueryTextChange(string newText)
-			{
-				return true;
-			}
-
-			public bool OnQueryTextSubmit(string newText)
-			{
-				Handler?.VirtualView?.SearchButtonPressed();
-
-				// TODO: Clear focus
-
-				return true;
-			}
+		void OnQueryTextChange(object? sender, QueryTextChangeEventArgs e)
+		{
+			VirtualView.UpdateText(e.NewText);
+			e.Handled = true;
 		}
 	}
 }

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -104,6 +104,8 @@ namespace Microsoft.Maui.Handlers
 		void OnQueryTextSubmit(object? sender, QueryTextSubmitEventArgs e)
 		{
 			VirtualView.SearchButtonPressed();
+			// TODO: Clear focus
+			e.Handled = true;
 		}
 
 		void OnQueryTextChange(object? sender, QueryTextChangeEventArgs e)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Maui.Handlers
 			NativeView?.ResignFirstResponder();
 		}
 
-		void OnTextPropertySet(object sender, EventArgs e)
+		void OnTextPropertySet(object? sender, EventArgs e)
 		{
 			if (VirtualView != null)
 				VirtualView.UpdateText(NativeView?.Text);

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -6,7 +6,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class SearchBarHandler : ViewHandler<ISearchBar, UISearchBar>
+	public partial class SearchBarHandler : ViewHandler<ISearchBar, MauiSearchBar>
 	{
 		UIColor? _defaultTextColor;
 
@@ -18,32 +18,33 @@ namespace Microsoft.Maui.Handlers
 
 		public UITextField? QueryEditor => _editor;
 
-		protected override UISearchBar CreateNativeView()
+		protected override MauiSearchBar CreateNativeView()
 		{
-			var searchBar = new UISearchBar(RectangleF.Empty) { ShowsCancelButton = true, BarStyle = UIBarStyle.Default };
+			var searchBar = new MauiSearchBar() { ShowsCancelButton = true, BarStyle = UIBarStyle.Default };
 
-			_editor = searchBar.FindDescendantView<UITextField>();
+			if (NativeVersion.IsAtLeast(13))
+				_editor = searchBar.SearchTextField;
+			else
+				_editor = searchBar.FindDescendantView<UITextField>();
 
 			return searchBar;
 		}
 
-		protected override void ConnectHandler(UISearchBar nativeView)
+		protected override void ConnectHandler(MauiSearchBar nativeView)
 		{
 			nativeView.CancelButtonClicked += OnCancelClicked;
 			nativeView.SearchButtonClicked += OnSearchButtonClicked;
-			nativeView.TextChanged += OnTextChanged;
+			nativeView.TextPropertySet += OnTextPropertySet;
 			nativeView.ShouldChangeTextInRange += ShouldChangeText;
-
 			base.ConnectHandler(nativeView);
 		}
 
-		protected override void DisconnectHandler(UISearchBar nativeView)
+		protected override void DisconnectHandler(MauiSearchBar nativeView)
 		{
 			nativeView.CancelButtonClicked -= OnCancelClicked;
 			nativeView.SearchButtonClicked -= OnSearchButtonClicked;
-			nativeView.TextChanged -= OnTextChanged;
+			nativeView.TextPropertySet -= OnTextPropertySet;
 			nativeView.ShouldChangeTextInRange -= ShouldChangeText;
-
 			base.DisconnectHandler(nativeView);
 		}
 
@@ -146,10 +147,10 @@ namespace Microsoft.Maui.Handlers
 			NativeView?.ResignFirstResponder();
 		}
 
-		void OnTextChanged(object? sender, UISearchBarTextChangedEventArgs a)
+		void OnTextPropertySet(object sender, EventArgs e)
 		{
 			if (VirtualView != null)
-				VirtualView.UpdateText(a.SearchText);
+				VirtualView.UpdateText(NativeView?.Text);
 		}
 
 		bool ShouldChangeText(UISearchBar searchBar, NSRange range, string text)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.Handlers
 		void OnTextChanged(object? sender, UISearchBarTextChangedEventArgs a)
 		{
 			if (VirtualView != null)
-				VirtualView.Text = a.SearchText;
+				VirtualView.UpdateText(a.SearchText);
 		}
 
 		bool ShouldChangeText(UISearchBar searchBar, NSRange range, string text)

--- a/src/Core/src/Platform/iOS/MauiSearchBar.cs
+++ b/src/Core/src/Platform/iOS/MauiSearchBar.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Drawing;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+
+namespace Microsoft.Maui.Handlers
+{
+	public class MauiSearchBar : UISearchBar
+	{
+		public MauiSearchBar() : this(RectangleF.Empty)
+		{
+		}
+
+		public MauiSearchBar(NSCoder coder) : base(coder)
+		{
+		}
+
+		public MauiSearchBar(CGRect frame) : base(frame)
+		{
+		}
+
+		protected MauiSearchBar(NSObjectFlag t) : base(t)
+		{
+		}
+
+		protected internal MauiSearchBar(IntPtr handle) : base(handle)
+		{
+		}
+
+		public override string? Text
+		{
+			get => base.Text;
+			set
+			{
+				var old = base.Text;
+
+				base.Text = value;
+
+				if (old != value)
+					TextPropertySet?.Invoke(this, EventArgs.Empty);
+			}
+		}
+
+		public event EventHandler? TextPropertySet;
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -1,4 +1,5 @@
-﻿using CoreGraphics;
+﻿using System;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 
@@ -63,5 +64,35 @@ namespace Microsoft.Maui.Platform.iOS
 			AddConstraints(hConstraints);
 			AddConstraints(vConstraints);
 		}
+
+		public override string? Text
+		{
+			get => base.Text;
+			set
+			{
+				var old = base.Text;
+
+				base.Text = value;
+
+				if (old != value)
+					TextPropertySet?.Invoke(this, EventArgs.Empty);
+			}
+		}
+
+		public override NSAttributedString AttributedText
+		{
+			get => base.AttributedText;
+			set
+			{
+				var old = base.AttributedText;
+
+				base.AttributedText = value;
+
+				if (old?.Value != value?.Value)
+					TextPropertySet?.Invoke(this, EventArgs.Empty);
+			}
+		}
+
+		public event EventHandler? TextPropertySet;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -39,11 +39,14 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.NativeViewValue, EmCoefficientPrecision);
 		}
 
-		AppCompatEditText GetNativeEditor(EditorHandler editorHandler) =>
+		static AppCompatEditText GetNativeEditor(EditorHandler editorHandler) =>
 			(AppCompatEditText)editorHandler.NativeView;
 
 		string GetNativeText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).Text;
+
+		static void SetNativeText(EditorHandler editorHandler, string text) =>
+			GetNativeEditor(editorHandler).Text = text;
 
 		string GetNativePlaceholderText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).Hint;

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -352,5 +352,16 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidatePropertyInitValue(editor, () => expected, GetNativeIsChatKeyboard, expected);
 		}
+
+
+
+		[Category(TestCategory.Editor)]
+		public class TextInputTests : TextInputHandlerTests<EditorHandler, EditorStub>
+		{
+			protected override void SetNativeText(EditorHandler entryHandler, string text)
+			{
+				EditorHandlerTests.SetNativeText(entryHandler, text);
+			}
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -353,10 +353,8 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(editor, () => expected, GetNativeIsChatKeyboard, expected);
 		}
 
-
-
 		[Category(TestCategory.Editor)]
-		public class TextInputTests : TextInputHandlerTests<EditorHandler, EditorStub>
+		public class TextInputTests : EditorTextInputHandlerTests<EditorHandler, EditorStub>
 		{
 			protected override void SetNativeText(EditorHandler entryHandler, string text)
 			{

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Category(TestCategory.Editor)]
-		public class TextInputTests : EditorTextInputHandlerTests<EditorHandler, EditorStub>
+		public class EditorTextInputTests : TextInputHandlerTests<EditorHandler, EditorStub>
 		{
 			protected override void SetNativeText(EditorHandler entryHandler, string text)
 			{

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -36,11 +36,14 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
 		}
 
-		MauiTextView GetNativeEditor(EditorHandler editorHandler) =>
+		static MauiTextView GetNativeEditor(EditorHandler editorHandler) =>
 			editorHandler.NativeView;
 
 		string GetNativeText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).Text;
+
+		static void SetNativeText(EditorHandler editorHandler, string text) =>
+			GetNativeEditor(editorHandler).Text = text;
 
 		string GetNativePlaceholderText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).PlaceholderText;

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -104,13 +104,13 @@ namespace Microsoft.Maui.DeviceTests
 			values.NativeViewValue.AssertHasFlag(expectedValue);
 		}
 
-		AppCompatEditText GetNativeEntry(EntryHandler entryHandler) =>
+		static AppCompatEditText GetNativeEntry(EntryHandler entryHandler) =>
 			entryHandler.NativeView;
 
 		string GetNativeText(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).Text;
 
-		void SetNativeText(EntryHandler entryHandler, string text) =>
+		static void SetNativeText(EntryHandler entryHandler, string text) =>
 			GetNativeEntry(entryHandler).Text = text;
 
 		Color GetNativeTextColor(EntryHandler entryHandler)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -189,50 +189,6 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(entryStub, () => expected, GetNativeClearButtonVisibility, expected);
 		}
 
-		[Theory(DisplayName = "TextChanged Events Fire Correctly")]
-		// null/empty
-		[InlineData(null, null, false)]
-		[InlineData(null, "", false)]
-		[InlineData("", null, false)]
-		[InlineData("", "", false)]
-		// whitespace
-		[InlineData(null, " ", true)]
-		[InlineData("", " ", true)]
-		[InlineData(" ", null, true)]
-		[InlineData(" ", "", true)]
-		[InlineData(" ", " ", false)]
-		// text
-		[InlineData(null, "Hello", true)]
-		[InlineData("", "Hello", true)]
-		[InlineData(" ", "Hello", true)]
-		[InlineData("Hello", null, true)]
-		[InlineData("Hello", "", true)]
-		[InlineData("Hello", " ", true)]
-		[InlineData("Hello", "Goodbye", true)]
-		public async Task TextChangedEventsFireCorrectly(string initialText, string newText, bool eventExpected)
-		{
-			var entry = new EntryStub
-			{
-				Text = initialText,
-			};
-
-			var eventFiredCount = 0;
-			entry.TextChanged += (sender, e) =>
-			{
-				eventFiredCount++;
-
-				Assert.Equal(initialText, e.OldValue);
-				Assert.Equal(newText ?? string.Empty, e.NewValue);
-			};
-
-			await SetValueAsync(entry, newText, SetNativeText);
-
-			if (eventExpected)
-				Assert.Equal(1, eventFiredCount);
-			else
-				Assert.Equal(0, eventFiredCount);
-		}
-
 		[Theory(DisplayName = "Validates Numeric Keyboard")]
 		[InlineData(nameof(Keyboard.Chat), false)]
 		[InlineData(nameof(Keyboard.Default), false)]
@@ -621,5 +577,16 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(text.Length, actualLength);
 		}
+
+
+		[Category(TestCategory.Entry)]
+		public class TextInputTests : TextInputHandlerTests<EntryHandler, EntryStub>
+		{
+			protected override void SetNativeText(EntryHandler entryHandler, string text)
+			{
+				EntryHandlerTests.SetNativeText(entryHandler, text);
+			}
+		}
+
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -580,7 +580,7 @@ namespace Microsoft.Maui.DeviceTests
 
 
 		[Category(TestCategory.Entry)]
-		public class TextInputTests : TextInputHandlerTests<EntryHandler, EntryStub>
+		public class EntryTextInputTests : TextInputHandlerTests<EntryHandler, EntryStub>
 		{
 			protected override void SetNativeText(EntryHandler entryHandler, string text)
 			{

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -118,13 +118,13 @@ namespace Microsoft.Maui.DeviceTests
 			return entry.AttributedText.GetCharacterSpacing();
 		}
 
-		UITextField GetNativeEntry(EntryHandler entryHandler) =>
+		static UITextField GetNativeEntry(EntryHandler entryHandler) =>
 			(UITextField)entryHandler.NativeView;
 
-		string GetNativeText(EntryHandler entryHandler) =>
+		static string GetNativeText(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).Text;
 
-		void SetNativeText(EntryHandler entryHandler, string text) =>
+		static void SetNativeText(EntryHandler entryHandler, string text) =>
 			GetNativeEntry(entryHandler).Text = text;
 
 		Color GetNativeTextColor(EntryHandler entryHandler) =>

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -90,11 +90,14 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		SearchView GetNativeSearchBar(SearchBarHandler searchBarHandler) =>
+		static SearchView GetNativeSearchBar(SearchBarHandler searchBarHandler) =>
 			searchBarHandler.NativeView;
 
 		string GetNativeText(SearchBarHandler searchBarHandler) =>
 			GetNativeSearchBar(searchBarHandler).Query;
+
+		static void SetNativeText(SearchBarHandler searchBarHandler, string text) =>
+			GetNativeSearchBar(searchBarHandler).SetQuery(text, false);
 
 		Color GetNativeTextColor(SearchBarHandler searchBarHandler)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Category(TestCategory.SearchBar)]
-		public class TextInputTests : TextInputHandlerTests<SearchBarHandler, SearchBarStub>
+		public class SearchBarTextInputTests : TextInputHandlerTests<SearchBarHandler, SearchBarStub>
 		{
 			protected override void SetNativeText(SearchBarHandler entryHandler, string text)
 			{

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -120,5 +120,14 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAsync(searchBar);
 		}
+
+		[Category(TestCategory.SearchBar)]
+		public class TextInputTests : TextInputHandlerTests<SearchBarHandler, SearchBarStub>
+		{
+			protected override void SetNativeText(SearchBarHandler entryHandler, string text)
+			{
+				SearchBarHandlerTests.SetNativeText(entryHandler, text);
+			}
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -61,11 +61,14 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.NativeViewValue);
 		}
 
-		UISearchBar GetNativeSearchBar(SearchBarHandler searchBarHandler) =>
+		static UISearchBar GetNativeSearchBar(SearchBarHandler searchBarHandler) =>
 			(UISearchBar)searchBarHandler.NativeView;
 
 		string GetNativeText(SearchBarHandler searchBarHandler) =>
 			GetNativeSearchBar(searchBarHandler).Text;
+
+		static void SetNativeText(SearchBarHandler searchBarHandler, string text) =>
+			GetNativeSearchBar(searchBarHandler).Text = text;
 
 		Color GetNativeTextColor(SearchBarHandler searchBarHandler)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/TextInput/TextInputHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TextInput/TextInputHandlerTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public abstract partial class TextInputHandlerTests<THandler, TStub> : HandlerTestBase<THandler, TStub>
+		where THandler : IViewHandler
+		where TStub : StubBase, ITextInputStub, new()
+	{
+		[Theory(DisplayName = "TextChanged Events Fire Correctly")]
+		// null/empty
+		[InlineData(null, null, false)]
+		[InlineData(null, "", false)]
+		[InlineData("", null, false)]
+		[InlineData("", "", false)]
+		// whitespace
+		[InlineData(null, " ", true)]
+		[InlineData("", " ", true)]
+		[InlineData(" ", null, true)]
+		[InlineData(" ", "", true)]
+		[InlineData(" ", " ", false)]
+		// text
+		[InlineData(null, "Hello", true)]
+		[InlineData("", "Hello", true)]
+		[InlineData(" ", "Hello", true)]
+		[InlineData("Hello", null, true)]
+		[InlineData("Hello", "", true)]
+		[InlineData("Hello", " ", true)]
+		[InlineData("Hello", "Goodbye", true)]
+		public async Task TextChangedEventsFireCorrectly(string initialText, string newText, bool eventExpected)
+		{
+			var textInput = Activator.CreateInstance<TStub>();
+			textInput.Text = initialText;
+
+			var eventFiredCount = 0;
+			textInput.TextChanged += (sender, e) =>
+			{
+				eventFiredCount++;
+
+				Assert.Equal(initialText, e.OldValue);
+				Assert.Equal(newText ?? string.Empty, e.NewValue);
+			};
+
+			await SetValueAsync(textInput, newText, SetNativeText);
+
+			if (eventExpected)
+				Assert.Equal(1, eventFiredCount);
+			else
+				Assert.Equal(0, eventFiredCount);
+		}
+
+		protected abstract void SetNativeText(THandler entryHandler, string text);
+	}
+}

--- a/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	public partial class EditorStub : StubBase, IEditor
+	public partial class EditorStub : StubBase, IEditor, ITextInputStub
 	{
 		private string _text;
 

--- a/src/Core/tests/DeviceTests/Stubs/EntryStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/EntryStub.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	public partial class EntryStub : StubBase, IEntry
+	public partial class EntryStub : StubBase, IEntry, ITextInputStub
 	{
 		private string _text;
 

--- a/src/Core/tests/DeviceTests/Stubs/ITextInputStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ITextInputStub.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public interface ITextInputStub : ITextInput
+	{
+		public event EventHandler<StubPropertyChangedEventArgs<string>> TextChanged;
+	}
+}

--- a/src/Core/tests/DeviceTests/Stubs/SearchBarStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/SearchBarStub.cs
@@ -1,12 +1,23 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	public partial class SearchBarStub : StubBase, ISearchBar
+	public partial class SearchBarStub : StubBase, ISearchBar, ITextInputStub
 	{
 		string _text;
 
-		public string Text { get => _text; set => SetProperty(ref _text, value); }
+		public string Text 
+		{ 
+			get => _text; 
+			set => SetProperty(ref _text, value, onChanged: OnTextChanged); 
+		}
+
+		public event EventHandler<StubPropertyChangedEventArgs<string>> TextChanged;
+
+		void OnTextChanged(string oldValue, string newValue) =>
+			TextChanged?.Invoke(this, new StubPropertyChangedEventArgs<string>(oldValue, newValue));
 
 		public string Placeholder { get; set; }
 		


### PR DESCRIPTION
### Description of Change ###

- Fixes Editor and SearchBar so they propagate native changes to xplat elements
- Standarize the UnitTests for testing `ITextInput` related properties so we can make sure to run the same set of tests across all things implementing ITextInput
- Where possible converted to using `event subscriptions` over `listeners`. This will let users also subscribe to those events without wiping our our listeners


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 

fixes #2712