### PR TITLE
Generate rollback files

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,6 +28,10 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>d84d8736af48eb08f13e782ad406d9f5ccb10cd0</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.0-rc.2.21464.1">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>9838ec0843442f761488cfec9cf34612c9f675e6</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-rc.2.21462.1" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>baf21f6cf308b81e25cd5c13f7e0bc88ee2488cc</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,6 +11,8 @@
     <MicrosoftMacCatalystSdkPackageVersion>15.0.101-preview.9.20</MicrosoftMacCatalystSdkPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>12.0.101-preview.9.20</MicrosoftmacOSSdkPackageVersion>
     <MicrosofttvOSSdkPackageVersion>15.0.101-preview.9.20</MicrosofttvOSSdkPackageVersion>
+    <!-- emsdk -->
+    <MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion>6.0.0-rc.2.21464.1</MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion>
     <!-- Everything else -->
     <MicrosoftAspNetCoreAppRuntimewinx64Version>6.0.0-rc.2.21462.1</MicrosoftAspNetCoreAppRuntimewinx64Version>
     <MicrosoftAspNetCoreAuthorizationPackageVersion>6.0.0-rc.2.21462.1</MicrosoftAspNetCoreAuthorizationPackageVersion>

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -172,6 +172,13 @@ stages:
                 TargetFolder: $(build.artifactstagingdirectory)
                 flattenFolders: true
             - task: CopyFiles@2
