### PR TITLE
Multi window close

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
@@ -10,6 +10,12 @@
             <Button 
                 Clicked="OnNewWindowClicked"
                 Text="Open new Window" />
+
+            <Button 
+                Clicked="OnCloseWindowClicked"
+                Text="Close this Window" />
+
+            <Label Text="Window Count: 0" x:Name="label" />
         </StackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
@@ -6,14 +6,25 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class MultiWindowPage : BasePage
 	{
+		static int windowCounter = 1;
+
 		public MultiWindowPage()
 		{
 			InitializeComponent();
+
+			label.Text = "Window Count: " + (windowCounter++).ToString();
 		}
 
 		void OnNewWindowClicked(object sender, EventArgs e)
 		{
 			Application.Current.OpenWindow(new Window(new MultiWindowPage()));
+		}
+
+		void OnCloseWindowClicked(object sender, EventArgs e)
+		{
+			var window = this.GetParentWindow();
+			if (window is not null)
+				Application.Current.CloseWindow(window);
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -17,14 +17,16 @@ namespace Maui.Controls.Sample
 
 			Debug.WriteLine($"The injected text service had a message: '{textService.GetText()}'");
 
-			MainPage = Services.GetRequiredService<Page>();
-
 			RequestedThemeChanged += (sender, args) =>
 			{
 				// Respond to the theme change
 				Debug.WriteLine($"Requested theme changed: {args.RequestedTheme}");
 			};
 		}
+
+		// Must not use MainPage for multi-window
+		protected override Window CreateWindow(IActivationState activationState)
+			=> new Window(Services.GetRequiredService<Page>());
 
 		public IServiceProvider Services { get; }
 	}

--- a/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
@@ -57,6 +57,22 @@ namespace Microsoft.Maui.Controls
 				OpenWindow(cwindow);
 		}
 
+		void IApplication.CloseWindow(IWindow window)
+		{
+			Handler?.Invoke(nameof(IApplication.CloseWindow), window);
+		}
+
+		void IApplication.OnWindowClosed(IWindow window)
+		{
+			var controlsWindow = window as Window;
+
+			if (controlsWindow is null)
+				return;
+
+			// Window was closed, stop tracking it
+			_windows.RemoveAll(w => w.Id == controlsWindow.Id);
+		}
+
 		public virtual void OpenWindow(Window window)
 		{
 			var id = Guid.NewGuid().ToString();

--- a/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
@@ -96,6 +96,11 @@ namespace Microsoft.Maui.Controls
 			Handler?.Invoke(nameof(IApplication.OpenWindow), new OpenWindowRequest(State: state));
 		}
 
+		public virtual void CloseWindow(Window window)
+		{
+			Handler?.Invoke(nameof(IApplication.CloseWindow), window);
+		}
+
 		public void ThemeChanged()
 		{
 			Current?.TriggerThemeChanged(new AppThemeChangedEventArgs(Current.RequestedTheme));

--- a/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
@@ -62,15 +62,24 @@ namespace Microsoft.Maui.Controls
 			Handler?.Invoke(nameof(IApplication.CloseWindow), window);
 		}
 
-		void IApplication.OnWindowClosed(IWindow window)
+		internal void RemoveWindow(Window window)
 		{
-			var controlsWindow = window as Window;
-
-			if (controlsWindow is null)
+			// Window was closed, stop tracking it
+			if (window is null)
 				return;
 
-			// Window was closed, stop tracking it
-			_windows.RemoveAll(w => w.Id == controlsWindow.Id);
+			if (window is NavigableElement ne)
+				ne.NavigationProxy.Inner = null;
+
+			if (window is Element windowElement)
+			{
+				var oldIndex = InternalChildren.IndexOf(windowElement);
+				InternalChildren.Remove(windowElement);
+				windowElement.Parent = null;
+				OnChildRemoved(windowElement, oldIndex);
+			}
+
+			_windows.Remove(window);
 		}
 
 		public virtual void OpenWindow(Window window)

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Maui.Controls
 		protected virtual void OnNavigatedTo(NavigatedToEventArgs args) { }
 		protected virtual void OnNavigatingFrom(NavigatingFromEventArgs args) { }
 		protected virtual void OnNavigatedFrom(NavigatedFromEventArgs args) { }
