### PR TITLE
Validate and Fix MAUI Navigation Pages against our legacy tests

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
@@ -12,6 +13,10 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class NavigationPage : INavigationView
 	{
+		TaskCompletionSource<object> _allPendingNavigationCompletionSource;
+		TaskCompletionSource<object> _currentNavigationCompletionSource;
+		int _waitingCount = 0;
+
 		partial void Init()
 		{
 			this.Appearing += OnAppearing;
@@ -50,12 +55,18 @@ namespace Microsoft.Maui.Controls
 		// with the new native Navigation Stack
 		void INavigationView.NavigationFinished(IReadOnlyList<IView> newStack)
 		{
-			SyncToNavigationStack(newStack);
-			var completionSource = _taskCompletionSource;
-			CurrentPage = (Page)newStack[newStack.Count - 1];
-			RootPage = (Page)newStack[0];
+			// If the user is performing multiple navigation then we don't want to sync the native stack yet
+			// We wait until the last requested navigation completes to sync native stack to xplat
+			if (_waitingCount == 1)
+			{
+				SyncToNavigationStack(newStack);
+				CurrentPage = (Page)newStack[newStack.Count - 1];
+				RootPage = (Page)newStack[0];
+			}
+
+			var completionSource = _currentNavigationCompletionSource;
 			CurrentNavigationTask = null;
-			_taskCompletionSource = null;
+			_currentNavigationCompletionSource = null;
 			completionSource?.SetResult(null);
 		}
 
@@ -110,62 +121,105 @@ namespace Microsoft.Maui.Controls
 				window.Toolbar.ApplyNavigationPage(this);
 		}
 
-		Task WaitForCurrentNavigationTask() =>
-			CurrentNavigationTask ?? Task.CompletedTask;
+
+		readonly SemaphoreSlim SemaphoreSlim = new SemaphoreSlim(1, 1);
 
 		// This is used for navigation events that don't effect the currently visible page
 		// InsertPageBefore/RemovePage
 		async void SendHandlerUpdate(bool animated)
 		{
-			await WaitForCurrentNavigationTask();
-			var trulyReadOnlyNavigationStack = new List<IView>(NavigationStack);
-			var request = new NavigationRequest(trulyReadOnlyNavigationStack, animated);
-			((INavigationView)this).RequestNavigation(request);
+			try
+			{
+				Interlocked.Increment(ref _waitingCount);
+				await SemaphoreSlim.WaitAsync();
+				var trulyReadOnlyNavigationStack = new List<IView>(NavigationStack);
+				var request = new NavigationRequest(trulyReadOnlyNavigationStack, animated);
+				((INavigationView)this).RequestNavigation(request);
+			}
+			finally
+			{
+				Interlocked.Decrement(ref _waitingCount);
+				SemaphoreSlim.Release();
+			}
 		}
 
-		TaskCompletionSource<object> _taskCompletionSource;
-
-		async Task SendHandlerUpdateAsync(bool animated, bool push = false, bool pop = false, bool popToRoot = false)
+		async Task SendHandlerUpdateAsync(
+			bool animated,
+			Action processStackChanges,
+			Action firePostNavigatingEvents,
+			Action fireNavigatedEvents)
 		{
-			// Wait for any pending navigation tasks to finish
-			await WaitForCurrentNavigationTask();
+			try
+			{
+				processStackChanges?.Invoke();
+				Interlocked.Increment(ref _waitingCount);
+				// Wait for pending navigation tasks to finish
+				await SemaphoreSlim.WaitAsync();
 
-			var completionSource = new TaskCompletionSource<object>();
-			CurrentNavigationTask = completionSource.Task;
-			_taskCompletionSource = completionSource;
+				var currentNavRequestTaskSource = new TaskCompletionSource<object>();
+				_allPendingNavigationCompletionSource ??= new TaskCompletionSource<object>();
 
-			// We create a new list to send to the handler because the structure backing 
-			// The Navigation stack isn't immutable
-			var previousPage = CurrentPage;
-			var immutableNavigationStack = new List<IView>(NavigationStack);
+				if (CurrentNavigationTask == null)
+				{
+					CurrentNavigationTask = _allPendingNavigationCompletionSource.Task;
+				}
+				else if (CurrentNavigationTask != _allPendingNavigationCompletionSource.Task)
+				{
+					throw new InvalidOperationException("Pending Navigations still processing");
+				}
 
-			// Alert currently visible pages that navigation is happening
-			SendNavigating();
+				_currentNavigationCompletionSource = currentNavRequestTaskSource;
 
-			// Create the request for the handler
-			var request = new NavigationRequest(immutableNavigationStack, animated);
-			((INavigationView)this).RequestNavigation(request);
+				// We create a new list to send to the handler because the structure backing 
+				// The Navigation stack isn't immutable
+				var immutableNavigationStack = new List<IView>(NavigationStack);
+				firePostNavigatingEvents?.Invoke();
 
-			// Wait for the handler to finish processing the navigation
-			await completionSource.Task;
+				// Create the request for the handler
+				var request = new NavigationRequest(immutableNavigationStack, animated);
+				((INavigationView)this).RequestNavigation(request);
+
+				// Wait for the handler to finish processing the navigation
+				// This task completes once the handler calls INavigationView.Finished
+				await currentNavRequestTaskSource.Task;
+			}
+			finally
+			{
+				if (Interlocked.Decrement(ref _waitingCount) == 0)
+				{
+					_allPendingNavigationCompletionSource.SetResult(new object());
+					_allPendingNavigationCompletionSource = null;
+				}
+
+				SemaphoreSlim.Release();
+			}
 
 			// Send navigated event to currently visible pages and associated navigation event
-			SendNavigated(previousPage);
-			if (push)
-				Pushed?.Invoke(this, new NavigationEventArgs(CurrentPage));
-			else if (pop)
-				Popped?.Invoke(this, new NavigationEventArgs(previousPage));
-			else
-				PoppedToRoot?.Invoke(this, new NavigationEventArgs(previousPage));
+			fireNavigatedEvents?.Invoke();
 		}
 
 		private protected override void OnHandlerChangedCore()
 		{
 			base.OnHandlerChangedCore();
-			var immutableNavigationStack = new List<IView>(NavigationStack);
-			SendNavigating();
-			var request = new NavigationRequest(immutableNavigationStack, false);
-			((INavigationView)this).RequestNavigation(request);
+
+			if (InternalChildren.Count > 0)
+			{
+				var navStack = Navigation.NavigationStack;
+				var visiblePage = Navigation.NavigationStack[NavigationStack.Count - 1];
+				RootPage = navStack[0];
+				CurrentPage = visiblePage;
+
+				SendHandlerUpdateAsync(false, null, 
+				() =>
+				{					
+					FireAppearing(CurrentPage);
+				},
+				() =>
+				{
+					SendNavigated(null);
+				})
+				.FireAndForget(Handler);
+			}
 		}
 
 		// Once we get all platforms over to the new APIs
@@ -185,13 +239,6 @@ namespace Microsoft.Maui.Controls
 			protected override IReadOnlyList<Page> GetNavigationStack()
 			{
 				return _castingList.Value;
-			}
-
-
-			void SendHandlerUpdate(bool animated)
-			{
-				var request = new NavigationRequest(GetNavigationStack(), false);
-				Owner.Handler?.Invoke(nameof(INavigationView.RequestNavigation), request);
 			}
 
 			protected override void OnInsertPageBefore(Page page, Page before)
@@ -214,39 +261,98 @@ namespace Microsoft.Maui.Controls
 				if (index == 0)
 					Owner.RootPage = page;
 
-				SendHandlerUpdate(false);
+				Owner.SendHandlerUpdate(false);
 			}
 
 			protected async override Task<Page> OnPopAsync(bool animated)
 			{
-				var page = (Page)Owner.InternalChildren.Last();
-				Owner.FireDisappearing(page);
+				if (Owner.InternalChildren.Count == 1)
+				{
+					return null;
+				}
 
-				if (Owner.InternalChildren.Last() == page)
-					Owner.FireAppearing((Page)Owner.InternalChildren[Owner.InternalChildren.Count - 2]);
+				var currentPage = NavigationStack[NavigationStack.Count - 1];
+				var newCurrentPage = NavigationStack[NavigationStack.Count - 2];
 
-				Owner.RemoveFromInnerChildren(page);
-				Owner.CurrentPage = (Page)Owner.InternalChildren.Last();
-				await Owner.SendHandlerUpdateAsync(animated, pop: true);
-				return page;
+				await Owner.SendHandlerUpdateAsync(animated, 
+					() =>
+					{
+						Owner.RemoveFromInnerChildren(currentPage);
+						Owner.CurrentPage = currentPage;
+					},
+					() =>
+					{
+						Owner.SendNavigating(currentPage);
+						Owner.FireDisappearing(currentPage);
+						Owner.FireAppearing(newCurrentPage);
+					},
+					() =>
+					{
+						Owner.SendNavigated(currentPage);
+						Owner?.Popped?.Invoke(Owner, new NavigationEventArgs(currentPage));
+					});
+
+				return newCurrentPage;
 			}
 
 			protected override Task OnPopToRootAsync(bool animated)
 			{
-				Element[] childrenToRemove = Owner.InternalChildren.Skip(1).ToArray();
-				foreach (Element child in childrenToRemove)
-				{
-					Owner.RemoveFromInnerChildren(child);
-				}
+				if (NavigationStack.Count == 1)
+					return Task.CompletedTask;
 
-				Owner.CurrentPage = Owner.RootPage;
-				return Owner.SendHandlerUpdateAsync(animated, popToRoot: true);
+				Page previousPage = Owner.CurrentPage;
+				Page newPage = Owner.RootPage;
+				List<Page> pagesToRemove = new List<Page>();
+
+				return Owner.SendHandlerUpdateAsync(animated,
+					() =>
+					{
+						var lastIndex = NavigationStack.Count - 1;
+						while (lastIndex > 0)
+						{
+							var page = (Page)NavigationStack[lastIndex];
+							Owner.RemoveFromInnerChildren(page);
+							lastIndex = NavigationStack.Count - 1;
+							pagesToRemove.Insert(0, page);
+						}
+						Owner.CurrentPage = newPage;
+					},
+					() =>
+					{
+						Owner.SendNavigating(previousPage);
+						Owner.FireDisappearing(previousPage);
+						Owner.FireAppearing(newPage);
+					},
+					() =>
+					{
+						Owner.SendNavigated(previousPage);
+						Owner?.PoppedToRoot?.Invoke(Owner, new PoppedToRootEventArgs(newPage, pagesToRemove));
+					});
 			}
 
 			protected override Task OnPushAsync(Page root, bool animated)
 			{
-				Owner.PushPage(root);
-				return Owner.SendHandlerUpdateAsync(animated, push: true);
+				if (Owner.InternalChildren.Contains(root))
+					return Task.CompletedTask;
+
+				var previousPage = Owner.CurrentPage;
+				
+				return Owner.SendHandlerUpdateAsync(animated,
+					() =>
+					{
+						Owner.PushPage(root);
+					},
+					() =>
+					{
+						Owner.SendNavigating(previousPage);
+						Owner.FireDisappearing(previousPage);
+						Owner.FireAppearing(root);
+					},
+					() =>
+					{
+						Owner.SendNavigated(previousPage);
+						Owner?.Pushed?.Invoke(Owner, new NavigationEventArgs(root));
+					});
 			}
 
 			protected override void OnRemovePage(Page page)

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Maui.Controls
 						Owner?.Popped?.Invoke(Owner, new NavigationEventArgs(currentPage));
 					});
 
