### PR TITLE
Add `ITextButton` and related Mappers

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Button/Button.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.Impl.cs
@@ -1,7 +1,9 @@
 namespace Microsoft.Maui.Controls
 {
-	public partial class Button : IButton, IText
+	public partial class Button : IButton, ITextButton, IImageButton
 	{
+		bool _wasImageLoading;
+
 		void IButton.Clicked()
 		{
 			(this as IButtonController).SendClicked();
@@ -17,13 +19,22 @@ namespace Microsoft.Maui.Controls
 			(this as IButtonController).SendReleased();
 		}
 
-		void IButton.ImageSourceLoaded()
+		void IImageSourcePart.UpdateIsLoading(bool isLoading)
 		{
-			Handler?.UpdateValue(nameof(ContentLayout));
+			if (!isLoading && _wasImageLoading)
+				Handler?.UpdateValue(nameof(ContentLayout));
+
+			_wasImageLoading = isLoading;
 		}
 
-		IImageSource IButton.ImageSource => ImageSource;
-
 		Font ITextStyle.Font => (Font)GetValue(FontElement.FontProperty);
+
+		Aspect IImage.Aspect => Aspect.Fill;
+
+		bool IImage.IsOpaque => true;
+
+		IImageSource IImageSourcePart.Source => ImageSource;
+
+		bool IImageSourcePart.IsAnimationPlaying => false;
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Button/Button.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Maui.Controls
 				[nameof(Padding)] = MapPadding,
 #endif
 #if WINDOWS
-			[nameof(IText.Text)] = MapText,
-			[nameof(IButton.ImageSource)] = MapImageSource
+				[nameof(IText.Text)] = MapText,
+				[nameof(ImageSource)] = MapImageSource
 #endif
 			};
 

--- a/src/Controls/src/Core/HandlerImpl/ImageButton/ImageButton.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ImageButton/ImageButton.Impl.cs
@@ -26,11 +26,5 @@ namespace Microsoft.Maui.Controls
 		{
 			(this as IButtonController).SendReleased();
 		}
-
-		void IButton.ImageSourceLoaded()
-		{
-		}
-
-		IImageSource IButton.ImageSource => Source;
 	}
 }

