### PR TITLE
Minimal changes required to support remotewebview

### DIFF
--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -143,15 +143,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			StartWebViewCoreIfPossible();
 		}
 
-		private void StartWebViewCoreIfPossible()
+		public virtual WebView2WebViewManager CreateWebViewManager(IWebView2Wrapper webview, IServiceProvider services, Dispatcher dispatcher, Web.JSComponentConfigurationStore store)
 		{
-			CheckDisposed();
-
-			if (!RequiredStartupPropertiesSet || _webviewManager != null)
-			{
-				return;
-			}
-
 			// We assume the host page is always in the root of the content directory, because it's
 			// unclear there's any other use case. We can add more options later if so.
 			var contentRootDir = Path.GetDirectoryName(Path.GetFullPath(HostPage));
@@ -163,7 +156,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				? assetFileProvider
 				: new CompositeFileProvider(customFileProvider, assetFileProvider);
 
-			_webviewManager = new WebView2WebViewManager(new WpfWebView2Wrapper(_webview), Services, ComponentsDispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
+			return new WebView2WebViewManager(webview, services, dispatcher, fileProvider, store, hostPageRelativePath);
+		}
+
+		private void StartWebViewCoreIfPossible()
+		{
+			CheckDisposed();
+
+			if (!RequiredStartupPropertiesSet || _webviewManager != null)
+			{
+				return;
+			}
+
+			_webviewManager = this.CreateWebViewManager(new WpfWebView2Wrapper(_webview), Services, ComponentsDispatcher, RootComponents.JSComponents);
+			
 			foreach (var rootComponent in RootComponents)
 			{
 				// Since the page isn't loaded yet, this will always complete synchronously


### PR DESCRIPTION


### Description of Change ###

Created a new virtual method CreateWebViewManager so that subclasses of BlazorWebView (Both the WinForms and WPF versison_ can override the WebViewManager

<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implements #1603

### Additions made ###
CreateWebViewManager method in both WinForms and WPF versions of BlazorWebView.cs

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
