### PR TITLE
Window extend toolbar

### DIFF
--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -26,7 +26,11 @@ namespace Maui.Controls.Sample
 
 		// Must not use MainPage for multi-window
 		protected override Window CreateWindow(IActivationState activationState)
-			=> new Window(Services.GetRequiredService<Page>());
+		{
+			var window = new Window(Services.GetRequiredService<Page>());
+			window.Title = ".NET MAUI Samples Gallery";
+			return window;
+		}
 
 		public IServiceProvider Services { get; }
 	}

--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Windows.cs
@@ -28,7 +28,10 @@ namespace Microsoft.Maui.Controls
 			if (NavigationRootManager.RootView is not MauiNavigationView)
 				return;
 
-			var commandBar = NavigationRootManager.GetCommandBar();
+			if (Handler.NativeView is not WindowHeader wh)
+				return;
+
+			var commandBar = wh.CommandBar;
 
 			if (commandBar == null)
 			{

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Maui.Controls.Platform
 
 				if (popping)
 				{
+					previousPage
+						.FindMauiContext()
+						?.GetNavigationRootManager()
+						?.Disconnect(previousPage);
+
 					previousPage.Handler = null;
 					// Un-parent the page; otherwise the Resources Changed Listeners won't be unhooked and the 
 					// page will leak 
@@ -89,6 +94,11 @@ namespace Microsoft.Maui.Controls.Platform
 					var windowManager = modalContext.GetNavigationRootManager();
 					windowManager.Connect(newPage);
 					Container.Children.Add(windowManager.RootView);
+
+					previousPage
+						.FindMauiContext()
+						?.GetNavigationRootManager()
+						?.UpdateAppTitleBar(false);
 				}
 				else
 				{
@@ -97,6 +107,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 					if(!Container.Children.Contains(windowManager.RootView))
 						Container.Children.Add(windowManager.RootView);
+
+					windowManager.UpdateAppTitleBar(true);
 				}
 
 				completedCallback?.Invoke();

--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Maui.Controls.Platform
 		public static void UpdateIsVisible(this WindowHeader nativeToolbar, Toolbar toolbar)
 		{
 			nativeToolbar.Visibility = (toolbar.IsVisible) ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
-			if (nativeToolbar.NavigationView?.HeaderContent != null)
-				nativeToolbar.NavigationView.HeaderContent.Visibility = nativeToolbar.Visibility;
 		}
 
 		public static void UpdateTitleIcon(this WindowHeader nativeToolbar, Toolbar toolbar)
@@ -35,14 +33,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void UpdateBackButton(this WindowHeader nativeToolbar, Toolbar toolbar)
 		{
-			if (nativeToolbar.NavigationView == null)
-				return;
-
 			nativeToolbar
-				.NavigationView
 				.IsBackButtonVisible = (toolbar.BackButtonVisible) ? NavigationViewBackButtonVisible.Visible : NavigationViewBackButtonVisible.Collapsed;
 
-			nativeToolbar.NavigationView.IsBackEnabled = toolbar.BackButtonVisible;
 			toolbar.Handler?.UpdateValue(nameof(Toolbar.BarBackground));
 		}
 
@@ -53,15 +46,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void UpdateBarBackground(this WindowHeader nativeToolbar, Toolbar toolbar)
 		{
-			if (nativeToolbar.NavigationView == null)
-				return;
+			var barBackground = toolbar.BarBackground?.ToBrush() ?? 
+				toolbar.BarBackgroundColor?.ToNative();
 
-
-			var barBackground = toolbar.BarBackground;
-			var barBackgroundColor = toolbar.BarBackgroundColor;
-
-			nativeToolbar.NavigationView.UpdateBarBackgroundBrush(
-				   barBackground?.ToBrush() ?? barBackgroundColor?.ToNative());
+			nativeToolbar.Background = barBackground;
 		}
 
 		public static void UpdateTitleView(this WindowHeader nativeToolbar, Toolbar toolbar)

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Windows.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Windows.cs
@@ -9,17 +9,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override WindowHeader CreateNativeElement()
 		{
-			if (NavigationRootManager?.RootView is NavigationView nv &&
-				nv.Header is WindowHeader windowHeader)
-			{
-				windowHeader.NavigationView = nv as MauiNavigationView;
-				return windowHeader;
-			}
-
-			return new WindowHeader()
-			{
-				NavigationView = NavigationRootManager?.RootView as MauiNavigationView
-			};
+			return new WindowHeader();
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -150,5 +150,40 @@ namespace Microsoft.Maui.Handlers
 
 			appbarLayout.AddView(nativeToolBar, 0);
 		}
+
+
+		internal static void MapToolbar(IElementHandler handler, IToolbarElement te)
+		{
+			if (te.Toolbar == null)
+				return;
+
+			var rootManager = handler.MauiContext?.GetNavigationRootManager();
+			rootManager?.SetToolbarElement(te);
+
+			var nativeView = handler.NativeView as View;
+			if (nativeView == null)
+				return;
+
+			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+			var appbarLayout = nativeView.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar) ??
+				rootManager?.RootView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar);
+
+			var nativeToolBar = te.Toolbar?.ToNative(handler.MauiContext, true);
+
+			if (appbarLayout == null)
+			{
+				return;
+			}
+
+			if (appbarLayout.ChildCount > 0 &&
+				appbarLayout.GetChildAt(0) == nativeToolBar)
+			{
+				return;
+			}
+
+			appbarLayout.AddView(nativeToolBar, 0);
+		}
+
+
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -161,11 +161,9 @@ namespace Microsoft.Maui.Handlers
 			rootManager?.SetToolbarElement(te);
 
 			var nativeView = handler.NativeView as View;