--- a/src/Core/src/Core/IButton.cs
+++ b/src/Core/src/Core/IButton.cs
@@ -6,14 +6,6 @@ namespace Microsoft.Maui
 	public interface IButton : IView, IPadding
 	{
 		/// <summary>
-		/// Allows you to display a bitmap image on the Button.
-		/// </summary>
-		IImageSource? ImageSource { get; }
-
-
-		void ImageSourceLoaded();
-
-		/// <summary>
 		/// Occurs when the Button is pressed.
 		/// </summary>
 		void Pressed();

--- a/src/Core/src/Core/IText.cs
+++ b/src/Core/src/Core/IText.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Provides functionality to be able to customize Text.
 	/// </summary>
-	public interface IText : ITextStyle, IElement
+	public interface IText : ITextStyle
 	{
 		/// <summary>
 		/// Gets the text.

--- a/src/Core/src/Core/ITextButton.cs
+++ b/src/Core/src/Core/ITextButton.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Maui
+{
+	public interface ITextButton : IView, IButton, IText
+	{
+	}
+}

--- a/src/Core/src/Core/ITextStyle.cs
+++ b/src/Core/src/Core/ITextStyle.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Provides functionality to be able to customize the appearance of text.
 	/// </summary>
-	public interface ITextStyle : IElement
+	public interface ITextStyle
 	{
 		/// <summary>
 		/// Gets the text color.

--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -105,23 +105,17 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdatePadding(button, DefaultPadding);
 		}
 
-		public static void MapImageSource(IButtonHandler handler, IButton image) =>
+		public static void MapImageSource(IButtonHandler handler, IImageButton image) =>
 			MapImageSourceAsync(handler, image).FireAndForget(handler);
 
-		public static Task MapImageSourceAsync(IButtonHandler handler, IButton image)
+		public static Task MapImageSourceAsync(IButtonHandler handler, IImageButton image)
 		{
-			if (image.ImageSource == null)
-			{
-				return Task.CompletedTask;
-			}
-
 			return handler.ImageSourceLoader.UpdateImageSourceAsync();
 		}
 
 		void OnSetImageSource(Drawable? obj)
 		{
 			NativeView.Icon = obj;
-			VirtualView?.ImageSourceLoaded();
 		}
 
 		bool NeedsExactMeasure()

--- a/src/Core/src/Handlers/Button/ButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.cs
@@ -14,25 +14,25 @@ namespace Microsoft.Maui.Handlers
 	{
 		ImageSourcePartLoader? _imageSourcePartLoader;
 		public ImageSourcePartLoader ImageSourceLoader =>
-			_imageSourcePartLoader ??= new ImageSourcePartLoader(this, () => VirtualView?.ImageSource, OnSetImageSource);
+			_imageSourcePartLoader ??= new ImageSourcePartLoader(this, () => (VirtualView as IImageButton), OnSetImageSource);
 
-		public static IPropertyMapper<ITextStyle, IButtonHandler> TextStyleMapper = new PropertyMapper<ITextStyle, IButtonHandler>(ViewHandler.ViewMapper)
+		public static IPropertyMapper<IImageButton, IButtonHandler> ImageButtonMapper = new PropertyMapper<IImageButton, IButtonHandler>()
+		{
+			[nameof(IImageButton.Source)] = MapImageSource,
+		};
+
+		public static IPropertyMapper<ITextButton, IButtonHandler> TextButtonMapper = new PropertyMapper<ITextButton, IButtonHandler>()
 		{
 			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(ITextStyle.Font)] = MapFont,
 			[nameof(ITextStyle.TextColor)] = MapTextColor,
-		};
-
-		public static IPropertyMapper<IText, IButtonHandler> TextMapper = new PropertyMapper<IText, IButtonHandler>(TextStyleMapper)
-		{
 			[nameof(IText.Text)] = MapText,
 		};
 
-		public static IPropertyMapper<IButton, IButtonHandler> Mapper = new PropertyMapper<IButton, IButtonHandler>(TextMapper)
+		public static IPropertyMapper<IButton, IButtonHandler> Mapper = new PropertyMapper<IButton, IButtonHandler>(TextButtonMapper, ImageButtonMapper, ViewHandler.ViewMapper)
 		{
 			[nameof(IButton.Background)] = MapBackground,
 			[nameof(IButton.Padding)] = MapPadding,
-			[nameof(IButton.ImageSource)] = MapImageSource
 		};
 
 		public ButtonHandler() : base(Mapper)

--- a/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
@@ -92,16 +92,14 @@ namespace Microsoft.Maui.Handlers
 			{
 				NativeView.SetImage(null, UIControlState.Normal);
 			}
-
-			VirtualView.ImageSourceLoaded();
 		}
 
-		public static void MapImageSource(IButtonHandler handler, IButton image) =>
+		public static void MapImageSource(IButtonHandler handler, IImageButton image) =>
 			MapImageSourceAsync(handler, image).FireAndForget(handler);
 
-		public static Task MapImageSourceAsync(IButtonHandler handler, IButton image)
+		public static Task MapImageSourceAsync(IButtonHandler handler, IImageButton image)
 		{
-			if (image.ImageSource == null)
+			if (image.Source == null)
 			{
 				return Task.CompletedTask;
 			}

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Handlers
 				var map = imv.GetPropertyMapperOverrides();
 				if (map is not null)
 				{
-					map.Chained = _defaultMapper;
+					map.Chained = new[] { _defaultMapper };
 					_mapper = map;
 				}
 			}

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Handlers
 #if __IOS__
 		UIKit.UIImageView IImageHandler.TypedNativeView => NativeView.ImageView;
 #elif WINDOWS
-		UI.Xaml.Controls.Image IImageHandler.TypedNativeView => (UI.Xaml.Controls.Image)NativeView.Content;
+		UI.Xaml.Controls.Image IImageHandler.TypedNativeView => NativeView.GetImage() ?? (UI.Xaml.Controls.Image)NativeView.Content;
 #elif __ANDROID__
 		Android.Widget.ImageView IImageHandler.TypedNativeView => NativeView;
 #else

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -42,16 +42,16 @@ namespace Microsoft.Maui
 			SetImage = setImage;
 		}
 
-		internal ImageSourcePartLoader(
-			IElementHandler handler,
-			Func<IImageSource?> imageSource,
-			Action<NativeImage?> setImage)
-		{
-			Handler = handler;
-			var wrapper = new ImageSourcePartWrapper(imageSource);
-			_imageSourcePart = () => wrapper;
-			SetImage = setImage;
-		}
+		//internal ImageSourcePartLoader(
+		//	IElementHandler handler,
+		//	Func<IImageSource?> imageSource,
+		//	Action<NativeImage?> setImage)
+		//{
+		//	Handler = handler;
+		//	var wrapper = new ImageSourcePartWrapper(imageSource);
+		//	_imageSourcePart = () => wrapper;
+		//	SetImage = setImage;
+		//}
 
 		public void Reset()
 		{
@@ -81,27 +81,6 @@ namespace Microsoft.Maui
 					SetImage?.Invoke(null);
 					SourceManager.CompleteLoad(null);
 				}
