### PR TITLE
Use GetActivity inside AlertManager to get Context

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Maui.Controls.Platform
 					return false;
 				}
 
-				return nativeView.Context.Equals(Activity);
+				return nativeView.Context.GetActivity()?.Equals(Activity) ?? false;
 			}
 
 			// This is a proxy dialog builder class to support both pre-appcompat and appcompat dialogs for Alert,


### PR DESCRIPTION
### Description of Change ###

The AlertManager compares the `Android Activity` with the `Android Context` on the created page. There's a chance this `Context` will be wrapped with a `ContextThemeWrapper` so we need to use `GetActivity` which will locate the `Activity` for the `Context`


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
