### PR TITLE
Fix BlazorWebView designer ancestor InDesignMode check

### DIFF
--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -124,6 +124,12 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 
 		private void OnServicesPropertyChanged() => StartWebViewCoreIfPossible();
 
+		private bool RequiredStartupPropertiesSet =>
+			Created &&
+			_webview != null &&
+			HostPage != null &&
+			Services != null;
+
 		private bool IsAncestorSiteInDesignMode2 =>
 			GetSitedParentSite(this) is ISite parentSite && parentSite.DesignMode;
 
@@ -134,17 +140,17 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 					? control.Site
 					: GetSitedParentSite(control.Parent);
 
-		private bool RequiredStartupPropertiesSet =>
-			Created &&
-			_webview != null &&
-			HostPage != null &&
-			Services != null;
-
 		private void StartWebViewCoreIfPossible()
 		{
 			// We never start the Blazor code in design time because it doesn't make sense to run
 			// a Blazor component in the designer.
-			if (!IsAncestorSiteInDesignMode2 && (!RequiredStartupPropertiesSet || _webviewManager != null))
+			if (IsAncestorSiteInDesignMode)
+			{
+				return;
+			}
+
+			// If we don't have all the required properties, or if there's already a WebViewManager, do nothing
+			if (!RequiredStartupPropertiesSet || _webviewManager != null)
 			{
 				return;
 			}

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -130,16 +130,6 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			HostPage != null &&
 			Services != null;
 
-		private bool IsAncestorSiteInDesignMode2 =>
-			GetSitedParentSite(this) is ISite parentSite && parentSite.DesignMode;
-
-		private ISite GetSitedParentSite(Control control) =>
-			control is null
-				? throw new ArgumentNullException(nameof(control))
-				: control.Site != null || control.Parent is null
-					? control.Site
-					: GetSitedParentSite(control.Parent);
-
 		private void StartWebViewCoreIfPossible()
 		{
 			// We never start the Blazor code in design time because it doesn't make sense to run


### PR DESCRIPTION
The logic for design mode was simply backwards - that meant that in some DesignMode scenarios (that is, the control appearing on the design surface), it would cause various kinds of errors and fail to display.

Fixes #3212

This change also switches to using WinForms' built-in IsAncestorSiteInDesignMode now that it's available (previously we had a copy of the code).

Fixes #3173