### PR TITLE
Don't reload image every time size of XamlRoot changes 

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -10,11 +10,6 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override Image CreateNativeView() => new Image();
 
-		protected override void ConnectHandler(Image nativeView)
-		{
-			base.ConnectHandler(nativeView);
-		}
-
 		protected override void DisconnectHandler(Image nativeView)
 		{
 			base.DisconnectHandler(nativeView);
@@ -28,7 +23,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapBackground(IImageHandler handler, IImage image)
 		{
 			handler.UpdateValue(nameof(IViewHandler.ContainerView));
-
 			handler.GetWrappedNativeView()?.UpdateBackground(image);
 		}
 

--- a/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Windows.cs
@@ -13,21 +13,11 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(Image nativeView)
 		{
 			base.ConnectHandler(nativeView);
-
-			nativeView.Loaded += OnNativeViewLoaded;
-			nativeView.Unloaded += OnNativeViewUnloaded;
 		}
 
 		protected override void DisconnectHandler(Image nativeView)
 		{
 			base.DisconnectHandler(nativeView);
-
-			if (nativeView.XamlRoot != null)
-				nativeView.XamlRoot.Changed -= OnXamlRootChanged;
-
-			nativeView.Loaded -= OnNativeViewLoaded;
-			nativeView.Unloaded -= OnNativeViewUnloaded;
-
 			SourceLoader.Reset();
 		}
 
@@ -63,25 +53,6 @@ namespace Microsoft.Maui.Handlers
 		void OnSetImageSource(ImageSource? obj)
 		{
 			NativeView.Source = obj;
-		}
-
-		void OnNativeViewLoaded(object sender = null!, RoutedEventArgs e = null!)
-		{
-			if (NativeView?.XamlRoot != null)
-			{
-				NativeView.XamlRoot.Changed += OnXamlRootChanged;
-			}
-		}
-
-		void OnNativeViewUnloaded(object sender = null!, RoutedEventArgs e = null!)
-		{
-			if (NativeView?.XamlRoot != null)
-				NativeView.XamlRoot.Changed -= OnXamlRootChanged;
-		}
-
-		void OnXamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs args)
-		{
-			UpdateValue(nameof(IImage.Source));
 		}
 	}
 }


### PR DESCRIPTION
Remove watch on XamlRoot changes - it fires on every size change and reloads the image.

Fixes #2663


