### PR TITLE
[Housekeeping] Slider issues using Minimum and Maximum values

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
@@ -12,6 +12,17 @@
                 Style="{StaticResource Headline}"/>
             <Slider/>
             <Label
+                Text="Minimum (5) and Maximum (15)"
+                Style="{StaticResource Headline}"/>
+            <Slider 
+                x:Name="MinMaxSlider"
+                Maximum="15"
+                Minimum="5"
+                ValueChanged="OnValueChanged"/>
+            <Label
+                FontSize="Micro"
+                Text="{Binding Source={x:Reference MinMaxSlider}, Path=Value}"/>
+            <Label
                 Text="Disabled"
                 Style="{StaticResource Headline}"/>
             <Slider

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml.cs
@@ -1,10 +1,18 @@
-﻿namespace Maui.Controls.Sample.Pages
+﻿using System.Diagnostics;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Pages
 {
 	public partial class SliderPage
 	{
 		public SliderPage()
 		{
 			InitializeComponent();
+		}
+
+		void OnValueChanged(object sender, ValueChangedEventArgs args)
+		{
+			Debug.WriteLine($"Slider Value: {args.NewValue}");
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Cannot reproduce the issue (from Preview 9). For that reason, this PR only include some changes to add a Slider sample in the Gallery using Minimum and Maximum values.

- fixes #3498 

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No