### PR TITLE
Return Size.Zero from measure when ScrollView Content is null

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -69,6 +69,11 @@ namespace Microsoft.Maui.Controls
 
 		Size IContentView.CrossPlatformMeasure(double contentWidthConstraint, double contentHeightConstraint)
 		{
+			if (Content == null)
+			{
+				return Size.Zero;
+			}
+
 			if (Content is not IView content)
 			{
 				return Content.DesiredSize;


### PR DESCRIPTION
Cross-platform measure for ScrollView Content should return Zero when the Content is null; avoids NRE attempting to get the Content's DesiredSize.

Fixes #2462