-			}
-		}
-
-		// TODO MAUI: This is currently here so that Button can continue to use IImageSource
-		// At a later point once we further define the interface for IButtonHandler we will probably
-		// change IButton to return an IImageSourcePart and we can get rid of this class
-		class ImageSourcePartWrapper : IImageSourcePart
-		{
-			readonly Func<IImageSource?> _imageSource;
-
-			public ImageSourcePartWrapper(Func<IImageSource?> imageSource)
-			{
-				_imageSource = imageSource;
-			}
-
-			IImageSource? IImageSourcePart.Source => _imageSource.Invoke();
-
-			bool IImageSourcePart.IsAnimationPlaying => false;
-
-			void IImageSourcePart.UpdateIsLoading(bool isLoading)
-			{
 			}
 		}
 	}

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -42,17 +42,6 @@ namespace Microsoft.Maui
 			SetImage = setImage;
 		}
 
-		//internal ImageSourcePartLoader(
-		//	IElementHandler handler,
-		//	Func<IImageSource?> imageSource,
-		//	Action<NativeImage?> setImage)
-		//{
-		//	Handler = handler;
-		//	var wrapper = new ImageSourcePartWrapper(imageSource);
-		//	_imageSourcePart = () => wrapper;
-		//	SetImage = setImage;
-		//}
-
 		public void Reset()
 		{
 			SourceManager.Reset();

--- a/src/Core/src/Platform/Windows/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Windows/ButtonExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui
 				image = contentImage;
 			}
 			// This means the users image hasn't loaded yet but we still want to setup the container for the user
-			else if (button.ImageSource != null)
+			else if (button is IImageButton ib && ib.Source != null)
 			{
 				image = nativeButton.GetImage() ?? new();
 			}

--- a/src/Core/tests/DeviceTests/Stubs/ButtonStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ButtonStub.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	public partial class ButtonStub : StubBase, IButton, IText
+	public partial class ButtonStub : StubBase, IButton, ITextButton, IImageButton
 	{
 		public string Text { get; set; }
 
@@ -16,6 +16,16 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public Thickness Padding { get; set; }
 
 		public IImageSource ImageSource { get; set; }
+
+		Aspect IImage.Aspect => Aspect.Fill;
+
+		bool IImage.IsOpaque => true;
+
+		IImageSource IImageSourcePart.Source => ImageSource;
+
+		bool IImageSourcePart.IsAnimationPlaying => false;
+
+		void IImageSourcePart.UpdateIsLoading(bool isLoading) { }
 
 		public event EventHandler Pressed;
 		public event EventHandler Released;

--- a/src/Core/tests/DeviceTests/Stubs/ImageButtonStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ImageButtonStub.cs
@@ -47,10 +47,5 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		void IButton.Pressed() => Pressed?.Invoke(this, EventArgs.Empty);
 		void IButton.Released() => Released?.Invoke(this, EventArgs.Empty);
 		void IButton.Clicked() => Clicked?.Invoke(this, EventArgs.Empty);
-
-		void IButton.ImageSourceLoaded()
-		{
-			throw new NotImplementedException();
-		}
 	}
 }

--- a/src/Core/tests/UnitTests/PropertyMapperTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperTests.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Maui.UnitTests
 				[nameof(IView.Background)] = (r, v) => wasMapper1Called = true
 			};
 
-			var mapper2 = new PropertyMapper<ITextStyle>(mapper1)
+			var mapper2 = new PropertyMapper<ITextButton>(mapper1)
 			{
-				[nameof(ITextStyle.TextColor)] = (r, v) => wasMapper2Called = true
+				[nameof(ITextButton.TextColor)] = (r, v) => wasMapper2Called = true
 			};
 
 			mapper2.UpdateProperties(null, new Button());
@@ -50,6 +50,53 @@ namespace Microsoft.Maui.UnitTests
 			Assert.True(wasMapper1Called);
 			Assert.True(wasMapper2Called);
 		}
