### PR TITLE
Request a re-layout if visibility started as Collapsed

### DIFF
--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui
 		public static void UpdateVisibility(this FrameworkElement nativeView, IView view)
 		{
 			double opacity = view.Opacity;
+			var wasCollapsed = nativeView.Visibility == UI.Xaml.Visibility.Collapsed;
 
 			switch (view.Visibility)
 			{
@@ -42,6 +43,12 @@ namespace Microsoft.Maui
 					nativeView.Opacity = opacity;
 					nativeView.Visibility = UI.Xaml.Visibility.Collapsed;
 					break;
+			}
+
+			if (view.Visibility != Visibility.Collapsed && wasCollapsed)
+			{
+				// We may need to force the parent layout (if any) to re-layout to accomodate the new size
+				(nativeView.Parent as FrameworkElement)?.InvalidateMeasure();
 			}
 		}
 


### PR DESCRIPTION
Fixes #2834 on Windows

If the view is initially Collapsed on Windows, just changing it to Visible doesn't trigger a re-layout in some circumstances. This change makes a re-layout request when changing from Collapsed to a Visibility which occupies space. If a re-layout request was already in play, this has no effect; if not, then this will tell the parent to re-layout the children accounting for the new size.