### PR TITLE
Fix Blazor project Android warnings and set WarningsAsErrors=true on template builds

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -95,6 +95,9 @@ Task("dotnet-templates")
             { "RestoreNoCache", "true" },
             { "RestorePackagesPath", MakeAbsolute(File("../templatesTest/packages")).FullPath },
             { "RestoreConfigFile", MakeAbsolute(File("../templatesTest/nuget.config")).FullPath },
+
+            // Avoid iOS build warning as error on Windows: There is no available connection to the Mac. Task 'VerifyXcodeVersion' will not be executed
+            { "IsRemoteBuild", "false" },
         };
 
         foreach (var template in new [] { "maui", "maui-blazor", "mauilib" })

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -97,7 +97,7 @@ Task("dotnet-templates")
             { "RestoreConfigFile", MakeAbsolute(File("../templatesTest/nuget.config")).FullPath },
 
             // Avoid iOS build warning as error on Windows: There is no available connection to the Mac. Task 'VerifyXcodeVersion' will not be executed
-            { "IsRemoteBuild", "false" },
+            { "CustomBeforeMicrosoftCSharpTargets", MakeAbsolute(File("./src/Templates/TemplateTestExtraTargets.targets")).FullPath },
         };
 
         foreach (var template in new [] { "maui", "maui-blazor", "mauilib" })

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -102,7 +102,7 @@ Task("dotnet-templates")
             var name = template.Replace("-", "") + " Space-Dash";
             StartProcess(dn, $"new {template} -o \"../templatesTest/{name}\"");
 
-            RunMSBuildWithDotNet($"../templatesTest/{name}", properties);
+            RunMSBuildWithDotNet($"../templatesTest/{name}", properties, warningsAsError: true);
         }
     });
 
@@ -330,7 +330,7 @@ void StartVisualStudioForDotNet6(string sln = null)
 
 // NOTE: These methods work as long as the "dotnet" target has already run
 
-void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = null, bool deployAndRun = false)
+void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = null, bool deployAndRun = false, bool warningsAsError = false)
 {
     var name = System.IO.Path.GetFileNameWithoutExtension(sln);
     var binlog = $"\"{logDirectory}/{name}-{configuration}.binlog\"";
@@ -344,6 +344,10 @@ void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = nu
         var msbuildSettings = new DotNetCoreMSBuildSettings()
             .SetConfiguration(configuration)
             .EnableBinaryLogger(binlog);
+        if (warningsAsError)
+        {
+            msbuildSettings.TreatAllWarningsAs(MSBuildTreatAllWarningsAs.Error);
+        }
 
         if (properties != null)
         {
@@ -375,6 +379,10 @@ void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = nu
             .WithRestore()
             .SetConfiguration(configuration)
             .EnableBinaryLogger(binlog);
+        if (warningsAsError)
+        {
+            msbuildSettings.WarningsAsError = true;
+        }
 
         if (properties != null)
         {

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -29,8 +29,8 @@
     </ItemGroup>
   </Target>
 
-  <!-- Targets temporarily remove Content items in the wwwroot folder so that they don't conflict with iOS/MacCatalyst SDK tasks -->
-  <Target Name="HideContentFromBundleResources" BeforeTargets="_CollectBundleResources">
+  <!-- Targets temporarily remove Content items in various folders so that they don't conflict with iOS/MacCatalyst SDK tasks -->
+  <Target Name="HideContentFromiOSBundleResources" BeforeTargets="_CollectBundleResources">
     <ItemGroup>
       <!-- Find all files outside the wwwroot folder -->
       <_NonWWWRootContent Include="@(Content)" Exclude="wwwroot/**/*" />
@@ -44,10 +44,26 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="RestoreHiddenContent" AfterTargets="_CollectBundleResources" BeforeTargets="ResolveCurrentProjectStaticWebAssetsInputs">
+  <!-- Restore hidden Content items for iOS/MacCatalyst -->
+  <Target Name="RestoreHiddeniOSContent" AfterTargets="_CollectBundleResources" BeforeTargets="ResolveCurrentProjectStaticWebAssetsInputs">
     <ItemGroup>
       <!-- Restore the previously removed Content items -->
       <Content Include="@(_TemporaryHiddenContent)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Targets temporarily remove Content items in various folders so that they don't conflict with Android SDK tasks -->
+  <Target Name="HideContentFromAndroidCheck" BeforeTargets="_CheckForContent">
+    <ItemGroup>
+      <_TemporaryAndroidHiddenContent Include="@(Content)" />
+      <Content Remove="@(Content)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Restore hidden Content items for Android -->
+  <Target Name="RestoreHiddenAndroidContent" AfterTargets="_CheckForContent">
+    <ItemGroup>
+      <Content Include="@(_TemporaryAndroidHiddenContent)" />
     </ItemGroup>
   </Target>
 

--- a/src/Templates/TemplateTestExtraTargets.targets
+++ b/src/Templates/TemplateTestExtraTargets.targets
@@ -1,0 +1,8 @@
+<Project>
+  <Target Name="SkipRemoteBuildVerifyXcodeVersion" AfterTargets="EvaluateRemoteBuild">
+    <PropertyGroup>
+      <IsRemoteBuild>False</IsRemoteBuild>
+    </PropertyGroup>
+    <Message Text="Setting IsRemoteBuild=False to avoid VerifyXcodeVersion warning" />
+  </Target>
+</Project>


### PR DESCRIPTION
This change covers 3 distinct things, all related:

1. The primary fix is to update the MAUI Blazor targets to work around spurious Android SDK warnings
2. To prevent such issues from creeping up in the future, I set WarningsAsErrors=true on the template builds (@mattleibow FYI)
3. To make (2) actually work, I had to do some "clever" (ahem, super hacky) things to hide irrelevant iOS SDK warnings that are un-ignorable, which would turn to errors. So I made them go away. I logged https://github.com/xamarin/xamarin-macios/issues/13002 to see if we can make the warning(s) ignorable in the future.