### PR TITLE
Fix incorrect error message for accessing `Device.PlatformServices` before `Init()` call

### DIFF
--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls
 			get
 			{
 				if (s_platformServices == null)
-					throw new InvalidOperationException("You must call Microsoft.Maui.Controls.Forms.Init(); prior to using this property.");
+					throw new InvalidOperationException("You must call Microsoft.Maui.Controls.Compatibility.Forms.Init(); prior to using this property.");
 				return s_platformServices;
 			}
 			set

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls
 			get
 			{
 				if (s_platformServices == null)
-					throw new InvalidOperationException("You must call Microsoft.Maui.Controls.Compatibility.Forms.Init(); prior to using this property.");
+					throw new InvalidOperationException($"You must call Microsoft.Maui.Controls.Compatibility.Forms.Init(); prior to using this property ({nameof(PlatformServices)}).");
 				return s_platformServices;
 			}
 			set


### PR DESCRIPTION
### Description of Change ###

Fixes the incorrect error message for the Xamarin.Forms compatibility

Fixes #821

### Additions made ###
Changes the error message thrown when accessing the `Device.PlatformServices` property from `You must call Microsoft.Maui.Controls.Forms.Init(); prior to using this property` to `You must call Microsoft.Maui.Controls.Compatibility.Forms.Init(); prior to using this property (PlatformServices).`

### PR Checklist ###

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
No