### PR TITLE
Load IConfigurationProviders once in WebApplicationBuilder

### DIFF
--- a/src/Controls/tests/Core.UnitTests/HostBuilderAppTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HostBuilderAppTests.cs
@@ -1,4 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Hosting;
 using NUnit.Framework;
@@ -41,6 +50,293 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var app2 = mauiApp.Services.GetRequiredService<IApplication>();
 
 			Assert.AreEqual(app1, app2);
+		}
+
+		[Test]
+		public void AddingMemoryStreamBackedConfigurationWorks()
+		{
+			var builder = MauiApp.CreateBuilder();
+
+			var jsonConfig = @"{ ""foo"": ""bar"" }";
+			using var ms = new MemoryStream();
+			using var sw = new StreamWriter(ms);
+			sw.WriteLine(jsonConfig);
+			sw.Flush();
+
+			ms.Position = 0;
+			builder.Configuration.AddJsonStream(ms);
+
+			Assert.AreEqual("bar", builder.Configuration["foo"]);
+
+			using var app = builder.Build();
+
+			Assert.AreEqual("bar", app.Configuration["foo"]);
+		}
+
+		[Test]
+		public void ConfigurationGetDebugViewWorks()
+		{
+			var builder = MauiApp.CreateBuilder();
+
+			builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["foo"] = "bar",
+			});
+
+			using var app = builder.Build();
+
+			// Make sure we don't lose "MemoryConfigurationProvider" from GetDebugView() when wrapping the provider.
+			Assert.True(((IConfigurationRoot)app.Configuration).GetDebugView().Contains("foo=bar (MemoryConfigurationProvider)"));
+		}
+
+		[Test]
+		public void ConfigurationProvidersAreLoadedOnceAfterBuild()
+		{
+			var builder = MauiApp.CreateBuilder();
+
+			var configSource = new TrackingConfigurationSource();
+			((IConfigurationBuilder)builder.Configuration).Sources.Add(configSource);
+
+			using var app = builder.Build();
+
+			Assert.AreEqual(1, configSource.ProvidersLoaded);
+		}
+
+		[Test]
+		public void ConfigurationProvidersAreDisposedWithMauiApp()
+		{
+			var builder = MauiApp.CreateBuilder();
+
+			var configSource = new TrackingConfigurationSource();
+			((IConfigurationBuilder)builder.Configuration).Sources.Add(configSource);
+
+			{
+				using var app = builder.Build();
+
+				Assert.AreEqual(0, configSource.ProvidersDisposed);
+			}
+
+			Assert.AreEqual(1, configSource.ProvidersDisposed);
+		}
+
+		[Test]
+		public void ConfigurationProviderTypesArePreserved()
+		{
+			var builder = MauiApp.CreateBuilder();
+
+			((IConfigurationBuilder)builder.Configuration).Sources.Add(new TrackingConfigurationSource());
+
+			var app = builder.Build();
+
+			Assert.That(((IConfigurationRoot)app.Configuration).Providers.OfType<TrackingConfigurationProvider>(), Has.One.Items);
+		}
+
+		[Test]
+		public void MauiAppCanObserveSourcesClearedInInnerBuild()
+		{
+			using var listener = new HostingListener(hostBuilder =>
+			{
+				hostBuilder.ConfigureHostConfiguration(config =>
+				{
+					// Clearing here would not remove the app config added via builder.Configuration.
+					config.AddInMemoryCollection(new Dictionary<string, string>()
+					{
+						{ "A", "A" },
+					});
+				});
+
+				hostBuilder.ConfigureAppConfiguration(config =>
+				{
+					// This clears both the chained host configuration and chained builder.Configuration.
+					config.Sources.Clear();
+					config.AddInMemoryCollection(new Dictionary<string, string>()
+					{
+						{ "B", "B" },
+					});
+				});
+			});
+
+			var builder = MauiApp.CreateBuilder();
+
+			builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>()
+			{
+				{ "C", "C" },
+			});
+
+			using var app = builder.Build();
+
+			Assert.True(string.IsNullOrEmpty(app.Configuration["A"]));
+			Assert.True(string.IsNullOrEmpty(app.Configuration["C"]));
+
+			Assert.AreEqual("B", app.Configuration["B"]);
+
+			Assert.AreSame(builder.Configuration, app.Configuration);
+		}
+
+		[Test]
+		public void MauiAppCanHandleStreamBackedConfigurationAddedInInnerBuild()
+		{
+			static Stream CreateStreamFromString(string data) => new MemoryStream(Encoding.UTF8.GetBytes(data));
+
+			using var jsonAStream = CreateStreamFromString(@"{ ""A"": ""A"" }");
+			using var jsonBStream = CreateStreamFromString(@"{ ""B"": ""B"" }");
+
+			using var listener = new HostingListener(hostBuilder =>
+			{
+				hostBuilder.ConfigureHostConfiguration(config => config.AddJsonStream(jsonAStream));
+				hostBuilder.ConfigureAppConfiguration(config => config.AddJsonStream(jsonBStream));
+			});
+
+			var builder = MauiApp.CreateBuilder();
+			using var app = builder.Build();
+
+			Assert.AreEqual("A", app.Configuration["A"]);
+			Assert.AreEqual("B", app.Configuration["B"]);
+
+			Assert.AreSame(builder.Configuration, app.Configuration);
+		}
+
+		[Test]
+		public void MauiAppDisposesConfigurationProvidersAddedInInnerBuild()
+		{
+			var hostConfigSource = new TrackingConfigurationSource();
+			var appConfigSource = new TrackingConfigurationSource();
+
+			using var listener = new HostingListener(hostBuilder =>
+			{
+				hostBuilder.ConfigureHostConfiguration(config => config.Add(hostConfigSource));
+				hostBuilder.ConfigureAppConfiguration(config => config.Add(appConfigSource));
+			});
+
+			var builder = MauiApp.CreateBuilder();
+
+			{
+				using var app = builder.Build();
+
+				Assert.AreEqual(1, hostConfigSource.ProvidersBuilt);
+				Assert.AreEqual(1, appConfigSource.ProvidersBuilt);
+				Assert.AreEqual(1, hostConfigSource.ProvidersLoaded);
+				Assert.AreEqual(1, appConfigSource.ProvidersLoaded);
+				Assert.AreEqual(0, hostConfigSource.ProvidersDisposed);
+				Assert.AreEqual(0, appConfigSource.ProvidersDisposed);
+			}
+
+			Assert.AreEqual(1, hostConfigSource.ProvidersBuilt);
+			Assert.AreEqual(1, appConfigSource.ProvidersBuilt);
+			Assert.AreEqual(1, hostConfigSource.ProvidersLoaded);
+			Assert.AreEqual(1, appConfigSource.ProvidersLoaded);
+			Assert.True(hostConfigSource.ProvidersDisposed > 0);
+			Assert.True(appConfigSource.ProvidersDisposed > 0);
+		}
+
+		[Test]
+		public void MauiAppMakesOriginalConfigurationProvidersAddedInBuildAccessable()
+		{
+			using var listener = new HostingListener(hostBuilder =>
+			{
+				hostBuilder.ConfigureAppConfiguration(config => config.Add(new TrackingConfigurationSource()));
+			});
+
+			var builder = MauiApp.CreateBuilder();
+			using var app = builder.Build();
+
+			var wrappedProviders = ((IConfigurationRoot)app.Configuration).Providers.OfType<IEnumerable<IConfigurationProvider>>();
+			var unwrappedProviders = wrappedProviders.Select(p =>
+			{
+				Assert.That(p, Has.One.Items);
+				return p.First();
+			});
+
+			Assert.That(unwrappedProviders.OfType<TrackingConfigurationProvider>(), Has.One.Items);
+		}
+
+		public class TrackingConfigurationSource : IConfigurationSource
+		{
+			public int ProvidersBuilt { get; set; }
+			public int ProvidersLoaded { get; set; }
+			public int ProvidersDisposed { get; set; }
+
+			public IConfigurationProvider Build(IConfigurationBuilder builder)
+			{
+				ProvidersBuilt++;
+				return new TrackingConfigurationProvider(this);
+			}
+		}
+
+		public class TrackingConfigurationProvider : ConfigurationProvider, IDisposable
+		{
+			private readonly TrackingConfigurationSource _source;
+
+			public TrackingConfigurationProvider(TrackingConfigurationSource source)
+			{
+				_source = source;
+			}
+
+			public override void Load()
+			{
+				_source.ProvidersLoaded++;
+			}
+
+			public void Dispose() => _source.ProvidersDisposed++;
+		}
+
+		private sealed class HostingListener : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object>>, IDisposable
+		{
+			private readonly Action<IHostBuilder> _configure;
+			private static readonly AsyncLocal<HostingListener> _currentListener = new();
+			private readonly IDisposable _subscription0;
+			private IDisposable _subscription1;
+
+			public HostingListener(Action<IHostBuilder> configure)
+			{
+				_configure = configure;
+
+				_subscription0 = DiagnosticListener.AllListeners.Subscribe(this);
+
+				_currentListener.Value = this;
+			}
+
+			public void OnCompleted()
+			{
+
+			}
+
+			public void OnError(Exception error)
+			{
+
+			}
+
+			public void OnNext(DiagnosticListener value)
+			{
+				if (_currentListener.Value != this)
+				{
+					// Ignore events that aren't for this listener
+					return;
+				}
+
+				if (value.Name == "Microsoft.Extensions.Hosting")
+				{
+					_subscription1 = value.Subscribe(this);
+				}
+			}
+
+			public void OnNext(KeyValuePair<string, object> value)
+			{
+				if (value.Key == "HostBuilding")
+				{
+					_configure?.Invoke((IHostBuilder)value.Value);
+				}
+			}
+
+			public void Dispose()
+			{
+				// Undo this here just in case the code unwinds synchronously since that doesn't revert
+				// the execution context to the original state. Only async methods do that on exit.
+				_currentListener.Value = null;
+
+				_subscription0.Dispose();
+				_subscription1?.Dispose();
+			}
 		}
 	}
 }

