### PR TITLE
Fix android so cursor doesn't reset to position zero

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,12 +10,7 @@
     Comment out this section if you need to update Resource.designer.cs files.
     See DEVELOPMENT.md#Android for details.
   -->
-  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'Android' and '$(AndroidApplication)' != 'true'">
-    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
-    <AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
+  <PropertyGroup Condition="($(TargetFramework.StartsWith('MonoAndroid')) or '$(TargetPlatformIdentifier)' == 'Android') and '$(AndroidApplication)' != 'true'">
     <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
     <AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,6 +15,12 @@
     <AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
+    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+    <AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
+  </PropertyGroup>
+  
+
   <!-- HACK: Prevent the Platform checks -->
   <Target Name="BinPlaceBootstrapDll" />
 

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -18,7 +18,12 @@ namespace Microsoft.Maui
 
 		public static void UpdateText(this AppCompatEditText editText, IEntry entry)
 		{
-			editText.Text = entry.Text;
+			// Setting the text causes the cursor to reset to position zero
+			// Therefore if:
+			// User Types => VirtualView Updated => Triggers Native Update
+			// Then it will cause the cursor to reset to position zero as the user typed
+			if (entry.Text != editText.Text)
+				editText.Text = entry.Text;
 
 			// TODO ezhart The renderer sets the text to selected and shows the keyboard if the EditText is focused
 		}

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -2,7 +2,6 @@
 using Android.Text;
 using Android.Text.Method;
 using AndroidX.AppCompat.Widget;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -48,10 +47,16 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(EditorHandler editorHandler, string text) =>
 			GetNativeEditor(editorHandler).Text = text;
 
-		static int GetCursorPosition(EditorHandler entryHandler)
+		static int GetCursorStartPosition(EditorHandler editorHandler)
 		{
-			var control = GetNativeEditor(entryHandler);
+			var control = GetNativeEditor(editorHandler);
 			return control.SelectionStart;
+		}
+
+		static void UpdateCursorStartPosition(EditorHandler editorHandler, int position)
+		{
+			var control = GetNativeEditor(editorHandler);
+			control.SetSelection(position);
 		}
 
 		string GetNativePlaceholderText(EditorHandler editorHandler) =>

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -48,6 +48,12 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(EditorHandler editorHandler, string text) =>
 			GetNativeEditor(editorHandler).Text = text;
 
+		static int GetCursorPosition(EditorHandler entryHandler)
+		{
+			var control = GetNativeEditor(entryHandler);
+			return control.SelectionStart;
+		}
+
 		string GetNativePlaceholderText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).Hint;
 

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -360,6 +360,11 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				EditorHandlerTests.SetNativeText(entryHandler, text);
 			}
+
+			protected override int GetCursorPosition(EditorHandler entryHandler)
+			{
+				return EditorHandlerTests.GetCursorPosition(entryHandler);
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -356,14 +356,19 @@ namespace Microsoft.Maui.DeviceTests
 		[Category(TestCategory.Editor)]
 		public class EditorTextInputTests : TextInputHandlerTests<EditorHandler, EditorStub>
 		{
-			protected override void SetNativeText(EditorHandler entryHandler, string text)
+			protected override void SetNativeText(EditorHandler editorHandler, string text)
 			{
-				EditorHandlerTests.SetNativeText(entryHandler, text);
+				EditorHandlerTests.SetNativeText(editorHandler, text);
 			}
 
-			protected override int GetCursorPosition(EditorHandler entryHandler)
+			protected override int GetCursorStartPosition(EditorHandler editorHandler)
 			{
-				return EditorHandlerTests.GetCursorPosition(entryHandler);
+				return EditorHandlerTests.GetCursorStartPosition(editorHandler);
+			}
+
+			protected override void UpdateCursorStartPosition(EditorHandler editorHandler, int position)
+			{
+				EditorHandlerTests.UpdateCursorStartPosition(editorHandler, position);
 			}
 		}
 	}

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(EditorHandler editorHandler, string text) =>
 			GetNativeEditor(editorHandler).Text = text;
 
