### PR TITLE
Use new dispatcher instance in each BlazorWebView

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			var mauiAssetFileProvider = new AndroidMauiAssetFileProvider(Context.Assets, contentRootDir);
 
-			_webviewManager = new AndroidWebKitWebViewManager(this, NativeView, Services!, MauiDispatcher.Instance, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath);
+			_webviewManager = new AndroidWebKitWebViewManager(this, NativeView, Services!, ComponentsDispatcher, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -20,6 +20,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 		}
 
+#if !NETSTANDARD
+		private MauiDispatcher ComponentsDispatcher { get; } = new MauiDispatcher();
+#endif
+
 		public static void MapHostPage(BlazorWebViewHandler handler, IBlazorWebView webView)
 		{
 #if !NETSTANDARD

--- a/src/BlazorWebView/src/Maui/MauiDispatcher.cs
+++ b/src/BlazorWebView/src/Maui/MauiDispatcher.cs
@@ -4,14 +4,8 @@ using Microsoft.Maui.Controls;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
-	internal class MauiDispatcher : Dispatcher
+	internal sealed class MauiDispatcher : Dispatcher
 	{
-		public static Dispatcher Instance { get; } = new MauiDispatcher();
-
-		private MauiDispatcher()
-		{
-		}
-
 #pragma warning disable CA1416 // Validate platform compatibility
 		public override bool CheckAccess()
 		{

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			// WinUIWebViewManager so that loading static assets is done entirely there.
 			var mauiAssetFileProvider = new NullFileProvider();
 
-			_webviewManager = new WinUIWebViewManager(NativeView, new WinUIWebView2Wrapper(NativeView), Services!, MauiDispatcher.Instance, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath, contentRootDir);
+			_webviewManager = new WinUIWebViewManager(NativeView, new WinUIWebView2Wrapper(NativeView), Services!, ComponentsDispatcher, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath, contentRootDir);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			var mauiAssetFileProvider = new iOSMauiAssetFileProvider(contentRootDir);
 
-			_webviewManager = new IOSWebViewManager(this, NativeView, Services!, MauiDispatcher.Instance, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath);
+			_webviewManager = new IOSWebViewManager(this, NativeView, Services!, ComponentsDispatcher, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// </summary>
 		public BlazorWebView()
 		{
-			Dispatcher = new WindowsFormsDispatcher(this);
+			ComponentsDispatcher = new WindowsFormsDispatcher(this);
 
 			RootComponents.CollectionChanged += HandleRootComponentsCollectionChanged;
 
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// </summary>
 		public WebView2WebViewManager WebViewManager => _webviewManager;
 
-		private WindowsFormsDispatcher Dispatcher { get; }
+		private WindowsFormsDispatcher ComponentsDispatcher { get; }
 
 		/// <inheritdoc />
 		protected override void OnCreateControl()
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage);
 			var fileProvider = new PhysicalFileProvider(contentRootDir);
 
-			_webviewManager = new WebView2WebViewManager(new WindowsFormsWebView2Wrapper(_webview), Services, Dispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
+			_webviewManager = new WebView2WebViewManager(new WindowsFormsWebView2Wrapper(_webview), Services, ComponentsDispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
 
 			foreach (var rootComponent in RootComponents)
 			{
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			if (_webviewManager != null)
 			{
 				// Dispatch because this is going to be async, and we want to catch any errors
-				_ = Dispatcher.InvokeAsync(async () =>
+				_ = ComponentsDispatcher.InvokeAsync(async () =>
 				{
 					var newItems = eventArgs.NewItems.Cast<RootComponent>();
 					var oldItems = eventArgs.OldItems.Cast<RootComponent>();

--- a/src/BlazorWebView/src/WindowsForms/WindowsFormsDispatcher.cs
+++ b/src/BlazorWebView/src/WindowsForms/WindowsFormsDispatcher.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 	/// class uses the async <see cref="Task"/> pattern so everything must be mapped from the <see cref="IAsyncResult"/>
 	/// pattern using techniques listed in https://docs.microsoft.com/dotnet/standard/asynchronous-programming-patterns/interop-with-other-asynchronous-patterns-and-types.
 	/// </summary>
-	internal class WindowsFormsDispatcher : Dispatcher
+	internal sealed class WindowsFormsDispatcher : Dispatcher
 	{
 		private static Action<Exception> RethrowException = exception =>
 			ExceptionDispatchInfo.Capture(exception).Throw();

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -59,6 +59,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		/// </summary>
 		public BlazorWebView()
 		{
+			ComponentsDispatcher = new WpfDispatcher(Application.Current.Dispatcher);
+
 			SetValue(RootComponentsProperty, new RootComponentsCollection());
 			RootComponents.CollectionChanged += HandleRootComponentsCollectionChanged;
 
@@ -156,7 +158,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage);
 			var fileProvider = new PhysicalFileProvider(contentRootDir);
 
-			_webviewManager = new WebView2WebViewManager(new WpfWebView2Wrapper(_webview), Services, WpfDispatcher.Instance, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
+			_webviewManager = new WebView2WebViewManager(new WpfWebView2Wrapper(_webview), Services, ComponentsDispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
 			foreach (var rootComponent in RootComponents)
 			{
 				// Since the page isn't loaded yet, this will always complete synchronously
@@ -164,6 +166,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			}
 			_webviewManager.Navigate("/");
 		}
+
+		private WpfDispatcher ComponentsDispatcher { get; }
 
 		private void HandleRootComponentsCollectionChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
 		{
@@ -173,7 +177,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			if (_webviewManager != null)
 			{
 				// Dispatch because this is going to be async, and we want to catch any errors
-				WpfDispatcher.Instance.InvokeAsync(async () =>
+				_ = ComponentsDispatcher.InvokeAsync(async () =>
 				{
 					var newItems = eventArgs.NewItems.Cast<RootComponent>();
 					var oldItems = eventArgs.OldItems.Cast<RootComponent>();

--- a/src/BlazorWebView/src/Wpf/WpfDispatcher.cs
+++ b/src/BlazorWebView/src/Wpf/WpfDispatcher.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-using System.Windows;
 using WindowsDispatcher = System.Windows.Threading.Dispatcher;
 
 namespace Microsoft.AspNetCore.Components.WebView.Wpf
@@ -13,12 +12,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 	{
 		private readonly WindowsDispatcher _windowsDispatcher;
 
-		private WpfDispatcher(WindowsDispatcher windowsDispatcher)
+		public WpfDispatcher(WindowsDispatcher windowsDispatcher)
 		{
 			_windowsDispatcher = windowsDispatcher ?? throw new ArgumentNullException(nameof(windowsDispatcher));
 		}
-
-		public static Dispatcher Instance { get; } = new WpfDispatcher(Application.Current.Dispatcher);
 
 		private static Action<Exception> RethrowException = exception =>
 			ExceptionDispatchInfo.Capture(exception).Throw();


### PR DESCRIPTION
The Components Dispatcher has some new per-BlazorWebView state, so we must create a new Dispatcher for each BlazorWebView, or else they will erroneously share some state. This was already the case in WinForms, but WPF and MAUI had to change. The code was updated in all 3 platforms to match each other more closely.

Fixes #2828