### PR TITLE
Fixes AL Task error by not trying to embed default resources

### DIFF
--- a/src/Compatibility/Core/src/Compatibility-net6.csproj
+++ b/src/Compatibility/Core/src/Compatibility-net6.csproj
@@ -8,6 +8,7 @@
     <iOSRoot>iOS\</iOSRoot>
     <WindowsRoot>Windows\</WindowsRoot>
     <IsPackable>false</IsPackable>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">


### PR DESCRIPTION
This fixes:

```
C:\Program Files\Microsoft Visual Studio\2022\Main\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets(3870,5): error MSB4018: The "AL" task failed unexpectedly.
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Build.Tasks.AL.GenerateFullPathToTool()
   at Microsoft.Build.Utilities.ToolTask.ComputePathToTool()
   at Microsoft.Build.Utilities.ToolTask.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [C:\code\maui\src\Compatibility\Core\src\Compatibility-net6.csproj]
```

