### PR TITLE
[Android] Fix issue drawing a Border without define the border width

### DIFF
--- a/src/Core/src/Graphics/MauiDrawable.Android.cs
+++ b/src/Core/src/Graphics/MauiDrawable.Android.cs
@@ -444,7 +444,7 @@ namespace Microsoft.Maui.Graphics
 		{
 			InitializeBorderIfNeeded();
 
-			return _shape != null && _strokeThickness > 0;
+			return _shape != null && (_stroke != null || _borderColor != null);
 		}
 
 		void InitializeBorderIfNeeded()


### PR DESCRIPTION
### Description of Change ###

Fix issue drawing a Border without define the border width on Android.

- fixes #3543 

To test, launch the Gallery and navigate to the Border page. Set the BorderThickness to zero, if the Border shape still renders, the test has passed.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No 
