### PR TITLE
Remove references to an "app window"

### DIFF
--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -240,9 +240,6 @@ namespace Microsoft.Maui
 		{
 			var nativeWindow = context.GetActivity();
 
-			if (nativeWindow is MauiAppCompatActivity mac && mac.VirtualWindow != null)
-				return mac.VirtualWindow;
-
 			foreach (var window in MauiApplication.Current.Application.Windows)
 			{
 				if (window?.Handler?.NativeView is AActivity win && win == nativeWindow)

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -8,18 +8,6 @@ namespace Microsoft.Maui
 {
 	public partial class MauiAppCompatActivity : AppCompatActivity
 	{
-		WeakReference<IWindow>? _virtualWindow;
-		internal IWindow? VirtualWindow
-		{
-			get
-			{
-				IWindow? window = null;
-				_virtualWindow?.TryGetTarget(out window);
-				return window;
-			}
-		}
-
-
 		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
 		protected virtual bool AllowFragmentRestore => false;
 
@@ -51,13 +39,12 @@ namespace Microsoft.Maui
 			if (mauiApp == null)
 				throw new InvalidOperationException($"The {nameof(IApplication)} instance was not found.");
 
-			var services = MauiApplication.Current.Services;
-			if (services == null)
+			if (mauiApp.Handler?.MauiContext is not IMauiContext applicationContext)
 				throw new InvalidOperationException($"The {nameof(IServiceProvider)} instance was not found.");
 
-			var mauiContext = MauiApplication.Current.MauiApplicationContext.MakeScoped(this);
+			var mauiContext = applicationContext.MakeScoped(this);
 
-			services.InvokeLifecycleEvents<AndroidLifecycle.OnMauiContextCreated>(del => del(mauiContext));
+			applicationContext.Services.InvokeLifecycleEvents<AndroidLifecycle.OnMauiContextCreated>(del => del(mauiContext));
 
 			// TODO: Fix once we have multiple windows
 			IWindow window;
@@ -73,7 +60,6 @@ namespace Microsoft.Maui
 				window = mauiApp.CreateWindow(state);
 			}
 
-			_virtualWindow = new WeakReference<IWindow>(window);
 			this.SetWindowHandler(window, mauiContext);
 		}
 	}

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -27,15 +27,13 @@ namespace Microsoft.Maui
 
 			var applicationContext = new MauiContext(mauiApp.Services, this);
 
-			MauiApplicationContext = applicationContext;
-
 			Services = mauiApp.Services;
 
 			Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationCreating>(del => del(this));
 
 			Application = Services.GetRequiredService<IApplication>();
 
-			this.SetApplicationHandler(Application, MauiApplicationContext);
+			this.SetApplicationHandler(Application, applicationContext);
 
 			Current.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnApplicationCreate>(del => del(this));
 
@@ -64,8 +62,6 @@ namespace Microsoft.Maui
 		}
 
 		public static MauiApplication Current { get; private set; } = null!;
-
-		internal IMauiContext MauiApplicationContext { get; private set; } = null!;
 
 		public IServiceProvider Services { get; protected set; } = null!;
 

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -27,9 +27,7 @@ namespace Microsoft.Maui
 
 			var winuiWndow = CreateNativeWindow(args, applicationContext);
 
-			MainWindow = winuiWndow;
-
-			MainWindow.Activate();
+			winuiWndow.Activate();
 
 			Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
 		}
@@ -55,8 +53,6 @@ namespace Microsoft.Maui
 		public static new MauiWinUIApplication Current => (MauiWinUIApplication)UI.Xaml.Application.Current;
 
 		public UI.Xaml.LaunchActivatedEventArgs LaunchActivatedEventArgs { get; protected set; } = null!;
-
-		public UI.Xaml.Window MainWindow { get; protected set; } = null!;
 
 		public IServiceProvider Services { get; protected set; } = null!;
 

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -10,17 +10,6 @@ namespace Microsoft.Maui
 	public abstract class MauiUIApplicationDelegate : UIApplicationDelegate, IUIApplicationDelegate
 	{
 		MauiContext _applicationContext = null!;
-		WeakReference<IWindow>? _virtualWindow;
-
-		internal IWindow? VirtualWindow
-		{
-			get
-			{
-				IWindow? window = null;
-				_virtualWindow?.TryGetTarget(out window);
-				return window;
-			}
-		}
 
 		protected MauiUIApplicationDelegate()
 		{
@@ -69,7 +58,6 @@ namespace Microsoft.Maui
 
 			var activationState = new ActivationState(mauiContext);
 			var window = Application.CreateWindow(activationState);
-			_virtualWindow = new WeakReference<IWindow>(window);
 			uiWindow.SetWindowHandler(window, mauiContext);
 
 			return uiWindow;

--- a/src/Core/src/Platform/iOS/UIApplicationExtensions.cs
+++ b/src/Core/src/Platform/iOS/UIApplicationExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using UIKit;
 
 namespace Microsoft.Maui
@@ -21,13 +20,11 @@ namespace Microsoft.Maui
 
 		public static IWindow? GetWindow(this UIApplication application)
 		{
-			if (MauiUIApplicationDelegate.Current.VirtualWindow != null)
-				return MauiUIApplicationDelegate.Current.VirtualWindow;
+			var windows = application.Windows;
 
-			var nativeWindow = application.GetKeyWindow();
 			foreach (var window in MauiUIApplicationDelegate.Current.Application.Windows)
 			{
-				if (window?.Handler?.NativeView is UIWindow win && win == nativeWindow)
+				if (window?.Handler?.NativeView is UIWindow win && windows.IndexOf(win) != -1)
 					return window;
 			}
 

--- a/src/TestUtils/src/DeviceTests/TestMainThread.cs
+++ b/src/TestUtils/src/DeviceTests/TestMainThread.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Maui.DeviceTests
 #if WINDOWS
 			var tcs = new TaskCompletionSource<T>();
 
-			var didQueue = MauiWinUIApplication.Current.MainWindow.DispatcherQueue.TryEnqueue(() =>
+			// TODO: this all needs to be cleaned up with the IDispatcher
+			var winuiApp = (UI.Xaml.Window)MauiWinUIApplication.Current.Application.Windows[0].Handler!.NativeView!;
+			var didQueue = winuiApp.DispatcherQueue.TryEnqueue(() =>
 			{
 				try
 				{
@@ -56,7 +58,9 @@ namespace Microsoft.Maui.DeviceTests
 #if WINDOWS
 			var tcs = new TaskCompletionSource<T>();
 
-			var didQueue = MauiWinUIApplication.Current.MainWindow.DispatcherQueue.TryEnqueue(async () =>
+			// TODO: this all needs to be cleaned up with the IDispatcher
+			var winuiApp = (UI.Xaml.Window)MauiWinUIApplication.Current.Application.Windows[0].Handler!.NativeView!;
+			var didQueue = winuiApp.DispatcherQueue.TryEnqueue(async () =>
 			{
 				try
 				{


### PR DESCRIPTION
### Description of Change ###

Remove the "app window" references on app objects. Not only is this a bit confusing in multi-window scenarios, we can now make use of the `Application.Windows[x].Handler.NativeView` to get the actual window.

Anything not in that list of windows has no native window nor handler yet and thus would not be found anyway.

A benefit of not looking on the Maui* objects for properties is that _any_ activity/window type can be used (maybe from a 3rd party) and it is all linked via the handler.

### Additions made ###

 - Removed `MainWindow` and `VirtualWindow` properties

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
