### PR TITLE
Apply layout updates to ShellPageContainer child pages

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Shell/ShellPageContainer.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellPageContainer.cs
@@ -26,15 +26,12 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-
-
-
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			var width = r - l;
 			var height = b - t;
 
-			if (changed && Child.NativeView is AView aView)
+			if (Child.NativeView is AView aView)
 				aView.Layout(0, 0, width, height);
 		}
 	}


### PR DESCRIPTION
Fixes #2834 for Android

ShellPageContainer is only applying layout updates to its child page if the size or location of ShellPageContainer itself changes; otherwise, it ignores the layout request. This change removes the `changed` check so that the page content can be lay itself out.
