### PR TITLE
[Core] make Microsoft.Maui.dll trimmable

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					if (fragmentManager != null || layoutInflater != null)
 						mauiContext = mauiContext.MakeScoped(layoutInflater, fragmentManager);
 
-					handler = mauiContext.Handlers.GetHandler(element.GetType()) as IViewHandler;
+					handler = mauiContext.Handlers.GetHandler(TrimmerHelper.GetType(element)) as IViewHandler;
 					handler.SetMauiContext(mauiContext);
 				}
 				catch

--- a/src/Compatibility/Core/src/Windows/Platform.cs
+++ b/src/Compatibility/Core/src/Windows/Platform.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				//TODO: Handle this with AppBuilderHost
 				try
 				{
-					handler = Forms.MauiContext.Handlers.GetHandler(element.GetType()) as IViewHandler;
+					handler = Forms.MauiContext.Handlers.GetHandler(TrimmerHelper.GetType(element)) as IViewHandler;
 					handler.SetMauiContext(Forms.MauiContext);
 				}
 				catch

--- a/src/Compatibility/Core/src/iOS/Platform.cs
+++ b/src/Compatibility/Core/src/iOS/Platform.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				//TODO: Handle this with AppBuilderHost
 				try
 				{
-					handler = Forms.MauiContext.Handlers.GetHandler(element.GetType()) as IViewHandler;
+					handler = Forms.MauiContext.Handlers.GetHandler(TrimmerHelper.GetType(element)) as IViewHandler;
 					handler.SetMauiContext(Forms.MauiContext);
 				}
 				catch

