### PR TITLE
Apply TextTransform for Controls Label

### DIFF
--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -150,8 +150,6 @@ namespace Microsoft.Maui.Controls.Hosting
 					Internals.Registrar.Registered.Register(typeof(StreamImageSource), typeof(StreamImagesourceHandler));
 					Internals.Registrar.Registered.Register(typeof(UriImageSource), typeof(ImageLoaderSourceHandler));
 					Internals.Registrar.Registered.Register(typeof(FontImageSource), typeof(FontImageSourceHandler));
-
-
 					Internals.Registrar.Registered.Register(typeof(Microsoft.Maui.EmbeddedFont), typeof(Microsoft.Maui.EmbeddedFontLoader));
 
 #endif
@@ -159,15 +157,15 @@ namespace Microsoft.Maui.Controls.Hosting
 #if __IOS__ || MACCATALYST
 					Internals.Registrar.RegisterEffect("Xamarin", "ShadowEffect", typeof(ShadowEffect));
 #endif
-
-					// Update the mappings for IView/View to work specifically for Controls
-					VisualElement.RemapForControls();
-					Label.RemapForControls();
-					Button.RemapForControls();
-					Window.RemapForControls();
-				});
+			});
 
 			builder.AddMauiCompat();
+
+			// Update the mappings for IView/View to work specifically for Controls
+			VisualElement.RemapForControls();
+			Label.RemapForControls();
+			Button.RemapForControls();
+			Window.RemapForControls();
 
 			return builder;
 		}

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls
 		{
 			[nameof(TextType)] = MapTextType,
 			[nameof(Text)] = MapText,
+			[nameof(TextTransform)] = MapText,
 #if __IOS__
 			[nameof(TextDecorations)] = MapTextDecorations,
 			[nameof(CharacterSpacing)] = MapCharacterSpacing,

--- a/src/Controls/src/Core/Platform/Android/Extensions/TextViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/TextViewExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Android.Widget;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -11,7 +12,7 @@ namespace Microsoft.Maui.Controls.Platform
 			switch (label.TextType)
 			{
 				case TextType.Text:
-					textView.UpdateTextPlainText(label);
+					textView.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
 					break;
 				case TextType.Html:
 					textView.UpdateTextHtml(label);

--- a/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/TextBlockExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Maui.Controls.Internals;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -56,7 +57,7 @@ namespace Microsoft.Maui.Controls.Platform
 					break;
 
 				default:
-					nativeControl.UpdateTextPlainText(label);
+					nativeControl.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
 					break;
 			}
 		}

--- a/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/LabelExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Maui;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
 using UIKit;
 
 namespace Microsoft.Maui.Controls.Platform
@@ -15,7 +16,7 @@ namespace Microsoft.Maui.Controls.Platform
 					break;
 
 				default:
-					nativeLabel.UpdateTextPlainText(label);
+					nativeLabel.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
 					break;
 			}
 		}

--- a/src/Controls/tests/DeviceTests/Elements/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/LabelTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Label)]
+	public partial class LabelTests : HandlerTestBase 
+	{
+		[Theory]
+		[InlineData("Hello There", TextTransform.None, "Hello There")]
+		[InlineData("Hello There", TextTransform.Uppercase, "HELLO THERE")]
+		[InlineData("Hello There", TextTransform.Lowercase, "hello there")]
+		public async Task TextTransformApplied(string text, TextTransform transform, string expected)
+		{
+			var label = new Label() { Text = text, TextTransform = transform };
+
+			var handler = await CreateHandlerAsync<LabelHandler>(label);
+
+			Assert.Equal(expected, handler.NativeView.Text);
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/LabelTests.cs
@@ -18,7 +18,12 @@ namespace Microsoft.Maui.DeviceTests
 
 			var handler = await CreateHandlerAsync<LabelHandler>(label);
 
-			Assert.Equal(expected, handler.NativeView.Text);
+			var nativeText = await InvokeOnMainThreadAsync(() =>
+			{ 
+				return handler.NativeView.Text;
+			});
+
+			Assert.Equal(expected, nativeText);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -2,6 +2,7 @@
 {
 	public static class TestCategory
 	{
+		public const string Label = "Label";
 		public const string VisualElement = "VisualElement";
 	}
 }


### PR DESCRIPTION
Adds a mapping to the Controls Label for handling TextTransform.

This is specifically a Controls-level property, included for continuity from Forms. TextTransform is not something we're adding to the Core MAUI layer. 

This PR covers Label specifically; it does not cover any other controls in Controls.

Fixes #2969
