### PR TITLE
[workload] collapse platform-specific packs into fewer packs

### DIFF
--- a/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
@@ -5,16 +5,16 @@
 
   <PropertyGroup>
     <Description>.NET MAUI Controls targeting pack</Description>
-    <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
+    <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 
   <!-- Android-only files -->
-  <ItemGroup Condition=" '$(MauiPlatformName)' == 'android' ">
+  <ItemGroup>
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Android.FormsViewGroup/src/bin/$(Configuration)/net6.0-android/ref/Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.dll" />
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Android.FormsViewGroup/src/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.aar" />
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Core/src/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.Compatibility.aar" />
     <_AndroidFiles Include="$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.aar" />
-    <None Include="@(_AndroidFiles)" FullTfm="net6.0-android30.0" Tfm="net6.0-android" Profile="Android" />
+    <None Include="@(_AndroidFiles)" FullTfm="net6.0-android$(_AndroidTargetPlatformVersion)" Tfm="net6.0-android" Profile="Android" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
     <_PackageFiles Include="@(None)" PackagePath="ref/%(FullTfm)%(SubFolder)" TargetPath="ref/%(FullTfm)%(SubFolder)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(MauiPlatformName)' == '' ">
+  <ItemGroup>
     <ProjectReference Include="../../../src/Controls/src/Core/Controls.Core-net6.csproj" />
     <ProjectReference Include="../../../src/Controls/src/Xaml/Controls.Xaml-net6.csproj" />
     <ProjectReference Include="../../../src/Controls/src/Core.Design/Controls.Core.Design-net6.csproj" />

--- a/src/Workload/Microsoft.Maui.Controls.Runtime/Microsoft.Maui.Controls.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Runtime/Microsoft.Maui.Controls.Runtime.csproj
@@ -5,14 +5,14 @@
 
   <PropertyGroup>
     <Description>.NET MAUI Controls runtime pack</Description>
-    <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
+    <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 
   <!-- Android-only files -->
-  <ItemGroup Condition=" '$(MauiPlatformName)' == 'android' ">
+  <ItemGroup>
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Android.FormsViewGroup/src/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.dll" />
     <_AndroidFiles Include="$(MauiRootDirectory)src/Compatibility/Android.FormsViewGroup/src/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Controls.Compatibility.Android.FormsViewGroup.pdb" />
-    <None Include="@(_AndroidFiles)" FullTfm="net6.0-android30.0" Tfm="net6.0-android" Profile="Android" />
+    <None Include="@(_AndroidFiles)" FullTfm="net6.0-android$(_AndroidTargetPlatformVersion)" Tfm="net6.0-android" Profile="Android" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,7 +26,7 @@
     <_PackageFiles Include="@(None)" PackagePath="lib/%(FullTfm)" TargetPath="lib/%(FullTfm)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(MauiPlatformName)' == '' ">
+  <ItemGroup>
     <ProjectReference Include="$(MauiRootDirectory)src/Controls/src/Core/Controls.Core-net6.csproj" />
     <ProjectReference Include="$(MauiRootDirectory)src/Controls/src/Xaml/Controls.Xaml-net6.csproj" />
     <ProjectReference Include="$(MauiRootDirectory)src/Compatibility/Core/src/Compatibility-net6.csproj" />

--- a/src/Workload/Microsoft.Maui.Core.Ref/Microsoft.Maui.Core.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Core.Ref/Microsoft.Maui.Core.Ref.csproj
@@ -5,13 +5,13 @@
 
   <PropertyGroup>
     <Description>.NET MAUI Core targeting pack</Description>
-    <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
+    <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 
   <!-- Android-only files -->
-  <ItemGroup Condition=" '$(MauiPlatformName)' == 'android' ">
+  <ItemGroup>
     <_AndroidFiles Include="$(MauiRootDirectory)src/Core/src/bin/$(Configuration)/net6.0-android/Microsoft.Maui.aar" />
-    <None Include="@(_AndroidFiles)" FullTfm="net6.0-android30.0" Tfm="net6.0-android" Profile="Android" />
+    <None Include="@(_AndroidFiles)" FullTfm="net6.0-android$(_AndroidTargetPlatformVersion)" Tfm="net6.0-android" Profile="Android" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,7 +20,7 @@
     <_PackageFiles Include="@(None)" PackagePath="ref/%(FullTfm)" TargetPath="ref/%(FullTfm)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(MauiPlatformName)' == '' ">
