### PR TITLE
[android] use a custom Resource.designer.cs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,3 +71,32 @@ To build and run WinUI 3 support, please install the additional components menti
 dotnet tool restore
 dotnet cake --target=VS-WINUI
 ```
+
+### Android
+
+To workaround a performance issue, all `Resource.designer.cs`
+generation is disabled for class libraries in this repo.
+
+If you need to add a new `@(AndroidResource)` value to be used from C#
+code in .NET MAUI:
+
+1. Comment out the `<PropertyGroup>` in `Directory.Build.targets` that
+   sets `$(AndroidGenerateResourceDesigner)` and
+   `$(AndroidUseIntermediateDesignerFile)` to `false`.
+
+2. Build .NET MAUI as you normally would. You will get compiler errors
+   about duplicate fields, but `obj\Debug\net6.0-android\Resource.designer.cs`
+   should now be generated.
+
+3. Open `obj\Debug\net6.0-android\Resource.designer.cs`, and find the
+   field you need such as:
+
+```csharp
+// aapt resource value: 0x7F010000
+public static int foo = 2130771968;
+```
+
+4. Copy this field to the `Resource.designer.cs` checked into source
+   control, such as: `src\Controls\src\Core\Platform\Android\Resource.designer.cs`
+
+5. Restore the commented code in `Directory.Build.targets`.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,15 @@
   <Import Project="eng\AndroidX.targets" />
   <Import Project="eng\Microsoft.Extensions.targets" />
 
+  <!--
+    Comment out this section if you need to update Resource.designer.cs files.
+    See DEVELOPMENT.md#Android for details.
+  -->
+  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'Android' and '$(AndroidApplication)' != 'true'">
+    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+    <AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
+  </PropertyGroup>
+
   <!-- HACK: Prevent the Platform checks -->
   <Target Name="BinPlaceBootstrapDll" />
 

--- a/src/Compatibility/Core/src/Android/Resource.designer.cs
+++ b/src/Compatibility/Core/src/Android/Resource.designer.cs
@@ -1,0 +1,143 @@
+#pragma warning disable 1591
+//------------------------------------------------------------------------------
+// This file was manually curated so we could avoid 5,172 fields.
+// See DEVELOPMENT.md#Android for details on updating this file.
+//------------------------------------------------------------------------------
+
+[assembly: global::Android.Runtime.ResourceDesignerAttribute("Microsoft.Maui.Controls.Compatibility.Resource", IsApplication=false)]
+
+namespace Microsoft.Maui.Controls.Compatibility
+{
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.0.99.31")]
+	public partial class Resource
+	{
+		static Resource()
+		{
+			global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+		}
+
+		public partial class Animation
+		{
+			// aapt resource value: 0x7F01001C
+			public static int enterfromleft = 2130771996;
+
+			// aapt resource value: 0x7F01001D
+			public static int enterfromright = 2130771997;
+
+			// aapt resource value: 0x7F01001E
+			public static int exittoleft = 2130771998;
+
+			// aapt resource value: 0x7F01001F
+			public static int exittoright = 2130771999;
+
+			static Animation()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Attribute
+		{
+			// aapt resource value: 0x7F030007
+			public static int actionBarSize = 2130903047;
+
+			// aapt resource value: 0x7F0300CE
+			public static int collectionViewStyle = 2130903246;
+
+			// aapt resource value: 0x7F030301
+			public static int scrollViewStyle = 2130903809;
+
+			static Attribute()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Drawable
+		{
+			// aapt resource value: 0x7F07001D
+			public static int abc_ic_clear_material = 2131165213;
+
+			// aapt resource value: 0x7F070026
+			public static int abc_ic_search_api_material = 2131165222;
+
+			static Drawable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Id
+		{
+			// aapt resource value: 0x7F080061
+			public static int bottomtab_navarea = 2131230817;
+
+			// aapt resource value: 0x7F080062
+			public static int bottomtab_tabbar = 2131230818;
+
+			// aapt resource value: 0x7F0800C7
+			public static int flyoutcontent_appbar = 2131230919;
+
+			// aapt resource value: 0x7F0800F4
+			public static int main_tablayout = 2131230964;
+
+			// aapt resource value: 0x7F0800F5
+			public static int main_viewpager = 2131230965;
+
+			// aapt resource value: 0x7F08010C
+			public static int maui_toolbar = 2131230988;
+
+			// aapt resource value: 0x7F08017D
+			public static int shellcontent_toolbar = 2131231101;
+
+			static Id()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Layout
+		{
+			// aapt resource value: 0x7F0B001C
+			public static int bottomtablayout = 2131427356;
+
+			// aapt resource value: 0x7F0B002F
+			public static int flyoutcontent = 2131427375;
+
+			// aapt resource value: 0x7F0B006B
+			public static int rootlayout = 2131427435;
+
+			// aapt resource value: 0x7F0B006F
+			public static int shellcontent = 2131427439;
+			
+			// aapt resource value: 0x7F0B0070
+			public static int shellrootlayout = 2131427440;
+
+			// aapt resource value: 0x7F0B0072
+			public static int tabbar = 2131427442;
+
+			// aapt resource value: 0x7F0B0082
+			public static int toolbar = 2131427458;
+			
+			static Layout()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Style
+		{
+			// aapt resource value: 0x7F0E02DF
+			public static int collectionViewTheme = 2131624671;
+
+			// aapt resource value: 0x7F0E02E1
+			public static int scrollViewTheme = 2131624673;
+
+			static Style()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+	}
+}
+#pragma warning restore 1591

--- a/src/Controls/src/Core/Platform/Android/Resource.designer.cs
+++ b/src/Controls/src/Core/Platform/Android/Resource.designer.cs
@@ -1,0 +1,140 @@
+#pragma warning disable 1591
+//------------------------------------------------------------------------------
+// This file was manually curated so we could avoid 5,167 fields.
+// See DEVELOPMENT.md#Android for details on updating this file.
+//-----------------------------------------------------------------------------
+
+[assembly: global::Android.Runtime.ResourceDesignerAttribute("Microsoft.Maui.Controls.Resource", IsApplication=false)]
+
+namespace Microsoft.Maui.Controls
+{
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.0.99.31")]
+	public partial class Resource
+	{
+		static Resource()
+		{
+			global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+		}
+
+		public partial class Animation
+		{
+			// aapt resource value: 0x7F01001C
+			public static int enterfromleft = 2130771996;
+
+			// aapt resource value: 0x7F01001D
+			public static int enterfromright = 2130771997;
+
+			// aapt resource value: 0x7F01001E
+			public static int exittoleft = 2130771998;
+
+			// aapt resource value: 0x7F01001F
+			public static int exittoright = 2130771999;
+
+			static Animation()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Attribute
+		{
+			// aapt resource value: 0x7F030007
+			public static int actionBarSize = 2130903047;
+
+			static Attribute()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Drawable
+		{
+			// aapt resource value: 0x7F07001D
+			public static int abc_ic_clear_material = 2131165213;
+
+			// aapt resource value: 0x7F070022
+			public static int abc_ic_menu_overflow_material = 2131165218;
+
+			// aapt resource value: 0x7F070026
+			public static int abc_ic_search_api_material = 2131165222;
+
+			static Drawable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Id
+		{
+			// aapt resource value: 0x7F080051
+			public static int appbar = 2131230801;
+
+			// aapt resource value: 0x7F080061
+			public static int bottomtab_navarea = 2131230817;
+
+			// aapt resource value: 0x7F080062
+			public static int bottomtab_tabbar = 2131230818;
+
+			// aapt resource value: 0x7F0800C7
+			public static int flyoutcontent_appbar = 2131230919;
+
+			// aapt resource value: 0x7F0800F4
+			public static int main_tablayout = 2131230964;
+
+			// aapt resource value: 0x7F0800F5
+			public static int main_viewpager = 2131230965;
+
+			// aapt resource value: 0x7F08010C
+			public static int maui_toolbar = 2131230988;
+
+			// aapt resource value: 0x7F08017C
+			public static int shellcontent_appbar = 2131231100;
+
+			// aapt resource value: 0x7F08017D
+			public static int shellcontent_toolbar = 2131231101;
+
+			static Id()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Layout
+		{
+			// aapt resource value: 0x7F0B001C
+			public static int bottomtablayout = 2131427356;
+
+			// aapt resource value: 0x7F0B002F
+			public static int flyoutcontent = 2131427375;
+
+			// aapt resource value: 0x7F0B006E
+			public static int shellcontent = 2131427438;
+
+			// aapt resource value: 0x7F0B006F
+			public static int shellrootlayout = 2131427439;
+
+			static Layout()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class String
+		{
+			// aapt resource value: 0x7F0D0065
+			public static int nav_app_bar_navigate_up_description = 2131558501;
+
+			// aapt resource value: 0x7F0D0066
+			public static int nav_app_bar_open_drawer_description = 2131558502;
+
+			// aapt resource value: 0x7F0D0067
+			public static int overflow_tab_title = 2131558503;
+
+			static String()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+	}
+}
+#pragma warning restore 1591

--- a/src/Core/src/Platform/Android/Resource.designer.cs
+++ b/src/Core/src/Platform/Android/Resource.designer.cs
@@ -1,0 +1,116 @@
+#pragma warning disable 1591
+//------------------------------------------------------------------------------
+// This file was manually curated so we could avoid 5,310 fields.
+// See DEVELOPMENT.md#Android for details on updating this file.
+//-----------------------------------------------------------------------------
+
+[assembly: global::Android.Runtime.ResourceDesignerAttribute("Microsoft.Maui.Resource", IsApplication=false)]
+
+namespace Microsoft.Maui
+{
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.0.99.31")]
+	public partial class Resource
+	{
+		static Resource()
+		{
+			global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+		}
+
+		public partial class Attribute
+		{
+			// aapt resource value: 0x7F0300E4
+			public static int colorSwitchThumbNormal = 2130903268;
+
+			// aapt resource value: 0x7F030269
+			public static int maui_splash = 2130903657;
+
+			// aapt resource value: 0x7F030301
+			public static int scrollViewStyle = 2130903809;
+
+			static Attribute()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Animation
+		{
+			// aapt resource value: 0x7F010020
+			public static int nav_default_enter_anim = 2130772000;
+			
+			// aapt resource value: 0x7F010021
+			public static int nav_default_exit_anim = 2130772001;
+			
+			// aapt resource value: 0x7F010022
+			public static int nav_default_pop_enter_anim = 2130772002;
+			
+			// aapt resource value: 0x7F010023
+			public static int nav_default_pop_exit_anim = 2130772003;
+
+			static Animation()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Drawable
+		{
+			// aapt resource value: 0x7F07001D
+			public static int abc_ic_clear_material = 2131165213;
+
+			static Drawable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Id
+		{
+			// aapt resource value: 0x7F080059
+			public static int automation_tag_id = 2131230809;
+
+			// aapt resource value: 0x7F080107
+			public static int maui_toolbar = 2131230983;
+
+			// aapt resource value: 0x7F08012D
+			public static int nav_host = 2131231021;
+
+			// aapt resource value: 0x7F08016A
+			public static int search_button = 2131231082;
+
+			// aapt resource value: 0x7F08016B
+			public static int search_close_btn = 2131231083;
+
+			static Id()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Layout
+		{
+			// aapt resource value: 0x7F0B0059
+			public static int navigationlayout = 2131427417;
+
+			static Layout()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+
+		public partial class Style
+		{
+			// aapt resource value: 0x7F0E00F8
+			public static int Maui_MainTheme_NoActionBar = 2131624184;
+
+			// aapt resource value: 0x7F0E02E1
+			public static int scrollViewTheme = 2131624673;
+
+			static Style()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+		}
+	}
+}
+#pragma warning restore 1591


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/jonathanpeppers/CustomResourceDesigner
Context: https://github.com/xamarin/xamarin-android/issues/6310

We found a systemic problem with Xamarin.Android class libraries:

* Include AndroidX & Google Material
* Include at least one `@(AndroidResource)` and use the ID from C#
* `Resource.designer.cs` has 2,700+ fields. That's a lot!

This problem compounds itself as you include more class libraries that
depend on each other. The main app will end up repeatedly setting
these fields at startup for each library that contains fields in
`Resource.designer.cs`...

Reviewing the .NET MAUI fields, I found:

    src\Core\src\obj\Debug\net6.0-android\Resource.designer.cs
    5310
    src\Controls\src\Core\obj\Debug\net6.0-android\Resource.designer.cs
    5167 fields
    src\Controls\src\Xaml\obj\Release\net6.0-android\Resource.designer.cs
    5167 fields
    src\Compatibility\Core\src\obj\Debug\net6.0-android\Resource.designer.cs
    5333 fields
    src\Essentials\src\obj\Debug\net6.0-android\Resource.designer.cs
    204 fields

In fact, I found 21,497 fields were set at startup for a `dotnet new
maui` app in `Resource.designer.cs`!

This shows up as a "hot path" if you profile Android startup:

![image](https://user-images.githubusercontent.com/840039/134078499-0fa5ef99-b0d9-4085-8dde-4804b73b8218.png)

In many projects you can simply set `$(AndroidGenerateResourceDesigner)`
to `false`, but the issue is .NET MAUI actually uses some of the C#
`Resource.designer.cs` values at runtime.

So to solve the problem here, I came up with a new pattern:

https://github.com/jonathanpeppers/CustomResourceDesigner

We can copy the contents of `Resource.designer.cs` and manually delete
all the fields we don't need. This allows
`$(AndroidGenerateResourceDesigner)` to be turned off.

We are working on a long-term solution for this issue in
Xamarin.Android, but we can do this workaround in .NET MAUI now.

### Results ###

Building a `dotnet new maui` then `dotnet build -c Release` and
running on a Pixel 5.

Before:

* 21,497 fields set at startup in `UpdateIdValues()`
* Activity Displayed: 1s454ms
* .apk size: 17300275 bytes

After:

* 65 fields set at startup in `UpdateIdValues()`
* Activity Displayed: 1s079ms
* .apk size: 16677683 bytes

```
> apkdiff -f before.apk after.apk
Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
-         233 assemblies/Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.dll
-       5,264 assemblies/Microsoft.Maui.Essentials.dll
-     103,010 assemblies/Microsoft.Maui.dll
-     103,260 assemblies/Microsoft.Maui.Controls.Compatibility.dll
-     103,811 assemblies/Microsoft.Maui.Controls.Xaml.dll
-     106,127 assemblies/Microsoft.Maui.Controls.dll
-     201,031 assemblies/foo.dll
Summary:
+           0 Other entries 0.00% (of 2,139,558)
-     622,736 Assemblies -6.93% (of 8,987,664)
+           0 Dalvik executables 0.00% (of 6,440,988)
+           0 Shared libraries 0.00% (of 9,860,264)
-   1,340,928 Uncompressed assemblies -6.55% (of 20,465,016)
-     622,592 Package size difference -3.60% (of 17,300,275)
```

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No