### PR TITLE
Make ApplicationId lowercase in Templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -15,7 +15,7 @@
 		<ApplicationTitle>MauiApp.1</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.MauiApp._1</ApplicationId>
+		<ApplicationId>com.companyname.mauiapp._1</ApplicationId>
 
 		<!-- Versions -->
 		<ApplicationVersion>1</ApplicationVersion>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -14,7 +14,7 @@
 		<ApplicationTitle>MauiApp.1</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.MauiApp._1</ApplicationId>
+		<ApplicationId>com.companyname.mauiapp._1</ApplicationId>
 
 		<!-- Versions -->
 		<ApplicationVersion>1</ApplicationVersion>


### PR DESCRIPTION
It seems this should make the new project name from the templates show up as a lowercase value in the CSPROJ for the `<ApplicationId>` property.

This is desirable since it's what's more expected for where this property is propagated to in the various platform application manifests.  Though it's allowed to be uppercase generally, it's not the norm, and in the past it's created some big problems.  For instance your android application id can start with an uppercase character however that is incompatible with C2DM (GCM) and has caused numerous Xamarin bugs over the year as a result.

- [x] Validate this actually works as intended through the PR artifacts
