### PR TITLE
ZIndex proof-of-concept

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ZIndexPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ZIndexPage.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.ZIndexPage"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    Title="VerticalStackLayout">
+    <ContentPage.Content>
+        <Grid x:Name="Root">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="*"></RowDefinition>
+            </Grid.RowDefinitions>
+
+            <HorizontalStackLayout>
+                <Label x:Name="CurrentZIndex" Text="0"/>
+                <Stepper x:Name="ZIndexStepper"/>
+            </HorizontalStackLayout>
+            
+        </Grid>
+    </ContentPage.Content>
+</views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ZIndexPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ZIndexPage.xaml.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Pages
+{
+	public partial class ZIndexPage 
+	{
+		public ZIndexPage()
+		{
+			InitializeComponent();
+
+			Label target = null;
+
+			for (int n = 0; n < 10; n++)
+			{
+				var label = new Label 
+				{ 
+					Text = $"This is Label {n}, z-index {n}", 
+					ZIndex = n,
+					HeightRequest = 100,
+					WidthRequest = 200,
+					HorizontalOptions = LayoutOptions.Start,
+					VerticalOptions = LayoutOptions.Start,
+					Margin = new Thickness(n * 15, n * 15, 0, 0), 
+					BackgroundColor = PickColor(n) 
+				};
+
+				Root.Add(label);
+				Root.SetRow(label, 1);
+
+				if (n == 5)
+				{
+					target = label;
+				}
+			}
+
+			CurrentZIndex.Text = $"Z-Index of Label 5: {target.ZIndex}";
+			ZIndexStepper.Value = target.ZIndex;
+			ZIndexStepper.ValueChanged += (sender, args) => {
+				target.ZIndex = (int)ZIndexStepper.Value;
+				CurrentZIndex.Text = $"Z-Index of Label 5: {target.ZIndex}";
+				target.Text = $"This is Label 5, z-index {target.ZIndex}"; 
+			};
+		}
+
+		Color[] _colors = new Color[] { 
+			Colors.Aquamarine, Colors.Orange, Colors.MediumOrchid, Colors.Red, Colors.Green, Colors.Blue
+		};
+
+		Color PickColor(int n) 
+		{ 
+			return _colors[n % _colors.Length];
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/ViewModels/LayoutsViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/LayoutsViewModel.cs
@@ -41,6 +41,9 @@ namespace Maui.Controls.Sample.ViewModels
 
 			new SectionModel(typeof(LayoutUpdatesPage), "Layout Updates",
 				"Demonstrations of updating layouts"),
+
+			new SectionModel(typeof(ZIndexPage), "Z-Index",
+				"Demonstrations of the ZIndex property"),
 		};
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -69,6 +69,24 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(ShadowProperty, value); }
 		}
 
+		internal static readonly BindableProperty ZIndexProperty =
+			BindableProperty.Create(nameof(ZIndex), typeof(int), typeof(View), default(int), 
+				propertyChanged: ZIndexPropertyChanged);
+
+		static void ZIndexPropertyChanged(BindableObject bindable, object oldValue, object newValue) 
+		{
+			if (bindable is IView view)
+			{
+				view.Handler?.Invoke(nameof(IView.ZIndex));
+			}
+		}
+
+		public int ZIndex
+		{
+			get { return (int)GetValue(ZIndexProperty); }
+			set { SetValue(ZIndexProperty, value); }
+		}
+
 		public Size DesiredSize { get; protected set; }
 
 		public void Arrange(Rectangle bounds)

--- a/src/Core/src/Core/IView.cs
+++ b/src/Core/src/Core/IView.cs
@@ -138,5 +138,10 @@ namespace Microsoft.Maui
 		/// Method that is called to invalidate the layout of this View.
 		/// </summary>
 		void InvalidateArrange();
+
+		/// <summary>
+		/// Determines the drawing order of this IView within an ILayout; higher z-indexes will draw over lower z-indexes.
+		/// </summary>
+		int ZIndex { get; }
 	}
 }

--- a/src/Core/src/Handlers/Layout/ILayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/ILayoutHandler.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Maui
 		void Clear();
 		void Insert(int index, IView view);
 		void Update(int index, IView view);
