### PR TITLE
Don't queue up layout changes from ScrollView

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -104,5 +104,16 @@ namespace Microsoft.Maui.Controls
 
 			return bounds.Size;
 		}
+
+		internal override void QueueLayoutResolution()
+		{
+			if (Handler != null)
+			{
+				// No need to queue up layout changes in ScrollView 
+				return;
+			}
+
+			base.QueueLayoutResolution();
+		}
 	}
 }

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -373,6 +373,11 @@ namespace Microsoft.Maui.Controls.Compatibility
 				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 			}
 
+			QueueLayoutResolution();
+		}
+
+		internal virtual void QueueLayoutResolution() 
+		{
 			s_resolutionList.Add(new KeyValuePair<Layout, int>(this, GetElementDepth(this)));
 
 			if (Device.PlatformInvalidator == null && !s_relayoutInProgress)

--- a/src/Controls/src/Core/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView.cs
@@ -377,5 +377,10 @@ namespace Microsoft.Maui.Controls
 
 			return args;
 		}
+
+		internal override void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger)
+		{
+			// No need to queue up layout changes in ScrollView 
+		}
 	}
 }

--- a/src/Controls/src/Core/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView.cs
@@ -377,10 +377,5 @@ namespace Microsoft.Maui.Controls
 
 			return args;
 		}
-
-		internal override void OnChildMeasureInvalidated(VisualElement child, InvalidationTrigger trigger)
-		{
-			// No need to queue up layout changes in ScrollView 
-		}
 	}
 }


### PR DESCRIPTION
Fixes #3348

No need to queue up layout changes in the ScrollView anymore. 

This will fix the immediate issue with stale layout changes from ScrollView causing crashes; we'll need to evaluate separately whether the queued layout change system can be removed entirely.