### PR TITLE
[core] do not configure loggers by default on mobile

### DIFF
--- a/src/Core/src/Hosting/MauiAppBuilder.cs
+++ b/src/Core/src/Hosting/MauiAppBuilder.cs
@@ -242,13 +242,16 @@ namespace Microsoft.Maui.Hosting
 						}
 
 						logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
-						logging.AddConsole();
 						logging.AddDebug();
-						logging.AddEventSourceLogger();
 
 						if (isWindows)
 						{
-							// Add the EventLogLoggerProvider on windows machines
+							// The Console logger creates a new thread, which isn't ideal for mobile platforms:
+							// https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs#L25-L29
+							// https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs#L64
+							logging.AddConsole();
+							logging.AddEventSourceLogger();
+							// AddEventLog() should be windows-only
 							logging.AddEventLog();
 						}
 


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/dotnet/maui/issues/2270#issuecomment-924953239
Context: https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs#L25-L29
Context: https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs#L64

I found that calling `AddConsole()` to configure the
Microsoft.Extensions console logger starts a new thread and uses
`ConsumingEnumerable` to process logging calls. This shows up in
`dotnet trace` as spending a lot of CPU time:

    Microsoft.Extensions.Logging.Console.ConsoleLoggerProcessor.ProcessLogQueue()

`dotnet trace` reports 73% of the CPU samples during startup were
inside this method.

This is particularly bad on Android, where new threads on startup
hurts performance. We should reserve all new threads for developers --
as they will want to do things like HTTP requests, etc.

Testing a Release build on a Pixel 5:

    > .\bin\dotnet\dotnet.exe build .\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj -t:Install -f net6.0-android -c Release

    Before:
    Activity: Displayed     01.610
    Activity: Displayed     01.620
    Activity: Displayed     01.621
    Activity: Displayed     01.607
    Activity: Displayed     01.621
    Activity: Displayed     01.632
    Activity: Displayed     01.688
    Activity: Displayed     01.626
    Activity: Displayed     01.601
    Activity: Displayed     01.622
    Activity: Displayed     01.611
    ------------------------------
    Average:                01.624

    After:
    Activity: Displayed     01.586
    Activity: Displayed     01.577
    Activity: Displayed     01.597
    Activity: Displayed     01.600
    Activity: Displayed     01.610
    Activity: Displayed     01.586
    Activity: Displayed     01.596
    Activity: Displayed     01.578
    Activity: Displayed     01.582
    Activity: Displayed     01.586
    ------------------------------
    Average:                01.590

I think this might save as much as ~34ms to startup for a simple change.

If developers want to use the console logger, should should be able to
call `AddConsole()` themselves. Although, I would probably only
recommend for `Debug` builds:

    #if DEBUG
    logging.AddConsole();
    #endif

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No