### PR TITLE
[AndroidX.targets] Bump to net6.0-android31.0 AndroidX packages.

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -2,47 +2,47 @@
   <ItemGroup>
     <PackageReference
         Update="Xamarin.AndroidX.AppCompat.AppCompatResources"
-        Version="1.3.1.1"
+        Version="1.3.1.3"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Browser"
-        Version="1.3.0.6"
+        Version="1.3.0.8"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Legacy.Support.V4"
-        Version="1.0.0.8"
+        Version="1.0.0.10"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Lifecycle.LiveData"
-        Version="2.3.1.1"
+        Version="2.3.1.3"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.UI"
-        Version="2.3.5.1"
+        Version="2.3.5.3"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Fragment"
-        Version="2.3.5.1"
+        Version="2.3.5.3"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Runtime"
-        Version="2.3.5.1"
+        Version="2.3.5.3"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Common"
-        Version="2.3.5.1"
+        Version="2.3.5.3"
     />
     <PackageReference
         Update="Xamarin.AndroidX.MediaRouter"
-        Version="1.2.4.1"
+        Version="1.2.5.2"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Palette"
-        Version="1.0.0.8"
+        Version="1.0.0.10"
     />
     <PackageReference
         Update="Xamarin.AndroidX.RecyclerView"
-        Version="1.2.1.1"
+        Version="1.2.1.3"
     />
     <PackageReference
         Update="Xamarin.Build.Download"
@@ -50,7 +50,7 @@
     />
     <PackageReference
         Update="Xamarin.Google.Android.Material"
-        Version="1.4.0.2"
+        Version="1.4.0.4"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Migration"


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/issues/389

We have released a full refresh of our AndroidX packages (and their dependencies) adding support for `net6.0-android31.0`.

This PR bumps AndroidX dependencies to these new versions.

Note this PR is completely untested.