+
+		public virtual Window GetParentWindow()
+			=> this.FindParentOfType<Window>();
 	}
 
 	public sealed class NavigatingFromEventArgs : EventArgs

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -206,6 +206,8 @@ namespace Microsoft.Maui.Controls
 		{
 			Destroying?.Invoke(this, EventArgs.Empty);
 			OnDestroying();
+
+			Application?.RemoveWindow(this);
 		}
 
 		void IWindow.Resumed()

--- a/src/Controls/tests/Core.UnitTests/TestClasses/ApplicationStub.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/ApplicationStub.cs
@@ -21,7 +21,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		public void OpenWindow(IWindow window)
 		{
-			throw new System.NotImplementedException();
+			_windows.Add(window);
+		}
+
+		public void CloseWindow(IWindow window)
+		{
+			_windows.Remove(window);
 		}
 
 		public void ThemeChanged() { }

--- a/src/Core/src/Core/IApplication.cs
+++ b/src/Core/src/Core/IApplication.cs
@@ -22,6 +22,18 @@ namespace Microsoft.Maui
 		void OpenWindow(IWindow window);
 
 		/// <summary>
+		/// Requests that the application closes the window.
+		/// </summary>
+		/// <param name="window">The window to close.</param>
+		void CloseWindow(IWindow window);
+
+		/// <summary>
+		/// Notifies a window was closed
+		/// </summary>
+		/// <param name="window">The closed window.</param>
+		void OnWindowClosed(IWindow window);
+
+		/// <summary>
 		/// Notify a theme change.
 		/// </summary>
 		void ThemeChanged();

--- a/src/Core/src/Core/IApplication.cs
+++ b/src/Core/src/Core/IApplication.cs
@@ -28,12 +28,6 @@ namespace Microsoft.Maui
 		void CloseWindow(IWindow window);
 
 		/// <summary>
-		/// Notifies a window was closed
-		/// </summary>
-		/// <param name="window">The closed window.</param>
-		void OnWindowClosed(IWindow window);
-
-		/// <summary>
 		/// Notify a theme change.
 		/// </summary>
 		void ThemeChanged();

--- a/src/Core/src/Handlers/Application/ApplicationHandler.Android.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.Android.cs
@@ -15,5 +15,24 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.NativeView?.RequestNewWindow(application, args as OpenWindowRequest);
 		}
+
+		public static void MapCloseWindow(ApplicationHandler handler, IApplication application, object? args)
+		{
+			if (args is IWindow window)
+			{
+				var activity = application.Handler?.MauiContext?.GetActivity();
+
+				if (activity != null)
+				{
+					activity.Finish();
+				}
+			}
+		}
+
+		public static void MapOnWindowClosed(ApplicationHandler handler, IApplication application, object? args)
+		{
+			if (args is IWindow window)
+				application.OnWindowClosed(window);
+		}
 	}
 }

--- a/src/Core/src/Handlers/Application/ApplicationHandler.Android.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.Android.cs
@@ -1,6 +1,7 @@
 using Android.App;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Platform;
+using Microsoft.Maui.LifecycleEvents;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -20,19 +21,9 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is IWindow window)
 			{
-				var activity = application.Handler?.MauiContext?.GetActivity();
-
-				if (activity != null)
-				{
+				if (window.Handler?.NativeView is Activity activity)
 					activity.Finish();
-				}
 			}
-		}
-
-		public static void MapOnWindowClosed(ApplicationHandler handler, IApplication application, object? args)
-		{
-			if (args is IWindow window)
-				application.OnWindowClosed(window);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Application/ApplicationHandler.Standard.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.Standard.cs
@@ -9,6 +9,5 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTerminate(ApplicationHandler handler, IApplication application, object? args) { }
 		public static void MapOpenWindow(ApplicationHandler handler, IApplication application, object? args) { }
 		public static void MapCloseWindow(ApplicationHandler handler, IApplication application, object? args) { }
-		public static void MapOnWindowClosed(ApplicationHandler handler, IApplication application, object? args) { }
 	}
 }