+
+
+		[Fact]
+		public void ConstructorChainingMappersWorks()
+		{
+			bool wasMapper1Called = false;
+			bool wasMapper2Called = false;
+			var mapper1 = new PropertyMapper<IView>
+			{
+				[nameof(IView.Background)] = (r, v) => wasMapper1Called = true
+			};
+
+			var mapper2 = new PropertyMapper<ITextButton>()
+			{
+				[nameof(ITextButton.TextColor)] = (r, v) => wasMapper2Called = true
+			};
+
+
+			new PropertyMapper<ITextButton>(mapper2, mapper1)
+				.UpdateProperties(null, new Button());
+
+			Assert.True(wasMapper1Called);
+			Assert.True(wasMapper2Called);
+		}
+
+		[Fact]
+		public void ConstructorChainingMappersOverrideBase()
+		{
+			bool wasMapper1Called = false;
+			bool wasMapper2Called = false;
+			var mapper1 = new PropertyMapper<IView>
+			{
+				[nameof(IView.Background)] = (r, v) => wasMapper1Called = true
+			};
+
+			var mapper2 = new PropertyMapper<IButton>()
+			{
+				[nameof(IView.Background)] = (r, v) => wasMapper2Called = true
+			};
+
+			new PropertyMapper<ITextButton>(mapper2, mapper1)
+				.UpdateProperties(null, new Button());
+
+			Assert.False(wasMapper1Called);
+			Assert.True(wasMapper2Called);
+		}
+
 
 		[Fact]
 		public void ChainingMappersStillAllowReplacingChainedRoot()
@@ -62,9 +109,9 @@ namespace Microsoft.Maui.UnitTests
 				[nameof(IView.Background)] = (r, v) => wasMapper1Called = true
 			};
 
-			var mapper2 = new PropertyMapper<ITextStyle>(mapper1)
+			var mapper2 = new PropertyMapper<ITextButton>(mapper1)
 			{
-				[nameof(ITextStyle.TextColor)] = (r, v) => wasMapper2Called = true
+				[nameof(ITextButton.TextColor)] = (r, v) => wasMapper2Called = true
 			};
 
 			mapper1[nameof(IView.Background)] = (r, v) => wasMapper3Called = true;

--- a/src/Core/tests/UnitTests/TestClasses/ButtonStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ButtonStub.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.UnitTests
 {
-	class ButtonStub : View, IButton, IText
+	class ButtonStub : View, IButton, ITextButton, IImageButton
 	{
 		public string Text { get; set; }
 
@@ -22,6 +22,15 @@ namespace Microsoft.Maui.UnitTests
 		public Font Font { get; set; }
 
 		public IImageSource ImageSource { get; set; }
+		Aspect IImage.Aspect => Aspect.Fill;
+
+		bool IImage.IsOpaque => true;
+
+		IImageSource IImageSourcePart.Source => ImageSource;
+
+		bool IImageSourcePart.IsAnimationPlaying => false;
+
+		void IImageSourcePart.UpdateIsLoading(bool isLoading) { }
 
 		public void ImageSourceLoaded()
 		{


### PR DESCRIPTION
### Description of Change ###

This adds the interface `ITextButton` and a related mapper to `ButtonHandler`. Previously I made it so `IText` and `ITextStyle` would inherit from `IElement` but it makes more sense to just have an `ITextButton`

The Controls Button now implements both `ITextButton` and `IImageButton`

`IButton` has been simplified to only have methods that relate to being a `clickable` type element

#### ButtonHandler

Currently `ButtonHandler` doesn't implement all aspects of the `IImageButton` API. Mainly because (AFAIK) we'd have to override `Draw` on Android in order to modify the `Drawable` on the AppCompatButton to obey the aspect properties. The `Drawable` part of a the Button on Android isn't represented by a native `ImageView`. At a later point we (or someone) can fill the rest of those properties in but for now this covers the APIs that we have. 

#### Property Mapper Changes
Modified PropertyMapper so that you can add multiple mappers inside of a constructor. This felt necessary because I wanted the Mapper for ButtonHandler to chain to both `ImageButtonMapper` and `TextButtonMapper`

### Additions made ###

```C#
public interface ITextButton : IView, IButton, IText
{
}
```

```C#
public partial class ButtonHandler : IButtonHandler
{
	public static IPropertyMapper<IImageButton, IButtonHandler> ImageButtonMapper = new PropertyMapper<IImageButton, IButtonHandler>()
	{
		[nameof(IImageButton.Source)] = MapImageSource,
	};

	public static IPropertyMapper<ITextButton, IButtonHandler> TextButtonMapper = new PropertyMapper<ITextButton, IButtonHandler>()
	{
		[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
		[nameof(ITextStyle.Font)] = MapFont,
		[nameof(ITextStyle.TextColor)] = MapTextColor,
		[nameof(IText.Text)] = MapText,
	};
```

Chained now accepts an array of chained mappers. Which allows us to composite multiple mappers together more easily
```C#
public PropertyMapper(params IPropertyMapper[] chained) : base(chained)
{
}
```

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
