### PR TITLE
[Windows] Port CursorPosition for Entry handler

### DIFF
--- a/src/Compatibility/Core/src/Windows/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/EntryRenderer.cs
@@ -413,6 +413,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 		}
 
+		[PortHandler]
 		void UpdateCursorPosition()
 		{
 			if (_nativeSelectionIsUpdating || Control == null || Element == null)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
@@ -102,7 +102,7 @@
                     Text="CursorPosition = 4"
                     Style="{StaticResource Headline}" />
                 <Entry
-                    x:Name="entry"
+                    x:Name="entryCursor"
                     Text="Cursor"
                     CursorPosition="4"/>
             </VerticalStackLayout>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
@@ -97,6 +97,14 @@
                     VerticalTextAlignment="End"
                     Text="This should be on the bottom"
                     HeightRequest="100"/>
+                <Label
+                    x:Name="lblCursor"
+                    Text="CursorPosition = 4"
+                    Style="{StaticResource Headline}" />
+                <Entry
+                    x:Name="entry"
+                    Text="Cursor"
+                    CursorPosition="4"/>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
@@ -8,13 +8,13 @@ namespace Maui.Controls.Sample.Pages
 		public EntryPage()
 		{
 			InitializeComponent();
-			entry.PropertyChanged += Entry_PropertyChanged;
+			entryCursor.PropertyChanged += OnEntryPropertyChanged;
 		}
 
-		private void Entry_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		void OnEntryPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == nameof(entry.CursorPosition))
-				lblCursor.Text = $"CursorPosition = {entry.CursorPosition}";
+			if (e.PropertyName == nameof(Entry.CursorPosition))
+				lblCursor.Text = $"CursorPosition = {((Entry)sender).CursorPosition}";
 		}
 
 		void OnEntryCompleted(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
@@ -8,6 +8,13 @@ namespace Maui.Controls.Sample.Pages
 		public EntryPage()
 		{
 			InitializeComponent();
+			entry.PropertyChanged += Entry_PropertyChanged;
+		}
+
+		private void Entry_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == nameof(entry.CursorPosition))
+				lblCursor.Text = $"CursorPosition = {entry.CursorPosition}";
 		}
 
 		void OnEntryCompleted(object sender, EventArgs e)

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -1,20 +1,22 @@
 ﻿#nullable enable
+using System;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Windows.System;
 
-﻿namespace Microsoft.Maui.Handlers
+namespace Microsoft.Maui.Handlers
 {
 	public partial class EntryHandler : ViewHandler<IEntry, MauiTextBox>
 	{
-		Brush? _defaultPplaceholderBrush;
+		Brush? _defaultPlaceholderBrush;
 		Brush? _defaultPlaceholderColorFocusBrush;
-
+	
 		protected override MauiTextBox CreateNativeView()
 		{
 			var nativeEntry = new MauiTextBox { Style = UI.Xaml.Application.Current.Resources["MauiTextBoxStyle"] as UI.Xaml.Style };
-			
-			_defaultPplaceholderBrush = nativeEntry.PlaceholderForeground;
+
+			_defaultPlaceholderBrush = nativeEntry.PlaceholderForeground;
 			_defaultPlaceholderColorFocusBrush = nativeEntry.PlaceholderForegroundFocusBrush;
 
 			return nativeEntry;
@@ -22,15 +24,18 @@ using Windows.System;
 
 		protected override void ConnectHandler(MauiTextBox nativeView)
 		{
+			NativeView.CursorPositionChangePending = VirtualView.CursorPosition > 0;
 			nativeView.KeyUp += OnNativeKeyUp;
+			nativeView.CursorPositionChanged += OnCursorPositionChanged;
 		}
 
 		protected override void DisconnectHandler(MauiTextBox nativeView)
 		{
 			nativeView.KeyUp -= OnNativeKeyUp;
+			nativeView.CursorPositionChanged -= OnCursorPositionChanged;
 		}
 
-		public static void MapText(EntryHandler handler, IEntry entry) 
+		public static void MapText(EntryHandler handler, IEntry entry)
 		{
 			handler.NativeView?.UpdateText(entry);
 		}
@@ -40,7 +45,7 @@ using Windows.System;
 			handler.NativeView?.UpdateTextColor(entry);
 		}
 
-		public static void MapIsPassword(EntryHandler handler, IEntry entry) 
+		public static void MapIsPassword(EntryHandler handler, IEntry entry)
 		{
 			handler.NativeView?.UpdateIsPassword(entry);
 		}
@@ -72,7 +77,7 @@ using Windows.System;
 
 		public static void MapPlaceholderColor(EntryHandler handler, IEntry entry)
 		{
-			handler.NativeView?.UpdatePlaceholderColor(entry, handler._defaultPplaceholderBrush, handler._defaultPlaceholderColorFocusBrush);
+			handler.NativeView?.UpdatePlaceholderColor(entry, handler._defaultPlaceholderBrush, handler._defaultPlaceholderColorFocusBrush);
 		}
 
 		public static void MapIsReadOnly(EntryHandler handler, IEntry entry)
@@ -103,8 +108,8 @@ using Windows.System;
 		}
 
 		public static void MapKeyboard(EntryHandler handler, IEntry entry)
-		{ 
-			handler.NativeView?.UpdateKeyboard(entry); 
+		{
+			handler.NativeView?.UpdateKeyboard(entry);
 		}
 
 		void OnNativeKeyUp(object? sender, KeyRoutedEventArgs args)
@@ -124,10 +129,18 @@ using Windows.System;
 			VirtualView?.Completed();
 		}
 
-		[MissingMapper]
-		public static void MapCursorPosition(IViewHandler handler, IEntry entry) { }
+		public static void MapCursorPosition(EntryHandler handler, IEntry entry)
+		{
+			handler.NativeView.CursorPosition = entry.CursorPosition;
+		}
 
 		[MissingMapper]
 		public static void MapSelectionLength(IViewHandler handler, IEntry entry) { }
+
+		void OnCursorPositionChanged(object? sender, EventArgs e)
+		{
+			VirtualView.CursorPosition = NativeView.CursorPosition;
+		}
+
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -12,6 +12,8 @@ using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WVisualStateManager = Microsoft.UI.Xaml.VisualStateManager;
 using System.Text;
 using Microsoft.UI.Input;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui
 {
@@ -210,9 +212,13 @@ namespace Microsoft.Maui
 					}
 					SelectionStart = start;
 				}