--- a/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryServiceBuilder.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryServiceBuilder.cs
@@ -62,7 +62,10 @@ namespace Maui.Controls.Sample.Controls
 
 			if (BordelessEntryServiceBuilder.PendingHandlers.Count > 0)
 			{
-				BordelessEntryServiceBuilder.HandlersCollection.TryAddHandlers(BordelessEntryServiceBuilder.PendingHandlers);
+				foreach (var pair in BordelessEntryServiceBuilder.PendingHandlers)
+				{
+					BordelessEntryServiceBuilder.HandlersCollection.TryAddHandler (pair.Key, pair.Value);
+				}
 				BordelessEntryServiceBuilder.PendingHandlers.Clear();
 			}
 		}

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Handlers.Items;
@@ -10,68 +11,60 @@ namespace Microsoft.Maui.Controls.Hosting
 {
 	public static partial class AppHostBuilderExtensions
 	{
-		static readonly Dictionary<Type, Type> DefaultMauiControlHandlers = new Dictionary<Type, Type>
+		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)
 		{
-#if __IOS__ || __ANDROID__
-			{ typeof(CollectionView), typeof(CollectionViewHandler) },
+#if __IOS__ || __ANDROID__ || WINDOWS
+			handlersCollection.AddHandler<CollectionView, CollectionViewHandler>();
 #endif
-
-#if WINDOWS
-			{ typeof(CollectionView), typeof(CollectionViewHandler) },
-#endif
-
 #if WINDOWS || __ANDROID__
-			{ typeof(Shell), typeof(ShellHandler) },
+			handlersCollection.AddHandler<Shell, ShellHandler>();
 #endif
-			{ typeof(Application), typeof(ApplicationHandler) },
-			{ typeof(ActivityIndicator), typeof(ActivityIndicatorHandler) },
-			{ typeof(BoxView), typeof(ShapeViewHandler) },
-			{ typeof(Button), typeof(ButtonHandler) },
-			{ typeof(CheckBox), typeof(CheckBoxHandler) },
-			{ typeof(DatePicker), typeof(DatePickerHandler) },
-			{ typeof(Editor), typeof(EditorHandler) },
-			{ typeof(Entry), typeof(EntryHandler) },
-			{ typeof(GraphicsView), typeof(GraphicsViewHandler) },
-			{ typeof(Image), typeof(ImageHandler) },
-			{ typeof(Label), typeof(LabelHandler) },
-			{ typeof(Layout), typeof(LayoutHandler) },
-			{ typeof(Picker), typeof(PickerHandler) },
-			{ typeof(ProgressBar), typeof(ProgressBarHandler) },
-			{ typeof(ScrollView), typeof(ScrollViewHandler) },
-			{ typeof(SearchBar), typeof(SearchBarHandler) },
-			{ typeof(Slider), typeof(SliderHandler) },
-			{ typeof(Stepper), typeof(StepperHandler) },
-			{ typeof(Switch), typeof(SwitchHandler) },
-			{ typeof(TimePicker), typeof(TimePickerHandler) },
-			{ typeof(Page), typeof(PageHandler) },
-			{ typeof(WebView), typeof(WebViewHandler) },
-			{ typeof(Border), typeof(BorderHandler) },
-			{ typeof(IContentView), typeof(ContentViewHandler) },
-			{ typeof(Shapes.Ellipse), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Line), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Path), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Polygon), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Polyline), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Rectangle), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.RoundRectangle), typeof(ShapeViewHandler) },
-			{ typeof(Window), typeof(WindowHandler) },
-			{ typeof(ImageButton), typeof(ImageButtonHandler) },
-			{ typeof(IndicatorView), typeof(IndicatorViewHandler) },
+			handlersCollection.AddHandler<Application, ApplicationHandler>();
+			handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
+			handlersCollection.AddHandler<BoxView, ShapeViewHandler>();
+			handlersCollection.AddHandler<Button, ButtonHandler>();
+			handlersCollection.AddHandler<CheckBox, CheckBoxHandler>();
+			handlersCollection.AddHandler<DatePicker, DatePickerHandler>();
+			handlersCollection.AddHandler<Editor, EditorHandler>();
+			handlersCollection.AddHandler<Entry, EntryHandler>();
+			handlersCollection.AddHandler<GraphicsView, GraphicsViewHandler>();
+			handlersCollection.AddHandler<Image, ImageHandler>();
+			handlersCollection.AddHandler<Label, LabelHandler>();
+			handlersCollection.AddHandler<Layout, LayoutHandler>();
+			handlersCollection.AddHandler<Picker, PickerHandler>();
+			handlersCollection.AddHandler<ProgressBar, ProgressBarHandler>();
+			handlersCollection.AddHandler<ScrollView, ScrollViewHandler>();
+			handlersCollection.AddHandler<SearchBar, SearchBarHandler>();
+			handlersCollection.AddHandler<Slider, SliderHandler>();
+			handlersCollection.AddHandler<Stepper, StepperHandler>();
+			handlersCollection.AddHandler<Switch, SwitchHandler>();
+			handlersCollection.AddHandler<TimePicker, TimePickerHandler>();
+			handlersCollection.AddHandler<Page, PageHandler>();
+			handlersCollection.AddHandler<WebView, WebViewHandler>();
+			handlersCollection.AddHandler<Border, BorderHandler>();
+			handlersCollection.AddHandler<IContentView, ContentViewHandler>();
+			handlersCollection.AddHandler<Shapes.Ellipse, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Line, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Path, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Polygon, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Polyline, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Rectangle, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.RoundRectangle, ShapeViewHandler>();
+			handlersCollection.AddHandler<Window, WindowHandler>();
+			handlersCollection.AddHandler<ImageButton, ImageButtonHandler>();
+			handlersCollection.AddHandler<IndicatorView, IndicatorViewHandler>();
 #if __ANDROID__ || __IOS__
-			{ typeof(RefreshView), typeof(RefreshViewHandler) },
-			
+			handlersCollection.AddHandler<RefreshView, RefreshViewHandler>();
 #endif
 #if WINDOWS || ANDROID
-			{ typeof(NavigationPage), typeof(NavigationViewHandler) },
-			{ typeof(Toolbar), typeof(Controls.Handlers.ToolbarHandler) },
+			handlersCollection.AddHandler<NavigationPage, NavigationViewHandler>();
+			handlersCollection.AddHandler<Toolbar, Controls.Handlers.ToolbarHandler>();
 #endif
 #if __ANDROID__
-			{ typeof(TabbedPage), typeof(Controls.Handlers.TabbedPageHandler) },
+			handlersCollection.AddHandler<TabbedPage, Controls.Handlers.TabbedPageHandler>();
 #endif
