### PR TITLE
Fix placeholder on iOS Editor so it doesn't overlap when text is present when text is set in code

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Handlers
 
 			nativeView.ShouldChangeText += OnShouldChangeText;
 			nativeView.Ended += OnEnded;
-			nativeView.TextPropertySet += OnTextPropertySet;
+			nativeView.TextSetOrChanged += OnTextPropertySet;
 		}
 
 		protected override void DisconnectHandler(MauiTextView nativeView)
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 
 			nativeView.ShouldChangeText -= OnShouldChangeText;
 			nativeView.Ended -= OnEnded;
-			nativeView.TextPropertySet -= OnTextPropertySet;
+			nativeView.TextSetOrChanged -= OnTextPropertySet;
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint) =>

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.ConnectHandler(nativeView);
 
-			nativeView.Changed += OnChanged;
 			nativeView.ShouldChangeText += OnShouldChangeText;
 			nativeView.Ended += OnEnded;
 			nativeView.TextPropertySet += OnTextPropertySet;
@@ -32,7 +31,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.DisconnectHandler(nativeView);
 
-			nativeView.Changed -= OnChanged;
 			nativeView.ShouldChangeText -= OnShouldChangeText;
 			nativeView.Ended -= OnEnded;
 			nativeView.TextPropertySet -= OnTextPropertySet;
@@ -97,16 +95,6 @@ namespace Microsoft.Maui.Handlers
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
 			handler.NativeView?.UpdateFont(editor, fontManager);
-		}
-
-		void OnChanged(object? sender, EventArgs e) => OnTextChanged();
-
-		void OnTextChanged()
-		{
-			if (NativeView == null)
-				return;
-
-			NativeView.HidePlaceholder(!string.IsNullOrEmpty(NativeView.Text));
 		}
 
 		bool OnShouldChangeText(UITextView textView, NSRange range, string replacementString)

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Platform.iOS
 		// via code or user interaction.
 		public event EventHandler? TextSetOrChanged;
 
-		UILabel PlaceholderLabel { get; } = new UILabel
+		internal UILabel PlaceholderLabel { get; } = new UILabel
 		{
 			BackgroundColor = UIColor.Clear,
 			Lines = 0

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -40,10 +40,6 @@ namespace Microsoft.Maui.Platform.iOS
 			set => PlaceholderLabel.TextColor = value;
 		}
 
-		public void HidePlaceholder(bool hide)
-		{
-			PlaceholderLabel.Hidden = hide;
-		}
 
 		void InitPlaceholderLabel()
 		{
@@ -107,7 +103,7 @@ namespace Microsoft.Maui.Platform.iOS
 
 		void HidePlaceholderIfTextIsPresent(string? value)
 		{
-			HidePlaceholder(!String.IsNullOrEmpty(value));
+			PlaceholderLabel.Hidden = !String.IsNullOrEmpty(value);
 		}
 
 		void OnChanged(object? sender, EventArgs e)

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -7,6 +7,11 @@ namespace Microsoft.Maui.Platform.iOS
 {
 	public class MauiTextView : UITextView
 	{
+		// Native Changed doesn't fire when the Text Property is set in code
+		// We use this event as a way to fire changes whenever the Text changes
+		// via code or user interaction.
+		public event EventHandler? TextSetOrChanged;
+
 		UILabel PlaceholderLabel { get; } = new UILabel
 		{
 			BackgroundColor = UIColor.Clear,
@@ -77,7 +82,7 @@ namespace Microsoft.Maui.Platform.iOS
 
 				if (old != value)
 				{
-					TextPropertySet?.Invoke(this, EventArgs.Empty);
+					TextSetOrChanged?.Invoke(this, EventArgs.Empty);
 					HidePlaceholderIfTextIsPresent(value);
 				}
 			}
@@ -94,7 +99,7 @@ namespace Microsoft.Maui.Platform.iOS
 
 				if (old?.Value != value?.Value)
 				{
-					TextPropertySet?.Invoke(this, EventArgs.Empty);
+					TextSetOrChanged?.Invoke(this, EventArgs.Empty);
 					HidePlaceholderIfTextIsPresent(value?.Value);
 				}
 			}
@@ -108,9 +113,7 @@ namespace Microsoft.Maui.Platform.iOS
 		void OnChanged(object? sender, EventArgs e)
 		{
 			HidePlaceholderIfTextIsPresent(Text);
-			TextPropertySet?.Invoke(this, EventArgs.Empty);
+			TextSetOrChanged?.Invoke(this, EventArgs.Empty);
 		}
-
-		public event EventHandler? TextPropertySet;
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Platform.iOS
 		public MauiTextView(CGRect frame) : base(frame)
 		{
 			InitPlaceholderLabel();
+			this.Changed += OnChanged;
 		}
 
 		public string? PlaceholderText
@@ -77,7 +78,7 @@ namespace Microsoft.Maui.Platform.iOS
 				if (old != value)
 				{
 					TextPropertySet?.Invoke(this, EventArgs.Empty);
-					HidePlaceholderIfTextIsPresent();
+					HidePlaceholderIfTextIsPresent(value);
 				}
 			}
 		}
