### PR TITLE
Trigger frame events when the frame changes

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/TransformationsPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TransformationsPage.xaml
@@ -4,122 +4,127 @@
     x:Class="Maui.Controls.Sample.Pages.TransformationsPage"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="Transformations">
-    <views:BasePage.Content>
-        <StackLayout 
-            Margin="20">
-            <Label 
-                x:Name="_label" 
-                Text="SCALE AND ROTATE" 
-                HorizontalOptions="Center" 
-                VerticalOptions="CenterAndExpand" />
-            <Grid Padding="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="0.5*" />
-                    <ColumnDefinition Width="0.5*" />
-                </Grid.ColumnDefinitions>
-                <Label 
-                    BindingContext="{x:Reference _sliderScale}"
-                    Text="{Binding Value, StringFormat='Scale = {0:F1}'}"
-                    VerticalTextAlignment="Center" />
-                <Slider 
-                    x:Name="_sliderScale"
-                    Grid.Column="1"
-                    BindingContext="{x:Reference _label}"
-                    Maximum="10"
-                    Value="{Binding Scale}" />
-                <Label Grid.Row="1"
-                   BindingContext="{x:Reference _sliderScaleX}"
-                   Text="{Binding Value, StringFormat='ScaleX = {0:F1}'}"
-                   VerticalTextAlignment="Center" />
-                <Slider x:Name="_sliderScaleX"
-                    Grid.Row="1"
-                    Grid.Column="1"
-                    BindingContext="{x:Reference _label}"
-                    Maximum="10"
-                    Value="{Binding ScaleX}" />
-                <Label 
-                    Grid.Row="2"
-                    BindingContext="{x:Reference _sliderScaleY}"
-                    Text="{Binding Value, StringFormat='ScaleY = {0:F1}'}"
-                    VerticalTextAlignment="Center" />
-                <Slider 
-                    x:Name="_sliderScaleY"
-                    Grid.Row="2"
-                    Grid.Column="1"
-                    BindingContext="{x:Reference _label}"
-                    Maximum="10"
-                    Value="{Binding ScaleY}" />
-                <Label 
-                    Grid.Row="3"
-                    BindingContext="{x:Reference _sliderRotation}"
-                    Text="{Binding Value, StringFormat='Rotation = {0:F0}'}"
-                    VerticalTextAlignment="Center" />
-                <Slider x:Name="_sliderRotation"
-                    Grid.Row="3"
-                    Grid.Column="1"
-                    BindingContext="{x:Reference _label}"
-                    Maximum="360"
-                    Value="{Binding Rotation}" />
-                <Label Grid.Row="4"
-                   BindingContext="{x:Reference _sliderRotationX}"
-                   Text="{Binding Value, StringFormat='RotationX = {0:F0}'}"
-                   VerticalTextAlignment="Center" />
-                <Slider x:Name="_sliderRotationX"
-                    Grid.Row="4"
-                    Grid.Column="1"
-                    BindingContext="{x:Reference _label}"
-                    Maximum="360"
-                    Value="{Binding RotationX}" />
-                <Label 
-                    Grid.Row="5"
-                    BindingContext="{x:Reference _sliderRotationY}"
-                    Text="{Binding Value, StringFormat='RotationY = {0:F0}'}"
-                    VerticalTextAlignment="Center" />
-                <Slider 
-                    x:Name="_sliderRotationY"
-                    Grid.Row="5"
-                    Grid.Column="1"
-                    BindingContext="{x:Reference _label}"
-                    Maximum="360"
-                    Value="{Binding RotationY}" />
-                <Label 
-                    Grid.Row="6"
-                    BindingContext="{x:Reference _stepperAnchorX}"
-                    Text="{Binding Value, StringFormat='AnchorX = {0:F1}'}"
-                    VerticalTextAlignment="Center" />
-                <Stepper 
-                    x:Name="_stepperAnchorX"
-                    Grid.Row="6"
-                    Grid.Column="1"
-                    BindingContext="{x:Reference _label}"
-                    Increment="0.5"
-                    Minimum="-1"
-                    Maximum="2"
-                    Value="{Binding AnchorX}" />
-                <Label  
-                    Grid.Row="7"
-                    BindingContext="{x:Reference _stepperAnchorY}"
-                    Text="{Binding Value, StringFormat='AnchorY = {0:F1}'}"
-                    VerticalTextAlignment="Center" />
-                <Stepper
-                    x:Name="_stepperAnchorY"
-                    Grid.Row="7"
-                    Grid.Column="1" 
-                    BindingContext="{x:Reference _label}"
-                    Increment="0.5"
-                    Minimum="-1"
-                    Maximum="2"
-                    Value="{Binding AnchorY}" />
-            </Grid>
-        </StackLayout>
-    </views:BasePage.Content>
+
+    <Grid
+        Padding="10"
+        RowDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+        ColumnDefinitions="Auto,*">
+
+        <!-- BLINKING LIGHT -->
+        <Button
+            x:Name="_label"
+            Grid.ColumnSpan="2"
+            Text="SCALE AND ROTATE"
+            HorizontalOptions="Center"
+            VerticalOptions="Center" />
+
+        <!-- KNOBS AND DIALS -->
+        <Label
+            Grid.Row="1"
+            BindingContext="{x:Reference _sliderScale}"
+            Text="{Binding Value, StringFormat='Scale = {0:F1}'}"
+            VerticalTextAlignment="Center" />
+        <Slider
+            x:Name="_sliderScale"
+            Grid.Row="1"
+            Grid.Column="1"
+            BindingContext="{x:Reference _label}"
+            Maximum="10"
+            Value="{Binding Scale}" />
+
+        <Label
+            Grid.Row="2"
+            BindingContext="{x:Reference _sliderScaleX}"
+            Text="{Binding Value, StringFormat='ScaleX = {0:F1}'}"
+            VerticalTextAlignment="Center" />
+        <Slider
+            x:Name="_sliderScaleX"
+            Grid.Row="2"
+            Grid.Column="1"
+            BindingContext="{x:Reference _label}"
+            Maximum="10"
+            Value="{Binding ScaleX}" />
+
+        <Label
+            Grid.Row="3"
+            BindingContext="{x:Reference _sliderScaleY}"
+            Text="{Binding Value, StringFormat='ScaleY = {0:F1}'}"
+            VerticalTextAlignment="Center" />
+        <Slider
+            x:Name="_sliderScaleY"
+            Grid.Row="3"
+            Grid.Column="1"
+            BindingContext="{x:Reference _label}"
+            Maximum="10"
+            Value="{Binding ScaleY}" />
+
+        <Label
+            Grid.Row="4"
+            BindingContext="{x:Reference _sliderRotation}"
+            Text="{Binding Value, StringFormat='Rotation = {0:F0}'}"
+            VerticalTextAlignment="Center" />
+        <Slider
+            x:Name="_sliderRotation"
+            Grid.Row="4"
+            Grid.Column="1"
+            BindingContext="{x:Reference _label}"
+            Maximum="360"
+            Value="{Binding Rotation}" />
+
+        <Label
+            Grid.Row="5"
+            BindingContext="{x:Reference _sliderRotationX}"
+            Text="{Binding Value, StringFormat='RotationX = {0:F0}'}"
+            VerticalTextAlignment="Center" />
+        <Slider x:Name="_sliderRotationX"
+            Grid.Row="5"
+            Grid.Column="1"
+            BindingContext="{x:Reference _label}"
+            Maximum="360"
+            Value="{Binding RotationX}" />
+
+        <Label
+            Grid.Row="6"
+            BindingContext="{x:Reference _sliderRotationY}"
+            Text="{Binding Value, StringFormat='RotationY = {0:F0}'}"
+            VerticalTextAlignment="Center" />
+        <Slider
+            x:Name="_sliderRotationY"
+            Grid.Row="6"
+            Grid.Column="1"
+            BindingContext="{x:Reference _label}"
+            Maximum="360"
+            Value="{Binding RotationY}" />
+
+        <Label
+            Grid.Row="7"
+            BindingContext="{x:Reference _stepperAnchorX}"
+            Text="{Binding Value, StringFormat='AnchorX = {0:F1}'}"
+            VerticalTextAlignment="Center" />
+        <Stepper
+            x:Name="_stepperAnchorX"
+            Grid.Row="7"
+            Grid.Column="1"
+            BindingContext="{x:Reference _label}"
+            Increment="0.5"
+            Minimum="-1"
+            Maximum="2"
+            Value="{Binding AnchorX}" />
+
+        <Label
+            Grid.Row="8"
+            BindingContext="{x:Reference _stepperAnchorY}"
+            Text="{Binding Value, StringFormat='AnchorY = {0:F1}'}"
+            VerticalTextAlignment="Center" />
+        <Stepper
+            x:Name="_stepperAnchorY"
+            Grid.Row="8"
+            Grid.Column="1"
+            BindingContext="{x:Reference _label}"
+            Increment="0.5"
+            Minimum="-1"
+            Maximum="2"
+            Value="{Binding AnchorY}" />
+
+    </Grid>
 </views:BasePage>