+		void UpdateZIndex(IView view);
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutExtensions.cs
+++ b/src/Core/src/Handlers/Layout/LayoutExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Maui.Handlers
+{
+	internal static class LayoutExtensions 
+	{
+		class ZIndexComparer : IComparer<IView>
+		{
+			public int Compare(IView? x, IView? y)
+			{
+				if (x == null || y == null)
+				{
+					return 0;
+				}
+
+				return x.ZIndex.CompareTo(y.ZIndex);
+			}
+		}
+
+		static ZIndexComparer s_comparer = new();
+
+		public static IView[] OrderByZIndex(this ILayout layout) 
+		{
+			var ordered = new IView[layout.Count];
+			layout.CopyTo(ordered, 0);
+			Array.Sort(ordered, s_comparer);
+			return ordered;
+		}
+		
+		public static int GetLayoutHandlerIndex(this ILayout layout, IView view) 
+		{
+			return layout.OrderByZIndex().IndexOf(view);
+		}
+	}
+}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -1,5 +1,6 @@
 using System;
 using Android.Views;
+using AView = Android.Views.View;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -36,7 +37,8 @@ namespace Microsoft.Maui.Handlers
 			NativeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
 
 			NativeView.RemoveAllViews();
-			foreach (var child in VirtualView)
+
+			foreach (var child in VirtualView.OrderByZIndex())
 			{
 				NativeView.AddView(child.ToNative(MauiContext, true));
 			}
@@ -48,7 +50,8 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.AddView(child.ToNative(MauiContext, true));
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			NativeView.AddView(child.ToNative(MauiContext, true), targetIndex);
 		}
 
 		public void Remove(IView child)
@@ -78,7 +81,8 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.AddView(child.ToNative(MauiContext, true), index);
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			NativeView.AddView(child.ToNative(MauiContext, true), targetIndex);
 		}
 
 		public void Update(int index, IView child)
@@ -88,12 +92,17 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			NativeView.RemoveViewAt(index);
-			NativeView.AddView(child.ToNative(MauiContext, true), index);
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			NativeView.AddView(child.ToNative(MauiContext, true), targetIndex);
 		}
 
-		public void UpdateZIndex(IView view) 
+		public void UpdateZIndex(IView child) 
 		{
-		
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
+			EnsureZIndexOrder(child);
 		}
 
 		protected override void DisconnectHandler(LayoutViewGroup nativeView)
@@ -101,6 +110,43 @@ namespace Microsoft.Maui.Handlers
 			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
 			Clear(nativeView);
 			base.DisconnectHandler(nativeView);
+		}
+
+		void EnsureZIndexOrder(IView child)
+		{
+			if (NativeView.ChildCount == 0)
+			{
+				return;
+			}
+
+			AView nativeChildView = child.ToNative(MauiContext!, true);
+			var currentIndex = IndexOf(NativeView, nativeChildView);
+
+			if (currentIndex == -1)
+			{
+				return;
+			}
+
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+
+			if (currentIndex != targetIndex)
+			{
+				NativeView.RemoveViewAt(currentIndex);
+				NativeView.AddView(nativeChildView, targetIndex);
+			}
+		}
+
+		int IndexOf(ViewGroup viewGroup, AView view) 
+		{
+			for (int n = 0; n < viewGroup.ChildCount; n++)
+			{
+				if (viewGroup.GetChildAt(n) == view)
+				{
+					return n;
+				}
+			}
+
+			return -1;
 		}
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -91,6 +91,11 @@ namespace Microsoft.Maui.Handlers
 			NativeView.AddView(child.ToNative(MauiContext, true), index);
 		}
 
+		public void UpdateZIndex(IView view) 
+		{
+		
+		}
+
 		protected override void DisconnectHandler(LayoutViewGroup nativeView)
 		{
 			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Standard.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Standard.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Handlers
 		public void Clear() => throw new NotImplementedException();
 		public void Insert(int index, IView view) => throw new NotImplementedException();
 		public void Update(int index, IView view) => throw new NotImplementedException();
+		public void UpdateZIndex(IView view) => throw new NotImplementedException();
 
 		protected override object CreateNativeView() => throw new NotImplementedException();
 	}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			NativeView.Children[index] = child.ToNative(MauiContext, true);
-			EnsureZIndexOrdering(child);
+			EnsureZIndexOrder(child);
 		}
 
 		public void UpdateZIndex(IView child) 
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			EnsureZIndexOrdering(child);
+			EnsureZIndexOrder(child);
 		}
 
 		protected override LayoutPanel CreateNativeView()
