### PR TITLE
Fix iOS Navigation

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -154,6 +154,11 @@ namespace Microsoft.Maui.Controls
 			Action firePostNavigatingEvents,
 			Action fireNavigatedEvents)
 		{
+			if (!_setForMaui || this.IsShimmed())
+			{
+				return;
+			}
+
 			try
 			{
 				processStackChanges?.Invoke();

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -40,23 +40,24 @@ namespace Microsoft.Maui.Controls
 
 		partial void Init();
 
-		public NavigationPage() : this(
 #if WINDOWS || ANDROID
-			true
+		const bool UseMauiHandler = true;
 #else
-			false
+		const bool UseMauiHandler = false;
 #endif
-			)
+
+		bool _setForMaui;
+		public NavigationPage() : this(UseMauiHandler)
 		{
 		}
 
-		public NavigationPage(Page root) : this()
+		public NavigationPage(Page root) : this(UseMauiHandler, root)
 		{
-			PushPage(root);
 		}
 
 		internal NavigationPage(bool setforMaui, Page root = null)
 		{
+			_setForMaui = setforMaui;
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<NavigationPage>>(() => new PlatformConfigurationRegistry<NavigationPage>(this));
 
 			if (setforMaui)

--- a/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
@@ -12,6 +12,41 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	{
 		[TestCase(false)]
 		[TestCase(true)]
+		public async Task HandlerUpdatesDontFireForLegacy(bool withPage)
+		{
+			TestNavigationPage nav =
+				new TestNavigationPage(false, (withPage) ? new ContentPage() : null);
+
+			var handler = new TestNavigationHandler();
+			(nav as IView).Handler = handler;
+
+
+			Assert.IsNull(nav.CurrentNavigationTask);
+			Assert.IsNull(handler.CurrentNavigationRequest);
+		}
+
+		[TestCase(false)]
+		[TestCase(true)]
+		public async Task HandlerUpdatesFireWithStartingPage(bool withPage)
+		{
+			TestNavigationPage nav = 
+				new TestNavigationPage(true, (withPage) ? new ContentPage() : null);
+
+			var handler = new TestNavigationHandler();
+			(nav as IView).Handler = handler;
+
+			if (!withPage)
+			{
+				Assert.IsNull(nav.CurrentNavigationTask);
+			}
+			else
+			{
+				Assert.IsNotNull(nav.CurrentNavigationTask);
+			}
+		}
+
+		[TestCase(false)]
+		[TestCase(true)]
 		public async Task TestNavigationImplPush(bool useMaui)
 		{
 			NavigationPage nav = new TestNavigationPage(useMaui);


### PR DESCRIPTION
### Description of Change ###

Legacy Navigation is currently firing off the handler navigation path which is queueing a navigation task that never gets fulfilled.  This PR checks to see if Navigation should be following a shimmed vs MAUI path and then correctly exits or continues.