### PR TITLE
Fix iOS splash screens in partial builds

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -121,8 +121,13 @@
         <ProcessMauiFontsBeforeTargets>
             $(ProcessMauiFontsBeforeTargets);
             _BeforeCoreCompileImageAssets;
-            _CompileAppManifest;
         </ProcessMauiFontsBeforeTargets>
+
+        <CollectAppManifestsDependsOn>
+            ProcessMauiFonts;
+            ProcessMauiSplashScreens;
+            $(CollectAppManifestsDependsOn)
+        </CollectAppManifestsDependsOn>
     </PropertyGroup>
 
     <!-- Android -->
@@ -383,15 +388,11 @@
             IntermediateOutputPath="$(_MauiIntermediateFonts)"
             PlistName="MauiInfo.plist"
             Storyboard="$(_MauiStoryboardForPList)"
-            CustomFonts="@(_MauiFontCopied)">
-            <Output
-                TaskParameter="PListFiles"
-                ItemName="_MauiFontPListFiles" />
-
-        </CreatePartialInfoPlistTask>
+            CustomFonts="@(_MauiFontCopied)" />
 
         <!-- iOS - Partial Info.plist for font registration  -->
         <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True' ">
+            <_MauiFontPListFiles Include="$(_MauiIntermediateFonts)MauiInfo.plist" />
             <PartialAppManifest Include="@(_MauiFontPListFiles)" Condition="'@(_MauiFontPListFiles)' != ''" />
             <FileWrites Include="@(_MauiFontPListFiles)" Condition="'@(_MauiFontPListFiles)' != ''" />
         </ItemGroup>

--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -392,7 +392,7 @@
 
         <!-- iOS - Partial Info.plist for font registration  -->
         <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True' ">
-            <_MauiFontPListFiles Include="$(_MauiIntermediateFonts)MauiInfo.plist" />
+            <_MauiFontPListFiles Include="$(_MauiIntermediateFonts)MauiInfo.plist" Condition="Exists('$(_MauiIntermediateFonts)MauiInfo.plist')" />
             <PartialAppManifest Include="@(_MauiFontPListFiles)" Condition="'@(_MauiFontPListFiles)' != ''" />
             <FileWrites Include="@(_MauiFontPListFiles)" Condition="'@(_MauiFontPListFiles)' != ''" />
         </ItemGroup>

--- a/src/SingleProject/Resizetizer/src/CreatePartialInfoPlistTask.cs
+++ b/src/SingleProject/Resizetizer/src/CreatePartialInfoPlistTask.cs
@@ -16,9 +16,6 @@ namespace Microsoft.Maui.Resizetizer
 
 		public string Storyboard { get; set; }
 
-		[Output]
-		public ITaskItem[] PlistFiles { get; set; }
-
 		const string plistHeader =
 @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
@@ -63,8 +60,6 @@ namespace Microsoft.Maui.Resizetizer
 
 					f.WriteLine(plistFooter);
 				}
-
-				PlistFiles = new[] { new TaskItem(plistFilename) };
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
### Description of Change ###

When a Target is skipped because it is already run or the outputs are up-to-date, the Tasks are skipped.

However, the actual <ItemGroup> and <PropertyGroup> elements are still "run". This is because a Target often sets up things - even though it does not need to actually do the work. For example, our target to generate the splash screen files does not need to run because the file already exists and is up-to-date. However, it still needs to set the property of where to find it.

This PR makes sure that the property is set, regardless of whether the file was generated or not.