### PR TITLE
Customize Android and Windows ScrollView behavior to include Padding inside of scroll area

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -24,14 +24,7 @@ namespace Microsoft.Maui.Controls
 
 		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			var content = (this as IContentView).PresentedContent;
-			var padding = Padding;
-
-			if (content != null)
-			{
-				_ = content.Measure(widthConstraint - padding.HorizontalThickness, heightConstraint - padding.VerticalThickness);
-			}
-
+			_ = this.MeasureContent(widthConstraint, heightConstraint);
 			return new Size(widthConstraint, heightConstraint);
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -44,60 +44,36 @@ namespace Microsoft.Maui.Controls
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
-			Thickness contentMargin = (Content as IView)?.Margin ?? Thickness.Zero;
-
-			// Account for the ScrollView's margins and use the rest of the available space to measure the actual Content
-			var contentWidthConstraint = widthConstraint - Margin.HorizontalThickness;
-			var contentHeightConstraint = heightConstraint - Margin.VerticalThickness;
-			(this as IContentView).CrossPlatformMeasure(contentWidthConstraint, contentHeightConstraint);
-
-			// Now measure the ScrollView itself (ComputeDesiredSize will account for the ScrollView margins)
-			var defaultSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-
-			// The value from ComputeDesiredSize won't account for any margins on the Content; we'll need to do that manually
-			// And we'll use ResolveConstraints to make sure we're sticking within and explicit Height/Width values or externally
-			// imposed constraints
-			var width = (this as IView).Width;
-			var height = (this as IView).Height;
-
-			var desiredWidth = ResolveConstraints(widthConstraint, width, defaultSize.Width + contentMargin.HorizontalThickness);
-			var desiredHeight = ResolveConstraints(heightConstraint, height, defaultSize.Height + contentMargin.VerticalThickness);
-
-			DesiredSize = new Size(desiredWidth, desiredHeight);
+			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
 			return DesiredSize;
 		}
 
-		Size IContentView.CrossPlatformMeasure(double contentWidthConstraint, double contentHeightConstraint)
+		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			if (Content == null)
+			if ((this as IContentView)?.PresentedContent is not IView content)
 			{
-				return Size.Zero;
-			}
-
-			if (Content is not IView content)
-			{
-				return Content.DesiredSize;
+				ContentSize = Size.Zero;
+				return ContentSize;
 			}
 
 			switch (Orientation)
 			{
 				case ScrollOrientation.Horizontal:
-					contentWidthConstraint = double.PositiveInfinity;
+					widthConstraint = double.PositiveInfinity;
 					break;
 				case ScrollOrientation.Neither:
 				case ScrollOrientation.Both:
-					contentHeightConstraint = double.PositiveInfinity;
-					contentWidthConstraint = double.PositiveInfinity;
+					heightConstraint = double.PositiveInfinity;
+					widthConstraint = double.PositiveInfinity;
 					break;
 				case ScrollOrientation.Vertical:
 				default:
-					contentHeightConstraint = double.PositiveInfinity;
+					heightConstraint = double.PositiveInfinity;
 					break;
 			}
 
-			content.Measure(contentWidthConstraint, contentHeightConstraint);
+			content.Measure(widthConstraint, heightConstraint);
 			ContentSize = content.DesiredSize;
-
 			return ContentSize;
 		}
 
