### PR TITLE
[Android] Fix mismatch date issue in DatePicker

### DIFF
--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -27,15 +27,20 @@ namespace Microsoft.Maui.Handlers
 			return mauiDatePicker;
 		}
 
+		internal DatePickerDialog? DatePickerDialog { get { return _dialog; } }
+
+		protected override void ConnectHandler(MauiDatePicker nativeView)
+		{
+			base.ConnectHandler(nativeView);
+
+			SetupDefaults(nativeView);
+		}
+
 		void SetupDefaults(MauiDatePicker nativeView)
 		{
 			_defaultBackground = nativeView.Background;
 			_defaultTextColors = nativeView.TextColors;
-
-
 		}
-
-		internal DatePickerDialog? DatePickerDialog { get { return _dialog; } }
 
 		protected override void DisconnectHandler(MauiDatePicker nativeView)
 		{
@@ -55,6 +60,9 @@ namespace Microsoft.Maui.Handlers
 			{
 				if (VirtualView != null)
 					VirtualView.Date = e.Date;
+
+				// TODO: Update IsFocused Property
+
 			}, year, month, day);
 
 			return dialog;
@@ -108,8 +116,11 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null)
 				return;
 
+			if (_dialog != null && _dialog.IsShowing)
+				return;
+
 			var date = VirtualView.Date;
-			ShowPickerDialog(date.Year, date.Month, date.Day);
+			ShowPickerDialog(date.Year, date.Month - 1, date.Day);
 		}
 
 		void ShowPickerDialog(int year, int month, int day)


### PR DESCRIPTION
### Description of Change ###

Fix mismatch date issue in DatePicker between the Entry and the Dialog. Align the behavior with Xamarin.Forms: https://github.com/xamarin/Xamarin.Forms/blob/caab66bcf9614aca0c0805d560a34e176d196e17/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs#L157

- fixes https://github.com/dotnet/maui/issues/1940

To test and validate the fix launch the Gallery on Android and navigate to the DatePicker page. Tap a DatePicker. If the date in the dialog is the same than the one in the text box, the fix is correct.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No
