### PR TITLE
[Windows] Add SelectionLength mapping to entry handler

### DIFF
--- a/src/Compatibility/Core/src/Windows/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/EntryRenderer.cs
@@ -357,6 +357,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			Control.InputScope = Element.ReturnType.ToInputScope();
 		}
 
+		[PortHandler]
 		void SelectionChanged(object sender, RoutedEventArgs e)
 		{
 			if (_nativeSelectionIsUpdating || Control == null || Element == null)
@@ -382,6 +383,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 		}
 
+		[PortHandler]
 		void UpdateSelectionLength()
 		{
 			if (_nativeSelectionIsUpdating || Control == null || Element == null)
@@ -448,6 +450,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 		}
 
+		[PortHandler]
 		void SetCursorPositionFromRenderer(int start)
 		{
 			try
@@ -465,6 +468,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			}
 		}
 
+		[PortHandler]
 		void SetSelectionLengthFromRenderer(int selectionLength)
 		{
 			try

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
@@ -10,8 +10,7 @@
     </views:BasePage.BindingContext>
     <views:BasePage.Content>
         <ScrollView>
-            <VerticalStackLayout
-                Margin="12">
+            <VerticalStackLayout Margin="12">
                 <Label
                     Text="Basic"
                     Style="{StaticResource Headline}" />
@@ -105,6 +104,15 @@
                     x:Name="entryCursor"
                     Text="Cursor"
                     CursorPosition="4"/>
+                <Label
+                    x:Name="lblSelection"
+                    Text="SelectionLength = 4"
+                    Style="{StaticResource Headline}" />
+                <Entry
+                    x:Name="entrySelection"
+                    Text="Selection"
+                    CursorPosition="2"
+                    SelectionLength="4"/>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
@@ -96,18 +96,24 @@
                     VerticalTextAlignment="End"
                     Text="This should be on the bottom"
                     HeightRequest="100"/>
-                <Label
+                <HorizontalStackLayout>
+                    <Label
                     x:Name="lblCursor"
                     Text="CursorPosition = 4"
                     Style="{StaticResource Headline}" />
+                    <Slider x:Name="sldCursorPosition" ValueChanged="OnSlideCursorPositionValueChanged" WidthRequest="100"/>
+                </HorizontalStackLayout>
                 <Entry
                     x:Name="entryCursor"
                     Text="Cursor"
                     CursorPosition="4"/>
-                <Label
+                <HorizontalStackLayout>
+                    <Label
                     x:Name="lblSelection"
                     Text="SelectionLength = 4"
                     Style="{StaticResource Headline}" />
+                    <Slider x:Name="sldSelection" ValueChanged="OnSlideSelectionValueChanged" WidthRequest="100"/>
+                </HorizontalStackLayout>
                 <Entry
                     x:Name="entrySelection"
                     Text="Selection"

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
@@ -9,12 +9,19 @@ namespace Maui.Controls.Sample.Pages
 		{
 			InitializeComponent();
 			entryCursor.PropertyChanged += OnEntryPropertyChanged;
+			entrySelection.PropertyChanged += OnEntrySelectionPropertyChanged;
 		}
 
 		void OnEntryPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(Entry.CursorPosition))
 				lblCursor.Text = $"CursorPosition = {((Entry)sender).CursorPosition}";
+		}
+
+		void OnEntrySelectionPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == nameof(Entry.SelectionLength))
+				lblSelection.Text = $"SelectionLength = {((Entry)sender).SelectionLength}";
 		}
 
 		void OnEntryCompleted(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
@@ -10,18 +10,36 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 			entryCursor.PropertyChanged += OnEntryPropertyChanged;
 			entrySelection.PropertyChanged += OnEntrySelectionPropertyChanged;
+			sldSelection.Maximum = entrySelection.Text.Length;
+			sldSelection.Value = entrySelection.SelectionLength;
+			sldCursorPosition.Maximum = entryCursor.Text.Length;
+			sldCursorPosition.Value = entryCursor.CursorPosition;
+		}
+
+		void OnSlideCursorPositionValueChanged(object sender, ValueChangedEventArgs e)
+		{
+			entryCursor.CursorPosition = (int)e.NewValue;
+		}
+
+		void OnSlideSelectionValueChanged(object sender, ValueChangedEventArgs e)
+		{
+			entrySelection.SelectionLength = (int)e.NewValue;
 		}
 
 		void OnEntryPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(Entry.CursorPosition))
 				lblCursor.Text = $"CursorPosition = {((Entry)sender).CursorPosition}";
+			if (e.PropertyName == nameof(Entry.Text))
+				sldCursorPosition.Maximum = ((Entry)sender).Text.Length;
 		}
 
 		void OnEntrySelectionPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(Entry.SelectionLength))
 				lblSelection.Text = $"SelectionLength = {((Entry)sender).SelectionLength}";
+			if (e.PropertyName == nameof(Entry.Text))
+				sldSelection.Maximum = ((Entry)sender).Text.Length;
 		}
 
 		void OnEntryCompleted(object sender, EventArgs e)

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapSelectionLength(EntryHandler handler, IEntry entry)
 		{
-			handler.NativeView.SelectionCount = entry.SelectionLength;
+			handler.NativeView.ViewSelectionLength = entry.SelectionLength;
 		}
 
 		void OnCursorPositionChanged(object? sender, EventArgs e)
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.Handlers
 
 		void OnSelectionLengthChanged(object? sender, EventArgs e)
 		{
-			VirtualView.SelectionLength = NativeView.SelectionCount;
+			VirtualView.SelectionLength = NativeView.ViewSelectionLength;
 		}
 
 	}