--- a/src/Core/src/Hosting/Internal/ConfigurationProviderSource.cs
+++ b/src/Core/src/Hosting/Internal/ConfigurationProviderSource.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Maui.Hosting
+{
+	internal sealed class ConfigurationProviderSource : IConfigurationSource
+	{
+		private readonly IConfigurationProvider _configurationProvider;
+
+		public ConfigurationProviderSource(IConfigurationProvider configurationProvider)
+		{
+			_configurationProvider = configurationProvider;
+		}
+
+		public IConfigurationProvider Build(IConfigurationBuilder builder)
+		{
+			return new IgnoreFirstLoadConfigurationProvider(_configurationProvider);
+		}
+
+		// These providers have already been loaded, so no need to reload initially.
+		// Otherwise, providers that cannot be reloaded like StreamConfigurationProviders will fail.
+		private sealed class IgnoreFirstLoadConfigurationProvider : IConfigurationProvider, IEnumerable<IConfigurationProvider>, IDisposable
+		{
+			private readonly IConfigurationProvider _provider;
+
+			private bool _hasIgnoredFirstLoad;
+
+			public IgnoreFirstLoadConfigurationProvider(IConfigurationProvider provider)
+			{
+				_provider = provider;
+			}
+
+			public IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string parentPath)
+			{
+				return _provider.GetChildKeys(earlierKeys, parentPath);
+			}
+
+			public IChangeToken GetReloadToken()
+			{
+				return _provider.GetReloadToken();
+			}
+
+			public void Load()
+			{
+				if (!_hasIgnoredFirstLoad)
+				{
+					_hasIgnoredFirstLoad = true;
+					return;
+				}
+
+				_provider.Load();
+			}
+
+			public void Set(string key, string value)
+			{
+				_provider.Set(key, value);
+			}
+
+			public bool TryGet(string key, out string value)
+			{
+				return _provider.TryGet(key, out value);
+			}
+
+			// Provide access to the original IConfigurationProvider via a single-element IEnumerable to code that goes out of its way to look for it.
+			public IEnumerator<IConfigurationProvider> GetEnumerator() => GetUnwrappedEnumerable().GetEnumerator();
+
+			IEnumerator IEnumerable.GetEnumerator() => GetUnwrappedEnumerable().GetEnumerator();
+
+			public override bool Equals(object? obj)
+			{
+				return _provider.Equals(obj);
+			}
+
+			public override int GetHashCode()
+			{
+				return _provider.GetHashCode();
+			}
+
+			public override string? ToString()
+			{
+				return _provider.ToString();
+			}
+
+			public void Dispose()
+			{
+				(_provider as IDisposable)?.Dispose();
+			}
+
+			private IEnumerable<IConfigurationProvider> GetUnwrappedEnumerable()
+			{
+				yield return _provider;
+			}
+		}
+	}
+}