+		static int GetCursorPosition(EditorHandler editorHandler)
+		{
+			var control = GetNativeEditor(editorHandler);
+			return (int)control.GetOffsetFromPosition(control.BeginningOfDocument, control.SelectedTextRange.Start);
+		}
+
 		string GetNativePlaceholderText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).PlaceholderText;
 

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -45,10 +45,17 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(EditorHandler editorHandler, string text) =>
 			GetNativeEditor(editorHandler).Text = text;
 
-		static int GetCursorPosition(EditorHandler editorHandler)
+		static int GetCursorStartPosition(EditorHandler editorHandler)
 		{
 			var control = GetNativeEditor(editorHandler);
 			return (int)control.GetOffsetFromPosition(control.BeginningOfDocument, control.SelectedTextRange.Start);
+		}
+
+		static void UpdateCursorStartPosition(EditorHandler editorHandler, int position)
+		{
+			var control = GetNativeEditor(editorHandler);
+			var endPosition = control.GetPosition(control.BeginningOfDocument, position);
+			control.SelectedTextRange = control.GetTextRange(endPosition, endPosition);
 		}
 
 		string GetNativePlaceholderText(EditorHandler editorHandler) =>

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -113,6 +113,12 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(EntryHandler entryHandler, string text) =>
 			GetNativeEntry(entryHandler).Text = text;
 
+		static int GetCursorPosition(EntryHandler entryHandler)
+		{
+			var control = GetNativeEntry(entryHandler);
+			return control.SelectionStart;
+		}
+
 		Color GetNativeTextColor(EntryHandler entryHandler)
 		{
 			int currentTextColorInt = GetNativeEntry(entryHandler).CurrentTextColor;

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -113,10 +113,16 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(EntryHandler entryHandler, string text) =>
 			GetNativeEntry(entryHandler).Text = text;
 
-		static int GetCursorPosition(EntryHandler entryHandler)
+		static int GetCursorStartPosition(EntryHandler entryHandler)
 		{
 			var control = GetNativeEntry(entryHandler);
 			return control.SelectionStart;
+		}
+
+		static void UpdateCursorStartPosition(EntryHandler entryHandler, int position)
+		{
+			var control = GetNativeEntry(entryHandler);
+			control.SetSelection(position);
 		}
 
 		Color GetNativeTextColor(EntryHandler entryHandler)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -586,9 +586,14 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				EntryHandlerTests.SetNativeText(entryHandler, text);
 			}
-			protected override int GetCursorPosition(EntryHandler entryHandler)
+			protected override int GetCursorStartPosition(EntryHandler entryHandler)
 			{
-				return EntryHandlerTests.GetCursorPosition(entryHandler);
+				return EntryHandlerTests.GetCursorStartPosition(entryHandler);
+			}
+
+			protected override void UpdateCursorStartPosition(EntryHandler entryHandler, int position)
+			{
+				EntryHandlerTests.UpdateCursorStartPosition(entryHandler, position);
 			}
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -586,6 +586,10 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				EntryHandlerTests.SetNativeText(entryHandler, text);
 			}
+			protected override int GetCursorPosition(EntryHandler entryHandler)
+			{
+				return EntryHandlerTests.GetCursorPosition(entryHandler);
+			}
 		}
 
 	}

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Foundation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
@@ -127,10 +128,17 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(EntryHandler entryHandler, string text) =>
 			GetNativeEntry(entryHandler).Text = text;
 
-		static int GetCursorPosition(EntryHandler entryHandler)
+		static int GetCursorStartPosition(EntryHandler entryHandler)
 		{
 			var control = GetNativeEntry(entryHandler);
 			return (int)control.GetOffsetFromPosition(control.BeginningOfDocument, control.SelectedTextRange.Start);
+		}
+
+		static void UpdateCursorStartPosition(EntryHandler entryHandler, int position)
+		{
+			var control = GetNativeEntry(entryHandler);
+			var endPosition = control.GetPosition(control.BeginningOfDocument, position);
+			control.SelectedTextRange = control.GetTextRange(endPosition, endPosition);
 		}
 
 		Color GetNativeTextColor(EntryHandler entryHandler) =>

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -127,6 +127,12 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(EntryHandler entryHandler, string text) =>
 			GetNativeEntry(entryHandler).Text = text;
 
