### PR TITLE
Set ImportantForAccessibility if properties are set

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -98,12 +98,12 @@ namespace Microsoft.Maui.Handlers
 						if (currentDelegate is MauiAccessibilityDelegateCompat)
 							currentDelegate = null;
 
-						var mauiDelegate = new MauiAccessibilityDelegateCompat(currentDelegate)
+						accessibilityDelegate = new MauiAccessibilityDelegateCompat(currentDelegate)
 						{
 							Handler = handler
 						};
 
-						ViewCompat.SetAccessibilityDelegate(nativeView, mauiDelegate);
+						ViewCompat.SetAccessibilityDelegate(nativeView, accessibilityDelegate);
 					}
 				}
 				else if (accessibilityDelegate != null)

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Android.cs
@@ -163,6 +163,9 @@ namespace Microsoft.Maui.DeviceTests
 			return FlowDirection.LeftToRight;
 		}
 
+		protected bool GetIsAccessibilityElement(IViewHandler viewHandler) =>
+			((View)viewHandler.NativeView).ImportantForAccessibility == ImportantForAccessibility.Yes;
+
 		protected string GetSemanticDescription(IViewHandler viewHandler) =>
 			((View)viewHandler.NativeView).ContentDescription;
 

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Android.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Android.Views;
+using Android.Widget;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -164,10 +165,27 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		protected bool GetIsAccessibilityElement(IViewHandler viewHandler) =>
-			((View)viewHandler.NativeView).ImportantForAccessibility == ImportantForAccessibility.Yes;
+			GetSemanticNativeElement(viewHandler).ImportantForAccessibility == ImportantForAccessibility.Yes;
+
+
+		public View GetSemanticNativeElement(IViewHandler viewHandler)
+		{
+			if (viewHandler.NativeView is AndroidX.AppCompat.Widget.SearchView sv)
+				return sv.FindViewById(Resource.Id.search_button)!;
+
+			return (View)viewHandler.NativeView;
+		}
 
 		protected string GetSemanticDescription(IViewHandler viewHandler) =>
-			((View)viewHandler.NativeView).ContentDescription;
+			GetSemanticNativeElement(viewHandler).ContentDescription;
+
+		protected string GetSemanticHint(IViewHandler viewHandler)
+		{
+			if (GetSemanticNativeElement(viewHandler) is EditText et)
+				return et.Hint;
+
+			return null;
+		}
 
 		protected SemanticHeadingLevel GetSemanticHeading(IViewHandler viewHandler)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
@@ -101,9 +101,9 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task SetSemanticHint()
 		{
 			var view = new TStub();
-			view.Semantics.Description = "Test";
-			var id = await GetValueAsync(view, handler => GetSemanticDescription(handler));
-			Assert.Equal(view.Semantics.Description, id);
+			view.Semantics.Hint = "Test";
+			var id = await GetValueAsync(view, handler => GetSemanticHint(handler));
+			Assert.Equal(view.Semantics.Hint, id);
 		}
 
 		[Fact(DisplayName = "Semantic Heading is set correctly")]

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Tests.cs
@@ -62,12 +62,29 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(view.Visibility, id);
 		}
 
+		[Fact(DisplayName = "Setting Semantic Description makes element accessible")]
+		public async Task SettingSemanticDescriptionMakesElementAccessible()
+		{
+			var view = new TStub();
+			view.Semantics.Description = "Test";
+			var important = await GetValueAsync(view, handler => GetIsAccessibilityElement(handler));
+			Assert.True(important);
+		}
+
+		[Fact(DisplayName = "Setting Semantic Hint makes element accessible")]
+		public async Task SettingSemanticHintMakesElementAccessible()
+		{
+			var view = new TStub();
+			view.Semantics.Hint = "Test";
+			var important = await GetValueAsync(view, handler => GetIsAccessibilityElement(handler));
+			Assert.True(important);
+		}
+
 		[Fact(DisplayName = "Semantic Description is set correctly"
 #if __ANDROID__
 			, Skip = "This value can't be validated through automated tests"
 #endif
 		)]
-		[InlineData()]
 		public async Task SetSemanticDescription()
 		{
 			var view = new TStub();
@@ -81,7 +98,6 @@ namespace Microsoft.Maui.DeviceTests
 			, Skip = "This value can't be validated through automated tests"
 #endif
 		)]
