### PR TITLE
BlazorWebView support for loading custom static assets

### DIFF
--- a/src/BlazorWebView/samples/BlazorWinFormsApp/CustomFilesBlazorWebView.cs
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/CustomFilesBlazorWebView.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components.WebView.WindowsForms;
+using Microsoft.Extensions.FileProviders;
+using WebViewAppShared;
+
+namespace BlazorWpfApp
+{
+	public class CustomFilesBlazorWebView : BlazorWebView
+	{
+		public override IFileProvider CreateFileProvider(string contentRootDir)
+		{
+			var inMemoryFiles = new InMemoryStaticFileProvider(
+				fileContentsMap: new Dictionary<string, string>
+				{
+					{ "customindex.html", StaticFilesContents.CustomIndexHtmlContent },
+				},
+				// The contentRoot is ignored here because in WinForms it would include the absolute physical path to the app's content, which this provider doesn't care about
+				contentRoot: null);
+			return inMemoryFiles;
+		}
+	}
+}

--- a/src/BlazorWebView/samples/BlazorWinFormsApp/Form1.cs
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/Form1.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Windows.Forms;
-using BlazorWinFormsApp.Pages;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView.WindowsForms;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,15 +16,24 @@ namespace BlazorWinFormsApp
 
 		public Form1()
 		{
-			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddBlazorWebView();
-			serviceCollection.AddSingleton<AppState>(_appState);
+			var services1 = new ServiceCollection();
+			services1.AddBlazorWebView();
+			services1.AddSingleton<AppState>(_appState);
+
+			var services2 = new ServiceCollection();
+			services2.AddBlazorWebView();
+			services2.AddSingleton<AppState>(_appState);
+
 			InitializeComponent();
 
 			blazorWebView1.HostPage = @"wwwroot\index.html";
-			blazorWebView1.Services = serviceCollection.BuildServiceProvider();
+			blazorWebView1.Services = services1.BuildServiceProvider();
 			blazorWebView1.RootComponents.Add<Main>("#app");
 			blazorWebView1.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
+
+			customFilesBlazorWebView.HostPage = @"wwwroot\customindex.html";
+			customFilesBlazorWebView.Services = services2.BuildServiceProvider();
+			customFilesBlazorWebView.RootComponents.Add<Main>("#app");
 		}
 
 		private void button1_Click(object sender, EventArgs e)

--- a/src/BlazorWebView/samples/BlazorWinFormsApp/Form1.designer.cs
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/Form1.designer.cs
@@ -35,12 +35,19 @@ namespace BlazorWinFormsApp
             this.blazorWebView1 = new Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
             this.option1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.sendScriptalertToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.tabControl1 = new System.Windows.Forms.TabControl();
+            this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.customFilesBlazorWebView = new BlazorWpfApp.CustomFilesBlazorWebView();
             this.groupBox1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
+            this.tabControl1.SuspendLayout();
+            this.tabPage1.SuspendLayout();
+            this.tabPage2.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -92,13 +99,11 @@ namespace BlazorWinFormsApp
             // 
             // blazorWebView1
             // 
-            this.blazorWebView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.blazorWebView1.Location = new System.Drawing.Point(7, 111);
+            this.blazorWebView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.blazorWebView1.Location = new System.Drawing.Point(3, 3);
             this.blazorWebView1.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
             this.blazorWebView1.Name = "blazorWebView1";
-            this.blazorWebView1.Size = new System.Drawing.Size(568, 290);
+            this.blazorWebView1.Size = new System.Drawing.Size(554, 257);
             this.blazorWebView1.TabIndex = 20;
             // 
             // menuStrip1
@@ -121,14 +126,6 @@ namespace BlazorWinFormsApp
             this.toolStripMenuItem1.Size = new System.Drawing.Size(93, 20);
             this.toolStripMenuItem1.Text = "&Menu options";
             // 
-            // toolStripMenuItem2
-            // 
-            this.toolStripMenuItem2.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.aboutToolStripMenuItem});
-            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(44, 20);
-            this.toolStripMenuItem2.Text = "&Help";
-            // 
             // option1ToolStripMenuItem
             // 
             this.option1ToolStripMenuItem.Name = "option1ToolStripMenuItem";
@@ -147,19 +144,71 @@ namespace BlazorWinFormsApp
             this.sendScriptalertToolStripMenuItem.Text = "Send script &alert";
             this.sendScriptalertToolStripMenuItem.Click += new System.EventHandler(this.sendScriptalertToolStripMenuItem_Click);
             // 
