### PR TITLE
[Windows] Add VerticalTextAlignment to SearchBar

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
@@ -9,45 +9,61 @@
         <viewmodels:SearchBarViewModel />
     </views:BasePage.BindingContext>
     <views:BasePage.Content>
-        <VerticalStackLayout
+        <ScrollView>
+            <VerticalStackLayout
             Margin="12">
-            <Label
+                <Label
                 Text="Default"
                 Style="{StaticResource Headline}"/>
-            <SearchBar/>
-            <Label
+                <SearchBar/>
+                <Label
                 Text="Disabled"
                 Style="{StaticResource Headline}"/>
-            <SearchBar
+                <SearchBar
                 IsEnabled="False"/>
-            <Label
+                <Label
                 Text="TextColor"
                 Style="{StaticResource Headline}"/>
-            <SearchBar
+                <SearchBar
                 TextColor="Green"/>
-            <Label
+                <Label
                 Text="With Placeholder"
                 Style="{StaticResource Headline}" />
-            <SearchBar 
+                <SearchBar 
                 Placeholder="Placeholder"/>
-            <Label
+                <Label
                 Text="Using PlaceholderColor"
                 Style="{StaticResource Headline}" />
-            <SearchBar 
+                <SearchBar 
                 PlaceholderColor="Pink"
                 Placeholder="Placeholder"/>
-            <Label
+                <Label
                 Text="Fonts"
                 Style="{StaticResource Headline}"/>
-            <SearchBar
+                <SearchBar
                 FontSize="24"
                 FontAttributes="Italic"/>
-            <Label
+                <Label
                 Text="SearchCommand"
                 Style="{StaticResource Headline}"/>
-            <SearchBar
+                <SearchBar
                 SearchCommand="{Binding SearchCommand}"
                 SearchCommandParameter="SearchCommandParameter"/>
-        </VerticalStackLayout>
+                <Label
+                Text="HorizontalTextAlignment"
+                Style="{StaticResource Headline}" />
+                <SearchBar 
+                HorizontalTextAlignment="End"
+                Text="end of the line"
+                />
+                <Label
+                Text="VerticalTextAlignment"
+                Style="{StaticResource Headline}" />
+                <SearchBar 
+                VerticalTextAlignment="Start"
+                Text="at the bottom"
+                HeightRequest="100"/>
+            </VerticalStackLayout>
+        </ScrollView>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -49,11 +49,10 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.UpdatePlaceholder(searchBar);
 		}
 			
-		[MissingMapper]
-		public static void MapHorizontalTextAlignment(IViewHandler handler, ISearchBar searchBar) { }
-		
-		[MissingMapper]
-		public static void MapVerticalTextAlignment(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapVerticalTextAlignment(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.NativeView?.UpdateVerticalTextAlignment(searchBar, handler._queryTextBox);
+		}
 
 		public static void MapPlaceholderColor(SearchBarHandler handler, ISearchBar searchBar)
 		{

--- a/src/Core/src/Platform/Windows/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/Windows/SearchBarExtensions.cs
@@ -60,6 +60,14 @@ namespace Microsoft.Maui
 			queryTextBox.TextAlignment = searchBar.HorizontalTextAlignment.ToNative();
 		}
 
+		public static void UpdateVerticalTextAlignment(this AutoSuggestBox nativeControl, ISearchBar searchBar, MauiTextBox? queryTextBox)
+		{
+			if (queryTextBox == null)
+				return;
+
+			queryTextBox.VerticalAlignment = searchBar.VerticalTextAlignment.ToNativeVerticalAlignment();
+		}
+
 		public static void UpdateMaxLength(this AutoSuggestBox nativeControl, ISearchBar searchBar, MauiTextBox? queryTextBox)
 		{
 			if (queryTextBox == null)


### PR DESCRIPTION
### Description of Change ###

Add the necessary code to map VerticalTextAlignment  on a SearchBar but ... this is not working ... we need to figure why in all MauiTextBox like Entry and Editor


### Additions made ###


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