-		[InlineData()]
 		public async Task SetSemanticHint()
 		{
 			var view = new TStub();
@@ -91,7 +107,6 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Semantic Heading is set correctly")]
-		[InlineData()]
 		public async Task SetSemanticHeading()
 		{
 			var view = new TStub();
@@ -101,7 +116,6 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Null Semantics Doesnt throw exception")]
-		[InlineData()]
 		public async Task NullSemanticsClass()
 		{
 			var view = new TStub

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Windows.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Media;
 using Xunit;
 
@@ -121,6 +122,9 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected string GetAutomationId(IViewHandler viewHandler) =>
 			AutomationProperties.GetAutomationId((FrameworkElement)viewHandler.NativeView);
+
+		protected bool GetIsAccessibilityElement(IViewHandler viewHandler) =>
+			((AccessibilityView)((FrameworkElement)viewHandler.NativeView).GetValue(AutomationProperties.AccessibilityViewProperty)) == AccessibilityView.Content;
 
 		protected string GetSemanticDescription(IViewHandler viewHandler) =>
 			AutomationProperties.GetName((FrameworkElement)viewHandler.NativeView);

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.Windows.cs
@@ -129,6 +129,9 @@ namespace Microsoft.Maui.DeviceTests
 		protected string GetSemanticDescription(IViewHandler viewHandler) =>
 			AutomationProperties.GetName((FrameworkElement)viewHandler.NativeView);
 
+		protected string GetSemanticHint(IViewHandler viewHandler) =>
+			AutomationProperties.GetHelpText((FrameworkElement)viewHandler.NativeView);
+
 		protected SemanticHeadingLevel GetSemanticHeading(IViewHandler viewHandler) =>
 			(SemanticHeadingLevel)AutomationProperties.GetHeadingLevel((FrameworkElement)viewHandler.NativeView);
 

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
@@ -135,6 +135,9 @@ namespace Microsoft.Maui.DeviceTests
 			return FlowDirection.LeftToRight;
 		}
 
+		protected bool GetIsAccessibilityElement(IViewHandler viewHandler) =>
+			((UIView)viewHandler.NativeView).IsAccessibilityElement;
+
 		protected string GetSemanticDescription(IViewHandler viewHandler) =>
 			((UIView)viewHandler.NativeView).AccessibilityLabel;
 

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
@@ -135,8 +135,18 @@ namespace Microsoft.Maui.DeviceTests
 			return FlowDirection.LeftToRight;
 		}
 
-		protected bool GetIsAccessibilityElement(IViewHandler viewHandler) =>
-			((UIView)viewHandler.NativeView).IsAccessibilityElement;
+		protected bool GetIsAccessibilityElement(IViewHandler viewHandler)
+		{
+			var nativeView = ((UIView)viewHandler.NativeView);
+
+			// UIControl elements when created have IsAccessibilityElement set to false
+			// when first created. Once they are added to the visual tree then IsAccessibilityElement
+			// will become true. In code we only set non UIControl elements ourselves to true.
+			if (nativeView is UIControl)
+				return true;
+
+			return nativeView.IsAccessibilityElement;
+		}
 
 		protected string GetSemanticDescription(IViewHandler viewHandler) =>
 			((UIView)viewHandler.NativeView).AccessibilityLabel;

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.iOS.cs
@@ -139,9 +139,9 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var nativeView = ((UIView)viewHandler.NativeView);
 
-			// UIControl elements when created have IsAccessibilityElement set to false
-			// when first created. Once they are added to the visual tree then IsAccessibilityElement
-			// will become true. In code we only set non UIControl elements ourselves to true.
+			// UIControl elements when instantiated have IsAccessibilityElement set to false.
+			// Once they are added to the visual tree then iOS transitions IsAccessibilityElement
+			// to true. In code we only set non UIControl elements ourselves to true.
 			if (nativeView is UIControl)
 				return true;
 


### PR DESCRIPTION
### Description of Change ###

The check for setting "ImportantForAccessibility" on Android isn't correctly checking if an accessibility delegate has been set in order to make the element "ImportantForAccessibility"