-				return newCurrentPage;
+				return currentPage;
 			}
 
 			protected override Task OnPopToRootAsync(bool animated)

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls
 			// If the user is performing multiple overlapping navigations then we don't want to sync the native stack to our xplat stack
 			// We wait until we get to the end of the queue and then we sync up.
 			// Otherwise intermediate results will wipe out the navigationstack
-			if (_waitingCount == 1)
+			if (_waitingCount <= 1)
 			{
 				SyncToNavigationStack(newStack);
 				CurrentPage = (Page)newStack[newStack.Count - 1];

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -40,21 +40,34 @@ namespace Microsoft.Maui.Controls
 
 		partial void Init();
 
-		public NavigationPage()
-		{
-			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<NavigationPage>>(() => new PlatformConfigurationRegistry<NavigationPage>(this));
-
-#if WINDOWS || __ANDROID__
-			Navigation = new MauiNavigationImpl(this);
+		public NavigationPage() : this(
+#if WINDOWS || ANDROID
+			true
 #else
-			Navigation = new NavigationImpl(this);
+			false
 #endif
-			Init();
+			)
+		{
 		}
 
 		public NavigationPage(Page root) : this()
 		{
 			PushPage(root);
+		}
+
+		internal NavigationPage(bool setforMaui, Page root = null)
+		{
+			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<NavigationPage>>(() => new PlatformConfigurationRegistry<NavigationPage>(this));
+
+			if (setforMaui)
+				Navigation = new MauiNavigationImpl(this);
+			else
+				Navigation = new NavigationImpl(this);
+
+			Init();
+
+			if (root != null)
+				PushPage(root);
 		}
 
 		public Color BarBackgroundColor
@@ -173,13 +186,10 @@ namespace Microsoft.Maui.Controls
 		public async Task<Page> PopAsync(bool animated)
 		{
 			// If Navigation interactions are being handled by the MAUI APIs
-			// this routes the pop call there instead of through old behavior
-			if (Navigation is MauiNavigationImpl && this is INavigationView nv)
+			// this routes the call there instead of through old behavior
+			if (Navigation is MauiNavigationImpl mvi && this is INavigationView)
 			{
-				var poppedPage = (Page)InternalChildren[InternalChildren.Count - 1];
-				RemoveFromInnerChildren(poppedPage);
-				await this.SendHandlerUpdateAsync(true, pop: true);
-				return poppedPage;
+				return await mvi.PopAsync(animated);
 			}
 
 			var tcs = new TaskCompletionSource<bool>();
@@ -219,6 +229,14 @@ namespace Microsoft.Maui.Controls
 
 		public async Task PopToRootAsync(bool animated)
 		{
+			// If Navigation interactions are being handled by the MAUI APIs
+			// this routes the call there instead of through old behavior
+			if (Navigation is MauiNavigationImpl mvi && this is INavigationView)
+			{
+				await mvi.PopToRootAsync(animated);
+				return;
+			}
+
 			if (CurrentNavigationTask != null && !CurrentNavigationTask.IsCompleted)
 			{
 				var tcs = new TaskCompletionSource<bool>();
@@ -242,7 +260,18 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public async Task PushAsync(Page page, bool animated)
-		{
+		{	
+			// If Navigation interactions are being handled by the MAUI APIs
+			// this routes the call there instead of through old behavior
+			if (Navigation is MauiNavigationImpl mvi && this is INavigationView)
+			{
+				if (InternalChildren.Contains(page))
+					return;
+
+				await mvi.PushAsync(page, animated);
+				return;
+			}
+
 			if (CurrentNavigationTask != null && !CurrentNavigationTask.IsCompleted)
 			{
 				var tcs = new TaskCompletionSource<bool>();
@@ -320,9 +349,9 @@ namespace Microsoft.Maui.Controls
 			CurrentPage.SendNavigatedTo(new NavigatedToEventArgs(previousPage));
 		}
 
-		void SendNavigating()
+		void SendNavigating(Page navigatingFrom = null)
 		{
-			CurrentPage?.SendNavigatingFrom(new NavigatingFromEventArgs());
+			(navigatingFrom ?? CurrentPage)?.SendNavigatingFrom(new NavigatingFromEventArgs());
 		}
 
 

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -287,10 +287,7 @@ namespace Microsoft.Maui.Controls
 			var canceled = false;
 			EventHandler handler = (sender, args) => { canceled = true; };
 			window.PopCanceled += handler;
-			Navigation
-				.PopModalAsync()
-				.ContinueWith(t => { throw t.Exception; }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.FromCurrentSynchronizationContext())
-				.FireAndForget(this.Handler);
+			Navigation.PopModalAsync().ContinueWith(t => { throw t.Exception; }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.FromCurrentSynchronizationContext());
 
 			window.PopCanceled -= handler;
 			return !canceled;

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -287,7 +287,10 @@ namespace Microsoft.Maui.Controls
 			var canceled = false;
 			EventHandler handler = (sender, args) => { canceled = true; };
 			window.PopCanceled += handler;
-			Navigation.PopModalAsync().ContinueWith(t => { throw t.Exception; }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.FromCurrentSynchronizationContext());
+			Navigation
+				.PopModalAsync()
+				.ContinueWith(t => { throw t.Exception; }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.FromCurrentSynchronizationContext())
+				.FireAndForget(this.Handler);
 
 			window.PopCanceled -= handler;
 			return !canceled;

--- a/src/Controls/src/Core/Platform/AlertManager/AlertMananger.Standard.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertMananger.Standard.cs
@@ -6,12 +6,10 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		internal static void Subscribe(Window window)
 		{
-			throw new NotImplementedException();
 		}
 
 		internal static void Unsubscribe(Window window)
 		{
-			throw new NotImplementedException();
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests-net6.csproj
+++ b/src/Controls/tests/Core.UnitTests/Controls.Core.UnitTests-net6.csproj
@@ -10,6 +10,7 @@
       src/Controls/tests/Core.UnitTests/TemplatedItemsListTests.cs(543,11): error CS0121: The call is ambiguous between the following methods or properties: 'Assert.That(TestDelegate, IResolveConstraint)' and 'Assert.That<TActual>(TActual, IResolveConstraint)'
     -->
     <LangVersion>9.0</LangVersion>
+    <RootNamespace>Microsoft.Maui.Controls.Core.UnitTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
@@ -9,8 +9,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	[TestFixture]
 	public class NavigationPageLifecycleTests : BaseTestFixture
 	{
-		[Test]
-		public async Task AppearingFiresForInitialPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task AppearingFiresForInitialPage(bool useMaui)
 		{
 			ContentPage contentPage = new ContentPage();
 			ContentPage resultPage = null;
@@ -18,15 +19,17 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			contentPage.Appearing += (sender, _)
 				=> resultPage = (ContentPage)sender;
 
-			NavigationPage nav = new NavigationPage(contentPage);
+			NavigationPage nav = new TestNavigationPage(useMaui, contentPage);
 
 			Assert.IsNull(resultPage);
 			_ = new Window(nav);
 			Assert.AreEqual(resultPage, contentPage);
 		}
 
-		[Test]
-		public async Task PushLifeCycle()
+
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task PushLifeCycle(bool useMaui)
 		{
 			ContentPage initialPage = new ContentPage();
 			ContentPage pushedPage = new ContentPage();
@@ -40,7 +43,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			pushedPage.Appearing += (sender, _)
 				=> pageAppearing = (ContentPage)sender;
 
-			NavigationPage nav = new NavigationPage(initialPage);
+			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
 			_ = new Window(nav);
 			nav.SendAppearing();
 
@@ -50,37 +53,39 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(pageAppearing, pushedPage);
 		}
 
-		[Test]
-		public async Task PopLifeCycle()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task PopLifeCycle(bool useMaui)
 		{
 			ContentPage initialPage = new ContentPage();
 			ContentPage pushedPage = new ContentPage();
 
-			ContentPage initialPageAppearing = null;
+			ContentPage rootPageFiresAppearingAfterPop = null;
 			ContentPage pageDisappeared = null;
 
-			NavigationPage nav = new NavigationPage(initialPage);
+			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
 			_ = new Window(nav);
 			nav.SendAppearing();
 
 			initialPage.Appearing += (sender, _)
-				=> initialPageAppearing = (ContentPage)sender;
+				=> rootPageFiresAppearingAfterPop = (ContentPage)sender;
 
 			pushedPage.Disappearing += (sender, _)
 				=> pageDisappeared = (ContentPage)sender;
 
 			await nav.PushAsync(pushedPage);
-			Assert.IsNull(initialPageAppearing);
+			Assert.IsNull(rootPageFiresAppearingAfterPop);
 			Assert.IsNull(pageDisappeared);
 
 			await nav.PopAsync();
 
-			Assert.AreEqual(initialPageAppearing, initialPage);
-			Assert.AreEqual(pageDisappeared, pushedPage);
+			Assert.AreEqual(initialPage, rootPageFiresAppearingAfterPop);
+			Assert.AreEqual(pushedPage, pageDisappeared);
 		}
 
-		[Test]
-		public async Task RemoveLastPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task RemoveLastPage(bool useMaui)
 		{
 			ContentPage initialPage = new ContentPage();
 			ContentPage pushedPage = new ContentPage();
@@ -88,7 +93,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			ContentPage initialPageAppearing = null;
 			ContentPage pageDisappeared = null;
 
-			NavigationPage nav = new NavigationPage(initialPage);
+			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
 			_ = new Window(nav);
 			nav.SendAppearing();
 
@@ -108,9 +113,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(pageDisappeared, pushedPage);
 		}
 
-
-		[Test]
-		public async Task RemoveInnerPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task RemoveInnerPage(bool useMaui)
 		{
 			ContentPage initialPage = new ContentPage();
 			ContentPage pushedPage = new ContentPage();
@@ -118,7 +123,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			ContentPage initialPageAppearing = null;
 			ContentPage pageDisappeared = null;
 
-			NavigationPage nav = new NavigationPage(initialPage);
+			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
 			_ = new Window(nav);
 			nav.SendAppearing();
 

--- a/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
@@ -453,7 +453,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		[TestCase(false)]
 		[TestCase(true)]
-		public void SendsBackButtonEventToCurrentPage(bool useMaui)
+		public async Task SendsBackButtonEventToCurrentPage(bool useMaui)
 		{
 			var current = new BackButtonPage();
 			var navPage = new TestNavigationPage(useMaui, current);
@@ -461,14 +461,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var emitted = false;
 			current.BackPressed += (sender, args) => emitted = true;
 
-			navPage.SendBackButtonPressed();
+			await navPage.SendBackButtonPressedAsync();
 
 			Assert.True(emitted);
 		}
 
 		[TestCase(false)]
 		[TestCase(true)]
-		public void DoesNotSendBackEventToNonCurrentPage(bool useMaui)
+		public async Task DoesNotSendBackEventToNonCurrentPage(bool useMaui)
 		{
 			var current = new BackButtonPage();
 			var navPage = new TestNavigationPage(useMaui, current);
@@ -477,7 +477,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var emitted = false;
 			current.BackPressed += (sender, args) => emitted = true;
 
-			navPage.SendBackButtonPressed();
+			await navPage.SendBackButtonPressedAsync();
 
 			Assert.False(emitted);
 		}
@@ -491,7 +491,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			await navPage.PushAsync(new ContentPage());
 
-			var result = navPage.SendBackButtonPressed();
+			var result = await navPage.SendBackButtonPressedAsync();
 
 			Assert.AreEqual(root, navPage.CurrentPage);
 			Assert.True(result);
@@ -507,19 +507,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			await navPage.PushAsync(second);
 
-			navPage.SendBackButtonPressed();
+			await navPage.SendBackButtonPressedAsync();
 
 			Assert.AreEqual(second, navPage.CurrentPage);
 		}
 
 		[TestCase(false)]
 		[TestCase(true)]
-		public void DoesNotHandleBackButtonWhenNoNavStack(bool useMaui)
+		public async Task DoesNotHandleBackButtonWhenNoNavStack(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
 			var navPage = new TestNavigationPage(useMaui, root);
 
-			var result = navPage.SendBackButtonPressed();
+			var result = await navPage.SendBackButtonPressedAsync();
 			Assert.False(result);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -9,10 +10,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	[TestFixture]
 	public class NavigationUnitTest : BaseTestFixture
 	{
-		[Test]
-		public async Task TestNavigationImplPush()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestNavigationImplPush(bool useMaui)
 		{
-			NavigationPage nav = new NavigationPage();
+			NavigationPage nav = new TestNavigationPage(useMaui);
 
 			Assert.IsNull(nav.RootPage);
 			Assert.IsNull(nav.CurrentPage);
@@ -27,10 +29,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
-		[Test]
-		public async Task TestNavigationImplPop()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestNavigationImplPop(bool useMaui)
 		{
-			NavigationPage nav = new NavigationPage();
+			NavigationPage nav = new TestNavigationPage(useMaui);
 
 			Label child = new Label();
 			Page childRoot = new ContentPage { Content = child };
@@ -65,10 +68,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
-		[Test]
-		public async Task TestPushRoot()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestPushRoot(bool useMaui)
 		{
-			NavigationPage nav = new NavigationPage();
+			NavigationPage nav = new TestNavigationPage(useMaui);
 
 			Assert.IsNull(nav.RootPage);
 			Assert.IsNull(nav.CurrentPage);
@@ -83,10 +87,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
-		[Test]
-		public async Task TestPushEvent()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestPushEvent(bool useMaui)
 		{
-			NavigationPage nav = new NavigationPage();
+			NavigationPage nav = new TestNavigationPage(useMaui);
 
 			Label child = new Label();
 			Page childRoot = new ContentPage { Content = child };
@@ -99,10 +104,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(fired);
 		}
 
-		[Test]
-		public async Task TestDoublePush()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestDoublePush(bool useMaui)
 		{
-			NavigationPage nav = new NavigationPage();
+			NavigationPage nav = new TestNavigationPage(useMaui);
 
 			Label child = new Label();
 			Page childRoot = new ContentPage { Content = child };
@@ -123,10 +129,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
-		[Test]
-		public async Task TestPop()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestPop(bool useMaui)
 		{
-			NavigationPage nav = new NavigationPage();
+			NavigationPage nav = new TestNavigationPage(useMaui);
 
 			Label child = new Label();
 			Page childRoot = new ContentPage { Content = child };
@@ -151,10 +158,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsNull(last);
 		}
 
-		[Test]
-		public async Task TestPopToRoot()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestPopToRoot(bool useMaui)
 		{
-			var nav = new NavigationPage();
+			var nav = new TestNavigationPage(useMaui);
 
 			bool signaled = false;
 			nav.PoppedToRoot += (sender, args) => signaled = true;
@@ -167,7 +175,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await nav.PushAsync(child1);
 			await nav.PushAsync(child2);
 
-			nav.PopToRootAsync();
+			await nav.PopToRootAsync();
 
 			Assert.True(signaled);
 			Assert.AreSame(root, nav.RootPage);
@@ -175,10 +183,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
-		[Test]
-		public async Task TestPopToRootEventArgs()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestPopToRootEventArgs(bool useMaui)
 		{
-			var nav = new NavigationPage();
+			var nav = new TestNavigationPage(useMaui);
 
 			List<Page> poppedChildren = null;
 			nav.PoppedToRoot += (sender, args) => poppedChildren = (args as PoppedToRootEventArgs).PoppedPages.ToList();
@@ -202,10 +211,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 		}
 
-		[Test]
-		public async Task PeekOne()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task PeekOne(bool useMaui)
 		{
-			var nav = new NavigationPage();
+			var nav = new TestNavigationPage(useMaui);
 
 			bool signaled = false;
 			nav.PoppedToRoot += (sender, args) => signaled = true;
@@ -221,10 +231,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(((INavigationPageController)nav).Peek(1), child1);
 		}
 
-		[Test]
-		public async Task PeekZero()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task PeekZero(bool useMaui)
 		{
-			var nav = new NavigationPage();
+			var nav = new TestNavigationPage(useMaui);
 
 			bool signaled = false;
 			nav.PoppedToRoot += (sender, args) => signaled = true;
@@ -241,10 +252,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(((INavigationPageController)nav).Peek(), child2);
 		}
 
-		[Test]
-		public async Task PeekPastStackDepth()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task PeekPastStackDepth(bool useMaui)
 		{
-			var nav = new NavigationPage();
+			var nav = new TestNavigationPage(useMaui);
 
 			bool signaled = false;
 			nav.PoppedToRoot += (sender, args) => signaled = true;
@@ -260,10 +272,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(((INavigationPageController)nav).Peek(3), null);
 		}
 
-		[Test]
-		public async Task PeekShallow()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task PeekShallow(bool useMaui)
 		{
-			var nav = new NavigationPage();
+			var nav = new TestNavigationPage(useMaui);
 
 			bool signaled = false;
 			nav.PoppedToRoot += (sender, args) => signaled = true;
@@ -280,9 +293,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public async Task PeekEmpty([Range(0, 3)] int depth)
+		public async Task PeekEmpty([Values(true, false)] bool useMaui, [Range(0, 3)] int depth)
 		{
-			var nav = new NavigationPage();
+			var nav = new TestNavigationPage(useMaui);
 
 			bool signaled = false;
 			nav.PoppedToRoot += (sender, args) => signaled = true;
@@ -291,23 +304,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 
-		[Test]
-		public void ConstructWithRoot()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void ConstructWithRoot(bool useMaui)
 		{
 			var root = new ContentPage();
-			var nav = new NavigationPage(root);
-
+			var nav = new TestNavigationPage(useMaui, root);
 
 			Assert.AreEqual(1, ((INavigationPageController)nav).StackDepth);
 			Assert.AreEqual(root, ((IElementController)nav).LogicalChildren[0]);
 
 		}
 
-		[Test]
-		public void TitleViewSetProperty()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void TitleViewSetProperty(bool useMaui)
 		{
 			var root = new ContentPage();
-			var nav = new NavigationPage(root);
+			var nav = new TestNavigationPage(useMaui, root);
 
 			View target = new View();
 
@@ -318,11 +332,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(result, target);
 		}
 
-		[Test]
-		public void TitleViewSetsParentWhenAdded()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void TitleViewSetsParentWhenAdded(bool useMaui)
 		{
 			var root = new ContentPage();
-			var nav = new NavigationPage(root);
+			var nav = new TestNavigationPage(useMaui, root);
 
 			View target = new View();
 
@@ -331,11 +346,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(root, target.Parent);
 		}
 
-		[Test]
-		public void TitleViewClearsParentWhenRemoved()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void TitleViewClearsParentWhenRemoved(bool useMaui)
 		{
 			var root = new ContentPage();
-			var nav = new NavigationPage(root);
+			var nav = new TestNavigationPage(useMaui, root);
 
 			View target = new View();
 
@@ -346,11 +362,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsNull(target.Parent);
 		}
 
-		[Test]
-		public async Task NavigationChangedEventArgs()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task NavigationChangedEventArgs(bool useMaui)
 		{
 			var rootPage = new ContentPage { Title = "Root" };
-			var navPage = new NavigationPage(rootPage);
+			var navPage = new TestNavigationPage(useMaui, rootPage);
 
 			var rootArg = new Page();
 
@@ -378,11 +395,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(rootArg, secondPushPage);
 		}
 
-		[Test]
-		public async Task CurrentPageChanged()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task CurrentPageChanged(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 
 			bool changing = false;
 			navPage.PropertyChanging += (object sender, PropertyChangingEventArgs e) =>
@@ -412,11 +430,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.That(changed, Is.True, "PropertyChanged was not raised for 'CurrentPage'");
 		}
 
-		[Test]
-		public async Task HandlesPopToRoot()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task HandlesPopToRoot(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 
 			await navPage.PushAsync(new ContentPage());
 			await navPage.PushAsync(new ContentPage());
@@ -432,11 +451,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(popped);
 		}
 
-		[Test]
-		public void SendsBackButtonEventToCurrentPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void SendsBackButtonEventToCurrentPage(bool useMaui)
 		{
 			var current = new BackButtonPage();
-			var navPage = new NavigationPage(current);
+			var navPage = new TestNavigationPage(useMaui, current);
 
 			var emitted = false;
 			current.BackPressed += (sender, args) => emitted = true;
@@ -446,11 +466,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(emitted);
 		}
 
-		[Test]
-		public void DoesNotSendBackEventToNonCurrentPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void DoesNotSendBackEventToNonCurrentPage(bool useMaui)
 		{
 			var current = new BackButtonPage();
-			var navPage = new NavigationPage(current);
+			var navPage = new TestNavigationPage(useMaui, current);
 			navPage.PushAsync(new ContentPage());
 
 			var emitted = false;
@@ -461,11 +482,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.False(emitted);
 		}
 
-		[Test]
-		public async Task NavigatesBackWhenBackButtonPressed()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task NavigatesBackWhenBackButtonPressed(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 
 			await navPage.PushAsync(new ContentPage());
 
@@ -475,12 +497,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(result);
 		}
 
-		[Test]
-		public async Task DoesNotNavigatesBackWhenBackButtonPressedIfHandled()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task DoesNotNavigatesBackWhenBackButtonPressedIfHandled(bool useMaui)
 		{
 			var root = new BackButtonPage { Title = "Root" };
 			var second = new BackButtonPage() { Handle = true };
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 
 			await navPage.PushAsync(second);
 
@@ -489,22 +512,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(second, navPage.CurrentPage);
 		}
 
-		[Test]
-		public void DoesNotHandleBackButtonWhenNoNavStack()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void DoesNotHandleBackButtonWhenNoNavStack(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 
 			var result = navPage.SendBackButtonPressed();
 			Assert.False(result);
 		}
 
-		[Test]
-		public void TestInsertPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void TestInsertPage(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
 			var newPage = new ContentPage();
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 
 			navPage.Navigation.InsertPageBefore(newPage, navPage.RootPage);
 
@@ -534,12 +559,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			});
 		}
 
-		[Test]
-		public async Task TestRemovePage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task TestRemovePage(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
 			var newPage = new ContentPage();
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 			await navPage.PushAsync(newPage);
 
 			navPage.Navigation.RemovePage(root);
@@ -565,23 +591,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			});
 		}
 
-		[Test(Description = "CurrentPage should not be set to null when you attempt to pop the last page")]
+		[TestCase(false, Description = "CurrentPage should not be set to null when you attempt to pop the last page")]
+		[TestCase(true, Description = "CurrentPage should not be set to null when you attempt to pop the last page")]
 		[Property("Bugzilla", 28335)]
-		public async Task CurrentPageNotNullPoppingRoot()
+		public async Task CurrentPageNotNullPoppingRoot(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 			var popped = await navPage.PopAsync();
 			Assert.That(popped, Is.Null);
 			Assert.That(navPage.CurrentPage, Is.SameAs(root));
 		}
 
-		[Test]
+		[TestCase(false)]
+		[TestCase(true)]
 		[Property("Bugzilla", 31171)]
-		public async Task ReleasesPoppedPage()
+		public async Task ReleasesPoppedPage(bool useMaui)
 		{
 			var root = new ContentPage { Title = "Root" };
-			var navPage = new NavigationPage(root);
+			var navPage = new TestNavigationPage(useMaui, root);
 
 			var isFinalized = false;
 
@@ -594,6 +622,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			GC.WaitForPendingFinalizers();
 
 			Assert.IsTrue(isFinalized);
+		}
+
+		[Test]
+		public async Task PushingPagesWhileNavigating()
+		{
+			ContentPage contentPage1 = new ContentPage();
+			ContentPage contentPage2 = new ContentPage();
+			ContentPage contentPage3 = new ContentPage();
+
+			var navigationPage = new TestNavigationPage(true, contentPage1);			
+			await navigationPage.PushAsync(contentPage2);
+			await navigationPage.PushAsync(contentPage3);
+
+			Assert.AreEqual(3, navigationPage.Navigation.NavigationStack.Count);
+			Assert.AreEqual(contentPage1, navigationPage.Navigation.NavigationStack[0]);
+			Assert.AreEqual(contentPage2, navigationPage.Navigation.NavigationStack[1]);
+			Assert.AreEqual(contentPage3, navigationPage.Navigation.NavigationStack[2]);
+			navigationPage.ValidateNavigationCompleted();
 		}
 	}
 

--- a/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
@@ -6,11 +6,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	[TestFixture]
 	public class PageLifeCycleTests : BaseTestFixture
 	{
-		[Test]
-		public void NavigationPageInitialPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void NavigationPageInitialPage(bool useMaui)
 		{
 			var lcPage = new LCPage();
-			NavigationPage navigationPage = new NavigationPage(lcPage);
+			NavigationPage navigationPage = new TestNavigationPage(useMaui, lcPage);
 			navigationPage.InitialNativeNavigationStackLoaded();
 			Assert.IsNull(lcPage.NavigatingFromArgs);
 			Assert.IsNull(lcPage.NavigatedFromArgs);
@@ -18,12 +19,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsNull(lcPage.NavigatedToArgs.PreviousPage);
 		}
 
-		[Test]
-		public async Task NavigationPagePushPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task NavigationPagePushPage(bool useMaui)
 		{
 			var previousPage = new LCPage();
 			var lcPage = new LCPage();
-			NavigationPage navigationPage = new NavigationPage(previousPage);
+			NavigationPage navigationPage = new TestNavigationPage(useMaui, previousPage);
 			await navigationPage.PushAsync(lcPage);
 
 			Assert.IsNotNull(previousPage.NavigatingFromArgs);
@@ -31,13 +33,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(lcPage, previousPage.NavigatedFromArgs.DestinationPage);
 		}
 
-		[Test]
-		public async Task NavigationPagePopPage()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task NavigationPagePopPage(bool useMaui)
 		{
 			var firstPage = new LCPage();
 			var poppedPage = new LCPage();
 
-			NavigationPage navigationPage = new NavigationPage(firstPage);
+			NavigationPage navigationPage = new TestNavigationPage(useMaui, firstPage);
 			await navigationPage.PushAsync(poppedPage);
 			await navigationPage.PopAsync();
 
@@ -46,13 +49,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(firstPage, poppedPage.NavigatedFromArgs.DestinationPage);
 		}
 
-		[Test]
-		public async Task NavigationPagePopToRoot()
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task NavigationPagePopToRoot(bool useMaui)
 		{
 			var firstPage = new LCPage();
 			var poppedPage = new LCPage();
 
-			NavigationPage navigationPage = new NavigationPage(firstPage);
+			NavigationPage navigationPage = new TestNavigationPage(useMaui, firstPage);
 			await navigationPage.PushAsync(new ContentPage());
 			await navigationPage.PushAsync(new ContentPage());
 			await navigationPage.PushAsync(poppedPage);

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		public new TestNavigationHandler Handler =>
-			Handler as TestNavigationHandler;
+			base.Handler as TestNavigationHandler;
 
 		public void ValidateNavigationCompleted()
 		{
@@ -37,6 +37,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			return result;
 		}
+
+		
 	}
 
 	public class TestNavigationHandler : ViewHandler<NavigationPage, object>

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
@@ -27,6 +27,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			if (Handler is TestNavigationHandler nh)
 				Assert.IsNull(nh.CurrentNavigationRequest);
 		}
+
+		public async Task<bool> SendBackButtonPressedAsync()
+		{
+			var result = base.SendBackButtonPressed();
+			var task = base.CurrentNavigationTask;
+			if (task != null)
+				await task;
+
+			return result;
+		}
 	}
 
 	public class TestNavigationHandler : ViewHandler<NavigationPage, object>

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class TestNavigationPage : NavigationPage
+	{
+		internal TestNavigationPage(bool setforMaui, Page root = null) : base(setforMaui, root)
+		{
+			if (setforMaui)
+			{
+				base.Handler = new TestNavigationHandler();
+			}
+		}
+
+		public new TestNavigationHandler Handler =>
+			Handler as TestNavigationHandler;
+
+		public void ValidateNavigationCompleted()
+		{
+			Assert.IsNull(CurrentNavigationTask);
+			if (Handler is TestNavigationHandler nh)
+				Assert.IsNull(nh.CurrentNavigationRequest);
+		}
+	}
+
+	public class TestNavigationHandler : ViewHandler<NavigationPage, object>
+	{
+		public static CommandMapper<INavigationView, TestNavigationHandler> NavigationViewCommandMapper = new(ViewCommandMapper)
+		{
+			[nameof(INavigationView.RequestNavigation)] = RequestNavigation
+		};
+
+		public static PropertyMapper<INavigationView, TestNavigationHandler> NavigationViewMapper
+			   = new PropertyMapper<INavigationView, TestNavigationHandler>();
+
+		public NavigationRequest CurrentNavigationRequest { get; private set; }
+
+
+		public void CompleteCurrentNavigation()
+		{
+			if (CurrentNavigationRequest == null)
+				throw new InvalidOperationException("No Active Navigation in the works");
+
+			var newStack = CurrentNavigationRequest.NavigationStack.ToList();
+			CurrentNavigationRequest = null;
+			(VirtualView as INavigationView)
+				.NavigationFinished(newStack);
+		}
+
+		async void RequestNavigation(NavigationRequest navigationRequest)
+		{
+			if (CurrentNavigationRequest != null)
+				throw new InvalidOperationException("Already Processing Navigation");
+
+			CurrentNavigationRequest = navigationRequest;
+
+			await Task.Delay(10);
+			CompleteCurrentNavigation();
+		}
+
+		public static void RequestNavigation(TestNavigationHandler arg1, INavigationView arg2, object arg3)
+		{
+			arg1.RequestNavigation((NavigationRequest)arg3);
+		}
+
+		public TestNavigationHandler() : base(NavigationViewMapper, NavigationViewCommandMapper)
+		{
+		}
+
+		protected override object CreateNativeView()
+		{
+			return new object();
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Stubs/ContextStub.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/ContextStub.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 	{
 		IServiceProvider _services;
 		IAnimationManager _manager;
-#if WINDOWS
+#if WINDOWS || ANDROID
 		NavigationRootManager _windowManager;
 #endif
 
@@ -23,9 +23,12 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		{
 			if (serviceType == typeof(IAnimationManager))
 				return _manager ??= _services.GetRequiredService<IAnimationManager>();
-#if __ANDROID__
+#if ANDROID
 			if (serviceType == typeof(Android.Content.Context))
 				return MauiProgram.CurrentContext;
+
+			if (serviceType == typeof(NavigationRootManager))
+				return _windowManager ??= new NavigationRootManager(this);
 #elif __IOS__
 			if (serviceType == typeof(UIKit.UIWindow))
 				return UIKit.UIApplication.SharedApplication.KeyWindow;

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Android.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Android.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Maui.Handlers
 	public partial class NavigationViewHandler :
 		ViewHandler<INavigationView, View>
 	{
-		StackNavigationManager? _navigationManager;
+		StackNavigationManager? _stackNavigationManager;
+		internal StackNavigationManager? StackNavigationManager => _stackNavigationManager;
 
 		protected override View CreateNativeView()
 		{
@@ -37,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 		}
 
 		StackNavigationManager CreateNavigationManager() =>
-			_navigationManager ??= new StackNavigationManager();
+			_stackNavigationManager ??= new StackNavigationManager();
 
 		protected override void ConnectHandler(View nativeView)
 		{
@@ -45,12 +46,12 @@ namespace Microsoft.Maui.Handlers
 			var navigationLayout = rootContainer.NavigationLayout;
 
 			base.ConnectHandler(nativeView);
-			_navigationManager?.Connect(VirtualView, navigationLayout);
+			_stackNavigationManager?.Connect(VirtualView, navigationLayout);
 		}
 
 		private protected override void OnDisconnectHandler(View nativeView)
 		{
-			_navigationManager?.Disconnect();
+			_stackNavigationManager?.Disconnect();
 			base.OnDisconnectHandler(nativeView);
 		}
 
@@ -62,7 +63,7 @@ namespace Microsoft.Maui.Handlers
 		public static void RequestNavigation(NavigationViewHandler arg1, INavigationView arg2, object? arg3)
 		{
 			if (arg3 is NavigationRequest ea)
-				arg1._navigationManager?.RequestNavigation(ea);
+				arg1._stackNavigationManager?.RequestNavigation(ea);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Android/MauiContextExtensions.cs
@@ -75,5 +75,13 @@ namespace Microsoft.Maui
 
 			return scopedContext;
 		}
+
+		internal static IServiceProvider GetApplicationServices(this IMauiContext mauiContext)
+		{
+			if (mauiContext.Context?.ApplicationContext is MauiApplication ma)
+				return ma.Services;
+
+			throw new InvalidOperationException("Unable to find Application Services");
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -320,9 +320,7 @@ namespace Microsoft.Maui
 		protected virtual void OnToolbarBackButtonClicked()
 		{
 			_ = NavigationView ?? throw new InvalidOperationException($"NavigationView cannot be null");
-			var stack = new List<IView>(NavigationStack);
-			stack.RemoveAt(stack.Count - 1);
-			ApplyNavigationRequest(new NavigationRequest(stack, true));
+			_ = MauiContext.GetActivity().GetWindow()?.BackButtonClicked();
 		}
 
 		internal void ToolbarBackButtonClicked() => OnToolbarBackButtonClicked();

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -284,8 +284,10 @@ namespace Microsoft.Maui
 			_ = fragmentManager ?? throw new InvalidOperationException($"GetFragmentManager returned null");
 			_ = NavigationView ?? throw new InvalidOperationException($"VirtualView cannot be null");
 
-			_navHost = (NavHostFragment)
-				fragmentManager.FindFragmentById(Resource.Id.nav_host);
+			var navHostFragment = fragmentManager.FindFragmentById(Resource.Id.nav_host);
+			_navHost = (NavHostFragment)navHostFragment;
+
+			System.Diagnostics.Debug.WriteLine($"_navHost: {_navHost} {_navHost.GetHashCode()}");
 
 			_fragmentNavigator =
 				(FragmentNavigator)NavHost

--- a/src/Core/src/Platform/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/MauiContextExtensions.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Maui
 	{
 		public static IAnimationManager GetAnimationManager(this IMauiContext mauiContext) =>
 			mauiContext.Services.GetRequiredService<IAnimationManager>();
+
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Windows/MauiContextExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Windows.ApplicationModel.Resources.Core;
 
 namespace Microsoft.Maui
@@ -31,6 +32,12 @@ namespace Microsoft.Maui
 			scopedContext.AddSpecific(nativeWindow);
 			scopedContext.AddSpecific(new NavigationRootManager(scopedContext));
 			return scopedContext;
+		}
+
+		public static IServiceProvider GetApplicationServices(this IMauiContext mauiContext)
+		{
+			return MauiWinUIApplication.Current.Services
+				?? throw new InvalidOperationException("Unable to find Application Services");
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/NavigationManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationManager.cs
@@ -83,8 +83,6 @@ namespace Microsoft.Maui
 				NavigationStack = new List<IView>(newPageStack);
 				NavigationFrame.GoBack(transition);
 			}
-
-			//NavigationView?.NavigationFinished(NavigationStack);
 		}
 
 		protected virtual Type GetDestinationPageType() =>

--- a/src/Core/src/Platform/Windows/NavigationManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationManager.cs
@@ -83,6 +83,8 @@ namespace Microsoft.Maui
 				NavigationStack = new List<IView>(newPageStack);
 				NavigationFrame.GoBack(transition);
 			}
+
+			//NavigationView?.NavigationFinished(NavigationStack);
 		}
 
 		protected virtual Type GetDestinationPageType() =>

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -62,6 +62,7 @@
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <Compile Remove="Handlers\*\*.cs" />
     <Compile Include="Handlers\ActivityIndicator\*.cs" />
+    <Compile Include="Handlers\Navigation\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">
     <Compile Remove="**\*.Android.cs" />

--- a/src/Core/tests/DeviceTests/DeviceTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/DeviceTests.Windows.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class Platform
+	{
+		public static Window DefaultWindow { get; private set; }
+
+		public static void Init(Window context)
+		{
+			DefaultWindow = context;
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
@@ -75,20 +75,20 @@ namespace Microsoft.Maui.DeviceTests
 
 		public IMauiContext MauiContext => _context;
 
-		protected THandler CreateHandler(IView view) =>
-			CreateHandler<THandler>(view);
+		protected THandler CreateHandler(IView view, IMauiContext mauiContext = null) =>
+			CreateHandler<THandler>(view, mauiContext);
 
-		protected TCustomHandler CreateHandler<TCustomHandler>(IView view)
+		protected TCustomHandler CreateHandler<TCustomHandler>(IView view, IMauiContext mauiContext = null)
 			where TCustomHandler : THandler, new()
 		{
 			var handler = new TCustomHandler();
-			InitializeViewHandler(view, handler);
+			InitializeViewHandler(view, handler, mauiContext);
 			return handler;
 		}
 
-		protected void InitializeViewHandler(IView view, IViewHandler handler)
+		protected void InitializeViewHandler(IView view, IViewHandler handler, IMauiContext mauiContext = null)
 		{
-			handler.SetMauiContext(MauiContext);
+			handler.SetMauiContext(mauiContext ?? MauiContext);
 
 			handler.SetVirtualView(view);
 			view.Handler = handler;

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Maui.DeviceTests
 			return events;
 		}
 
-		protected new TCustomHandler CreateHandler<TCustomHandler>(IView view)
+		protected TCustomHandler CreateHandler<TCustomHandler>(IView view)
 			where TCustomHandler : IImageHandler, new()
 		{
 			var handler = new TCustomHandler();

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Android.OS;
+using Android.Views;
+using AndroidX.AppCompat.App;
+using AndroidX.AppCompat.Widget;
+using AndroidX.Fragment.App;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Xunit;
+using ATextAlignment = Android.Views.TextAlignment;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class NavigationViewHandlerTests
+	{
+		int GetNativeNavigationStackCount(NavigationViewHandler navigationViewHandler) =>
+			navigationViewHandler.StackNavigationManager.NavHost.NavController.BackStack.Size() - 1;
+
+		Task CreateNavigationViewHandlerAsync(INavigationView navigationView, Action<NavigationViewHandler> action)
+		{
+			return InvokeOnMainThreadAsync(async () =>
+			{
+				ViewGroup rootView = (DefaultContext as AppCompatActivity).Window.DecorView as ViewGroup;
+				var linearLayoutCompat = new LinearLayoutCompat(DefaultContext);
+
+				try
+				{
+					var mauiContext = new ContextStub(MauiContext.GetApplicationServices());
+					var viewFragment = new NavViewFragment(mauiContext);
+
+
+					var fragmentManager = (DefaultContext as AppCompatActivity).GetFragmentManager();
+					linearLayoutCompat.Id = View.GenerateViewId();
+
+					fragmentManager
+						.BeginTransaction()
+						.Add(linearLayoutCompat.Id, viewFragment)
+						.Commit();
+
+					rootView.AddView(linearLayoutCompat);
+					await viewFragment.FinishedLoading;
+					var handler = CreateHandler(navigationView, viewFragment.ScopedMauiContext);
+
+					if (navigationView is NavigationViewStub nvs && nvs.NavigationStack?.Count > 0)
+					{
+						navigationView.RequestNavigation(new NavigationRequest(nvs.NavigationStack, false));
+						await nvs.OnNavigationFinished;
+					}
+
+					action(handler);
+				}
+				finally
+				{
+					rootView.RemoveView(linearLayoutCompat);
+				}
+			});
+		}
+
+
+
+		class NavViewFragment : Fragment
+		{
+			TaskCompletionSource<bool> _taskCompletionSource = new TaskCompletionSource<bool>();
+			readonly IMauiContext _mauiContext;
+			public IMauiContext ScopedMauiContext { get; set; }
+
+			public Task FinishedLoading => _taskCompletionSource.Task;
+			public NavViewFragment(IMauiContext mauiContext)
+			{
+				_mauiContext = mauiContext;
+			}
+
+			public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+			{
+				ScopedMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
+				return ScopedMauiContext.GetNavigationRootManager().RootView;
+			}
+
+			public override void OnResume()
+			{
+				base.OnResume();
+				_taskCompletionSource.SetResult(true);
+			}
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.DeviceTests
 		int GetNativeNavigationStackCount(NavigationViewHandler navigationViewHandler) =>
 			navigationViewHandler.StackNavigationManager.NavHost.NavController.BackStack.Size() - 1;
 
-		Task CreateNavigationViewHandlerAsync(INavigationView navigationView, Action<NavigationViewHandler> action)
+		Task CreateNavigationViewHandlerAsync(INavigationView navigationView, Func<NavigationViewHandler, Task> action)
 		{
 			return InvokeOnMainThreadAsync(async () =>
 			{
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.DeviceTests
 						await nvs.OnNavigationFinished;
 					}
 
-					action(handler);
+					await action(handler);
 				}
 				finally
 				{

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Windows.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class NavigationViewHandlerTests
+	{
+		int GetNativeNavigationStackCount(NavigationViewHandler navigationViewHandler) =>
+			navigationViewHandler.NativeView.BackStackDepth + 1;
+
+		Task CreateNavigationViewHandlerAsync(INavigationView navigationView, Func<NavigationViewHandler, Task> action)
+		{
+			return InvokeOnMainThreadAsync(async () =>
+			{
+			FrameworkElement frameworkElement = null;
+			var content = (Panel)DefaultWindow.Content;
+			try
+			{
+				var mauiContext = new ContextStub(MauiContext.GetApplicationServices());
+				var handler = CreateHandler(navigationView, mauiContext);
+				frameworkElement = handler.NativeView;
+				content.Children.Add(frameworkElement);
+				if (navigationView is NavigationViewStub nvs && nvs.NavigationStack?.Count > 0)
+				{
+					navigationView.RequestNavigation(new NavigationRequest(nvs.NavigationStack, false));
+					await nvs.OnNavigationFinished;
+				}
+
+				await action(handler);
+			}
+			finally
+			{
+				if (frameworkElement != null)
+					content.Children.Remove(frameworkElement);
+				}				
+			});
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
@@ -1,0 +1,39 @@
+﻿
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.NavigationView)]
+	public partial class NavigationViewHandlerTests : HandlerTestBase<NavigationViewHandler, NavigationViewStub>
+	{
+#if ANDROID || WINDOWS
+		[Fact(DisplayName = "Push Multiple Pages At Start")]
+		public async Task PushMultiplePagesAtStart()
+		{
+			PageStub page1 = new PageStub();
+			PageStub page2 = new PageStub();
+			NavigationViewStub navigationViewStub = new NavigationViewStub()
+			{
+				NavigationStack = new List<IView>()
+				{
+					page1, page2
+				}
+			};
+
+			await CreateNavigationViewHandlerAsync(navigationViewStub, (handler) =>
+			{
+				Assert.Equal(2, GetNativeNavigationStackCount(handler));
+				return Task.CompletedTask;
+
+
+			});
+		}
+
+#endif
+
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				Assert.Equal(2, GetNativeNavigationStackCount(handler));
 				return Task.CompletedTask;
-
-
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Startup.cs
+++ b/src/Core/tests/DeviceTests/Startup.cs
@@ -12,10 +12,15 @@ namespace Microsoft.Maui.DeviceTests
 			appBuilder
 				.ConfigureLifecycleEvents(life =>
 				{
-#if __ANDROID__
+#if ANDROID
 					life.AddAndroid(android =>
 					{
 						android.OnCreate((a, b) => Platform.Init(a));
+					});
+#elif WINDOWS
+					life.AddWindows(windows =>
+					{
+						windows.OnWindowCreated((w) => Platform.Init(w));
 					});
 #endif
 				})

--- a/src/Core/tests/DeviceTests/Stubs/ContextStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ContextStub.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 	{
 		IServiceProvider _services;
 		IAnimationManager _manager;
-#if WINDOWS
+#if WINDOWS || ANDROID
 		NavigationRootManager _windowManager;
 #endif
 
@@ -23,9 +23,12 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		{
 			if (serviceType == typeof(IAnimationManager))
 				return _manager ??= _services.GetRequiredService<IAnimationManager>();
-#if __ANDROID__
+#if ANDROID
 			if (serviceType == typeof(Android.Content.Context))
 				return Platform.DefaultContext;
+
+			if (serviceType == typeof(NavigationRootManager))
+				return _windowManager ??= new NavigationRootManager(this);
 #elif __IOS__
 			if (serviceType == typeof(UIKit.UIWindow))
 				return UIKit.UIApplication.SharedApplication.GetKeyWindow();

--- a/src/Core/tests/DeviceTests/Stubs/NavigationViewStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/NavigationViewStub.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public partial class NavigationViewStub : StubBase, INavigationView
+	{
+		TaskCompletionSource<IReadOnlyList<IView>> _onNavigationFinished;
+		public Task<IReadOnlyList<IView>> OnNavigationFinished => _onNavigationFinished.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+		public void NavigationFinished(IReadOnlyList<IView> newStack)
+		{
+			var completion = _onNavigationFinished;
+			_onNavigationFinished = null;
+			completion.SetResult(newStack);
+		}
+
+		public void RequestNavigation(NavigationRequest eventArgs)
+		{
+			_onNavigationFinished = new TaskCompletionSource<IReadOnlyList<IView>>();
+			Handler?.Invoke(nameof(INavigationView.RequestNavigation), eventArgs);
+		}
+
+		public List<IView> NavigationStack { get; set; }
+	}
+}

--- a/src/Core/tests/DeviceTests/TestBase.Windows.cs
+++ b/src/Core/tests/DeviceTests/TestBase.Windows.cs
@@ -1,0 +1,12 @@
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class TestBase
+	{
+		public const int EmCoefficientPrecision = 4;
+
+		public Window DefaultWindow =>
+			Platform.DefaultWindow;
+	}
+}

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -17,6 +17,7 @@
 		public const string ImageSource = "ImageSource";
 		public const string Label = "Label";
 		public const string Layout = "Layout";
+		public const string NavigationView = "NavigationView";
 		public const string Page = "Page";
 		public const string Picker = "Picker";
 		public const string ProgressBar = "ProgressBar";


### PR DESCRIPTION
### Description of Change ###
The `Controls.NavigationPage` currently takes different paths to process requests based on if it's using a MAUI Handler or a legacy Renderer. This PR sets up all the NavigationPage tests so that they test and pass both paths. 

A lot of the fixes in here deal with processing push requests that are happening before the previous one finishes and also adds the code necessary to run native handler tests.

The majority of the changes with this PR are the unit tests and then just adjustments to the `NavigationPage.impl.cs`

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
