### PR TITLE
Make factory fall back to CreateNativeView

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -67,12 +67,7 @@ namespace Microsoft.Maui.Handlers
 
 		private protected override NativeView OnCreateNativeView()
 		{
-			if (NativeViewFactory != null)
-			{
-				return NativeViewFactory.Invoke(this);
-			}
-
-			return CreateNativeView();
+			return NativeViewFactory?.Invoke(this) ?? CreateNativeView();
 		}
 
 		private protected override void OnConnectHandler(NativeView nativeView) =>

--- a/src/Core/tests/UnitTests/AbstractViewHandlerTests.cs
+++ b/src/Core/tests/UnitTests/AbstractViewHandlerTests.cs
@@ -127,5 +127,63 @@ namespace Microsoft.Maui.UnitTests
 			Assert.True(wasMapper1Called);
 			Assert.False(wasMapper2Called);
 		}
+
+		class CustomNativeButton : object
+		{
+
+		}
+
+		class CustomButton : Maui.Controls.Button
+		{
+
+		}
+
+		[Fact]
+		public void CanUseFactoryForAlternateType()
+		{
+			HandlerStub.NativeViewFactory = (h) => { return new CustomNativeButton(); };
+
+			HandlerStub handlerStub = new HandlerStub();
+			handlerStub.SetVirtualView(new Maui.Controls.Button());
+
+			Assert.True(handlerStub.NativeView is CustomNativeButton);
+		}
+
+		[Fact]
+		public void FactoryCanPuntAndUseOriginalType()
+		{
+			HandlerStub.NativeViewFactory = (h) => { return null; };
+
+			HandlerStub handlerStub = new HandlerStub();
+			handlerStub.SetVirtualView(new Maui.Controls.Button());
+
+			Assert.NotNull(handlerStub.NativeView);
+			Assert.False(handlerStub.NativeView is CustomNativeButton);
+			Assert.True(handlerStub.NativeView is object);
+		}
+
+		[Fact]
+		public void FactoryCanCustomizeBasedOnVirtualView()
+		{
+			HandlerStub.NativeViewFactory = (h) =>
+			{
+				if (h.VirtualView is CustomButton)
+				{
+					return new CustomNativeButton();
+				}
+
+				return null;
+			};
+
+			HandlerStub handlerStub = new HandlerStub();
+			handlerStub.SetVirtualView(new CustomButton());
+
+			Assert.True(handlerStub.NativeView is CustomNativeButton);
+
+			HandlerStub handlerStub2 = new HandlerStub();
+			handlerStub2.SetVirtualView(new Maui.Controls.Button());
+
+			Assert.True(handlerStub2.NativeView is object);
+		}
 	}
 }


### PR DESCRIPTION
This allows the factory to return null if it doesn't know/care what to create, and the handler will fall back on CreateNativeView if it's implemented.