### PR TITLE
[Windows] Fix ImageButton Background

### DIFF
--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
@@ -44,6 +44,11 @@ namespace Microsoft.Maui.Handlers
 			SourceLoader.Reset();
 		}
 
+		public static void MapBackground(IImageButtonHandler handler, IImageButton imageButton)
+		{
+			(handler.NativeView as Button)?.UpdateBackground(imageButton);
+		}
+
 		void OnSetImageSource(ImageSource? nativeImageSource)
 		{
 			NativeView.UpdateImageSource(nativeImageSource);

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -22,7 +22,12 @@ namespace Microsoft.Maui.Handlers
 	public partial class ImageButtonHandler : IImageButtonHandler
 	{
 		public static IPropertyMapper<IImage, IImageHandler> ImageMapper = new PropertyMapper<IImage, IImageHandler>(ImageHandler.Mapper);
-		public static IPropertyMapper<IImageButton, IImageButtonHandler> Mapper = new PropertyMapper<IImageButton, IImageButtonHandler>(ImageMapper);
+		public static IPropertyMapper<IImageButton, IImageButtonHandler> Mapper = new PropertyMapper<IImageButton, IImageButtonHandler>(ImageMapper)
+		{
+#if WINDOWS
+			[nameof(IImageButton.Background)] = MapBackground,
+#endif
+		};
 
 		ImageSourcePartLoader? _imageSourcePartLoader;
 		public ImageSourcePartLoader SourceLoader =>


### PR DESCRIPTION
### Description of Change ###

Set the same behavior that we already had in the Button with the different VisualStates (Hover, etc). 

Before
![imagebutton-win-01](https://user-images.githubusercontent.com/6755973/144584050-ac7ea81e-64e7-4e11-9855-d358da24843e.gif)

After
![imagebutton-win-02](https://user-images.githubusercontent.com/6755973/144584053-3f0cece8-0a46-4f77-9a73-ec81b9f1770c.gif)

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No