### PR TITLE
[Windows] Add IndicatorView handler

### DIFF
--- a/src/Compatibility/Core/src/Windows/CollectionView/CarouselViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CollectionView/CarouselViewRenderer.cs
@@ -518,7 +518,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (e.NewSize.Width > 0 && e.NewSize.Height > 0)
 			{
 				ListViewBase.SizeChanged -= InitialSetup;
-				_scrollViewer.SizeChanged -= InitialSetup;
+				if (_scrollViewer != null)
+					_scrollViewer.SizeChanged -= InitialSetup;
 
 				UpdateItemsSource();
 				UpdateSnapPointsType();

--- a/src/Controls/samples/Controls.Sample/ViewModels/ControlsViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/ControlsViewModel.cs
@@ -33,6 +33,9 @@ namespace Maui.Controls.Sample.ViewModels
 			new SectionModel(typeof(ImagePage), "Image",
 				"Displays an image."),
 
+			new SectionModel(typeof(IndicatorPage), "IndicatorView",
+				"IndicatorView displays indicators. It can also represent the number of items in a CarouselView. Set the CarouselView.IndicatorView property to the IndicatorView object to display indicators for the CarouselView."),
+
 			new SectionModel(typeof(LabelPage), "Label",
 				"The Label view is used for displaying text, both single and multi-line."),
 
@@ -62,9 +65,6 @@ namespace Maui.Controls.Sample.ViewModels
 
 			new SectionModel(typeof(TimePickerPage), "TimePicker",
 				"A view that allows the user to select a time."),
-
-			new SectionModel(typeof(IndicatorPage), "IndicatorView",
-				"IndicatorView displays indicators. It can also represent the number of items in a CarouselView. Set the CarouselView.IndicatorView property to the IndicatorView object to display indicators for the CarouselView."),
 
 	  new SectionModel(typeof(WebViewPage), "WebView",
 				"WebView is a view for displaying web and HTML content in your app.")

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -45,9 +45,10 @@ namespace Microsoft.Maui.Controls.Hosting
 			{ typeof(Shapes.RoundRectangle), typeof(ShapeViewHandler) },
 			{ typeof(Window), typeof(WindowHandler) },
 			{ typeof(ImageButton), typeof(ImageButtonHandler) },
+			{ typeof(IndicatorView), typeof(IndicatorViewHandler) },
 #if __ANDROID__ || __IOS__
 			{ typeof(RefreshView), typeof(RefreshViewHandler) },
-			{ typeof(IndicatorView), typeof(IndicatorViewHandler) },
+			
 #endif
 #if __ANDROID__  || WINDOWS
 			{ typeof(NavigationPage), typeof(NavigationPageHandler) },

--- a/src/Controls/src/Core/IndicatorView.cs
+++ b/src/Controls/src/Core/IndicatorView.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Maui.Controls
 	{
 		const int DefaultPadding = 4;
 
-		const int DefaultViewSize = 10;
-
 		public static readonly BindableProperty IndicatorsShapeProperty = BindableProperty.Create(nameof(IndicatorsShape), typeof(IndicatorShape), typeof(IndicatorView), Controls.IndicatorShape.Circle);
 
 		public static readonly BindableProperty PositionProperty = BindableProperty.Create(nameof(Position), typeof(int), typeof(IndicatorView), default(int), BindingMode.TwoWay);
@@ -39,10 +37,7 @@ namespace Microsoft.Maui.Controls
 
 		static readonly BindableProperty IndicatorLayoutProperty = BindableProperty.Create(nameof(IndicatorLayout), typeof(IBindableLayout), typeof(IndicatorView), null, propertyChanged: TemplateUtilities.OnContentChanged);
 
-		public IndicatorView()
-		{
-
-		}
+		public IndicatorView() { }
 
 		public IndicatorShape IndicatorsShape
 		{
@@ -126,7 +121,7 @@ namespace Microsoft.Maui.Controls
 			}
 			else if (indicatorView.IndicatorLayout == null)
 			{
-				(indicatorView.IndicatorLayout as IndicatorStackLayout).Remove();
+				(indicatorView.IndicatorLayout as IndicatorStackLayout)?.Remove();
 				indicatorView.IndicatorLayout = null;
 			}
 		}

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.Windows.cs
@@ -1,19 +1,52 @@
 ﻿using System;
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Platform.Windows;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, UserControl>
+	public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, ItemsControl>
 	{
-		protected override UserControl CreateNativeView() => throw new NotImplementedException();
+		MauiPageControl? MauiPagerControl => NativeView as MauiPageControl;
 
-		public static void MapCount(IndicatorViewHandler handler, IIndicatorView indicator) { }
-		public static void MapPosition(IndicatorViewHandler handler, IIndicatorView indicator) { }
-		public static void MapHideSingle(IndicatorViewHandler handler, IIndicatorView indicator) { }
-		public static void MapMaximumVisible(IndicatorViewHandler handler, IIndicatorView indicator) { }
-		public static void MapIndicatorSize(IndicatorViewHandler handler, IIndicatorView indicator) { }
-		public static void MapIndicatorColor(IndicatorViewHandler handler, IIndicatorView indicator) { }
-		public static void MapSelectedIndicatorColor(IndicatorViewHandler handler, IIndicatorView indicator) { }
-		public static void MapIndicatorShape(IndicatorViewHandler handler, IIndicatorView indicator) { }
+		protected override ItemsControl CreateNativeView() => new MauiPageControl();
+
+		protected override void ConnectHandler(ItemsControl nativeView)
+		{
+			base.ConnectHandler(nativeView);
+			MauiPagerControl?.SetIndicatorView(VirtualView);
+			UpdateIndicator();
+		}
+
+		public static void MapCount(IndicatorViewHandler handler, IIndicatorView indicator) => handler.MauiPagerControl?.CreateIndicators();
+		public static void MapPosition(IndicatorViewHandler handler, IIndicatorView indicator) => handler.MauiPagerControl?.UpdateIndicatorsColor();
+		public static void MapHideSingle(IndicatorViewHandler handler, IIndicatorView indicator) => handler.MauiPagerControl?.CreateIndicators();
+		public static void MapMaximumVisible(IndicatorViewHandler handler, IIndicatorView indicator) => handler.MauiPagerControl?.CreateIndicators();
+		public static void MapIndicatorSize(IndicatorViewHandler handler, IIndicatorView indicator) => handler.MauiPagerControl?.CreateIndicators();
+		public static void MapIndicatorColor(IndicatorViewHandler handler, IIndicatorView indicator) => handler.MauiPagerControl?.UpdateIndicatorsColor();
+		public static void MapSelectedIndicatorColor(IndicatorViewHandler handler, IIndicatorView indicator) => handler.MauiPagerControl?.UpdateIndicatorsColor();
+		public static void MapIndicatorShape(IndicatorViewHandler handler, IIndicatorView indicator) => handler.MauiPagerControl?.CreateIndicators();
+
+		void UpdateIndicator()
+		{
+			if (VirtualView is ITemplatedIndicatorView iTemplatedIndicatorView)
+			{
+				var indicatorsLayoutOverride = iTemplatedIndicatorView.IndicatorsLayoutOverride;
+				FrameworkElement handler;
+				if (MauiContext != null && indicatorsLayoutOverride != null)
+				{
+					ClearIndicators();
+					handler = indicatorsLayoutOverride.ToNative(MauiContext);
+					if (handler != null)
+						NativeView.ItemsSource = new ObservableCollection<FrameworkElement>() { handler };
+				}
+			}
+
+			void ClearIndicators()
+			{
+				NativeView.Items.Clear();
+			}
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiPageControl.cs
+++ b/src/Core/src/Platform/Windows/MauiPageControl.cs
@@ -66,8 +66,11 @@ namespace Microsoft.Maui.Platform.Windows
 				for (int i = 0; i < indicatorCount; i++)
 				{
 					var shape = CreateIndicator(i, position);
+					
 					if (shape != null)
+					{
 						indicators.Add(shape);
+					}
 				}
 			}
 
@@ -92,9 +95,10 @@ namespace Microsoft.Maui.Platform.Windows
 				return null;
 
 			var indicatorSize = _indicatorView.IndicatorSize;
+			WShape? shape = null;
 			if (_indicatorView.IsCircleShape())
 			{
-				return new WEllipse()
+				shape = new WEllipse()
 				{
 					Fill = i == position ? _selectedColor : _fillColor,
 					Height = indicatorSize,
@@ -104,7 +108,7 @@ namespace Microsoft.Maui.Platform.Windows
 			}
 			else
 			{
-				return new WRectangle()
+				shape = new WRectangle()
 				{
 					Fill = i == position ? _selectedColor : _fillColor,
 					Height = indicatorSize,
@@ -112,6 +116,15 @@ namespace Microsoft.Maui.Platform.Windows
 					Margin = WinUIHelpers.CreateThickness(DefaultPadding, 0, DefaultPadding, 0)
 				};
 			}
+			shape.Tag = i;
+			shape.PointerPressed += (s,e) =>
+			{
+				if (_indicatorView == null)
+					return;
+
+				_indicatorView.Position = (int)((WShape)s).Tag;
+			};
+			return shape;
 		}
 
 		int GetIndexFromPosition()

--- a/src/Core/src/Platform/Windows/MauiPageControl.cs
+++ b/src/Core/src/Platform/Windows/MauiPageControl.cs
@@ -1,0 +1,127 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using WEllipse = Microsoft.UI.Xaml.Shapes.Ellipse;
+using WRectangle = Microsoft.UI.Xaml.Shapes.Rectangle;
+using WShape = Microsoft.UI.Xaml.Shapes.Shape;
+using WBrush = Microsoft.UI.Xaml.Media.Brush;
+using Microsoft.Maui.Graphics;
+using System;
+
+namespace Microsoft.Maui.Platform.Windows
+{
+	public class MauiPageControl : ItemsControl
+	{
+		IIndicatorView? _indicatorView;
+		const int DefaultPadding = 4;
+		WBrush? _selectedColor;
+		WBrush? _fillColor;
+		ObservableCollection<WShape>? _dots;
+
+		public MauiPageControl()
+		{
+			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center;
+			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center;
+			ItemsPanel = GetItemsPanelTemplate();
+		}
+		public void SetIndicatorView(IIndicatorView indicatorView)
+		{
+			_indicatorView = indicatorView;
+
+			if (indicatorView == null)
+				Items.Clear();
+		}
+
+		internal void UpdateIndicatorsColor()
+		{
+			if (_indicatorView == null)
+				return;
+
+			if (_indicatorView.IndicatorColor is SolidPaint solidPaint)
+				_fillColor = solidPaint?.ToNative();
+			if (_indicatorView.SelectedIndicatorColor is SolidPaint selectedSolidPaint)
+				_selectedColor = selectedSolidPaint.ToNative();
+			var position = _indicatorView.Position;
+			int i = 0;
+			foreach (var item in Items)
+			{
+				((WShape)item).Fill = i == position ? _selectedColor : _fillColor;
+				i++;
+			}
+		}
+
+		internal void CreateIndicators()
+		{
+			if (_indicatorView == null)
+				return;
+
+			var position = GetIndexFromPosition();
+			var indicators = new List<WShape>();
+
+			var indicatorCount = _indicatorView.GetMaximumVisible();
+			if (indicatorCount > 0)
+			{
+				for (int i = 0; i < indicatorCount; i++)
+				{
+					var shape = CreateIndicator(i, position);
+					if (shape != null)
+						indicators.Add(shape);
+				}
+			}
+
+			_dots = new ObservableCollection<WShape>(indicators);
+			ItemsSource = _dots;
+		}
+
+		ItemsPanelTemplate GetItemsPanelTemplate()
+		{
+			var itemsPanelTemplateXaml =
+				$@"<ItemsPanelTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                                  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+                        <StackPanel  Orientation='Horizontal'></StackPanel>
+			   </ItemsPanelTemplate>";
+
+			return (ItemsPanelTemplate)XamlReader.Load(itemsPanelTemplateXaml);
+		}
+
+		WShape? CreateIndicator(int i, int position)
+		{
+			if (_indicatorView == null)
+				return null;
+
+			var indicatorSize = _indicatorView.IndicatorSize;
+			if (_indicatorView.IsCircleShape())
+			{
+				return new WEllipse()
+				{
+					Fill = i == position ? _selectedColor : _fillColor,
+					Height = indicatorSize,
+					Width = indicatorSize,
+					Margin = WinUIHelpers.CreateThickness(DefaultPadding, 0, DefaultPadding, 0)
+				};
+			}
+			else
+			{
+				return new WRectangle()
+				{
+					Fill = i == position ? _selectedColor : _fillColor,
+					Height = indicatorSize,
+					Width = indicatorSize,
+					Margin = WinUIHelpers.CreateThickness(DefaultPadding, 0, DefaultPadding, 0)
+				};
+			}
+		}
+
+		int GetIndexFromPosition()
+		{
+			if (_indicatorView == null)
+				return 0;
+
+			var maxVisible = _indicatorView.GetMaximumVisible();
+			var position = _indicatorView.Position;
+			return Math.Max(0, position >= maxVisible ? maxVisible - 1 : position);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Adding handler for IndicatorView for WINUI, everything works except when using the DataTemplate/BindableLayout right now 

![image](https://user-images.githubusercontent.com/1235097/135326825-a1d7a90f-641d-4fd5-9938-b5eec3034df2.png)

### Additions made ###

- Adds ItemsControl subclass MauiPagerControl  (to support creating the shapes for pager)

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