-		};
-
-		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)
-			=> handlersCollection.AddHandlers(DefaultMauiControlHandlers);
+			return handlersCollection;
+		}
 
 		internal static MauiAppBuilder ConfigureImageSourceHandlers(this MauiAppBuilder builder)
 		{

--- a/src/Core/src/Core/TrimmerHelper.cs
+++ b/src/Core/src/Core/TrimmerHelper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Maui
+{
+	class TrimmerHelper
+	{
+		public const string ConcurrentDictionary = "We cannot specify DynamicallyAccessedMemberTypes on ConcurrentDictionary.GetOrAdd().";
+		public const string MakeGenericType = "We will need to suppress this warning until we can remove usage of Type.MakeGenericType().";
+
+		/// <summary>
+		/// Calls Type.GetType(), but with DynamicallyAccessedMemberTypes.Interfaces|PublicParameterlessConstructor.
+		/// This allows illink to statically analyze System.Reflection usage.
+		/// </summary>
+		[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "We cannot specify DynamicallyAccessedMemberTypes on object.GetType().")]
+		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		public static Type GetType(object obj) => obj.GetType();
+	}
+}

--- a/src/Core/src/Hosting/IMauiHandlersFactory.cs
+++ b/src/Core/src/Hosting/IMauiHandlersFactory.cs
@@ -1,16 +1,17 @@
 #nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Maui.Hosting;
 
 namespace Microsoft.Maui
 {
 	public interface IMauiHandlersFactory : IMauiFactory
 	{
-		Type? GetHandlerType(Type iview);
+		Type? GetHandlerType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type iview);
 
-		IElementHandler? GetHandler(Type type);
+		IElementHandler? GetHandler([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type);
 
-		IElementHandler? GetHandler<T>() where T : IElement;
+		IElementHandler? GetHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>() where T : IElement;
 
 		IMauiHandlersCollection GetCollection();
 	}

--- a/src/Core/src/Hosting/ImageSources/IImageSourceServiceProvider.cs
+++ b/src/Core/src/Hosting/ImageSources/IImageSourceServiceProvider.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui
 {
@@ -8,10 +9,12 @@ namespace Microsoft.Maui
 	{
 		IServiceProvider HostServiceProvider { get; }
 
-		IImageSourceService? GetImageSourceService(Type imageSource);
+		IImageSourceService? GetImageSourceService([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type imageSource);
 
-		Type GetImageSourceServiceType(Type imageSource);
+		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+		Type GetImageSourceServiceType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type imageSource);
 
-		Type GetImageSourceType(Type imageSource);
+		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+		Type GetImageSourceType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type imageSource);
 	}
 }