--- a/src/Core/src/Handlers/Application/ApplicationHandler.Standard.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.Standard.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapTerminate(ApplicationHandler handler, IApplication application, object? args) { }
 		public static void MapOpenWindow(ApplicationHandler handler, IApplication application, object? args) { }
+		public static void MapCloseWindow(ApplicationHandler handler, IApplication application, object? args) { }
+		public static void MapOnWindowClosed(ApplicationHandler handler, IApplication application, object? args) { }
 	}
 }

--- a/src/Core/src/Handlers/Application/ApplicationHandler.Windows.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.Windows.cs
@@ -21,11 +21,5 @@ namespace Microsoft.Maui.Handlers
 				// TODO: Get native window and close it
 			}
 		}
-
-		public static void MapOnWindowClosed(ApplicationHandler handler, IApplication application, object? args)
-		{
-			if (args is IWindow window)
-				application.OnWindowClosed(window);
-		}
 	}
 }

--- a/src/Core/src/Handlers/Application/ApplicationHandler.Windows.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.Windows.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Platform;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -18,7 +19,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (args is IWindow window)
 			{
-				// TODO: Get native window and close it
+				(window.Handler?.NativeView as Window)?.Close();
 			}
 		}
 	}

--- a/src/Core/src/Handlers/Application/ApplicationHandler.Windows.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.Windows.cs
@@ -13,5 +13,19 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.NativeView?.CreateNativeWindow(application, args as OpenWindowRequest);
 		}
+
+		public static void MapCloseWindow(ApplicationHandler handler, IApplication application, object? args)
+		{
+			if (args is IWindow window)
+			{
+				// TODO: Get native window and close it
+			}
+		}
+
+		public static void MapOnWindowClosed(ApplicationHandler handler, IApplication application, object? args)
+		{
+			if (args is IWindow window)
+				application.OnWindowClosed(window);
+		}
 	}
 }

--- a/src/Core/src/Handlers/Application/ApplicationHandler.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Maui.Handlers
 			[TerminateCommandKey] = MapTerminate,
 			[nameof(IApplication.OpenWindow)] = MapOpenWindow,
 			[nameof(IApplication.CloseWindow)] = MapCloseWindow,
-			[nameof(IApplication.OnWindowClosed)] = MapOnWindowClosed,
 		};
 
 		ILogger<ApplicationHandler>? _logger;

--- a/src/Core/src/Handlers/Application/ApplicationHandler.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Maui.Handlers
 		public static CommandMapper<IApplication, ApplicationHandler> CommandMapper = new(ElementCommandMapper)
 		{
 			[TerminateCommandKey] = MapTerminate,
-			[nameof(IApplication.OpenWindow)] = MapOpenWindow
+			[nameof(IApplication.OpenWindow)] = MapOpenWindow,
+			[nameof(IApplication.CloseWindow)] = MapCloseWindow,
+			[nameof(IApplication.OnWindowClosed)] = MapOnWindowClosed,
 		};
 
 		ILogger<ApplicationHandler>? _logger;

--- a/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapCloseWindow(ApplicationHandler handler, IApplication application, object? args)
 		{
-#if __MACCATALYST__ || __IOS__
 			if (args is IWindow window)
 			{
 				// See if the window's handler has an associated UIWindowScene and UISceneSession
@@ -38,7 +37,6 @@ namespace Microsoft.Maui.Handlers
 					UIApplication.SharedApplication.RequestSceneSessionDestruction(sceneSession, null, null);
 				}
 			}
-#endif
 		}
 
 #if __MACCATALYST__

--- a/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
@@ -41,12 +41,6 @@ namespace Microsoft.Maui.Handlers
 #endif
 		}
 
