### PR TITLE
Handle query strings in Blazor static assets by trimming them out

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -65,6 +65,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				}
 			}
 
+			requestUri = QueryStringHelper.RemovePossibleQueryString(requestUri);
+
 			if (requestUri != null &&
 				_webViewHandler != null &&
 				_webViewHandler.WebviewManager != null &&

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\SharedSource\QueryStringHelper.cs" Link="QueryStringHelper.cs" />
     <Compile Include="..\WebView2\Internal\StaticContentProvider.cs" Link="Windows\SharedSource\StaticContentProvider.cs" />
   </ItemGroup>
 

--- a/src/BlazorWebView/src/Maui/Windows/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/SharedSource/WebView2WebViewManager.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebView.Maui;
 using Microsoft.AspNetCore.Components.WebView.WebView2.Internal;
 using Microsoft.Extensions.FileProviders;
 using Windows.ApplicationModel;
@@ -102,10 +103,12 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 				eventArgs.ResourceContext == CoreWebView2WebResourceContextWrapper.Document ||
 				eventArgs.ResourceContext == CoreWebView2WebResourceContextWrapper.Other; // e.g., dev tools requesting page source
 
+			var requestUri = QueryStringHelper.RemovePossibleQueryString(eventArgs.Request.Uri);
+
 			// First, call into WebViewManager to see if it has a framework file for this request. It will
 			// fall back to an IFileProvider, but on WinUI it's always a NullFileProvider, so that will never
 			// return a file.
-			if (TryGetResponseContent(eventArgs.Request.Uri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers))
+			if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers))
 			{
 				// NOTE: This is stream copying is to work around a hanging bug in WinRT with managed streams
 				var memStream = new MemoryStream();

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -42,10 +42,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			// Get a deferral object so that WebView2 knows there's some async stuff going on. We call Complete() at the end of this method.
 			using var deferral = eventArgs.GetDeferral();
 
+			var requestUri = QueryStringHelper.RemovePossibleQueryString(eventArgs.Request.Uri);
+
 			// First, call into WebViewManager to see if it has a framework file for this request. It will
 			// fall back to an IFileProvider, but on WinUI it's always a NullFileProvider, so that will never
 			// return a file.
-			if (TryGetResponseContent(eventArgs.Request.Uri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers)
+			if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers)
 				&& statusCode != 404)
 			{
 				// NOTE: This is stream copying is to work around a hanging bug in WinRT with managed streams.
@@ -61,7 +63,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			else
 			{
 				// Next, try to go through WinUI Storage to find a static web asset
-				var uri = new Uri(eventArgs.Request.Uri);
+				var uri = new Uri(requestUri);
 				if (new Uri(AppOrigin).IsBaseOf(uri))
 				{
 					var relativePath = new Uri(AppOrigin).MakeRelativeUri(uri).ToString();

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -180,6 +180,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			private byte[] GetResponseBytes(string url, out string contentType, out int statusCode)
 			{
 				var allowFallbackOnHostPage = url.EndsWith("/");
+				url = QueryStringHelper.RemovePossibleQueryString(url);
 				if (_webViewHandler._webviewManager!.TryGetResponseContentInternal(url, allowFallbackOnHostPage, out statusCode, out var statusMessage, out var content, out var headers))
 				{
 					statusCode = 200;

--- a/src/BlazorWebView/src/SharedSource/QueryStringHelper.cs
+++ b/src/BlazorWebView/src/SharedSource/QueryStringHelper.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+	public static class QueryStringHelper
+	{
+		public static string RemovePossibleQueryString(string? url)
+		{
+			if (string.IsNullOrEmpty(url))
+			{
+				return string.Empty;
+			}
+			var indexOfQueryString = url.IndexOf('?');
+			return (indexOfQueryString == -1)
+				? url
+				: url.Substring(0, indexOfQueryString);
+		}
+	}
+}

--- a/src/BlazorWebView/src/WebView2/Microsoft.AspNetCore.Components.WebView.WebView2.csproj
+++ b/src/BlazorWebView/src/WebView2/Microsoft.AspNetCore.Components.WebView.WebView2.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\SharedSource\QueryStringHelper.cs" Link="QueryStringHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView" />
   </ItemGroup>
 

--- a/src/BlazorWebView/src/WebView2/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/WebView2/WebView2WebViewManager.cs
@@ -74,7 +74,9 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 					eventArgs.ResourceContext == CoreWebView2WebResourceContextWrapper.Document ||
 					eventArgs.ResourceContext == CoreWebView2WebResourceContextWrapper.Other; // e.g., dev tools requesting page source
 
-				if (TryGetResponseContent(eventArgs.Request.Uri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers))
+				var requestUri = QueryStringHelper.RemovePossibleQueryString(eventArgs.Request.Uri);
+
+				if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers))
 				{
 					var headerString = GetHeaderString(headers);
 					eventArgs.SetResponse(content, statusCode, statusMessage, headerString);


### PR DESCRIPTION
Each platform has a slightly different place to handle this because it's a behavior between each platform's unique web view and each platform's unique way of loading static assets:
- WPF/WinForms: Handled in one place in common WebView2 project
- .NET MAUI: Handled individually for Android, iOS/MacCatalyst, and WinUI (WinUI has 2 places due to an async oddity of WinUI)

Fixes #3061