--- a/src/Core/src/CommandMapper.cs
+++ b/src/Core/src/CommandMapper.cs
@@ -26,16 +26,16 @@ namespace Microsoft.Maui
 
 		private protected virtual void InvokeCore(string key, IElementHandler viewHandler, IElement virtualView, object? args)
 		{
-			var action = GetCommandCore(key);
+			var action = GetCommand(key);
 			action?.Invoke(viewHandler, virtualView, args);
 		}
 
-		private protected virtual Command? GetCommandCore(string key)
+		public virtual Command? GetCommand(string key)
 		{
 			if (_mapper.TryGetValue(key, out var action))
 				return action;
 			else if (Chained is not null)
-				return Chained.GetCommandCore(key);
+				return Chained.GetCommand(key);
 			else
 				return null;
 		}
@@ -75,7 +75,7 @@ namespace Microsoft.Maui
 		{
 			get
 			{
-				var action = GetCommandCore(key) ?? throw new IndexOutOfRangeException($"Unable to find mapping for '{nameof(key)}'.");
+				var action = GetCommand(key) ?? throw new IndexOutOfRangeException($"Unable to find mapping for '{nameof(key)}'.");
 				return new Action<TViewHandler, TVirtualView, object?>((h, v, o) => action.Invoke(h, v, o));
 			}
 			set => Add(key, value);

--- a/src/Core/src/CommandMapperExtensions.cs
+++ b/src/Core/src/CommandMapperExtensions.cs
@@ -1,0 +1,67 @@
+﻿using System;
+
+namespace Microsoft.Maui
+{
+	public static class CommandMapperExtensions
+	{
+		/// <summary>
+		/// Modify a command mapping in place.
+		/// </summary>
+		/// <typeparam name="TVirtualView">The cross-platform type.</typeparam>
+		/// <typeparam name="TViewHandler">The handler type.</typeparam>
+		/// <param name="commandMapper">The command mapper in which to change the mapping.</param>
+		/// <param name="key">The name of the command.</param>
+		/// <param name="method">The modified method to call when the command is updated.</param>
+		public static void ModifyMapping<TVirtualView, TViewHandler>(this CommandMapper<TVirtualView, TViewHandler> commandMapper,
+			string key, Action<TViewHandler, TVirtualView, object?, Action<IElementHandler, IElement, object?>?> method)
+			where TVirtualView : IElement where TViewHandler : IElementHandler
+		{
+			var previousMethod = commandMapper.GetCommand(key);
+
+			commandMapper.Add(key, newMethod);
+
+			void newMethod(TViewHandler handler, TVirtualView view, object? args)
+			{
+				method(handler, view, args, previousMethod);
+			}
+		}
+
+		/// <summary>
+		/// Specify a method to be run after an existing command mapping.
+		/// </summary>
+		/// <typeparam name="TVirtualView">The cross-platform type.</typeparam>
+		/// <typeparam name="TViewHandler">The handler type.</typeparam>
+		/// <param name="commandMapper">The command mapper in which to change the mapping.</param>
+		/// <param name="key">The name of the command.</param>
+		/// <param name="method">The method to call after the existing mapping is finished.</param>
+		public static void AppendToMapping<TVirtualView, TViewHandler>(this CommandMapper<TVirtualView, TViewHandler> commandMapper,
+			string key, Action<TViewHandler, TVirtualView, object?> method)
+			where TVirtualView : IElement where TViewHandler : IElementHandler
+		{
+			commandMapper.ModifyMapping(key, (handler, view, args, action) =>
+			{
+				action?.Invoke(handler, view, args);
+				method(handler, view, args);
+			});
+		}
+
+		/// <summary>
+		/// Specify a method to be run before an existing command mapping.
+		/// </summary>
+		/// <typeparam name="TVirtualView">The cross-platform type.</typeparam>
+		/// <typeparam name="TViewHandler">The handler type.</typeparam>
+		/// <param name="commandMapper">The command mapper in which to change the mapping.</param>
+		/// <param name="key">The name of the command.</param>
+		/// <param name="method">The method to call before the existing mapping begins.</param>
+		public static void PrependToMapping<TVirtualView, TViewHandler>(this CommandMapper<TVirtualView, TViewHandler> commandMapper,
+			string key, Action<TViewHandler, TVirtualView, object?> method)
+			where TVirtualView : IElement where TViewHandler : IElementHandler
+		{
+			commandMapper.ModifyMapping(key, (handler, view, args, action) =>
+			{
+				method(handler, view, args);
+				action?.Invoke(handler, view, args);
+			});
+		}
+	}
+}

--- a/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.iOS.cs
@@ -47,10 +47,5 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateContent();
 		}
