### PR TITLE
Add option to specify static factory method for creating native views

### DIFF
--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -214,9 +214,9 @@ namespace Maui.Controls.Sample
 					}
 
 #if __ANDROID__
-					Microsoft.Maui.Handlers.ButtonHandler.NativeViewFactory = (context) => 
+					Microsoft.Maui.Handlers.ButtonHandler.NativeViewFactory = (handler) => 
 					{
-						return new Google.Android.Material.Button.MaterialButton(context) 
+						return new Google.Android.Material.Button.MaterialButton(handler.Context) 
 						{ 
 							CornerRadius = 50, SoundEffectsEnabled = true 
 						};

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -212,6 +212,16 @@ namespace Maui.Controls.Sample
 						Debug.WriteLine($"Lifecycle event: {eventName}{(type == null ? "" : $" ({type})")}");
 						return true;
 					}
+
+#if __ANDROID__
+					Microsoft.Maui.Handlers.ButtonHandler.NativeViewFactory = (context) => 
+					{
+						return new Google.Android.Material.Button.MaterialButton(context) 
+						{ 
+							CornerRadius = 50, SoundEffectsEnabled = true 
+						};
+					};
+#endif
 				});
 
 			return appBuilder.Build();

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -53,6 +53,22 @@ namespace Microsoft.Maui.Handlers
 		public sealed override void SetVirtualView(IElement view) =>
 			SetVirtualView((IView)view);
 
+#if MONOANDROID
+		public static Func<Android.Content.Context, TNativeView>? NativeViewFactory { get; set; } 
+
+		TNativeView InvokeFactory()
+		{
+			return NativeViewFactory!.Invoke(Context);
+		}
+#else
+		public static Func<TNativeView>? NativeViewFactory { get; set; }
+
+		TNativeView InvokeFactory()
+		{
+			return NativeViewFactory!.Invoke();
+		}
+#endif
+
 		protected abstract TNativeView CreateNativeView();
 
 		protected virtual void ConnectHandler(TNativeView nativeView)
@@ -63,8 +79,15 @@ namespace Microsoft.Maui.Handlers
 		{
 		}
 
-		private protected override NativeView OnCreateNativeView() =>
-			CreateNativeView();
+		private protected override NativeView OnCreateNativeView()
+		{
+			if (NativeViewFactory != null)
+			{
+				return InvokeFactory();
+			}
+
+			return CreateNativeView();
+		}
 
 		private protected override void OnConnectHandler(NativeView nativeView) =>
 			ConnectHandler((TNativeView)nativeView);

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -53,21 +53,7 @@ namespace Microsoft.Maui.Handlers
 		public sealed override void SetVirtualView(IElement view) =>
 			SetVirtualView((IView)view);
 
-#if MONOANDROID
-		public static Func<Android.Content.Context, TNativeView>? NativeViewFactory { get; set; } 
-
-		TNativeView InvokeFactory()
-		{
-			return NativeViewFactory!.Invoke(Context);
-		}
-#else
-		public static Func<TNativeView>? NativeViewFactory { get; set; }
-
-		TNativeView InvokeFactory()
-		{
-			return NativeViewFactory!.Invoke();
-		}
-#endif
+		public static Func<ViewHandler<TVirtualView, TNativeView>, TNativeView>? NativeViewFactory { get; set; }
 
 		protected abstract TNativeView CreateNativeView();
 
@@ -83,7 +69,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (NativeViewFactory != null)
 			{
-				return InvokeFactory();
+				return NativeViewFactory.Invoke(this);
 			}
 
 			return CreateNativeView();


### PR DESCRIPTION
Adds `public static Func<ViewHandler<TVirtualView, TNativeView>, TNativeView>? NativeViewFactory { get; set; }` to ViewHandler. 

Defaults to `null`. When the handler is ready to create a native view, it checks to see if the static factory is available; if so, it uses the factory to create the native view. Otherwise it falls back to `CreateNativeView()`.

This allows users to substitute their own native control creation methods application-wide. It is intended as a low-effort alternatve to handler subclassing in situations where the user needs to substitute a subclass of the native type or where the user needs to use an alternate constructor for the native type. 