+              condition: always()
+              displayName: 'Copy rollbacks to staging'
+              inputs:
+                Contents: |
+                  artifacts/rollbacks/**
+                TargetFolder: $(build.artifactstagingdirectory)
+            - task: CopyFiles@2
               displayName: 'Copy Log Files'
               condition: always()
               inputs:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -175,9 +175,9 @@ stages:
               condition: always()
               displayName: 'Copy rollbacks to staging'
               inputs:
-                SourceFolder: artifacts/rollbacks
+                SourceFolder: artifacts
                 Contents: |
-                  **
+                  rollbacks/**
                 TargetFolder: $(build.artifactstagingdirectory)
             - task: CopyFiles@2
               displayName: 'Copy Log Files'

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -175,8 +175,9 @@ stages:
               condition: always()
               displayName: 'Copy rollbacks to staging'
               inputs:
+                SourceFolder: artifacts/rollbacks
                 Contents: |
-                  artifacts/rollbacks/**
+                  **
                 TargetFolder: $(build.artifactstagingdirectory)
             - task: CopyFiles@2
               displayName: 'Copy Log Files'

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -19,8 +19,20 @@
     <ProjectReference Include="$(MauiRootDirectory)src/SingleProject/Resizetizer/src/Resizetizer.csproj" />
   </ItemGroup>
 
-  <Target Name="_GenerateWorkloadManifest" BeforeTargets="Build;AssignTargetPaths" DependsOnTargets="SetVersions" Inputs="$(MSBuildProjectFile);WorkloadManifest.in.json" Outputs="$(IntermediateOutputPath)WorkloadManifest.json">
+  <ItemGroup>
+    <_JsonInputFile Include="WorkloadManifest.in.json" OutputPath="$(IntermediateOutputPath)WorkloadManifest.json" Pack="true" />
+    <_JsonInputFile Include="Rollback.in.json" OutputPath="$(IntermediateOutputPath)Rollback.json" Pack="false" />
+  </ItemGroup>
+
+  <Target Name="_GenerateWorkloadManifest" BeforeTargets="Build;AssignTargetPaths" DependsOnTargets="SetVersions" Inputs="$(MSBuildProjectFile);@(_JsonInputFile)" Outputs="@(_JsonInputFile->'%(OutputPath)')">
     <ItemGroup>
+      <_VersionsToReplace Include="MicrosoftDotnetSdkInternalPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftNETCoreAppRefPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftAndroidSdkWindowsPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftiOSSdkPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftMacCatalystSdkPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftmacOSSdkPackageVersion" />
+      <_VersionsToReplace Include="MicrosofttvOSSdkPackageVersion" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreAuthorizationPackageVersion" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsAnalyzersPackageVersion" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsFormsPackageVersion" />
@@ -66,21 +78,28 @@
       <_VersionsToReplace Update="@(_VersionsToReplace)" PropertyName="%(Identity)" />
       <_VersionsToReplace Include="MicrosoftMauiGraphicsWin2DWinUIDesktopPackageVersion" PropertyName="MicrosoftMauiGraphicsVersion" />
     </ItemGroup>
+    <CreateItem
+        Include="@(_JsonInputFile)"
+        AdditionalMetadata="OldValue=@%(_VersionsToReplace.Identity)@;NewValue=$(%(_VersionsToReplace.PropertyName))">
+        <Output
+            TaskParameter="Include"
+            ItemName="_JsonVariableMatrix"/>
+    </CreateItem>
     <ReplaceText
-        Input="WorkloadManifest.in.json"
-        Output="$(IntermediateOutputPath)WorkloadManifest.json"
+        Input="%(_JsonInputFile.Identity)"
+        Output="%(_JsonInputFile.OutputPath)"
         OldValue="@VERSION@"
         NewValue="$(PackageReferenceVersion)"
     />
     <ReplaceText
-        Input="$(IntermediateOutputPath)WorkloadManifest.json"
-        Output="$(IntermediateOutputPath)WorkloadManifest.json"
-        OldValue="@%(_VersionsToReplace.Identity)@"
-        NewValue="$(%(_VersionsToReplace.PropertyName))"
+        Input="%(_JsonVariableMatrix.OutputPath)"
+        Output="%(_JsonVariableMatrix.OutputPath)"
+        OldValue="%(_JsonVariableMatrix.OldValue)"
+        NewValue="%(_JsonVariableMatrix.NewValue)"
     />
     <ItemGroup>
-      <None Include="$(IntermediateOutputPath)WorkloadManifest.json" Link="WorkloadManifest.json" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="data" Visible="false" />
-      <FileWrites Include="$(IntermediateOutputPath)WorkloadManifest.json" />
+      <FileWrites Include="@(_JsonInputFile->'%(OutputPath)')" />
+      <None Include="%(_JsonInputFile.OutputPath)" Link="$([System.IO.Path]::GetFileName('%(_JsonInputFile.OutputPath)'))" CopyToOutputDirectory="PreserveNewest" Pack="%(_JsonInputFile.Pack)" PackagePath="data" Visible="false" />
     </ItemGroup>
   </Target>
 
@@ -90,6 +109,15 @@
     <ItemGroup>
       <FileWrites Include="$(PackageOutputPath)/vs-workload.props" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_CopyRollbackFile" AfterTargets="Build">
+    <Copy SourceFiles="$(OutputPath)Rollback.json" DestinationFiles="$(PackageOutputPath)/rollbacks/$(Version)/$(GitSha).json" />
+    <Copy SourceFiles="$(OutputPath)Rollback.json" DestinationFiles="$(PackageOutputPath)/rollbacks/$(Version)/$(GitSemVerLabel).$(BUILDVERSION).json" />
+    <Copy SourceFiles="$(OutputPath)Rollback.json" DestinationFiles="$(PackageOutputPath)/rollbacks/$(Version)/$(GitSemVerLabel).json" />
+    <Copy SourceFiles="$(OutputPath)Rollback.json" DestinationFiles="$(PackageOutputPath)/rollbacks/$(GitSha).json" />
+    <Copy SourceFiles="$(OutputPath)Rollback.json" DestinationFiles="$(PackageOutputPath)/rollbacks/$(GitSemVerLabel).json" />
+    <Copy SourceFiles="$(OutputPath)Rollback.json" DestinationFiles="$(PackageOutputPath)/rollbacks/$(GitBranch).json" />
   </Target>
 
   <Target Name="_CopyManifest" AfterTargets="Build">

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -33,6 +33,7 @@
       <_VersionsToReplace Include="MicrosoftMacCatalystSdkPackageVersion" />
       <_VersionsToReplace Include="MicrosoftmacOSSdkPackageVersion" />
       <_VersionsToReplace Include="MicrosofttvOSSdkPackageVersion" />
+      <_VersionsToReplace Include="MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreAuthorizationPackageVersion" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsAnalyzersPackageVersion" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsFormsPackageVersion" />

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
@@ -1,0 +1,10 @@
+{
+  "microsoft.net.sdk.android": "@MicrosoftAndroidSdkWindowsPackageVersion@",
+  "microsoft.net.sdk.ios": "@MicrosoftiOSSdkPackageVersion@",
+  "microsoft.net.sdk.maccatalyst": "@MicrosoftMacCatalystSdkPackageVersion@",
+  "microsoft.net.sdk.macos": "@MicrosoftmacOSSdkPackageVersion@",
+  "microsoft.net.sdk.maui": "@VERSION@",
+  "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@",
+  "microsoft.net.workload.emscripten": "@MicrosoftNETCoreAppRefPackageVersion@",
+  "microsoft.net.workload.mono.toolchain": "@MicrosoftNETCoreAppRefPackageVersion@"
+}

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
@@ -5,6 +5,6 @@
   "microsoft.net.sdk.macos": "@MicrosoftmacOSSdkPackageVersion@",
   "microsoft.net.sdk.maui": "@VERSION@",
   "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@",
-  "microsoft.net.workload.emscripten": "@MicrosoftNETCoreAppRefPackageVersion@",
+  "microsoft.net.workload.emscripten": "@MicrosoftNETWorkloadEmscriptenManifest60100PackageVersion@",
   "microsoft.net.workload.mono.toolchain": "@MicrosoftNETCoreAppRefPackageVersion@"
 }


### PR DESCRIPTION
### Description of Change ###

Generate an easy rollback file for quick installs.

```
https://aka.ms/dotnet/maui/<branch-name>.json
  main = https://aka.ms/dotnet/maui/main.json
  release/6.0.1xx-rc1 = https://aka.ms/dotnet/maui/6.0.1xx-rc1.json

BASE VERSION
  https://aka.ms/dotnet/maui/preview.9.json
  https://aka.ms/dotnet/maui/6.0.101/preview.9.json

FULL VErSION
  https://aka.ms/dotnet/maui/6.0.101/preview.9.12345.json

SHA
  https://aka.ms/dotnet/maui/6.0.101/<sha>.json
  https://aka.ms/dotnet/maui/<sha>.json
```

Usage:

```
dotnet workload update --from-rollback-file https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json
dotnet workload install XXX --skip-manifest-update
```

All we need now is a nice way to do the 2 commands in 1:

```
dotnet workload install --versions https://aka.ms/dotnet/maui/main.json --source https://aka.ms/dotnet6/nuget/index.json
```