-
-		public static void MapFrame(BorderHandler handler, IBorder border)
-		{
-
-		}
 	}
 }

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
@@ -10,9 +10,6 @@ namespace Microsoft.Maui.Handlers
 
 		public static CommandMapper<IPicker, PickerHandler> ContentViewCommandMapper = new(ViewCommandMapper)
 		{
-#if __IOS__
-			[nameof(IView.Frame)] = MapFrame,
-#endif
 		};
 
 		public ContentViewHandler() : base(ContentViewMapper, ContentViewCommandMapper)

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.iOS.cs
@@ -45,14 +45,5 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.UpdateContent();
 		}
-
-		public static void MapFrame(ContentViewHandler handler, IContentView view)
-		{
-			ViewHandler.MapFrame(handler, view, null);
-
-			// TODO MAUI: Currently the background layer frame is tied to the layout system
-			// which needs to be investigated more
-			handler.NativeView?.UpdateBackgroundLayerFrame();
-		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -5,6 +5,13 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ViewHandler
 	{
+		static partial void MappingFrame(IViewHandler handler, IView view)
+		{
+			// Both Clip and Shadow depend on the Control size.
+			handler.GetWrappedNativeView()?.UpdateClip(view);
+			handler.GetWrappedNativeView()?.UpdateShadow(view);
+		}
+
 		public static void MapTranslationX(IViewHandler handler, IView view) 
 		{ 
 			handler.GetWrappedNativeView()?.UpdateTransformation(view);

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -257,11 +257,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFrame(IViewHandler handler, IView view, object? args)
 		{
 			MappingFrame(handler, view);
-#if WINDOWS
-			// Both Clip and Shadow depend on the Control size.
-			MapClip(handler, view);
-			MapShadow(handler, view);
-#endif
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.iOS.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Handlers
 		static partial void MappingFrame(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
+			handler.GetWrappedNativeView()?.UpdateBackgroundLayerFrame();
 		}
 
 		public static void MapTranslationX(IViewHandler handler, IView view)

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Maui.Handlers
 			var right = Context.ToPixels(frame.Right);
 
 			nativeView.Layout((int)left, (int)top, (int)right, (int)bottom);
+
+			Invoke(nameof(IView.Frame), frame);
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			nativeView.Arrange(new global::Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height));
+
+			Invoke(nameof(IView.Frame), rect);
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.iOS.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 			// So just leave it a whatever value iOS thinks it should be.
 			nativeView.Bounds = new CoreGraphics.CGRect(nativeView.Bounds.X, nativeView.Bounds.Y, rect.Width, rect.Height);
 
-			nativeView.UpdateBackgroundLayerFrame();
+			Invoke(nameof(IView.Frame), rect);
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Handlers\ActivityIndicator\*.cs" />
     <Compile Include="Handlers\Button\*.cs" />
     <Compile Include="Handlers\Navigation\*.cs" />
+    <Compile Include="Handlers\View\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">
     <Compile Remove="**\*.Android.cs" />

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Android.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.Maui.Handlers;
+using Android.Views;
+using Android.Widget;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ViewHandlerTests
 	{
-		protected static Thing CreateNativeView() =>
-			
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Android.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ViewHandlerTests
+	{
+		protected static Thing CreateNativeView() =>
+			
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Windows.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Maui.Handlers;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.DeviceTests
 {

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.Windows.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ViewHandlerTests
+	{
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
@@ -1,8 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
-using Microsoft.Maui;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -30,6 +31,30 @@ namespace Microsoft.Maui.DeviceTests
 			});
 
 			Assert.Equal(1, didUpdateFrame);
+		}
+
+		[Fact(DisplayName = "Subsequint NativeArrange triggers MapFrame")]
+		public async Task SubsequintNativeArrangeTriggersMapFrame()
+		{
+			var didUpdateFrame = 0;
+
+			var view = new StubBase();
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = new StubBaseHandler();
+
+				handler.CommandMapper.AppendToMapping(nameof(IView.Frame), (h, v, a) =>
+				{
+					didUpdateFrame++;
+				});
+
+				InitializeViewHandler(view, handler);
+
+				handler.NativeArrange(new Rectangle(0, 0, 100, 100));
+			});
+
+			Assert.Equal(2, didUpdateFrame);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
@@ -1,37 +1,35 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.View)]
-	public partial class ViewHandlerTests : HandlerTestBase<StubBase, StubBaseHandler>
+	public partial class ViewHandlerTests : HandlerTestBase<StubBaseHandler, StubBase>
 	{
 		[Fact(DisplayName = "NativeArrange triggers MapFrame")]
-		public Task NativeArrangeTriggersMapFrame()
+		public async Task NativeArrangeTriggersMapFrame()
 		{
-			var commandMapperField = typeof(ElementHandler).GetField("_commandMapper");
+			var didUpdateFrame = 0;
 
 			var view = new StubBase();
 
-			return InvokeOnMainThreadAsync(() =>
+			await InvokeOnMainThreadAsync(() =>
 			{
-				var handler = new StubBaseHandler(CreateNativeView());
+				var handler = new StubBaseHandler();
 
-				var viewHandler = handler as ViewHandler;
-				var commandMapper = commandMapperField.GetValue(handler) as CommandMapper;
-
-
-
-				handler.Com
+				handler.CommandMapper.AppendToMapping(nameof(IView.Frame), (h, v, a) =>
+				{
+					didUpdateFrame++;
+				});
 
 				InitializeViewHandler(view, handler);
-
-				var handler = CreateHandler(view);
-
-
 			});
+
+			Assert.Equal(1, didUpdateFrame);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.View)]
+	public partial class ViewHandlerTests : HandlerTestBase<StubBase, StubBaseHandler>
+	{
+		[Fact(DisplayName = "NativeArrange triggers MapFrame")]
+		public Task NativeArrangeTriggersMapFrame()
+		{
+			var commandMapperField = typeof(ElementHandler).GetField("_commandMapper");
+
+			var view = new StubBase();
+
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var handler = new StubBaseHandler(CreateNativeView());
+
+				var viewHandler = handler as ViewHandler;
+				var commandMapper = commandMapperField.GetValue(handler) as CommandMapper;
+
+
+
+				handler.Com
+
+				InitializeViewHandler(view, handler);
+
+				var handler = CreateHandler(view);
+
+
+			});
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.iOS.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Maui.Handlers;
+using UIKit;
 
 namespace Microsoft.Maui.DeviceTests
 {

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.iOS.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ViewHandlerTests
+	{
+	}
+}

--- a/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
@@ -1,10 +1,5 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
-using Microsoft.Maui.Primitives;
 
 #if __IOS__ || MACCATALYST
 using NativeView = UIKit.UIView;
@@ -18,26 +13,50 @@ using NativeView = System.Object;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	public class StubBaseHandler : ViewHandler<StubBase, NativeView>
+	public class StubBaseHandler : ViewHandler<StubBase, StubNativeView>
 	{
-		readonly NativeView _nativeView;
+		public static IPropertyMapper<StubBase, StubBaseHandler> StubMapper =
+			new PropertyMapper<StubBase, StubBaseHandler>(ViewMapper)
+			{
+			};
 
+		public static CommandMapper<StubBase, StubBaseHandler> StubCommandMapper =
+			new(ViewCommandMapper)
+			{
+			};
 
-		public static IPropertyMapper<StubBase, StubBaseHandler> StubMapper = new PropertyMapper<StubBase, StubBaseHandler>(ViewMapper)
+		public StubBaseHandler()
+			: this(null, null)
 		{
-		};
-
-		public static CommandMapper<StubBase, StubBaseHandler> StubCommandMapper = new(ViewCommandMapper)
-		{
-		};
-
-		protected StubBaseHandler(NativeView nativeView, IPropertyMapper? mapper = null, CommandMapper? commandMapper = null)
-			: base(mapper ?? StubMapper, commandMapper ?? ViewCommandMapper)
-		{
-			_nativeView = nativeView;
 		}
 
-		protected override NativeView CreateNativeView() =>
-			_nativeView;
+		public StubBaseHandler(IPropertyMapper? mapper = null, CommandMapper? commandMapper = null)
+			: base(
+				new PropertyMapper<StubBase, StubBaseHandler>(mapper ?? StubMapper),
+				new CommandMapper<StubBase, StubBaseHandler>(commandMapper ?? ViewCommandMapper))
+		{
+		}
+
+		public CommandMapper<StubBase, StubBaseHandler>? CommandMapper =>
+			_commandMapper as CommandMapper<StubBase, StubBaseHandler>;
+
+		public PropertyMapper<StubBase, StubBaseHandler>? PropertyMapper =>
+			_mapper as PropertyMapper<StubBase, StubBaseHandler>;
+
+		protected override StubNativeView CreateNativeView() =>
+			new StubNativeView(MauiContext!);
+	}
+
+	public class StubNativeView : NativeView
+	{
+		public StubNativeView(IMauiContext mauiContext)
+#if __ANDROID__
+			: base(mauiContext.Context)
+#endif
+		{
+			MauiContext = mauiContext;
+		}
+
+		public IMauiContext MauiContext { get; }
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Primitives;
+
+#if __IOS__ || MACCATALYST
+using NativeView = UIKit.UIView;
+#elif __ANDROID__
+using NativeView = Android.Views.View;
+#elif WINDOWS
+using NativeView = Microsoft.UI.Xaml.FrameworkElement;
+#elif NETSTANDARD
+using NativeView = System.Object;
+#endif
+
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public class StubBaseHandler : ViewHandler<StubBase, NativeView>
+	{
+		readonly NativeView _nativeView;
+
+
+		public static IPropertyMapper<StubBase, StubBaseHandler> StubMapper = new PropertyMapper<StubBase, StubBaseHandler>(ViewMapper)
+		{
+		};
+
+		public static CommandMapper<StubBase, StubBaseHandler> StubCommandMapper = new(ViewCommandMapper)
+		{
+		};
+
+		protected StubBaseHandler(NativeView nativeView, IPropertyMapper? mapper = null, CommandMapper? commandMapper = null)
+			: base(mapper ?? StubMapper, commandMapper ?? ViewCommandMapper)
+		{
+			_nativeView = nativeView;
+		}
+
+		protected override NativeView CreateNativeView() =>
+			_nativeView;
+	}
+}


### PR DESCRIPTION
### Description of Change ###

At some point in the past, we no longer triggered the `Frame` property and then command, so certain updates were not propagated.

This PR makes sue that when `NativeArrange` is called and updates the native view, it triggers the `Frame` command which in turn allows the ViewHandlers to update things like transforms, shadows and backgrounds.

On iOS, this gave rise to the case where if the transforms were set in the XAML, then they would reach the handler before the first layout event. This meant that the width/height would still be -1 and the transforms would be skipped. Then, when the layout happened, the transforms would not be calculated.