### PR TITLE
Added Shell Page dependency resolution with DataTemplate and Shell global routes…

### DIFF
--- a/src/Controls/src/Core/ElementTemplate.cs
+++ b/src/Controls/src/Core/ElementTemplate.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Maui.Controls
 		List<Action<object, ResourcesChangedEventArgs>> _changeHandlers;
 		Element _parent;
 		bool _canRecycle; // aka IsDeclarative
+		readonly Type _type;
 
 		internal ElementTemplate()
 		{
@@ -20,15 +21,9 @@ namespace Microsoft.Maui.Controls
 				throw new ArgumentNullException("type");
 
 			_canRecycle = true;
+			_type = type;
 
-			LoadTemplate = () =>
-			{
-				if (_parent?.FindMauiContext()?.Services != null)
-				{
-					return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(_parent.FindMauiContext().Services, type);
-				}
-				return Activator.CreateInstance(type);
-			};
+			LoadTemplate = () => Activator.CreateInstance(type);
 		}
 
 		internal ElementTemplate(Func<object> loadTemplate) : this() => LoadTemplate = loadTemplate ?? throw new ArgumentNullException("loadTemplate");
@@ -42,6 +37,8 @@ namespace Microsoft.Maui.Controls
 		}
 
 		internal bool CanRecycle => _canRecycle;
+		internal Type Type => _type;
+
 		Element IElement.Parent
 		{
 			get { return _parent; }

--- a/src/Controls/src/Core/ElementTemplate.cs
+++ b/src/Controls/src/Core/ElementTemplate.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Maui.Controls
 
 			LoadTemplate = () =>
 			{
-				if (Application.Current?.Handler?.MauiContext?.Services != null)
+				if (_parent?.FindMauiContext()?.Services != null)
 				{
-					return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(Application.Current.Handler.MauiContext.Services, type);
+					return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(_parent.FindMauiContext().Services, type);
 				}
 				return Activator.CreateInstance(type);
 			};

--- a/src/Controls/src/Core/ElementTemplate.cs
+++ b/src/Controls/src/Core/ElementTemplate.cs
@@ -21,7 +21,14 @@ namespace Microsoft.Maui.Controls
 
 			_canRecycle = true;
 
-			LoadTemplate = () => Activator.CreateInstance(type);
+			LoadTemplate = () =>
+			{
+				if (Application.Current?.Handler?.MauiContext?.Services != null)
+				{
+					return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(Application.Current.Handler.MauiContext.Services, type);
+				}
+				return Activator.CreateInstance(type);
+			};
 		}
 
 		internal ElementTemplate(Func<object> loadTemplate) : this() => LoadTemplate = loadTemplate ?? throw new ArgumentNullException("loadTemplate");

--- a/src/Controls/src/Core/RouteFactory.cs
+++ b/src/Controls/src/Core/RouteFactory.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Maui.Controls
 {
 	public abstract class RouteFactory
 	{
+		public abstract Element GetOrCreate();
 		public abstract Element GetOrCreate(IServiceProvider services);
 	}
 }

--- a/src/Controls/src/Core/RouteFactory.cs
+++ b/src/Controls/src/Core/RouteFactory.cs
@@ -4,6 +4,6 @@ namespace Microsoft.Maui.Controls
 {
 	public abstract class RouteFactory
 	{
-		public abstract Element GetOrCreate();
+		public abstract Element GetOrCreate(IServiceProvider services);
 	}
 }

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.Controls
 			return keys;
 		}
 
-		public static Element GetOrCreateContent(string route, IServiceProvider services)
+		public static Element GetOrCreateContent(string route, IServiceProvider services = null)
 		{
 			Element result = null;
 

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -143,7 +143,16 @@ namespace Microsoft.Maui.Controls
 				// okay maybe its a type, we'll try that just to be nice to the user
 				var type = Type.GetType(route);
 				if (type != null)
-					result = Activator.CreateInstance(type) as Element;
+				{
+					if (Application.Current?.Handler?.MauiContext?.Services != null)
+					{
+						result = Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(Application.Current.Handler.MauiContext.Services, type) as Element;
+					}
+					else
+					{
+						result = Activator.CreateInstance(type) as Element;
+					}
+				}
 			}
 
 			if (result != null)
