### PR TITLE
Clean up Shell Chrome Behaviors

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml
@@ -7,6 +7,9 @@
     xmlns:shellPages="clr-namespace:Maui.Controls.Sample.Pages.ShellGalleries"
     FlyoutBackground="{AppThemeBinding Dark=Black, Light=White}"
     >
+    <Shell.FlyoutHeader>
+        <Image Source="dotnet_bot.png"></Image>
+    </Shell.FlyoutHeader>
     <FlyoutItem Title = "Flyout Item 1">
         <ShellContent Title = "Flyout Gallery" ContentTemplate="{DataTemplate shellPages:ShellChromeGallery}"></ShellContent>
         <ShellContent Title = "Button Page" ContentTemplate="{DataTemplate pages:ButtonPage}"></ShellContent>

--- a/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml
@@ -4,12 +4,13 @@
     x:Class="Maui.Controls.Sample.Pages.AppShell"
     xmlns:controls="using:Maui.Controls.Sample.Controls"
     xmlns:pages="using:Maui.Controls.Sample.Pages"
-    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
-    xmlns:viewmodels="clr-namespace:Maui.Controls.Sample.ViewModels"
+    xmlns:shellPages="clr-namespace:Maui.Controls.Sample.Pages.ShellGalleries"
+    FlyoutBackground="{AppThemeBinding Dark=Black, Light=White}"
     >
     <FlyoutItem Title = "Flyout Item 1">
-        <ShellContent Title = "Semantics Page"  ContentTemplate="{DataTemplate pages:SemanticsPage}"></ShellContent>
+        <ShellContent Title = "Flyout Gallery" ContentTemplate="{DataTemplate shellPages:ShellChromeGallery}"></ShellContent>
         <ShellContent Title = "Button Page" ContentTemplate="{DataTemplate pages:ButtonPage}"></ShellContent>
+        <ShellContent Title = "Semantics Page"  ContentTemplate="{DataTemplate pages:SemanticsPage}"></ShellContent>
     </FlyoutItem>
     <ShellSection Title="Flyout Item 3">
         <ShellContent Title = "Semantics Page" ContentTemplate="{DataTemplate pages:SemanticsPage}"></ShellContent>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     x:Class="Maui.Controls.Sample.Pages.SemanticsPage"
+    Shell.NavBarIsVisible="False"
     Title="Semantics">
     <ScrollView
         Margin="15,20">

