### PR TITLE
Reference Win2D in the templates

### DIFF
--- a/Microsoft.Maui.Samples-net6.slnf
+++ b/Microsoft.Maui.Samples-net6.slnf
@@ -2,6 +2,7 @@
   "solution": {
     "path": "Microsoft.Maui-net6.sln",
     "projects": [
+      "src\\BlazorWebView\\samples\\MauiRazorClassLibrarySample\\MauiRazorClassLibrarySample.csproj",
       "src\\Controls\\samples\\Controls.Sample.SingleProject\\Maui.Controls.Sample.SingleProject.csproj",
       "src\\Controls\\samples\\Controls.Sample\\Maui.Controls.Sample-net6.csproj"
     ]

--- a/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
+++ b/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
@@ -14,7 +14,6 @@
     <ApplicationId>com.microsoft.maui.sample</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>
     <_FastDeploymentDiagnosticLogging>True</_FastDeploymentDiagnosticLogging>
-    <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework.Contains('-windows')) ">

--- a/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
+++ b/src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj
@@ -14,9 +14,10 @@
     <ApplicationId>com.microsoft.maui.sample</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>
     <_FastDeploymentDiagnosticLogging>True</_FastDeploymentDiagnosticLogging>
+    <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(UseMaui)' != 'true' and $(TargetFramework.Contains('-windows')) ">
+  <ItemGroup Condition=" $(TargetFramework.Contains('-windows')) ">
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.WindowsAppSDK.Foundation" />
     <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" />

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -31,7 +31,8 @@
       <_TemplateJsonFileWithContent
           Include="@(_TemplateJsonFile)"
           Contents="$([System.IO.File]::ReadAllText('%(FullPath)')
-              .Replace('WINDOWSAPPSDK_VERSION_VALUE', '$(_MicrosoftWindowsAppSdkVersion)'))" />
+              .Replace('WINDOWSAPPSDK_VERSION_VALUE', '$(_MicrosoftWindowsAppSdkVersion)')
+              .Replace('WIN2D_VERSION_VALUE', '$(MicrosoftGraphicsWin2DVersion)'))" />
     </ItemGroup>
     <WriteLinesToFile
         File="@(_TemplateJsonFileWithContent -> '$(IntermediateOutputPath)%(Identity)')"

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -45,6 +45,12 @@
         "replaces": "WINDOWSAPPSDK_VERSION",
         "defaultValue": "WINDOWSAPPSDK_VERSION_VALUE"
       },
+      "win2dVersion": {
+        "type": "parameter",
+        "dataType": "string",
+        "replaces": "WIN2D_VERSION",
+        "defaultValue": "WIN2D_VERSION_VALUE"
+      },
       "HostIdentifier": {
         "type": "bind",
         "binding": "HostIdentifier"

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -51,16 +51,12 @@
 		<PackageReference Include="Microsoft.WindowsAppSDK.Foundation" Version="WINDOWSAPPSDK_VERSION" />
 		<PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="WINDOWSAPPSDK_VERSION" />
 		<PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="WINDOWSAPPSDK_VERSION" NoWarn="NU1701" />
+		<PackageReference Include="Microsoft.Graphics.Win2D" Version="WIN2D_VERSION" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
 		<OutputType>WinExe</OutputType>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
-	</PropertyGroup>
-	
-	<PropertyGroup>
-		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Templates/src/templates/maui-lib/.template.config/template.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/template.json
@@ -14,12 +14,6 @@
     "sourceName": "MauiLib1",
     "preferNameDirectory": true,
     "symbols": {
-      "windowsAppSdkVersion": {
-        "type": "parameter",
-        "dataType": "string",
-        "replaces": "WINDOWSAPPSDK_VERSION",
-        "defaultValue": "WINDOWSAPPSDK_VERSION_VALUE"
-      }
     },
     "defaultName": "MauiLib1",
     "primaryOutputs": [

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -14,8 +14,4 @@
 		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.18362.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
-	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="WINDOWSAPPSDK_VERSION" />
-	</ItemGroup>
-
 </Project>

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -45,6 +45,12 @@
         "replaces": "WINDOWSAPPSDK_VERSION",
         "defaultValue": "WINDOWSAPPSDK_VERSION_VALUE"
       },
+      "win2dVersion": {
+        "type": "parameter",
+        "dataType": "string",
+        "replaces": "WIN2D_VERSION",
+        "defaultValue": "WIN2D_VERSION_VALUE"
+      },
       "HostIdentifier": {
         "type": "bind",
         "binding": "HostIdentifier"

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -51,6 +51,7 @@
 		<PackageReference Include="Microsoft.WindowsAppSDK.Foundation" Version="WINDOWSAPPSDK_VERSION" />
 		<PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="WINDOWSAPPSDK_VERSION" />
 		<PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="WINDOWSAPPSDK_VERSION" NoWarn="NU1701" />
+		<PackageReference Include="Microsoft.Graphics.Win2D" Version="WIN2D_VERSION" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
@@ -58,9 +59,4 @@
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 	
-	<PropertyGroup>
-		<!-- Required - WinUI can't deploy in a multi-targeting environment -->
-		<RuntimeIdentifier Condition="$(TargetFramework.Contains('-windows'))">win-x64</RuntimeIdentifier>
-	</PropertyGroup>
-
 </Project>


### PR DESCRIPTION
### Description of Change ###

Since we started making use of graphics views and shapes, we actually make use of Win2D features. As a result, we actually need to reference the native libraries in the app. It seems that they are only copied into the app via a targets file, and that is in the `build` folder.

We never noticed before since our sample in the repository directly references it, and when we do build with workloads, this is a runtime error.