@@ -234,8 +243,13 @@ namespace Microsoft.Maui.Controls
 
 			public override Element GetOrCreate()
 			{
-				return (Element)Activator.CreateInstance(_type);
+				if (Application.Current?.Handler?.MauiContext?.Services != null)
+				{
+					return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(Application.Current.Handler.MauiContext.Services, _type) as Element;
+				}
+				return Activator.CreateInstance(_type) as Element;
 			}
+
 			public override bool Equals(object obj)
 			{
 				if ((obj is TypeRouteFactory typeRouteFactory))

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.Controls
 			return keys;
 		}
 
-		public static Element GetOrCreateContent(string route)
+		public static Element GetOrCreateContent(string route, IServiceProvider services)
 		{
 			Element result = null;
 
@@ -136,7 +136,7 @@ namespace Microsoft.Maui.Controls
 			}
 
 			if (s_routes.TryGetValue(route, out var content))
-				result = content.GetOrCreate();
+				result = content.GetOrCreate(services);
 
 			if (result == null)
 			{
@@ -144,9 +144,9 @@ namespace Microsoft.Maui.Controls
 				var type = Type.GetType(route);
 				if (type != null)
 				{
-					if (Application.Current?.Handler?.MauiContext?.Services != null)
+					if (services != null)
 					{
-						result = Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(Application.Current.Handler.MauiContext.Services, type) as Element;
+						result = Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(services, type) as Element;
 					}
 					else
 					{
@@ -241,11 +241,11 @@ namespace Microsoft.Maui.Controls
 				_type = type;
 			}
 
-			public override Element GetOrCreate()
+			public override Element GetOrCreate(IServiceProvider services)
 			{
-				if (Application.Current?.Handler?.MauiContext?.Services != null)
+				if (services != null)
 				{
-					return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(Application.Current.Handler.MauiContext.Services, _type) as Element;
+					return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(services, _type) as Element;
 				}
 				return Activator.CreateInstance(_type) as Element;
 			}

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -240,6 +240,11 @@ namespace Microsoft.Maui.Controls
 			{
 				_type = type;
 			}
+			
+			public override Element GetOrCreate()
+			{
+				return (Element)Activator.CreateInstance(_type);
+			}
 
 			public override Element GetOrCreate(IServiceProvider services)
 			{

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -63,6 +63,17 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
+				if (template.Type != null)
+				{
+					template.LoadTemplate = () =>
+					{
+						if (Parent?.FindMauiContext()?.Services != null)
+						{
+							return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(Parent.FindMauiContext().Services, template.Type);
+						}
+						return Activator.CreateInstance(template.Type);
+					};
+				}
 				result = ContentCache ?? (Page)template.CreateContent(content, this);
 				ContentCache = result;
 			}

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -67,9 +67,10 @@ namespace Microsoft.Maui.Controls
 				{
 					template.LoadTemplate = () =>
 					{
-						if (Parent?.FindMauiContext()?.Services != null)
+						var services = Parent?.FindMauiContext()?.Services;
+						if (services != null)
 						{
-							return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(Parent.FindMauiContext().Services, template.Type);
+							return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(services, template.Type);
 						}
 						return Activator.CreateInstance(template.Type);
 					};

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 				modalStackPreBuilt = true;
 
 				bool? isAnimated = (nextActiveSection != currentShellSection) ? false : animate;
-				await nextActiveSection.GoToAsync(navigationRequest, parameters, isAnimated, isRelativePopping);
+				await nextActiveSection.GoToAsync(navigationRequest, parameters, _shell.FindMauiContext()?.Services, isAnimated, isRelativePopping);
 			}
 
 			if (shellItem != null)
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.Controls
 					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
 					await Device.InvokeOnMainThreadAsync(() =>
 					{
-						return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameters, animate, isRelativePopping);
+						return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameters, _shell.FindMauiContext()?.Services, animate, isRelativePopping);
 					});
 				}
 				else if (navigationRequest.Request.GlobalRoutes.Count == 0 &&
@@ -159,13 +159,13 @@ namespace Microsoft.Maui.Controls
 					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
 					await Device.InvokeOnMainThreadAsync(() =>
 					{
-						return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameters, animate, isRelativePopping);
+						return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameters, _shell.FindMauiContext()?.Services, animate, isRelativePopping);
 					});
 				}
 			}
 			else
 			{
-				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameters, animate, isRelativePopping);
+				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameters, _shell.FindMauiContext()?.Services, animate, isRelativePopping);
 			}
 
 			(_shell as IShellController).UpdateCurrentState(source);

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Maui.Controls
 			return (ShellSection)(ShellContent)page;
 		}
 
