### PR TITLE
Fix Scoping of MauiContext as it relates to Modal Pages

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml
@@ -2,13 +2,14 @@
 <views:BasePage 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    x:Class="Maui.Controls.Sample.Pages.ModalPage"
+    x:Class="Maui.Controls.Sample.Pages.ModalPage"    
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base">
     <views:BasePage.Content>
-        <StackLayout
-            Margin="12">
+        <VerticalStackLayout Margin="12">
+            <Button Clicked="PushClicked" Text="Push Page" />
             <Button Clicked="PushModalClicked" Text="Push Modal Page" />
+            <Button Clicked="PushNavigationModalClicked" Text="Push Modal Navigation Page" />
             <Button x:Name="PushModal" Clicked="PopModalClicked" Text="Pop Modal Page" />
-        </StackLayout>
+        </VerticalStackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
@@ -10,10 +10,12 @@ namespace Maui.Controls.Sample.Pages
 {
 	public partial class ModalPage
 	{
+		static int s_instanceCount = 0;
 		public ModalPage()
 		{
 			InitializeComponent();
 			BackgroundColor = Colors.Purple;
+			Title = $"Modal Page {s_instanceCount++}";
 		}
 
 		protected override void OnAppearing()
@@ -22,9 +24,34 @@ namespace Maui.Controls.Sample.Pages
 			PushModal.IsVisible = Navigation.ModalStack.Count > 0;
 		}
 
+		async void PushNavigationModalClicked(object sender, EventArgs e)
+		{
+			var modalPage = new ModalPage();
+			Page pushMe = new NavigationPage(modalPage)
+			{
+				BackgroundColor =
+						(BackgroundColor == Colors.Purple) ? Colors.Pink : Colors.Purple,
+				Title = $"Navigation Root: {modalPage.Title}"
+			};
+
+			await Navigation.PushModalAsync(pushMe);
+
+		}
+
 		async void PushModalClicked(object sender, EventArgs e)
 		{
-			await Navigation.PushModalAsync(new ModalPage()
+			Page pushMe = new ModalPage()
+			{
+				BackgroundColor =
+						   (BackgroundColor == Colors.Purple) ? Colors.Pink : Colors.Purple
+			};
+
+			await Navigation.PushModalAsync(pushMe);
+		}
+
+		async void PushClicked(object sender, EventArgs e)
+		{
+			await Navigation.PushAsync(new ModalPage()
 			{
 				BackgroundColor =
 					(BackgroundColor == Colors.Purple) ? Colors.Pink : Colors.Purple

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -157,7 +157,7 @@ namespace Maui.Controls.Sample
 					// Log everything in this one
 					events.AddAndroid(android => android
 						.OnActivityResult((a, b, c, d) => LogEvent(nameof(AndroidLifecycle.OnActivityResult), b.ToString()))
-						.OnBackPressed((a) => LogEvent(nameof(AndroidLifecycle.OnBackPressed)))
+						.OnBackPressed((a) => LogEvent(nameof(AndroidLifecycle.OnBackPressed)) && false)
 						.OnConfigurationChanged((a, b) => LogEvent(nameof(AndroidLifecycle.OnConfigurationChanged)))
 						.OnCreate((a, b) => LogEvent(nameof(AndroidLifecycle.OnCreate)))
 						.OnDestroy((a) => LogEvent(nameof(AndroidLifecycle.OnDestroy)))
@@ -187,7 +187,7 @@ namespace Maui.Controls.Sample
 
 							return shouldPreventBack-- > 0;
 						})
-						.OnBackPressed(a => LogEvent(nameof(AndroidLifecycle.OnBackPressed), "shortcut"))
+						.OnBackPressed(a => LogEvent(nameof(AndroidLifecycle.OnBackPressed), "shortcut") && false)
 						.OnRestoreInstanceState((a, b) =>
 						{
 							LogEvent(nameof(AndroidLifecycle.OnRestoreInstanceState), "shortcut");

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -165,7 +165,6 @@ namespace Maui.Controls.Sample
 						.OnPause((a) => LogEvent(nameof(AndroidLifecycle.OnPause)))
 						.OnPostCreate((a, b) => LogEvent(nameof(AndroidLifecycle.OnPostCreate)))
 						.OnPostResume((a) => LogEvent(nameof(AndroidLifecycle.OnPostResume)))
-						.OnPressingBack((a) => LogEvent(nameof(AndroidLifecycle.OnPressingBack)) && false)
 						.OnRequestPermissionsResult((a, b, c, d) => LogEvent(nameof(AndroidLifecycle.OnRequestPermissionsResult)))
 						.OnRestart((a) => LogEvent(nameof(AndroidLifecycle.OnRestart)))
 						.OnRestoreInstanceState((a, b) => LogEvent(nameof(AndroidLifecycle.OnRestoreInstanceState)))
@@ -181,13 +180,7 @@ namespace Maui.Controls.Sample
 						{
 							LogEvent(nameof(AndroidLifecycle.OnResume), "shortcut");
 						})
-						.OnPressingBack(a =>
-						{
-							LogEvent(nameof(AndroidLifecycle.OnPressingBack), "shortcut");
-
-							return shouldPreventBack-- > 0;
-						})
-						.OnBackPressed(a => LogEvent(nameof(AndroidLifecycle.OnBackPressed), "shortcut") && false)
+						.OnBackPressed(a => LogEvent(nameof(AndroidLifecycle.OnBackPressed), "shortcut") && (shouldPreventBack-- > 0))
 						.OnRestoreInstanceState((a, b) =>
 						{
 							LogEvent(nameof(AndroidLifecycle.OnRestoreInstanceState), "shortcut");

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -122,10 +122,11 @@ namespace Microsoft.Maui.Controls
 
 		void OnAppearing(object sender, EventArgs e)
 		{
-			// Update the Window level Toolbar with my Toolbar information
-			var window = this.FindParentOfType<Window>();
-			if (window?.Toolbar != null)
-				window.Toolbar.ApplyNavigationPage(this);
+			// Update the Container level Toolbar with my Toolbar information
+			if(this.FindParentWith(x => (x is IToolbarElement te && te.Toolbar != null), true) is IToolbarElement te)
+			{
+				te.Toolbar.ApplyNavigationPage(this);
+			}
 		}
 
 		// This is used for navigation events that don't effect the currently visible page

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -4,8 +4,25 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
-	public partial class Page : IView, ITitledElement
+	public partial class Page : IView, ITitledElement, IToolbarElement
 	{
+		Toolbar _toolbar;
+		Toolbar IToolbarElement.Toolbar
+		{
+			get => _toolbar;
+		}
+
+		internal Toolbar Toolbar
+		{
+			get => _toolbar;
+			set
+			{
+				_toolbar = value;
+				if (this is NavigationPage np)
+					_toolbar.ApplyNavigationPage(np);
+			}
+		}
+
 		internal void SendNavigatedTo(NavigatedToEventArgs args)
 		{
 			NavigatedTo?.Invoke(this, args);

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -12,7 +12,7 @@ using Microsoft.Maui.Controls.Xaml.Diagnostics;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Page))]
-	public partial class Window : NavigableElement, IWindow, IVisualTreeElement
+	public partial class Window : NavigableElement, IWindow, IVisualTreeElement, IToolbarElement
 	{
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(
 			nameof(Title), typeof(string), typeof(Window), default(string?));
@@ -24,11 +24,12 @@ namespace Microsoft.Maui.Controls
 		ReadOnlyCollection<Element>? _logicalChildren;
 		List<IVisualTreeElement> _visualChildren;
 
-		internal Toolbar Toolbar { get; }
+		Toolbar IToolbarElement.Toolbar => _toolBar;
+		Toolbar _toolBar;
 
 		public Window()
 		{
-			Toolbar = new Toolbar();
+			_toolBar = new Toolbar();
 			_visualChildren = new List<IVisualTreeElement>();
 			AlertManager = new AlertManager(this);
 			ModalNavigationManager = new ModalNavigationManager(this);
@@ -274,6 +275,11 @@ namespace Microsoft.Maui.Controls
 
 		bool IWindow.BackButtonClicked()
 		{
+			if (Navigation.ModalStack.Count > 0)
+			{
+				return Navigation.ModalStack[Navigation.ModalStack.Count - 1].SendBackButtonPressed();
+			}
+
 			return this.Page?.SendBackButtonPressed() ?? false;
 		}
 
@@ -326,6 +332,7 @@ namespace Microsoft.Maui.Controls
 				_owner.OnModalPushing(modal);
 
 				modal.Parent = _owner;
+				modal.Toolbar ??= new Toolbar();
 
 				if (modal.NavigationProxy.ModalStack.Count == 0)
 				{

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Maui.Controls
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(handler.MauiContext)} null");
 
-			if (view is Window window && window.Toolbar != null)
+			if (view is IToolbarElement tb && tb.Toolbar != null)
 			{
-				_ = window.Toolbar.ToNative(handler.MauiContext);
+				_ = tb.Toolbar.ToNative(handler.MauiContext);
 			}
 		}
 

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -287,7 +287,9 @@ namespace Microsoft.Maui.Controls
 			var canceled = false;
 			EventHandler handler = (sender, args) => { canceled = true; };
 			window.PopCanceled += handler;
-			Navigation.PopModalAsync().ContinueWith(t => { throw t.Exception; }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.FromCurrentSynchronizationContext());
+			Navigation
+				.PopModalAsync()
+				.FireAndForget(Handler);
 
 			window.PopCanceled -= handler;
 			return !canceled;

--- a/src/Controls/src/Core/Platform/Android/Extensions/ViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ViewExtensions.cs
@@ -114,8 +114,8 @@ namespace Microsoft.Maui.Controls.Platform
 		internal static T GetParentOfType<T>(this AView view)
 			where T : class
 		{
-			T t = view as T;
-			if (view != null)
+
+			if (view is T t)
 				return t;
 
 			return view.Parent.GetParentOfType<T>();

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				Modal.PropertyChanged += OnModalPagePropertyChanged;
 
-				_modalFragment = new ModalFragment(_windowMauiContext, window, modal);
+				_modalFragment = new ModalFragment(_windowMauiContext, modal);
 				_fragmentManager = _windowMauiContext.GetFragmentManager();
 
 				_fragmentManager
@@ -269,7 +269,6 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				readonly Page _modal;
 				readonly IMauiContext _mauiWindowContext;
-				readonly IWindow _window;
 				NavigationRootManager? _navigationRootManager;
 
 				public NavigationRootManager? NavigationRootManager
@@ -278,11 +277,10 @@ namespace Microsoft.Maui.Controls.Platform
 					private set => _navigationRootManager = value;
 				}
 
-				public ModalFragment(IMauiContext mauiContext, IWindow window, Page modal)
+				public ModalFragment(IMauiContext mauiContext, Page modal)
 				{
 					_modal = modal;
 					_mauiWindowContext = mauiContext;
-					_window = window;
 				}
 
 				public override AView OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)

--- a/src/Controls/src/Core/Toolbar.cs
+++ b/src/Controls/src/Core/Toolbar.cs
@@ -6,6 +6,11 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
+	internal interface IToolbarElement
+	{
+		Toolbar Toolbar { get;}
+	}
+
 	public class Toolbar : Microsoft.Maui.IElement
 	{
 		NavigationPage _currentNavigationPage;
@@ -154,6 +159,17 @@ namespace Microsoft.Maui.Controls
 			TitleIcon = NavigationPage.GetTitleIconImageSource(currentPage);
 			BarBackgroundColor = navigationPage.BarBackgroundColor;
 			BarBackground = navigationPage.BarBackground;
+
+#if WINDOWS
+			if (Brush.IsNullOrEmpty(BarBackground) && BarBackgroundColor == null)
+			{
+				BarBackgroundColor = navigationPage.CurrentPage.BackgroundColor ??
+					navigationPage.BackgroundColor;
+
+				BarBackground = navigationPage.CurrentPage.Background ??
+					navigationPage.Background;
+			}
+#endif
 			BarTextColor = navigationPage.BarTextColor;
 			IconColor = NavigationPage.GetIconColor(currentPage);
 			Title = currentPage.Title;

--- a/src/Controls/src/Core/ViewExtensions.cs
+++ b/src/Controls/src/Core/ViewExtensions.cs
@@ -191,6 +191,20 @@ namespace Microsoft.Maui.Controls
 			return default;
 		}
 
+		internal static Element? FindParentWith(this Element element, Func<Element, bool> withMatch, bool includeThis = false)			
+		{
+			if (includeThis && withMatch(element))
+				return element;
+
+			foreach (var parent in element.GetParentsPath())
+			{
+				if (withMatch(parent))
+					return parent;
+			}
+
+			return default;
+		}
+
 		internal static T? FindParentOfType<T>(this Element element, bool includeThis = false)
 			where T : Maui.IElement
 		{

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Windows.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Handlers
 	public partial class NavigationViewHandler :
 		ViewHandler<INavigationView, Frame>
 	{
-		NavigationManager? _navigationManager;
+		StackNavigationManager? _navigationManager;
 		protected override Frame CreateNativeView()
 		{
 			_navigationManager = CreateNavigationManager();
@@ -45,8 +45,8 @@ namespace Microsoft.Maui.Handlers
 
 
 		// this should move to a factory method
-		protected virtual NavigationManager CreateNavigationManager() =>
-			_navigationManager ??= new NavigationManager(MauiContext ?? throw new InvalidOperationException("MauiContext cannot be null"));
+		protected virtual StackNavigationManager CreateNavigationManager() =>
+			_navigationManager ??= new StackNavigationManager(MauiContext ?? throw new InvalidOperationException("MauiContext cannot be null"));
 	}
 }
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(UI.Xaml.Window nativeView)
 		{
 			var windowManager = MauiContext?.GetNavigationRootManager();
-			windowManager?.Connect(VirtualView);
+			windowManager?.Connect(VirtualView.Content);
 
 			_rootPanel?.Children?.Clear();
 			nativeView.Content = null;
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var windowManager = handler.MauiContext.GetNavigationRootManager();
-			windowManager.Connect(handler.VirtualView);
+			windowManager.Connect(handler.VirtualView.Content);
 			handler?._rootPanel?.Children?.Clear();
 			handler?._rootPanel?.Children?.Add(windowManager.RootView);
 		}

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.Android.cs
@@ -51,6 +51,10 @@ namespace Microsoft.Maui.LifecycleEvents
 				.OnDestroy(activity =>
 				{
 					// Android's onDestroy is not reliably called
+				})
+				.OnBackPressed(activity =>
+				{
+					return activity.GetWindow()?.BackButtonClicked() ?? false;
 				});
 		}
 	}

--- a/src/Core/src/LifecycleEvents/Android/AndroidLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/Android/AndroidLifecycle.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.LifecycleEvents
 
 		// Events called by Activity overrides (calling base is optional)
 		public delegate void OnActivityResult(Activity activity, int requestCode, Result resultCode, Intent? data);
-		public delegate void OnBackPressed(Activity activity);
+		public delegate bool OnBackPressed(Activity activity);
 		public delegate void OnConfigurationChanged(Activity activity, Configuration newConfig);
 		public delegate void OnNewIntent(Activity activity, Intent? intent);
 		public delegate void OnRequestPermissionsResult(Activity activity, int requestCode, string[] permissions, Permission[] grantResults);

--- a/src/Core/src/LifecycleEvents/Android/AndroidLifecycle.cs
+++ b/src/Core/src/LifecycleEvents/Android/AndroidLifecycle.cs
@@ -37,9 +37,6 @@ namespace Microsoft.Maui.LifecycleEvents
 		public delegate void OnRequestPermissionsResult(Activity activity, int requestCode, string[] permissions, Permission[] grantResults);
 		public delegate void OnRestoreInstanceState(Activity activity, Bundle savedInstanceState);
 
-		// Custom events
-		public delegate bool OnPressingBack(Activity activity);
-
 		// Internal events
 		internal delegate void OnMauiContextCreated(IMauiContext mauiContext);
 	}

--- a/src/Core/src/LifecycleEvents/Android/AndroidLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/Android/AndroidLifecycleBuilderExtensions.cs
@@ -17,7 +17,6 @@
 		public static IAndroidLifecycleBuilder OnPause(this IAndroidLifecycleBuilder lifecycle, AndroidLifecycle.OnPause del) => lifecycle.OnEvent(del);
 		public static IAndroidLifecycleBuilder OnPostCreate(this IAndroidLifecycleBuilder lifecycle, AndroidLifecycle.OnPostCreate del) => lifecycle.OnEvent(del);
 		public static IAndroidLifecycleBuilder OnPostResume(this IAndroidLifecycleBuilder lifecycle, AndroidLifecycle.OnPostResume del) => lifecycle.OnEvent(del);
-		public static IAndroidLifecycleBuilder OnPressingBack(this IAndroidLifecycleBuilder lifecycle, AndroidLifecycle.OnPressingBack del) => lifecycle.OnEvent(del);
 		public static IAndroidLifecycleBuilder OnRequestPermissionsResult(this IAndroidLifecycleBuilder lifecycle, AndroidLifecycle.OnRequestPermissionsResult del) => lifecycle.OnEvent(del);
 		public static IAndroidLifecycleBuilder OnRestart(this IAndroidLifecycleBuilder lifecycle, AndroidLifecycle.OnRestart del) => lifecycle.OnEvent(del);
 		public static IAndroidLifecycleBuilder OnRestoreInstanceState(this IAndroidLifecycleBuilder lifecycle, AndroidLifecycle.OnRestoreInstanceState del) => lifecycle.OnEvent(del);

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
@@ -27,9 +27,14 @@ namespace Microsoft.Maui
 
 			if (!preventBack)
 			{
-				MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnBackPressed>(del => del(this));
+				var preventBackPropagation = false;
+				MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnBackPressed>(del =>
+				{
+					preventBackPropagation = del(this) || preventBackPropagation;
+				});
 
-				base.OnBackPressed();
+				if (!preventBackPropagation)
+					base.OnBackPressed();
 			}
 		}
 

--- a/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
+++ b/src/Core/src/Platform/Android/MauiAppCompatActivity.Lifecycle.cs
@@ -18,24 +18,14 @@ namespace Microsoft.Maui
 
 		public override void OnBackPressed()
 		{
-			var preventBack = false;
-
-			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnPressingBack>(del =>
+			var preventBackPropagation = false;
+			MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnBackPressed>(del =>
 			{
-				preventBack = del(this) || preventBack;
+				preventBackPropagation = del(this) || preventBackPropagation;
 			});
 
-			if (!preventBack)
-			{
-				var preventBackPropagation = false;
-				MauiApplication.Current?.Services?.InvokeLifecycleEvents<AndroidLifecycle.OnBackPressed>(del =>
-				{
-					preventBackPropagation = del(this) || preventBackPropagation;
-				});
-
-				if (!preventBackPropagation)
-					base.OnBackPressed();
-			}
+			if (!preventBackPropagation)
+				base.OnBackPressed();
 		}
 
 		public override void OnConfigurationChanged(Configuration newConfig)

--- a/src/Core/src/Platform/Android/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Android/MauiContextExtensions.cs
@@ -67,6 +67,9 @@ namespace Microsoft.Maui
 
 			if (registerNewNavigationRoot)
 			{
+				if (fragmentManager == null)
+					throw new InvalidOperationException("If you're creating a new Navigation Root you need to use a new Fragment Manager");
+
 				scopedContext.AddWeakSpecific(new NavigationRootManager(scopedContext));
 			}
 

--- a/src/Core/src/Platform/Android/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Android/MauiContextExtensions.cs
@@ -51,9 +51,10 @@ namespace Microsoft.Maui
 		public static IMauiContext MakeScoped(this IMauiContext mauiContext,
 			LayoutInflater? layoutInflater = null,
 			FragmentManager? fragmentManager = null,
-			Android.Content.Context? context = null)
+			Android.Content.Context? context = null,
+			bool registerNewNavigationRoot = false)
 		{
-			var scopedContext = new MauiContext(mauiContext);
+			var scopedContext = new MauiContext(mauiContext.Services);
 
 			if (layoutInflater != null)
 				scopedContext.AddWeakSpecific(layoutInflater);
@@ -63,6 +64,11 @@ namespace Microsoft.Maui
 
 			if (context != null)
 				scopedContext.AddWeakSpecific(context);
+
+			if (registerNewNavigationRoot)
+			{
+				scopedContext.AddWeakSpecific(new NavigationRootManager(scopedContext));
+			}
 
 			return scopedContext;
 		}

--- a/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
@@ -2,12 +2,8 @@
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
-using Android.Views.Animations;
-using AndroidX.AppCompat.Widget;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Fragment.App;
-using Google.Android.Material.AppBar;
-using Google.Android.Material.Tabs;
 using AView = Android.Views.View;
 
 namespace Microsoft.Maui

--- a/src/Core/src/Platform/Android/Navigation/ProcessBackClick.cs
+++ b/src/Core/src/Platform/Android/Navigation/ProcessBackClick.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Maui
 {
 	class ProcessBackClick : AndroidX.Activity.OnBackPressedCallback, AView.IOnClickListener
 	{
-		StackNavigationManager _navigationManager;
+		StackNavigationManager _stackNavigationManager;
 
 		public ProcessBackClick(StackNavigationManager navHostPageFragment)
 			: base(true)
 		{
-			_navigationManager = navHostPageFragment;
+			_stackNavigationManager = navHostPageFragment;
 		}
 
 		public override void HandleOnBackPressed()
 		{
-			_navigationManager.HardwareBackButtonClicked();
+			_stackNavigationManager.HardwareBackButtonClicked();
 		}
 
 		public void OnClick(AView? v)
 		{
-			_navigationManager.ToolbarBackButtonClicked();
+			_stackNavigationManager.ToolbarBackButtonClicked();
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/Navigation/ProcessBackClick.cs
+++ b/src/Core/src/Platform/Android/Navigation/ProcessBackClick.cs
@@ -5,19 +5,13 @@ using AView = Android.Views.View;
 
 namespace Microsoft.Maui
 {
-	class ProcessBackClick : AndroidX.Activity.OnBackPressedCallback, AView.IOnClickListener
+	class ProcessBackClick : Java.Lang.Object, AView.IOnClickListener
 	{
 		StackNavigationManager _stackNavigationManager;
 
 		public ProcessBackClick(StackNavigationManager navHostPageFragment)
-			: base(true)
 		{
 			_stackNavigationManager = navHostPageFragment;
-		}
-
-		public override void HandleOnBackPressed()
-		{
-			_stackNavigationManager.HardwareBackButtonClicked();
 		}
 
 		public void OnClick(AView? v)

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -406,18 +406,18 @@ namespace Microsoft.Maui
 			AndroidX.Fragment.App.FragmentManager.FragmentLifecycleCallbacks,
 			NavController.IOnDestinationChangedListener
 		{
-			StackNavigationManager _navigationManager;
+			StackNavigationManager _stackNavigationManager;
 
 			public Callbacks(StackNavigationManager navigationLayout)
 			{
-				_navigationManager = navigationLayout;
+				_stackNavigationManager = navigationLayout;
 			}
 			#region IOnDestinationChangedListener
 
 			void NavController.IOnDestinationChangedListener.OnDestinationChanged(
 				NavController p0, NavDestination p1, Bundle p2)
 			{
-				_navigationManager.OnDestinationChanged(p0, p1, p2);
+				_stackNavigationManager.OnDestinationChanged(p0, p1, p2);
 			}
 			#endregion
 
@@ -425,14 +425,13 @@ namespace Microsoft.Maui
 			public override void OnFragmentResumed(AndroidX.Fragment.App.FragmentManager fm, AndroidX.Fragment.App.Fragment f)
 			{
 				if (f is NavigationViewFragment pf)
-					_navigationManager.OnNavigationViewFragmentResumed(fm, pf);
+					_stackNavigationManager.OnNavigationViewFragmentResumed(fm, pf);
 
 
 				// This wires up the hardware back button to this fragment
 				f.RequireActivity()
 					.OnBackPressedDispatcher
-					.AddCallback(f, _navigationManager.BackClick);
-
+					.AddCallback(f, _stackNavigationManager.BackClick);
 
 				// Wire up the toolbar to the currently made visible Fragment
 				var controller = NavHostFragment.FindNavController(f);
@@ -441,18 +440,13 @@ namespace Microsoft.Maui
 						.Builder(controller.Graph)
 						.Build();
 
-				if (_navigationManager.Toolbar != null)
+				if (_stackNavigationManager.Toolbar != null)
 				{
 					NavigationUI
-						.SetupWithNavController(_navigationManager.Toolbar, controller, appbarConfig);
+						.SetupWithNavController(_stackNavigationManager.Toolbar, controller, appbarConfig);
 
-					_navigationManager.Toolbar.SetNavigationOnClickListener(_navigationManager.BackClick);
+					_stackNavigationManager.Toolbar.SetNavigationOnClickListener(_stackNavigationManager.BackClick);
 				}
-			}
-
-			public override void OnFragmentAttached(AndroidX.Fragment.App.FragmentManager fm, AndroidX.Fragment.App.Fragment f, Context context)
-			{
-				base.OnFragmentAttached(fm, f, context);
 			}
 
 			public override void OnFragmentViewDestroyed(
@@ -460,8 +454,9 @@ namespace Microsoft.Maui
 				AndroidX.Fragment.App.Fragment f)
 			{
 				if (f is NavigationViewFragment pf)
-					_navigationManager.OnNavigationViewFragmentDestroyed(fm, pf);
+					_stackNavigationManager.OnNavigationViewFragmentDestroyed(fm, pf);
 
+				_stackNavigationManager.BackClick.Remove();
 				base.OnFragmentViewDestroyed(fm, f);
 			}
 
@@ -472,7 +467,7 @@ namespace Microsoft.Maui
 				// This wires up the hardware back button to this fragment
 				f.RequireActivity()
 					.OnBackPressedDispatcher
-					.AddCallback(f, _navigationManager.BackClick);
+					.AddCallback(f, _stackNavigationManager.BackClick);
 			}
 			#endregion
 

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -325,17 +325,6 @@ namespace Microsoft.Maui
 
 		internal void ToolbarBackButtonClicked() => OnToolbarBackButtonClicked();
 
-		protected virtual void OnHardwareBackButtonClicked()
-		{
-			if (MauiContext.GetActivity().GetWindow()?.BackButtonClicked() == false &&
-				NavigationStack.Count == 1)
-			{
-				MauiContext.GetActivity().FinishAffinity();
-			}
-		}
-
-		internal void HardwareBackButtonClicked() => OnHardwareBackButtonClicked();
-
 		// Fragments are always destroyed if they aren't visible
 		// The Handler/NativeView associated with the visible IView remain intact
 		// The performance hit of destorying/recreating fragments should be negligible
@@ -427,12 +416,6 @@ namespace Microsoft.Maui
 				if (f is NavigationViewFragment pf)
 					_stackNavigationManager.OnNavigationViewFragmentResumed(fm, pf);
 
-
-				// This wires up the hardware back button to this fragment
-				f.RequireActivity()
-					.OnBackPressedDispatcher
-					.AddCallback(f, _stackNavigationManager.BackClick);
-
 				// Wire up the toolbar to the currently made visible Fragment
 				var controller = NavHostFragment.FindNavController(f);
 				var appbarConfig =
@@ -455,19 +438,8 @@ namespace Microsoft.Maui
 			{
 				if (f is NavigationViewFragment pf)
 					_stackNavigationManager.OnNavigationViewFragmentDestroyed(fm, pf);
-
-				_stackNavigationManager.BackClick.Remove();
+				
 				base.OnFragmentViewDestroyed(fm, f);
-			}
-
-			public override void OnFragmentCreated(AndroidX.Fragment.App.FragmentManager fm, AndroidX.Fragment.App.Fragment f, Bundle savedInstanceState)
-			{
-				base.OnFragmentCreated(fm, f, savedInstanceState);
-
-				// This wires up the hardware back button to this fragment
-				f.RequireActivity()
-					.OnBackPressedDispatcher
-					.AddCallback(f, _stackNavigationManager.BackClick);
 			}
 			#endregion
 

--- a/src/Core/src/Platform/MauiContext.cs
+++ b/src/Core/src/Platform/MauiContext.cs
@@ -7,25 +7,18 @@ namespace Microsoft.Maui
 	public class MauiContext : IMauiContext
 	{
 		readonly WrappedServiceProvider _services;
-		readonly IMauiContext? _parent;
-
-		public MauiContext(IMauiContext parent)
-			: this(parent.Services, parent)
-		{
-		}
 
 #if __ANDROID__
-		public MauiContext(IServiceProvider services, Android.Content.Context context, IMauiContext? parent = null)
-			: this(services, parent)
+		public MauiContext(IServiceProvider services, Android.Content.Context context)
+			: this(services)
 		{
 			AddWeakSpecific(context);
 		}
 #endif
 
-		public MauiContext(IServiceProvider services, IMauiContext? parent = null)
+		public MauiContext(IServiceProvider services)
 		{
 			_services = new WrappedServiceProvider(services ?? throw new ArgumentNullException(nameof(services)));
-			_parent = parent;
 		}
 
 		public IServiceProvider Services => _services;

--- a/src/Core/src/Platform/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/MauiContextExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui
 
 		public static IMauiContext MakeApplicationScope(this IMauiContext mauiContext, NativeApplication nativeApplication)
 		{
-			var scopedContext = new MauiContext(mauiContext);
+			var scopedContext = new MauiContext(mauiContext.Services);
 
 			scopedContext.AddSpecific(nativeApplication);
 
@@ -46,9 +46,9 @@ namespace Microsoft.Maui
 			scope = mauiContext.Services.CreateScope();
 
 #if __ANDROID__
-			var scopedContext = new MauiContext(scope.ServiceProvider, nativeWindow, mauiContext);
+			var scopedContext = new MauiContext(scope.ServiceProvider, nativeWindow);
 #else
-			var scopedContext = new MauiContext(scope.ServiceProvider, mauiContext);
+			var scopedContext = new MauiContext(scope.ServiceProvider);
 #endif
 
 			scopedContext.AddWeakSpecific(nativeWindow);

--- a/src/Core/src/Platform/Windows/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Windows/MauiContextExtensions.cs
@@ -31,5 +31,18 @@ namespace Microsoft.Maui
 			return MauiWinUIApplication.Current.Services
 				?? throw new InvalidOperationException("Unable to find Application Services");
 		}
+
+
+		public static IMauiContext MakeScoped(this IMauiContext mauiContext, bool registerNewNavigationRoot)
+		{
+			var scopedContext = new MauiContext(mauiContext.Services);
+
+			if (registerNewNavigationRoot)
+			{
+				scopedContext.AddWeakSpecific(new NavigationRootManager(scopedContext));
+			}
+
+			return scopedContext;
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -77,6 +77,10 @@ namespace Microsoft.Maui
 
 		internal void UpdateBarBackgroundBrush(WBrush? brush)
 		{
+
+			if (brush == null)
+				return;
+
 			if (PaneToggleButtonGrid != null)
 				PaneToggleButtonGrid.Background = brush;
 

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Maui
 	{
 		IMauiContext _mauiContext;
 		MauiNavigationView _navigationView;
-		IView? _content;
-		IWindow? _window;
 
 		public NavigationRootManager(IMauiContext mauiContext)
 		{
@@ -23,22 +21,20 @@ namespace Microsoft.Maui
 
 		void OnBackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args)
 		{
-			_window?.BackButtonClicked();
+			_mauiContext.GetNativeWindow().GetWindow()?.BackButtonClicked();
 		}
 
 		public FrameworkElement RootView => _navigationView;
 
-		public virtual void Connect(IWindow window)
+		public virtual void Connect(IView view)
 		{
-			_window = window;
-			_content = window?.Content;
-			_navigationView.Content = _content?.ToNative(_mauiContext);
+			_ = view.ToNative(_mauiContext);
+			var nativeView = view.GetNative(true);
+			_navigationView.Content = nativeView;
 		}
 
-		public virtual void Disconnect(IWindow window)
+		public virtual void Disconnect(IView view)
 		{
-			_window = null;
-			_content = null;
 			_navigationView.Content = null;
 		}
 

--- a/src/Core/src/Platform/Windows/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Windows/StackNavigationManager.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Navigation;
 
 namespace Microsoft.Maui
 {
-	public class NavigationManager
+	public class StackNavigationManager
 	{
 		IView? _currentPage;
 		IMauiContext _mauiContext;
@@ -23,7 +23,7 @@ namespace Microsoft.Maui
 		public Frame NavigationFrame =>
 			_navigationFrame ?? throw new InvalidOperationException("NavigationFrame Null");
 
-		public NavigationManager(IMauiContext mauiContext)
+		public StackNavigationManager(IMauiContext mauiContext)
 		{
 			_mauiContext = mauiContext;
 		}
@@ -95,7 +95,7 @@ namespace Microsoft.Maui
 
 			if (NavigationStack.Count > args.NavigationStack.Count)
 				return new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromLeft };
-
+						
 			return new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromRight };
 		}
 

--- a/src/Core/src/Platform/Windows/WindowHeader.xaml
+++ b/src/Core/src/Platform/Windows/WindowHeader.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d" Background="Purple"
+    mc:Ignorable="d"
     HorizontalContentAlignment="Stretch"
     VerticalContentAlignment="Stretch"
     VerticalAlignment="Stretch" 

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
@@ -24,14 +24,11 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				ViewGroup rootView = (DefaultContext as AppCompatActivity).Window.DecorView as ViewGroup;
 				var linearLayoutCompat = new LinearLayoutCompat(DefaultContext);
+				var fragmentManager = MauiContext.GetFragmentManager();
+				var viewFragment = new NavViewFragment(MauiContext);
 
 				try
-				{
-					var mauiContext = new ContextStub(MauiContext.GetApplicationServices());
-					var viewFragment = new NavViewFragment(mauiContext);
-
-
-					var fragmentManager = (DefaultContext as AppCompatActivity).GetFragmentManager();
+				{										
 					linearLayoutCompat.Id = View.GenerateViewId();
 
 					fragmentManager
@@ -54,11 +51,14 @@ namespace Microsoft.Maui.DeviceTests
 				finally
 				{
 					rootView.RemoveView(linearLayoutCompat);
+
+					fragmentManager
+						.BeginTransaction()
+						.Remove(viewFragment)
+						.Commit();
 				}
 			});
 		}
-
-
 
 		class NavViewFragment : Fragment
 		{
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 			{
-				ScopedMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
+				ScopedMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager, registerNewNavigationRoot: true);
 				return ScopedMauiContext.GetNavigationRootManager().RootView;
 			}
 

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Windows.cs
@@ -17,27 +17,27 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(async () =>
 			{
-			FrameworkElement frameworkElement = null;
-			var content = (Panel)DefaultWindow.Content;
-			try
-			{
-				var mauiContext = new ContextStub(MauiContext.GetApplicationServices());
-				var handler = CreateHandler(navigationView, mauiContext);
-				frameworkElement = handler.NativeView;
-				content.Children.Add(frameworkElement);
-				if (navigationView is NavigationViewStub nvs && nvs.NavigationStack?.Count > 0)
+				FrameworkElement frameworkElement = null;
+				var content = (Panel)DefaultWindow.Content;
+				try
 				{
-					navigationView.RequestNavigation(new NavigationRequest(nvs.NavigationStack, false));
-					await nvs.OnNavigationFinished;
-				}
+					var mauiContext = MauiContext.MakeScoped(true);
+					var handler = CreateHandler(navigationView, mauiContext);
+					frameworkElement = handler.NativeView;
+					content.Children.Add(frameworkElement);
+					if (navigationView is NavigationViewStub nvs && nvs.NavigationStack?.Count > 0)
+					{
+						navigationView.RequestNavigation(new NavigationRequest(nvs.NavigationStack, false));
+						await nvs.OnNavigationFinished;
+					}
 
-				await action(handler);
-			}
-			finally
-			{
-				if (frameworkElement != null)
-					content.Children.Remove(frameworkElement);
-				}				
+					await action(handler);
+				}
+				finally
+				{
+					if (frameworkElement != null)
+						content.Children.Remove(frameworkElement);
+				}
 			});
 		}
 	}

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.NavigationView)]
 	public partial class NavigationViewHandlerTests : HandlerTestBase<NavigationViewHandler, NavigationViewStub>
 	{
-#if ANDROID || WINDOWS
+#if ANDROID || WINDOWS || true
 		[Fact(DisplayName = "Push Multiple Pages At Start")]
 		public async Task PushMultiplePagesAtStart()
 		{
-			PageStub page1 = new PageStub();
-			PageStub page2 = new PageStub();
+			var page1 = new ButtonStub();
+			var page2 = new ButtonStub();
 			NavigationViewStub navigationViewStub = new NavigationViewStub()
 			{
 				NavigationStack = new List<IView>()

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.NavigationView)]
 	public partial class NavigationViewHandlerTests : HandlerTestBase<NavigationViewHandler, NavigationViewStub>
 	{
-#if ANDROID || WINDOWS || true
+#if ANDROID || WINDOWS
 		[Fact(DisplayName = "Push Multiple Pages At Start")]
 		public async Task PushMultiplePagesAtStart()
 		{

--- a/src/Core/tests/UnitTests/MauiContextTests.cs
+++ b/src/Core/tests/UnitTests/MauiContextTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.UnitTests
 			var services = new MauiFactory(collection, false);
 
 			var first = new MauiContext(services);
-			var second = new MauiContext(first);
+			var second = new MauiContext(first.Services);
 
 			Assert.Same(obj, second.Services.GetService<TestThing>());
 		}
@@ -93,7 +93,7 @@ namespace Microsoft.Maui.UnitTests
 
 			var first = new MauiContext(services);
 
-			var second = new MauiContext(first);
+			var second = new MauiContext(first.Services);
 			second.AddSpecific<TestThing>(obj2);
 
 			Assert.Same(obj2, second.Services.GetService<TestThing>());


### PR DESCRIPTION
### Description of Change ###

Setup Modal Pages with their own NavigationRoot on Windows and Android. 

Remove the `OnBackButtonPressing` event and instead just uses `OnBackButtonPressed` to implement conditional behavior. 

Remove the ctor on `MauiContext` that takes a parent `MauiContext`


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
