### PR TITLE
Ensure that AbsoluteLayout measures children at their target sizes

### DIFF
--- a/src/Core/src/Layouts/AbsoluteLayoutManager.cs
+++ b/src/Core/src/Layouts/AbsoluteLayoutManager.cs
@@ -33,13 +33,15 @@ namespace Microsoft.Maui.Layouts
 					continue;
 				}
 
-				var measure = child.Measure(availableWidth, availableHeight);
-
 				var bounds = AbsoluteLayout.GetLayoutBounds(child);
 				var flags = AbsoluteLayout.GetLayoutFlags(child);
-
 				bool isWidthProportional = HasFlag(flags, AbsoluteLayoutFlags.WidthProportional);
 				bool isHeightProportional = HasFlag(flags, AbsoluteLayoutFlags.HeightProportional);
+
+				var measureWidth = ResolveChildMeasureConstraint(bounds.Width, isWidthProportional, widthConstraint);
+				var measureHeight = ResolveChildMeasureConstraint(bounds.Height, isHeightProportional, heightConstraint);
+
+				var measure = child.Measure(measureWidth, measureHeight);
 
 				var width = ResolveDimension(isWidthProportional, bounds.Width, availableWidth, measure.Width);
 				var height = ResolveDimension(isHeightProportional, bounds.Height, availableHeight, measure.Height);
@@ -121,6 +123,22 @@ namespace Microsoft.Maui.Layouts
 			}
 
 			return value;
+		}
+
+		static double ResolveChildMeasureConstraint(double boundsValue, bool proportional, double constraint) 
+		{
+			if (boundsValue < 0)
+			{
+				// If the child view doesn't have bounds set by the AbsoluteLayout, then we'll measure using the full constraint value
+				return constraint;
+			}
+
+			if (proportional)
+			{
+				return boundsValue * constraint;
+			}
+
+			return boundsValue;
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/AbsoluteLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/AbsoluteLayoutManagerTests.cs
@@ -405,5 +405,45 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(arrangedWidth, actual.Width);
 			Assert.Equal(arrangedHeight, actual.Height);
 		}
+
+		[Fact]
+		public void ChildMeasureRespectsAbsoluteBounds() 
+		{
+			double expectedWidth = 115;
+			double expectedHeight = 230;
+
+			var abs = CreateTestLayout();
+			var child = CreateTestView();
+			SubstituteChildren(abs, child);
+			var childBounds = new Rectangle(0, 0, expectedWidth, expectedHeight);
+			SetLayoutBounds(abs, child, childBounds);
+
+			var gridLayoutManager = new AbsoluteLayoutManager(abs);
+			var measure = gridLayoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			child.Received().Measure(Arg.Is(expectedWidth), Arg.Is(expectedHeight));
+		}
+
+		[Fact]
+		public void ChildMeasureRespectsProportionalBounds()
+		{
+			double expectedWidth = 0.5;
+			double expectedHeight = 0.6;
+
+			double widthConstraint = 200;
+			double heightConstraint = 200;
+
+			var abs = CreateTestLayout();
+			var child = CreateTestView();
+			SubstituteChildren(abs, child);
+			var childBounds = new Rectangle(0, 0, expectedWidth, expectedHeight);
+			SetLayoutBounds(abs, child, childBounds);
+			SetLayoutFlags(abs, child, AbsoluteLayoutFlags.SizeProportional);
+
+			var gridLayoutManager = new AbsoluteLayoutManager(abs);
+			var measure = gridLayoutManager.Measure(widthConstraint, heightConstraint);
+
+			child.Received().Measure(Arg.Is(expectedWidth * widthConstraint), Arg.Is(expectedHeight * heightConstraint));
+		}
 	}
 }


### PR DESCRIPTION
AbsoluteLayout is measuring all children using the full constraints, even though their final bounds are already set by the AbsoluteLayout itself. 

These changes measure the children using the bounds set by the AbsoluteLayout (if any).