### PR TITLE
[Android,IOS] Update picker TextColor

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
@@ -215,6 +215,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 			_hintColorSwitcher.UpdateTextColor(EditText, Element.TitleColor, EditText.SetHintTextColor);
 		}
 
+		[PortHandler]
 		protected override void UpdateTextColor()
 		{
 			_textColorSwitcher = _textColorSwitcher ?? new TextColorSwitcher(EditText.TextColors, Element.UseLegacyColorManagement());

--- a/src/Compatibility/Core/src/iOS/Renderers/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/PickerRenderer.cs
@@ -296,6 +296,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			Control.VerticalAlignment = Element.VerticalTextAlignment.ToNativeTextAlignment();
 		}
 
+		[PortHandler]
 		protected internal virtual void UpdateTextColor()
 		{
 			var textColor = Element.TextColor;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/PickerPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/PickerPage.xaml
@@ -49,6 +49,20 @@
                     </x:Array>
                 </Picker.ItemsSource>
             </Picker>
+
+            <Label
+                Text="TextColor"
+                Style="{StaticResource Headline}"/>
+            <Picker TextColor="Blue"
+                Title="Select an item">
+                <Picker.ItemsSource>
+                    <x:Array Type="{x:Type x:String}">
+                        <x:String>Item 1</x:String>
+                        <x:String>Item 2</x:String>
+                        <x:String>Item 3</x:String>
+                    </x:Array>
+                </Picker.ItemsSource>
+            </Picker>
         </VerticalStackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -1,23 +1,19 @@
 ﻿using System;
-using System.Collections.Specialized;
-using System.Linq;
 using Android.App;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Text.Style;
-using Microsoft.Maui.Graphics;
 using AResource = Android.Resource;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class PickerHandler : ViewHandler<IPicker, MauiPicker>
 	{
-		static Drawable? DefaultBackground;
-
+		static Drawable? s_defaultBackground;
+		static ColorStateList? s_defaultTitleColors { get; set; }
+		static ColorStateList? s_defaultTextColors { get; set; }
 		AlertDialog? _dialog;
-
-		static ColorStateList? DefaultTitleColors { get; set; }
 
 		protected override MauiPicker CreateNativeView() =>
 			new MauiPicker(Context);
@@ -28,6 +24,8 @@ namespace Microsoft.Maui.Handlers
 			nativeView.Click += OnClick;
 
 			base.ConnectHandler(nativeView);
+
+			SetupDefaults(nativeView);
 		}
 
 		protected override void DisconnectHandler(MauiPicker nativeView)
@@ -40,25 +38,17 @@ namespace Microsoft.Maui.Handlers
 
 		void SetupDefaults(MauiPicker nativeView)
 		{
-
-
-			DefaultBackground = nativeView.Background;
-			DefaultTitleColors = nativeView.HintTextColors;
+			s_defaultBackground = nativeView.Background;
+			s_defaultTitleColors = nativeView.HintTextColors;
+			s_defaultTextColors = nativeView.TextColors;
 		}
 
 		// This is a Android-specific mapping
 		public static void MapBackground(PickerHandler handler, IPicker picker)
 		{
-			handler.NativeView?.UpdateBackground(picker, DefaultBackground);
+			handler.NativeView?.UpdateBackground(picker, s_defaultBackground);
 		}
 
-		void Reload()
-		{
-			if (VirtualView == null || NativeView == null)
-				return;
-
-			NativeView.UpdatePicker(VirtualView);
-		}
 		public static void MapReload(PickerHandler handler, IPicker picker, object? args) => handler.Reload();
 
 		public static void MapTitle(PickerHandler handler, IPicker picker)
@@ -68,7 +58,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapTitleColor(PickerHandler handler, IPicker picker)
 		{
-			handler.NativeView?.UpdateTitleColor(picker, DefaultTitleColors);
+			handler.NativeView?.UpdateTitleColor(picker, s_defaultTitleColors);
 		}
 
 		public static void MapSelectedIndex(PickerHandler handler, IPicker picker)
@@ -95,8 +85,10 @@ namespace Microsoft.Maui.Handlers
 			nativePicker?.UpdateHorizontalAlignment(picker.HorizontalTextAlignment, hasRtlSupport);
 		}
 
-		[MissingMapper]
-		public static void MapTextColor(PickerHandler handler, IPicker view) { }
+		public static void MapTextColor(PickerHandler handler, IPicker picker)
+		{
+			handler.NativeView.UpdateTextColor(picker, s_defaultTextColors);
+		}
 
 		void OnFocusChange(object? sender, global::Android.Views.View.FocusChangeEventArgs e)
 		{
@@ -162,6 +154,14 @@ namespace Microsoft.Maui.Handlers
 
 				_dialog.Show();
 			}
+		}
+
+		void Reload()
+		{
+			if (VirtualView == null || NativeView == null)
+				return;
+
+			NativeView.UpdatePicker(VirtualView);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -128,8 +128,10 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdateHorizontalTextAlignment(picker);
 		}
 
-		[MissingMapper]
-		public static void MapTextColor(PickerHandler handler, IPicker view) { }
+		public static void MapTextColor(PickerHandler handler, IPicker picker)
+		{
+			handler.NativeView?.UpdateTextColor(picker);		
+		}
 
 		void OnEnded(object? sender, EventArgs eventArgs)
 		{

--- a/src/Core/src/Platform/Android/PickerExtensions.cs
+++ b/src/Core/src/Platform/Android/PickerExtensions.cs
@@ -33,6 +33,26 @@ namespace Microsoft.Maui
 			}
 		}
 
