### PR TITLE
Use app div instead of app tag for Blazor templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml
@@ -7,7 +7,7 @@
 
     <b:BlazorWebView HostPage="wwwroot/index.html">
         <b:BlazorWebView.RootComponents>
-            <b:RootComponent Selector="app" ComponentType="{x:Type local:Main}" />
+            <b:RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
         </b:BlazorWebView.RootComponents>
     </b:BlazorWebView>
 

--- a/src/Templates/src/templates/maui-blazor/wwwroot/index.html
+++ b/src/Templates/src/templates/maui-blazor/wwwroot/index.html
@@ -12,7 +12,7 @@
 
 <body>
 
-	<app></app>
+	<div id="app">Loading...</div>
 
 	<div id="blazor-error-ui">
 		An unhandled error has occurred.


### PR DESCRIPTION
This better matches the equivalent ASP.NET Core Blazor templates.

Fixes #1645
Fixes #2507

Refer to relevant ASP.NET Core Blazor template content here:

* https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/index.html#L24
* https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.cs#L13