+            // toolStripMenuItem2
+            // 
+            this.toolStripMenuItem2.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.aboutToolStripMenuItem});
+            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(44, 20);
+            this.toolStripMenuItem2.Text = "&Help";
+            // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
             this.aboutToolStripMenuItem.Text = "About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
+            // 
+            // tabControl1
+            // 
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tabControl1.Controls.Add(this.tabPage1);
+            this.tabControl1.Controls.Add(this.tabPage2);
+            this.tabControl1.Location = new System.Drawing.Point(7, 104);
+            this.tabControl1.Name = "tabControl1";
+            this.tabControl1.SelectedIndex = 0;
+            this.tabControl1.Size = new System.Drawing.Size(568, 291);
+            this.tabControl1.TabIndex = 22;
+            // 
+            // tabPage1
+            // 
+            this.tabPage1.Controls.Add(this.blazorWebView1);
+            this.tabPage1.Location = new System.Drawing.Point(4, 24);
+            this.tabPage1.Name = "tabPage1";
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage1.Size = new System.Drawing.Size(560, 263);
+            this.tabPage1.TabIndex = 0;
+            this.tabPage1.Text = "BlazorWebView";
+            this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // tabPage2
+            // 
+            this.tabPage2.Controls.Add(this.customFilesBlazorWebView);
+            this.tabPage2.Location = new System.Drawing.Point(4, 24);
+            this.tabPage2.Name = "tabPage2";
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage2.Size = new System.Drawing.Size(560, 263);
+            this.tabPage2.TabIndex = 1;
+            this.tabPage2.Text = "Custom Files BlazorWebView";
+            this.tabPage2.UseVisualStyleBackColor = true;
+            // 
+            // customFilesBlazorWebView
+            // 
+            this.customFilesBlazorWebView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.customFilesBlazorWebView.Location = new System.Drawing.Point(3, 3);
+            this.customFilesBlazorWebView.Name = "customFilesBlazorWebView";
+            this.customFilesBlazorWebView.Size = new System.Drawing.Size(554, 257);
+            this.customFilesBlazorWebView.TabIndex = 0;
+            this.customFilesBlazorWebView.Text = "blazorWebView2";
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(582, 407);
-            this.Controls.Add(this.blazorWebView1);
+            this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.menuStrip1);
             this.MainMenuStrip = this.menuStrip1;
@@ -170,6 +219,9 @@ namespace BlazorWinFormsApp
             this.groupBox1.PerformLayout();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
+            this.tabControl1.ResumeLayout(false);
+            this.tabPage1.ResumeLayout(false);
+            this.tabPage2.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -188,5 +240,9 @@ namespace BlazorWinFormsApp
 		private System.Windows.Forms.ToolStripMenuItem sendScriptalertToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem2;
 		private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
+		private System.Windows.Forms.TabControl tabControl1;
+		private System.Windows.Forms.TabPage tabPage1;
+		private System.Windows.Forms.TabPage tabPage2;
+		private BlazorWpfApp.CustomFilesBlazorWebView customFilesBlazorWebView;
 	}
 }

--- a/src/BlazorWebView/samples/BlazorWpfApp/CustomFilesBlazorWebView.cs
+++ b/src/BlazorWebView/samples/BlazorWpfApp/CustomFilesBlazorWebView.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components.WebView.Wpf;
+using Microsoft.Extensions.FileProviders;
+using WebViewAppShared;
+
+namespace BlazorWpfApp
+{
+	public class CustomFilesBlazorWebView : BlazorWebView
+	{
+		public override IFileProvider CreateFileProvider(string contentRootDir)
+		{
+			var inMemoryFiles = new InMemoryStaticFileProvider(
+				fileContentsMap: new Dictionary<string, string>
+				{
+					{ "customindex.html", StaticFilesContents.CustomIndexHtmlContent },
+				},
+				// The contentRoot is ignored here because in WPF it would include the absolute physical path to the app's content, which this provider doesn't care about
+				contentRoot: null);
+			return inMemoryFiles;
+		}
+	}
+}

--- a/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml
+++ b/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml
@@ -13,10 +13,22 @@
             <Button Click="Button_Click" Margin="4" Padding="4">Check counter</Button>
             <Button Click="WebViewAlertButton_Click" Margin="4" Padding="4">WebView alert</Button>
         </StackPanel>
