### PR TITLE
[Windows] Fix issue not rendering Border if Background is null

### DIFF
--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Maui.Platform
 				return;
 
 			_borderPath.Fill = background?.ToNative();
-			_borderPath.Visibility = background != null ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
 		}
 
 		public void UpdateStroke(Paint borderBrush)


### PR DESCRIPTION
### Description of Change ###

Fix issue not rendering Border if Background is null on Windows.

- fixes #3349 

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No