### PR TITLE
Avoid NRE using a Path without Data

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Path.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Path.Impl.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Maui.Controls.Shapes
 		{
 			var path = new PathF();
 
-			Data.AppendPath(path);
+			if (Data != null)
+				Data.AppendPath(path);
 
 			return path;
 		}


### PR DESCRIPTION
### Description of Change ###

Avoid NRE using a Path without Data.

Example:

`<Path  x:Name="Test"/>`

- fixes #2466 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No
