### PR TITLE
[Proposal] Obsolete AndExpand

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core-net6.csproj
+++ b/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core-net6.csproj
@@ -11,13 +11,13 @@
     <DefineConstants>TRACE;DEBUG;PERF;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
+    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>TRACE;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
+    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap10.0'))">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>

--- a/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
@@ -9,6 +9,14 @@
     <DefineConstants>$(DefineConstants);__ANDROID__;UITEST;__SHELL__</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;0618</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;0618</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <DefineConstants>$(DefineConstants);WINDOWS;UITEST</DefineConstants>
-    <NoWarn>0114;0108;4014;0649;0169;0168;0219</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0169;0168;0219;0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -9,6 +9,14 @@
     <DefineConstants>$(DefineConstants);__IOS__;UITEST;__SHELL__</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;0618</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;0618</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/Controls/Maps/src/Map.cs
+++ b/src/Controls/Maps/src/Map.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Maui.Controls.Maps
 		{
 			LastMoveToRegion = region;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			VerticalOptions = HorizontalOptions = LayoutOptions.FillAndExpand;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			_pins.CollectionChanged += PinsOnCollectionChanged;
 		}

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
@@ -56,6 +56,12 @@
     <MauiSplashScreen Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" />
   </ItemGroup>
 
+  <ItemGroup>
+    <MauiXaml Update="Pages\Compatibility\AndExpandPage.xaml">
+      <Generator></Generator>
+    </MauiXaml>
+  </ItemGroup>
+
   <Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\..\BlazorWebView\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.targets" />
 
 </Project>

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml.cs
@@ -19,7 +19,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 
 #if NET6_0_OR_GREATER
