### PR TITLE
[build] remove library-packs from workload

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -88,6 +88,8 @@ Task("dotnet-templates")
 
         // Create an empty NuGet.config
         StartProcess(dn, "new nugetconfig -o ../templatesTest/");
+        // NOTE: this should be temporary until 'library-packs' are working for .msi-based installs
+        StartProcess(dn, "nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json --name dotnet6 --configfile ../templatesTest/nuget.config");
         var properties = new Dictionary<string, string> {
             // Properties that ensure we don't use cached packages, and *only* the empty NuGet.config
             { "RestoreNoCache", "true" },

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -37,38 +37,7 @@
           "Microsoft.Maui.Controls.Ref.any",
           "Microsoft.Maui.Controls.Runtime.any",
           "Microsoft.Maui.Essentials.Ref.any",
-          "Microsoft.Maui.Essentials.Runtime.any",
-          "Microsoft.Extensions.Configuration",
-          "Microsoft.Extensions.Configuration.Abstractions",
-          "Microsoft.Extensions.Configuration.Binder",
-          "Microsoft.Extensions.Configuration.CommandLine",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables",
-          "Microsoft.Extensions.Configuration.FileExtensions",
-          "Microsoft.Extensions.Configuration.Json",
-          "Microsoft.Extensions.Configuration.UserSecrets",
-          "Microsoft.Extensions.DependencyInjection",
-          "Microsoft.Extensions.DependencyInjection.Abstractions",
-          "Microsoft.Extensions.FileProviders.Abstractions",
-          "Microsoft.Extensions.FileProviders.Physical",
-          "Microsoft.Extensions.FileSystemGlobbing",
-          "Microsoft.Extensions.Hosting",
-          "Microsoft.Extensions.Hosting.Abstractions",
-          "Microsoft.Extensions.Logging",
-          "Microsoft.Extensions.Logging.Abstractions",
-          "Microsoft.Extensions.Logging.Console",
-          "Microsoft.Extensions.Logging.Configuration",
-          "Microsoft.Extensions.Logging.Debug",
-          "Microsoft.Extensions.Logging.EventLog",
-          "Microsoft.Extensions.Logging.EventSource",
-          "Microsoft.Extensions.Primitives",
-          "Microsoft.Extensions.Options",
-          "Microsoft.Extensions.Options.ConfigurationExtensions",
-          "Microsoft.Maui.Graphics",
-          "System.Diagnostics.DiagnosticSource",
-          "System.Diagnostics.EventLog",
-          "System.Runtime.CompilerServices.Unsafe",
-          "System.Text.Encodings.Web",
-          "System.Text.Json"
+          "Microsoft.Maui.Essentials.Runtime.any"
       ]
     },
     "maui-blazor": {
@@ -76,18 +45,7 @@
       "description": ".NET MAUI SDK Blazor Packages",
       "extends": [ "maui-core" ],
       "packs": [
-          "Microsoft.AspNetCore.Components.WebView.Maui",
-          "Microsoft.AspNetCore.Authorization",
-          "Microsoft.AspNetCore.Components",
-          "Microsoft.AspNetCore.Components.Analyzers",
-          "Microsoft.AspNetCore.Components.Forms",
-          "Microsoft.AspNetCore.Components.Web",
-          "Microsoft.AspNetCore.Components.WebView",
-          "Microsoft.AspNetCore.Metadata",
-          "Microsoft.Extensions.FileProviders.Composite",
-          "Microsoft.Extensions.FileProviders.Embedded",
-          "Microsoft.JSInterop",
-          "System.IO.Pipelines"
+          "Microsoft.AspNetCore.Components.WebView.Maui"
       ]
     },
     "maui-android": {
@@ -144,8 +102,7 @@
           "Microsoft.Maui.Controls.Ref.win",
           "Microsoft.Maui.Controls.Runtime.win",
           "Microsoft.Maui.Essentials.Ref.win",
-          "Microsoft.Maui.Essentials.Runtime.win",
-          "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop"
+          "Microsoft.Maui.Essentials.Runtime.win"
       ]
     }
   },