--- a/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Windows.cs
@@ -25,14 +25,17 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiTextBox nativeView)
 		{
 			NativeView.CursorPositionChangePending = VirtualView.CursorPosition > 0;
+			NativeView.SelectionLengthChangePending = VirtualView.SelectionLength > 0;
 			nativeView.KeyUp += OnNativeKeyUp;
 			nativeView.CursorPositionChanged += OnCursorPositionChanged;
+			nativeView.SelectionLengthChanged += OnSelectionLengthChanged;
 		}
 
 		protected override void DisconnectHandler(MauiTextBox nativeView)
 		{
 			nativeView.KeyUp -= OnNativeKeyUp;
 			nativeView.CursorPositionChanged -= OnCursorPositionChanged;
+			nativeView.SelectionLengthChanged -= OnSelectionLengthChanged;
 		}
 
 		public static void MapText(EntryHandler handler, IEntry entry)
@@ -134,12 +137,19 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView.CursorPosition = entry.CursorPosition;
 		}
 
-		[MissingMapper]
-		public static void MapSelectionLength(IViewHandler handler, IEntry entry) { }
+		public static void MapSelectionLength(EntryHandler handler, IEntry entry)
+		{
+			handler.NativeView.SelectionCount = entry.SelectionLength;
+		}
 
 		void OnCursorPositionChanged(object? sender, EventArgs e)
 		{
 			VirtualView.CursorPosition = NativeView.CursorPosition;
+		}
+
+		void OnSelectionLengthChanged(object? sender, EventArgs e)
+		{
+			VirtualView.SelectionLength = NativeView.SelectionCount;
 		}
 
 	}

--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -275,9 +275,13 @@ namespace Microsoft.Maui
 
 				SelectionLength = selectionLength;
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
-
+				MauiWinUIApplication
+					.Current
+					.Services
+					.CreateLogger<ILogger>()
+					.LogWarning($"Failed to set Control.SelectionLength from SelectionLength: {ex}");
 			}
 			finally
 			{

--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Maui
 
 		public int CursorPosition { get; set; }
 
-		public int SelectionCount { get; set; } = -1;
+		public int ViewSelectionLength { get; set; } = -1;
 
 		internal bool CursorPositionChangePending { get; set; }
 
@@ -247,9 +247,9 @@ namespace Microsoft.Maui
 			try
 			{
 				int selectionLength = 0;
-				int elemSelectionLength = SelectionLength;
+				int elemSelectionLength = ViewSelectionLength;
 
-				if (SelectionLength != -1)
+				if (ViewSelectionLength != -1)
 					selectionLength = Math.Max(0, Math.Min(Text.Length - CursorPosition, elemSelectionLength));
 
 				if (elemSelectionLength != selectionLength)
@@ -279,7 +279,7 @@ namespace Microsoft.Maui
 		void SetSelectionLength(int selection)
 		{
 			_nativeSelectionIsUpdating = true;
-			SelectionCount = selection;
+			ViewSelectionLength = selection;
 			SelectionLengthChanged?.Invoke(this, EventArgs.Empty);
 			_nativeSelectionIsUpdating = false;
 		}
@@ -419,7 +419,7 @@ namespace Microsoft.Maui
 
 			if (!SelectionLengthChangePending)
 			{
-				int elementSelectionLength = Math.Min(Text.Length - cursorPosition, SelectionLength);
+				int elementSelectionLength = Math.Min(Text.Length - cursorPosition, ViewSelectionLength);
 				int controlSelectionLength = SelectionLength;
 				if (controlSelectionLength != elementSelectionLength)
 					SetSelectionLength(controlSelectionLength);

--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Maui
 	public class MauiTextBox : TextBox
 	{
 		const char ObfuscationCharacter = '●';
+		int _cursorPosition = -1;
+		int _viewSelectionLength = -1;
 
 		public static readonly DependencyProperty PlaceholderForegroundBrushProperty =
 			DependencyProperty.Register(nameof(PlaceholderForegroundBrush), typeof(WBrush), typeof(MauiTextBox),
@@ -128,9 +130,25 @@ namespace Microsoft.Maui
 
 		public event EventHandler SelectionLengthChanged;
 
-		public int CursorPosition { get; set; }
+		public int CursorPosition
+		{
+			get { return _cursorPosition; }
+			set
+			{
+				_cursorPosition = value;
+				UpdateCursorPosition();
+			}
+		}
 
-		public int ViewSelectionLength { get; set; } = -1;
+		public int ViewSelectionLength
+		{
+			get { return _viewSelectionLength; }
+			set
+			{
+				_viewSelectionLength = value;
+				UpdateSelectionLength();
+			}
+		}
 
 		internal bool CursorPositionChangePending { get; set; }
 


### PR DESCRIPTION
### Description of Change ###

Implement SelectionLength  on Windows Entry handler, this goes after #2742 

### Additions made ###

None

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