-		async Task PrepareCurrentStackForBeingReplaced(ShellNavigationRequest request, ShellRouteParameters queryData, bool? animate, List<string> globalRoutes, bool isRelativePopping)
+		async Task PrepareCurrentStackForBeingReplaced(ShellNavigationRequest request, ShellRouteParameters queryData, IServiceProvider services, bool? animate, List<string> globalRoutes, bool isRelativePopping)
 		{
 			string route = "";
 			List<Page> navStack = null;
@@ -350,7 +350,7 @@ namespace Microsoft.Maui.Controls
 							continue;
 						}
 
-						var page = GetOrCreateFromRoute(globalRoutes[i], queryData, i == globalRoutes.Count - 1, false);
+						var page = GetOrCreateFromRoute(globalRoutes[i], queryData, services, i == globalRoutes.Count - 1, false);
 						if (IsModal(page))
 						{
 							await PushModalAsync(page, IsNavigationAnimated(page));
@@ -468,9 +468,9 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		Page GetOrCreateFromRoute(string route, ShellRouteParameters queryData, bool isLast, bool isPopping)
+		Page GetOrCreateFromRoute(string route, ShellRouteParameters queryData, IServiceProvider services, bool isLast, bool isPopping)
 		{
-			var content = Routing.GetOrCreateContent(route) as Page;
+			var content = Routing.GetOrCreateContent(route, services) as Page;
 			if (content == null)
 			{
 				Internals.Log.Warning(nameof(Shell), $"Failed to Create Content For: {route}");
@@ -480,7 +480,7 @@ namespace Microsoft.Maui.Controls
 			return content;
 		}
 
-		internal async Task GoToAsync(ShellNavigationRequest request, ShellRouteParameters queryData, bool? animate, bool isRelativePopping)
+		internal async Task GoToAsync(ShellNavigationRequest request, ShellRouteParameters queryData, IServiceProvider services, bool? animate, bool isRelativePopping)
 		{
 			List<string> globalRoutes = request.Request.GlobalRoutes;
 			if (globalRoutes == null || globalRoutes.Count == 0)
@@ -493,7 +493,7 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			await PrepareCurrentStackForBeingReplaced(request, queryData, animate, globalRoutes, isRelativePopping);
+			await PrepareCurrentStackForBeingReplaced(request, queryData, services, animate, globalRoutes, isRelativePopping);
 
 			List<Page> modalPageStacks = new List<Page>();
 			List<Page> nonModalPageStacks = new List<Page>();
@@ -511,7 +511,7 @@ namespace Microsoft.Maui.Controls
 			for (int i = whereToStartNavigation; i < globalRoutes.Count; i++)
 			{
 				bool isLast = i == globalRoutes.Count - 1;
-				var content = GetOrCreateFromRoute(globalRoutes[i], queryData, isLast, false);
+				var content = GetOrCreateFromRoute(globalRoutes[i], queryData, services, isLast, false);
 				if (content == null)
 				{
 					break;

--- a/src/Controls/tests/Core.UnitTests/DataTemplateTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DataTemplateTests.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Microsoft.Maui.Controls;
-using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using Microsoft.Maui;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -121,43 +119,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 			};
 			Assert.That(() => template.CreateContent(), Throws.InstanceOf<InvalidOperationException>());
-		}
-
-		[Test]
-		public void CreateContentWithDependencyResolution()
-		{
-			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddTransient<Dependency>();
-			IServiceProvider services = serviceCollection.BuildServiceProvider();
-			var fakeMauiContext = Substitute.For<IMauiContext>();
-			var fakeHandler = Substitute.For<IElementHandler>();
-			fakeMauiContext.Services.Returns(services);
-			fakeHandler.MauiContext.Returns(fakeMauiContext);
-			var fakeApplication = new Application();
-			fakeApplication.Handler = fakeHandler;
-			Application.Current = fakeApplication;
-
-			var template = new DataTemplate(typeof(PageWithDependency));
-			var obj = template.CreateContent();
-			Assert.That(obj, Is.InstanceOf<PageWithDependency>());
-			var page = obj as PageWithDependency;
-			Assert.That(page, Is.Not.Null);
-			Assert.That(page.TestDependency, Is.Not.Null);
-		}
-
-		class PageWithDependency : ContentPage
-		{
-			public Dependency TestDependency { get; set; }
-
-			public PageWithDependency(Dependency dependency)
-			{
-				TestDependency = dependency;
-			}
-		}
-
-		class Dependency
-		{
-			public int Test { get; set; }
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/DataTemplateTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DataTemplateTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Controls/tests/Core.UnitTests/DataTemplateTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DataTemplateTests.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using Microsoft.Maui.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Microsoft.Maui;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
@@ -117,6 +121,43 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 			};
 			Assert.That(() => template.CreateContent(), Throws.InstanceOf<InvalidOperationException>());
+		}
+
+		[Test]
+		public void CreateContentWithDependencyResolution()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<Dependency>();
+			IServiceProvider services = serviceCollection.BuildServiceProvider();
+			var fakeMauiContext = Substitute.For<IMauiContext>();
+			var fakeHandler = Substitute.For<IElementHandler>();
+			fakeMauiContext.Services.Returns(services);
+			fakeHandler.MauiContext.Returns(fakeMauiContext);
+			var fakeApplication = new Application();
+			fakeApplication.Handler = fakeHandler;
+			Application.Current = fakeApplication;
+
+			var template = new DataTemplate(typeof(PageWithDependency));
+			var obj = template.CreateContent();
+			Assert.That(obj, Is.InstanceOf<PageWithDependency>());
+			var page = obj as PageWithDependency;
+			Assert.That(page, Is.Not.Null);
+			Assert.That(page.TestDependency, Is.Not.Null);
+		}
+
+		class PageWithDependency : ContentPage
+		{
+			public Dependency TestDependency { get; set; }
+
+			public PageWithDependency(Dependency dependency)
+			{
+				TestDependency = dependency;
+			}
+		}
+
+		class Dependency
+		{
+			public int Test { get; set; }
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -963,20 +963,5 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		ShellNavigatingEventArgs CreateShellNavigatedEventArgs() =>
 			new ShellNavigatingEventArgs("..", "../newstate", ShellNavigationSource.Push, true);
-
-		public class PageWithDependency : ContentPage
-		{
-			public Dependency TestDependency { get; set; }
-
-			public PageWithDependency(Dependency dependency)
-			{
-				TestDependency = dependency;
-			}
-		}
-
-		public class Dependency
-		{
-			public int Test { get; set; }
-		} 
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -644,7 +644,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var routeName = typeForRouteName.AssemblyQualifiedName;
 			Routing.RegisterRoute(routeName, type);
-			shell.GoToAsync(routeName);
+			await shell.GoToAsync(routeName);
 
 			Assert.IsNotNull(shell.Navigation);
 			Assert.IsNotNull(shell.Navigation.NavigationStack);

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -627,10 +627,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[TestCase(typeof(PageWithDependency), typeof(Dependency))]
 		public async Task GlobalRouteWithDependencyResolution(Type typeForRouteName, Type type)
 		{
-			var shell = new Shell();
-			var item1 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "dogs");
-			shell.Items.Add(item1);
-
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddTransient<Dependency>();
 			IServiceProvider services = serviceCollection.BuildServiceProvider();
@@ -638,10 +634,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var fakeHandler = Substitute.For<IElementHandler>();
 			fakeMauiContext.Services.Returns(services);
 			fakeHandler.MauiContext.Returns(fakeMauiContext);
-			var fakeApplication = new Application();
-			fakeApplication.Handler = fakeHandler;
-			Application.Current = fakeApplication;
 
+			var flyoutItem = CreateShellItem<FlyoutItem>();
+			flyoutItem.Items.Add(CreateShellContent(asImplicit: true, shellContentRoute: "cats"));
+			var shell = new TestShell
+			{
+				Items = { flyoutItem }
+			};
+			shell.Parent.Handler = fakeHandler;
 			var routeName = typeForRouteName.AssemblyQualifiedName;
 			Routing.RegisterRoute(routeName, type);
 			await shell.GoToAsync(routeName);

--- a/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					_contentPage = contentPage;
 				}
 
-				public override Element GetOrCreate() => _contentPage;
+				public override Element GetOrCreate(IServiceProvider services) => _contentPage;
 			}
 
 			public Action<ShellNavigatedEventArgs> OnNavigatedHandler { get; set; }

