### PR TITLE
[workload] move SingleProject.targets to Microsoft.Maui.Sdk

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.targets
+++ b/.nuspec/Microsoft.Maui.Controls.targets
@@ -13,8 +13,6 @@
 		<AndroidUseDefaultAotProfile Condition="'$(AndroidEnableProfiledAot)' == 'true' and '$(AndroidUseDefaultAotProfile)' == ''">false</AndroidUseDefaultAotProfile>
 	</PropertyGroup>
 
-	<Import Project="$(MSBuildThisFileDirectory)Microsoft.Maui.Controls.DefaultItems.targets" Condition="'$(MSBuildSDKsPath)'!=''" />
-
 	<ItemGroup>
 		<ProjectCapability Include="Maui" Condition="'$(_ExcludeMauiProjectCapability)' != 'true'" />
 		<AvailableItemName Include="MauiXaml" />

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -87,6 +87,16 @@ Task("dotnet-templates")
         FileWriteText(File("../templatesTest/Directory.Build.targets"), "<Project/>");
         CopyFileToDirectory(File("./NuGet.config"), Directory("../templatesTest/"));
 
+        // See: https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md
+        var designTime = new Dictionary<string, string> {
+            { "DesignTimeBuild", "true" },
+            { "BuildingInsideVisualStudio", "true" },
+            { "SkipCompilerExecution", "true" },
+            // NOTE: this overrides a default setting that supports VS Mac
+            // See: https://github.com/xamarin/xamarin-android/blob/94c2a3d86a2e0e74863b57e3c5c61dbd29daa9ea/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in#L19
+            { "AndroidUseManagedDesignTimeResourceGenerator", "true" },
+        };
+
         var properties = new Dictionary<string, string> {
             // Properties that ensure we don't use cached packages, and *only* the empty NuGet.config
             { "RestoreNoCache", "true" },
@@ -97,11 +107,24 @@ Task("dotnet-templates")
             { "CustomBeforeMicrosoftCSharpTargets", MakeAbsolute(File("./src/Templates/TemplateTestExtraTargets.targets")).FullPath },
         };
 
+        var frameworks = new [] {
+            "net6.0-android",
+            "net6.0-ios",
+            "net6.0-maccatalyst",
+        };
+
         foreach (var template in new [] { "maui", "maui-blazor", "mauilib" })
         {
             var name = template.Replace("-", "") + " Space-Dash";
             StartProcess(dn, $"new {template} -o \"../templatesTest/{name}\"");
 
+            // Design-time build without restore
+            foreach (var framework in frameworks)
+            {
+                RunMSBuildWithDotNet($"../templatesTest/{name}", designTime, target: "Compile", restore: false, warningsAsError: true, targetFramework: framework);
+            }
+
+            // Build
             RunMSBuildWithDotNet($"../templatesTest/{name}", properties, warningsAsError: true);
         }
     });
@@ -231,7 +254,7 @@ Task("SAMPLE-ANDROID")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
-        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj", deployAndRun: true);
+        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.Droid/Maui.Controls.Sample.Droid-net6.csproj", target: "Run");
     });
 
 Task("SAMPLE-IOS")
@@ -240,7 +263,7 @@ Task("SAMPLE-IOS")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
-        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj", deployAndRun: true);
+        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.iOS/Maui.Controls.Sample.iOS-net6.csproj", target: "Run");
     });
 
 Task("SAMPLE-MAC")
@@ -249,7 +272,7 @@ Task("SAMPLE-MAC")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
-        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.MacCatalyst/Maui.Controls.Sample.MacCatalyst-net6.csproj", deployAndRun: true);
+        RunMSBuildWithDotNet("./src/Controls/samples/Controls.Sample.MacCatalyst/Maui.Controls.Sample.MacCatalyst-net6.csproj",  target: "Run");
     });
 
 
@@ -331,19 +354,28 @@ void StartVisualStudioForDotNet6(string sln = null)
 
 // NOTE: These methods work as long as the "dotnet" target has already run
 