-			if (nativeView == null)
-				return;
 
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			var appbarLayout = nativeView.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar) ??
+			var appbarLayout = nativeView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar) ??
 				rootManager?.RootView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar);
 
 			var nativeToolBar = te.Toolbar?.ToNative(handler.MauiContext, true);

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System;
 using NativeView = Microsoft.UI.Xaml.FrameworkElement;
 
 namespace Microsoft.Maui.Handlers
@@ -59,7 +60,24 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapAnchorY(IViewHandler handler, IView view) 
 		{ 
-			handler.GetWrappedNativeView()?.UpdateTransformation(view); 
+			handler.GetWrappedNativeView()?.UpdateTransformation(view);
+		}
+
+		public static void MapToolbar(IViewHandler handler, IView view)
+		{
+			if (view is IToolbarElement tb)
+				MapToolbar(handler, tb);
+		}
+
+		internal static void MapToolbar(IElementHandler handler, IToolbarElement toolbarElement)
+		{
+			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(handler.MauiContext)} null");
+
+			if (toolbarElement.Toolbar != null)
+			{
+				var toolBar = toolbarElement.Toolbar.ToNative(handler.MauiContext, true);
+				handler.MauiContext.GetNavigationRootManager().SetToolbar(toolBar);
+			}
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IView.AnchorX)] = MapAnchorX,
 			[nameof(IView.AnchorY)] = MapAnchorY,
 			[nameof(IViewHandler.ContainerView)] = MapContainerView,
-#if ANDROID
+#if ANDROID || WINDOWS
 			[nameof(IToolbarElement.Toolbar)] = MapToolbar,
 #endif
 		};

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -7,23 +7,6 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class WindowHandler : ElementHandler<IWindow, Activity>
 	{
-		void UpdateToolbar()
-		{
-			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-
-			var appbarLayout = NativeView.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar);
-
-			if (appbarLayout == null || VirtualView is not IToolbarElement te)
-				return;
-
-			var nativeToolBar = te.Toolbar?.ToNative(MauiContext, true);
-			if (nativeToolBar == null || nativeToolBar.Parent == nativeToolBar)
-				return;
-
-			appbarLayout.AddView(nativeToolBar, 0);
-
-		}
-
 		public static void MapTitle(WindowHandler handler, IWindow window) { }
 
 		public static void MapContent(WindowHandler handler, IWindow window)