+		static int GetCursorPosition(EntryHandler entryHandler)
+		{
+			var control = GetNativeEntry(entryHandler);
+			return (int)control.GetOffsetFromPosition(control.BeginningOfDocument, control.SelectedTextRange.Start);
+		}
+
 		Color GetNativeTextColor(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextColor.ToColor();
 

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -99,11 +99,18 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(SearchBarHandler searchBarHandler, string text) =>
 			GetNativeSearchBar(searchBarHandler).SetQuery(text, false);
 
-		static int GetCursorPosition(SearchBarHandler entryHandler)
+		static int GetCursorStartPosition(SearchBarHandler searchBarHandler)
 		{
-			var control = GetNativeSearchBar(entryHandler);
+			var control = GetNativeSearchBar(searchBarHandler);
 			var editText = control.GetChildrenOfType<EditText>().FirstOrDefault();
 			return editText.SelectionStart;
+		}
+
+		static void UpdateCursorStartPosition(SearchBarHandler searchBarHandler, int position)
+		{
+			var control = GetNativeSearchBar(searchBarHandler);
+			var editText = control.GetChildrenOfType<EditText>().FirstOrDefault();
+			editText.SetSelection(position);
 		}
 
 		Color GetNativeTextColor(SearchBarHandler searchBarHandler)

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -99,6 +99,13 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(SearchBarHandler searchBarHandler, string text) =>
 			GetNativeSearchBar(searchBarHandler).SetQuery(text, false);
 
+		static int GetCursorPosition(SearchBarHandler entryHandler)
+		{
+			var control = GetNativeSearchBar(entryHandler);
+			var editText = control.GetChildrenOfType<EditText>().FirstOrDefault();
+			return editText.SelectionStart;
+		}
+
 		Color GetNativeTextColor(SearchBarHandler searchBarHandler)
 		{
 			var searchView = GetNativeSearchBar(searchBarHandler);

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -129,9 +129,14 @@ namespace Microsoft.Maui.DeviceTests
 				SearchBarHandlerTests.SetNativeText(searchBarHandler, text);
 			}
 
-			protected override int GetCursorPosition(SearchBarHandler searchBarHandler)
+			protected override int GetCursorStartPosition(SearchBarHandler searchBarHandler)
 			{
-				return SearchBarHandlerTests.GetCursorPosition(searchBarHandler);
+				return SearchBarHandlerTests.GetCursorStartPosition(searchBarHandler);
+			}
+
+			protected override void UpdateCursorStartPosition(SearchBarHandler searchBarHandler, int position)
+			{
+				SearchBarHandlerTests.UpdateCursorStartPosition(searchBarHandler, position);
 			}
 		}
 	}

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -124,9 +124,14 @@ namespace Microsoft.Maui.DeviceTests
 		[Category(TestCategory.SearchBar)]
 		public class SearchBarTextInputTests : TextInputHandlerTests<SearchBarHandler, SearchBarStub>
 		{
-			protected override void SetNativeText(SearchBarHandler entryHandler, string text)
+			protected override void SetNativeText(SearchBarHandler searchBarHandler, string text)
 			{
-				SearchBarHandlerTests.SetNativeText(entryHandler, text);
+				SearchBarHandlerTests.SetNativeText(searchBarHandler, text);
+			}
+
+			protected override int GetCursorPosition(SearchBarHandler searchBarHandler)
+			{
+				return SearchBarHandlerTests.GetCursorPosition(searchBarHandler);
 			}
 		}
 	}

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -70,10 +70,17 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(SearchBarHandler searchBarHandler, string text) =>
 			GetNativeSearchBar(searchBarHandler).Text = text;
 
