### PR TITLE
[workload] add support for 'dotnet test' and 'net6.0'

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -118,6 +118,7 @@ Task("dotnet-test")
             "**/Core.UnitTests-net6.csproj",
             "**/Essentials.UnitTests-net6.csproj",
             "**/Resizetizer.UnitTests-net6.csproj",
+            "**/Controls.Sample.Tests.csproj"
         };
 
         var success = true;

--- a/src/Controls/samples/Controls.Sample.Tests/Controls.Sample.Tests.csproj
+++ b/src/Controls/samples/Controls.Sample.Tests/Controls.Sample.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<UseMaui>true</UseMaui>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+</Project>

--- a/src/Controls/samples/Controls.Sample.Tests/MauiTests.cs
+++ b/src/Controls/samples/Controls.Sample.Tests/MauiTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Xunit;
+
+namespace Controls.Sample.Tests
+{
+	public class MauiTests
+	{
+		public MauiTests()
+		{
+			Device.PlatformServices = new MockPlatformServices();
+		}
+
+		[Fact]
+		public void ShadowInitializesCorrectly()
+		{
+			// Arrange
+			const float expectedOpacity = 1.0f;
+			const float expectedRadius = 10.0f;
+			var expectedOffset = new Point(10, 10);
+
+			// Act
+			var shadow = new Shadow
+			{
+				Offset = expectedOffset,
+				Opacity = expectedOpacity,
+				Radius = expectedRadius
+			};
+
+			// Assert
+			Assert.Equal(expectedOffset, shadow.Offset);
+			Assert.Equal(expectedOpacity, shadow.Opacity);
+			Assert.Equal(expectedRadius, shadow.Radius);
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample.Tests/MockPlatformServices.cs
+++ b/src/Controls/samples/Controls.Sample.Tests/MockPlatformServices.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Graphics;
+
+namespace Controls.Sample.Tests
+{
+    public class MockPlatformServices : IPlatformServices
+    {
+        public string GetHash(string input) => string.Empty;
+
+        public string GetMD5Hash(string input) => string.Empty;
+
+        public double GetNamedSize(NamedSize size, Type targetElement, bool useOldSizes) => 0;
+
+        public Color GetNamedColor(string name) => Colors.Transparent;
+
+        public void OpenUriAction(Uri uri)
+        {
+        }
+
+        public bool IsInvokeRequired { get; } = false;
+
+        public OSAppTheme RequestedTheme { get; } = OSAppTheme.Unspecified;
+
+        public string RuntimePlatform { get; set; } = string.Empty;
+
+        public void BeginInvokeOnMainThread(Action action) => action();
+
+        public void StartTimer(TimeSpan interval, Func<bool> callback)
+        {
+        }
+
+        public Task<Stream> GetStreamAsync(Uri uri, CancellationToken cancellationToken)
+            => Task.FromResult<Stream>(new MemoryStream());
+
+        public Assembly[] GetAssemblies() => Array.Empty<Assembly>();
+
+        public IIsolatedStorageFile? GetUserStoreForApplication() => null;
+
+        public void QuitApplication()
+        {
+        }
+
+        public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint) => default;
+    }
+}

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -8,6 +8,7 @@
     <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">win</_MauiPlatformName>
     <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' != 'windows' ">$(TargetPlatformIdentifier.ToLowerInvariant())</_MauiPlatformName>
     <_MauiPlatformName Condition=" '$(_MauiPlatformName)' == '' ">any</_MauiPlatformName>
+    <_MauiRuntimePackAlwaysCopyLocal Condition=" '$(_MauiPlatformName)' == 'any' ">true</_MauiRuntimePackAlwaysCopyLocal>
   </PropertyGroup>
 
   <!-- Framework references -->
@@ -25,6 +26,7 @@
         RuntimePackNamePatterns="Microsoft.Maui.Core.Runtime.**RID**"
         RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"
+        RuntimePackAlwaysCopyLocal="$(_MauiRuntimePackAlwaysCopyLocal)"
     />
     <KnownFrameworkReference
         Condition=" '$(UseMaui)' == 'true' "
@@ -38,6 +40,7 @@
         RuntimePackNamePatterns="Microsoft.Maui.Controls.Runtime.**RID**"
         RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"
+        RuntimePackAlwaysCopyLocal="$(_MauiRuntimePackAlwaysCopyLocal)"
     />
     <KnownFrameworkReference
         Condition=" '$(UseMaui)' == 'true' or '$(UseMauiEssentials)' == 'true' "
@@ -51,6 +54,7 @@
         RuntimePackNamePatterns="Microsoft.Maui.Essentials.Runtime.**RID**"
         RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
         Profile="$(TargetPlatformIdentifier)"
+        RuntimePackAlwaysCopyLocal="$(_MauiRuntimePackAlwaysCopyLocal)"
     />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change ###

Fixes: https://github.com/dotnet/sdk/issues/21845

If you create a `net6.0` class library with `UseMaui=true`, `dotnet
test` fails with:

    Testhost process exited with error: It was not possible to find any compatible framework version
    The framework 'Microsoft.Maui.Core', version '**FromWorkload**' (x64) was not found.

@dsplaisted suggested adding `%(RuntimePackAlwaysCopyLocal)` to any
`@(KnownFrameworkReference)` that is meant for `net6.0`:

https://github.com/dotnet/sdk/issues/21845#issuecomment-944534166

If a class library does not have a platform specified, then the
`Microsoft.Maui.*.any` packs are brought in. These packs need
`%(RuntimePackAlwaysCopyLocal)` for `dotnet test` to work.

I added a sample project that appears to work now:

    > .\bin\dotnet\dotnet.exe test .\src\Controls\samples\Controls.Sample.Tests\Controls.Sample.Tests.csproj
    Determining projects to restore...
    Restored C:\src\maui\src\Controls\samples\Controls.Sample.Tests\Controls.Sample.Tests.csproj (in 1.89 sec).
    You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
    Controls.Sample.Tests -> C:\src\maui\src\Controls\samples\Controls.Sample.Tests\bin\Debug\net6.0\Controls.Sample.Tests.dll
    Test run for C:\src\maui\src\Controls\samples\Controls.Sample.Tests\bin\Debug\net6.0\Controls.Sample.Tests.dll (.NETCoreApp,Version=v6.0)
    Microsoft (R) Test Execution Command Line Tool Version 17.0.0
    Copyright (c) Microsoft Corporation.  All rights reserved.
    Starting test execution, please wait...
    A total of 1 test files matched the specified pattern.
    Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: < 1 ms - Controls.Sample.Tests.dll (net6.0)

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No