### PR TITLE
[build] make sure 'dotnet workload install' uses single source

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,6 +61,7 @@
     <DotNetLibraryPacksDirectory>$(DotNetDirectory)library-packs/</DotNetLibraryPacksDirectory>
     <DotNetSdkManifestsDirectory>$(DotNetDirectory)sdk-manifests/$(DotNetPreviewVersionBand)/</DotNetSdkManifestsDirectory>
     <DotNetTemplatePacksDirectory>$(DotNetDirectory)template-packs/</DotNetTemplatePacksDirectory>
+    <DotNet6Feed>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json</DotNet6Feed>
     <_MauiBuildTasksLocation>$(_MauiBuildTasksLocation)</_MauiBuildTasksLocation>
     <_MauiBuildTasksLocation Condition="'$(_MauiBuildTasksLocation)' == ''">$(MSBuildThisFileDirectory).nuspec\</_MauiBuildTasksLocation>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -67,7 +67,7 @@
     <!-- Run 'dotnet workload install' for the current running 'dotnet' install -->
     <ItemGroup>
       <_WorkloadSource Include="$(PackageOutputPath)" />
-      <_WorkloadSource Include="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+      <_WorkloadSource Include="$(DotNet6Feed)" />
     </ItemGroup>
     <Exec
         Command="&quot;$(MSBuildExtensionsPath)../../dotnet&quot; workload install maui --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; @(_WorkloadSource->'--source &quot;%(Identity)&quot;', ' ')"
@@ -151,7 +151,7 @@
       Inputs="$(_Inputs)"
       Outputs="$(DotNetPacksDirectory).stamp">
     <Exec
-        Command="&quot;$(DotNetToolPath)&quot; workload install %(_WorkloadIds.Identity) --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot;"
+        Command="&quot;$(DotNetToolPath)&quot; workload install %(_WorkloadIds.Identity) --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --source &quot;$(DotNet6Feed)&quot;"
         WorkingDirectory="$(MauiRootDirectory)"
     />
     <Touch Files="$(DotNetPacksDirectory).stamp" AlwaysCreate="true" />


### PR DESCRIPTION
### Description of Change ###

There is a place during .NET MAUI's build that was just using the
repo-wide `NuGet.config` to install workloads:

    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />

We should use the `--source` switch instead, so that only a single
feed will be used during the command.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No