-			var grid = new Grid() { VerticalOptions = LayoutOptions.FillAndExpand, BackgroundColor = Colors.Purple, };
+			var grid = new Grid() { VerticalOptions = LayoutOptions.Fill, BackgroundColor = Colors.Purple, };
 			grid.AddRowDefinition(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
 			grid.AddRowDefinition(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
 			grid.AddRowDefinition(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/AndExpandPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/AndExpandPage.xaml
@@ -1,0 +1,32 @@
+﻿<views:BasePage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.AndExpandPage"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    Title="AndExpand">
+    <views:BasePage.Content>
+        <StackLayout x:Name="MyStackLayout" Spacing="10">
+
+            <Button Text="Toggle Expansion on Label" x:Name="Toggle"></Button>
+
+            <Label Text="Normal non-expanded label"
+                HorizontalOptions="Center" Margin="20" />
+
+            <Label Text="Expanded Label with FillAndExpand"
+                FontSize="18"
+                FontAttributes="Bold"
+                x:Name="ExpandLabel"
+                BackgroundColor="LightBlue"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                VerticalOptions="FillAndExpand" />
+
+            <Image 
+                Source="dotnet_bot.png"
+                SemanticProperties.Description="Cute dotnet bot waving hi to you!"
+                HeightRequest="200"
+                HorizontalOptions="Center" />
+
+        </StackLayout>
+    </views:BasePage.Content>
+</views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/AndExpandPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/AndExpandPage.xaml.cs
@@ -10,6 +10,7 @@
 
 			Toggle.Clicked += (sender, args) => {
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				switch (_counter % 5)
 				{
 					case 1:
@@ -33,6 +34,7 @@
 						ExpandLabel.Text = "Not Expanded";
 						break;
 				}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				_counter += 1;
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/AndExpandPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/AndExpandPage.xaml.cs
@@ -1,0 +1,41 @@
+﻿namespace Maui.Controls.Sample.Pages
+{
+	public partial class AndExpandPage 
+	{
+		int _counter = 0;
+
+		public AndExpandPage()
+		{
+			InitializeComponent();
+
+			Toggle.Clicked += (sender, args) => {
+
+				switch (_counter % 5)
+				{
+					case 1:
+						ExpandLabel.VerticalOptions = Microsoft.Maui.Controls.LayoutOptions.CenterAndExpand;
+						ExpandLabel.Text = "Expanded Label with CenterAndExpand";
+						break;
+					case 2:
+						ExpandLabel.VerticalOptions = Microsoft.Maui.Controls.LayoutOptions.StartAndExpand;
+						ExpandLabel.Text = "Expanded Label with StartAndExpand";
+						break;
+					case 3:
+						ExpandLabel.VerticalOptions = Microsoft.Maui.Controls.LayoutOptions.EndAndExpand;
+						ExpandLabel.Text = "Expanded Label with EndAndExpand";
+						break;
+					case 4:
+						ExpandLabel.VerticalOptions = Microsoft.Maui.Controls.LayoutOptions.FillAndExpand;
+						ExpandLabel.Text = "Expanded Label with FillAndExpand";
+						break;
+					default:
+						ExpandLabel.VerticalOptions = Microsoft.Maui.Controls.LayoutOptions.Center;
+						ExpandLabel.Text = "Not Expanded";
+						break;
+				}
+
+				_counter += 1;
+			};
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/GalleryBuilder.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/GalleryBuilder.cs
@@ -16,7 +16,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				AutomationId = automationId,
 				FontSize = 10,
 				HeightRequest = Device.RuntimePlatform == Device.Android ? 40 : 30,
-				HorizontalOptions = LayoutOptions.FillAndExpand,
+				HorizontalOptions = LayoutOptions.Fill,
 				Margin = 5,
 				Padding = 5
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -57,8 +57,8 @@ namespace Maui.Controls.Sample.Pages
 
 			changeColorBoxView = new Label
 			{
-				VerticalOptions = LayoutOptions.CenterAndExpand,
-				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
 				WidthRequest = 200,
 				HeightRequest = 50,
 				Text = "Tap Gesture Gallery"

--- a/src/Controls/samples/Controls.Sample/ViewModels/CompatibilityViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/CompatibilityViewModel.cs
@@ -29,6 +29,9 @@ namespace Maui.Controls.Sample.ViewModels
 
 			new SectionModel(typeof(TabbedPageGallery), "TabbedPage",
 				"Display pages as a set of Tabs."),
+
+			new SectionModel(typeof(AndExpandPage), "AndExpand",
+				"StackLayout with legacy AndExpand options"),
 		};
 	}
 }

--- a/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
+++ b/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+
+namespace Microsoft.Maui.Controls
+{
+	public class AndExpandLayoutManager : ILayoutManager
+	{
+		IGridLayout _gridLayout;
+		readonly StackLayout _stackLayout;
+		GridLayoutManager _manager;
+
+		public AndExpandLayoutManager(StackLayout stackLayout) 
+		{
+			_stackLayout = stackLayout;
+		}
+
+		public Size Measure(double widthConstraint, double heightConstraint)
+		{
+			// We have to rebuild this every time because the StackLayout contents
+			// and values may have changed
+			_gridLayout = Gridify(_stackLayout);
+			_manager = new GridLayoutManager(_gridLayout);
+
+			return _manager.Measure(widthConstraint, heightConstraint);
+		}
+
+		public Size ArrangeChildren(Rectangle bounds)
+		{
+			return _manager.ArrangeChildren(bounds);
+		}
+
+		IGridLayout Gridify(StackLayout stackLayout)
+		{
+			if (stackLayout.Orientation == StackOrientation.Vertical)
+			{
+				return ConvertToRows(stackLayout);
+			}
+
+			return ConvertToColumns(stackLayout);
+		}
+
+		IGridLayout ConvertToRows(StackLayout stackLayout)
+		{
+			GridLayout grid = new GridLayout
+			{
+				ColumnDefinitions = new ColumnDefinitionCollection { new ColumnDefinition { Width = GridLength.Star } },
+				RowDefinitions = new RowDefinitionCollection()
+			};
+
+			for (int n = 0; n < stackLayout.Count; n++)
+			{
+				var child = stackLayout[n];
+
+				if (child is View view && view.VerticalOptions.Expands)
+				{
+					grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+				}
+				else
+				{
+					grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+				}
+
+				grid.Add(child);
+				grid.SetRow(child, n);
+			}
+
+			return grid;
+		}
+
+		IGridLayout ConvertToColumns(StackLayout stackLayout)
+		{
+			GridLayout grid = new GridLayout
+			{
+				RowDefinitions = new RowDefinitionCollection { new RowDefinition { Height = GridLength.Star } },
+				ColumnDefinitions = new ColumnDefinitionCollection()
+			};
+
+			for (int n = 0; n < stackLayout.Count; n++)
+			{
+				var child = stackLayout[n];
+
+				if (child is View view && view.HorizontalOptions.Expands)
+				{
+					grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star });
+				}
+				else
+				{
+					grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+				}
+
+				grid.Add(child);
+				grid.SetColumn(child, n);
+			}
+
+			return grid;
+		}
+	}
+}

--- a/src/Controls/src/Core/Layout/StackBase.cs
+++ b/src/Controls/src/Core/Layout/StackBase.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	public abstract class StackBase : Layout, IStackLayout
+	{
+		public static readonly BindableProperty SpacingProperty = BindableProperty.Create(nameof(Spacing), typeof(double), typeof(StackBase), 0d,
+				propertyChanged: (bindable, oldvalue, newvalue) => ((IView)bindable).InvalidateMeasure());
+
+		public double Spacing
+		{
+			get { return (double)GetValue(SpacingProperty); }
+			set { SetValue(SpacingProperty, value); }
+		}
+	}
+}

--- a/src/Controls/src/Core/Layout/StackLayout.cs
+++ b/src/Controls/src/Core/Layout/StackLayout.cs
@@ -1,19 +1,8 @@
-﻿using Microsoft.Maui.Layouts;
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls
 {
-	public abstract class StackBase : Layout, IStackLayout
-	{
-		public static readonly BindableProperty SpacingProperty = BindableProperty.Create(nameof(Spacing), typeof(double), typeof(StackBase), 0d,
-				propertyChanged: (bindable, oldvalue, newvalue) => ((IView)bindable).InvalidateMeasure());
-
-		public double Spacing
-		{
-			get { return (double)GetValue(SpacingProperty); }
-			set { SetValue(SpacingProperty, value); }
-		}
-	}
-
 	public class StackLayout : StackBase, IStackLayout
 	{
 		public static readonly BindableProperty OrientationProperty = BindableProperty.Create(nameof(Orientation), typeof(StackOrientation), typeof(StackLayout), StackOrientation.Vertical,
@@ -28,19 +17,12 @@ namespace Microsoft.Maui.Controls
 		static void OrientationChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var layout = (StackLayout)bindable;
-
-			// Clear out the current layout manager; when the layout system needs it again, it'll call CreateLayoutManager
-			layout._layoutManager = null;
 			layout.InvalidateMeasure();
 		}
 
 		protected override ILayoutManager CreateLayoutManager()
 		{
-			return Orientation switch
-			{
-				StackOrientation.Horizontal => new HorizontalStackLayoutManager(this),
-				_ => new VerticalStackLayoutManager(this),
-			};
+			return new StackLayoutManager(this);
 		}
 	}
 }

--- a/src/Controls/src/Core/Layout/StackLayoutManager.cs
+++ b/src/Controls/src/Core/Layout/StackLayoutManager.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+
+namespace Microsoft.Maui.Controls
+{
+	public class StackLayoutManager : ILayoutManager 
+	{
+		readonly StackLayout _stackLayout;
+
+		public StackLayoutManager(StackLayout stackLayout) 
+		{
+			_stackLayout = stackLayout;
+		}
+
+		VerticalStackLayoutManager _verticalStackLayoutManager;
+		HorizontalStackLayoutManager _horizontalStackLayoutManager;
+		AndExpandLayoutManager _andExpandLayoutManager;
+
+		ILayoutManager SelectLayoutManager() 
+		{
+			if (UsesExpansion(_stackLayout))
+			{
+				return _andExpandLayoutManager ??= new AndExpandLayoutManager(_stackLayout);
+			}
+
+			if (_stackLayout.Orientation == StackOrientation.Vertical)
+			{ 
+				return _verticalStackLayoutManager ??= new VerticalStackLayoutManager(_stackLayout);
+			}
+
+			return _horizontalStackLayoutManager ??= new HorizontalStackLayoutManager(_stackLayout);
+		}
+
+		public Size ArrangeChildren(Rectangle bounds)
+		{
+			return SelectLayoutManager().ArrangeChildren(bounds);
+		}
+
+		public Size Measure(double widthConstraint, double heightConstraint)
+		{
+			return SelectLayoutManager().Measure(widthConstraint, heightConstraint);
+		}
+
+		static bool UsesExpansion(StackLayout stackLayout) 
+		{
+			var orientation = stackLayout.Orientation;
+
+			for (int n = 0; n < stackLayout.Count; n++)
+			{
+				if (stackLayout[n] is View view)
+				{
+					// Validate the expansion direction against the orientation of the StackLayout
+					// Horizontal expansion in a vertical stack layout makes no sense, so we ignore it
+					// Same with vertical expansion in a horizontal layout
+
+					if (orientation == StackOrientation.Vertical && view.VerticalOptions.Expands)
+					{
+						return true;
+					}
+
+					if (orientation == StackOrientation.Horizontal && view.HorizontalOptions.Expands)
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/Controls/src/Core/LayoutOptions.cs
+++ b/src/Controls/src/Core/LayoutOptions.cs
@@ -11,9 +11,17 @@ namespace Microsoft.Maui.Controls
 		public static readonly LayoutOptions Center = new LayoutOptions(LayoutAlignment.Center, false);
 		public static readonly LayoutOptions End = new LayoutOptions(LayoutAlignment.End, false);
 		public static readonly LayoutOptions Fill = new LayoutOptions(LayoutAlignment.Fill, false);
+
+		[Obsolete("The StackLayout expansion options are deprecated; please use a Grid instead.")]
 		public static readonly LayoutOptions StartAndExpand = new LayoutOptions(LayoutAlignment.Start, true);
+
+		[Obsolete("The StackLayout expansion options are deprecated; please use a Grid instead.")]
 		public static readonly LayoutOptions CenterAndExpand = new LayoutOptions(LayoutAlignment.Center, true);
+
+		[Obsolete("The StackLayout expansion options are deprecated; please use a Grid instead.")]
 		public static readonly LayoutOptions EndAndExpand = new LayoutOptions(LayoutAlignment.End, true);
+
+		[Obsolete("The StackLayout expansion options are deprecated; please use a Grid instead.")]
 		public static readonly LayoutOptions FillAndExpand = new LayoutOptions(LayoutAlignment.Fill, true);
 
 		public LayoutOptions(LayoutAlignment alignment, bool expands)

--- a/src/Controls/src/Core/LayoutOptionsConverter.cs
+++ b/src/Controls/src/Core/LayoutOptionsConverter.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Controls
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> true;
 
+#pragma warning disable CS0618 // Type or member is obsolete (AndExpand options)
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
 			var strValue = value?.ToString();
@@ -52,6 +53,7 @@ namespace Microsoft.Maui.Controls
 
 			throw new InvalidOperationException($"Cannot convert \"{strValue}\" into {typeof(LayoutOptions)}");
 		}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{

--- a/src/Controls/src/Core/LegacyLayouts/RelativeLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/RelativeLayout.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		public RelativeLayout()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			VerticalOptions = HorizontalOptions = LayoutOptions.FillAndExpand;
+#pragma warning restore CS0618 // Type or member is obsolete
 			_children = new RelativeElementCollection(InternalChildren, this);
 			_children.Parent = this;
 

--- a/src/Controls/src/Core/ListView.cs
+++ b/src/Controls/src/Core/ListView.cs
@@ -80,7 +80,9 @@ namespace Microsoft.Maui.Controls
 
 		public ListView()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			VerticalOptions = HorizontalOptions = LayoutOptions.FillAndExpand;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			TemplatedItems.IsGroupingEnabledProperty = IsGroupingEnabledProperty;
 			TemplatedItems.GroupHeaderTemplateProperty = GroupHeaderTemplateProperty;

--- a/src/Controls/src/Core/RefreshView.cs
+++ b/src/Controls/src/Core/RefreshView.cs
@@ -14,8 +14,9 @@ namespace Microsoft.Maui.Controls
 		public RefreshView()
 		{
 			IsClippedToBounds = true;
-			VerticalOptions = LayoutOptions.FillAndExpand;
-			HorizontalOptions = LayoutOptions.FillAndExpand;
+#pragma warning disable CS0618 // Type or member is obsolete
+			VerticalOptions = HorizontalOptions = LayoutOptions.FillAndExpand;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<RefreshView>>(() => new PlatformConfigurationRegistry<RefreshView>(this));
 		}

--- a/src/Controls/src/Core/TableView.cs
+++ b/src/Controls/src/Core/TableView.cs
@@ -31,7 +31,9 @@ namespace Microsoft.Maui.Controls
 
 		public TableView(TableRoot root)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			VerticalOptions = HorizontalOptions = LayoutOptions.FillAndExpand;
+#pragma warning restore CS0618 // Type or member is obsolete
 			Model = _tableModel = new TableSectionModel(this, root);
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<TableView>>(() => new PlatformConfigurationRegistry<TableView>(this));
 		}

--- a/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
@@ -1,0 +1,284 @@
+﻿#nullable enable
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+using System.Collections;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
+{
+	[TestFixture, Category("Layout")]
+	public class AndExpandTests : BaseTestFixture
+	{
+		const double TestAreaWidth = 640;
+		const double TestAreaHeight = 480;
+		const double TestViewHeight = 20;
+		const double TestViewWidth = 100;
+
+		public class TestView : Button
+		{
+			Size _desiredSize = new(TestViewWidth, TestViewHeight);
+
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint) 
+			{
+				DesiredSize = _desiredSize;
+				return _desiredSize;
+			}
+		}
+
+		static StackLayout SetUpTestLayout(StackOrientation orientation, params View[] views)
+		{
+			var layout = new StackLayout() { Orientation = orientation };
+
+			foreach (var view in views)
+			{
+				layout.Add(view);
+			}
+
+			var layoutSize = new Size(TestAreaWidth, TestAreaHeight);
+			var rect = new Rectangle(Point.Zero, layoutSize);
+
+			(layout as Maui.ILayout).CrossPlatformMeasure(layoutSize.Width, layoutSize.Height);
+			(layout as Maui.ILayout).CrossPlatformArrange(rect);
+
+			return layout;
+		}
+
+		[Test]
+		public void SingleChildExpandsToFillVertical()
+		{
+			var view0 = new TestView { 
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var layout = SetUpTestLayout(StackOrientation.Vertical, view0);
+
+			Assert.AreEqual(TestAreaWidth, view0.Bounds.Width);
+			Assert.AreEqual(TestAreaHeight, view0.Bounds.Height);
+			Assert.AreEqual(0, view0.Bounds.X);
+			Assert.AreEqual(0, view0.Bounds.Y);
+		}
+
+		[Test]
+		public void SingleChildExpandsToFillHorizontal()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var layout = SetUpTestLayout(StackOrientation.Horizontal, view0);
+
+			Assert.AreEqual(TestAreaWidth, view0.Bounds.Width);
+			Assert.AreEqual(TestAreaHeight, view0.Bounds.Height);
+			Assert.AreEqual(0, view0.Bounds.X);
+			Assert.AreEqual(0, view0.Bounds.Y);
+		}
+
+		[Test]
+		public void TwoChildrenSplit5050Vertical()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			SetUpTestLayout(StackOrientation.Vertical, view0, view1);
+
+			var expectedHeight = TestAreaHeight / 2;
+
+			Assert.AreEqual(expectedHeight, view0.Bounds.Height);
+			Assert.AreEqual(expectedHeight, view1.Bounds.Height);
+
+			Assert.AreEqual(0, view0.Bounds.Y);
+			Assert.AreEqual(expectedHeight, view1.Bounds.Y);
+		}
+
+		[Test]
+		public void TwoChildrenSplit5050Horizontal()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+
+			SetUpTestLayout(StackOrientation.Horizontal, view0, view1);
+
+			var expectedWidth = TestAreaWidth / 2;
+
+			Assert.AreEqual(expectedWidth, view0.Bounds.Width);
+			Assert.AreEqual(expectedWidth, view1.Bounds.Width);
+
+			Assert.AreEqual(0, view0.Bounds.X);
+			Assert.AreEqual(expectedWidth, view1.Bounds.X);
+		}
+
+		static IEnumerable ExpansionYCases
+		{
+			get
+			{
+				yield return new object[] { LayoutOptions.StartAndExpand, 0 };
+				yield return new object[] { LayoutOptions.EndAndExpand, (TestAreaHeight / 2) - TestViewHeight };
+				yield return new object[] { LayoutOptions.CenterAndExpand, (TestAreaHeight / 4) - (TestViewHeight / 2) };
+				yield return new object[] { LayoutOptions.FillAndExpand, 0 };
+			}
+		}
+
+		static IEnumerable ExpansionXCases
+		{
+			get
+			{
+				yield return new object[] { LayoutOptions.StartAndExpand, 0 };
+				yield return new object[] { LayoutOptions.EndAndExpand, (TestViewWidth / 2) - TestViewWidth };
+				yield return new object[] { LayoutOptions.CenterAndExpand, (TestViewWidth / 4) - (TestViewWidth / 2) };
+				yield return new object[] { LayoutOptions.FillAndExpand, 0 };
+			}
+		}
+
+		[Test, TestCaseSource(nameof(ExpansionYCases))]
+		public void AlignmentRespectedWithinVerticalSegment(LayoutOptions layoutOptions, double expectedY)
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = layoutOptions
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			SetUpTestLayout(StackOrientation.Vertical, view0, view1);
+
+			Assert.AreEqual(expectedY, view0.Bounds.Y);
+		}
+
+		[Test, TestCaseSource(nameof(ExpansionYCases))]
+		public void AlignmentRespectedWithinHorizontalSegment(LayoutOptions layoutOptions, double expectedX)
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = layoutOptions
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+
+			SetUpTestLayout(StackOrientation.Horizontal, view0, view1);
+
+			Assert.AreEqual(expectedX, view0.Bounds.X);
+		}
+
+		[Test]
+		public void StackLayoutWithNoExpansionDoesNotExpand() 
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.Start
+			};
+
+			SetUpTestLayout(StackOrientation.Vertical, view0, view1);
+
+			Assert.AreEqual(0, view0.Bounds.X);
+			Assert.AreEqual(0, view0.Bounds.Y);
+
+			Assert.AreEqual(0, view1.Bounds.X);
+			Assert.AreEqual(TestViewHeight, view1.Bounds.Y);
+		}
+
+		[Test]
+		public void StackLayoutWithPointlessExpansionDoesNotExpand()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+
+			SetUpTestLayout(StackOrientation.Vertical, view0, view1);
+
+			Assert.AreEqual(0, view0.Bounds.X);
+			Assert.AreEqual(0, view0.Bounds.Y);
+
+			Assert.AreEqual(0, view1.Bounds.X);
+			Assert.AreEqual(TestViewHeight, view1.Bounds.Y);
+		}
+
+		[Test]
+		public void UpdatedStackLayoutExpandsCorrectly()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var stackLayout = SetUpTestLayout(StackOrientation.Vertical, view0, view1);
+
+			Assert.AreEqual(0, view0.Bounds.X);
+			Assert.AreEqual(0, view0.Bounds.Y);
+
+			Assert.AreEqual(0, view1.Bounds.X);
+			Assert.AreEqual(TestAreaHeight / 2, view1.Bounds.Y);
+
+			var view2 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			stackLayout.Add(view2);
+
+			(stackLayout as Maui.ILayout).CrossPlatformMeasure(TestAreaWidth, TestAreaHeight);
+			(stackLayout as Maui.ILayout).CrossPlatformArrange(new Rectangle(0, 0, TestAreaWidth, TestAreaHeight));
+
+			Assert.AreEqual(0, view0.Bounds.X);
+			Assert.AreEqual(0, view0.Bounds.Y);
+
+			Assert.AreEqual(0, view1.Bounds.X);
+			Assert.AreEqual(TestAreaHeight / 3, view1.Bounds.Y);
+
+			Assert.AreEqual(0, view2.Bounds.X);
+			Assert.AreEqual(2 * (TestAreaHeight / 3), view2.Bounds.Y);
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests-net6.csproj
+++ b/src/Controls/tests/Xaml.UnitTests/Controls.Xaml.UnitTests-net6.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Microsoft.Maui.Controls.Xaml.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Maui.Controls.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0672;0219;0414;CS0436</NoWarn>
+    <NoWarn>0672;0219;0414;CS0436;0618</NoWarn>
     <IsPackable>false</IsPackable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>