+  <ItemGroup>
     <ProjectReference Include="$(MauiRootDirectory)src/Core/src/Core-net6.csproj" />
   </ItemGroup>
 

--- a/src/Workload/Microsoft.Maui.Core.Runtime/Microsoft.Maui.Core.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Core.Runtime/Microsoft.Maui.Core.Runtime.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <Description>.NET MAUI Core runtime pack</Description>
-    <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
+    <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +15,7 @@
     <_PackageFiles Include="@(None)" PackagePath="lib/%(FullTfm)" TargetPath="lib/%(FullTfm)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(MauiPlatformName)' == '' ">
+  <ItemGroup>
     <ProjectReference Include="$(MauiRootDirectory)src/Core/src/Core-net6.csproj" />
   </ItemGroup>
 

--- a/src/Workload/Microsoft.Maui.Essentials.Ref/Microsoft.Maui.Essentials.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Essentials.Ref/Microsoft.Maui.Essentials.Ref.csproj
@@ -5,13 +5,13 @@
 
   <PropertyGroup>
     <Description>.NET MAUI Essentials targeting pack</Description>
-    <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
+    <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 
   <!-- Android-only files -->
-  <ItemGroup Condition=" '$(MauiPlatformName)' == 'android' ">
+  <ItemGroup>
     <_AndroidFiles Include="$(MauiRootDirectory)src/Essentials/src/bin/$(Configuration)/net6.0-android/Microsoft.Maui.Essentials.aar" />
-    <None Include="@(_AndroidFiles)" FullTfm="net6.0-android30.0" Tfm="net6.0-android" Profile="Android" />
+    <None Include="@(_AndroidFiles)" FullTfm="net6.0-android$(_AndroidTargetPlatformVersion)" Tfm="net6.0-android" Profile="Android" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,7 +20,7 @@
     <_PackageFiles Include="@(None)" PackagePath="ref/%(FullTfm)" TargetPath="ref/%(FullTfm)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(MauiPlatformName)' == '' ">
+  <ItemGroup>
     <ProjectReference Include="$(MauiRootDirectory)src/Essentials/src/Essentials-net6.csproj" />
   </ItemGroup>
 

--- a/src/Workload/Microsoft.Maui.Essentials.Runtime/Microsoft.Maui.Essentials.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Essentials.Runtime/Microsoft.Maui.Essentials.Runtime.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <Description>.NET MAUI Essentials runtime pack</Description>
-    <OutputPath Condition=" '$(MauiPlatformName)' != '' ">$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
+    <OutputPath>$(DotNetPacksDirectory)$(PackageId)/$(PackageVersion)/</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +15,7 @@
     <_PackageFiles Include="@(None)" PackagePath="lib/%(FullTfm)" TargetPath="lib/%(FullTfm)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(MauiPlatformName)' == '' ">
+  <ItemGroup>
     <ProjectReference Include="$(MauiRootDirectory)src/Essentials/src/Essentials-net6.csproj" />
   </ItemGroup>
 

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -4,10 +4,6 @@
     <_MauiRuntimePackVersion Condition=" '$(_MauiRuntimePackVersion)' == '' ">**FromWorkload**</_MauiRuntimePackVersion>
     <MauiWorkloadVersion>@VERSION@</MauiWorkloadVersion>
     <MauiVersion Condition=" '$(MauiVersion)' == '' ">$(MauiWorkloadVersion)</MauiVersion>
-    <!-- $(_MauiPlatformName) is used as RIDs as well as a suffix to targeting pack names -->
-    <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">win</_MauiPlatformName>
-    <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' != 'windows' ">$(TargetPlatformIdentifier.ToLowerInvariant())</_MauiPlatformName>
-    <_MauiPlatformName Condition=" '$(_MauiPlatformName)' == '' ">any</_MauiPlatformName>
   </PropertyGroup>
 
   <!-- Framework references -->
@@ -20,10 +16,10 @@
         RuntimeFrameworkName="Microsoft.Maui.Core"
         DefaultRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
         LatestRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
-        TargetingPackName="Microsoft.Maui.Core.Ref.$(_MauiPlatformName)"
+        TargetingPackName="Microsoft.Maui.Core.Ref"
         TargetingPackVersion="$(_MauiRuntimePackVersion)"