@@ -94,14 +95,20 @@ namespace Microsoft.Maui.Platform.iOS
 				if (old?.Value != value?.Value)
 				{
 					TextPropertySet?.Invoke(this, EventArgs.Empty);
-					HidePlaceholderIfTextIsPresent();
+					HidePlaceholderIfTextIsPresent(value?.Value);
 				}
 			}
 		}
 
-		void HidePlaceholderIfTextIsPresent()
+		void HidePlaceholderIfTextIsPresent(string? value)
 		{
+			HidePlaceholder(!String.IsNullOrEmpty(value));
+		}
 
+		void OnChanged(object? sender, EventArgs e)
+		{
+			HidePlaceholderIfTextIsPresent(Text);
+			TextPropertySet?.Invoke(this, EventArgs.Empty);
 		}
 
 		public event EventHandler? TextPropertySet;

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -75,7 +75,10 @@ namespace Microsoft.Maui.Platform.iOS
 				base.Text = value;
 
 				if (old != value)
+				{
 					TextPropertySet?.Invoke(this, EventArgs.Empty);
+					HidePlaceholderIfTextIsPresent();
+				}
 			}
 		}
 
@@ -89,8 +92,16 @@ namespace Microsoft.Maui.Platform.iOS
 				base.AttributedText = value;
 
 				if (old?.Value != value?.Value)
+				{
 					TextPropertySet?.Invoke(this, EventArgs.Empty);
+					HidePlaceholderIfTextIsPresent();
+				}
 			}
+		}
+
+		void HidePlaceholderIfTextIsPresent()
+		{
+
 		}
 
 		public event EventHandler? TextPropertySet;

