### PR TITLE
Fix CodeDom reference

### DIFF
--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
@@ -15,12 +15,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mono.Cecil" Version="0.11.3" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="System.CodeDom" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" PrivateAssets="all" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.3" GeneratePathProperty="true" />
+		<PackageReference Include="System.CodeDom" GeneratePathProperty="true" />
+		<PackageReference Include="Microsoft.Build" Version="15.9.20" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
 		<PackageReference Include="Microsoft.Maui.Graphics" GeneratePathProperty="true" />
 	</ItemGroup>
 
@@ -53,9 +53,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Core\Controls.Core-net6.csproj" PrivateAssets="all" />
-		<ProjectReference Include="..\Xaml\Controls.Xaml-net6.csproj" PrivateAssets="all" />
-		<ProjectReference Include="..\SourceGen\Controls.SourceGen.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\Core\Controls.Core-net6.csproj" />
+		<ProjectReference Include="..\Xaml\Controls.Xaml-net6.csproj" />
+		<ProjectReference Include="..\SourceGen\Controls.SourceGen.csproj" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 	
 	<ItemGroup>
@@ -84,4 +84,9 @@
 
 	<Import Project="$(MauiRootDirectory)src\Workload\Shared\LibraryPacks.targets" />
 
+	<ItemGroup>
+		<!-- Ensure all references are PrivateAssets=all, so they are not transitive to end-user projects. -->
+		<PackageReference Update="@(PackageReference)" PrivateAssets="all" />
+		<ProjectReference Update="@(ProjectReference)" PrivateAssets="all" />
+	</ItemGroup>
 </Project>

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks-net6.csproj
@@ -16,8 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Mono.Cecil" Version="0.11.3" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="System.CodeDom" GeneratePathProperty="true" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-		<PackageReference Include="System.CodeDom" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageReference Include="System.CodeDom" PrivateAssets="all" GeneratePathProperty="true" />
 		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />

--- a/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
+++ b/src/Controls/src/Build.Tasks/Controls.Build.Tasks.csproj
@@ -9,12 +9,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mono.Cecil" Version="0.11.3" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="System.CodeDom" Version="5.0.0" PrivateAssets="all" GeneratePathProperty="true" />
-		<PackageReference Include="Microsoft.Build" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" PrivateAssets="all" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.3" GeneratePathProperty="true" />
+		<PackageReference Include="System.CodeDom" Version="5.0.0" GeneratePathProperty="true" />
+		<PackageReference Include="Microsoft.Build" Version="15.9.20" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
 		<PackageReference Include="Microsoft.Maui.Graphics" GeneratePathProperty="true" />
 	</ItemGroup>
 
@@ -52,9 +52,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Core\Controls.Core.csproj" PrivateAssets="all" />
-		<ProjectReference Include="..\Xaml\Controls.Xaml.csproj" PrivateAssets="all" />
-		<ProjectReference Include="..\SourceGen\Controls.SourceGen.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\Core\Controls.Core.csproj" />
+		<ProjectReference Include="..\Xaml\Controls.Xaml.csproj" />
+		<ProjectReference Include="..\SourceGen\Controls.SourceGen.csproj" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -81,4 +81,9 @@
 		<Copy SourceFiles="@(_CopyItems)" DestinationFolder="$(MauiNuSpecDirectory)" ContinueOnError="true" Retries="0" />
 	</Target>
 
+	<ItemGroup>
+		<!-- Ensure all references are PrivateAssets=all, so they are not transitive to end-user projects. -->
+		<PackageReference Update="@(PackageReference)" PrivateAssets="all" />
+		<ProjectReference Update="@(ProjectReference)" PrivateAssets="all" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
I noticed that in my Maui application System.CodeDom was being referenced. This is because we don't have a `PrivateAssets="all"` on the PackageReference in Microsoft.Maui.Controls.Build.Tasks.csproj.

This causes a problem when submitting an app to the Apple App Store, because CodeDom is preventing some unnecessary System.Diagnostics.Process code from being trimmed.

Adding the PrivateAssets="all", and removing unnecessary Conditions since this project only builds for netstandard2.0.

Fix #3290
Fix https://github.com/dotnet/runtime/issues/61265

Reimplementing the fix from #888

cc @Redth @PureWeen 