--- a/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/SemanticsPage.xaml
@@ -3,7 +3,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     x:Class="Maui.Controls.Sample.Pages.SemanticsPage"
-    Shell.NavBarIsVisible="False"
     Title="Semantics">
     <ScrollView
         Margin="15,20">

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
@@ -45,13 +45,17 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 
 		void OnToggleFlyoutBackgroundColor(object sender, EventArgs e)
 		{
-			if (AppShell.FlyoutBackground == null ||
-				AppShell.FlyoutBackground.IsEmpty || 
+			AppShell.RemoveBinding(Shell.FlyoutBackgroundProperty);
+			if (AppShell.FlyoutBackground.IsEmpty || 
 				AppShell.FlyoutBackground == SolidColorBrush.Purple)
 			{
 				AppShell.FlyoutBackground = SolidColorBrush.Black;
 			}
 			else if (AppShell.FlyoutBackground == SolidColorBrush.Black)
+			{
+				AppShell.FlyoutBackground = SolidColorBrush.Purple;
+			}
+			else
 			{
 				AppShell.FlyoutBackground = SolidColorBrush.Purple;
 			}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Pages.ShellGalleries
+{
+	public partial class ShellChromeGallery
+	{
+		AppShell AppShell => Application.Current.MainPage as AppShell;
+
+		public ShellChromeGallery()
+		{
+			InitializeComponent();
+
+			flyoutBehavior.ItemsSource = Enum.GetNames(typeof(FlyoutBehavior));
+			flyoutBehavior.SelectedIndexChanged += OnFlyoutBehaviorSelectedIndexChanged;
+
+			if (AppShell != null)
+				flyoutBehavior.SelectedIndex = (int)AppShell.FlyoutBehavior;
+			else
+				flyoutBehavior.SelectedIndex = 1;
+		}
+
+		async void OnPushPage(object sender, EventArgs e)
+		{
+			await Navigation.PushAsync(new ShellChromeGallery());
+		}
+
+		async void OnPopPage(object sender, EventArgs e)
+		{
+			if (Navigation.NavigationStack.Count > 1)
+				await Navigation.PopAsync();
+		}
+
+		void OnFlyoutBehaviorSelectedIndexChanged(object sender, EventArgs e)
+		{
+			AppShell.FlyoutBehavior = (FlyoutBehavior)flyoutBehavior.SelectedIndex;
+		}
+
+		protected override void OnAppearing()
+		{
+			AppShell.FlyoutBehavior = (FlyoutBehavior)flyoutBehavior.SelectedIndex;
+		}
+
+		void OnToggleFlyoutBackgroundColor(object sender, EventArgs e)
+		{
+			if (AppShell.FlyoutBackground == null ||
+				AppShell.FlyoutBackground.IsEmpty || 
+				AppShell.FlyoutBackground == SolidColorBrush.Purple)
+			{
+				AppShell.FlyoutBackground = SolidColorBrush.Black;
+			}
+			else if (AppShell.FlyoutBackground == SolidColorBrush.Black)
+			{
+				AppShell.FlyoutBackground = SolidColorBrush.Purple;
+			}
+
+			flyoutBackgroundColor.Background = AppShell.FlyoutBackground;
+		}
+
+		void OnToggleNavBarIsVisible(object sender, EventArgs e)
+		{
+			Shell.SetNavBarIsVisible(this, !Shell.GetNavBarIsVisible(this));
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
@@ -67,5 +67,12 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 		{
 			Shell.SetNavBarIsVisible(this, !Shell.GetNavBarIsVisible(this));
 		}
+
+		void OnToggleBackButtonIsVisible(object sender, EventArgs e)
+		{
+			var backButtonBehavior = Shell.GetBackButtonBehavior(this) ?? new BackButtonBehavior();
+			backButtonBehavior.IsVisible = !backButtonBehavior.IsVisible;
+			Shell.SetBackButtonBehavior(this, backButtonBehavior);
+		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
@@ -21,6 +21,10 @@
                 Style="{StaticResource Headline}"/>
             <Button Text="Toggle Navbar Visibility" Clicked="OnToggleNavBarIsVisible" />
             <Label
+                Text="Toggle BackButton Visibility"
+                Style="{StaticResource Headline}"/>
+            <Button Text="Toggle Back Button Visibility" Clicked="OnToggleBackButtonIsVisible" />
+            <Label
                 Text="Push Page"
                 Style="{StaticResource Headline}"/>
             <Button Text="Push Page" Clicked="OnPushPage" />

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.ShellGalleries.ShellChromeGallery"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"    
+    Title="Chrome Gallery">
+    <views:BasePage.Content>
+        <StackLayout
+            Margin="12">
+            <Label
+                Text="Flyout Behavior"
+                Style="{StaticResource Headline}"/>
+            <Picker x:Name="flyoutBehavior" />
+            <Label
+                Text="Flyout Background Color"
+                Style="{StaticResource Headline}"/>
+            <Button Text="Toggle Flyout Background" x:Name="flyoutBackgroundColor" Clicked="OnToggleFlyoutBackgroundColor" />
+            <Label
+                Text="Toggle Navbar Visibility"
+                Style="{StaticResource Headline}"/>
+            <Button Text="Toggle Navbar Visibility" Clicked="OnToggleNavBarIsVisible" />
+            <Label
+                Text="Push Page"
+                Style="{StaticResource Headline}"/>
+            <Button Text="Push Page" Clicked="OnPushPage" />
+            <Label
+                Text="Pop Page"
+                Style="{StaticResource Headline}"/>
+            <Button Text="Pop Page" Clicked="OnPopPage" />
+        </StackLayout>
+    </views:BasePage.Content>
+</views:BasePage>

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellItemView.cs
@@ -210,13 +210,26 @@ namespace Microsoft.Maui.Controls.Platform
 			if (appearance != null)
 			{
 				var a = (IShellAppearanceElement)appearance;
-				tabBarBackgroundColor = a.EffectiveTabBarBackgroundColor.ToWindowsColor();
-				tabBarForegroundColor = a.EffectiveTabBarForegroundColor.ToWindowsColor();
+
+				if (a.EffectiveTabBarBackgroundColor != null)
+					tabBarBackgroundColor = a.EffectiveTabBarBackgroundColor.ToWindowsColor();
+
+				if (a.EffectiveTabBarForegroundColor != null)
+					tabBarForegroundColor = a.EffectiveTabBarForegroundColor.ToWindowsColor();
+
 				if (!appearance.TitleColor.IsDefault())
 					titleColor = appearance.TitleColor.ToWindowsColor();
 			}
-			_BottomBarArea.Background = _HeaderArea.Background =
-				new UwpSolidColorBrush(tabBarBackgroundColor);
+
+			_HeaderArea.Background = new UwpSolidColorBrush(tabBarBackgroundColor);
+
+			// Only color the bottom area if there are tabs present
+			if (ShellItem?.Items.Count > 1)
+			{
+				_BottomBarArea.Background = 
+					new UwpSolidColorBrush(tabBarBackgroundColor);
+			}
+
 			_Title.Foreground = new UwpSolidColorBrush(titleColor);
 			var tabbarForeground = new UwpSolidColorBrush(tabBarForegroundColor);
 			foreach (var button in _BottomBar.Children.OfType<AppBarButton>())

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellItemView.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		IShellItemController ShellItemController => ShellItem;
 		IShellController ShellController => ShellContext?.Shell;
+		BackButtonBehavior BackButtonBehavior { get; set; }
 
 		public ShellItemView(ShellView shellContext)
 		{
@@ -344,6 +345,7 @@ namespace Microsoft.Maui.Controls.Platform
 			UpdatePageTitle();
 			UpdateToolbar();
 			UpdateNavBarVisibility();
+			SetBackButtonBehavior(Shell.GetBackButtonBehavior(DisplayedPage));
 		}
 
 		void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -360,6 +362,33 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				UpdateNavBarVisibility();
 			}
+			else if (e.PropertyName == Shell.BackButtonBehaviorProperty.PropertyName)
+			{
+				SetBackButtonBehavior(Shell.GetBackButtonBehavior(DisplayedPage));
+			}
+		}
+
+		void SetBackButtonBehavior(BackButtonBehavior value)
+		{
+			if (BackButtonBehavior == value)
+				return;
+
+			if (BackButtonBehavior != null)
+				BackButtonBehavior.PropertyChanged -= OnBackButtonBehaviorPropertyChanged;
+
+			BackButtonBehavior = value;
+
+			if (BackButtonBehavior != null)
+				BackButtonBehavior.PropertyChanged += OnBackButtonBehaviorPropertyChanged;
+
+			ShellContext.UpdateToolBar();
+			UpdateHeaderInsets();
+		}
+
+		void OnBackButtonBehaviorPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			ShellContext.UpdateToolBar();
+			UpdateHeaderInsets();
 		}
 
 		void UpdateNavBarVisibility()
@@ -374,6 +403,7 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			ShellContext.UpdateToolBar();
+			UpdateHeaderInsets();
 		}
 
 		void UpdatePageTitle()

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellSectionView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellSectionView.cs
@@ -406,8 +406,12 @@ namespace Microsoft.Maui.Controls.Platform
 			if (appearance != null)
 			{
 				var a = (IShellAppearanceElement)appearance;
-				tabBarBackgroundColor = a.EffectiveTabBarBackgroundColor.ToWindowsColor();
-				tabBarForegroundColor = a.EffectiveTabBarForegroundColor.ToWindowsColor();
+
+				if (a.EffectiveTabBarBackgroundColor != null)
+					tabBarBackgroundColor = a.EffectiveTabBarBackgroundColor.ToWindowsColor();
+
+				if (a.EffectiveTabBarForegroundColor != null)
+					tabBarForegroundColor = a.EffectiveTabBarForegroundColor.ToWindowsColor();
 			}
 
 			UpdateBrushColor("NavigationViewTopPaneBackground", tabBarBackgroundColor);

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
@@ -512,10 +512,6 @@ namespace Microsoft.Maui.Controls.Platform
 				_flyoutHeight = appearance.FlyoutHeight;
 			}
 
-			// TODO WINUI
-			//var titleBar = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().TitleBar;
-			//titleBar.BackgroundColor = titleBar.ButtonBackgroundColor = backgroundColor;
-			//titleBar.ForegroundColor = titleBar.ButtonForegroundColor = titleColor;
 			UpdatePaneButtonColor(TogglePaneButton, !IsPaneOpen);
 			UpdatePaneButtonColor(NavigationViewBackButton, !IsPaneOpen);
 			UpdateFlyoutBackdrop();

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
@@ -358,15 +358,19 @@ namespace Microsoft.Maui.Controls.Platform
 				isNavBarVisible = false;
 			}
 