--- a/src/Core/src/Hosting/ImageSources/ImageSourceServiceCollectionExtensions.cs
+++ b/src/Core/src/Hosting/ImageSources/ImageSourceServiceCollectionExtensions.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Hosting
 {
 	public static class ImageSourceServiceCollectionExtensions
 	{
-		public static IImageSourceServiceCollection AddService<TImageSource, TImageSourceService>(this IImageSourceServiceCollection services)
+		public static IImageSourceServiceCollection AddService<TImageSource, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImageSourceService>(this IImageSourceServiceCollection services)
 			where TImageSource : IImageSource
 			where TImageSourceService : class, IImageSourceService<TImageSource>
 		{

--- a/src/Core/src/Hosting/ImageSources/ImageSourceServiceProviderExtensions.cs
+++ b/src/Core/src/Hosting/ImageSources/ImageSourceServiceProviderExtensions.cs
@@ -1,26 +1,27 @@
 ﻿#nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui
 {
 	public static class ImageSourceServiceProviderExtensions
 	{
 		public static IImageSourceService? GetImageSourceService(this IImageSourceServiceProvider provider, IImageSource imageSource) =>
-			provider.GetImageSourceService(imageSource.GetType());
+			provider.GetImageSourceService(TrimmerHelper.GetType(imageSource));
 
-		public static IImageSourceService? GetImageSourceService<T>(this IImageSourceServiceProvider provider)
+		public static IImageSourceService? GetImageSourceService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T>(this IImageSourceServiceProvider provider)
 			where T : IImageSource =>
 			provider.GetImageSourceService(typeof(T));
 
 		public static IImageSourceService GetRequiredImageSourceService(this IImageSourceServiceProvider provider, IImageSource imageSource) =>
-			provider.GetRequiredImageSourceService(imageSource.GetType());
+			provider.GetRequiredImageSourceService(TrimmerHelper.GetType(imageSource));
 
-		public static IImageSourceService GetRequiredImageSourceService<T>(this IImageSourceServiceProvider provider)
+		public static IImageSourceService GetRequiredImageSourceService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T>(this IImageSourceServiceProvider provider)
 			where T : IImageSource =>
 			provider.GetRequiredImageSourceService(typeof(T));
 
-		public static IImageSourceService GetRequiredImageSourceService(this IImageSourceServiceProvider provider, Type imageSourceType)
+		public static IImageSourceService GetRequiredImageSourceService(this IImageSourceServiceProvider provider, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type imageSourceType)
 		{
 			var service = provider.GetImageSourceService(imageSourceType);
 			if (service != null)

--- a/src/Core/src/Hosting/Internal/MauiHandlersFactory.cs
+++ b/src/Core/src/Hosting/Internal/MauiHandlersFactory.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Hosting.Internal
 {
@@ -24,13 +25,13 @@ namespace Microsoft.Maui.Hosting.Internal
 			return collection;
 		}
 
-		public IElementHandler? GetHandler(Type type)
+		public IElementHandler? GetHandler([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
 			=> GetService(type) as IElementHandler;
 
-		public IElementHandler? GetHandler<T>() where T : IElement
+		public IElementHandler? GetHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>() where T : IElement
 			=> GetHandler(typeof(T));
 
-		public Type? GetHandlerType(Type iview)
+		public Type? GetHandlerType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type iview)
 		{
 			foreach (var descriptor in GetServiceDescriptors(iview))
 			{

--- a/src/Core/src/Hosting/MauiHandlersCollectionExtensions.cs
+++ b/src/Core/src/Hosting/MauiHandlersCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -7,45 +8,27 @@ namespace Microsoft.Maui.Hosting
 {
 	public static partial class MauiHandlersCollectionExtensions
 	{
-		public static IMauiHandlersCollection AddHandlers(this IMauiHandlersCollection handlersCollection, Dictionary<Type, Type> handlers)
-		{
-			foreach (var handler in handlers)
-			{
-				handlersCollection.AddTransient(handler.Key, handler.Value);
-			}
-			return handlersCollection;
-		}
-
-		public static IMauiHandlersCollection AddHandler(this IMauiHandlersCollection handlersCollection, Type viewType, Type handlerType)
+		public static IMauiHandlersCollection AddHandler(this IMauiHandlersCollection handlersCollection, Type viewType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type handlerType)
 		{
 			handlersCollection.AddTransient(viewType, handlerType);
 			return handlersCollection;
 		}
 
-		public static IMauiHandlersCollection AddHandler<TType, TTypeRender>(this IMauiHandlersCollection handlersCollection)
-			where TType : IView
-			where TTypeRender : IViewHandler
+		public static IMauiHandlersCollection AddHandler<TType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTypeRender>(this IMauiHandlersCollection handlersCollection)
+			where TType : IElement
+			where TTypeRender : IElementHandler
 		{
 			handlersCollection.AddTransient(typeof(TType), typeof(TTypeRender));
 			return handlersCollection;
 		}
 
-		public static IMauiHandlersCollection TryAddHandlers(this IMauiHandlersCollection handlersCollection, Dictionary<Type, Type> handlers)
-		{
-			foreach (var handler in handlers)
-			{
-				handlersCollection.TryAddTransient(handler.Key, handler.Value);
-			}
-			return handlersCollection;
-		}
-
-		public static IMauiHandlersCollection TryAddHandler(this IMauiHandlersCollection handlersCollection, Type viewType, Type handlerType)
+		public static IMauiHandlersCollection TryAddHandler(this IMauiHandlersCollection handlersCollection, Type viewType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type handlerType)
 		{
 			handlersCollection.TryAddTransient(viewType, handlerType);
 			return handlersCollection;
 		}
 
-		public static IMauiHandlersCollection TryAddHandler<TType, TTypeRender>(this IMauiHandlersCollection handlersCollection)
+		public static IMauiHandlersCollection TryAddHandler<TType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTypeRender>(this IMauiHandlersCollection handlersCollection)
 			where TType : IView
 			where TTypeRender : IViewHandler
 		{

--- a/src/Core/src/HotReload/HotReloadHelper.cs
+++ b/src/Core/src/HotReload/HotReloadHelper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,6 +52,8 @@ namespace Microsoft.Maui.HotReload
 				return false;
 			return newView.GetType() == newViewType;
 		}
+
+		[UnconditionalSuppressMessage("Trimming", "IL2062", Justification = "Hot Reload is not supported in Release (trimmed) scenarios.")]
 		public static IView GetReplacedView(IHotReloadableView view)
 		{
 			if (!IsEnabled)

--- a/src/Core/src/Platform/Android/HandlerExtensions.cs
+++ b/src/Core/src/Platform/Android/HandlerExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Android.App;
 using Android.Content;
 using AView = Android.Views.View;
@@ -56,7 +57,7 @@ namespace Microsoft.Maui.Platform
 				handler = null;
 
 			if (handler == null)
-				handler = context.Handlers.GetHandler(view.GetType());
+				handler = context.Handlers.GetHandler(TrimmerHelper.GetType(view));
 
 			if (handler == null)
 				throw new Exception($"Handler not found for view {view}.");
@@ -88,7 +89,7 @@ namespace Microsoft.Maui.Platform
 				handler = null;
 
 			if (handler == null)
-				handler = context.Handlers.GetHandler(element.GetType());
+				handler = context.Handlers.GetHandler(TrimmerHelper.GetType(element));
 
 			if (handler == null)
 				throw new Exception($"Handler not found for window {element}.");

--- a/src/Core/src/Platform/Windows/HandlerExtensions.cs
+++ b/src/Core/src/Platform/Windows/HandlerExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Platform
 			var handler = view.Handler;
 
 			if (handler == null)
-				handler = context.Handlers.GetHandler(view.GetType());
+				handler = context.Handlers.GetHandler(TrimmerHelper.GetType(view));
 
 			if (handler == null)
 				throw new Exception($"Handler not found for view {view}.");
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Platform
 
 			var handler = element.Handler;
 			if (handler == null)
-				handler = context.Handlers.GetHandler(element.GetType());
+				handler = context.Handlers.GetHandler(TrimmerHelper.GetType(element));
 
 			if (handler == null)
 				throw new Exception($"Handler not found for window {element}.");

--- a/src/Core/src/Platform/iOS/HandlerExtensions.cs
+++ b/src/Core/src/Platform/iOS/HandlerExtensions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Platform
 
 			var handler = view.Handler;
 			if (handler == null)
-				handler = context.Handlers.GetHandler(view.GetType());
+				handler = context.Handlers.GetHandler(TrimmerHelper.GetType(view));
 
 			if (handler == null)
 				throw new Exception($"Handler not found for view {view}.");
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Platform
 
 			var handler = element.Handler;
 			if (handler == null)
-				handler = mauiContext.Handlers.GetHandler(element.GetType());
+				handler = mauiContext.Handlers.GetHandler(TrimmerHelper.GetType(element));
 
 			if (handler == null)
 				throw new Exception($"Handler not found for window {element}.");

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
+[assembly: AssemblyMetadata ("IsTrimmable", "True")]
 [assembly: InternalsVisibleTo("iOSUnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility")]

--- a/src/Core/src/System.Diagnostics.CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+++ b/src/Core/src/System.Diagnostics.CodeAnalysis/DynamicallyAccessedMemberTypes.cs
@@ -83,6 +83,11 @@ namespace System.Diagnostics.CodeAnalysis
 		NonPublicEvents = 0x1000,
 
 		/// <summary>
+		/// Specifies all interfaces implemented by the type.
+		/// </summary>
+		Interfaces = 0x2000,
+
+		/// <summary>
 		/// Specifies all members.
 		/// </summary>
 		All = ~None

--- a/src/Core/tests/UnitTests/Hosting/HostBuilderHandlerTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/HostBuilderHandlerTests.cs
@@ -78,7 +78,13 @@ namespace Microsoft.Maui.UnitTests.Hosting
 			};
 
 			var mauiApp = MauiApp.CreateBuilder()
-				.ConfigureMauiHandlers(handlers => handlers.AddHandlers(dic))
+				.ConfigureMauiHandlers(handlers =>
+				{
+					foreach (var pair in dic)
+					{
+						handlers.AddHandler(pair.Key, pair.Value);
+					}
+				})
 				.Build();
 
 			var handler = mauiApp.Services.GetRequiredService<IMauiHandlersFactory>().GetHandler(typeof(IViewStub));


### PR DESCRIPTION
### Description of Change ###

Related to 3c8e1581, this is part two.

I started off with ~27 illink warnings:

    src\Core\src\Platform\MauiContext.cs(86,50): error IL2091: Microsoft.Maui.MauiContext.<>c__DisplayClass14_0<TService>.<AddSpecific>b__1(): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in 'System.Lazy<T>'. The generic parameter 'TService' of 'Microsoft.Maui.MauiContext.<>c__DisplayClass14_0<TService>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink error IL2091: System.Lazy`1<TService> Microsoft.Maui.MauiContext/<>c__DisplayClass14_0`1::lazy: 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in 'System.Lazy<T>'. The generic parameter 'TService' of 'Microsoft.Maui.MauiContext.<>c__DisplayClass14_0<TService>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Platform\MauiContext.cs(95,50): error IL2091: Microsoft.Maui.MauiContext.<>c__DisplayClass15_0<TService,TImplementation>.<AddSpecific>b__1(): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in 'System.Lazy<T>'. The generic parameter 'TImplementation' of 'Microsoft.Maui.MauiContext.<>c__DisplayClass15_0<TService,TImplementation>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    ILLink error IL2091: System.Lazy`1<TImplementation> Microsoft.Maui.MauiContext/<>c__DisplayClass15_0`2::lazy: 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in 'System.Lazy<T>'. The generic parameter 'TImplementation' of 'Microsoft.Maui.MauiContext.<>c__DisplayClass15_0<TService,TImplementation>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\HotReload\HotReloadHelper.cs(133,36): error IL2026: Microsoft.Maui.HotReload.MauiHotReloadHelper.<>c__DisplayClass17_0.<RegisterReplacedView>b__2(Assembly): Using member 'System.Reflection.Assembly.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.
    src\Core\src\HotReload\HotReloadExtensions.cs(44,4): error IL2080: Microsoft.Maui.HotReload.HotReloadExtensions.<getOnHotReloadMethods>d__2.MoveNext(): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The field 'System.Type Microsoft.Maui.HotReload.HotReloadExtensions/<getOnHotReloadMethods>d__2::type' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\ImageSources\ImageSourceServiceCollectionExtensions.cs(12,4): error IL2091: Microsoft.Maui.Hosting.ImageSourceServiceCollectionExtensions.AddService<TImageSource,TImageSourceService>(IImageSourceServiceCollection): 'TImplementation' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in 'Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<TService,TImplementation>(IServiceCollection)'. The generic parameter 'TImageSourceService' of 'Microsoft.Maui.Hosting.ImageSourceServiceCollectionExtensions.AddService<TImageSource,TImageSourceService>(IImageSourceServiceCollection)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\ImageSources\ImageSourceServiceProvider.cs(31,5): error IL2055: Microsoft.Maui.Hosting.ImageSourceServiceProvider.<GetImageSourceServiceType>b__9_0(Type): Call to 'System.Type.MakeGenericType(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
    src\Core\src\Hosting\ImageSources\ImageSourceServiceProvider.cs(36,5): error IL2055: Microsoft.Maui.Hosting.ImageSourceServiceProvider.<GetImageSourceServiceType>b__9_0(Type): Call to 'System.Type.MakeGenericType(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
    src\Core\src\Hosting\ImageSources\ImageSourceServiceProvider.cs(46,5): error IL2070: Microsoft.Maui.Hosting.ImageSourceServiceProvider.CreateImageSourceTypeCacheEntry(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterface(String)'. The parameter 'type' of method 'Microsoft.Maui.Hosting.ImageSourceServiceProvider.CreateImageSourceTypeCacheEntry(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\ImageSources\ImageSourceServiceProvider.cs(51,37): error IL2070: Microsoft.Maui.Hosting.ImageSourceServiceProvider.CreateImageSourceTypeCacheEntry(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'type' of method 'Microsoft.Maui.Hosting.ImageSourceServiceProvider.CreateImageSourceTypeCacheEntry(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\ImageSources\ImageSourceServiceProvider.cs(53,6): error IL2065: Microsoft.Maui.Hosting.ImageSourceServiceProvider.CreateImageSourceTypeCacheEntry(Type): Value passed to implicit 'this' parameter of method 'System.Type.GetInterface(String)' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.
    src\Core\src\Platform\MauiContext.cs(84,4): error IL2091: Microsoft.Maui.MauiContext.AddSpecific<TService>(Func<TService>): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in 'System.Lazy<T>'. The generic parameter 'TService' of 'Microsoft.Maui.MauiContext.AddSpecific<TService>(Func<TService>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Platform\MauiContext.cs(93,4): error IL2091: Microsoft.Maui.MauiContext.AddSpecific<TService,TImplementation>(Func<TImplementation>): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in 'System.Lazy<T>'. The generic parameter 'TImplementation' of 'Microsoft.Maui.MauiContext.AddSpecific<TService,TImplementation>(Func<TImplementation>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\MauiHandlersCollectionExtensions.cs(21,4): error IL2067: Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler(IMauiHandlersCollection,Type,Type): 'implementationType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddTransient(IServiceCollection,Type,Type)'. The parameter 'handlerType' of method 'Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler(IMauiHandlersCollection,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\MauiHandlersCollectionExtensions.cs(29,4): error IL2087: Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler<TType,TTypeRender>(IMauiHandlersCollection): 'implementationType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddTransient(IServiceCollection,Type,Type)'. The generic parameter 'TTypeRender' of 'Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler<TType,TTypeRender>(IMauiHandlersCollection)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\MauiHandlersCollectionExtensions.cs(14,5): error IL2072: Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandlers(IMauiHandlersCollection,Dictionary<Type,Type>): 'implementationType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddTransient(IServiceCollection,Type,Type)'. The return value of method 'System.Collections.Generic.KeyValuePair<TKey,TValue>.Value.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\MauiHandlersCollectionExtensions.cs(44,4): error IL2067: Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler(IMauiHandlersCollection,Type,Type): 'implementationType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddTransient(IServiceCollection,Type,Type)'. The parameter 'handlerType' of method 'Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler(IMauiHandlersCollection,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\MauiHandlersCollectionExtensions.cs(52,4): error IL2087: Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler<TType,TTypeRender>(IMauiHandlersCollection): 'implementationType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddTransient(IServiceCollection,Type,Type)'. The generic parameter 'TTypeRender' of 'Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandler<TType,TTypeRender>(IMauiHandlersCollection)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\MauiHandlersCollectionExtensions.cs(37,5): error IL2072: Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.TryAddHandlers(IMauiHandlersCollection,Dictionary<Type,Type>): 'implementationType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddTransient(IServiceCollection,Type,Type)'. The return value of method 'System.Collections.Generic.KeyValuePair<TKey,TValue>.Value.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\HotReload\HotReloadHelper.cs(67,5): error IL2062: Microsoft.Maui.HotReload.MauiHotReloadHelper.GetReplacedView(IHotReloadableView): Value passed to parameter '#0' of method 'System.Object System.Activator::CreateInstance(System.Type)' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.
    src\Core\src\HotReload\HotReloadHelper.cs(67,5): error IL2062: Microsoft.Maui.HotReload.MauiHotReloadHelper.GetReplacedView(IHotReloadableView): Value passed to parameter '#0' of method 'System.Object System.Activator::CreateInstance(System.Type,System.Object[])' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.
    src\Core\src\HotReload\HotReloadHelper.cs(154,5): error IL2055: Microsoft.Maui.HotReload.MauiHotReloadHelper.RegisterHandler(KeyValuePair<Type,Type>,Type): Call to 'System.Type.MakeGenericType(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
    src\Core\src\Hosting\Internal\MauiServiceProvider.cs(184,4): error IL2070: Microsoft.Maui.Hosting.Internal.MauiServiceProvider.CreateInstance(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructors(BindingFlags)'. The parameter 'implementationType' of method 'Microsoft.Maui.Hosting.Internal.MauiServiceProvider.CreateInstance(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\Internal\MauiServiceProvider.cs(149,5): error IL2055: Microsoft.Maui.Hosting.Internal.MauiServiceProvider.GetService(Type,ServiceDescriptor,IEnumerable<ServiceDescriptor>): Call to 'System.Type.MakeGenericType(Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic type.
    src\Core\src\Hosting\Internal\MauiServiceProvider.cs(149,5): error IL2077: Microsoft.Maui.Hosting.Internal.MauiServiceProvider.GetService(Type,ServiceDescriptor,IEnumerable<ServiceDescriptor>): '#0' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Object System.Activator::CreateInstance(System.Type)'. The field 'System.Type Microsoft.Maui.Hosting.Internal.MauiServiceProvider::ListType' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    src\Core\src\Hosting\Internal\MauiServiceProvider.cs(117,29): error IL2070: Microsoft.Maui.Hosting.Internal.MauiServiceProvider.GetServiceBaseTypes(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'. The parameter 'serviceType' of method 'Microsoft.Maui.Hosting.Internal.MauiServiceProvider.GetServiceBaseTypes(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

When building:

    > .\bin\dotnet\dotnet.exe build `
        .\src\Controls\samples\Controls.Sample.SingleProject\Maui.Controls.Sample.SingleProject.csproj `
        -f net6.0-android `
        -c Release `
        -p:SuppressTrimAnalysisWarnings=false `
        -p:TrimmerSingleWarn=false `
        -bl

I addressed each warning and ensured apps still start.

### Public API Changes ###

Removed two methods because the linker cannot statically analyze
`Dictionary<Type,Type>`:

    public static partial class MauiHandlersCollectionExtensions
    {
        public static IMauiHandlersCollection AddHandlers(this IMauiHandlersCollection handlersCollection, Dictionary<Type, Type> handlers)
        public static IMauiHandlersCollection TryAddHandlers(this IMauiHandlersCollection handlersCollection, Dictionary<Type, Type> handlers)

Usage of this in `AddMauiControlsHandlers` should just call
`AddHandler()` for each type? No need for a `Dictionary`?

I loosened the generic constrains on one other method:

    public static IMauiHandlersCollection AddHandler<TType, TTypeRender>(this IMauiHandlersCollection handlersCollection)
    --    where TType : IView
    --    where TTypeRender : IViewHandler
    ++    where TType : IElement
    ++    where TTypeRender : IElementHandler

This allowed its usage for `Application` and `Window`.

### Results ###

A Release build of `Maui.Controls.Sample.SingleProject.csproj` in bytes:

Before: 30193687
After:  30136343

    > apkdiff -f before.apk after.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
    +         224 assemblies/Microsoft.Maui.Controls.dll
    +         128 assemblies/Maui.Controls.Sample.dll
    +          24 assemblies/Microsoft.Maui.Controls.Compatibility.dll
    +           4 assemblies/armeabi-v7a/System.Collections.dll
    +           4 assemblies/x86/System.Collections.dll
    -           1 assemblies/arm64-v8a/System.Collections.dll
    -           1 assemblies/Microsoft.Maui.Controls.Xaml.dll
    -           1 assemblies/x86_64/System.Collections.dll
    -          23 assemblies/Microsoft.Extensions.Configuration.Abstractions.dll
    -          70 assemblies/System.Runtime.dll
    -         123 assemblies/System.Security.Cryptography.Primitives.dll
    -         197 assemblies/Microsoft.Extensions.Logging.Abstractions.dll
    -         270 assemblies/Microsoft.Extensions.Configuration.dll
    -       1,125 assemblies/x86/System.Private.CoreLib.dll
    -       1,141 assemblies/armeabi-v7a/System.Private.CoreLib.dll
    -       1,150 assemblies/x86_64/System.Private.CoreLib.dll
    -       1,176 assemblies/arm64-v8a/System.Private.CoreLib.dll
    -       1,216 assemblies/Mono.Android.dll
    -       1,479 assemblies/Microsoft.Extensions.Hosting.Abstractions.dll
    -       3,992 assemblies/Xamarin.Android.Glide.dll
    -       4,096 lib/x86_64/libxamarin-app.so
    -       4,282 assemblies/Microsoft.Extensions.Hosting.dll
    -       6,496 classes.dex
    -      38,724 assemblies/Microsoft.Maui.dll
    Summary:
    +           0 Other entries 0.00% (of 12,105,126)
    -      54,587 Assemblies -0.53% (of 10,222,577)
    -       6,496 Dalvik executables -0.10% (of 6,448,724)
    -       4,096 Shared libraries -0.02% (of 18,457,156)
    -     138,240 Uncompressed assemblies -0.62% (of 22,456,808)
    -      57,344 Package size difference -0.19% (of 30,193,687)

Startup might help a small amount, maybe ~18ms? An average of 10 runs
of a Release build of `Maui.Controls.Sample.SingleProject.csproj` on a
Pixel 5:

    Before: 1.677s
    After:  1.659s

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No
