### PR TITLE
iOS 13+ always uses the scenes if there is one registered in the manifest

### DIFF
--- a/src/Core/src/Platform/iOS/HandlerExtensions.cs
+++ b/src/Core/src/Platform/iOS/HandlerExtensions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui
 
 		// If < iOS 13 or the Info.plist does not have a scene manifest entry we need to assume no multi window, and no UISceneDelegate.
 		// We cannot check for iPads/Mac because even on the iPhone it uses the scene delegate if one is specified in the manifest.
-		public static bool IsUsingMultiWindow(this UIApplicationDelegate nativeApplication) =>
+		public static bool HasSceneManifest(this UIApplicationDelegate nativeApplication) =>
 			UIDevice.CurrentDevice.CheckSystemVersion(13, 0) &&
 			NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString(UIApplicationSceneManifestKey));
 

--- a/src/Core/src/Platform/iOS/HandlerExtensions.cs
+++ b/src/Core/src/Platform/iOS/HandlerExtensions.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Maui
 {
 	public static class HandlerExtensions
 	{
+		const string UIApplicationSceneManifestKey = "UIApplicationSceneManifest";
+
 		internal static UIView? GetNative(this IElement view, bool returnWrappedIfPresent)
 		{
 			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
@@ -73,6 +75,12 @@ namespace Microsoft.Maui
 
 			return (INativeViewHandler)handler;
 		}
+
+		// If < iOS 13 or the Info.plist does not have a scene manifest entry we need to assume no multi window, and no UISceneDelegate.
+		// We cannot check for iPads/Mac because even on the iPhone it uses the scene delegate if one is specified in the manifest.
+		public static bool IsUsingMultiWindow(this UIApplicationDelegate nativeApplication) =>
+			UIDevice.CurrentDevice.CheckSystemVersion(13, 0) &&
+			NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString(UIApplicationSceneManifestKey));
 
 		public static void SetApplicationHandler(this UIApplicationDelegate nativeApplication, IApplication application, IMauiContext context) =>
 			SetHandler(nativeApplication, application, context);

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -43,12 +43,12 @@ namespace Microsoft.Maui
 
 			this.SetApplicationHandler(Application, _applicationContext);
 
-			// If < iOS 13, or we're not on mac/ipad, or the Info.plist does not have a scene manifest entry
-			// we need to assume no multi window, and no UISceneDelegate
-			if (!UIDevice.CurrentDevice.CheckSystemVersion(13, 0)
-				|| (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Mac
-					&& UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
-				|| !NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString("UIApplicationSceneManifest")))
+			// If < iOS 13 or the Info.plist does not have a scene manifest entry
+			// we need to assume no multi window, and no UISceneDelegate.
+			// We cannot check for iPads/Mac because even on the iPhone it uses the
+			// scene delegate if one is specified in the manifest.
+			if (!UIDevice.CurrentDevice.CheckSystemVersion(13, 0) ||
+				!NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString("UIApplicationSceneManifest")))
 			{
 				this.CreateNativeWindow(Application, application, launchOptions);
 			}

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui
 			this.SetApplicationHandler(Application, _applicationContext);
 
 			// if there is no scene delegate or support for scene delegates, then we set up the window here
-			if (!this.IsUsingMultiWindow())
+			if (!this.HasSceneManifest())
 				this.CreateNativeWindow(Application, application, launchOptions);
 
 			Services?.InvokeLifecycleEvents<iOSLifecycle.FinishedLaunching>(del => del(application!, launchOptions!));

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui
 		public override bool RespondsToSelector(Selector? sel)
 		{
 			// if the app is not a multi-window app, then we cannot override the GetConfiguration method
-			if (sel?.Name == GetConfigurationSelectorName && !this.IsUsingMultiWindow())
+			if (sel?.Name == GetConfigurationSelectorName && !this.HasSceneManifest())
 				return false;
 
 			return base.RespondsToSelector(sel);

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui
 	public abstract class MauiUIApplicationDelegate : UIApplicationDelegate, IUIApplicationDelegate
 	{
 		internal const string MauiSceneConfigurationKey = "__MAUI_DEFAULT_SCENE_CONFIGURATION__";
+		internal const string GetConfigurationSelectorName = "application:configurationForConnectingSceneSession:options:";
 
 		IMauiContext _applicationContext = null!;
 
@@ -43,19 +44,22 @@ namespace Microsoft.Maui
 
 			this.SetApplicationHandler(Application, _applicationContext);
 
-			// If < iOS 13 or the Info.plist does not have a scene manifest entry
-			// we need to assume no multi window, and no UISceneDelegate.
-			// We cannot check for iPads/Mac because even on the iPhone it uses the
-			// scene delegate if one is specified in the manifest.
-			if (!UIDevice.CurrentDevice.CheckSystemVersion(13, 0) ||
-				!NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString("UIApplicationSceneManifest")))
-			{
+			// if there is no scene delegate or support for scene delegates, then we set up the window here
+			if (!this.IsUsingMultiWindow())
 				this.CreateNativeWindow(Application, application, launchOptions);
-			}
 
 			Services?.InvokeLifecycleEvents<iOSLifecycle.FinishedLaunching>(del => del(application!, launchOptions!));
 
 			return true;
+		}
+
+		public override bool RespondsToSelector(Selector? sel)
+		{
+			// if the app is not a multi-window app, then we cannot override the GetConfiguration method
+			if (sel?.Name == GetConfigurationSelectorName && !this.IsUsingMultiWindow())
+				return false;
+
+			return base.RespondsToSelector(sel);
 		}
 
 		public override UISceneConfiguration GetConfiguration(UIApplication application, UISceneSession connectingSceneSession, UISceneConnectionOptions options)


### PR DESCRIPTION
### Description of Change ###

This PR fixes the issue of a secret double init of the main window on iOS 13+ on iPhone. Even though the iPhone does not _support_ multi-window, it still uses the scene delegates and will just throw internally.

### Additions made ###

 - Move and correct the logic in the UIApplicationDelegate to not consider the platform type when scene delegates are used
 - Make sure to return false for RespondsToSelector for GetConfiguration if scenes are not being used
