### PR TITLE
Enable GitHub action to apply labels based on who opened the issue/PR

### DIFF
--- a/.github/workflows/label-partner-issues.yml
+++ b/.github/workflows/label-partner-issues.yml
@@ -1,0 +1,26 @@
+name: 'Label partner issues'
+
+# Available triggers: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
+
+jobs:
+  label-partner-issues:
+    runs-on: ubuntu-latest
+
+    # Check out the repo into the workspace within the VM
+    steps:
+    - uses: actions/checkout@v2
+
+    # Run the labeler
+    - name: 'Apply labels to issue/PR based on who opened it'
+      id: issue-opener-labeler
+      uses: eilon/IssueOpenerLabeler@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        repo: ${{ github.repository }}
+        issue: ${{ format('{0}{1}', github.event.issue.number, github.event.number) }} # Coalesce the issue/PR number into a single number

--- a/issueopenerlabels.json
+++ b/issueopenerlabels.json
@@ -1,0 +1,7 @@
+{
+	"labels":
+	{
+		// Map of labels to arrays of GitHub users for whom that label will be applied on each issue and PR that they open
+		"partner": [ "jmongaras" ]
+    }
+}

--- a/issueopenerlabels.json
+++ b/issueopenerlabels.json
@@ -1,7 +1,22 @@
 {
-	"labels":
-	{
-		// Map of labels to arrays of GitHub users for whom that label will be applied on each issue and PR that they open
-		"partner": [ "jmongaras" ]
+    "labels": {
+        // Map of labels to arrays of GitHub users for whom that label will be applied on each issue and PR that they open
+        "partner": [
+            "alexeystrakh",
+            "alexkblount",
+            "DeanFaizal",
+            "jgold6",
+            "jmongaras",
+            "jonlipsky",
+            "JoonghyunCho",
+            "juanlao",
+            "migueBarrera",
+            "mikeparker104",
+            "myroot",
+            "rookiejava",
+            "shyunMin",
+            "sung-su",
+            "Sweekriti91"
+        ]
     }
 }


### PR DESCRIPTION
I wrote a simple GitHub Action at https://github.com/Eilon/IssueOpenerLabeler that uses a JSON file in the repo to configure which labels to apply depending on who opened the issue/PR.

We can update the JSON file as needed.