-			if (_shell.Navigation.NavigationStack.Count > 1 && isNavBarVisible)
+
+			bool backButtonEnabled = false;
+
+			// WinUI seems to reset these values if you modify Pane Properties
+			if (_shell.Navigation.NavigationStack.Count > 1 &&
+				(isNavBarVisible || flyoutBehavior == FlyoutBehavior.Locked))
 			{
-				IsBackEnabled = true;
-				IsBackButtonVisible = NavigationViewBackButtonVisible.Visible;
+				var backButtonBehavior = Shell.GetBackButtonBehavior(_shell.CurrentPage);
+				backButtonEnabled = backButtonBehavior?.IsVisible ?? true;
 			}
 			else
 			{
-				IsBackEnabled = false;
-				IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
+				backButtonEnabled = false;
 			}
 
 			switch (flyoutBehavior)
@@ -389,6 +393,22 @@ namespace Microsoft.Maui.Controls.Platform
 					IsPaneToggleButtonVisible = false;
 					PaneDisplayMode = NavigationViewPaneDisplayMode.Left;
 					break;
+			}
+
+
+			
+			// Don't move these above the pane display settings
+			// WinUI seems to reset these values if you modify Pane Properties
+			if (backButtonEnabled)
+			{
+				IsBackEnabled = true;
+				IsBackButtonVisible = NavigationViewBackButtonVisible.Visible;
+				IsPaneToggleButtonVisible = false;
+			}
+			else
+			{
+				IsBackEnabled = false;
+				IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
@@ -350,20 +350,17 @@ namespace Microsoft.Maui.Controls.Platform
 			if (SelectedItem == null)
 				return;
 
-
-			var flyoutBehavior = _flyoutBehavior;
 			bool isNavBarVisible = true;
 			if (_shell.CurrentPage != null && !Shell.GetNavBarIsVisible(_shell.CurrentPage))
 			{
 				isNavBarVisible = false;
 			}
 
-
 			bool backButtonEnabled = false;
 
 			// WinUI seems to reset these values if you modify Pane Properties
 			if (_shell.Navigation.NavigationStack.Count > 1 &&
-				(isNavBarVisible || flyoutBehavior == FlyoutBehavior.Locked))
+				(isNavBarVisible || _flyoutBehavior == FlyoutBehavior.Locked))
 			{
 				var backButtonBehavior = Shell.GetBackButtonBehavior(_shell.CurrentPage);
 				backButtonEnabled = backButtonBehavior?.IsVisible ?? true;
@@ -373,7 +370,7 @@ namespace Microsoft.Maui.Controls.Platform
 				backButtonEnabled = false;
 			}
 