@@ -113,15 +89,17 @@ namespace Microsoft.Maui.Controls
 
 		Size IContentView.CrossPlatformArrange(Rectangle bounds)
 		{
-			if (Content is IView content)
+			if ((this as IContentView).PresentedContent is IView presentedContent)
 			{
+				var padding = Padding;
+
 				// Normally we'd just want the content to be arranged within the ContentView's Frame,
 				// but ScrollView content might be larger than the ScrollView itself (for obvious reasons)
 				// So in each dimension, we assume the larger of the two values.
-				var width = Math.Max(Frame.Width, content.DesiredSize.Width);
-				var height = Math.Max(Frame.Height, content.DesiredSize.Height);
+				bounds.Width = Math.Max(Frame.Width, presentedContent.DesiredSize.Width + padding.HorizontalThickness);
+				bounds.Height = Math.Max(Frame.Height, presentedContent.DesiredSize.Height + padding.VerticalThickness);
 
-				content.Arrange(new Rectangle(0, 0, width, height));
+				(this as IContentView).ArrangeContent(bounds);
 			}
 
 			return bounds.Size;

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -1,9 +1,14 @@
-﻿using Android.Views;
+﻿using System;
+using Android.Views;
+using Microsoft.Maui.Graphics;
+using static Microsoft.Maui.Layouts.LayoutExtensions;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class ScrollViewHandler : ViewHandler<IScrollView, MauiScrollView>
 	{
+		const string InsetPanelTag = "MAUIContentInsetPanel";
+
 		protected override MauiScrollView CreateNativeView()
 		{
 			return new MauiScrollView(
@@ -41,7 +46,14 @@ namespace Microsoft.Maui.Handlers
 			if (handler.NativeView == null || handler.MauiContext == null)
 				return;
 
-			handler.NativeView.UpdateContent(scrollView.PresentedContent, handler.MauiContext);
+			if (NeedsInsetView(scrollView))
+			{
+				UpdateInsetView(scrollView, handler);
+			}
+			else
+			{
+				handler.NativeView.UpdateContent(scrollView.PresentedContent, handler.MauiContext);
+			}
 		}
 
 		public static void MapHorizontalScrollBarVisibility(ScrollViewHandler handler, IScrollView scrollView)
@@ -78,6 +90,124 @@ namespace Microsoft.Maui.Handlers
 
 			handler.NativeView.ScrollTo(horizontalOffsetDevice, verticalOffsetDevice,
 				request.Instant, () => handler.VirtualView.ScrollFinished());
+		}
+
+		/*
+			Problem 1: Android treats Padding differently than what we want for MAUI; Padding creates space
+			_around_ the scrollable area, rather than padding the content inside of it. 
+			
+			Problem 2: The Android ScrollView control will ignore the cross-platform Margin of its content when 
+			making native Measure calls. The internal content size values recorded by the native ScrollView will 
+			not account for the margin, and the control won't scroll all the way to the bottom of the content. 
+
+			To handle both issues, we detect whether the content has a Margin or the cross-platform ScrollView has a Padding;
+			if so, we insert a container ContentViewGroup which always lays out at the origin but provides both the Padding
+			and the Margin for the content. The extra layer is only inserted if necessary, and is removed if the Padding
+			and Margin are set to zero. The extra layer uses the native ContentViewGroup control (the same one we already 
+			use as the backing for ContentView, Page, etc.). 
+
+			The methods below exist to support inserting/updating the extra padding/margin layer.
+		*/
+
+		static bool NeedsInsetView(IScrollView scrollView)
+		{
+			if (scrollView.PresentedContent == null)
+			{
+				return false;
+			}
+
+			if (scrollView.Padding != Thickness.Zero)
+			{
+				return true;
+			}
+
+			if (scrollView.PresentedContent.Margin != Thickness.Zero)
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		static void UpdateInsetView(IScrollView scrollView, ScrollViewHandler handler)
+		{
+			if (scrollView.PresentedContent == null || handler.MauiContext == null)
+			{
+				return;
+			}
+
+			var nativeContent = scrollView.PresentedContent.ToNative(handler.MauiContext);
+
+			if (handler.NativeView.FindViewWithTag(InsetPanelTag) is ContentViewGroup currentPaddingLayer)
+			{
+				if (currentPaddingLayer.ChildCount == 0 || currentPaddingLayer.GetChildAt(0) != nativeContent)
+				{
+					currentPaddingLayer.RemoveAllViews();
+					currentPaddingLayer.AddView(nativeContent);
+				}
+			}
+			else
+			{
+				InsertInsetView(handler, scrollView, nativeContent);
+			}
+		}
+
+		static void InsertInsetView(ScrollViewHandler handler, IScrollView scrollView, View nativeContent)
+		{
+			if (scrollView.PresentedContent == null || handler.MauiContext?.Context == null)
+			{
+				return;
+			}
+
+			var paddingShim = new ContentViewGroup(handler.MauiContext.Context)
+			{
+				CrossPlatformMeasure = IncludeScrollViewInsets(scrollView.CrossPlatformMeasure, scrollView),
+				CrossPlatformArrange = scrollView.CrossPlatformArrange,
+				Tag = InsetPanelTag
+			};
+
+			handler.NativeView.RemoveAllViews();
+			paddingShim.AddView(nativeContent);
+			handler.NativeView.SetContent(paddingShim);
+		}
+
+		static Func<double, double, Size> IncludeScrollViewInsets(Func<double, double, Size> internalMeasure, IScrollView scrollView)
+		{
+			return (widthConstraint, heightConstraint) =>
+			{
+				return InsetScrollView(widthConstraint, heightConstraint, internalMeasure, scrollView);
+			};
+		}
+
+		static Size InsetScrollView(double widthConstraint, double heightConstraint, Func<double, double, Size> internalMeasure, IScrollView scrollView)
+		{
+			var padding = scrollView.Padding;
+
+			if (scrollView.PresentedContent == null)
+			{
+				return new Size(padding.HorizontalThickness, padding.VerticalThickness);
+			}
+
+			// Exclude the padding while measuring the internal content ...
+			var measurementWidth = widthConstraint - padding.HorizontalThickness;
+			var measurementHeight = heightConstraint - padding.VerticalThickness;
+
+			var result = internalMeasure.Invoke(measurementWidth, measurementHeight);
+
+			// ... and add the padding back in to the final result
+			var fullSize = new Size(result.Width + padding.HorizontalThickness, result.Height + padding.VerticalThickness);
+
+			if (double.IsInfinity(widthConstraint))
+			{
+				widthConstraint = result.Width;
+			}
+
+			if (double.IsInfinity(heightConstraint))
+			{
+				heightConstraint = result.Height;
+			}
+
+			return fullSize.AdjustForFill(new Rectangle(0, 0, widthConstraint, heightConstraint), scrollView.PresentedContent);
 		}
 	}
 }

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -3,12 +3,17 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using static Microsoft.Maui.Layouts.LayoutExtensions;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
 	{
+		const string InsetPanelTag = "MAUIContentInsetPanel";
+
 		protected override ScrollViewer CreateNativeView()
 		{
 			return new ScrollViewer();
@@ -31,7 +36,16 @@ namespace Microsoft.Maui.Handlers
 			if (handler.NativeView == null || handler.MauiContext == null)
 				return;
 
-			handler.NativeView.UpdateContent(scrollView.PresentedContent, handler.MauiContext);
+			if (NeedsInsetPanel(scrollView))
+			{
+				UpdateInsetPanel(scrollView, handler);
+			}
+			else
+			{
+				var scrollViewer = handler.NativeView;
+				RemoveInsetPanel(scrollViewer);
+				scrollViewer.UpdateContent(scrollView.PresentedContent, handler.MauiContext);
+			}
 		}
 
 		public static void MapHorizontalScrollBarVisibility(ScrollViewHandler handler, IScrollView scrollView)
@@ -66,6 +80,151 @@ namespace Microsoft.Maui.Handlers
 			{
 				VirtualView.ScrollFinished();
 			}
+		}
+
+		/*
+			Problem 1: Windows treats Padding differently than what we want for MAUI; Padding creates space
+			_around_ the scrollable area, rather than padding the content inside of it. 
+
+			Problem 2: The ScrollViewer will force any content to start at the origin (0,0), even if we ask 
+			to arrange it at an offset. This defeats our content's Margin properties. 
+
+			To handle this, we detect whether the content has a Margin or the cross-platform ScrollView has a Padding;
+			if so, we insert a container ContentPanel which always lays out at the origin but provides both the Padding
+			and the Margin for the content. The extra layer is only inserted if necessary, and is removed if the Padding
+			and Margin are set to zero. The extra layer uses the native ContentPanel control we already provide
+			as the backing control for ContentView, Page, etc. 
+
+			The methods below exist to support inserting/updating the padding/margin panel.
+		 */
+
+		static bool NeedsInsetPanel(IScrollView scrollView)
+		{
+			if (scrollView.PresentedContent == null)
+			{
+				return false;
+			}
+
+			if (scrollView.Padding != Thickness.Zero)
+			{
+				return true;
+			}
+
+			if (scrollView.PresentedContent.Margin != Thickness.Zero)
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		static ContentPanel? GetInsetPanel(ScrollViewer scrollViewer) 
+		{
+			if (scrollViewer.Content is ContentPanel contentPanel)
+			{
+				if (contentPanel.Tag is string tag && tag == InsetPanelTag)
+				{
+					return contentPanel;
+				}
+			}
+
+			return null;
+		}
+
+		static void RemoveInsetPanel(ScrollViewer scrollViewer) 
+		{
+			if (GetInsetPanel(scrollViewer) is ContentPanel currentPaddingLayer)
+			{
+				if (currentPaddingLayer.Children.Count > 0)
+				{
+					currentPaddingLayer.Children.Clear();
+					scrollViewer.Content = null;
+				}
+			}
+		}
+
+		static void UpdateInsetPanel(IScrollView scrollView, ScrollViewHandler handler)
+		{
+			if (scrollView.PresentedContent == null || handler.MauiContext == null)
+			{
+				return;
+			}
+
+			var scrollViewer = handler.NativeView;
+			var nativeContent = scrollView.PresentedContent.ToNative(handler.MauiContext);
+
+			if (GetInsetPanel(scrollViewer) is ContentPanel currentPaddingLayer)
+			{
+				if (currentPaddingLayer.Children.Count == 0 || currentPaddingLayer.Children[0] != nativeContent)
+				{
+					currentPaddingLayer.Children.Clear();
+					currentPaddingLayer.Children.Add(nativeContent);
+				}
+			}
+			else
+			{
+				InsertInsetPanel(scrollViewer, scrollView, nativeContent);
+			}
+		}
+
+		static void InsertInsetPanel(ScrollViewer scrollViewer, IScrollView scrollView, FrameworkElement nativeContent)
+		{
+			if (scrollView.PresentedContent == null)
+			{
+				return;
+			}
+
+			var paddingShim = new ContentPanel()
+			{
+				CrossPlatformMeasure = IncludeScrollViewInsets(scrollView.CrossPlatformMeasure, scrollView),
+				CrossPlatformArrange = scrollView.CrossPlatformArrange,
+				Tag = InsetPanelTag
+			};
+
+			scrollViewer.Content = null;
+			paddingShim.Children.Add(nativeContent);
+			scrollViewer.Content = paddingShim;
+		}
+
+		static Func<double, double, Size> IncludeScrollViewInsets(Func<double, double, Size> internalMeasure, IScrollView scrollView)
+		{
+			return (widthConstraint, heightConstraint) =>
+			{
+				return InsetScrollView(widthConstraint, heightConstraint, internalMeasure, scrollView);
+			};
+		}
+
+		static Size InsetScrollView(double widthConstraint, double heightConstraint, Func<double, double, Size> internalMeasure, IScrollView scrollView) 
+		{
+			var padding = scrollView.Padding;
+			var presentedContent = scrollView.PresentedContent;
+
+			if (presentedContent == null)
+			{
+				return new Size(padding.HorizontalThickness, padding.VerticalThickness);
+			}
+
+			// Exclude the padding while measuring the internal content ...
+			var measurementWidth = widthConstraint - padding.HorizontalThickness;
+			var measurementHeight = heightConstraint - padding.VerticalThickness;
+
+			var result = internalMeasure.Invoke(measurementWidth, measurementHeight);
+
+			// ... and add the padding back in to the final result
+			var fullSize = new Size(result.Width + padding.HorizontalThickness, result.Height + padding.VerticalThickness);
+
+			if (double.IsInfinity(widthConstraint))
+			{
+				widthConstraint = result.Width;
+			}
+
+			if (double.IsInfinity(heightConstraint))
+			{
+				heightConstraint = result.Height;
+			}
+
+			// If the presented content has LayoutAlignment Fill, we'll need to adjust the measurement to account for that
+			return fullSize.AdjustForFill(new Rectangle(0, 0, widthConstraint, heightConstraint), presentedContent);
 		}
 	}
 }

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.iOS.cs
@@ -34,10 +34,12 @@ namespace Microsoft.Maui.Handlers
 		{
 			var nativeView = this.GetWrappedNativeView();
 
-			if (nativeView == null)
+			if (nativeView == null || VirtualView == null)
 			{
 				return new Size(widthConstraint, heightConstraint);
 			}
+
+			VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
 
 			var explicitWidth = VirtualView.Width;
 			var explicitHeight = VirtualView.Height;

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -26,12 +26,7 @@ namespace Microsoft.Maui.Handlers
 			if (rect.Width < 0 || rect.Height < 0)
 				return;
 
-			if (nativeView.Parent is ScrollViewer)
-			{
-				rect = AdjustForScrollViewer(nativeView, VirtualView, rect);
-			}
-
-			nativeView.Arrange(new global::Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height));
+			nativeView.Arrange(new Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height));
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
@@ -87,26 +82,6 @@ namespace Microsoft.Maui.Handlers
 				oldParent?.Children.Insert(idx, NativeView);
 			else
 				oldParent?.Children.Add(NativeView);