@@ -103,7 +103,7 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(nativeView);
 		}
 
-		void EnsureZIndexOrdering(IView child) 
+		void EnsureZIndexOrder(IView child) 
 		{
 			if (NativeView.Children.Count == 0)
 			{

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.Children.Add(child.ToNative(MauiContext, true));
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			NativeView.Children.Insert(targetIndex, child.ToNative(MauiContext, true));
 		}
 
 		public override void SetVirtualView(IView view)
@@ -27,9 +28,10 @@ namespace Microsoft.Maui.Handlers
 			NativeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
 
 			NativeView.Children.Clear();
-			foreach (var child in VirtualView)
+
+			foreach (var child in VirtualView.OrderByZIndex())
 			{
-				Add(child);
+				NativeView.Children.Add(child.ToNative(MauiContext, true));
 			}
 		}
 
@@ -55,7 +57,8 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.Children.Insert(index, child.ToNative(MauiContext, true));
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			NativeView.Children.Insert(targetIndex, child.ToNative(MauiContext, true));
 		}
 
 		public void Update(int index, IView child) 
@@ -65,6 +68,16 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			NativeView.Children[index] = child.ToNative(MauiContext, true);
+			EnsureZIndexOrdering(child);
+		}
+
+		public void UpdateZIndex(IView child) 
+		{
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
+			EnsureZIndexOrdering(child);
 		}
 
 		protected override LayoutPanel CreateNativeView()
@@ -85,9 +98,31 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(LayoutPanel nativeView)
 		{
-			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
+			// If we're being disconnected from the xplat element, then we should no longer be managing its children
 			Clear();
 			base.DisconnectHandler(nativeView);
+		}
+
+		void EnsureZIndexOrdering(IView child) 
+		{
+			if (NativeView.Children.Count == 0)
+			{
+				return;
+			}
+
+			var currentIndex = NativeView.Children.IndexOf(child.ToNative(MauiContext!, true));
+
+			if (currentIndex == -1)
+			{
+				return;
+			}
+
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			
+			if (currentIndex != targetIndex)
+			{
+				NativeView.Children.Move((uint)currentIndex, (uint)targetIndex);
+			}
 		}
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ILayoutHandler.Clear)] = MapClear,
 			[nameof(ILayoutHandler.Insert)] = MapInsert,
 			[nameof(ILayoutHandler.Update)] = MapUpdate,
+			[nameof(ILayoutHandler.UpdateZIndex)] = MapUpdateZIndex,
 		};
 
 		public LayoutHandler() : base(LayoutMapper, LayoutCommandMapper)
@@ -37,7 +38,6 @@ namespace Microsoft.Maui.Handlers
 		{
 
 		}
-
 
 		public static void MapBackground(ILayoutHandler handler, ILayout layout)
 		{
@@ -78,6 +78,14 @@ namespace Microsoft.Maui.Handlers
 			if (arg is LayoutHandlerUpdate args)
 			{
 				handler.Update(args.Index, args.View);
+			}
+		}
+
+		private static void MapUpdateZIndex(ILayoutHandler handler, ILayout layout, object? arg)
+		{
+			if (arg is IView view)
+			{
+				handler.UpdateZIndex(view);
 			}
 		}
 	}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Handlers
 			// Remove any previous children 
 			NativeView.ClearSubviews();
 
-			foreach (var child in VirtualView)
+			foreach (var child in VirtualView.OrderByZIndex())
 			{
 				NativeView.AddSubview(child.ToNative(MauiContext, true));
 			}
@@ -50,7 +50,8 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.AddSubview(child.ToNative(MauiContext, true));
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			NativeView.InsertSubview(child.ToNative(MauiContext, true), targetIndex);
 		}
 
 		public void Remove(IView child)
@@ -75,7 +76,8 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.InsertSubview(child.ToNative(MauiContext, true), index);
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			NativeView.InsertSubview(child.ToNative(MauiContext, true), targetIndex);
 		}
 
 		public void Update(int index, IView child)
@@ -86,19 +88,48 @@ namespace Microsoft.Maui.Handlers
 
 			var existing = NativeView.Subviews[index];
 			existing.RemoveFromSuperview();
-			NativeView.InsertSubview(child.ToNative(MauiContext, true), index);
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+			NativeView.InsertSubview(child.ToNative(MauiContext, true), targetIndex);
 			NativeView.SetNeedsLayout();
 		}
 
