### PR TITLE
Arrange implementations for layouts now return size which accounts for Fill

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Maui.Layouts
 				view.Arrange(cell);
 			}
 
-			return new Size(structure.MeasuredGridWidth(), structure.MeasuredGridHeight());
+			var actual = new Size(structure.MeasuredGridWidth(), structure.MeasuredGridHeight());
+
+			return actual.AdjustForFill(bounds, Grid);
 		}
 
 		class GridStructure

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Maui.Layouts
 				stackWidth = ArrangeRightToLeft(height, left, top, Stack.Spacing, Stack);
 			}
 
-			return new Size(height, stackWidth);
+			var actual = new Size(height, stackWidth);
+
+			return actual.AdjustForFill(bounds, Stack);
 		}
 
 		static double ArrangeLeftToRight(double height, double left, double top, double spacing, IList<IView> children)

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -180,5 +180,20 @@ namespace Microsoft.Maui.Layouts
 
 			_ = contentView.PresentedContent.Arrange(targetBounds);
 		}
+
+		public static Size AdjustForFill(this Size size, Rectangle bounds, IView view)
+		{
+			if (view.HorizontalLayoutAlignment == LayoutAlignment.Fill)
+			{
+				size.Width = Math.Max(bounds.Width, size.Width);
+			}
+
+			if (view.VerticalLayoutAlignment == LayoutAlignment.Fill)
+			{
+				size.Height = Math.Max(bounds.Height, size.Height);
+			}
+
+			return size;
+		}
 	}
 }

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -62,7 +62,9 @@ namespace Microsoft.Maui.Layouts
 				stackHeight += destination.Height + Stack.Spacing;
 			}
 
-			return new Size(width, stackHeight);
+			var actual =  new Size(width, stackHeight);
+
+			return actual.AdjustForFill(bounds, Stack);
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/AbsoluteLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/AbsoluteLayoutManagerTests.cs
@@ -374,11 +374,36 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			abs.MinimumHeight.Returns(75);
 			abs.MaximumHeight.Returns(50);
 
-			var gridLayoutManager = new AbsoluteLayoutManager(abs);
-			var measure = gridLayoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			var layoutManager = new AbsoluteLayoutManager(abs);
+			var measure = layoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
 
 			// The minimum value should beat out the maximum value
 			Assert.Equal(75, measure.Height);
+		}
+
+		[Fact]
+		public void ArrangeAccountsForFill()
+		{
+			var abs = CreateTestLayout();
+			var child = CreateTestView();
+			SubstituteChildren(abs, child);
+			var childBounds = new Rectangle(0, 0, 100, 100);
+			SetLayoutBounds(abs, child, childBounds);
+
+			var layoutManager = new AbsoluteLayoutManager(abs);
+			_ = layoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var arrangedWidth = 1000;
+			var arrangedHeight = 1000;
+
+			var target = new Rectangle(Point.Zero, new Size(arrangedWidth, arrangedHeight));
+
+			var actual = layoutManager.ArrangeChildren(target);
+
+			// Since we're arranging in a space larger than needed and the layout is set to Fill in both directions,
+			// we expect the returned actual arrangement size to be as large as the target space
+			Assert.Equal(arrangedWidth, actual.Width);
+			Assert.Equal(arrangedHeight, actual.Height);
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1562,5 +1562,32 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, expectedRectangle);
 			AssertArranged(view1, expectedRectangle);
 		}
+
+		[Fact]
+		public void ArrangeAccountsForFill()
+		{
+			var grid = CreateGridLayout();
+			var view = CreateTestView(new Size(100, 100));
+			SubstituteChildren(grid, view);
+			SetLocation(grid, view);
+
+			grid.HorizontalLayoutAlignment.Returns(Primitives.LayoutAlignment.Fill);
+			grid.VerticalLayoutAlignment.Returns(Primitives.LayoutAlignment.Fill);
+
+			var layoutManager = new GridLayoutManager(grid);
+			_ = layoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var arrangedWidth = 1000;
+			var arrangedHeight = 1000;
+
+			var target = new Rectangle(Point.Zero, new Size(arrangedWidth, arrangedHeight));
+
+			var actual = layoutManager.ArrangeChildren(target);
+
+			// Since we're arranging in a space larger than needed and the layout is set to Fill in both directions,
+			// we expect the returned actual arrangement size to be as large as the target space
+			Assert.Equal(arrangedWidth, actual.Width);
+			Assert.Equal(arrangedHeight, actual.Height);
+		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
@@ -348,11 +348,35 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			stack.MinimumHeight.Returns(75);
 			stack.MaximumHeight.Returns(50);
 
-			var gridLayoutManager = new HorizontalStackLayoutManager(stack);
-			var measure = gridLayoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			var layoutManager = new HorizontalStackLayoutManager(stack);
+			var measure = layoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
 
 			// The minimum value should beat out the maximum value
 			Assert.Equal(75, measure.Height);
+		}
+
+		[Fact]
+		public void ArrangeAccountsForFill()
+		{
+			var stack = BuildStack(viewCount: 1, viewWidth: 100, viewHeight: 100);
+
+			stack.HorizontalLayoutAlignment.Returns(LayoutAlignment.Fill);
+			stack.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var layoutManager = new HorizontalStackLayoutManager(stack);
+			_ = layoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var arrangedWidth = 1000;
+			var arrangedHeight = 1000;
+
+			var target = new Rectangle(Point.Zero, new Size(arrangedWidth, arrangedHeight));
+
+			var actual = layoutManager.ArrangeChildren(target);
+
+			// Since we're arranging in a space larger than needed and the layout is set to Fill in both directions,
+			// we expect the returned actual arrangement size to be as large as the target space
+			Assert.Equal(arrangedWidth, actual.Width);
+			Assert.Equal(arrangedHeight, actual.Height);
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
@@ -312,5 +312,29 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// The minimum value should beat out the maximum value
 			Assert.Equal(75, measure.Height);
 		}
+
+		[Fact]
+		public void ArrangeAccountsForFill()
+		{
+			var stack = BuildStack(viewCount: 1, viewWidth: 100, viewHeight: 100);
+
+			stack.HorizontalLayoutAlignment.Returns(LayoutAlignment.Fill);
+			stack.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var layoutManager = new VerticalStackLayoutManager(stack);
+			_ = layoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var arrangedWidth = 1000;
+			var arrangedHeight = 1000;
+
+			var target = new Rectangle(Point.Zero, new Size(arrangedWidth, arrangedHeight));
+
+			var actual = layoutManager.ArrangeChildren(target);
+
+			// Since we're arranging in a space larger than needed and the layout is set to Fill in both directions,
+			// we expect the returned actual arrangement size to be as large as the target space
+			Assert.Equal(arrangedWidth, actual.Width);
+			Assert.Equal(arrangedHeight, actual.Height);
+		}
 	}
 }


### PR DESCRIPTION
Layout managers were returning only the actual size necessary to lay out the children. But if the layout alignment is Fill, the actual arranged size will usually be larger. For most platforms this isn't a big deal, but Windows needs accurate values from the Panel's ArrangeOverride implementation.

This change modifies the layout managers to account for Fill when returning the actual size from ArrangeChildren. 

Fixes #2582
Fixes #2061