--- a/src/Core/src/Hosting/Internal/TrackingChainedConfigurationSource.cs
+++ b/src/Core/src/Hosting/Internal/TrackingChainedConfigurationSource.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Maui.Hosting
+{
+	internal sealed class TrackingChainedConfigurationSource : IConfigurationSource
+	{
+		private readonly ChainedConfigurationSource _chainedConfigurationSource = new();
+
+		public TrackingChainedConfigurationSource(ConfigurationManager configManager)
+		{
+			_chainedConfigurationSource.Configuration = configManager;
+		}
+
+		public IConfigurationProvider? BuiltProvider { get; set; }
+
+		public IConfigurationProvider Build(IConfigurationBuilder builder)
+		{
+			BuiltProvider = _chainedConfigurationSource.Build(builder);
+			return BuiltProvider;
+		}
+	}
+}

--- a/src/Core/src/Hosting/MauiAppBuilder.cs
+++ b/src/Core/src/Hosting/MauiAppBuilder.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.EventLog;
-using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
 
 namespace Microsoft.Maui.Hosting
@@ -42,6 +42,8 @@ namespace Microsoft.Maui.Hosting
 
 			_logging = new LoggingBuilder(Services);
 			_host = new ConfigureHostBuilder(hostContext, Configuration, Services);