-        <blazor:BlazorWebView HostPage="wwwroot\index.html" Services="{StaticResource services}" x:Name="blazorWebView1">
-            <blazor:BlazorWebView.RootComponents>
-                <blazor:RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
-            </blazor:BlazorWebView.RootComponents>
-        </blazor:BlazorWebView>
+
+        <TabControl>
+            <TabItem Header="BlazorWebView">
+                <blazor:BlazorWebView HostPage="wwwroot\index.html" Services="{StaticResource services1}" x:Name="blazorWebView1">
+                    <blazor:BlazorWebView.RootComponents>
+                        <blazor:RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
+                    </blazor:BlazorWebView.RootComponents>
+                </blazor:BlazorWebView>
+            </TabItem>
+            <TabItem Header="Custom Files BlazorWebView">
+                <local:CustomFilesBlazorWebView HostPage="wwwroot\customindex.html" Services="{StaticResource services2}" x:Name="blazorWebView2">
+                    <blazor:BlazorWebView.RootComponents>
+                        <blazor:RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
+                    </blazor:BlazorWebView.RootComponents>
+                </local:CustomFilesBlazorWebView>
+            </TabItem>
+        </TabControl>
     </DockPanel>
 </Window>

--- a/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml.cs
+++ b/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Windows;
@@ -17,10 +17,15 @@ namespace BlazorWpfApp
 
 		public MainWindow()
 		{
-			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddBlazorWebView();
-			serviceCollection.AddSingleton<AppState>(_appState);
-			Resources.Add("services", serviceCollection.BuildServiceProvider());
+			var services1 = new ServiceCollection();
+			services1.AddBlazorWebView();
+			services1.AddSingleton<AppState>(_appState);
+			Resources.Add("services1", services1.BuildServiceProvider());
+
+			var services2 = new ServiceCollection();
+			services2.AddBlazorWebView();
+			services2.AddSingleton<AppState>(_appState);
+			Resources.Add("services2", services2.BuildServiceProvider());
 
 			InitializeComponent();
 

--- a/src/BlazorWebView/samples/WebViewAppShared/InMemoryStaticFileProvider.cs
+++ b/src/BlazorWebView/samples/WebViewAppShared/InMemoryStaticFileProvider.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace WebViewAppShared
+{
+	/// <summary>
+	/// Sample <see cref="IFileProvider"/> that returns file contents from a provided <see cref="IDictionary{TKey, TValue}"/>.
+	/// </summary>
+	public sealed class InMemoryStaticFileProvider : IFileProvider
+	{
+		private readonly Dictionary<string, string> _fileContentsMap;
+		private readonly string _contentRoot;
+
+		public InMemoryStaticFileProvider(Dictionary<string, string> fileContentsMap, string contentRoot)
+		{
+			_fileContentsMap = fileContentsMap;
+			_contentRoot = contentRoot ?? string.Empty;
+		}
+
+		public IDirectoryContents GetDirectoryContents(string subpath)
+			=> new InMemoryDirectoryContents(Path.Combine(_contentRoot, subpath));
+
+		public IFileInfo GetFileInfo(string subpath)
+			=> new InMemoryFileInfo(_fileContentsMap, Path.Combine(_contentRoot, subpath));
+
+		public IChangeToken Watch(string filter)
+			=> null;
+
+		private sealed class InMemoryFileInfo : IFileInfo
+		{
+			private readonly string _filePath;
+			private readonly string _contents;
+
+			public InMemoryFileInfo(Dictionary<string, string> fileContentsMap, string filePath)
+			{
+				_filePath = filePath;
+				Exists = fileContentsMap.TryGetValue(_filePath.Replace('\\', '/'), out _contents);
+				Length = Exists ? _contents.Length : -1;
+
+				Name = Path.GetFileName(filePath);
+
+			}
+
+			public bool Exists { get; }
+			public long Length { get; }
+			public string PhysicalPath { get; } = null!;
+			public string Name { get; }
+			public DateTimeOffset LastModified { get; } = DateTimeOffset.FromUnixTimeSeconds(0);
+			public bool IsDirectory => false;
+
+			public Stream CreateReadStream()
+				=> new MemoryStream(System.Text.Encoding.UTF8.GetBytes(_contents));
+		}
+
+		// This is never used by BlazorWebView or WebViewManager
+		private sealed class InMemoryDirectoryContents : IDirectoryContents
+		{
+			public InMemoryDirectoryContents(string filePath)
+			{
+			}
+
+			public bool Exists => false;
+
+			public IEnumerator<IFileInfo> GetEnumerator()
+				=> throw new NotImplementedException();
+
+			IEnumerator IEnumerable.GetEnumerator()
+				=> throw new NotImplementedException();
+		}
+	}
+}

--- a/src/BlazorWebView/samples/WebViewAppShared/StaticFilesContents.cs
+++ b/src/BlazorWebView/samples/WebViewAppShared/StaticFilesContents.cs
@@ -1,0 +1,36 @@
+﻿namespace WebViewAppShared
+{
+	/// <summary>
+	/// Sample static file contents used with custom BlazorWebView implementations that load
+	/// static assets in a custom manner.
+	/// </summary>
+	public static class StaticFilesContents
+	{
+		public static readonly string CustomIndexHtmlContent = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=""utf-8"" />
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"" />
+    <title>Blazor Desktop app</title>
+    <base href=""/"" />
+    <link href=""css/app.css"" rel=""stylesheet"" />
+</head>
+
+<body>
+	This HTML is coming from a custom provider!
+    <div id=""app""></div>
+
+    <div id=""blazor-error-ui"">
+        An unhandled error has occurred.
+        <a href="""" class=""reload"">Reload</a>
+        <a class=""dismiss"">🗙</a>
+    </div>
+    <script src=""_framework/blazor.webview.js""></script>
+
+</body>
+
+</html>
+";
+	}
+}

--- a/src/BlazorWebView/samples/WebViewAppShared/WebViewAppShared.csproj
+++ b/src/BlazorWebView/samples/WebViewAppShared/WebViewAppShared.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -93,7 +93,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			var contentRootDir = Path.GetDirectoryName(HostPage!) ?? string.Empty;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage!);
 
+			var customFileProvider = VirtualView.CreateFileProvider(contentRootDir);
 			var mauiAssetFileProvider = new AndroidMauiAssetFileProvider(Context.Assets, contentRootDir);
+			IFileProvider fileProvider = customFileProvider == null
+				? mauiAssetFileProvider
+				: new CompositeFileProvider(customFileProvider, mauiAssetFileProvider);
 
 			_webviewManager = new AndroidWebKitWebViewManager(this, NativeView, Services!, ComponentsDispatcher, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath);
 

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
@@ -16,5 +17,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		public string? HostPage { get; set; }
 
 		public RootComponentsCollection RootComponents { get; }
+
+		/// <inheritdoc/>
+		public virtual IFileProvider? CreateFileProvider(string contentRootDir)
+		{
+			return null;
+		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Maui;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -8,5 +9,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		string? HostPage { get; set; }
 		RootComponentsCollection RootComponents { get; }
 		JSComponentConfigurationStore JSComponents { get; }
+
+		/// <summary>
+		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. Override
+		/// this method to return a custom <see cref="IFileProvider"/> to serve assets such as <c>wwwroot/index.html</c>.
+		/// </summary>
+		/// <param name="contentRootDir">The base directory to use for all requested assets, such as <c>wwwroot</c>.</param>
+		/// <returns>Returns a <see cref="IFileProvider"/> for static assets, or <c>null</c> if there is no custom provider.</returns>
+		public IFileProvider? CreateFileProvider(string contentRootDir);
 	}
 }

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -57,12 +57,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			var contentRootDir = Path.GetDirectoryName(HostPage!) ?? string.Empty;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage!);
 
-			// On Windows we don't use IFileProvider because it is sync-only, whereas in WinUI all the
-			// file storage APIs are async-only. So instead we override HandleWebResourceRequest in
-			// WinUIWebViewManager so that loading static assets is done entirely there.
-			var mauiAssetFileProvider = new NullFileProvider();
+			// On WinUI we override HandleWebResourceRequest in WinUIWebViewManager so that loading static assets is done entirely there in an async manner.
+			// This allows the code to be async because in WinUI all the file storage APIs are async-only, but IFileProvider is sync-only and we need to control
+			// the precedence of which files are loaded from where.
+			var customFileProvider = VirtualView.CreateFileProvider(contentRootDir) ?? new NullFileProvider();
 
-			_webviewManager = new WinUIWebViewManager(NativeView, new WinUIWebView2Wrapper(NativeView), Services!, ComponentsDispatcher, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath, contentRootDir);
+			_webviewManager = new WinUIWebViewManager(NativeView, new WinUIWebView2Wrapper(NativeView), Services!, ComponentsDispatcher, customFileProvider, VirtualView.JSComponents, hostPageRelativePath, contentRootDir);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -113,9 +113,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			var contentRootDir = Path.GetDirectoryName(HostPage!) ?? string.Empty;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage!);
 
+			var customFileProvider = VirtualView.CreateFileProvider(contentRootDir);
 			var mauiAssetFileProvider = new iOSMauiAssetFileProvider(contentRootDir);
+			IFileProvider fileProvider = customFileProvider == null
+				? mauiAssetFileProvider
+				: new CompositeFileProvider(customFileProvider, mauiAssetFileProvider);
 
-			_webviewManager = new IOSWebViewManager(this, NativeView, Services!, ComponentsDispatcher, mauiAssetFileProvider, VirtualView.JSComponents, hostPageRelativePath);
+			_webviewManager = new IOSWebViewManager(this, NativeView, Services!, ComponentsDispatcher, fileProvider, VirtualView.JSComponents, hostPageRelativePath);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -153,7 +153,12 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			// unclear there's any other use case. We can add more options later if so.
 			var contentRootDir = Path.GetDirectoryName(Path.GetFullPath(HostPage));
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage);
-			var fileProvider = new PhysicalFileProvider(contentRootDir);
+
+			var customFileProvider = CreateFileProvider(contentRootDir);
+			var assetFileProvider = new PhysicalFileProvider(contentRootDir);
+			IFileProvider fileProvider = customFileProvider == null
+				? assetFileProvider
+				: new CompositeFileProvider(customFileProvider, assetFileProvider);
 
 			_webviewManager = new WebView2WebViewManager(new WindowsFormsWebView2Wrapper(_webview), Services, ComponentsDispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
 
@@ -187,6 +192,17 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 					}
 				});
 			}
+		}
+
+		/// <summary>
+		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. Override
+		/// this method to return a custom <see cref="IFileProvider"/> to serve assets such as <c>wwwroot/index.html</c>.
+		/// </summary>
+		/// <param name="contentRootDir">The base directory to use for all requested assets, such as <c>wwwroot</c>.</param>
+		/// <returns>Returns a <see cref="IFileProvider"/> for static assets, or <c>null</c> if there is no custom provider.</returns>
+		public virtual IFileProvider CreateFileProvider(string contentRootDir)
+		{
+			return null;
 		}
 
 		/// <inheritdoc />

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -156,7 +156,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			// unclear there's any other use case. We can add more options later if so.
 			var contentRootDir = Path.GetDirectoryName(Path.GetFullPath(HostPage));
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage);
-			var fileProvider = new PhysicalFileProvider(contentRootDir);
+
+			var customFileProvider = CreateFileProvider(contentRootDir);
+			var assetFileProvider = new PhysicalFileProvider(contentRootDir);
+			IFileProvider fileProvider = customFileProvider == null
+				? assetFileProvider
+				: new CompositeFileProvider(customFileProvider, assetFileProvider);
 
 			_webviewManager = new WebView2WebViewManager(new WpfWebView2Wrapper(_webview), Services, ComponentsDispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
 			foreach (var rootComponent in RootComponents)
@@ -193,6 +198,17 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 					}
 				});
 			}
+		}
+
+		/// <summary>
+		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. Override
+		/// this method to return a custom <see cref="IFileProvider"/> to serve assets such as <c>wwwroot/index.html</c>.
+		/// </summary>
+		/// <param name="contentRootDir">The base directory to use for all requested assets, such as <c>wwwroot</c>.</param>
+		/// <returns>Returns a <see cref="IFileProvider"/> for static assets, or <c>null</c> if there is no custom provider.</returns>
+		public virtual IFileProvider CreateFileProvider(string contentRootDir)
+		{
+			return null;
 		}
 
 		private void CheckDisposed()

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml.cs
@@ -28,6 +28,7 @@ namespace Maui.Controls.Sample.Pages
 			grid.Add(headerLabel);
 			GridLayout.SetRow(headerLabel, 0);
 
+			// You can replace this BlazorWebView with CustomBlazorWebView to see loading custom static assets
 			var bwv = new BlazorWebView
 			{
 				// General properties

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/CustomBlazorWebView.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/CustomBlazorWebView.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.Components.WebView.Maui;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace Maui.Controls.Sample.Pages.Blazor
+{
+	public class CustomBlazorWebView : BlazorWebView
+	{
+		const string IndexHtml = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=""utf-8"" />
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"" />
+    <title>Blazor Desktop app</title>
+    <base href=""/"" />
+    <link href=""css/app.css"" rel=""stylesheet"" />
+    <link href=""Maui.Controls.Sample.styles.css"" rel=""stylesheet"" />
+</head>
+
+<body>
+	This HTML is coming from a custom provider!
+    <div id=""app""></div>
+
+    <div id=""blazor-error-ui"">
+        An unhandled error has occurred.
+        <a href="""" class=""reload"">Reload</a>
+        <a class=""dismiss"">🗙</a>
+    </div>
+    <script src=""_framework/blazor.webview.js"" autostart=""false""></script>
+
+</body>
+
+</html>
+";
+		public override IFileProvider CreateFileProvider(string contentRootDir)
+		{
+			var inMemoryFiles = new InMemoryFileProvider(new Dictionary<string, string>
+			{
+				{ "wwwroot/index.html", IndexHtml },
+			}, contentRootDir);
+			return inMemoryFiles;
+		}
+
+		internal sealed class InMemoryFileProvider : IFileProvider
+		{
+			private readonly string _contentRootDir;
+			private Dictionary<string, string> _fileContentsMap;
+
+			public InMemoryFileProvider(Dictionary<string, string> fileContentsMap, string contentRootDir)
+			{
+				_fileContentsMap = fileContentsMap;
+				_contentRootDir = contentRootDir;
+			}
+
+			public IDirectoryContents GetDirectoryContents(string subpath)
+				=> new InMemoryDirectoryContents(Path.Combine(_contentRootDir, subpath));
+
+			public IFileInfo GetFileInfo(string subpath)
+				=> new InMemoryFileInfo(_fileContentsMap, Path.Combine(_contentRootDir, subpath));
+
+			public IChangeToken Watch(string filter)
+				=> null;
+
+			private sealed class InMemoryFileInfo : IFileInfo
+			{
+				private readonly string _filePath;
+				private readonly string _contents;
+				private Dictionary<string, string> _fileContentsMap;
+
+				public InMemoryFileInfo(Dictionary<string, string> fileContentsMap, string filePath)
+				{
+					_fileContentsMap = fileContentsMap;
+					_filePath = filePath;
+					Exists = fileContentsMap.TryGetValue(_filePath.Replace('\\', '/'), out _contents);
+					Length = Exists ? _contents.Length : -1;
+
+					Name = Path.GetFileName(filePath);
+
+				}
+
+				public bool Exists { get; }
+				public long Length { get; }
+				public string PhysicalPath { get; } = null!;
+				public string Name { get; }
+				public DateTimeOffset LastModified { get; } = DateTimeOffset.FromUnixTimeSeconds(0);
+				public bool IsDirectory => false;
+
+				public Stream CreateReadStream()
+					=> new MemoryStream(System.Text.Encoding.UTF8.GetBytes(_contents));
+			}
+
+			// This is never used by BlazorWebView or WebViewManager
+			private sealed class InMemoryDirectoryContents : IDirectoryContents
+			{
+				public InMemoryDirectoryContents(string filePath)
+				{
+				}
+
+				public bool Exists => false;
+
+				public IEnumerator<IFileInfo> GetEnumerator()
+					=> throw new NotImplementedException();
+
+				IEnumerator IEnumerable.GetEnumerator()
+					=> throw new NotImplementedException();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Each platform's BlazorWebView has a new virtual CreateFileProvider() method that you can override to return a custom IFileProvider to return static assets from wherever you want (such as embedded resources, generated, etc.).

Fixes #1520

The .NET MAUI/WinForms/WPF BlazorWebViews can now all load static assets from a custom [IFileProvider](https://docs.microsoft.com/dotnet/api/microsoft.extensions.fileproviders.ifileprovider).

Each platform's BlazorWebView control has a new virtual method:

```c#
	/// <summary>
	/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. Override
	/// this method to return a custom <see cref="IFileProvider"/> to serve assets such as <c>wwwroot/index.html</c>.
	/// </summary>
	/// <param name="contentRootDir">The base directory to use for all requested assets, such as <c>wwwroot</c>.</param>
	/// <returns>Returns a <see cref="IFileProvider"/> for static assets, or <c>null</c> if there is no custom provider.</returns>
	public virtual IFileProvider CreateFileProvider(string contentRootDir)
	{
		return null;
	}
```

To serve custom static assets, create a derived BlazorWebView that overrides the new `CreateFileProvider` method to return custom assets:

```c#
	public class CustomFilesBlazorWebView : BlazorWebView
	{
		public override IFileProvider CreateFileProvider(string contentRootDir)
		{
			return new CustomFileProvider(...);
		}
	}
```

This PR includes samples for each platform that shows how to serve static files from an "in-memory" storage.
