### PR TITLE
Validate Handler Type getting assigned to View

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Controls
 					NativeView.AddView(_nativeTitleView);
 				}
 
-				_nativeTitleView.Child = (INativeViewHandler)_nativeTitleViewHandler;
+				_nativeTitleView.Child = (INativeViewHandler?)_nativeTitleViewHandler;
 			}
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 
 		new public IViewHandler? Handler
 		{
-			get => base.Handler as IViewHandler;
+			get => (IViewHandler?)base.Handler;
 			set => base.Handler = value;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.ComponentModel;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
@@ -21,7 +22,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		new public IViewHandler Handler
+		new public IViewHandler? Handler
 		{
 			get => base.Handler as IViewHandler;
 			set => base.Handler = value;
@@ -34,7 +35,7 @@ namespace Microsoft.Maui.Controls
 			IsPlatformEnabled = Handler != null;
 		}
 
-		Paint IView.Background
+		Paint? IView.Background
 		{
 			get
 			{
@@ -42,6 +43,7 @@ namespace Microsoft.Maui.Controls
 					return Background;
 				if (BackgroundColor.IsNotDefault())
 					return new SolidColorBrush(BackgroundColor);
+
 				return null;
 			}
 		}
@@ -235,6 +237,18 @@ namespace Microsoft.Maui.Controls
 
 		Thickness IView.Margin => Thickness.Zero;
 
+		IElementHandler? Maui.IElement.Handler
+		{
+			get => base.Handler;
+			set
+			{
+				if (value != null && value is not IViewHandler)
+					throw new InvalidOperationException("Handler must be of type IViewHandler");
+
+				base.Handler = value;
+			}
+		}
+
 		void NotifyShadowChanges()
 		{
 			if (Shadow != null)
@@ -254,7 +268,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		void OnShadowChanged(object sender, PropertyChangedEventArgs e)
+		void OnShadowChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			OnPropertyChanged(nameof(Shadow));
 		}

--- a/src/Controls/tests/Core.UnitTests/TestClasses/ElementHandlerStub.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/ElementHandlerStub.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class ElementHandlerStub : ElementHandler
+	{
+		public ElementHandlerStub() : base(ElementHandler.ElementMapper)
+		{
+		}
+
+		private protected override void OnConnectHandler(object nativeView)
+		{
+		}
+
+		private protected override object OnCreateNativeElement()
+		{
+			return new object();
+		}
+
+		private protected override void OnDisconnectHandler(object nativeView)
+		{
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/ViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ViewUnitTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
 using NSubstitute;
 using NUnit.Framework;
 using Rectangle = Microsoft.Maui.Graphics.Rectangle;
@@ -741,6 +742,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			view.Clip = null;
 
 			Assert.Null(view.Clip);
+		}
+
+		[Test]
+		public void AssigningElementHandlerThrowsException()
+		{
+			Maui.IElement view = new View();
+			Assert.Throws(typeof(InvalidOperationException), () => view.Handler = new ElementHandlerStub());
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This came up when converting the XCT Dialog to MAUI.  The XCT PopupDialog implements `VisualElement` but we want to use an `ElementHandler` not a `VisualElementHandler`. This led to a confusing situation where the `Handler` property was  always null. This is due to the fact that `VisualElement` shadows `Handler` and returns it as an `IViewHandler`. The fix was to change `PopupDialog` to implement `Element`. This PR adds some checks so the code will fail earlier with a useful exception. 


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