-		public static void MapOnWindowClosed(ApplicationHandler handler, IApplication application, object? args)
-		{
-			if (args is IWindow window)
-				application.OnWindowClosed(window);
-		}
-
 #if __MACCATALYST__
 		class NSApplication
 		{

--- a/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Handlers
 			if (args is IWindow window)
 			{
 				// See if the window's handler has an associated UIWindowScene and UISceneSession
-				var sceneSession = window.Handler?.MauiContext?.GetNativeWindow()?.WindowScene?.Session;
+				var sceneSession = (window.Handler?.NativeView as UIWindow)?.WindowScene?.Session;
 
 				if (sceneSession != null)
 				{

--- a/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
@@ -23,6 +23,30 @@ namespace Microsoft.Maui.Handlers
 			handler.NativeView?.RequestNewWindow(application, args as OpenWindowRequest);
 		}
 
+		public static void MapCloseWindow(ApplicationHandler handler, IApplication application, object? args)
+		{
+#if __MACCATALYST__ || __IOS__
+			if (args is IWindow window)
+			{
+				// See if the window's handler has an associated UIWindowScene and UISceneSession
+				var sceneSession = window.Handler?.MauiContext?.GetNativeWindow()?.WindowScene?.Session;
+
+				if (sceneSession != null)
+				{
+					// Request that the scene be destroyed
+					// TODO: Error handler?
+					UIApplication.SharedApplication.RequestSceneSessionDestruction(sceneSession, null, null);
+				}
+			}
+#endif
+		}
+
+		public static void MapOnWindowClosed(ApplicationHandler handler, IApplication application, object? args)
+		{
+			if (args is IWindow window)
+				application.OnWindowClosed(window);
+		}
+
 #if __MACCATALYST__
 		class NSApplication
 		{

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
@@ -37,12 +37,20 @@ namespace Microsoft.Maui.LifecycleEvents
 				})
 				.OnStop(activity =>
 				{
+					var window = activity.GetWindow();
+
 					// Activity is no longer visible
-					activity.GetWindow()?.Stopped();
+					window?.Stopped();
+
+					// As of Ice Cream Sandwich, Stopped is guaranteed to be called
+					// even when the activity is finishing or being destroyed
+					// We check for finishing and call destroying here if so
+					if (activity.IsFinishing)
+						window?.Destroying();
 				})
 				.OnDestroy(activity =>
 				{
-					activity.GetWindow()?.Destroying();
+					// Android's onDestroy is not reliably called
 				});
 		}
 	}

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Maui.LifecycleEvents
 				})
 				.WillTerminate(app =>
 				{
+					// By this point if we were a multi window app, the GetWindow would be null anyway
 					app.GetWindow()?.Destroying();
 				})
 				.SceneDidDisconnect(scene =>

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.iOS.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
+using UIKit;
 
 namespace Microsoft.Maui.LifecycleEvents
 {
@@ -36,6 +37,13 @@ namespace Microsoft.Maui.LifecycleEvents
 				.WillTerminate(app =>
 				{
 					app.GetWindow()?.Destroying();
+				})
+				.SceneDidDisconnect(scene =>
+				{
+					if (scene is UIWindowScene windowScene)
+					{
+						windowScene.GetWindow()?.Destroying();
+					}
 				});
 		}
 	}

--- a/src/Core/src/LifecycleEvents/iOS/iOSLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/iOS/iOSLifecycle.cs
@@ -17,6 +17,11 @@ namespace Microsoft.Maui.LifecycleEvents
 		public delegate void WillEnterForeground(UIApplication application);
 		public delegate void WillTerminate(UIApplication application);
 
+
+		// Scene
+		public delegate void SceneWillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions);
+		public delegate void SceneDidDisconnect(UIScene scene);
+
 		// Internal events
 		internal delegate void OnMauiContextCreated(IMauiContext mauiContext);
 	}

--- a/src/Core/src/LifecycleEvents/iOS/iOSLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/iOS/iOSLifecycleBuilderExtensions.cs
@@ -13,6 +13,9 @@
 		public static IiOSLifecycleBuilder WillEnterForeground(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.WillEnterForeground del) => lifecycle.OnEvent(del);
 		public static IiOSLifecycleBuilder WillTerminate(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.WillTerminate del) => lifecycle.OnEvent(del);
 
+		public static IiOSLifecycleBuilder SceneWillConnect(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.SceneWillConnect del) => lifecycle.OnEvent(del);
+		public static IiOSLifecycleBuilder SceneDidDisconnect(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.SceneDidDisconnect del) => lifecycle.OnEvent(del);
+
 		internal static IiOSLifecycleBuilder OnMauiContextCreated(this IiOSLifecycleBuilder lifecycle, iOSLifecycle.OnMauiContextCreated del) => lifecycle.OnEvent(del);
 	}
 }

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -1,6 +1,5 @@
 using Android.OS;
 using AndroidX.AppCompat.App;