-		static int GetCursorPosition(SearchBarHandler searchBarHandler)
+		static int GetCursorStartPosition(SearchBarHandler searchBarHandler)
 		{
 			var control = searchBarHandler.QueryEditor;
 			return (int)control.GetOffsetFromPosition(control.BeginningOfDocument, control.SelectedTextRange.Start);
+		}
+
+		static void UpdateCursorStartPosition(SearchBarHandler searchBarHandler, int position)
+		{
+			var control = searchBarHandler.QueryEditor;
+			var endPosition = control.GetPosition(control.BeginningOfDocument, position);
+			control.SelectedTextRange = control.GetTextRange(endPosition, endPosition);
 		}
 
 		Color GetNativeTextColor(SearchBarHandler searchBarHandler)

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -70,6 +70,12 @@ namespace Microsoft.Maui.DeviceTests
 		static void SetNativeText(SearchBarHandler searchBarHandler, string text) =>
 			GetNativeSearchBar(searchBarHandler).Text = text;
 
+		static int GetCursorPosition(SearchBarHandler searchBarHandler)
+		{
+			var control = searchBarHandler.QueryEditor;
+			return (int)control.GetOffsetFromPosition(control.BeginningOfDocument, control.SelectedTextRange.Start);
+		}
+
 		Color GetNativeTextColor(SearchBarHandler searchBarHandler)
 		{
 			var uiSearchBar = GetNativeSearchBar(searchBarHandler);

--- a/src/Core/tests/DeviceTests/Handlers/TextInput/TextInputHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TextInput/TextInputHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData("Hello", "Goodbye", true)]
 		public async Task TextChangedEventsFireCorrectly(string initialText, string newText, bool eventExpected)
 		{
-			var textInput = Activator.CreateInstance<TStub>();
+			var textInput = new TStub();
 			textInput.Text = initialText;
 
 			var eventFiredCount = 0;
@@ -54,6 +54,23 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(0, eventFiredCount);
 		}
 
+		[Fact]
+		public async Task CursorPositionDoesntResetWhenNativeTextValueChanges()
+		{
+			var textInput = new TStub();
+
+
+			int cursorPosition = 0;
+			await SetValueAsync(textInput, "Hello", (handler, input) =>
+			{
+				SetNativeText(handler, input);
+				cursorPosition = GetCursorPosition(handler);
+			});
+
+			Assert.Equal(5, cursorPosition);
+		}
+
+		protected abstract int GetCursorPosition(THandler entryHandler);
 		protected abstract void SetNativeText(THandler entryHandler, string text);
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/TextInput/TextInputHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TextInput/TextInputHandlerTests.cs
@@ -57,20 +57,26 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact]
 		public async Task CursorPositionDoesntResetWhenNativeTextValueChanges()
 		{
-			var textInput = new TStub();
+			var textInput = new TStub()
+			{
+				Text = "Hello"
+			};
 
 
 			int cursorPosition = 0;
-			await SetValueAsync(textInput, "Hello", (handler, input) =>
+			await InvokeOnMainThreadAsync(() =>
 			{
-				SetNativeText(handler, input);
-				cursorPosition = GetCursorPosition(handler);
+				var handler = CreateHandler(textInput);
+				UpdateCursorStartPosition(handler, 5);
+				handler.UpdateValue(nameof(ITextInput.Text));
+				cursorPosition = GetCursorStartPosition(handler);
 			});
 
 			Assert.Equal(5, cursorPosition);
 		}
 
-		protected abstract int GetCursorPosition(THandler entryHandler);
+		protected abstract void UpdateCursorStartPosition(THandler entryHandler, int position);
+		protected abstract int GetCursorStartPosition(THandler entryHandler);
 		protected abstract void SetNativeText(THandler entryHandler, string text);
 	}
 }


### PR DESCRIPTION
### Description of Change ###

On android when you set the native text it causes the cursor to reset to position 0. 

When entering text into the native field it would cause

- fixes: #2201

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