@@ -39,7 +22,8 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapToolbar(WindowHandler handler, IWindow view)
 		{
-			handler.UpdateToolbar();
+			if (view is IToolbarElement tb)
+				ViewHandler.MapToolbar(handler, tb);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Maui.Handlers
 			if (_rootPanel == null)
 			{
 				// TODO WINUI should this be some other known constant or via some mechanism? Or done differently?
-				//MauiWinUIApplication.Current.Resources.TryGetValue("MauiRootContainerStyle", out object? style);
+				MauiWinUIApplication.Current.Resources.TryGetValue("MauiRootContainerStyle", out object? style);
 
 				_rootPanel = new RootPanel
 				{
-					//Style = style as UI.Xaml.Style
+					Style = style as UI.Xaml.Style
 				};
 			}
 

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -1,4 +1,6 @@
 using System;
+using Microsoft.UI.Xaml.Controls;
+using WThickness = Microsoft.UI.Xaml.Thickness;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -13,21 +15,22 @@ namespace Microsoft.Maui.Handlers
 			if (_rootPanel == null)
 			{
 				// TODO WINUI should this be some other known constant or via some mechanism? Or done differently?
-				MauiWinUIApplication.Current.Resources.TryGetValue("MauiRootContainerStyle", out object? style);
+				//MauiWinUIApplication.Current.Resources.TryGetValue("MauiRootContainerStyle", out object? style);
 
 				_rootPanel = new RootPanel
 				{
-					Style = style as UI.Xaml.Style
+					//Style = style as UI.Xaml.Style
 				};
 			}
-						
+
+			nativeView.ExtendsContentIntoTitleBar = true;
 			nativeView.Content = _rootPanel;
 		}
 
 		protected override void DisconnectHandler(UI.Xaml.Window nativeView)
 		{
 			var windowManager = MauiContext?.GetNavigationRootManager();
-			windowManager?.Connect(VirtualView.Content);
+			windowManager?.Disconnect(VirtualView.Content);
 
 			_rootPanel?.Children?.Clear();
 			nativeView.Content = null;
@@ -41,26 +44,24 @@ namespace Microsoft.Maui.Handlers
 		public static void MapContent(WindowHandler handler, IWindow window)
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-
 			var windowManager = handler.MauiContext.GetNavigationRootManager();
 			windowManager.Connect(handler.VirtualView.Content);
-			handler?._rootPanel?.Children?.Clear();
+			var rootPanel = handler._rootPanel;
 
-			handler?._rootPanel?.Children?.Add(windowManager.RootView);
+			if (rootPanel == null)
+				return;
 
-			if (window.VisualDiagnosticsOverlay != null && handler?._rootPanel != null)
+			rootPanel.Children.Clear();
+			rootPanel.Children.Add(windowManager.RootView);
+
+			if (window.VisualDiagnosticsOverlay != null)
 				window.VisualDiagnosticsOverlay.Initialize();
 		}
 
 		public static void MapToolbar(WindowHandler handler, IWindow view)
 		{
-			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(handler.MauiContext)} null");
-
-			if (view is IToolbarElement tb && tb.Toolbar != null)
-			{
-				_ = tb.Toolbar.ToNative(handler.MauiContext);
-			}
+			if (view is IToolbarElement tb)
+				ViewHandler.MapToolbar(handler, tb);
 		}
-
 	}
 }

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -83,9 +83,6 @@ namespace Microsoft.Maui.Platform
 			_navigationRootView.SetWindowTitle(title);
 		}
 
