### PR TITLE
Fix publishing WPF/WinForms Blazor apps with MSIX

### DIFF
--- a/src/BlazorWebView/src/WindowsForms/build/Microsoft.AspNetCore.Components.WebView.WindowsForms.targets
+++ b/src/BlazorWebView/src/WindowsForms/build/Microsoft.AspNetCore.Components.WebView.WindowsForms.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
     <StaticWebAssetProjectMode>Root</StaticWebAssetProjectMode>
-    <CoreCompileDependsOn Condition="'$(PublishProtocol)' == 'ClickOnce'">$(CoreCompileDependsOn);StaticWebAssetsPrepareForRun</CoreCompileDependsOn>
+    <CoreCompileDependsOn Condition="'$(PublishProtocol)' == 'ClickOnce' or '$(PublishProtocol)' == 'FileSystem'">$(CoreCompileDependsOn);StaticWebAssetsPrepareForRun</CoreCompileDependsOn>
   </PropertyGroup>
 
   <Target Name="AddStaticWebAssetsForClickOnce" AfterTargets="ComputeFilesToPublish" Condition="'$(PublishProtocol)' == 'ClickOnce'">
@@ -12,6 +12,15 @@
     </ComputeStaticWebAssetsTargetPaths>
     <ItemGroup>
       <ContentWithTargetPath Include="@(_ClickOnceAssetCandidate)" KeepMetadata="TargetPath" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddStaticWebAssetsForAppXBundle" BeforeTargets="PublishItemsOutputGroup" Condition="'$(PublishProtocol)' == 'FileSystem'">
+    <ComputeStaticWebAssetsTargetPaths Assets="@(StaticWebAsset)" PathPrefix="wwwroot">
+      <Output TaskParameter="AssetsWithTargetPath" ItemName="_AppXBundleAssetCandidate" />
+    </ComputeStaticWebAssetsTargetPaths>
+    <ItemGroup>
+      <ResolvedFileToPublish Include="@(_AppXBundleAssetCandidate)" RelativePath="%(_AppXBundleAssetCandidate.TargetPath)" KeepMetadata="TargetPath" />
     </ItemGroup>
   </Target>
 

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -154,11 +155,22 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 
 			// We assume the host page is always in the root of the content directory, because it's
 			// unclear there's any other use case. We can add more options later if so.
-			var contentRootDir = Path.GetDirectoryName(Path.GetFullPath(HostPage));
-			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage);
+			string appRootDir;
+			var entryAssemblyLocation = Assembly.GetEntryAssembly()?.Location;
+			if (!string.IsNullOrEmpty(entryAssemblyLocation))
+			{
+				appRootDir = Path.GetDirectoryName(entryAssemblyLocation);
+			}
+			else
+			{
+				appRootDir = Environment.CurrentDirectory;
+			}
+			var hostPageFullPath = Path.GetFullPath(Path.Combine(appRootDir, HostPage));
+			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath);
+			var hostPageRelativePath = Path.GetRelativePath(contentRootDirFullPath, hostPageFullPath);
 
-			var customFileProvider = CreateFileProvider(contentRootDir);
-			var assetFileProvider = new PhysicalFileProvider(contentRootDir);
+			var customFileProvider = CreateFileProvider(contentRootDirFullPath);
+			var assetFileProvider = new PhysicalFileProvider(contentRootDirFullPath);
 			IFileProvider fileProvider = customFileProvider == null
 				? assetFileProvider
 				: new CompositeFileProvider(customFileProvider, assetFileProvider);

--- a/src/BlazorWebView/src/Wpf/build/Microsoft.AspNetCore.Components.WebView.Wpf.targets
+++ b/src/BlazorWebView/src/Wpf/build/Microsoft.AspNetCore.Components.WebView.Wpf.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
     <StaticWebAssetProjectMode>Root</StaticWebAssetProjectMode>
-    <CoreCompileDependsOn Condition="'$(PublishProtocol)' == 'ClickOnce'">$(CoreCompileDependsOn);StaticWebAssetsPrepareForRun</CoreCompileDependsOn>
+    <CoreCompileDependsOn Condition="'$(PublishProtocol)' == 'ClickOnce' or '$(PublishProtocol)' == 'FileSystem'">$(CoreCompileDependsOn);StaticWebAssetsPrepareForRun</CoreCompileDependsOn>
   </PropertyGroup>
 
   <Target Name="AddStaticWebAssetsForClickOnce" AfterTargets="ComputeFilesToPublish" Condition="'$(PublishProtocol)' == 'ClickOnce'">
@@ -12,6 +12,15 @@
     </ComputeStaticWebAssetsTargetPaths>
     <ItemGroup>
       <ContentWithTargetPath Include="@(_ClickOnceAssetCandidate)" KeepMetadata="TargetPath" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddStaticWebAssetsForAppXBundle" BeforeTargets="PublishItemsOutputGroup" Condition="'$(PublishProtocol)' == 'FileSystem'">
+    <ComputeStaticWebAssetsTargetPaths Assets="@(StaticWebAsset)" PathPrefix="wwwroot">
+      <Output TaskParameter="AssetsWithTargetPath" ItemName="_AppXBundleAssetCandidate" />
+    </ComputeStaticWebAssetsTargetPaths>
+    <ItemGroup>
+      <ResolvedFileToPublish Include="@(_AppXBundleAssetCandidate)" RelativePath="%(_AppXBundleAssetCandidate.TargetPath)" KeepMetadata="TargetPath" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Two parts to this fix:
1. Make sure static assets are located relative to the running app (and not the current directory)
2. Update targets to ensure static assets are available prior to publish

Fixes #3275

@SteveSandersonMS / @pranavkm - can one of you review while @javiercn is out? I can gladly walk you through this change. It mostly boils down to copying logic from the existing publish target to a new target for MSIX/WAP published apps.