### PR TITLE
Fix warnings from #3519

### DIFF
--- a/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
+++ b/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui.Controls
 		{
 			// We have to rebuild this every time because the StackLayout contents
 			// and values may have changed
+			_gridLayout?.Clear();
 			_gridLayout = Gridify(_stackLayout);
 			_manager = new GridLayoutManager(_gridLayout);
 
@@ -41,7 +42,7 @@ namespace Microsoft.Maui.Controls
 
 		IGridLayout ConvertToRows(StackLayout stackLayout)
 		{
-			GridLayout grid = new GridLayout
+			GridLayout grid = new AndExpandGrid
 			{
 				ColumnDefinitions = new ColumnDefinitionCollection { new ColumnDefinition { Width = GridLength.Star } },
 				RowDefinitions = new RowDefinitionCollection()
@@ -69,7 +70,7 @@ namespace Microsoft.Maui.Controls
 
 		IGridLayout ConvertToColumns(StackLayout stackLayout)
 		{
-			GridLayout grid = new GridLayout
+			GridLayout grid = new AndExpandGrid
 			{
 				RowDefinitions = new RowDefinitionCollection { new RowDefinition { Height = GridLength.Star } },
 				ColumnDefinitions = new ColumnDefinitionCollection()
@@ -93,6 +94,14 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return grid;
+		}
+
+		class AndExpandGrid : GridLayout
+		{
+			protected override void OnChildAdded(Element child)
+			{
+				// We don't want to actually re-parent the stuff we add to this			
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes the "X is already a child of Y" warnings when using the legacy AndExpand layout options (as reported in #3519).