### PR TITLE
Prevent layout cycle after ScrollView layout cycle check

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Maui.Controls
 			Thickness contentMargin = (Content as IView)?.Margin ?? Thickness.Zero;
 
 			// Account for the ScrollView's margins and use the rest of the available space to measure the actual Content
-			var contentWidthConstraint = widthConstraint - Margin.HorizontalThickness;
-			var contentHeightConstraint = heightConstraint - Margin.VerticalThickness;
+			var contentWidthConstraint = widthConstraint - Margin.HorizontalThickness - Padding.HorizontalThickness;
+			var contentHeightConstraint = heightConstraint - Margin.VerticalThickness - Padding.VerticalThickness;
 			(this as IContentView).CrossPlatformMeasure(contentWidthConstraint, contentHeightConstraint);
 
 			// Now measure the ScrollView itself (ComputeDesiredSize will account for the ScrollView margins)
@@ -118,10 +118,10 @@ namespace Microsoft.Maui.Controls
 				// Normally we'd just want the content to be arranged within the ContentView's Frame,
 				// but ScrollView content might be larger than the ScrollView itself (for obvious reasons)
 				// So in each dimension, we assume the larger of the two values.
-				var width = Math.Max(Frame.Width, content.DesiredSize.Width);
-				var height = Math.Max(Frame.Height, content.DesiredSize.Height);
+				bounds.Width = Math.Max(Frame.Width, content.DesiredSize.Width + Padding.HorizontalThickness);
+				bounds.Height = Math.Max(Frame.Height, content.DesiredSize.Height + Padding.VerticalThickness);
 
-				content.Arrange(new Rectangle(0, 0, width, height));
+				this.ArrangeContent(bounds);
 			}
 
 			return bounds.Size;

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -100,21 +100,16 @@ namespace Microsoft.Maui.Handlers
 			// ScrollViewer.Padding - the ScrollViewer puts the padding _outside_ of the scrollable area, which is not
 			// the behavior we want.
 
-			if (rect.X == 0 && rect.Y == 0)
-			{
-				return rect;
-			}
-
 			var margin = virtualView.Margin;
 			var padding = (virtualView.Parent as IPadding)?.Padding ?? Thickness.Zero;
 
 			var marginAndPadding = new Thickness(margin.Left + padding.Left, margin.Top + padding.Top,
 				margin.Right + padding.Right, margin.Bottom + padding.Bottom);
 
-			nativeView.Margin = marginAndPadding.ToNative();
+			var nativeMarginAndPadding = marginAndPadding.ToNative();
+			nativeView.Margin = nativeMarginAndPadding;
 
 			rect = new Rectangle(0, 0, rect.Width + marginAndPadding.HorizontalThickness, rect.Height + marginAndPadding.VerticalThickness);
-
 			return rect;
 		}
 	}

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			// The Windows ScrollViewer doesn't allow us to arrange content at an offset; it forces the content to 0,0
 			// So if we want to account for ScrollView.Padding and any margins on the ScrollView's Content, we need 
-			// do that by setting the Content's native Margin, and then update the bounds for Arrange to start
+			// to do that by setting the Content's native Margin, and then update the bounds for Arrange to start
 			// at 0,0 and be large enough to account for the updated margin.
 
 			// We include the cross-platform ScrollView's Padding here because we can't map it directly to 

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -93,8 +93,12 @@ namespace Microsoft.Maui.Handlers
 		{
 			// The Windows ScrollViewer doesn't allow us to arrange content at an offset; it forces the content to 0,0
 			// So if we want to account for ScrollView.Padding and any margins on the ScrollView's Content, we need 
-			// do do that by setting the Content's native Margin, and then update the bounds for Arrange to start
+			// do that by setting the Content's native Margin, and then update the bounds for Arrange to start
 			// at 0,0 and be large enough to account for the updated margin.
+
+			// We include the cross-platform ScrollView's Padding here because we can't map it directly to 
+			// ScrollViewer.Padding - the ScrollViewer puts the padding _outside_ of the scrollable area, which is not
+			// the behavior we want.
 
 			var margin = virtualView.Margin;
 			var padding = (virtualView.Parent as IPadding)?.Padding ?? Thickness.Zero;

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -100,6 +100,11 @@ namespace Microsoft.Maui.Handlers
 			// ScrollViewer.Padding - the ScrollViewer puts the padding _outside_ of the scrollable area, which is not
 			// the behavior we want.
 
+			if (rect.X == 0 && rect.Y == 0)
+			{
+				return rect;
+			}
+
 			var margin = virtualView.Margin;
 			var padding = (virtualView.Parent as IPadding)?.Padding ?? Thickness.Zero;
 


### PR DESCRIPTION
Adds a check to the Windows ScrollViewer offset check to leave the target Rectangle alone if it's already at the origin. Prevents layout cycles when resizing the window.

Related to #2755