-		}
-
-		static Rectangle AdjustForScrollViewer(FrameworkElement nativeView, TVirtualView virtualView, Rectangle rect)
-		{
-			// The Windows ScrollViewer doesn't allow us to arrange content at an offset; it forces the content to 0,0
-			// So if we want to account for ScrollView.Padding and any margins on the ScrollView's Content, we need 
-			// do do that by setting the Content's native Margin, and then update the bounds for Arrange to start
-			// at 0,0 and be large enough to account for the updated margin.
-
-			var margin = virtualView.Margin;
-			var padding = (virtualView.Parent as IPadding)?.Padding ?? Thickness.Zero;
-
-			var marginAndPadding = new Thickness(margin.Left + padding.Left, margin.Top + padding.Top,
-				margin.Right + padding.Right, margin.Bottom + padding.Bottom);
-
-			nativeView.Margin = marginAndPadding.ToNative();
-
-			rect = new Rectangle(0, 0, rect.Width + marginAndPadding.HorizontalThickness, rect.Height + marginAndPadding.VerticalThickness);
-
-			return rect;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/ScrollViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ScrollViewExtensions.cs
@@ -35,13 +35,12 @@ namespace Microsoft.Maui
 		{
 			var nativeContent = content == null ? null : content.ToNative(context);
 
-			if (nativeContent == null)
-			{
-				scrollView.RemoveAllViews();
-			}
-			else
+			scrollView.RemoveAllViews();
+
+			if (nativeContent != null)
 			{
 				scrollView.SetContent(nativeContent);
+				
 			}
 		}
 	}


### PR DESCRIPTION
Modify the Android and Windows ScrollView behavior to work as it does in Forms (and on iOS in MAUI) - include the ScrollView's Padding _inside_ the scrollable area rather than outside of it. 

This brings the behavior of all 3 platforms into line with one another and maintains the expected behavior from Forms. 

This also fixes layout cycle issues with the ScrollViewer on Windows.

Fixes #2755
Fixes #2637
Fixes #2634