-		public void UpdateZIndex(IView view) 
+		public void UpdateZIndex(IView child) 
 		{
-			
+			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
+			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
+			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
+			EnsureZIndexOrder(child);
 		}
 
 		protected override void DisconnectHandler(LayoutView nativeView)
 		{
 			base.DisconnectHandler(nativeView);
 			nativeView.ClearSubviews();
+		}
+
+		void EnsureZIndexOrder(IView child)
+		{
+			if (NativeView.Subviews.Length == 0)
+			{
+				return;
+			}
+
+			NativeView nativeChildView = child.ToNative(MauiContext!, true);
+			var currentIndex = NativeView.Subviews.IndexOf(nativeChildView);
+
+			if (currentIndex == -1)
+			{
+				return;
+			}
+
+			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
+
+			if (currentIndex != targetIndex)
+			{
+				NativeView.Subviews.RemoveAt(currentIndex);
+				NativeView.InsertSubview(nativeChildView, targetIndex);
+			}
 		}
 	}
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -90,6 +90,11 @@ namespace Microsoft.Maui.Handlers
 			NativeView.SetNeedsLayout();
 		}
 
+		public void UpdateZIndex(IView view) 
+		{
+			
+		}
+
 		protected override void DisconnectHandler(LayoutView nativeView)
 		{
 			base.DisconnectHandler(nativeView);

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			[nameof(IView.InvalidateMeasure)] = MapInvalidateMeasure,
 			[nameof(IView.Frame)] = MapFrame,
+			[nameof(IView.ZIndex)] = MapZIndex,
 		};
 
 		bool _hasContainer;
@@ -260,6 +261,14 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFrame(IViewHandler handler, IView view, object? args)
 		{
 			MappingFrame(handler, view);
+		}
+
+		public static void MapZIndex(IViewHandler handler, IView view, object? args)
+		{
+			if (view.Parent is ILayout layout)
+			{
+				layout.Handler?.Invoke(nameof(ILayoutHandler.UpdateZIndex), view);
+			}
 		}
 	}
 }

--- a/src/Core/tests/Benchmarks/Stubs/StubBase.cs
+++ b/src/Core/tests/Benchmarks/Stubs/StubBase.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 
 		public Semantics Semantics { get; set; } = new Semantics();
 
+		public int ZIndex { get; set; }
+
 		public Size Arrange(Rectangle bounds)
 		{
 			Frame = bounds;

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Handlers\Button\*.cs" />
     <Compile Include="Handlers\Navigation\*.cs" />
     <Compile Include="Handlers\View\*.cs" />
+    <Compile Include="Handlers\Layout\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">
     <Compile Remove="**\*.Android.cs" />

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Android.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Xunit;
 using AView = Android.Views.View;
 
 namespace Microsoft.Maui.DeviceTests.Handlers.Layout
@@ -66,6 +69,28 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 				action?.Invoke();
 				nativeLayout.AssertContainsColor(color);
 			});
+		}
+
+		async Task<string> GetNativeText(AView view)
+		{
+			return await InvokeOnMainThreadAsync<string>(() => (view as TextView).Text);
+		}
+
+		async Task AssertZIndexOrder(IReadOnlyList<AView> children)
+		{
+			// Lots of ways we could compare the two lists, but dumping them both to comma-separated strings
+			// makes it easy to give the test useful output
+
+			string expected = await InvokeOnMainThreadAsync(() => {
+				return children.OrderBy(nativeView => GetNativeText(nativeView))
+					.Aggregate("", (str, nativeView) => str + (str.Length > 0 ? ", " : "") + GetNativeText(nativeView));
+			});
+
+			string actual = await InvokeOnMainThreadAsync(() => {
+				return children.Aggregate("", (str, nativeView) => str + (str.Length > 0 ? ", " : "") + GetNativeText(nativeView));
+			});
+
+			Assert.Equal(expected, actual);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Android.cs
@@ -71,9 +71,9 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			});
 		}
 
