### PR TITLE
Make shimmed Frame work on Android/Windows

### DIFF
--- a/src/Compatibility/Core/src/Android/FastRenderers/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/FrameRenderer.cs
@@ -65,10 +65,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 		VisualElement IVisualElementRenderer.Element => Element;
 		AView IVisualElementRenderer.View => this;
 
-		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
+		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthMeasureSpec, int heightMeasureSpec)
 		{
-			Context context = Context;
-			return new SizeRequest(new Size(context.ToPixels(20), context.ToPixels(20)));
+			Measure(widthMeasureSpec, heightMeasureSpec);
+			return new SizeRequest(new Size(MeasuredWidth, MeasuredHeight));
 		}
 
 		void IVisualElementRenderer.SetElement(VisualElement element)

--- a/src/Compatibility/Core/src/Android/FastRenderers/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/FrameRenderer.cs
@@ -198,8 +198,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 			if (Element == null)
 				return;
 
-			System.Diagnostics.Debug.WriteLine($">>>>>> FR OnLayout, {left}, {top}, {right}, {bottom}");
-
 			var children = ((IElementController)Element).LogicalChildren;
 			for (var i = 0; i < children.Count; i++)
 			{

--- a/src/Compatibility/Core/src/Android/FastRenderers/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/FrameRenderer.cs
@@ -67,8 +67,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 
 		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthMeasureSpec, int heightMeasureSpec)
 		{
-			Measure(widthMeasureSpec, heightMeasureSpec);
-			return new SizeRequest(new Size(MeasuredWidth, MeasuredHeight));
+			Context context = Context;
+			return new SizeRequest(new Size(context.ToPixels(20), context.ToPixels(20)));
 		}
 
 		void IVisualElementRenderer.SetElement(VisualElement element)
@@ -197,6 +197,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 		{
 			if (Element == null)
 				return;
+
+			System.Diagnostics.Debug.WriteLine($">>>>>> FR OnLayout, {left}, {top}, {right}, {bottom}");
 
 			var children = ((IElementController)Element).LogicalChildren;
 			for (var i = 0; i < children.Count; i++)

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Maui.Controls.Hosting
 
 #if __ANDROID__ || __IOS__ || WINDOWS || MACCATALYST
 
+					handlers.TryAddCompatibilityRenderer(typeof(Frame), typeof(FrameRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(BoxView), typeof(BoxRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(Entry), typeof(EntryRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(Editor), typeof(EditorRenderer));

--- a/src/Controls/src/Core/Frame.cs
+++ b/src/Controls/src/Core/Frame.cs
@@ -5,7 +5,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Content))]
-	public class Frame : ContentView, IElementConfiguration<Frame>, IPaddingElement, IBorderElement
+	public partial class Frame : ContentView, IElementConfiguration<Frame>, IPaddingElement, IBorderElement
 	{
 		public static readonly BindableProperty BorderColorProperty = BorderElement.BorderColorProperty;
 

--- a/src/Controls/src/Core/HandlerImpl/Frame.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Frame.Impl.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+using static Microsoft.Maui.Layouts.LayoutManager;
+
+namespace Microsoft.Maui.Controls
+{
+	public partial class Frame
+	{
+		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+		{
+			Thickness contentMargin = (Content as IView)?.Margin ?? Thickness.Zero;
+			Thickness padding = Padding;
+
+			// Account for the Frame's margins and use the rest of the available space to measure the actual Content
+			var contentWidthConstraint = widthConstraint - Margin.HorizontalThickness;
+			var contentHeightConstraint = heightConstraint - Margin.VerticalThickness;
+			(this as IContentView).CrossPlatformMeasure(contentWidthConstraint, contentHeightConstraint);
+
+			// Now measure the Frame itself 
+			var defaultSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
+
+			// The value from ComputeDesiredSize won't account for any margins on the Content; we'll need to do that manually
+			// And we'll use ResolveConstraints to make sure we're sticking within and explicit Height/Width values or externally
+			// imposed constraints
+			var width = (this as IView).Width;
+			var height = (this as IView).Height;
+
+			var desiredWidth = ResolveConstraints(widthConstraint, width, defaultSize.Width + contentMargin.HorizontalThickness + padding.HorizontalThickness);
+			var desiredHeight = ResolveConstraints(heightConstraint, height, defaultSize.Height + contentMargin.VerticalThickness + padding.VerticalThickness);
+
+			DesiredSize = new Size(desiredWidth, desiredHeight);
+			return DesiredSize;
+		}
+
+		protected override Size ArrangeOverride(Rectangle bounds)
+		{
+			Frame = this.ComputeFrame(bounds);
+			Handler?.NativeArrange(Frame);
+
+			(this as IContentView).CrossPlatformArrange(new Rectangle(Point.Zero, Frame.Size));
+
+			return Frame.Size;
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Frame.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Frame.Impl.cs
@@ -13,23 +13,20 @@ namespace Microsoft.Maui.Controls
 		{
 			Thickness contentMargin = (Content as IView)?.Margin ?? Thickness.Zero;
 			Thickness padding = Padding;
+			Thickness margin = Margin;
 
-			// Account for the Frame's margins and use the rest of the available space to measure the actual Content
-			var contentWidthConstraint = widthConstraint - Margin.HorizontalThickness;
-			var contentHeightConstraint = heightConstraint - Margin.VerticalThickness;
-			(this as IContentView).CrossPlatformMeasure(contentWidthConstraint, contentHeightConstraint);
+			// Account for the Frame's margins and padding and use the rest of the available space to measure the actual Content
+			var contentWidthConstraint = widthConstraint - margin.HorizontalThickness - padding.HorizontalThickness;
+			var contentHeightConstraint = heightConstraint - margin.VerticalThickness - padding.VerticalThickness;
+			var contentSize = (this as IContentView).CrossPlatformMeasure(contentWidthConstraint, contentHeightConstraint);
 
-			// Now measure the Frame itself 
-			var defaultSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-
-			// The value from ComputeDesiredSize won't account for any margins on the Content; we'll need to do that manually
-			// And we'll use ResolveConstraints to make sure we're sticking within and explicit Height/Width values or externally
+			// We'll use ResolveConstraints to make sure we're sticking within any explicit Height/Width values or externally
 			// imposed constraints
 			var width = (this as IView).Width;
 			var height = (this as IView).Height;
 
-			var desiredWidth = ResolveConstraints(widthConstraint, width, defaultSize.Width + contentMargin.HorizontalThickness + padding.HorizontalThickness);
-			var desiredHeight = ResolveConstraints(heightConstraint, height, defaultSize.Height + contentMargin.VerticalThickness + padding.VerticalThickness);
+			var desiredWidth = ResolveConstraints(widthConstraint, width, contentSize.Width + margin.HorizontalThickness);
+			var desiredHeight = ResolveConstraints(heightConstraint, height, contentSize.Height + margin.VerticalThickness);
 
 			DesiredSize = new Size(desiredWidth, desiredHeight);
 			return DesiredSize;


### PR DESCRIPTION
This PR updates the Android FrameRenderer to actually do native measurement. It also adds cross-platform measure/arrange implementations to fit into the new layout system.

These changes make Frame (in a shimmed renderer) display as expected on Android and Windows. (And maybe iOS, but I don't currently have a way to test that. If it's broken, we'll fix it later.)