### PR TITLE
Ensure ScrollView performs cross-platform measure

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ScrollViewPage.xaml
@@ -5,8 +5,7 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="ScrollView">
     <views:BasePage.Content>
-        <StackLayout
-            Margin="12">
+        <GridLayout RowDefinitions="Auto,*,Auto" Margin="12">
             <Label 
                 Text="THE BLACK CAT by Edgar Allan Poe"
                 FontSize="Medium"
@@ -14,7 +13,7 @@
                 HorizontalOptions="Center" />
             <ScrollView 
                 x:Name="scrollView"
-                VerticalOptions="FillAndExpand"
+                GridLayout.Row="1"
                 Scrolled="OnScrollViewScrolled">
                 <StackLayout>
                     <Label Text="FOR the most wild, yet most homely narrative which I am about to pen, I neither expect nor solicit belief. Mad indeed would I be to expect it, in a case where my very senses reject their own evidence. Yet, mad am I not -- and very surely do I not dream. But to-morrow I die, and to-day I would unburthen my soul. My immediate purpose is to place before the world, plainly, succinctly, and without comment, a series of mere household events. In their consequences, these events have terrified -- have tortured -- have destroyed me. Yet I will not attempt to expound them. To me, they have presented little but Horror -- to many they will seem less terrible than barroques. Hereafter, perhaps, some intellect may be found which will reduce my phantasm to the common-place -- some intellect more calm, more logical, and far less excitable than my own, which will perceive, in the circumstances I detail with awe, nothing more than an ordinary succession of very natural causes and effects." />
@@ -31,7 +30,8 @@
             </ScrollView>
             <Button 
                 Text="Scroll to end"
+                GridLayout.Row="2"
                 Clicked="OnButtonClicked" />
-        </StackLayout>
+        </GridLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Controls
 			Frame = this.ComputeFrame(bounds);
 			Handler?.NativeArrange(Frame);
 
-			(this as IContentView).CrossPlatformArrange(Frame);
+			(this as IContentView).CrossPlatformArrange(new Rectangle(Point.Zero, Frame.Size));
 
 			return Frame.Size;
 		}
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Controls
 				bounds.Width = Math.Max(Frame.Width, presentedContent.DesiredSize.Width + padding.HorizontalThickness);
 				bounds.Height = Math.Max(Frame.Height, presentedContent.DesiredSize.Height + padding.VerticalThickness);
 
-				(this as IContentView).ArrangeContent(bounds);
+				this.ArrangeContent(bounds);
 			}
 
 			return bounds.Size;

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -11,9 +11,13 @@ namespace Microsoft.Maui.Handlers
 
 		protected override MauiScrollView CreateNativeView()
 		{
-			return new MauiScrollView(
+			var scrollView =  new MauiScrollView(
 				new Android.Views.ContextThemeWrapper(MauiContext!.Context, Resource.Style.scrollViewTheme), null!,
 					Resource.Attribute.scrollViewStyle);
+
+			scrollView.ClipToOutline = true;
+
+			return scrollView;
 		}
 
 		protected override void ConnectHandler(MauiScrollView nativeView)
@@ -26,6 +30,18 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.DisconnectHandler(nativeView);
 			nativeView.ScrollChange -= ScrollChange;
+		}
+
+		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
+
+			if (FindInsetPanel(this) == null)
+			{
+				VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
+			}
+
+			return result;
 		}
 
 		void ScrollChange(object? sender, AndroidX.Core.Widget.NestedScrollView.ScrollChangeEventArgs e)
@@ -129,6 +145,11 @@ namespace Microsoft.Maui.Handlers
 			return false;
 		}
 
+		static ContentViewGroup? FindInsetPanel(ScrollViewHandler handler) 
+		{ 
+			return handler.NativeView.FindViewWithTag(InsetPanelTag) as ContentViewGroup;
+		}
+
 		static void UpdateInsetView(IScrollView scrollView, ScrollViewHandler handler)
 		{
 			if (scrollView.PresentedContent == null || handler.MauiContext == null)
@@ -138,7 +159,7 @@ namespace Microsoft.Maui.Handlers
 
 			var nativeContent = scrollView.PresentedContent.ToNative(handler.MauiContext);
 
-			if (handler.NativeView.FindViewWithTag(InsetPanelTag) is ContentViewGroup currentPaddingLayer)
+			if (FindInsetPanel(handler) is ContentViewGroup currentPaddingLayer)
 			{
 				if (currentPaddingLayer.ChildCount == 0 || currentPaddingLayer.GetChildAt(0) != nativeContent)
 				{

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -31,6 +31,18 @@ namespace Microsoft.Maui.Handlers
 			nativeView.ViewChanged -= ViewChanged;
 		}
 
+		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
+
+			if (GetInsetPanel(NativeView) == null)
+			{
+				VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
+			}
+
+			return result;
+		}
+
 		public static void MapContent(ScrollViewHandler handler, IScrollView scrollView)
 		{
 			if (handler.NativeView == null || handler.MauiContext == null)

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Handlers
 			if (rect.Width < 0 || rect.Height < 0)
 				return;
 
-			nativeView.Arrange(new Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height));
+			nativeView.Arrange(new global::Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height));
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)


### PR DESCRIPTION
Android and WASDK ScrollViews are behaving badly when they have no padding or margin and are not the root controls on a Page. These changes fix those issues.

Also forces the Android ScrollView to clip the contents, fixes a build error with WASDK rectangles, and uses a more appropriate layout for the ScrollView sample page.