+		public static void UpdateTextColor(this MauiPicker nativePicker, IPicker picker, ColorStateList? defaultColor)
+		{
+			var textColor = picker.TextColor;
+
+			if (textColor == null)
+			{
+				nativePicker.SetTextColor(defaultColor);
+			}
+			else
+			{
+				var androidColor = textColor.ToNative();
+
+				if (!nativePicker.TextColors.IsOneColor(ColorStates, androidColor))
+				{
+					var acolor = androidColor.ToArgb();
+					nativePicker.SetTextColor(new ColorStateList(ColorStates, new[] { acolor, acolor }));
+				}
+			}
+		}
+
 		public static void UpdateSelectedIndex(this MauiPicker nativePicker, IPicker picker) =>
 			UpdatePicker(nativePicker, picker);
 

--- a/src/Core/src/Platform/iOS/PickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/PickerExtensions.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Maui
 		public static void UpdateTitleColor(this MauiPicker nativePicker, IPicker picker) =>
  			nativePicker.SetTitleColor(picker);
 
+		public static void UpdateTextColor(this MauiPicker nativePicker, IPicker picker) =>
+			nativePicker.TextColor = picker.TextColor?.ToNative();
+
 		public static void UpdateSelectedIndex(this MauiPicker nativePicker, IPicker picker) =>
 			nativePicker.SetSelectedIndex(picker, picker.SelectedIndex);
 

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Android.cs
@@ -35,6 +35,20 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(picker, () => picker.TitleColor, GetNativeTitleColor, picker.TitleColor);
 		}
 
+		[Fact(DisplayName = "Text Color Initializes Correctly")]
+		public async Task TextColorInitializesCorrectly()
+		{
+			var picker = new PickerStub
+			{
+				Title = "Select an Item",
+				TextColor = Colors.CadetBlue,
+				Items = new[] {"Item 1", "Item2", "Item3"},
+				SelectedIndex = 1	
+			};
+
+			await ValidatePropertyInitValue(picker, () => picker.TextColor, GetNativeTextColor, picker.TextColor);
+		}
+
 		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
 		public async Task CharacterSpacingInitializesCorrectly()
 		{
@@ -95,6 +109,13 @@ namespace Microsoft.Maui.DeviceTests
 		Color GetNativeTitleColor(PickerHandler pickerHandler)
 		{
 			var currentTextColorInt = GetNativePicker(pickerHandler).CurrentHintTextColor;
+			var currentTextColor = new AColor(currentTextColorInt);
+			return currentTextColor.ToColor();
+		}
+
+		Color GetNativeTextColor(PickerHandler pickerHandler)
+		{
+			var currentTextColorInt = GetNativePicker(pickerHandler).CurrentTextColor;
 			var currentTextColor = new AColor(currentTextColorInt);
 			return currentTextColor.ToColor();
 		}

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.iOS.cs
@@ -35,6 +35,34 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.NativeViewValue);
 		}
 
+		[Fact(DisplayName = "Text Color Initializes Correctly")]
+		public async Task TextColorInitializesCorrectly()
+		{
+			var xplatTitleColor = Colors.CadetBlue;
+
+			var picker = new PickerStub
+			{
+				Title = "Select an Item",
+				TextColor = xplatTitleColor,
+				Items = new[] { "Item 1", "Item2", "Item3" },
+				SelectedIndex = 1
+			};
+
+			var expectedValue = xplatTitleColor.ToNative();
+
+			var values = await GetValueAsync(picker, (handler) =>
+			{
+				return new
+				{
+					ViewValue = picker.TextColor,
+					NativeViewValue = GetNativeTextColor(handler)
+				};
+			});
+
+			Assert.Equal(xplatTitleColor, values.ViewValue);
+			Assert.Equal(expectedValue, values.NativeViewValue);
+		}
+
 		MauiPicker GetNativePicker(PickerHandler pickerHandler) =>
 			pickerHandler.NativeView;
 
@@ -73,6 +101,12 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var mauiPicker = GetNativePicker(pickerHandler);
 			return mauiPicker.AttributedPlaceholder.GetForegroundColor();
+		}
+
+		UIColor GetNativeTextColor(PickerHandler pickerHandler)
+		{
+			var mauiPicker = GetNativePicker(pickerHandler);
+			return mauiPicker.TextColor;
 		}
 
 		UIControlContentVerticalAlignment GetNativeVerticalTextAlignment(PickerHandler pickerHandler) =>


### PR DESCRIPTION
### Description of Change ###

Update TextColor on Android Picker

Android: 
![image](https://user-images.githubusercontent.com/1235097/134897023-46c98511-b67d-4617-bfb7-14e035628737.png)

iOS:
<img width="426" alt="Screenshot 2021-09-27 at 12 48 45" src="https://user-images.githubusercontent.com/1235097/134902279-fc50c6a5-266d-4e35-916f-b699d4606152.png">


win: 

![image](https://user-images.githubusercontent.com/1235097/134897140-93be1699-93d5-4b12-9217-89f3fe5b7e55.png)

### Additions made ###

PickerExtensions.cs
Android
```
public static void UpdateTextColor(this MauiPicker nativePicker, IPicker picker, ColorStateList? defaultColor)
```
iOS
```
public static void UpdateTextColor(this MauiPicker nativePicker, IPicker picker) =>
```
		
### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