-void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = null, bool deployAndRun = false, bool warningsAsError = false)
+void RunMSBuildWithDotNet(
+    string sln,
+    Dictionary<string, string> properties = null,
+    string target = "Build",
+    bool warningsAsError = false,
+    bool restore = true,
+    string targetFramework = null)
 {
     var name = System.IO.Path.GetFileNameWithoutExtension(sln);
-    var binlog = $"\"{logDirectory}/{name}-{configuration}.binlog\"";
+    var binlog = string.IsNullOrEmpty(targetFramework) ?
+        $"\"{logDirectory}/{name}-{configuration}-{target}.binlog\"" :
+        $"\"{logDirectory}/{name}-{configuration}-{target}-{targetFramework}.binlog\"";
     
     if(localDotnet)
         SetDotNetEnvironmentVariables();
 
     // If we're not on Windows, use ./bin/dotnet/dotnet
-    if (!IsRunningOnWindows() || deployAndRun)
+    if (!IsRunningOnWindows() || target == "Run")
     {
         var msbuildSettings = new DotNetCoreMSBuildSettings()
             .SetConfiguration(configuration)
+            .WithTarget(target)
             .EnableBinaryLogger(binlog);
         if (warningsAsError)
         {
@@ -358,12 +390,19 @@ void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = nu
             }
         }
 
-        if (deployAndRun)
-            msbuildSettings.WithTarget("Run");
-
         var dotnetBuildSettings = new DotNetCoreBuildSettings
         {
             MSBuildSettings = msbuildSettings,
+        };
+        dotnetBuildSettings.ArgumentCustomization = args =>
+        {
+            if (!restore)
+                args.Append("--no-restore");
+
+            if (!string.IsNullOrEmpty(targetFramework))
+                args.Append($"-f {targetFramework}");
+
+            return args;
         };
 
         if (localDotnet)
@@ -377,12 +416,20 @@ void RunMSBuildWithDotNet(string sln, Dictionary<string, string> properties = nu
         var msbuild = FindMSBuild();
         Information("Using MSBuild: {0}", msbuild);
         var msbuildSettings = new MSBuildSettings { ToolPath = msbuild }
-            .WithRestore()
             .SetConfiguration(configuration)
+            .WithTarget(target)
             .EnableBinaryLogger(binlog);
         if (warningsAsError)
         {
             msbuildSettings.WarningsAsError = true;
+        }
+        if (restore)
+        {
+            msbuildSettings.WithRestore();
+        }
+        if (!string.IsNullOrEmpty(targetFramework))
+        {
+            msbuildSettings.WithProperty("TargetFramework", targetFramework);
         }
 
         if (properties != null)

--- a/src/Compatibility/ControlGallery/src/Core/Directory.Build.targets
+++ b/src/Compatibility/ControlGallery/src/Core/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.DefaultItems.targets" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets"  />

--- a/src/Compatibility/ControlGallery/src/Core/Source.Build.targets
+++ b/src/Compatibility/ControlGallery/src/Core/Source.Build.targets
@@ -1,6 +1,7 @@
 <Project>
   <Import Project="..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="..\.nuspec\Microsoft.Maui.Controls.DefaultItems.targets" />
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
     <ProjectReference Include="..\Microsoft.Maui.Controls\Microsoft.Maui.Controls.csproj" />

--- a/src/Compatibility/ControlGallery/src/WinUI/Directory.Build.targets
+++ b/src/Compatibility/ControlGallery/src/WinUI/Directory.Build.targets
@@ -2,6 +2,7 @@
   <Import Project="..\Nuget.targets" Condition="$(FromSource) == 'false'" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.DefaultItems.targets" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets"  />

--- a/src/Controls/samples/Maui.InTree.targets
+++ b/src/Controls/samples/Maui.InTree.targets
@@ -1,6 +1,7 @@
 <Project>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.DefaultItems.targets" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets"  />

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
@@ -26,8 +26,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.SingleProject.targets" />
-		<_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.DefaultItems.targets" />
 		<_Files Include="$(PkgMicrosoft_Maui_Graphics)\lib\netstandard2.0\Microsoft.Maui.Graphics.dll" />
 		<_Files Include="$(PkgMicrosoft_Maui_Graphics)\lib\netstandard2.0\Microsoft.Maui.Graphics.pdb" />
 		<_Files Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.dll" />

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -25,8 +25,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.SingleProject.targets" />
-		<_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.DefaultItems.targets" />
 		<_Files Include="$(PkgMicrosoft_Maui_Graphics)\lib\netstandard2.0\Microsoft.Maui.Graphics.dll" />
 		<_Files Include="$(PkgMicrosoft_Maui_Graphics)\lib\netstandard2.0\Microsoft.Maui.Graphics.pdb" />
 		<_Files Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.dll" />

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
 
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.DefaultItems.targets" />
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Core.targets" />
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.TestUtils.DeviceTests.Runners.targets" />
 

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/_Directory.Build.targets
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/_Directory.Build.targets
@@ -1,4 +1,5 @@
 <Project>
   <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.DefaultItems.targets" />
 </Project>

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -73,8 +73,9 @@
     <Compile Remove="**\*.Windows.cs" />
   </ItemGroup>
 
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" />
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Core.targets" />
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.TestUtils.DeviceTests.Runners.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.DefaultItems.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Core.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.TestUtils.DeviceTests.Runners.targets" />
 
 </Project>

--- a/src/Essentials/samples/Maui.InTree.targets
+++ b/src/Essentials/samples/Maui.InTree.targets
@@ -1,6 +1,7 @@
 <Project>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.DefaultItems.targets" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets"  />

--- a/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
+++ b/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
@@ -75,8 +75,9 @@
     <Compile Remove="**\Windows\**\*.cs" />
   </ItemGroup>
 
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" />
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Core.targets" />
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.TestUtils.DeviceTests.Runners.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.DefaultItems.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Core.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.TestUtils.DeviceTests.Runners.targets" />
 
 </Project>

--- a/src/TestUtils/samples/DeviceTests.Sample/TestUtils.DeviceTests.Sample.csproj
+++ b/src/TestUtils/samples/DeviceTests.Sample/TestUtils.DeviceTests.Sample.csproj
@@ -47,8 +47,9 @@
     <UseInterpreter Condition="$(TargetFramework.Contains('-android'))">true</UseInterpreter>
   </PropertyGroup>
 
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" />
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Core.targets" />
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.TestUtils.DeviceTests.Runners.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.DefaultItems.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Core.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.TestUtils.DeviceTests.Runners.targets" />
 
 </Project>

--- a/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners/TestUtils.DeviceTests.Runners.csproj
@@ -41,9 +41,10 @@
     </Compile>
   </ItemGroup>
 
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" />
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Core.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.DefaultItems.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Core.targets" />
 
-  <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.MultiTargeting.targets" />
+  <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
 
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -11,7 +11,9 @@
   <ItemGroup>
     <None Remove="**/*.in.*" />
     <None Update="@(None)" PackagePath="" />
-    <None Include="@(_Files)" PackagePath="targets" Link="targets/%(FileName)%(Extension)" Visible="false" />
+    <_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.SingleProject.targets" />
+    <_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.DefaultItems.targets" />
+    <None Include="@(_Files)" PackagePath="Sdk" Link="Sdk/%(FileName)%(Extension)" Visible="false" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Pack="true" />
   </ItemGroup>
 

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
@@ -14,4 +14,5 @@
     <ProjectCapability Include="MauiCore"       Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' " />
     <ProjectCapability Include="MauiEssentials" Condition=" '$(UseMaui)' == 'true' or '$(UseMauiEssentials)' == 'true' " />
   </ItemGroup>
+  <Import Project="Microsoft.Maui.Controls.DefaultItems.targets" />
 </Project>


### PR DESCRIPTION
### Description of Change ###

Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1428787

Currently, if you mimic a design-time build that would happen inside
Visual Studio:

    > dotnet new maui
    > dotnet build -f net6.0-android -t:Compile -p:DesignTimeBuild=true -p:BuildingInsideVisualStudio=true -p:SkipCompilerExecution=true --no-restore

This fails because of the `--no-restore` flag:

    C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.101-preview.11.74\tools\Xamarin.Android.Common.targets(511,3):
    error XA1018: Specified AndroidManifest file does not exist: foo\AndroidManifest.xml.

I was able to reproduce this failure in our template tests in
`dotnet.cake`.

In 974cac45, several of .NET MAUI's MSBuild targets were moved to
`library-packs`, such as `Microsoft.Maui.Controls.Build.Tasks`. This
means that files like `Microsoft.Maui.Controls.SingleProject.targets`
won't be evaluated until NuGet restore completes.

To solve this problem:

* Move `Microsoft.Maui.Controls.SingleProject.targets` and
  `Microsoft.Maui.Controls.DefaultItems.targets` to the
  `Microsoft.Maui.Sdk` pack. These `.targets` are no longer affected by
  `$(MauiVersion)`, and just exist in the workload.

* Stop importing these files in `Microsoft.Maui.Controls.targets` in
  `Microsoft.Maui.Controls.Build.Tasks`.

* Import these files in `Microsoft.Maui.Sdk.After.targets`.

Overall, I think the loss of `$(MauiVersion)` is fine for the moved
`.targets` files, because they are not invoking MSBuild tasks.

The design-time build tests now complete successfully.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

Nope