### PR TITLE
Init Essentials (Android) in MauiAppCompatActivity

### DIFF
--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -31,5 +31,11 @@ namespace Microsoft.Maui
 			Microsoft.Maui.Essentials.Platform.Init(this, savedInstanceState);
 			this.CreateNativeWindow(MauiApplication.Current.Application, savedInstanceState);
 		}
+
+		public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Android.Content.PM.Permission[] grantResults)
+		{
+			Microsoft.Maui.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+			base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui
 
 			base.OnCreate(savedInstanceState);
 
+			Microsoft.Maui.Essentials.Platform.Init(this, savedInstanceState);
 			this.CreateNativeWindow(MauiApplication.Current.Application, savedInstanceState);
 		}
 	}

--- a/src/Templates/src/templates/maui-blazor/Platforms/Android/MainActivity.cs
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Android/MainActivity.cs
@@ -7,16 +7,4 @@ namespace MauiApp._1;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
 public class MainActivity : MauiAppCompatActivity
 {
-	protected override void OnCreate(Bundle savedInstanceState)
-	{
-		base.OnCreate(savedInstanceState);
-		Platform.Init(this, savedInstanceState);
-	}
-
-	public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
-	{
-		Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
-
-		base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
-	}
 }

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/MainActivity.cs
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/MainActivity.cs
@@ -7,16 +7,4 @@ namespace MauiApp._1;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
 public class MainActivity : MauiAppCompatActivity
 {
-	protected override void OnCreate(Bundle savedInstanceState)
-	{
-		base.OnCreate(savedInstanceState);
-		Platform.Init(this, savedInstanceState);
-	}
-
-	public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
-	{
-		Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
-
-		base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
-	}
 }


### PR DESCRIPTION
Platform-specific APIs (like Microsoft.Maui.Essentials.Platform.CurrentActivity) are not working as expected, because Essentials is not initialized.

### Description of Change ###
#3346 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