-			switch (flyoutBehavior)
+			switch (_flyoutBehavior)
 			{
 				case FlyoutBehavior.Disabled:
 					PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
@@ -394,8 +391,6 @@ namespace Microsoft.Maui.Controls.Platform
 					PaneDisplayMode = NavigationViewPaneDisplayMode.Left;
 					break;
 			}
-
-
 			
 			// Don't move these above the pane display settings
 			// WinUI seems to reset these values if you modify Pane Properties

--- a/src/Controls/src/Core/Shell/BackButtonBehavior.cs
+++ b/src/Controls/src/Core/Shell/BackButtonBehavior.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty IsEnabledProperty =
 			BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(BackButtonBehavior), true, BindingMode.OneTime);
 
+		public static readonly BindableProperty IsVisibleProperty =
+			BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(BackButtonBehavior), true, BindingMode.OneTime);
+
 		public static readonly BindableProperty TextOverrideProperty =
 			BindableProperty.Create(nameof(TextOverride), typeof(string), typeof(BackButtonBehavior), null, BindingMode.OneTime);
 
@@ -44,6 +47,12 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return (bool)GetValue(IsEnabledProperty); }
 			set { SetValue(IsEnabledProperty, value); }
+		}
+
+		public bool IsVisible
+		{
+			get { return (bool)GetValue(IsVisibleProperty); }
+			set { SetValue(IsVisibleProperty, value); }
 		}
 
 		public string TextOverride

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -559,7 +559,7 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create(nameof(FlyoutBackgroundColor), typeof(Color), typeof(Shell), null, BindingMode.OneTime);
 
 		public static readonly BindableProperty FlyoutBackgroundProperty =
