### PR TITLE
Add extension method for modifying an existing mapping.

### DIFF
--- a/src/Core/src/PropertyMapperExtensions.cs
+++ b/src/Core/src/PropertyMapperExtensions.cs
@@ -4,34 +4,38 @@ namespace Microsoft.Maui
 {
 	public static class PropertyMapperExtensions
 	{
-		public static void AppendToMapping<TVirtualView, TViewHandler>(this IPropertyMapper<TVirtualView, TViewHandler> propertyMapper,
-			string key, Action<TViewHandler, TVirtualView> method)
+		public static void ModifyMapping<TVirtualView, TViewHandler>(this IPropertyMapper<TVirtualView, TViewHandler> propertyMapper,
+			string key, Action<TViewHandler, TVirtualView, Action<IElementHandler, IElement>?> method)
 			where TVirtualView : IElement where TViewHandler : IElementHandler
 		{
 			var previousMethod = propertyMapper.GetProperty(key);
 
 			void newMethod(TViewHandler handler, TVirtualView view)
 			{
-				previousMethod?.Invoke(handler, view);
-				method(handler, view);
+				method(handler, view, previousMethod);
 			}
 
 			propertyMapper.Add(key, newMethod);
+		}
+
+		public static void AppendToMapping<TVirtualView, TViewHandler>(this IPropertyMapper<TVirtualView, TViewHandler> propertyMapper,
+			string key, Action<TViewHandler, TVirtualView> method)
+			where TVirtualView : IElement where TViewHandler : IElementHandler
+		{
+			propertyMapper.ModifyMapping(key, (handler, view, action) => { 
+				action?.Invoke(handler, view);
+				method(handler, view);
+			});
 		}
 
 		public static void PrependToMapping<TVirtualView, TViewHandler>(this IPropertyMapper<TVirtualView, TViewHandler> propertyMapper,
 			string key, Action<TViewHandler, TVirtualView> method)
 			where TVirtualView : IElement where TViewHandler : IElementHandler
 		{
-			var previousMethod = propertyMapper.GetProperty(key);
-
-			void newMethod(TViewHandler handler, TVirtualView view)
-			{
+			propertyMapper.ModifyMapping(key, (handler, view, action) => {
 				method(handler, view);
-				previousMethod?.Invoke(handler, view);
-			}
-
-			propertyMapper.Add(key, newMethod);
+				action?.Invoke(handler, view);
+			});
 		}
 	}
 }

--- a/src/Core/src/PropertyMapperExtensions.cs
+++ b/src/Core/src/PropertyMapperExtensions.cs
@@ -4,6 +4,14 @@ namespace Microsoft.Maui
 {
 	public static class PropertyMapperExtensions
 	{
+		/// <summary>
+		/// Modify a property mapping in place.
+		/// </summary>
+		/// <typeparam name="TVirtualView">The cross-platform type.</typeparam>
+		/// <typeparam name="TViewHandler">The handler type.</typeparam>
+		/// <param name="propertyMapper">The property mapper in which to change the mapping.</param>
+		/// <param name="key">The name of the property.</param>
+		/// <param name="method">The modified method to call when the property is updated.</param>
 		public static void ModifyMapping<TVirtualView, TViewHandler>(this IPropertyMapper<TVirtualView, TViewHandler> propertyMapper,
 			string key, Action<TViewHandler, TVirtualView, Action<IElementHandler, IElement>?> method)
 			where TVirtualView : IElement where TViewHandler : IElementHandler
@@ -18,6 +26,14 @@ namespace Microsoft.Maui
 			propertyMapper.Add(key, newMethod);
 		}
 
+		/// <summary>
+		/// Specify a method to be run after an existing property mapping.
+		/// </summary>
+		/// <typeparam name="TVirtualView">The cross-platform type.</typeparam>
+		/// <typeparam name="TViewHandler">The handler type.</typeparam>
+		/// <param name="propertyMapper">The property mapper in which to change the mapping.</param>
+		/// <param name="key">The name of the property.</param>
+		/// <param name="method">The method to call after the existing mapping is finished.</param>
 		public static void AppendToMapping<TVirtualView, TViewHandler>(this IPropertyMapper<TVirtualView, TViewHandler> propertyMapper,
 			string key, Action<TViewHandler, TVirtualView> method)
 			where TVirtualView : IElement where TViewHandler : IElementHandler
@@ -28,6 +44,14 @@ namespace Microsoft.Maui
 			});
 		}
 
+		/// <summary>
+		/// Specify a method to be run before an existing property mapping.
+		/// </summary>
+		/// <typeparam name="TVirtualView">The cross-platform type.</typeparam>
+		/// <typeparam name="TViewHandler">The handler type.</typeparam>
+		/// <param name="propertyMapper">The property mapper in which to change the mapping.</param>
+		/// <param name="key">The name of the property.</param>
+		/// <param name="method">The method to call before the existing mapping begins.</param>
 		public static void PrependToMapping<TVirtualView, TViewHandler>(this IPropertyMapper<TVirtualView, TViewHandler> propertyMapper,
 			string key, Action<TViewHandler, TVirtualView> method)
 			where TVirtualView : IElement where TViewHandler : IElementHandler

--- a/src/Core/tests/UnitTests/PropertyMapperExtensionTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperExtensionTests.cs
@@ -57,5 +57,26 @@ namespace Microsoft.Maui.UnitTests
 
 			Assert.True(additionalIndex < originalIndex);
 		}
+
+		[Fact]
+		public void ModifyMapping()
+		{
+			string log = string.Empty;
+
+			var msg1 = "original";
+			var msg2 = "modification";
+
+			var mapper1 = new PropertyMapper<IView, IViewHandler>
+			{
+				[nameof(IView.Background)] = (r, v) => log += msg1
+			};
+
+			mapper1.ModifyMapping(nameof(IView.Background), (h, v, a) => log += msg2);
+
+			mapper1.UpdateProperties(null, new Button());
+
+			Assert.DoesNotContain(msg1, log);
+			Assert.Contains(msg2, log);
+		}
 	}
 }


### PR DESCRIPTION
Also rewrite `PrependToMapping` and `AppendToMapping` using modify.

This is a convenience method for modifying a mapping in place without replacing the entire property mapper. An example usage might be to prevent a mapping from running under certain conditions:

```
Microsoft.Maui.Handlers.LabelHandler.LabelMapper.ModifyMapping(nameof(ILabel.Font), (handler, view, action) => {
		// Don't let any Label's font be set to anything over 20
		if (view.Font.Size < 20) { 
			action?.Invoke(handler, view);
		}
	});
```