-				catch (Exception)
+				catch (Exception ex)
 				{
-					
+					MauiWinUIApplication
+						.Current
+						.Services
+						.CreateLogger<ILogger>()
+						.LogWarning($"Failed to set Control.SelectionStart from CursorPosition: {ex}");
 				}
 				finally
 				{

--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Maui
 		CancellationTokenSource _cts;
 		bool _internalChangeFlag;
 		int _cachedSelectionLength;
+		bool _nativeSelectionIsUpdating;
 
 		public MauiTextBox()
 		{
@@ -80,7 +81,7 @@ namespace Microsoft.Maui
 		public bool ClearButtonVisible
 		{
 			get { return (bool)GetValue(ClearButtonVisibleProperty); }
-			set { SetValue(ClearButtonVisibleProperty, value);}
+			set { SetValue(ClearButtonVisibleProperty, value); }
 		}
 
 		public WBrush BackgroundFocusBrush
@@ -120,6 +121,12 @@ namespace Microsoft.Maui
 			get { return (string)GetValue(TextProperty); }
 			set { SetValue(TextProperty, value); }
 		}
+
+		public event EventHandler CursorPositionChanged;
+
+		public int CursorPosition { get; set; }
+
+		internal bool CursorPositionChangePending { get; set; }
 
 		InputScope PasswordInputScope
 		{
@@ -169,7 +176,55 @@ namespace Microsoft.Maui
 				UpdateClearButtonVisible();
 			}
 
-			_scrollViewer= GetTemplateChild("ContentElement") as ScrollViewer;
+			_scrollViewer = GetTemplateChild("ContentElement") as ScrollViewer;
+		}
+
+		protected override void OnGotFocus(RoutedEventArgs e)
+		{
+			base.OnGotFocus(e);
+
+			if (CursorPositionChangePending)
+				MapCursorPosition();
+
+			UpdateCurrentPosition(SelectionStart);
+		}
+
+		void MapCursorPosition()
+		{
+			if (_nativeSelectionIsUpdating)
+				return;
+
+			if (Focus(FocusState.Programmatic))
+			{
+				try
+				{
+					int cursorPosition = CursorPosition;
+
+					int start = Math.Min(Text.Length, cursorPosition);
+
+					if (start != cursorPosition)
+					{
+						_nativeSelectionIsUpdating = true;
+						UpdateCurrentPosition(start);
+						_nativeSelectionIsUpdating = false;
+					}
+					SelectionStart = start;
+				}
+				catch (Exception)
+				{
+					
+				}
+				finally
+				{
+					CursorPositionChangePending = false;
+				}
+			}
+		}
+
+		void UpdateCurrentPosition(int position)
+		{
+			CursorPosition = position;
+			CursorPositionChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		void OnSizeChanged(object sender, SizeChangedEventArgs e)
@@ -294,6 +349,14 @@ namespace Microsoft.Maui
 		{
 			// Cache this value for later use as explained in OnKeyDown below
 			_cachedSelectionLength = SelectionLength;
+
+			if (!CursorPositionChangePending)
+			{
+				var start = CursorPosition;
+				int selectionStart = SelectionStart;
+				if (selectionStart != start)
+					UpdateCurrentPosition(selectionStart);
+			}
 		}
 
 		// Because the implementation of a password entry is based around inheriting from TextBox (via MauiTextBox), there
@@ -398,7 +461,7 @@ namespace Microsoft.Maui
 			{
 				if (ClearButtonVisible && !states.Contains(visibleState))
 					states.Add(visibleState);
-				else if(!ClearButtonVisible)
+				else if (!ClearButtonVisible)
 					states.Remove(visibleState);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Implement Cursor Position on Entry handler for windows


### Additions made ###

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