-        RuntimePackNamePatterns="Microsoft.Maui.Core.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
+        RuntimePackNamePatterns="Microsoft.Maui.Core.Runtime"
+        RuntimePackRuntimeIdentifiers="any"
         Profile="$(TargetPlatformIdentifier)"
     />
     <KnownFrameworkReference
@@ -33,10 +29,10 @@
         RuntimeFrameworkName="Microsoft.Maui.Controls"
         DefaultRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
         LatestRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
-        TargetingPackName="Microsoft.Maui.Controls.Ref.$(_MauiPlatformName)"
+        TargetingPackName="Microsoft.Maui.Controls.Ref"
         TargetingPackVersion="$(_MauiRuntimePackVersion)"
-        RuntimePackNamePatterns="Microsoft.Maui.Controls.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
+        RuntimePackNamePatterns="Microsoft.Maui.Controls.Runtime"
+        RuntimePackRuntimeIdentifiers="any"
         Profile="$(TargetPlatformIdentifier)"
     />
     <KnownFrameworkReference
@@ -46,10 +42,10 @@
         RuntimeFrameworkName="Microsoft.Maui.Essentials"
         DefaultRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
         LatestRuntimeFrameworkVersion="$(_MauiRuntimePackVersion)"
-        TargetingPackName="Microsoft.Maui.Essentials.Ref.$(_MauiPlatformName)"
+        TargetingPackName="Microsoft.Maui.Essentials.Ref"
         TargetingPackVersion="$(_MauiRuntimePackVersion)"
-        RuntimePackNamePatterns="Microsoft.Maui.Essentials.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
+        RuntimePackNamePatterns="Microsoft.Maui.Essentials.Runtime"
+        RuntimePackRuntimeIdentifiers="any"
         Profile="$(TargetPlatformIdentifier)"
     />
   </ItemGroup>

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -32,12 +32,12 @@
           "Microsoft.Maui.Extensions",
           "Microsoft.Maui.Resizetizer.Sdk",
           "Microsoft.Maui.Templates",
