### PR TITLE
Add ContainerView to Layout if it's present

### DIFF
--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 			NativeView.RemoveAllViews();
 			foreach (var child in VirtualView)
 			{
-				NativeView.AddView(child.ToNative(MauiContext));
+				NativeView.AddView(child.ToNative(MauiContext, true));
 			}
 		}
 
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.AddView(child.ToNative(MauiContext));
+			NativeView.AddView(child.ToNative(MauiContext, true));
 		}
 
 		public void Remove(IView child)
@@ -56,12 +56,11 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child?.Handler?.NativeView is View view)
+			if (child.GetNative(true) is View view)
 			{
 				NativeView.RemoveView(view);
 			}
 		}
-
 
 		void Clear(LayoutViewGroup nativeView)
 		{
@@ -79,7 +78,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.AddView(child.ToNative(MauiContext), index);
+			NativeView.AddView(child.ToNative(MauiContext, true), index);
 		}
 
 		public void Update(int index, IView child)
@@ -89,7 +88,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			NativeView.RemoveViewAt(index);
-			NativeView.AddView(child.ToNative(MauiContext), index);
+			NativeView.AddView(child.ToNative(MauiContext, true), index);
 		}
 
 		protected override void DisconnectHandler(LayoutViewGroup nativeView)

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child.GetNative(true) is View view)
+			if (child?.GetNative(true) is View view)
 			{
 				NativeView.RemoveView(view);
 			}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.Children.Add(child.ToNative(MauiContext));
+			NativeView.Children.Add(child.ToNative(MauiContext, true));
 		}
 
 		public override void SetVirtualView(IView view)
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child?.Handler?.NativeView is UIElement view)
+			if (child.GetNative(true) is UIElement view)
 			{
 				NativeView.Children.Remove(view);
 			}
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.Children.Insert(index, child.ToNative(MauiContext));
+			NativeView.Children.Insert(index, child.ToNative(MauiContext, true));
 		}
 
 		public void Update(int index, IView child) 
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.Children[index] = child.ToNative(MauiContext);
+			NativeView.Children[index] = child.ToNative(MauiContext, true);
 		}
 
 		protected override LayoutPanel CreateNativeView()

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child.GetNative(true) is UIElement view)
+			if (child?.GetNative(true) is UIElement view)
 			{
 				NativeView.Children.Remove(view);
 			}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Handlers
 
 			foreach (var child in VirtualView)
 			{
-				NativeView.AddSubview(child.ToNative(MauiContext));
+				NativeView.AddSubview(child.ToNative(MauiContext, true));
 			}
 		}
 
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.AddSubview(child.ToNative(MauiContext));
+			NativeView.AddSubview(child.ToNative(MauiContext, true));
 		}
 
 		public void Remove(IView child)
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child?.Handler?.NativeView is NativeView childView)
+			if (child.GetNative(true) is NativeView childView)
 			{
 				childView.RemoveFromSuperview();
 			}
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.InsertSubview(child.ToNative(MauiContext), index);
+			NativeView.InsertSubview(child.ToNative(MauiContext, true), index);
 		}
 
 		public void Update(int index, IView child)
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.Handlers
 
 			var existing = NativeView.Subviews[index];
 			existing.RemoveFromSuperview();
-			NativeView.InsertSubview(child.ToNative(MauiContext), index);
+			NativeView.InsertSubview(child.ToNative(MauiContext, true), index);
 			NativeView.SetNeedsLayout();
 		}
 

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child.GetNative(true) is NativeView childView)
+			if (child?.GetNative(true) is NativeView childView)
 			{
 				childView.RemoveFromSuperview();
 			}

