### PR TITLE
Update GitHub issue templates to use updated labels, syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[Bug] "
-labels: 'bug'
+labels: ["t/bug"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: "[Enhancement] YOUR IDEA!"
-labels: proposal-open, enhancement
+labels: ["proposal/open", "t/enhancement"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -2,7 +2,7 @@
 name: Spec
 about: An official specification for enhancements
 title: "[Spec]  "
-labels: proposal-open, enhancement
+labels: ["proposal/open", "t/enhancement"]
 assignees: ''
 
 ---


### PR DESCRIPTION
The templates were using non-existent labels, causing them to not show up.

In the future, there are also much fancier template options we could consider using, such as having a proper form with textboxes, dropdowns, and checkboxes. More info here:
* https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
* https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