-		async Task<string> GetNativeText(AView view)
+		string GetNativeText(AView view)
 		{
-			return await InvokeOnMainThreadAsync<string>(() => (view as TextView).Text);
+			return (view as TextView).Text;
 		}
 
 		async Task AssertZIndexOrder(IReadOnlyList<AView> children)

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.Windows.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
+using Xunit;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Maui.DeviceTests.Handlers.Layout
+{
+	public partial class LayoutHandlerTests
+	{
+		string GetNativeText(UIElement view) 
+		{
+			return (view as TextBlock).Text;
+		}
+
+		double GetNativeChildCount(LayoutHandler layoutHandler)
+		{
+			return layoutHandler.NativeView.Children.Count;
+		}
+
+		double GetNativeChildCount(object nativeView)
+		{
+			return (nativeView as LayoutPanel).Children.Count;
+		}
+
+		IReadOnlyList<UIElement> GetNativeChildren(LayoutHandler layoutHandler)
+		{
+			var views = new List<UIElement>();
+
+			for (int i = 0; i < layoutHandler.NativeView.Children.Count; i++)
+			{
+				views.Add(layoutHandler.NativeView.Children[i]);
+			}
+
+			return views;
+		}
+
+		async Task AssertZIndexOrder(IReadOnlyList<UIElement> children)
+		{
+			// Lots of ways we could compare the two lists, but dumping them both to comma-separated strings
+			// makes it easy to give the test useful output
+
+			string expected = await InvokeOnMainThreadAsync(() => {
+				return children.OrderBy(nativeView => GetNativeText(nativeView))
+					.Aggregate("", (str, nativeView) => str + (str.Length > 0 ? ", " : "") + GetNativeText(nativeView));
+			});
+
+			string actual = await InvokeOnMainThreadAsync(() => {
+				return children.Aggregate("", (str, nativeView) => str + (str.Length > 0 ? ", " : "") + GetNativeText(nativeView));
+			});
+
+			Assert.Equal(expected, actual);
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -190,5 +190,147 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			Assert.Same(insertedSlider.Handler.ContainerView, children[0]);
 			Assert.Same(addedSlider.Handler.ContainerView, children[1]);
 		}
+
+		LabelStub CreateZTestLabel(int zIndex) 
+		{
+			return new LabelStub() { Text = zIndex.ToString("000"), ZIndex = zIndex };
+		}
+
+		async Task AddZTestLabels(ILayout layout, params ILabel[] labels)
+		{
+			foreach (var label in labels)
+			{
+				layout.Add(label);
+				await InitZTestLabel(label);
+			}
+		}
+
+		async Task InitZTestLabel(ILabel label) 
+		{
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = new LabelHandler();
+				InitializeViewHandler(label, handler, MauiContext);
+			});
+		}
+
+		async Task AssertZIndexOrder(LayoutHandler handler)
+		{
+			var children = await InvokeOnMainThreadAsync(() =>
+			{
+				return GetNativeChildren(handler);
+			});
+
+			await AssertZIndexOrder(children);
+		}
+
+		[Fact]
+		public async Task NativeChildrenStartInZIndexOrder()
+		{
+			var layout = new LayoutStub();
+
+			var view0 = CreateZTestLabel(zIndex: 1);
+			var view1 = CreateZTestLabel(zIndex: 0);
+
+			await AddZTestLabels(layout, view0, view1);
+
+			var handler = await CreateHandlerAsync(layout);
+			await AssertZIndexOrder(handler);
+		}
+
+		[Fact]
+		public async Task AddChildPreservesZIndexOrder()
+		{
+			var layout = new LayoutStub();
+
+			var view0 = CreateZTestLabel(zIndex: 10);
+			var view1 = CreateZTestLabel(zIndex: 20);
+
+			await AddZTestLabels(layout, view0, view1);
+
+			var handler = await CreateHandlerAsync(layout);
+
+			// Add the third item with zIndex that should put it at the beginning of the native child collection
+			var view2 = CreateZTestLabel(zIndex: 0);
+			await AddZTestLabels(layout, view2);
+
+			// The stubs won't trigger the actual handler commands, so we'll do it manually
+			await InvokeOnMainThreadAsync(() => handler.Invoke(nameof(ILayoutHandler.Add), new LayoutHandlerUpdate(2, view2)));
+
+			// Verify the views are in the correct order
+			await AssertZIndexOrder(handler);
+		}
+
+		[Fact]
+		public async Task InsertChildPreservesZIndexOrder()
+		{
+			var layout = new LayoutStub();
+
+			var view0 = CreateZTestLabel(zIndex: 10);
+			var view1 = CreateZTestLabel(zIndex: 20);
+
+			await AddZTestLabels(layout, view0, view1);
+
+			var handler = await CreateHandlerAsync(layout);
+
+			// Add the third item with zIndex that should put it at the beginning of the native child collection
+			var view2 = CreateZTestLabel(zIndex: 0);
+			await InitZTestLabel(view2);
+			layout.Insert(1, view2);
+
+			// The stubs won't trigger the actual handler commands, so we'll do it manually
+			await InvokeOnMainThreadAsync(() => handler.Invoke(nameof(ILayoutHandler.Insert), new LayoutHandlerUpdate(1, view2)));
+
+			// Verify the views are in the correct order
+			await AssertZIndexOrder(handler);
+		}
+
+		[Fact]
+		public async Task UpdateChildPreservesZIndexOrder()
+		{
+			var layout = new LayoutStub();
+
+			var view0 = CreateZTestLabel(zIndex: 10);
+			var view1 = CreateZTestLabel(zIndex: 20);
+
+			await AddZTestLabels(layout, view0, view1);
+
+			var handler = await CreateHandlerAsync(layout);
+
+			// Add the third item with zIndex that should put it at the beginning of the native child collection
+			var view2 = CreateZTestLabel(zIndex: 0);
+			await InitZTestLabel(view2);
+			layout[1] = view2;
+
+			// The stubs won't trigger the actual handler commands, so we'll do it manually
+			await InvokeOnMainThreadAsync(() => handler.Invoke(nameof(ILayoutHandler.Update), new LayoutHandlerUpdate(1, view2)));
+
+			// Verify the views are in the correct order
+			await AssertZIndexOrder(handler);
+		}
+
+		[Fact]
+		public async Task UpdateChildZindexPreservesZIndexOrder()
+		{
+			var layout = new LayoutStub();
+
+			var view0 = CreateZTestLabel(zIndex: 10);
+			var view1 = CreateZTestLabel(zIndex: 20);
+
+			await AddZTestLabels(layout, view0, view1);
+
+			var handler = await CreateHandlerAsync(layout);
+
+			// Update the z-index for view0 in a way that should move it to the end of the collection
+			view0.Text = "030";
+			view0.ZIndex = 30;
+
+			// The stubs won't trigger the actual handler commands, so we'll do it manually
+			await InvokeOnMainThreadAsync(() => view0.Handler.UpdateValue(nameof(ILabel.Text)));
+			await InvokeOnMainThreadAsync(() => handler.Invoke(nameof(ILayoutHandler.UpdateZIndex), view0));
+
+			// Verify the views are in the correct order
+			await AssertZIndexOrder(handler);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			children = await InvokeOnMainThreadAsync(() =>
 			{
+				layout[0] = button;
 				handler.Update(0, button);
 				return GetNativeChildren(handler);
 			});

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			children = await InvokeOnMainThreadAsync(() =>
 			{
+				layout.Insert(0, button);
 				handler.Insert(0, button);
 				return GetNativeChildren(handler);
 			});
@@ -182,6 +183,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			children = await InvokeOnMainThreadAsync(() =>
 			{
+				layout.Insert(0, insertedSlider);
 				handler.Insert(0, insertedSlider);
 				return GetNativeChildren(handler);
 			});

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using ObjCRuntime;
 using UIKit;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 {
@@ -60,6 +62,28 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 				action?.Invoke();
 				nativeLayout.AssertContainsColor(color);
 			});