--- a/src/Core/src/Platform/Android/HandlerExtensions.cs
+++ b/src/Core/src/Platform/Android/HandlerExtensions.cs
@@ -7,6 +7,26 @@ namespace Microsoft.Maui
 {
 	public static class HandlerExtensions
 	{
+		internal static AView? GetNative(this IElement view, bool returnWrappedIfPresent)
+		{
+			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
+				return nativeHandler.NativeView;
+
+			return (view.Handler?.NativeView as AView);
+
+		}
+
+		internal static AView ToNative(this IElement view, IMauiContext context, bool returnWrappedIfPresent)
+		{
+			var nativeView = view.ToNative(context);
+
+			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
+				return nativeHandler.NativeView;
+
+			return nativeView;
+
+		}
+
 		public static AView ToContainerView(this IElement view, IMauiContext context) =>
 			new ContainerView(context) { CurrentView = view };
 

--- a/src/Core/src/Platform/Windows/HandlerExtensions.cs
+++ b/src/Core/src/Platform/Windows/HandlerExtensions.cs
@@ -5,6 +5,26 @@ namespace Microsoft.Maui
 {
 	public static class HandlerExtensions
 	{
+		internal static FrameworkElement? GetNative(this IElement view, bool returnWrappedIfPresent)
+		{
+			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
+				return nativeHandler.NativeView;
+
+			return (view.Handler?.NativeView as FrameworkElement);
+
+		}
+
+		internal static FrameworkElement ToNative(this IElement view, IMauiContext context, bool returnWrappedIfPresent)
+		{
+			var nativeView = view.ToNative(context);
+
+			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
+				return nativeHandler.NativeView;
+
+			return nativeView;
+
+		}
+
 		public static FrameworkElement ToNative(this IElement view, IMauiContext context)
 		{
 			_ = view ?? throw new ArgumentNullException(nameof(view));

--- a/src/Core/src/Platform/iOS/HandlerExtensions.cs
+++ b/src/Core/src/Platform/iOS/HandlerExtensions.cs
@@ -6,6 +6,26 @@ namespace Microsoft.Maui
 {
 	public static class HandlerExtensions
 	{
+		internal static UIView? GetNative(this IElement view, bool returnWrappedIfPresent)
+		{
+			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
+				return nativeHandler.NativeView;
+
+			return (view.Handler?.NativeView as UIView);
+
+		}
+
+		internal static UIView ToNative(this IElement view, IMauiContext context, bool returnWrappedIfPresent)
+		{
+			var nativeView = view.ToNative(context);
+
+			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
+				return nativeHandler.NativeView;
+
+			return nativeView;
+			
+		}
+
 		public static UIViewController ToUIViewController(this IElement view, IMauiContext context)
 		{
 			var nativeView = view.ToNative(context);

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Maui.DeviceTests
 				.CreateBuilder()
 				.ConfigureMauiHandlers(handlers =>
 				{
+					handlers.AddHandler(typeof(ButtonWithContainerStub), typeof(ButtonWithContainerStubHandler));
 					handlers.AddHandler(typeof(SliderStub), typeof(SliderHandler));
 					handlers.AddHandler(typeof(ButtonStub), typeof(ButtonHandler));
 				})

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -160,5 +160,35 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			Assert.Equal(1, children.Count);
 			Assert.Same(button.Handler.NativeView, children[0]);
 		}
+
+		[Fact]
+		public async Task ContainerViewAddedToLayout()
+		{
+			var layout = new LayoutStub();
+			var addedSlider = new ButtonWithContainerStub();
+			var insertedSlider = new ButtonWithContainerStub();
+
+			layout.Add(addedSlider);
+
+			var handler = await CreateHandlerAsync(layout);
+
+			var children = await InvokeOnMainThreadAsync(() =>
+			{
+				return GetNativeChildren(handler);
+			});
+
+			Assert.Equal(1, children.Count);
+			Assert.Same(addedSlider.Handler.ContainerView, children[0]);
+
+			children = await InvokeOnMainThreadAsync(() =>
+			{
+				handler.Insert(0, insertedSlider);
+				return GetNativeChildren(handler);
+			});
+
+			Assert.Equal(2, children.Count);
+			Assert.Same(insertedSlider.Handler.ContainerView, children[0]);
+			Assert.Same(addedSlider.Handler.ContainerView, children[1]);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/ButtonWithContainerStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ButtonWithContainerStub.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public class ButtonWithContainerStub : ButtonStub
+	{
+	}
+
+
+	public class ButtonWithContainerStubHandler : ButtonHandler
+	{
+		public override void SetVirtualView(IView view)
+		{
+			base.SetVirtualView(view);
+#if ANDROID
+			ContainerView = new WrapperView(Context);
+#else
+			ContainerView = new WrapperView();
+#endif
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Layouts are currently adding the root view from a handler but ignoring if a ContainerView is present. 

This PR fixes Layouts so they will add the ContainerView if the ContainerView is present 🎁 

For now I just added an internal version of ToNative that lets us easily return the wrapped view when all we care about is adding it to the layout

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