@@ -281,178 +238,6 @@
     "Microsoft.Maui.Extensions": {
       "kind": "library",
       "version": "@VERSION@"
-    },
-    "Microsoft.AspNetCore.Authorization": {
-      "kind": "library",
-      "version": "@MicrosoftAspNetCoreAuthorizationPackageVersion@"
-    },
-    "Microsoft.AspNetCore.Components": {
-      "kind": "library",
-      "version": "@MicrosoftAspNetCoreComponentsPackageVersion@"
-    },
-    "Microsoft.AspNetCore.Components.Analyzers": {
-      "kind": "library",
-      "version": "@MicrosoftAspNetCoreComponentsAnalyzersPackageVersion@"
-    },
-    "Microsoft.AspNetCore.Components.Forms": {
-      "kind": "library",
-      "version": "@MicrosoftAspNetCoreComponentsFormsPackageVersion@"
-    },
-    "Microsoft.AspNetCore.Components.Web": {
-      "kind": "library",
-      "version": "@MicrosoftAspNetCoreComponentsWebPackageVersion@"
-    },
-    "Microsoft.AspNetCore.Components.WebView": {
-      "kind": "library",
-      "version": "@MicrosoftAspNetCoreComponentsWebViewPackageVersion@"
-    },
-    "Microsoft.AspNetCore.Metadata": {
-      "kind": "library",
-      "version": "@MicrosoftAspNetCoreMetadataPackageVersion@"
-    },
-    "Microsoft.Extensions.Configuration": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationPackageVersion@"
-    },
-    "Microsoft.Extensions.Configuration.Abstractions": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationAbstractionsPackageVersion@"
-    },
-    "Microsoft.Extensions.Configuration.Binder": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationBinderPackageVersion@"
-    },
-    "Microsoft.Extensions.Configuration.CommandLine": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationCommandLinePackageVersion@"
-    },
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion@"
-    },
-    "Microsoft.Extensions.Configuration.FileExtensions": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationFileExtensionsPackageVersion@"
-    },
-    "Microsoft.Extensions.Configuration.Json": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationJsonPackageVersion@"
-    },
-    "Microsoft.Extensions.Configuration.UserSecrets": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsConfigurationUserSecretsPackageVersion@"
-    },
-    "Microsoft.Extensions.DependencyInjection": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsDependencyInjectionPackageVersion@"
-    },
-    "Microsoft.Extensions.DependencyInjection.Abstractions": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion@"
-    },
-    "Microsoft.Extensions.FileProviders.Abstractions": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsFileProvidersAbstractionsPackageVersion@"
-    },
-    "Microsoft.Extensions.FileProviders.Composite": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsFileProvidersCompositePackageVersion@"
-    },
-    "Microsoft.Extensions.FileProviders.Embedded": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsFileProvidersEmbeddedPackageVersion@"
-    },
-    "Microsoft.Extensions.FileProviders.Physical": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsFileProvidersPhysicalPackageVersion@"
-    },
-    "Microsoft.Extensions.FileSystemGlobbing": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsFileSystemGlobbingPackageVersion@"
-    },
-    "Microsoft.Extensions.Hosting": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsHostingPackageVersion@"
-    },
-    "Microsoft.Extensions.Hosting.Abstractions": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsHostingAbstractionsPackageVersion@"
-    },
-    "Microsoft.Extensions.Logging": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsLoggingPackageVersion@"
-    },
-    "Microsoft.Extensions.Logging.Abstractions": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsLoggingAbstractionsPackageVersion@"
-    },
-    "Microsoft.Extensions.Logging.Configuration": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsLoggingConfigurationPackageVersion@"
-    },
-    "Microsoft.Extensions.Logging.Console": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsLoggingConsolePackageVersion@"
-    },
-    "Microsoft.Extensions.Logging.Debug": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsLoggingDebugPackageVersion@"
-    },
-    "Microsoft.Extensions.Logging.EventLog": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsLoggingEventLogPackageVersion@"
-    },
-    "Microsoft.Extensions.Logging.EventSource": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsLoggingEventSourcePackageVersion@"
-    },
-    "Microsoft.Extensions.Options": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsOptionsPackageVersion@"
-    },
-    "Microsoft.Extensions.Options.ConfigurationExtensions": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion@"
-    },
-    "Microsoft.Extensions.Primitives": {
-      "kind": "library",
-      "version": "@MicrosoftExtensionsPrimitivesPackageVersion@"
-    },
-    "Microsoft.JSInterop": {
-      "kind": "library",
-      "version": "@MicrosoftJSInteropPackageVersion@"
-    },
-    "Microsoft.Maui.Graphics": {
-      "kind": "library",
-      "version": "@MicrosoftMauiGraphicsVersion@"
-    },
-    "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop": {
-      "kind": "library",
-      "version": "@MicrosoftMauiGraphicsWin2DWinUIDesktopPackageVersion@"
-    },
-    "System.Diagnostics.EventLog": {
-      "kind": "library",
-      "version": "@SystemDiagnosticsEventLogPackageVersion@"
-    },
-    "System.Diagnostics.DiagnosticSource": {
-      "kind": "library",
-      "version": "@SystemDiagnosticsDiagnosticSourcePackageVersion@"
-    },
-    "System.IO.Pipelines": {
-      "kind": "library",
-      "version": "@SystemIOPipelinesPackageVersion@"
-    },
-    "System.Runtime.CompilerServices.Unsafe": {
-      "kind": "library",
-      "version": "@SystemRuntimeCompilerServicesUnsafePackageVersion@"
-    },
-    "System.Text.Encodings.Web": {
-      "kind": "library",
-      "version": "@SystemTextEncodingsWebPackageVersion@"
-    },
-    "System.Text.Json": {
-      "kind": "library",
-      "version": "@SystemTextJsonPackageVersion@"
     },
     "Microsoft.Maui.Sdk": {
       "kind": "sdk",


### PR DESCRIPTION
### Description of Change ###

Context: https://docs.microsoft.com/dotnet/core/tools/dotnet-nuget-add-source

This partially reverts 00507dc6.

When installing the `maui` workload in an Admin location on Windows,
you get the error:

    Workload installation failed: microsoft.aspnetcore.authorization.msi.x64::6.0.0-rc.2.21462.1 is not found in NuGet feeds

What the *actual* problem is that this package does not exist:

    Microsoft.AspNetCore.Authorization.Msi.x64

`library-packs` were not really considered during the
design/implementation of Admin installs on Windows. dotnet/maui has a
dependency on certain packages, but if those packages are produced by
another repo/team -- then nothing makes `.Msi` packages for them.

For now, the simple solution is to remove the `library-packs` from the
workload. This will at least get things working, but dogfooders of
MAUI will need to setup the `dotnet6` feed again until this is
resolved.

I also adjusted the templates that build on CI so they will build with
an additional source:

    dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json --name dotnet6 --configfile ../templatesTest/nuget.config

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No