### PR TITLE
Fix layout cycle on Windows when ScrollView content has Margin

### DIFF
--- a/src/Core/src/Core/IContentView.cs
+++ b/src/Core/src/Core/IContentView.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// A View that contains another View.
 	/// </summary>
-	public interface IContentView : IView
+	public interface IContentView : IView, IPadding
 	{
 		/// <summary>
 		/// Gets the raw content of this view.
@@ -16,11 +16,6 @@ namespace Microsoft.Maui
 		/// Gets the content of this view as it will be rendered in the user interface, including any transformations or applied templates.
 		/// </summary>
 		IView? PresentedContent { get; }
-
-		/// <summary>
-		/// The space between the outer edge of the IContentViews's content area and its content.
-		/// </summary>
-		Thickness Padding { get; }
 
 		/// <summary>
 		/// Measures the desired size of the IContentView within the given constraints.

--- a/src/Core/src/Core/ILayout.cs
+++ b/src/Core/src/Core/ILayout.cs
@@ -7,13 +7,8 @@ namespace Microsoft.Maui
 	/// Provides the base properties and methods for all Layout elements.
 	/// Use Layout elements to position and size child elements in .NET MAUI applications.
 	/// </summary>
-	public interface ILayout : IView, IContainer, ISafeAreaView
+	public interface ILayout : IView, IContainer, ISafeAreaView, IPadding
 	{
-		/// <summary>
-		/// The space between the outer edge of the ILayout's content area and its children.
-		/// </summary>
-		Thickness Padding { get; }
-
 		/// <summary>
 		/// Measures the desired size of the ILayout within the given constraints.
 		/// </summary>

--- a/src/Core/src/Core/IPadding.cs
+++ b/src/Core/src/Core/IPadding.cs
@@ -6,7 +6,7 @@
 	public interface IPadding
 	{
 		/// <summary>
-		/// Gets the Padding
+		/// The space between the outer edge of the control and its content.
 		/// </summary>
 		Thickness Padding { get; }
 	}


### PR DESCRIPTION
Attempting to arrange ScrollView content at an offset on Windows (e.g., by adding a Margin to the ScrollView Content) was triggering another layout pass because the ScrollViewer forces the content to the origin. Since each layout pass would then try to arrange the content at the margin offset, we'd end up in a layout cycle and crash. 

(Big thanks @paymicro for the comments about this in the [Forms ScrollViewRenderer](https://github.com/dotnet/maui/blob/261ea69297faa7d5cd4951137e1ce46318e2c28e/src/Compatibility/Core/src/Windows/ScrollViewRenderer.cs#L241)!)

These changes check for ScrollViewer content when arranging and adjust the bounds to the origin while setting the native Margin to account for both the Content Margin and the ScrollView Padding.