### PR TITLE
[Windows] Fix issue setting the Image Background 

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
@@ -19,6 +19,7 @@
                     Text="FileSource"
                     Style="{StaticResource Headline}"/>
                 <Image 
+                    Background="Purple"
                     Source="dotnet_bot.png"
                     HeightRequest="200" 
                     WidthRequest="200"/>

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<IImage, IImageHandler> Mapper = new PropertyMapper<IImage, IImageHandler>(ViewHandler.ViewMapper)
 		{
-#if __ANDROID__
+#if __ANDROID__ || WINDOWS
 			[nameof(IImage.Background)] = MapBackground,
 #endif
 			[nameof(IImage.Aspect)] = MapAspect,


### PR DESCRIPTION
### Description of Change ###

Fix issue setting the Image Background . We needed to map the Background property in the Windows ImageHandler to set the background color to the parent control of the image itself.

- fixes #3478 
 
### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No