### PR TITLE
Call defaults in some handlers

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.Windows.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Windows.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiTextBox nativeView)
 		{
 			nativeView.LostFocus += OnLostFocus;
+			SetupDefaults(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiTextBox nativeView)
@@ -32,8 +33,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			_placeholderDefaultBrush = nativeView.PlaceholderForeground;
 			_defaultPlaceholderColorFocusBrush = nativeView.PlaceholderForegroundFocusBrush;
-
-			
 		}
 
 		public static void MapText(EditorHandler handler, IEditor editor)

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -37,6 +37,12 @@ namespace Microsoft.Maui.Handlers
 			base.NativeArrange(frame);
 		}
 
+		protected override void ConnectHandler(AppCompatTextView nativeView)
+		{
+			base.ConnectHandler(nativeView);
+			SetupDefaults(nativeView);
+		}
+
 		void SetupDefaults(AppCompatTextView nativeView)
 		{
 			if (nativeView.TextColors == null)

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.Click += OnClick;
 
 			base.ConnectHandler(nativeView);
+			SetupDefaults(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiPicker nativeView)
@@ -40,8 +41,6 @@ namespace Microsoft.Maui.Handlers
 
 		void SetupDefaults(MauiPicker nativeView)
 		{
-
-
 			DefaultBackground = nativeView.Background;
 			DefaultTitleColors = nativeView.HintTextColors;
 		}

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiComboBox nativeView)
 		{
 			nativeView.SelectionChanged += OnControlSelectionChanged;
+			SetupDefaults(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiComboBox nativeView)
@@ -35,7 +36,6 @@ namespace Microsoft.Maui.Handlers
 
 		void Reload()
 		{
-
 			if (VirtualView == null || NativeView == null)
 				return;
 			NativeView.ItemsSource = new ItemDelegateList<string>(VirtualView);

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -61,8 +61,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			nativeView.EditingDidEnd += OnEnded;
 			nativeView.EditingChanged += OnEditing;
-
-
 			base.ConnectHandler(nativeView);
 		}
 

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			nativeView.QueryTextChange += OnQueryTextChange;
 			nativeView.QueryTextSubmit += OnQueryTextSubmit;
+			SetupDefaults(nativeView);
 		}
 
 		protected override void DisconnectHandler(SearchView nativeView)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Handlers
 		Brush? _defaultPlaceholderColorBrush;
 		Brush? _defaultPlaceholderColorFocusBrush;
 		
-    Brush? _defaultTextColorBrush;
+		Brush? _defaultTextColorBrush;
 		Brush? _defaultTextColorFocusBrush;
     
 		Brush? _defaultDeleteButtonForegroundColorBrush;
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Handlers
 		[MissingMapper]
 		public static void MapHorizontalTextAlignment(IViewHandler handler, ISearchBar searchBar) { }
 		
-    [MissingMapper]
+		[MissingMapper]
 		public static void MapVerticalTextAlignment(IViewHandler handler, ISearchBar searchBar) { }
 
 		public static void MapPlaceholderColor(SearchBarHandler handler, ISearchBar searchBar)

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.TextPropertySet += OnTextPropertySet;
 			nativeView.ShouldChangeTextInRange += ShouldChangeText;
 			base.ConnectHandler(nativeView);
+			SetupDefaults(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiSearchBar nativeView)


### PR DESCRIPTION
### Description of Change ###

There's some code to setupdefaults but they are never call, this PR fixes that.

Implements #

### Additions made ###

None

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
