### PR TITLE
Call Application.SendStart from the First Windows Create

### DIFF
--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.Controls
 
 		IAppIndexingProvider? _appIndexProvider;
 		ReadOnlyCollection<Element>? _logicalChildren;
+		bool _isStarted;
 
 		static readonly SemaphoreSlim SaveSemaphore = new SemaphoreSlim(1, 1);
 
@@ -343,6 +344,10 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendStart()
 		{
+			if (_isStarted)
+				return;
+
+			_isStarted = true;
 			OnStart();
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -221,6 +221,7 @@ namespace Microsoft.Maui.Controls
 		{
 			Created?.Invoke(this, EventArgs.Empty);
 			OnCreated();
+			Application?.SendStart();
 		}
 
 		void IWindow.Activated()

--- a/src/Controls/tests/Core.UnitTests/ApplicationTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ApplicationTests.cs
@@ -165,13 +165,41 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(window.Page, app.MainPage);
 		}
 
+		[Test]
+		public void OnStartFiresOnceFromWindowCreated()
+		{
+			var window = new Window { Page = new ContentPage() };
+			var app = new StubApp { MainWindow = window };
+			var iapp = app as IApplication;
+			var win = iapp.CreateWindow(null);
+
+			Assert.AreEqual(0, app.OnStartCount);
+			(window as IWindow).Created();
+			Assert.AreEqual(1, app.OnStartCount);
+			(window as IWindow).Created();
+			Assert.AreEqual(1, app.OnStartCount);
+
+		}
+
 		class StubApp : Application
 		{
+			public int OnStartCount { get; private set; }
+			public StubApp() : base(false)
+			{
+
+			}
+
 			public Window MainWindow { get; set; }
 
 			protected override Window CreateWindow(IActivationState activationState)
 			{
 				return MainWindow;
+			}
+
+			protected override void OnStart()
+			{
+				base.OnStart();
+				OnStartCount++;
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

`SendStart` was never wired up to the new `Window` Lifecycle events

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