-using Microsoft.Maui.LifecycleEvents;
 using Microsoft.Maui.Platform;
 
 namespace Microsoft.Maui

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -1,5 +1,6 @@
 using Android.OS;
 using AndroidX.AppCompat.App;
+using Microsoft.Maui.LifecycleEvents;
 using Microsoft.Maui.Platform;
 
 namespace Microsoft.Maui
@@ -29,6 +30,20 @@ namespace Microsoft.Maui
 			base.OnCreate(savedInstanceState);
 
 			this.CreateNativeWindow(MauiApplication.Current.Application, savedInstanceState);
+
+			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnCreate>(del => del(this, savedInstanceState));
+		}
+
+		protected override void OnDestroy()
+		{
+			base.OnDestroy();
+
+			var window = this.GetWindow();
+
+			if (window is not null)
+				window.Handler?.Invoke(nameof(IApplication.OnWindowClosed), window);
+			
+			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnDestroy>(del => del(this));
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -30,20 +30,6 @@ namespace Microsoft.Maui
 			base.OnCreate(savedInstanceState);
 
 			this.CreateNativeWindow(MauiApplication.Current.Application, savedInstanceState);
-
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnCreate>(del => del(this, savedInstanceState));
-		}
-
-		protected override void OnDestroy()
-		{
-			base.OnDestroy();
-
-			var window = this.GetWindow();
-
-			if (window is not null)
-				window.Handler?.Invoke(nameof(IApplication.OnWindowClosed), window);
-			
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnDestroy>(del => del(this));
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -41,9 +41,15 @@ namespace Microsoft.Maui
 
 			this.SetApplicationHandler(Application, _applicationContext);
 
-			// iOS 13+ uses scene delegates, so skip this
-			if (!UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+			// If < iOS 13, or we're not on mac/ipad, or the Info.plist does not have a scene manifest entry
+			// we need to assume no multi window, and no UISceneDelegate
+			if (!UIDevice.CurrentDevice.CheckSystemVersion(13, 0)
+				|| (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Mac
+					&& UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
+				|| !NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString("UIApplicationSceneManifest")))
+			{
 				this.CreateNativeWindow(Application, application, launchOptions);
+			}
 
 			Services?.InvokeLifecycleEvents<iOSLifecycle.FinishedLaunching>(del => del(application!, launchOptions!));
 

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui
 		}
 
 		public override UISceneConfiguration GetConfiguration(UIApplication application, UISceneSession connectingSceneSession, UISceneConnectionOptions options)
-			=> new("Default Configuration", connectingSceneSession.Role);
+			=> new(MauiUIApplicationDelegate.MauiSceneConfigurationKey, connectingSceneSession.Role);
 
 		public override void PerformActionForShortcutItem(UIApplication application, UIApplicationShortcutItem shortcutItem, UIOperationHandler completionHandler)
 		{

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -2,6 +2,7 @@
 using Microsoft.Maui.Platform;
 using ObjCRuntime;
 using UIKit;
+using Microsoft.Maui.LifecycleEvents;
 
 namespace Microsoft.Maui
 {
@@ -11,20 +12,17 @@ namespace Microsoft.Maui
 
 		public override void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
 		{
-			if (session.Configuration.Name != MauiUIApplicationDelegate.MauiSceneConfigurationKey)
-				return;
+			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneWillConnect>(del => del(scene, session, connectionOptions));
 
-			this.CreateNativeWindow(MauiUIApplicationDelegate.Current.Application, scene, session, connectionOptions);
+			if (session.Configuration.Name != MauiUIApplicationDelegate.MauiSceneConfigurationKey && MauiUIApplicationDelegate.Current?.Application != null)
+			{
+				this.CreateNativeWindow(MauiUIApplicationDelegate.Current.Application, scene, session, connectionOptions);
+			}
 		}
 
 		public override void DidDisconnect(UIScene scene)
 		{
-			var window = (scene as UIWindowScene)?.KeyWindow?.GetWindow() ?? Window?.GetWindow();
-
-			if (window is not null)
-			{
-				MauiUIApplicationDelegate.Current?.Application?.Handler?.Invoke(nameof(IApplication.OnWindowClosed), window);
-			}
+			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneDidDisconnect>(del => del(scene));
 		}
 
 		public override NSUserActivity? GetStateRestorationActivity(UIScene scene)

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui
 		{
 			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneWillConnect>(del => del(scene, session, connectionOptions));
 
-			if (session.Configuration.Name != MauiUIApplicationDelegate.MauiSceneConfigurationKey && MauiUIApplicationDelegate.Current?.Application != null)
+			if (session.Configuration.Name == MauiUIApplicationDelegate.MauiSceneConfigurationKey && MauiUIApplicationDelegate.Current?.Application != null)
 			{
 				this.CreateNativeWindow(MauiUIApplicationDelegate.Current.Application, scene, session, connectionOptions);
 			}

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -17,6 +17,16 @@ namespace Microsoft.Maui
 			this.CreateNativeWindow(MauiUIApplicationDelegate.Current.Application, scene, session, connectionOptions);
 		}
 
+		public override void DidDisconnect(UIScene scene)
+		{
+			var window = (scene as UIWindowScene)?.KeyWindow?.GetWindow() ?? Window?.GetWindow();
+
+			if (window is not null)
+			{
+				MauiUIApplicationDelegate.Current?.Application?.Handler?.Invoke(nameof(IApplication.OnWindowClosed), window);
+			}
+		}
+
 		public override NSUserActivity? GetStateRestorationActivity(UIScene scene)
 		{
 			var window = Window.GetWindow();

--- a/src/Core/src/Platform/iOS/UIApplicationExtensions.cs
+++ b/src/Core/src/Platform/iOS/UIApplicationExtensions.cs
@@ -35,5 +35,21 @@ namespace Microsoft.Maui
 
 			return null;
 		}
+
+		public static IWindow? GetWindow(this UIWindowScene? windowScene)
+		{
+			if (windowScene is null)
+				return null;
+
+			foreach (var window in windowScene.Windows)
+			{
+				var managedWindow = window.GetWindow();
+
+				if (managedWindow is not null)
+					return managedWindow;
+			}
+
+			return null;
+		}
 	}
 }

--- a/src/Core/tests/Benchmarks/Stubs/ApplicationStub.cs
+++ b/src/Core/tests/Benchmarks/Stubs/ApplicationStub.cs
@@ -21,7 +21,12 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 
 		public void OpenWindow(IWindow window)
 		{
-			throw new System.NotImplementedException();
+			_windows.Add(window);
+		}
+
+		public void CloseWindow(IWindow window)
+		{
+			_windows.Remove(window);
 		}
 
 		public void ThemeChanged() { }

--- a/src/Core/tests/DeviceTests/Stubs/ApplicationStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ApplicationStub.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 			_windows.Add(window);
 		}
 
+		public void CloseWindow(IWindow window)
+		{
+			_windows.Remove(window);
+		}
+
 		public void ThemeChanged() { }
 	}
 }

--- a/src/Core/tests/UnitTests/TestClasses/ApplicationStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ApplicationStub.cs
@@ -21,7 +21,12 @@ namespace Microsoft.Maui.UnitTests
 
 		public void OpenWindow(IWindow window)
 		{
-			throw new System.NotImplementedException();
+			_windows.Add(window);
+		}
+
+		public void CloseWindow(IWindow window)
+		{
+			_windows.Remove(window);
 		}
 
 		public void ThemeChanged() { }


### PR DESCRIPTION
Adds:

- `IApplication.OnWindowClosed`

This now tracks when a UISceneSession disconnects, an Activity is destroyed, and a Window is closed and remove its Window from the Application's collection of windows.

- `IApplication.CloseWindow`

This method provides a way to request that an `IWindow`'s platform scene/activity/window is closed intentionally without the user requesting it specifically through the platform's mechanism to do so.

- [x] TODO: Windows support for detecting the window is closed
- [x] Question: Is the `OnWindowClosed` mapper the right way to do this?