+		}
+
+		async Task<string> GetNativeText(UIView view)
+		{
+			return await InvokeOnMainThreadAsync<string>(() => (view as UILabel).Text);
+		}
+
+		async Task AssertZIndexOrder(IReadOnlyList<UIView> children)
+		{
+			// Lots of ways we could compare the two lists, but dumping them both to comma-separated strings
+			// makes it easy to give the test useful output
+
+			string expected = await InvokeOnMainThreadAsync(() => {
+				return children.OrderBy(nativeView => GetNativeText(nativeView))
+					.Aggregate("", (str, nativeView) => str + (str.Length > 0 ? ", " : "") + GetNativeText(nativeView));
+			});
+
+			string actual = await InvokeOnMainThreadAsync(() => {
+				return children.Aggregate("", (str, nativeView) => str + (str.Length > 0 ? ", " : "") + GetNativeText(nativeView));
+			});
+
+			Assert.Equal(expected, actual);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.iOS.cs
@@ -64,9 +64,9 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			});
 		}
 
-		async Task<string> GetNativeText(UIView view)
+		string GetNativeText(UIView view)
 		{
-			return await InvokeOnMainThreadAsync<string>(() => (view as UILabel).Text);
+			return (view as UILabel).Text;
 		}
 
 		async Task AssertZIndexOrder(IReadOnlyList<UIView> children)

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Semantics Semantics { get; set; } = new Semantics();
 
