### PR TITLE
Don't fire platform navigation requests if no handler is present

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -162,6 +162,10 @@ namespace Microsoft.Maui.Controls
 
 			if (Handler == null)
 			{
+				// Just process the stack changes and exit.
+				// We don't want the `finally` block to run
+				// which is why we invoke the stack changes here and 
+				// then exit opposed to letting it reach the try block
 				processStackChanges?.Invoke();
 				return;
 			}
@@ -170,6 +174,7 @@ namespace Microsoft.Maui.Controls
 			{
 				processStackChanges?.Invoke();
 				Interlocked.Increment(ref _waitingCount);
+
 				// Wait for pending navigation tasks to finish
 				await SemaphoreSlim.WaitAsync();
 

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -160,19 +160,15 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
+			processStackChanges?.Invoke();
+
 			if (Handler == null)
 			{
-				// Just process the stack changes and exit.
-				// We don't want the `finally` block to run
-				// which is why we invoke the stack changes here and 
-				// then exit opposed to letting it reach the try block
-				processStackChanges?.Invoke();
 				return;
 			}
 
 			try
 			{
-				processStackChanges?.Invoke();
 				Interlocked.Increment(ref _waitingCount);
 
 				// Wait for pending navigation tasks to finish

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -160,6 +160,12 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
+			if (Handler == null)
+			{
+				processStackChanges?.Invoke();
+				return;
+			}
+
 			try
 			{
 				processStackChanges?.Invoke();

--- a/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
@@ -688,6 +688,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(contentPage3, navigationPage.Navigation.NavigationStack[2]);
 			navigationPage.ValidateNavigationCompleted();
 		}
+
+		[Test]
+		public async Task PushingPageBeforeSettingHandlerPropagatesAfterSettingHandler()
+		{
+			ContentPage contentPage1 = new ContentPage();
+
+			var navigationPage = new TestNavigationPage(true, setHandler: false);
+			await navigationPage.PushAsync(contentPage1);
+			(navigationPage as IView).Handler = new TestNavigationHandler();
+			var navTask = navigationPage.CurrentNavigationTask;
+			Assert.IsNotNull(navTask);
+			await navTask;
+			navigationPage.ValidateNavigationCompleted();
+		}
 	}
 
 	internal class BackButtonPage : ContentPage

--- a/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
@@ -693,10 +693,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public async Task PushingPageBeforeSettingHandlerPropagatesAfterSettingHandler()
 		{
 			ContentPage contentPage1 = new ContentPage();
-
 			var navigationPage = new TestNavigationPage(true, setHandler: false);
+
 			await navigationPage.PushAsync(contentPage1);
 			(navigationPage as IView).Handler = new TestNavigationHandler();
+
 			var navTask = navigationPage.CurrentNavigationTask;
 			Assert.IsNotNull(navTask);
 			await navTask;

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	public class TestNavigationPage : NavigationPage
 	{
-		internal TestNavigationPage(bool setforMaui, Page root = null) : base(setforMaui, root)
+		internal TestNavigationPage(bool setforMaui, Page root = null, bool setHandler = true) : base(setforMaui, root)
 		{
-			if (setforMaui)
+			if (setforMaui && setHandler)
 			{
 				base.Handler = new TestNavigationHandler();
 			}


### PR DESCRIPTION
### Description of Change ###

If no handler is present then just modify the internal children on the NavigationPage and don't fire navigation requests to the non existent handler. Once the handler is set the NavigationStack will propagate to the platform.


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
