### PR TITLE
[android] bump to Xamarin.Android.Glide 4.12.0.2

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <!-- Android related Packages -->
   <PropertyGroup>
-    <_XamarinAndroidGlideVersion>4.11.0.1</_XamarinAndroidGlideVersion>
+    <_XamarinAndroidGlideVersion>4.12.0.2</_XamarinAndroidGlideVersion>
   </PropertyGroup>
   <!-- SkiaSharp related Packages -->
   <PropertyGroup>


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/xamarin/XamarinComponents/commit/a245afa0aa6a5ecc3729f927ee0785771aad793d
Context: https://www.nuget.org/packages/Xamarin.Android.Glide/4.12.0.2

The latest version of Xamarin.Android.Glide includes .NET 6 packages. .NET MAUI should use this version.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No

Did some manual testing, images still display with `dotnet new maui`:

![image](https://user-images.githubusercontent.com/840039/133805398-53f46246-67a7-4575-a4d0-4409ea3f28be.png)

