### PR TITLE
[p11] iOS: Load fonts from filename instead of NSData in CGDataProvider

### DIFF
--- a/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.iOS.cs
@@ -14,14 +14,25 @@ namespace Microsoft.Maui
 		{
 			try
 			{
-				if (font.ResourceStream == null)
-					throw new InvalidOperationException("ResourceStream was null.");
+				CGFont? cgFont;
 
-				var data = NSData.FromStream(font.ResourceStream);
-				if (data == null)
-					throw new InvalidOperationException("Unable to load font stream data.");
-				var provider = new CGDataProvider(data);
-				var cgFont = CGFont.CreateFromProvider(provider);
+				if (font.ResourceStream == null)
+				{
+					if (!System.IO.File.Exists(font.FontName))
+						throw new InvalidOperationException("ResourceStream was null.");
+
+					var provider = new CGDataProvider(font.FontName);
+					cgFont = CGFont.CreateFromProvider(provider);
+				}
+				else
+				{
+					var data = NSData.FromStream(font.ResourceStream);
+					if (data == null)
+						throw new InvalidOperationException("Unable to load font stream data.");
+					var provider = new CGDataProvider(data);
+					cgFont = CGFont.CreateFromProvider(provider);
+				}
+				
 				if (cgFont == null)
 					throw new InvalidOperationException("Unable to load font from the stream.");
 

--- a/src/Core/src/Fonts/FontRegistrar.cs
+++ b/src/Core/src/Fonts/FontRegistrar.cs
@@ -64,6 +64,18 @@ namespace Microsoft.Maui
 			return _fontLookupCache[font] = null;
 		}
 
+		string? LoadFileSystemFont(string cacheKey, string filename, string? alias)
+		{
+			var font = new EmbeddedFont { FontName = filename };
+
+			if (_fontLoader == null)
+				throw new InvalidOperationException("Font loader was not set on the font registrar.");
+
+			var result = _fontLoader.LoadFont(font);
+
+			return _fontLookupCache[cacheKey] = result;
+		}
+
 		string? LoadEmbeddedFont(string cacheKey, string filename, string? alias, Stream stream)
 		{
 			var font = new EmbeddedFont { FontName = filename, ResourceStream = stream };


### PR DESCRIPTION
Instead of loading font files into an NSData object via a .NET managed stream, load them by filename via the CGDataProvider directly (no need to marshal the file byte data).

This also mitigates the issue addressed in https://github.com/dotnet/runtime/issues/61153 for the specific instance encountered by loading fonts this way.

