### PR TITLE
Expose the window hwnd

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -54,6 +54,12 @@ namespace Microsoft.Maui
 		#region Native Window
 
 		IntPtr _hwnd = IntPtr.Zero;
+		
+		/// <summary>
+		/// Returns a pointer to the underlying platform window handle (hWnd).
+		/// </summary>
+		public IntPtr WindowHandle => _hwnd;
+		
 		delegate IntPtr WinProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 		WinProc? newWndProc = null;
 		IntPtr oldWndProc = IntPtr.Zero;


### PR DESCRIPTION
There's a lot of things in WinAppSDK that requiring p/invoke'ing and it's easier to allow access to the window's hWnd to do so.