-		internal CommandBar? GetCommandBar() =>
-			_windowHeader?.CommandBar;
-
 		internal void SetToolbar(FrameworkElement toolBar)
 		{
 			_windowHeader = toolBar as WindowHeader;

--- a/src/Core/src/Platform/Windows/NavigationRootView.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootView.cs
@@ -1,0 +1,141 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation;
+using WThickness = Microsoft.UI.Xaml.Thickness;
+
+namespace Microsoft.Maui.Platform
+{
+
+	public partial class NavigationRootView : ContentControl
+	{
+		public NavigationRootView()
+		{
+
+		}
+
+		public Image? AppFontIcon { get; private set; }
+		public TextBlock? AppTitle { get; private set; }
+		public MauiNavigationView? NavigationViewControl { get; private set; }
+		public FrameworkElement? AppTitleBar { get; private set; } 
+		public event TypedEventHandler<NavigationView, NavigationViewBackRequestedEventArgs>? BackRequested;
+		bool _hasTitleBarImage = false;
+		internal event EventHandler? OnApplyTemplateFinished;
+		string? _windowTitle;
+
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();			
+			NavigationViewControl = (MauiNavigationView)GetTemplateChild("NavigationViewControl");
+			AppTitleBar = (FrameworkElement)GetTemplateChild("AppTitleBar");
+			AppFontIcon = (Image)GetTemplateChild("AppFontIcon");
+			AppTitle = (TextBlock)GetTemplateChild("AppTitle");
+
+			NavigationViewControl.DisplayModeChanged += OnNavigationViewControlDisplayModeChanged;
+			NavigationViewControl.BackRequested += OnNavigationViewBackRequested;
+
+			OnApplyTemplateFinished?.Invoke(this, EventArgs.Empty);
+
+			UpdateAppTitleBarMargins();
+			NavigationViewControl.RegisterPropertyChangedCallback(NavigationView.IsBackButtonVisibleProperty, AppBarNavigationIconsChanged);
+			NavigationViewControl.RegisterPropertyChangedCallback(NavigationView.IsPaneToggleButtonVisibleProperty, AppBarNavigationIconsChanged);
+
+			AppFontIcon.ImageOpened += OnImageOpened;
+			AppFontIcon.ImageFailed += OnImageFailed;
+			SetWindowTitle(_windowTitle);
+		}
+
+		void OnNavigationViewBackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args) =>
+			BackRequested?.Invoke(sender, args);
+
+		void OnNavigationViewControlDisplayModeChanged(NavigationView sender, NavigationViewDisplayModeChangedEventArgs args)
+		{
+			UpdateAppTitleBarMargins();
+		}
+
+		void AppBarNavigationIconsChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			UpdateAppTitleBarMargins();
+		}
+
+		void OnImageOpened(object sender, RoutedEventArgs e)
+		{
+			_hasTitleBarImage = true;
+			UpdateAppTitleBarMargins();
+		}
+
+		void OnImageFailed(object sender, ExceptionRoutedEventArgs e)
+		{
+			_hasTitleBarImage = false;
+			UpdateAppTitleBarMargins();
+		}
+
+		internal void SetWindowTitle(string? title)
+		{
+			_windowTitle = title;
+			if (AppTitle != null)
+				AppTitle.Text = title;
+		}
+
+		void UpdateAppTitleBarMargins()
+		{
+			if (NavigationViewControl == null)
+				return;
+
+			if (AppTitleBar == null)
+				return;
+
+			const int topIndent = 16;
+			const int expandedIndent = 48;
+			int minimalIndent = 0;
+
+			// TODO: Once we implement Left pane navigation we'll probably need to adjust these calculations a bit
+			if (!NavigationViewControl.IsBackButtonVisible.Equals(NavigationViewBackButtonVisible.Collapsed))
+			{
+				minimalIndent += 48;
+			}
+
+			if (NavigationViewControl.IsPaneToggleButtonVisible)
+			{
+				minimalIndent += 48;
+			}
+
+			WThickness currMargin = AppTitleBar.Margin;
+
+			// Set the TitleBar margin dependent on NavigationView display mode
+			if (NavigationViewControl.PaneDisplayMode == NavigationViewPaneDisplayMode.Top)
+			{
+				AppTitleBar.Margin = new WThickness(topIndent, currMargin.Top, currMargin.Right, currMargin.Bottom);
+			}
+			else if (NavigationViewControl.DisplayMode == NavigationViewDisplayMode.Minimal)
+			{
+				AppTitleBar.Margin = new WThickness(minimalIndent, currMargin.Top, currMargin.Right, currMargin.Bottom);
+			}
+			else
+			{
+				AppTitleBar.Margin = new WThickness(expandedIndent, currMargin.Top, currMargin.Right, currMargin.Bottom);
+			}
+						
+			// If the AppIcon loads correctly then we set a margin for the text from the image
+			if (_hasTitleBarImage)
+			{
+				if(AppTitle != null)
+					AppTitle.Margin = new WThickness(12, 0, 0, 0);
+
+				if(AppFontIcon != null)
+					AppFontIcon.Visibility = UI.Xaml.Visibility.Visible;
+			}
+			else
+			{
+				// If there is no AppIcon then we hide the image and the layout already
+				// has a margin set
+
+				if (AppTitle != null)
+					AppTitle.Margin = new WThickness(0);
+
+				if (AppFontIcon != null)
+					AppFontIcon.Visibility = UI.Xaml.Visibility.Collapsed;
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/Styles/NavigationRootViewStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/NavigationRootViewStyle.xaml
@@ -1,0 +1,59 @@
+<ResourceDictionary
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:maui="using:Microsoft.Maui.Platform">
+
+    <Style TargetType="maui:NavigationRootView">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="maui:NavigationRootView">
+                    <Page Margin="0" Padding="0">
+                        <Page.Resources>
+                            <!--This top margin is the height of the custom TitleBar-->
+                            <Thickness x:Key="NavigationViewContentMargin">0,48,0,0</Thickness>
+                            
+                            <!-- 
+                            This is the margin around the NavigationView.Header. By default WinUI will set a 
+                            margin on the left when the backbutton appears, but our backbutton is in the
+                            AppTitle so we don't need/want the title to offset
+                            -->
+                            
+                            <Thickness x:Key="NavigationViewMinimalHeaderMargin">0,0,0,0</Thickness>
+
+                            <!-- This removes a one pixel spacing between the AppBarTitle and the NavigationViews top edge -->
+                            <Thickness x:Key="NavigationViewMinimalContentGridBorderThickness">0,0,0,0</Thickness>
+                        </Page.Resources>
+                        <Grid x:Name="RootGrid" RowSpacing="0" ColumnSpacing="0" Margin="0" Padding="0">
+                            <Border x:Name="AppTitleBar"
+                                VerticalAlignment="Top"
+                                Height="48"
+                                Canvas.ZIndex="1" 
+                                Margin="0,0,0,0">
+                                <StackPanel Orientation="Horizontal" Margin="12, 0, 0, 0">
+                                    <Image 
+                                        x:Name="AppFontIcon"
+                                        HorizontalAlignment="Left" 
+                                        VerticalAlignment="Center"
+                                        Source="Assets/Square44x44Logo.png" 
+                                        Width="16" 
+                                        Height="16"/>
+                                    <TextBlock 
+                                        x:Name="AppTitle"
+                                        VerticalAlignment="Center"
+                                        Style="{StaticResource CaptionTextBlockStyle}" />
+                                </StackPanel>
+                            </Border>
+                            <maui:MauiNavigationView 
+                                    x:Name="NavigationViewControl"
+                                    IsTitleBarAutoPaddingEnabled="False"
+                                    Canvas.ZIndex="0">
+                                <ContentPresenter></ContentPresenter>
+                            </maui:MauiNavigationView>
+                        </Grid>
+                    </Page>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary> 

--- a/src/Core/src/Platform/Windows/Styles/Resources.xaml
+++ b/src/Core/src/Platform/Windows/Styles/Resources.xaml
@@ -19,7 +19,6 @@
     <uwp:ColorConverter x:Key="ColorConverter" />
     
     <Style x:Key="MauiRootContainerStyle" TargetType="Grid">
-        <!--<Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />-->
 	</Style>
 
 </ResourceDictionary>

--- a/src/Core/src/Platform/Windows/Styles/Resources.xaml
+++ b/src/Core/src/Platform/Windows/Styles/Resources.xaml
@@ -11,14 +11,15 @@
         <ResourceDictionary Source="MauiComboBoxStyle.xaml" />
         <ResourceDictionary Source="MauiSliderStyle.xaml" />
         <ResourceDictionary Source="MauiStepperStyle.xaml" />
+        <ResourceDictionary Source="NavigationRootViewStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <x:Boolean x:Key="MicrosoftMauiCoreIncluded">true</x:Boolean>
 
     <uwp:ColorConverter x:Key="ColorConverter" />
     
-    <Style x:Key="MauiRootContainerStyle" TargetType="Panel">
-		<Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+    <Style x:Key="MauiRootContainerStyle" TargetType="Grid">
+        <!--<Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />-->
 	</Style>
 
 </ResourceDictionary>

--- a/src/Core/src/Platform/Windows/Styles/Resources.xaml
+++ b/src/Core/src/Platform/Windows/Styles/Resources.xaml
@@ -17,8 +17,8 @@
     <x:Boolean x:Key="MicrosoftMauiCoreIncluded">true</x:Boolean>
 
     <uwp:ColorConverter x:Key="ColorConverter" />
-    
-    <Style x:Key="MauiRootContainerStyle" TargetType="Grid">
+
+    <Style x:Key="MauiRootContainerStyle" TargetType="Panel">
 	</Style>
 
 </ResourceDictionary>

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -4,8 +4,16 @@ namespace Microsoft.Maui.Platform
 {
 	public static class WindowExtensions
 	{
-		public static void UpdateTitle(this UI.Xaml.Window nativeWindow, IWindow window) =>
+		public static void UpdateTitle(this UI.Xaml.Window nativeWindow, IWindow window)
+		{
 			nativeWindow.Title = window.Title;
+
+			var rootManager = window.Handler?.MauiContext?.GetNavigationRootManager();
+			if(rootManager != null)
+			{
+				rootManager.SetWindowTitle(window.Title);
+			}
+		}
 
 		public static IWindow? GetWindow(this UI.Xaml.Window nativeWindow)
 		{

--- a/src/Core/src/Platform/Windows/WindowHeader.xaml.cs
+++ b/src/Core/src/Platform/Windows/WindowHeader.xaml.cs
@@ -18,24 +18,30 @@ namespace Microsoft.Maui.Platform
 {
 	public partial class WindowHeader
 	{
-		internal TranslateTransform? ClipGeometryTransform { get; private set; }
-		internal RectangleGeometry? LayoutRootClip { get; private set; }
-		internal Grid? LayoutRoot { get; private set; }
+		public static readonly DependencyProperty IsBackButtonVisibleProperty
+			= DependencyProperty.Register(nameof(IsBackButtonVisible), typeof(NavigationViewBackButtonVisible), typeof(WindowHeader), 
+				new PropertyMetadata(default(NavigationViewBackButtonVisible), OnIsBackButtonVisibleChanged));
+
+		static void OnIsBackButtonVisibleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+		}
+
+		//internal TranslateTransform? ClipGeometryTransform { get; private set; }
+		//internal RectangleGeometry? LayoutRootClip { get; private set; }
+		//internal Grid? LayoutRoot { get; private set; }
 
 		public WindowHeader()
 		{
 			InitializeComponent();
 		}
 
-		internal MauiNavigationView? NavigationView { get; set; }
-
-		protected override void OnApplyTemplate()
-		{
-			base.OnApplyTemplate();
-			ClipGeometryTransform = (TranslateTransform)GetTemplateChild("ClipGeometryTransform");
-			LayoutRoot = (Grid)GetTemplateChild("LayoutRoot");
-			LayoutRootClip = LayoutRoot.Clip;
-		}
+		//protected override void OnApplyTemplate()
+		//{
+		//	base.OnApplyTemplate();
+		//	ClipGeometryTransform = (TranslateTransform)GetTemplateChild("ClipGeometryTransform");
+		//	LayoutRoot = (Grid)GetTemplateChild("LayoutRoot");
+		//	LayoutRootClip = LayoutRoot.Clip;
+		//}
 
 		internal string? Title
 		{
@@ -71,5 +77,11 @@ namespace Microsoft.Maui.Platform
 		internal WGrid ContentGrid => contentGrid;
 
 		internal Border TextBlockBorder => textBlockBorder;
+
+		public NavigationViewBackButtonVisible IsBackButtonVisible
+		{
+			get => (NavigationViewBackButtonVisible)GetValue(IsBackButtonVisibleProperty);
+			set => SetValue(IsBackButtonVisibleProperty, value);
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/WindowHeader.xaml.cs
+++ b/src/Core/src/Platform/Windows/WindowHeader.xaml.cs
@@ -20,28 +20,12 @@ namespace Microsoft.Maui.Platform
 	{
 		public static readonly DependencyProperty IsBackButtonVisibleProperty
 			= DependencyProperty.Register(nameof(IsBackButtonVisible), typeof(NavigationViewBackButtonVisible), typeof(WindowHeader), 
-				new PropertyMetadata(default(NavigationViewBackButtonVisible), OnIsBackButtonVisibleChanged));
-
-		static void OnIsBackButtonVisibleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-		{
-		}
-
-		//internal TranslateTransform? ClipGeometryTransform { get; private set; }
-		//internal RectangleGeometry? LayoutRootClip { get; private set; }
-		//internal Grid? LayoutRoot { get; private set; }
+				null);
 
 		public WindowHeader()
 		{
 			InitializeComponent();
 		}
-
-		//protected override void OnApplyTemplate()
-		//{
-		//	base.OnApplyTemplate();
-		//	ClipGeometryTransform = (TranslateTransform)GetTemplateChild("ClipGeometryTransform");
-		//	LayoutRoot = (Grid)GetTemplateChild("LayoutRoot");
-		//	LayoutRootClip = LayoutRoot.Clip;
-		//}
 
 		internal string? Title
 		{


### PR DESCRIPTION
### Description of Change ###

This PR leverages the [AppTitleBar customizations ](https://docs.microsoft.com/en-us/windows/apps/design/shell/title-bar) for WinUI. 

This PR does nothing to improve the story of FlyoutPage and TabbedPage. The purpose of this work is to fix up the basic window chrome for a .NET MAUI WinUI application. Once this is merged I will build on that to fix FlyoutPage/TabbedPage

Open Questions we can resolve here or in other PRs

1) Currently there's no way to change the background color of the BackButton. We have an API `IconColorProperty` that isn't wired up on XF but on iOS/Android that just colors the icon. If you look at the photos app it sets the background to blue

2) Currently there's no way to set the background color on the AppTitleBar. Should we tie this into the API here? https://github.com/dotnet/maui/pull/2049

3) I'm lukewarm on the height of the AppTitleBar. If you look at the Photos app it looks like it uses a reduced size for the backbutton 

![image](https://user-images.githubusercontent.com/5375137/145092795-c84371af-fac9-4efe-ad29-66b1b73bfbfc.png)

The default size for the NavigationView is 48 px

## Examples

### Basic View with NavigationBar colored purple

<img width="927" alt="image" src="https://user-images.githubusercontent.com/5375137/145088153-1f3de724-ce6a-4ef5-970c-aaf69f9f8703.png">

### Basic View with NavigationBar colored purple with BackButton Visible

<img width="927" alt="image" src="https://user-images.githubusercontent.com/5375137/145088212-4b077720-9090-4dd4-8968-78656638c6dc.png">


#### Toggle BackButton off

<img width="927" alt="image" src="https://user-images.githubusercontent.com/5375137/145088406-19bc958d-2d86-4a72-9f7f-28f4aa7c2c7e.png">

#### Toggle NavigationBar visibility

<img width="927" alt="image" src="https://user-images.githubusercontent.com/5375137/145088552-62cfbd6a-f7de-4e61-9994-0e69ce6264e3.png">