-			BindableProperty.Create(nameof(FlyoutBackground), typeof(Brush), typeof(Shell), Brush.Default, BindingMode.OneTime);
+			BindableProperty.Create(nameof(FlyoutBackground), typeof(Brush), typeof(Shell), SolidColorBrush.White, BindingMode.OneTime);
 
 		public static readonly BindableProperty FlyoutHeaderBehaviorProperty =
 			BindableProperty.Create(nameof(FlyoutHeaderBehavior), typeof(FlyoutHeaderBehavior), typeof(Shell), FlyoutHeaderBehavior.Default, BindingMode.OneTime);
@@ -616,8 +616,10 @@ namespace Microsoft.Maui.Controls
 
 			if (Application.Current != null)
 			{
-				this.SetAppThemeColor(Shell.FlyoutBackgroundColorProperty, Colors.White, Colors.Black);
-				this.SetOnAppTheme<Brush>(Shell.FlyoutBackgroundProperty, Brush.White, Brush.Black);
+				// This currently makes these two property unchangeable without clearing the binding
+				// Which is a bug in how AppTheme binding works. Once that bug is resolved we can uncomment these lines
+				//this.SetAppThemeColor(Shell.FlyoutBackgroundColorProperty, Colors.White, Colors.Black);
+				//this.SetOnAppTheme<Brush>(Shell.FlyoutBackgroundProperty, Brush.White, Brush.Black);
 			}
 		}
 

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -559,7 +559,7 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.Create(nameof(FlyoutBackgroundColor), typeof(Color), typeof(Shell), null, BindingMode.OneTime);
 
 		public static readonly BindableProperty FlyoutBackgroundProperty =
-			BindableProperty.Create(nameof(FlyoutBackground), typeof(Brush), typeof(Shell), SolidColorBrush.White, BindingMode.OneTime);
+			BindableProperty.Create(nameof(FlyoutBackground), typeof(Brush), typeof(Shell), SolidColorBrush.Default, BindingMode.OneTime);
 
 		public static readonly BindableProperty FlyoutHeaderBehaviorProperty =
 			BindableProperty.Create(nameof(FlyoutHeaderBehavior), typeof(FlyoutHeaderBehavior), typeof(Shell), FlyoutHeaderBehavior.Default, BindingMode.OneTime);
@@ -616,10 +616,8 @@ namespace Microsoft.Maui.Controls
 
 			if (Application.Current != null)
 			{
-				// This currently makes these two property unchangeable without clearing the binding
-				// Which is a bug in how AppTheme binding works. Once that bug is resolved we can uncomment these lines
-				//this.SetAppThemeColor(Shell.FlyoutBackgroundColorProperty, Colors.White, Colors.Black);
-				//this.SetOnAppTheme<Brush>(Shell.FlyoutBackgroundProperty, Brush.White, Brush.Black);
+				this.SetBinding(Shell.FlyoutBackgroundColorProperty,
+					new AppThemeBinding { Light = Colors.White, Dark = Colors.Black, Mode = BindingMode.OneWay });
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

- Fixes NavBarIsVisible on WinUI
- Fixes FlyoutBackgroundColor on all platforms (it looks like there's a bug with AppThemeBinding which was making this value un-settable by the user.  Once that issue is fixed we'll fix this property to have better defaults
- Cleaned up a few issues around presentation on WinUI when hiding navbar and locking the flyout
- Added the beginning Pages for the Shell Gallery

To test swap out the XamlApp root page with AppShell

### Added

- BackButtonBehavior.IsVisible  (https://github.com/xamarin/Xamarin.Forms/issues/11404)

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
