### PR TITLE
[Android] Fix swap EmptyView on CollectionView handler

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/SimpleViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SimpleViewHolder.cs
@@ -8,8 +8,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 {
 	internal class SimpleViewHolder : RecyclerView.ViewHolder
 	{
+		global::Android.Views.View _itemView;
 		public SimpleViewHolder(global::Android.Views.View itemView, View rootElement) : base(itemView)
 		{
+			_itemView = itemView;
 			View = rootElement;
 		}
 
@@ -17,6 +19,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public void Recycle(ItemsView itemsView)
 		{
+			if(_itemView is SizedItemContentView _sizedItemContentView)
+			{
+				_sizedItemContentView.Recycle();
+			}
 			itemsView.RemoveLogicalChild(View);
 		}
 


### PR DESCRIPTION
### Description of Change ###

If you swap between empty views you could hit a issue because the NativeView wasn't removed from previous parent (ItemContentView ViewGroup). This fix calls recycle on the `ItemContentView` that removes the NativeView (handler) 

To test the fix go Controls ->  CollectionView -> EmptyView galleries -> Swap EmptyView

Swapping using the toggle button should not make the application crash

### Additions made ###

None

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
