### PR TITLE
Let XAML Hot Reload work with MAUI Samples

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,11 @@
   <Import Project="eng\AndroidX.targets" />
   <Import Project="eng\Microsoft.Extensions.targets" />
 
+  <PropertyGroup>
+     <!-- Allows for MAUI Xaml Hot Reload Samples to run without  -->
+    <IgnoreMauiXamlHotReloadCompatibilityCheck>True</IgnoreMauiXamlHotReloadCompatibilityCheck>
+  </PropertyGroup>
+
   <!-- platform version number information -->
   <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,7 @@
   <Import Project="eng\Microsoft.Extensions.targets" />
 
   <PropertyGroup>
-     <!-- Allows for MAUI Xaml Hot Reload Samples to run without  -->
+     <!-- Allows for MAUI Xaml Hot Reload Samples to run without checks  -->
     <IgnoreMauiXamlHotReloadCompatibilityCheck>True</IgnoreMauiXamlHotReloadCompatibilityCheck>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR enables XAML Hot Reload to work correctly with the MAUI Sample Projects built-in source.

This requires `main` builds of Visual Studio or VSMac, and should be shipped into public builds in the next 17.1 Preview.

https://user-images.githubusercontent.com/898335/138949877-0aecfafe-dd54-49ca-8107-c14f0af5ac93.mp4

 