### PR TITLE
Fix font path on catalyst

### DIFF
--- a/src/Core/src/Fonts/FontRegistrar.iOS.cs
+++ b/src/Core/src/Fonts/FontRegistrar.iOS.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Maui
 		{
 			var mainBundlePath = Foundation.NSBundle.MainBundle.BundlePath;
 
+#if MACCATALYST
+			// MacOS Apps have Contents folder in the bundle root, iOS does not
+			mainBundlePath = Path.Combine(mainBundlePath, "Contents");
+#endif
+
 			var fontBundlePath = Path.Combine(mainBundlePath, filename);
 			if (File.Exists(fontBundlePath))
 				return File.OpenRead(fontBundlePath);


### PR DESCRIPTION
Fixes #3032

MacCatalyst gives us a bundle root in which there's a Contents folder which most of the things we expect to be in the bundle root of an iOS app are nested inside.

This just adds Contents to the lookup path for MacCatalyst