+
+			Services.AddSingleton<IConfiguration>(_ => Configuration);
 
 			if (useDefaults)
 			{
@@ -82,20 +84,22 @@ namespace Microsoft.Maui.Hosting
 		/// <returns>A configured <see cref="MauiApp"/>.</returns>
 		public MauiApp Build()
 		{
-			// Copy the configuration sources into the final IConfigurationBuilder
 			_hostBuilder.ConfigureHostConfiguration(builder =>
 			{
-				foreach (var source in ((IConfigurationBuilder)Configuration).Sources)
-				{
-					builder.Sources.Add(source);
-				}
+				builder.AddInMemoryCollection(new Dictionary<string, string> { { HostDefaults.ApplicationKey, BootstrapHostBuilder.GetDefaultApplicationName() } });
+			});
+
+			// Chain the configuration sources into the final IConfigurationBuilder
+			var chainedConfigSource = new TrackingChainedConfigurationSource(Configuration);
+
+			_hostBuilder.ConfigureAppConfiguration(builder =>
+			{
+				builder.Add(chainedConfigSource);
 
 				foreach (var kvp in ((IConfigurationBuilder)Configuration).Properties)
 				{
 					builder.Properties[kvp.Key] = kvp.Value;
 				}
-
-				builder.AddInMemoryCollection(new Dictionary<string, string> { { HostDefaults.ApplicationKey, BootstrapHostBuilder.GetDefaultApplicationName() } });
 			});
 
 			// This needs to go here to avoid adding the IHostedService that boots the server twice (the GenericWebHostService).
@@ -114,6 +118,25 @@ namespace Microsoft.Maui.Hosting
 				// Drop the reference to the existing collection and set the inner collection
 				// to the new one. This allows code that has references to the service collection to still function.
 				_services.InnerCollection = services;
+
+				var hostBuilderProviders = ((IConfigurationRoot)context.Configuration).Providers;
+
+				if (!hostBuilderProviders.Contains(chainedConfigSource.BuiltProvider))
+				{
+					// Something removed the _hostBuilder's TrackingChainedConfigurationSource pointing back to the ConfigurationManager.
+					// Replicate the effect by clearing the ConfingurationManager sources.
+					((IConfigurationBuilder)Configuration).Sources.Clear();
+				}
+
+				// Make builder.Configuration match the final configuration. To do that, we add the additional
+				// providers in the inner _hostBuilders's Configuration to the ConfigurationManager.
+				foreach (var provider in hostBuilderProviders)
+				{
+					if (!ReferenceEquals(provider, chainedConfigSource.BuiltProvider))
+					{
+						((IConfigurationBuilder)Configuration).Add(new ConfigurationProviderSource(provider));
+					}
+				}
 			});
 
 			// Run the other callbacks on the final host builder
@@ -121,14 +144,12 @@ namespace Microsoft.Maui.Hosting
 
 			_builtApplication = new MauiApp(_hostBuilder.Build());
 
