### PR TITLE
[build] Add maui-blazor to vs-workload.props

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -13,6 +13,7 @@
     <ComponentResources Include="maui-mobile"       Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Mobile" Description=".NET SDK Workload for building MAUI applications that target mobile platforms." />
     <ComponentResources Include="maui-desktop"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Desktop" Description=".NET SDK Workload for building MAUI applications that target desktop platforms." />
     <ComponentResources Include="maui-core"         Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK Core" Description=".NET SDK Workload containing core MAUI SDK packages." />
+    <ComponentResources Include="maui-blazor"       Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK Core" Description=".NET SDK Workload containing MAUI SDK Blazor packages." />
     <ComponentResources Include="maui-android"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Android" Description=".NET SDK Workload for building MAUI applications that target Android." />
     <ComponentResources Include="maui-maccatalyst"  Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Mac Catalyst" Description=".NET SDK Workload for building MAUI applications that target Mac Catalyst." />
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />

--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -13,7 +13,7 @@
     <ComponentResources Include="maui-mobile"       Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Mobile" Description=".NET SDK Workload for building MAUI applications that target mobile platforms." />
     <ComponentResources Include="maui-desktop"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Desktop" Description=".NET SDK Workload for building MAUI applications that target desktop platforms." />
     <ComponentResources Include="maui-core"         Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK Core" Description=".NET SDK Workload containing core MAUI SDK packages." />
-    <ComponentResources Include="maui-blazor"       Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK Core" Description=".NET SDK Workload containing MAUI SDK Blazor packages." />
+    <ComponentResources Include="maui-blazor"       Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Blazor Desktop" Description=".NET SDK Workload containing MAUI SDK Blazor packages." />
     <ComponentResources Include="maui-android"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Android" Description=".NET SDK Workload for building MAUI applications that target Android." />
     <ComponentResources Include="maui-maccatalyst"  Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Mac Catalyst" Description=".NET SDK Workload for building MAUI applications that target Mac Catalyst." />
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />


### PR DESCRIPTION
The `@(ComponentResources)` item in the vs-workload.props file is used
by the [`<GenerateVisualStudioWorkload/>` task][0] to fill out missing
information when generating Visual Studio installer manifests for Mauis
.NET workloads.  Whenever a new workload is added to the
[`WorkloadManifest.json` file][1], a corresponding entry must be added
to `vs-workload.template.props` or the generated VS manifests will
contain incomplete information.

[0]: https://github.com/dotnet/arcade/blob/5aa9d32c0fd7f412ea60aba2b9650fcbd3b8766c/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.cs#L18
[1]: https://github.com/dotnet/maui/blob/ed9088699a589a8dfdd3ad6f2c0d36a16d270380/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