--- a/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
@@ -365,6 +365,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 
 				public override Element GetOrCreate(IServiceProvider services) => _contentPage;
+
+				public override Element GetOrCreate() => _contentPage;
 			}
 
 			public Action<ShellNavigatedEventArgs> OnNavigatedHandler { get; set; }
@@ -479,5 +481,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public class TestPage1 : ContentPage { }
 		public class TestPage2 : ContentPage { }
 		public class TestPage3 : ContentPage { }
+		
+		public class PageWithDependency : ContentPage
+		{
+			public Dependency TestDependency { get; set; }
+
+			public PageWithDependency(Dependency dependency)
+			{
+				TestDependency = dependency;
+			}
+		}
+
+		public class Dependency
+		{
+			public int Test { get; set; }
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -259,13 +260,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public async Task CaseIgnoreRouting()
 		{
 			var routes = new[] { "Tab1", "TAB2", "@-_-@", "+:~", "=%", "Super_Simple+-Route.doc", "1/2", @"1\2/3", "app://tab" };
+			var services = Substitute.For<IServiceProvider>();
 
 			foreach (var route in routes)
 			{
 				var formattedRoute = Routing.FormatRoute(route);
 				Routing.RegisterRoute(formattedRoute, typeof(ShellItem));
 
-				var content1 = Routing.GetOrCreateContent(formattedRoute);
+				var content1 = Routing.GetOrCreateContent(formattedRoute, services);
 				Assert.IsNotNull(content1);
 				Assert.AreEqual(Routing.GetRoute(content1), formattedRoute);
 			}


### PR DESCRIPTION
…; added unit tests

@PureWeen I've written a couple of unit tests for this, and the device tests worked on Android. I can't get the device tests app (or anything else for that matter, including the Single Project sample app) to run on iOS.

### Description of Change ###

Implements #3147 

### Additions made ###

* Adds ability to use dependency resolution for Shell pages constructed with DataTemplates
* Adds ability to use dependency resolution for pages constructed via Shell global routes

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [x] I'm not sure, please help me