### PR DESCRIPTION
For context, see the other discussions at #1702, #29, #1872, and https://github.com/dotnet/maui/discussions/3324.

And also https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/layouts/layout-options#expansion

With this pull request I am proposing the following:

1. The "AndExpand" options _will not_ go into MAUI Core. 
2. The "AndExpand" options in Controls will be marked Obsolete
3. The Controls implementation of `StackLayout` will, for the time being, honor the "AndExpand" options. We may choose to remove that capability in the future.
4. No new form of the "AndExpand" options will be added to any future versions of Core or Controls.

This pull request marks all of the "AndExpand" `LayoutOptions` in Controls as Obsolete. Current usages are preserved with warnings disabled. 

The pull request also adds "AndExpand" legacy capabilities to the new StackLayout. When the new `StackLayout` detects the use of "AndExpand" it will drop into a separate mode which lays out child views as expected. `VerticalStackLayout` and `HorizontalStackLayout` _do not_ honor "AndExpand" - only `StackLayout` does this. This is to ease the transition for existing Xamarin.Forms applications. 

All of the functionality provided by "AndExpand" is already available to layouts via the Grid, so no new attached properties or other `StackLayout`-specific properties are required. 

This will achieve the following goals:

- Reduce the confusion caused by "AndExpand"
- Push users who want layouts which subdivide the container area to use the correct layout types
- Preserve the speed and simplicity of the StackLayout types
- Provide an easy transition from Forms to MAUI for users who have historically used the "AndExpand" options
- Prevent future packaged templates from using/misusing the "AndExpand" options