### PR TITLE
Return a blank Label when LoadTemplate is null to prevent Hot Reload crashes

### DIFF
--- a/src/Controls/src/Core/ElementTemplate.cs
+++ b/src/Controls/src/Core/ElementTemplate.cs
@@ -60,7 +60,13 @@ namespace Microsoft.Maui.Controls
 		public object CreateContent()
 		{
 			if (LoadTemplate == null)
-				throw new InvalidOperationException("LoadTemplate should not be null");
+			{
+				// Returning a Label here instead of throwing an exception because HotReload may temporarily be in state
+				// where the user is creating a template; this keeps everything else (which expects a result from CreateContent)
+				// from crashing during that time. 
+				return new Label(); 
+			}
+
 			if (this is DataTemplateSelector)
 				throw new InvalidOperationException("Cannot call CreateContent directly on a DataTemplateSelector");
 

--- a/src/Controls/tests/Core.UnitTests/DataTemplateTests.cs
+++ b/src/Controls/tests/Core.UnitTests/DataTemplateTests.cs
@@ -118,5 +118,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 			Assert.That(() => template.CreateContent(), Throws.InstanceOf<InvalidOperationException>());
 		}
+
+		[Test]
+		public void HotReloadTransitionDoesNotCrash() 
+		{
+			// Hot Reload may need to create a template while the content portion isn't ready yet
+			// We need to make sure that a call to CreateContent during that time doesn't crash
+			var template = new DataTemplate();
+			Assert.DoesNotThrow(() => template.CreateContent());
+		}
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/LoaderTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/LoaderTests.cs
@@ -506,7 +506,8 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			var page = new ContentPage();
 			page.LoadFromXaml(xaml);
 			var template = page.Resources["datatemplate"] as Maui.Controls.DataTemplate;
-			Assert.Throws<InvalidOperationException>(() => template.CreateContent());
+
+			Assert.NotNull(template.CreateContent());
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes #2526

The parameterless constructor Hot Reload is using for DataTemplate doesn't set a LoadTemplate Func, so when anything tries to load up and run CreateContent it crashes. 

This change just returns a blank Label rather than throwing an exception, so any Hot Reloaded content can display without crashing.