### PR TITLE
Fix keyboard navigation with modal pages

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Controls
 					NativeView.AddView(_nativeTitleView);
 				}
 
-				_nativeTitleView.Child = (INativeViewHandler)_nativeTitleViewHandler;
+				_nativeTitleView.Child = (INativeViewHandler?)_nativeTitleViewHandler;
 			}
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.ComponentModel;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
@@ -21,7 +22,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		new public IViewHandler Handler
+		new public IViewHandler? Handler
 		{
 			get => base.Handler as IViewHandler;
 			set => base.Handler = value;
@@ -34,7 +35,7 @@ namespace Microsoft.Maui.Controls
 			IsPlatformEnabled = Handler != null;
 		}
 
-		Paint IView.Background
+		Paint? IView.Background
 		{
 			get
 			{
@@ -254,7 +255,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		void OnShadowChanged(object sender, PropertyChangedEventArgs e)
+		void OnShadowChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			OnPropertyChanged(nameof(Shadow));
 		}

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -83,12 +83,36 @@ namespace Microsoft.Maui.Controls.Platform
 
 			UpdateAccessibilityImportance(CurrentPage, ImportantForAccessibility.Auto, true);
 
+			if (_navModel.Modals.Count == 0 && _rootDecorView.ChildCount > 0 && _rootDecorView.GetChildAt(0) is AView view)
+			{
+				view.ImportantForAccessibility = ImportantForAccessibility.Auto;
+
+				if (NativeVersion.IsAtLeast(26))
+					view.SetFocusable(ViewFocusability.FocusableAuto);
+
+				if (view is ViewGroup vg)
+					vg.DescendantFocusability = DescendantFocusability.BeforeDescendants;
+			}
+
 			return source.Task;
 		}
 
 		public async Task PushModalAsync(Page modal, bool animated)
 		{
 			UpdateAccessibilityImportance(CurrentPage, ImportantForAccessibility.NoHideDescendants, false);
+
+			if (_rootDecorView.ChildCount > 0 && _rootDecorView.GetChildAt(0) is AView view)
+			{
+				view.ImportantForAccessibility = ImportantForAccessibility.NoHideDescendants;
+
+				if (NativeVersion.IsAtLeast(26))
+					view.SetFocusable(ViewFocusability.NotFocusable);
+
+				// Without setting this the keyboard will still navigate to components behind the modal page
+				if (view is ViewGroup vg)
+					vg.DescendantFocusability = DescendantFocusability.BlockDescendants;
+			}
+
 
 			_navModel.PushModal(modal);
 


### PR DESCRIPTION
### Description of Change ###

In order to block keyboard navigation from reaching elements beneath the current modal page you have to block the focusability of thenview being covered. This PR also grabs the current platform root view on Android which is the more correct view to modify accessibility on than the `CurrentPage`


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
