### PR TITLE
Fix typo AddEmeddedResourceFont

### DIFF
--- a/src/Core/src/Hosting/Fonts/FontCollectionExtensions.cs
+++ b/src/Core/src/Hosting/Fonts/FontCollectionExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Hosting
 			return fontCollection;
 		}
 
-		public static IFontCollection AddEmeddedResourceFont(this IFontCollection fontCollection, Assembly assembly, string filename, string? alias = null)
+		public static IFontCollection AddEmbeddedResourceFont(this IFontCollection fontCollection, Assembly assembly, string filename, string? alias = null)
 		{
 			_ = assembly ?? throw new ArgumentNullException(nameof(assembly));
 			_ = filename ?? throw new ArgumentNullException(nameof(filename));

--- a/src/Core/tests/UnitTests/Hosting/HostBuilderFontsTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/HostBuilderFontsTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.UnitTests.Hosting
 
 			var builder = MauiApp
 				.CreateBuilder()
-				.ConfigureFonts(fonts => fonts.AddEmeddedResourceFont(GetType().Assembly, filename, alias));
+				.ConfigureFonts(fonts => fonts.AddEmbeddedResourceFont(GetType().Assembly, filename, alias));
 			builder.Services.AddSingleton<IEmbeddedFontLoader>(_ => new FileSystemEmbeddedFontLoader(root));
 			var mauiApp = builder.Build();
 
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		{
 			var builder = MauiApp
 				.CreateBuilder()
-				.ConfigureFonts(fonts => fonts.AddEmeddedResourceFont(null, "test.ttf"));
+				.ConfigureFonts(fonts => fonts.AddEmbeddedResourceFont(null, "test.ttf"));
 
 			var ex = Assert.Throws<ArgumentNullException>(() => builder.Build());
 			Assert.Equal("assembly", ex.ParamName);
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		{
 			var builder = MauiApp
 				.CreateBuilder()
-				.ConfigureFonts(fonts => fonts.AddEmeddedResourceFont(GetType().Assembly, filename));
+				.ConfigureFonts(fonts => fonts.AddEmbeddedResourceFont(GetType().Assembly, filename));
 
 			var ex = Assert.ThrowsAny<ArgumentException>(() => builder.Build());
 			Assert.Equal("filename", ex.ParamName);
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		{
 			var builder = MauiApp
 				.CreateBuilder()
-				.ConfigureFonts(fonts => fonts.AddEmeddedResourceFont(GetType().Assembly, "test.ttf", null));
+				.ConfigureFonts(fonts => fonts.AddEmbeddedResourceFont(GetType().Assembly, "test.ttf", null));
 
 			_ = builder.Build();
 		}


### PR DESCRIPTION
This PR corrects a typo in `IFontCollection`: from `AddEmeddedResourceFont` to `AddEmbeddedResourceFont`