### PR TITLE
Fix multiline InputType on IEditor

### DIFF
--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Maui
 		{
 			if (editor.IsReadOnly)
 			{
-				editText.InputType = InputTypes.Null;
+				editText.InputType = InputTypes.Null | Android.Text.InputTypes.TextFlagMultiLine;
 			}
 			else
 			{
@@ -324,7 +324,7 @@ namespace Microsoft.Maui
 					editText.KeyListener = LocalizedDigitsKeyListener.Create(editText.InputType);
 				}
 
-				editText.InputType = nativeInputTypeToUpdate;
+				editText.InputType = nativeInputTypeToUpdate | Android.Text.InputTypes.TextFlagMultiLine;
 			}
 		}
 

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -297,46 +297,15 @@ namespace Microsoft.Maui
 			return end;
 		}
 
-		internal static void SetInputType(this AppCompatEditText editText, IEditor editor)
+		internal static void SetInputType(this AppCompatEditText editText, ITextInput textInput)
 		{
-			if (editor.IsReadOnly)
-			{
-				editText.InputType = InputTypes.Null | Android.Text.InputTypes.TextFlagMultiLine;
-			}
-			else
-			{
-				var keyboard = editor.Keyboard;
-				var nativeInputTypeToUpdate = keyboard.ToInputType();
-
-				if (keyboard is not CustomKeyboard)
-				{
-					// TODO: IsSpellCheckEnabled handling must be here.
-
-					if ((nativeInputTypeToUpdate & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
-					{
-						if (!editor.IsTextPredictionEnabled)
-							nativeInputTypeToUpdate |= InputTypes.TextFlagNoSuggestions;
-					}
-				}
-
-				if (keyboard == Keyboard.Numeric)
-				{
-					editText.KeyListener = LocalizedDigitsKeyListener.Create(editText.InputType);
-				}
-
-				editText.InputType = nativeInputTypeToUpdate | Android.Text.InputTypes.TextFlagMultiLine;
-			}
-		}
-
-		internal static void SetInputType(this AppCompatEditText editText, IEntry entry)
-		{
-			if (entry.IsReadOnly)
+			if (textInput.IsReadOnly)
 			{
 				editText.InputType = InputTypes.Null;
 			}
 			else
 			{
-				var keyboard = entry.Keyboard;
+				var keyboard = textInput.Keyboard;
 				var nativeInputTypeToUpdate = keyboard.ToInputType();
 
 				if (keyboard is not CustomKeyboard)
@@ -345,7 +314,7 @@ namespace Microsoft.Maui
 
 					if ((nativeInputTypeToUpdate & InputTypes.TextFlagNoSuggestions) != InputTypes.TextFlagNoSuggestions)
 					{
-						if (!entry.IsTextPredictionEnabled)
+						if (!textInput.IsTextPredictionEnabled)
 							nativeInputTypeToUpdate |= InputTypes.TextFlagNoSuggestions;
 					}
 				}
@@ -355,7 +324,7 @@ namespace Microsoft.Maui
 					editText.KeyListener = LocalizedDigitsKeyListener.Create(editText.InputType);
 				}
 
-				if (entry.IsPassword)
+				if (textInput is IEntry entry && entry.IsPassword)
 				{
 					if ((nativeInputTypeToUpdate & InputTypes.ClassText) == InputTypes.ClassText)
 						nativeInputTypeToUpdate |= InputTypes.TextVariationPassword;
@@ -366,6 +335,9 @@ namespace Microsoft.Maui
 
 				editText.InputType = nativeInputTypeToUpdate;
 			}
+
+			if (textInput is IEditor)
+				editText.InputType |= InputTypes.TextFlagMultiLine;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -14,6 +14,30 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EditorHandlerTests
 	{
+		[Fact(DisplayName = "InputType Keeps MultiLine Flag")]
+		public async Task InputTypeKeepsMultiLineFlag()
+		{
+			var editor = new EditorStub();
+			var inputType = await GetValueAsync(editor, (handler) =>
+			{
+				return GetNativeEditor(handler).InputType;
+			});
+
+			Assert.True(inputType.HasFlag(InputTypes.TextFlagMultiLine));
+		}
+
+		[Fact(DisplayName = "ReadOnly Keeps MultiLine Flag")]
+		public async Task InputTypeInitializesWithMultiLineFlag()
+		{
+			var editor = new EditorStub() { IsReadOnly = true };
+			var inputType = await GetValueAsync(editor, (handler) =>
+			{
+				return GetNativeEditor(handler).InputType;
+			});
+
+			Assert.True(inputType.HasFlag(InputTypes.TextFlagMultiLine));
+		}
+
 		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
 		public async Task CharacterSpacingInitializesCorrectly()
 		{


### PR DESCRIPTION
### Description of Change ###

The Keyboard handler implementation is wiping out the MultiLine InputType on the native android EditText. This causes the Editor control to just stick everything on a single line.

Consolidated the two SetInputType extension methods into one that works against ITextInputType
### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