--- a/src/Core/src/Platform/iOS/TextViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextViewExtensions.cs
@@ -1,4 +1,5 @@
-﻿using UIKit;
+﻿using Microsoft.Maui.Platform.iOS;
+using UIKit;
 
 namespace Microsoft.Maui
 {
@@ -30,7 +31,12 @@ namespace Microsoft.Maui
 			if (textAttr != null)
 				textView.AttributedText = textAttr;
 
-			// TODO: Include AttributedText to Label Placeholder
+			if (textView is MauiTextView mauiTextView)
+			{
+				var phAttr = mauiTextView.PlaceholderLabel.AttributedText?.WithCharacterSpacing(textStyle.CharacterSpacing);
+				if (phAttr != null)
+					mauiTextView.PlaceholderLabel.AttributedText = phAttr;
+			}
 		}
 
 		public static void UpdateMaxLength(this UITextView textView, IEditor editor)

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -11,12 +11,65 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EditorHandlerTests
 	{
+		[Fact(DisplayName = "Placeholder Toggles Correctly When Text Changes")]
+		public async Task PlaceholderTogglesCorrectlyWhenTextChanges()
+		{
+			var editor = new EditorStub();
+
+			bool testPassed = false;
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler(editor);
+
+				Assert.False(GetNativePlaceholder(handler).Hidden);
+				editor.Text = "test";
+				handler.UpdateValue(nameof(EditorStub.Text));
+				Assert.True(GetNativePlaceholder(handler).Hidden);
+				editor.Text = "";
+				Assert.False(GetNativePlaceholder(handler).Hidden);
+				testPassed = true;
+			});
+
+			Assert.True(testPassed);
+		}
+
 		[Fact(DisplayName = "Placeholder Hidden When Control Has Text")]
 		public async Task PlaceholderHiddenWhenControlHasText()
 		{
 			var editor = new EditorStub()
 			{
 				Text = "Text"
+			};
+
+			var isHidden = await GetValueAsync(editor, handler =>
+			{
+				return GetNativePlaceholder(handler).Hidden;
+			});
+
+			Assert.True(isHidden);
+		}
+
+		[Fact(DisplayName = "Placeholder Visible When Control No Text")]
+		public async Task PlaceholderVisibleWhenControlHasNoText()
+		{
+			var editor = new EditorStub();
+
+			var isHidden = await GetValueAsync(editor, handler =>
+			{
+				return GetNativePlaceholder(handler).Hidden;
+			});
+
+			Assert.False(isHidden);
+		}
+
+		[Fact(DisplayName = "Placeholder Hidden When Control Has Attributed Text")]
+		public async Task PlaceholderHiddenWhenControlHasAttributedText()
+		{
+			var editor = new EditorStub()
+			{
+				Text = "Text",
+				CharacterSpacing = 43
 			};
 
 			var isHidden = await GetValueAsync(editor, handler =>

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -11,6 +11,22 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EditorHandlerTests
 	{
+		[Fact(DisplayName = "Placeholder Hidden When Control Has Text")]
+		public async Task PlaceholderHiddenWhenControlHasText()
+		{
+			var editor = new EditorStub()
+			{
+				Text = "Text"
+			};
+
+			var isHidden = await GetValueAsync(editor, handler =>
+			{
+				return GetNativePlaceholder(handler).Hidden;
+			});
+
+			Assert.True(isHidden);
+		}
+
 		[Fact(DisplayName = "CharacterSpacing Initializes Correctly")]
 		public async Task CharacterSpacingInitializesCorrectly()
 		{
@@ -83,6 +99,10 @@ namespace Microsoft.Maui.DeviceTests
 			var endPosition = control.GetPosition(control.BeginningOfDocument, position);
 			control.SelectedTextRange = control.GetTextRange(endPosition, endPosition);
 		}
+
+		UILabel GetNativePlaceholder(EditorHandler editorHandler) =>
+			GetNativeEditor(editorHandler).FindDescendantView<UILabel>() ??
+			throw new System.InvalidOperationException("Unable to find Native Placehold");
 
 		string GetNativePlaceholderText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).PlaceholderText;

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -154,8 +154,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		UILabel GetNativePlaceholder(EditorHandler editorHandler) =>
-			GetNativeEditor(editorHandler).FindDescendantView<UILabel>() ??
-			throw new System.InvalidOperationException("Unable to find Native Placehold");
+			GetNativeEditor(editorHandler).PlaceholderLabel;
 
 		string GetNativePlaceholderText(EditorHandler editorHandler) =>
 			GetNativeEditor(editorHandler).PlaceholderText;


### PR DESCRIPTION
### Description of Change ###

Modified iOS `MauiTextView` so that it will propagate changed events when the text is modified by the user or in code.  We were using two different events for `Changed` (Changes via UI) vs `TextPropertySet` (Changes via code) which was causing some scenarios to get wired up for one type of change but not the other.  Now that we just propagate all changes out of a single event we can just streamline everything that needs to know about text changes. 

This also moves the PlaceholderVisibility code into the `MauiTextView`. The visibility of the placeholder should just be an implicit behavior of the control and not require something from an outside actor


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
