### PR TITLE
Allow to use Color type where a Brush is expected

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ShapesPage.xaml
@@ -4,6 +4,13 @@
     x:Class="Maui.Controls.Sample.Pages.ShapesPage"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="Shapes">
+    <views:BasePage.Resources>
+        <ResourceDictionary>
+            
+            <Color x:Key="CustomColor">#2B0B98</Color>
+            
+        </ResourceDictionary>
+    </views:BasePage.Resources>
     <ScrollView>
         <VerticalStackLayout Padding="12" Spacing="6">
 
@@ -11,7 +18,7 @@
                 Text="Ellipse"
                 Style="{StaticResource Headline}" />
             <Ellipse
-                Fill="DarkBlue"
+                Fill="{StaticResource CustomColor}"
                 Stroke="Red"
                 StrokeThickness="4"
                 WidthRequest="150"

--- a/src/Controls/src/Core/Brush.cs
+++ b/src/Controls/src/Core/Brush.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return new SolidColorBrush(null); }
 		}
+		
+		public static implicit operator Brush(Color color) => new SolidColorBrush(color);
 
 		public abstract bool IsEmpty { get; }
 


### PR DESCRIPTION
### Description of Change ###

Added implicit casting between Color and SolidColorBrush. In that way, can use a Color type with brushes properties like Background, Fill, etc.

- fixes #2858 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No