-          "Microsoft.Maui.Core.Ref.any",
-          "Microsoft.Maui.Core.Runtime.any",
-          "Microsoft.Maui.Controls.Ref.any",
-          "Microsoft.Maui.Controls.Runtime.any",
-          "Microsoft.Maui.Essentials.Ref.any",
-          "Microsoft.Maui.Essentials.Runtime.any"
+          "Microsoft.Maui.Core.Ref",
+          "Microsoft.Maui.Core.Runtime",
+          "Microsoft.Maui.Controls.Ref",
+          "Microsoft.Maui.Controls.Runtime",
+          "Microsoft.Maui.Essentials.Ref",
+          "Microsoft.Maui.Essentials.Runtime"
       ]
     },
     "maui-blazor": {
@@ -53,14 +53,6 @@
       "extends": [ 
         "maui-blazor",
         "android"
-      ],
-      "packs": [
-          "Microsoft.Maui.Core.Ref.android",
-          "Microsoft.Maui.Core.Runtime.android",
-          "Microsoft.Maui.Controls.Ref.android",
-          "Microsoft.Maui.Controls.Runtime.android",
-          "Microsoft.Maui.Essentials.Ref.android",
-          "Microsoft.Maui.Essentials.Runtime.android"
       ]
     },
     "maui-maccatalyst": {
@@ -68,14 +60,6 @@
       "extends": [ 
         "maui-blazor",
         "maccatalyst"
-      ],
-      "packs": [
-          "Microsoft.Maui.Core.Ref.maccatalyst",
-          "Microsoft.Maui.Core.Runtime.maccatalyst",
-          "Microsoft.Maui.Controls.Ref.maccatalyst",
-          "Microsoft.Maui.Controls.Runtime.maccatalyst",
-          "Microsoft.Maui.Essentials.Ref.maccatalyst",
-          "Microsoft.Maui.Essentials.Runtime.maccatalyst"
       ]
     },
     "maui-ios": {
@@ -83,27 +67,11 @@
       "extends": [ 
         "maui-blazor",
         "ios"
-      ],
-      "packs": [
-          "Microsoft.Maui.Core.Ref.ios",
-          "Microsoft.Maui.Core.Runtime.ios",
-          "Microsoft.Maui.Controls.Ref.ios",
-          "Microsoft.Maui.Controls.Runtime.ios",
-          "Microsoft.Maui.Essentials.Ref.ios",
-          "Microsoft.Maui.Essentials.Runtime.ios"
       ]
     },
     "maui-windows": {
       "description": ".NET MAUI SDK for Windows",
-      "extends": [ "maui-blazor" ],
-      "packs": [
-          "Microsoft.Maui.Core.Ref.win",
-          "Microsoft.Maui.Core.Runtime.win",
-          "Microsoft.Maui.Controls.Ref.win",
-          "Microsoft.Maui.Controls.Runtime.win",
-          "Microsoft.Maui.Essentials.Ref.win",
-          "Microsoft.Maui.Essentials.Runtime.win"
-      ]
+      "extends": [ "maui-blazor" ]
     }
   },
   "packs": {
@@ -111,83 +79,19 @@
       "kind": "library",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Core.Ref.any": {
+    "Microsoft.Maui.Core.Ref": {
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Core.Ref.android": {
+    "Microsoft.Maui.Core.Runtime": {
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Core.Ref.maccatalyst": {
+    "Microsoft.Maui.Controls.Ref": {
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Core.Ref.ios": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Core.Ref.win": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Core.Runtime.any": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Core.Runtime.android": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Core.Runtime.maccatalyst": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Core.Runtime.ios": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Core.Runtime.win": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Ref.any": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Ref.android": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Ref.maccatalyst": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Ref.ios": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Ref.win": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Runtime.any": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Runtime.android": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Runtime.maccatalyst": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Runtime.ios": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Controls.Runtime.win": {
+    "Microsoft.Maui.Controls.Runtime": {
       "kind": "framework",
       "version": "@VERSION@"
     },
@@ -195,43 +99,11 @@
       "kind": "library",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Essentials.Ref.any": {
+    "Microsoft.Maui.Essentials.Ref": {
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Essentials.Ref.android": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Essentials.Ref.maccatalyst": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Essentials.Ref.ios": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Essentials.Ref.win": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Essentials.Runtime.any": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Essentials.Runtime.android": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Essentials.Runtime.maccatalyst": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Essentials.Runtime.ios": {
-      "kind": "framework",
-      "version": "@VERSION@"
-    },
-    "Microsoft.Maui.Essentials.Runtime.win": {
+    "Microsoft.Maui.Essentials.Runtime": {
       "kind": "framework",
       "version": "@VERSION@"
     },

--- a/src/Workload/Shared/FrameworkList.targets
+++ b/src/Workload/Shared/FrameworkList.targets
@@ -1,8 +1,6 @@
 <Project>
 
   <ItemGroup>
-    <_FrameworkListFile Condition=" !$(MSBuildProjectName.Contains('.Runtime')) " Include="$(IntermediateOutputPath)FrameworkList.xml" />
-    <_FrameworkListFile Condition=" !$(MSBuildProjectName.Contains('.Ref')) " Include="$(IntermediateOutputPath)RuntimeList.xml" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging"  Version="6.0.0-beta.21169.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.21169.1" PrivateAssets="all" />
   </ItemGroup>
@@ -13,26 +11,34 @@
   <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->
   <Target Name="_GenerateFrameworkListFile"
       BeforeTargets="Build;AssignTargetPaths">
+    <PropertyGroup>
+      <_FrameworkListFile Condition=" $(MSBuildProjectName.Contains('.Ref')) ">$(IntermediateOutputPath)FrameworkList.xml</_FrameworkListFile>
+      <_FrameworkListFile Condition=" $(MSBuildProjectName.Contains('.Runtime')) ">$(IntermediateOutputPath)RuntimeList.xml</_FrameworkListFile>
+    </PropertyGroup>
     <ItemGroup>
       <_RootAttribute Include="Name" Value=".NET MAUI" />
       <_RootAttribute Include="TargetFrameworkIdentifier" Value=".NETCoreApp" />
       <_RootAttribute Include="TargetFrameworkVersion" Value="6.0" />
       <_RootAttribute Include="FrameworkName" Value="$(MSBuildProjectName.Replace('.Ref','').Replace('.Runtime',''))" />
       <_AssemblyFiles Include="@(_PackageFiles)" Condition=" '%(_PackageFiles.Extension)' == '.dll' and '%(_PackageFiles.SubFolder)' == '' " />
-      <_Classifications Include="@(_AssemblyFiles->'%(FileName)%(Extension)')" Profile="%(_AssemblyFiles.Profile)" />
     </ItemGroup>
 
     <!-- https://github.com/dotnet/arcade/blob/1924d7ea148c9f26ca3d82b60f0a775a5389ed22/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs -->
     <CreateFrameworkListFile
         Files="@(_AssemblyFiles)"
-        FileClassifications="@(_Classifications)"
-        TargetFile="%(_FrameworkListFile.Identity)"
+        FileClassifications="@(_AssemblyFiles->'%(FileName)%(Extension)'->Distinct())"
+        TargetFile="$(_FrameworkListFile)"
         TargetFilePrefixes="ref;lib"
         RootAttributes="@(_RootAttribute)"
     />
+    <!-- We have to manually add @Profile, because <CreateFrameworkList/> doesn't support multiple -->
+    <AddFrameworkListProfile
+        FrameworkListFile="$(_FrameworkListFile)"
+        Files="@(_AssemblyFiles)"
+    />
     <ItemGroup>
-      <FileWrites Include="@(_FrameworkListFile)" />
-      <Content Include="@(_FrameworkListFile)" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="data" Link="data/%(FileName)%(Extension)" />
+      <FileWrites Include="$(_FrameworkListFile)" />
+      <Content Include="$(_FrameworkListFile)" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="data" Link="data/$([System.IO.Path]::GetFileName($(_FrameworkListFile)))" />
     </ItemGroup>
   </Target>
 
@@ -48,5 +54,42 @@
       />
     </ItemGroup>
   </Target>
+
+  <UsingTask TaskName="AddFrameworkListProfile"
+      TaskFactory="RoslynCodeTaskFactory"
+      AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <FrameworkListFile ParameterType="System.String" Required="true" />
+      <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.Linq" />
+      <Using Namespace="System.Xml" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+          // This is in C# because the <XmlPoke/> task cannot create attributes
+          var doc = new XmlDocument();
+          doc.Load(FrameworkListFile);
+
+          var lookup = Files.ToDictionary(f => f.GetMetadata("Link"));
+          foreach (XmlElement element in doc.SelectNodes("/FileList/File"))
+          {
+              var path = element.GetAttribute("Path");
+              if (lookup.TryGetValue (path, out var item))
+              {
+                  var profile = item.GetMetadata("Profile");
+                  if (!string.IsNullOrEmpty (profile))
+                  {
+                      Log.LogMessage($"Set {path}, Profile={profile}");
+                      element.SetAttribute("Profile", profile);
+                  }
+              }
+          }
+
+          doc.Save(FrameworkListFile);
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 
 </Project>

--- a/src/Workload/Shared/FrameworkList.targets
+++ b/src/Workload/Shared/FrameworkList.targets
@@ -19,7 +19,7 @@
       <_RootAttribute Include="TargetFrameworkVersion" Value="6.0" />
       <_RootAttribute Include="FrameworkName" Value="$(MSBuildProjectName.Replace('.Ref','').Replace('.Runtime',''))" />
       <_AssemblyFiles Include="@(_PackageFiles)" Condition=" '%(_PackageFiles.Extension)' == '.dll' and '%(_PackageFiles.SubFolder)' == '' " />
-      <_Classifications Include="@(_AssemblyFiles->'%(FileName)%(Extension)'->Distinct())" Profile="@(_TargetPlatform->'%(Profile)')" />
+      <_Classifications Include="@(_AssemblyFiles->'%(FileName)%(Extension)')" Profile="%(_AssemblyFiles.Profile)" />
     </ItemGroup>
 
     <!-- https://github.com/dotnet/arcade/blob/1924d7ea148c9f26ca3d82b60f0a775a5389ed22/src/Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk/src/CreateFrameworkListFile.cs -->
@@ -38,7 +38,7 @@
 
   <Target Name="_AddWindowsPriFiles"
       AfterTargets="_GenerateFrameworkListFile"
-      Condition=" '$(MauiPlatformName)' == 'win' and $(MSBuildProjectName.Contains('.Ref')) ">
+      Condition=" $(MSBuildProjectName.Contains('.Ref')) ">
     <ItemGroup>
       <!-- Look for WinUI .pri files a directory above ref/*.dll files -->
       <Content

--- a/src/Workload/Shared/Frameworks.targets
+++ b/src/Workload/Shared/Frameworks.targets
@@ -1,59 +1,45 @@
 <Project>
 
-  <PropertyGroup Condition=" '$(MauiPlatformName)' != '' ">
-    <!-- NOTE: $(MauiPlatformName) is expected to be passed in: android, maccatalyst, ios, or win -->
-    <PackageId>$(PackageId).$(MauiPlatformName)</PackageId>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(MauiPlatformName)' == '' ">
-    <IsPackable>false</IsPackable>
+  <PropertyGroup>
+    <_AndroidTargetPlatformVersion>31.0</_AndroidTargetPlatformVersion>
+    <_iOSTargetPlatformVersion>15.0</_iOSTargetPlatformVersion>
+    <_MacCatalystTargetPlatformVersion>15.0</_MacCatalystTargetPlatformVersion>
+    <_WindowsTargetPlatformVersion>10.0.18362</_WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'any' "
         Include="net6.0"
         FullTfm="%(Identity)"
         Tfm="net6.0"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'android' "
-        Include="net6.0-android30.0"
+        Include="net6.0-android$(_AndroidTargetPlatformVersion)"
         FullTfm="%(Identity)"
         Tfm="net6.0-android"
         Profile="Android"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'ios' "
-        Include="net6.0-ios13.6"
+        Include="net6.0-ios$(_iOSTargetPlatformVersion)"
         FullTfm="%(Identity)"
         Tfm="net6.0-ios"
         Profile="iOS"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'maccatalyst' "
-        Include="net6.0-maccatalyst13.5"
+        Include="net6.0-maccatalyst$(_MacCatalystTargetPlatformVersion)"
         FullTfm="%(Identity)"
         Tfm="net6.0-maccatalyst"
         Profile="MacCatalyst"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'win' "
-        Include="net6.0-windows10.0.18362"
+        Condition=" '$(IncludeWindowsTargetFrameworks)' == 'true' "
+        Include="net6.0-windows$(_WindowsTargetPlatformVersion)"
         FullTfm="%(Identity)"
-        Tfm="net6.0-windows10.0.18362"
+        Tfm="net6.0-windows$(_WindowsTargetPlatformVersion)"
         Profile="Windows"
     />
   </ItemGroup>
 
-  <Import Condition=" '$(MauiPlatformName)' != '' " Project="FrameworkList.targets" />
-
-  <ItemGroup>
-    <_Platforms Include="any;android;maccatalyst;ios" />
-    <_Platforms Include="win" Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'" />
-  </ItemGroup>
-
-  <Target Name="_PackPerPlatform" Condition=" '$(MauiPlatformName)' == '' " AfterTargets="Build">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Pack" Properties="MauiPlatformName=%(_Platforms.Identity)" />
-  </Target>
+  <Import Project="FrameworkList.targets" />
 
 </Project>


### PR DESCRIPTION
### Description of Change ###

Context: https://dev.azure.com/xamarin/public/_build/results?buildId=47358&view=logs&j=315f0946-8789-5c0c-d2c2-240b442d8ae9&t=d968ec34-829f-5ead-e8e1-d01494979c11&l=782

Currently, the `-t:Install` target

    Successfully installed workload(s) maui.
    ...
    Time Elapsed 00:00:50.03

We're thinking we can improve this time by reducing the number of
packs that the `maui` workload contains. The managed layer of .NET
MAUI is pretty small, so we aren't gaining much by splitting up packs.
Few users will install `maui-android` or `maui-ios` individually. They
will likely just check the box in Visual Studio or install all of
`maui`.

So for example, previously we had packs like this for each platform:

    Microsoft.Maui.Core.Ref.android
    Microsoft.Maui.Core.Runtime.android
    Microsoft.Maui.Controls.Ref.android
    Microsoft.Maui.Controls.Runtime.android
    Microsoft.Maui.Essentials.Ref.android
    Microsoft.Maui.Essentials.Runtime.android

We can simply have a single pack for each, with all the platforms inside:

    Microsoft.Maui.Core.Ref
    Microsoft.Maui.Core.Runtime
    Microsoft.Maui.Controls.Ref
    Microsoft.Maui.Controls.Runtime
    Microsoft.Maui.Essentials.Ref
    Microsoft.Maui.Essentials.Runtime

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No