### PR TITLE
Don't force GridLayout * weights to integer values;

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -463,13 +463,13 @@ namespace Microsoft.Maui.Layouts
 			{
 				// Count up the total weight of star columns (e.g., "*, 3*, *" == 5)
 
-				var starCount = 0;
+				var starCount = 0.0;
 
 				foreach (var definition in defs)
 				{
 					if (definition.IsStar)
 					{
-						starCount += (int)definition.GridLength.Value;
+						starCount += definition.GridLength.Value;
 					}
 				}
 
@@ -506,7 +506,7 @@ namespace Microsoft.Maui.Layouts
 					if (definition.IsStar)
 					{
 						// Give the star row/column the appropriate portion of the space based on its weight
-						definition.Size = starSize * (int)definition.GridLength.Value;
+						definition.Size = starSize * definition.GridLength.Value;
 					}
 				}
 			}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1589,5 +1589,85 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(arrangedWidth, actual.Width);
 			Assert.Equal(arrangedHeight, actual.Height);
 		}
+
+		[Category(GridStarSizing)]
+		[Fact(DisplayName = "We can specify fractional star sizes for columns")]
+		public void FractionalStarColumns()
+		{
+			var screenWidth = 300;
+			var screenHeight = 600;
+			var viewSize = new Size(50, 50);
+
+			var grid = CreateGridLayout(rows: "auto", columns: $"*,0.5*,0.5*");
+			var view0 = CreateTestView(viewSize);
+			var view1 = CreateTestView(viewSize);
+			var view2 = CreateTestView(viewSize);
+
+			SubstituteChildren(grid, view0, view1, view2);
+
+			SetLocation(grid, view0);
+			SetLocation(grid, view1, col: 1);
+			SetLocation(grid, view2, col: 2);
+
+			MeasureAndArrange(grid, screenWidth, screenHeight);
+
+			// Row height is auto, so it gets the height of the view
+			var expectedHeight = viewSize.Height;
+
+			// Columns are *,0.5*,0.5*, so the first column should be half the space
+			// and the other two columns should be a quarter of the space
+			var expectedWidthColumn0 = screenWidth / 2;
+			var expectedWidthOthers = screenWidth / 4;
+
+			// Make sure that the views in the columns are actually getting measured at the column width,
+			// and not just at the width of the whole grid
+			view0.Received().Measure(Arg.Is<double>(expectedWidthColumn0), Arg.Any<double>());
+			view1.Received().Measure(Arg.Is<double>(expectedWidthOthers), Arg.Any<double>());
+			view2.Received().Measure(Arg.Is<double>(expectedWidthOthers), Arg.Any<double>());
+
+			AssertArranged(view0, 0, 0, expectedWidthColumn0, expectedHeight);
+			AssertArranged(view1, expectedWidthColumn0, 0, expectedWidthOthers, expectedHeight);
+			AssertArranged(view2, expectedWidthColumn0 + expectedWidthOthers, 0, expectedWidthOthers, expectedHeight);
+		}
+
+		[Category(GridStarSizing)]
+		[Fact(DisplayName = "We can specify fractional star sizes for rows")]
+		public void FractionalStarRows()
+		{
+			var screenWidth = 300;
+			var screenHeight = 600;
+			var viewSize = new Size(50, 50);
+
+			var grid = CreateGridLayout(rows: "*,0.5*,0.5*", columns: "auto");
+			var view0 = CreateTestView(viewSize);
+			var view1 = CreateTestView(viewSize);
+			var view2 = CreateTestView(viewSize);
+
+			SubstituteChildren(grid, view0, view1, view2);
+
+			SetLocation(grid, view0);
+			SetLocation(grid, view1, row: 1);
+			SetLocation(grid, view2, row: 2);
+
+			MeasureAndArrange(grid, screenWidth, screenHeight);
+
+			// Column width is auto, so it gets the width of the view
+			var expectedWidth = viewSize.Width;
+
+			// Rows are *,0.5*,0.5*, so row 0 should be half the screen height
+			// And the other rows should be one quarter the screen height
+			var expectedHeightRow0 = screenHeight / 2;
+			var expectedHeightOther = screenHeight / 4;
+
+			// Make sure that the views in the columns are actually getting measured at the column width,
+			// and not just at the width of the whole grid
+			view0.Received().Measure(Arg.Any<double>(), Arg.Is<double>(expectedHeightRow0));
+			view1.Received().Measure(Arg.Any<double>(), Arg.Is<double>(expectedHeightOther));
+			view2.Received().Measure(Arg.Any<double>(), Arg.Is<double>(expectedHeightOther));
+
+			AssertArranged(view0, 0, 0, expectedWidth, expectedHeightRow0);
+			AssertArranged(view1, 0, expectedHeightRow0, expectedWidth, expectedHeightOther);
+			AssertArranged(view2, 0, expectedHeightRow0 + expectedHeightOther, expectedWidth, expectedHeightOther);
+		}
 	}
 }


### PR DESCRIPTION
GridLayoutManager was casting star weights to integers, truncating any fractional values. These changes remove the forcing to integer.

Fixes #3053