+		public int ZIndex { get; set; }
+
 		public Size Arrange(Rectangle bounds)
 		{
 			Frame = bounds;

--- a/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
@@ -1,0 +1,236 @@
+﻿using Microsoft.Maui.Primitives;
+using NSubstitute;
+using Xunit;
+using Microsoft.Maui.Handlers;
+using System.Collections.Generic;
+using Microsoft.Maui.Graphics;
+using System.Collections;
+
+namespace Microsoft.Maui.UnitTests.Layouts
+{
+	[Category(TestCategory.Core, TestCategory.Layout)]
+	public class ZIndexTests
+	{
+		// These tests need a real collection to work with; we can't reasonably use a substitute here
+		class FakeLayout : ILayout, IList<IView>
+		{
+			#region IView stuff
+
+			public string AutomationId { get; }
+			public FlowDirection FlowDirection { get; }
+			public LayoutAlignment HorizontalLayoutAlignment { get; }
+			public LayoutAlignment VerticalLayoutAlignment { get; }
+			public Semantics Semantics { get; }
+			public IShape Clip { get; }
+			public IShadow Shadow { get; }
+			public bool IsEnabled { get; }
+			public Visibility Visibility { get; }
+			public double Opacity { get; }
+			public Paint Background { get; }
+			public Rectangle Frame { get; set; }
+			public double Width { get; }
+			public double MinimumWidth { get; }
+			public double MaximumWidth { get; }
+			public double Height { get; }
+			public double MinimumHeight { get; }
+			public double MaximumHeight { get; }
+			public Thickness Margin { get; }
+			public IViewHandler Handler { get; set; }
+			public Size DesiredSize { get; }
+			public int ZIndex { get; }
+			public IElement Parent { get; }
+			public double TranslationX { get; }
+			public double TranslationY { get; }
+			public double Scale { get; }
+			public double ScaleX { get; }
+			public double ScaleY { get; }
+			public double Rotation { get; }
+			public double RotationX { get; }
+			public double RotationY { get; }
+			public double AnchorX { get; }
+			public double AnchorY { get; }
+			public bool IgnoreSafeArea { get; }
+			public Thickness Padding { get; }
+			IElementHandler IElement.Handler { get; set; }
+			
+			public void InvalidateArrange()
+			{
+				throw new System.NotImplementedException();
+			}
+
+			public void InvalidateMeasure()
+			{
+				throw new System.NotImplementedException();
+			}
+
+			public Size Measure(double widthConstraint, double heightConstraint)
+			{
+				throw new System.NotImplementedException();
+			}
+
+			#endregion
+
+			#region IList stuff
+
+			IList<IView> _views = new List<IView>();
+
+			public int Count => _views.Count;
+
+			public bool IsReadOnly => _views.IsReadOnly;
+
+			public IView this[int index] { get => _views[index]; set => _views[index] = value; }
+
+			public void Add(IView item)
+			{
+				_views.Add(item);
+			}
+
+			public Size Arrange(Rectangle bounds)
+			{
+				throw new System.NotImplementedException();
+			}
+
+			public void Clear()
+			{
+				_views.Clear();
+			}
+
+			public bool Contains(IView item)
+			{
+				return _views.Contains(item);
+			}
+
+			public void CopyTo(IView[] array, int arrayIndex)
+			{
+				_views.CopyTo(array, arrayIndex);
+			}
+
+			public Size CrossPlatformArrange(Rectangle bounds)
+			{
+				throw new System.NotImplementedException();
+			}
+
+			public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+			{
+				throw new System.NotImplementedException();
+			}
+
+			public IEnumerator<IView> GetEnumerator()
+			{
+				return _views.GetEnumerator();
+			}
+
+			public int IndexOf(IView item)
+			{
+				return _views.IndexOf(item);
+			}
+
+			public void Insert(int index, IView item)
+			{
+				_views.Insert(index, item);
+			}
+
+			public bool Remove(IView item)
+			{
+				return _views.Remove(item);
+			}
+
+			public void RemoveAt(int index)
+			{
+				_views.RemoveAt(index);
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return ((IEnumerable)_views).GetEnumerator();
+			}
+
+			#endregion
+		}
+
+		static IView CreateTestView(int zIndex = 0)
+		{
+			var view = Substitute.For<IView>();
+			view.ZIndex.Returns(zIndex);
+			return view;
+		}
+
+		[Fact]
+		public void LayoutHandlerIndexFollowsZOrder() 
+		{
+			var layout = new FakeLayout();
+			var view0 = CreateTestView(zIndex: 10);
+			var view1 = CreateTestView(zIndex: 0);
+			layout.Add(view0);
+			layout.Add(view1);
+
+			Assert.Equal(0, layout.GetLayoutHandlerIndex(view1));
+			Assert.Equal(1, layout.GetLayoutHandlerIndex(view0));
+		}
+
+		[Fact]
+		public void LayoutHandlerIndexFollowsAddOrderWhenZIndexesAreEqual()
+		{
+			var layout = new FakeLayout();
+			var view0 = CreateTestView(zIndex: 0);
+			var view1 = CreateTestView(zIndex: 10);
+			var view2 = CreateTestView(zIndex: 10);
+			var view3 = CreateTestView(zIndex: 100);
+			
+			layout.Add(view0);
+			layout.Add(view1);
+			layout.Add(view2);
+			layout.Add(view3);
+
+			Assert.Equal(0, layout.GetLayoutHandlerIndex(view0));
+			Assert.Equal(1, layout.GetLayoutHandlerIndex(view1));
+			Assert.Equal(2, layout.GetLayoutHandlerIndex(view2));
+			Assert.Equal(3, layout.GetLayoutHandlerIndex(view3));
+		}
+
+		[Fact]
+		public void ItemsOrderByZIndex()
+		{
+			var layout = new FakeLayout();
+			var view0 = CreateTestView(zIndex: 10);
+			var view1 = CreateTestView(zIndex: 0);
+
+			layout.Add(view0);
+			layout.Add(view1);
+
+			var zordered = layout.OrderByZIndex();
+			Assert.Equal(view1, zordered[0]);
+			Assert.Equal(view0, zordered[1]);
+		}
+
+		[Fact]
+		public void ZIndexUpdatePreservesAddOrderForEqualZIndexes()
+		{
+			var layout = new FakeLayout();
+			var view0 = CreateTestView(zIndex: 0);
+			var view1 = CreateTestView(zIndex: 5);
+			var view2 = CreateTestView(zIndex: 5);
+			var view3 = CreateTestView(zIndex: 10);
+
+			layout.Add(view0);
+			layout.Add(view1);
+			layout.Add(view2);
+			layout.Add(view3);
+
+			var zordered = layout.OrderByZIndex();
+			Assert.Equal(view0, zordered[0]);
+			Assert.Equal(view1, zordered[1]);
+			Assert.Equal(view2, zordered[2]);
+			Assert.Equal(view3, zordered[3]);
+
+			// Fake an update
+			view3.ZIndex.Returns(5);
+
+			zordered = layout.OrderByZIndex();
+			Assert.Equal(view0, zordered[0]);
+			Assert.Equal(view1, zordered[1]);
+			Assert.Equal(view2, zordered[2]);
+			Assert.Equal(view3, zordered[3]);
+		}
+	}
+}

--- a/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/ViewStub.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Maui.UnitTests
 
 		public double AnchorY { get; set; }
 
+		public int ZIndex { get; set; }
+
 		public Size Arrange(Rectangle bounds) => Size.Zero;
 
 		public void InvalidateArrange() { }


### PR DESCRIPTION
Adds an `int ZIndex` property to `IView`.

The Controls implementation defaults it to zero. The z-index is honored in the layout handlers - items with a higher z-index are drawn above items with a lower z-index. The ordering happens in the handler/native view layer - the order of items in the Core layouts is preserved. 

If the z-index is unused, the original behavior (items are drawn in the order they are added to the layout) is preserved. 

Z-indexes can be negative, and will behave accordingly (lower values will be draw below higher values). When z-indexes of elements are equal, they will be drawn in the order they were added to the layout.

This _only_ affects the ordering of the elements in the layouts; this implementation _does not_ map to any native properties (e.g., Elevation on Android or CALayer.zorder on iOS). Alternate handler mappings can use those properties if desired.

