### PR TITLE
[Windows] Fix crash typing in Editor

### DIFF
--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -441,13 +441,13 @@ namespace Microsoft.Maui
 
 			if (!SelectionLengthChangePending)
 			{
-				int elementSelectionLength = Math.Min(Text.Length - cursorPosition, ViewSelectionLength);
+				int elementSelectionLength = string.IsNullOrEmpty(Text) ? 0 : Math.Min(Text.Length - cursorPosition, ViewSelectionLength);
 				int controlSelectionLength = SelectionLength;
+
 				if (controlSelectionLength != elementSelectionLength)
 					SetSelectionLength(controlSelectionLength);
 			}
 		}
-
 
 		// Because the implementation of a password entry is based around inheriting from TextBox (via MauiTextBox), there
 		// are some inaccuracies in the behavior. OnKeyDown is what needs to be used for a workaround in this case because 


### PR DESCRIPTION
### Description of Change ###

 Fix crash typing in Editor on Windows.

- fixes #3370 
- fixes #3477

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No