-			// Make builder.Configuration match the final configuration. To do that
-			// we clear the sources and add the built configuration as a source
-			((IConfigurationBuilder)Configuration).Sources.Clear();
-			Configuration.AddConfiguration(_builtApplication.Configuration);
-
 			// Mark the service collection as read-only to prevent future modifications
 			_services.IsReadOnly = true;
 
+			// Resolve both the _hostBuilder's Configuration and builder.Configuration to mark both as resolved within the
+			// service provider ensuring both will be properly disposed with the provider.
+			_ = _builtApplication.Services.GetService<IEnumerable<IConfiguration>>();
 
 			var initServices = _builtApplication.Services.GetServices<IMauiInitializeService>();
 			if (initServices != null)
@@ -138,7 +159,6 @@ namespace Microsoft.Maui.Hosting
 					instance.Initialize(_builtApplication.Services);
 				}
 			}
-
 
 			return _builtApplication;
 		}

--- a/src/Core/src/Hosting/MauiAppBuilder.cs
+++ b/src/Core/src/Hosting/MauiAppBuilder.cs
@@ -86,7 +86,11 @@ namespace Microsoft.Maui.Hosting
 		{
 			_hostBuilder.ConfigureHostConfiguration(builder =>
 			{
-				builder.AddInMemoryCollection(new Dictionary<string, string> { { HostDefaults.ApplicationKey, BootstrapHostBuilder.GetDefaultApplicationName() } });
+				builder.AddInMemoryCollection(
+					new Dictionary<string, string> {
+						{ HostDefaults.ApplicationKey, BootstrapHostBuilder.GetDefaultApplicationName() },
+						{ HostDefaults.ContentRootKey,  Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) },
+					});
 			});
 
 			// Chain the configuration sources into the final IConfigurationBuilder


### PR DESCRIPTION
### Description of Change ###

This is the `MauiAppBuilder` version of https://github.com/dotnet/aspnetcore/pull/37039 which makes a similar change to ASP.NET Core's `WebApplicationBuilder. Do I need to open a backport PR targeting another branch for 6.0? @Eilon 

This updates `MauiAppBuilder` to only load `IConfigurationProvider`s once. Before this change, they would be loaded twice. Once by `ConfigurationManager` and then again by the inner generic host's `ConfigurationBuilder`.

This causes problems with `StreamConfigurationSource`s like the one used by `builder.Configuration.AddJsonStream(jsonStream)` throwing errors similar to the following:

```
System.Text.Json.JsonReaderException
  HResult=0x80131500
  Message=The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.
  Source=System.Text.Json
  StackTrace:
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException(Utf8JsonReader& json, ExceptionResource resource, Byte nextByte, ReadOnlySpan`1 bytes)
   at System.Text.Json.Utf8JsonReader.Read()
   at System.Text.Json.JsonDocument.Parse(ReadOnlySpan`1 utf8JsonSpan, JsonReaderOptions readerOptions, MetadataDb& database, StackRowStack& stack)
   at System.Text.Json.JsonDocument.Parse(ReadOnlyMemory`1 utf8Json, JsonReaderOptions readerOptions, Byte[] extraRentedArrayPoolBytes, PooledByteBufferWriter extraPooledByteBufferWriter)
   at System.Text.Json.JsonDocument.Parse(ReadOnlyMemory`1 json, JsonDocumentOptions options)
   at System.Text.Json.JsonDocument.Parse(String json, JsonDocumentOptions options)
   at Microsoft.Extensions.Configuration.Json.JsonConfigurationFileParser.ParseStream(Stream input)
   at Microsoft.Extensions.Configuration.Json.JsonStreamConfigurationProvider.Load(Stream stream)
   at Microsoft.Extensions.Configuration.StreamConfigurationProvider.Load()
   at Microsoft.Extensions.Configuration.ConfigurationRoot..ctor(IList`1 providers)
   at Microsoft.Extensions.Configuration.ConfigurationBuilder.Build()
   at Microsoft.Extensions.Hosting.HostBuilder.BuildAppConfiguration()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at Microsoft.AspNetCore.Builder.WebApplicationBuilder.Build()
```

Implements https://github.com/dotnet/aspnetcore/issues/37030

### Additions made ###
<!-- List all the additions made here, example:

- Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for Android and iOS
- Adds extension methods to apply Padding on Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on iOS and Android

 -->

* Adds HostBuilderAppTests
* Adds internal classes (No API change)

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
