### PR TITLE
Collapse HeaderContent container when header content is collapsed

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/ControlsNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/Windows/ControlsNavigationManager.cs
@@ -28,18 +28,22 @@ namespace Microsoft.Maui.Controls.Platform
 		// TODO MAUI: This will need to be updated to handle multiple nested navigation pages
 		protected virtual void UpdateToolbar()
 		{
-			if (WindowManager.RootView is not MauiNavigationView navigationView || NavigationStack.Count == 0)
+			if (WindowManager.RootView is not MauiNavigationView nativeNavigationView || NavigationStack.Count == 0)
 				return;
 
 			var commandBar = WindowManager.GetCommandBar();
-			var header = navigationView.Header as WindowHeader;
+			var header = nativeNavigationView.Header as WindowHeader;
 
 			// TODO MAUI: these only apply for the top level NavigationManager
 			if (commandBar != null)
 				commandBar.IsDynamicOverflowEnabled = NavigationView.OnThisPlatform().GetToolbarDynamicOverflowEnabled();
 
 			bool hasNavigationBar = NavigationPage.GetHasNavigationBar(CurrentPage);
-			bool hasBackButton = NavigationPage.GetHasBackButton(CurrentPage) && NavigationStack.Count > 1;
+			bool hasBackButton = 
+				NavigationPage.GetHasBackButton(CurrentPage) &&
+				hasNavigationBar &&
+				NavigationStack.Count > 1;
+
 			var title = CurrentPage.Title;
 			var titleIcon = NavigationPage.GetTitleIconImageSource(CurrentPage);
 			var titleView = NavigationPage.GetTitleView(CurrentPage);
@@ -58,6 +62,12 @@ namespace Microsoft.Maui.Controls.Platform
 			if (header != null)
 			{
 				header.Visibility = (hasNavigationBar) ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
+
+				// HeaderContent is set to a MinHeight of 48 so we have to collapse it if we
+				// don't want it if we want to hide the navbar completely
+				if (nativeNavigationView.HeaderContent != null)
+					nativeNavigationView.HeaderContent.Visibility = header.Visibility;
+
 				header.Title = title;
 
 				ImageSourceLoader.LoadImage(titleIcon, MauiContext, (result) =>
@@ -70,14 +80,14 @@ namespace Microsoft.Maui.Controls.Platform
 				header.TitleView = titleView?.ToNative(MauiContext);
 			}
 
-			navigationView.IsBackButtonVisible = (hasBackButton) ? NavigationViewBackButtonVisible.Visible : NavigationViewBackButtonVisible.Collapsed;
-			navigationView.IsBackEnabled = true;
-			navigationView.UpdateBarBackgroundBrush(
+			nativeNavigationView.IsBackButtonVisible = (hasBackButton) ? NavigationViewBackButtonVisible.Visible : NavigationViewBackButtonVisible.Collapsed;
+			nativeNavigationView.IsBackEnabled = true;
+			nativeNavigationView.UpdateBarBackgroundBrush(
 				barBackground?.ToBrush() ?? barBackgroundColor?.ToNative());
 
 			UpdateToolbarItems();
-			navigationView.PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
-			navigationView.IsPaneOpen = false;
+			nativeNavigationView.PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
+			nativeNavigationView.IsPaneOpen = false;
 		}
 
 		//TODO MAUI: This will need to be updated to handle nested pages propagating up

--- a/src/Controls/src/Core/Platform/Windows/ControlsNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/Windows/ControlsNavigationManager.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.Platform
 				header.Visibility = (hasNavigationBar) ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
 
 				// HeaderContent is set to a MinHeight of 48 so we have to collapse it if we
-				// don't want it if we want to hide the navbar completely
+				// we want to hide the navbar completely
 				if (nativeNavigationView.HeaderContent != null)
 					nativeNavigationView.HeaderContent.Visibility = header.Visibility;
 

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Maui
 			HeaderContent = (ContentControl)GetTemplateChild("HeaderContent");
 			NavigationViewBackButton = (Button)GetTemplateChild("NavigationViewBackButton");
 
+			// HeaderContent is set to a MinHeight of 48 so we have to collapse it if we
+			// don't want it to take up any space
+			HeaderContent.Visibility = _windowHeader.Visibility;
+
 			// Read comment on MarginPropertyChanged
 			var currentMargin = HeaderContent.Margin;
 			HeaderContentMargin = new WThickness(


### PR DESCRIPTION
### Description of Change ###

- The container for the Header on NavigationView has a MinHeight of 48. This means if the users hides the navbar or we don't have a navigation page that it still takes up space. This PR collapses the HeaderContainer if the inner content is also collapsed
- If the user wants to hide the navigation bar also hide the backbutton

Before: 
![image](https://user-images.githubusercontent.com/5375137/134421541-1842fdb6-89e0-44d6-9a38-db1149dc5da1.png)


After:
![image](https://user-images.githubusercontent.com/5375137/134421254-a312ebda-b03b-49a8-bd26-f5e2cca28902.png)

