### PR TITLE
Modifed XAML Source Generator to emit MemberNotNull attributes for named XAML controls

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -165,6 +165,14 @@ namespace Microsoft.Maui.Controls.SourceGen
 
 				//initializeComponent
 				sb.AppendLine($"\t\t[global::System.CodeDom.Compiler.GeneratedCode(\"Microsoft.Maui.Controls.SourceGen\", \"1.0.0.0\")]");
+
+				// add MemberNotNull attributes
+				if (namedFields != null)
+					foreach ((var fname, _, _) in namedFields)
+					{
+						sb.AppendLine($"\t\t[global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(this.{(CSharpKeywords.Contains(fname) ? "@" + fname : fname)}))]");
+					}
+
 				sb.AppendLine("\t\tprivate void InitializeComponent()");
 				sb.AppendLine("\t\t{");
 				sb.AppendLine($"\t\t\tglobal::Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml(this, typeof({rootType}));");

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -168,10 +168,16 @@ namespace Microsoft.Maui.Controls.SourceGen
 
 				// add MemberNotNull attributes
 				if (namedFields != null)
+				{
+					sb.AppendLine($"#if NET5_0_OR_GREATER");
 					foreach ((var fname, _, _) in namedFields)
 					{
+
 						sb.AppendLine($"\t\t[global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof({(CSharpKeywords.Contains(fname) ? "@" + fname : fname)}))]");
 					}
+
+					sb.AppendLine($"#endif");
+				}
 
 				sb.AppendLine("\t\tprivate void InitializeComponent()");
 				sb.AppendLine("\t\t{");

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 				if (namedFields != null)
 					foreach ((var fname, _, _) in namedFields)
 					{
-						sb.AppendLine($"\t\t[global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof(this.{(CSharpKeywords.Contains(fname) ? "@" + fname : fname)}))]");
+						sb.AppendLine($"\t\t[global::System.Diagnostics.CodeAnalysis.MemberNotNullAttribute(nameof({(CSharpKeywords.Contains(fname) ? "@" + fname : fname)}))]");
 					}
 
 				sb.AppendLine("\t\tprivate void InitializeComponent()");


### PR DESCRIPTION

### Description of Change ###
As the title says. Modified the XAML Source Generator to emit MemberNotNull attributes for named XAML controls. After the approval of @StephaneDelcroix 😊 of course, this shouldn't be a problem to merge
<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implements #1796

### Additions made ###
NONE

### PR Checklist ###

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [ ] ~~Targets a single property for a single control (or intertwined few properties)~~
- [ ] ~~Adds the property to the appropriate interface~~
- [ ] ~~Avoids any changes not essential to the handler property~~
- [ ] ~~Adds the mapping to the PropertyMapper in the handler~~
- [ ] ~~Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler~~
- [ ] ~~Implements the actual property updates (usually in extension methods in the Platform section of Core)~~
- [ ] ~~Tags ported renderer methods with [PortHandler]~~
- [ ] ~~Adds an example of the property to the sample project (MainPage)~~
- [ ] ~~Adds the property to the stub class~~
- [ ] ~~Implements basic property tests in DeviceTests~~

#### Does this PR touch anything that might affect accessibility?
No