### PR TITLE
Close stream instead of dispose and fix unit test

### DIFF
--- a/src/Core/src/ImageSources/Android/Glide/PassThroughModelLoader.cs
+++ b/src/Core/src/ImageSources/Android/Glide/PassThroughModelLoader.cs
@@ -4,6 +4,7 @@ using Bumptech.Glide.Load;
 using Bumptech.Glide.Load.Data;
 using Bumptech.Glide.Load.Model;
 using Bumptech.Glide.Signature;
+using Java.IO;
 
 namespace Microsoft.Maui.BumptechGlide
 {
@@ -32,8 +33,17 @@ namespace Microsoft.Maui.BumptechGlide
 
 			public void Cancel() { }
 
-			public void Cleanup() =>
-				_model?.Dispose();
+			public void Cleanup()
+			{
+				if (_model is InputStream inputStream)
+				{
+					try
+					{
+						inputStream.Close();
+					}
+					catch (IOException) { }
+				}
+			}
 
 			public void LoadData(Priority priority, IDataFetcherDataCallback callback) =>
 				callback.OnDataReady(_model);

--- a/src/Core/tests/DeviceTests/Services/ImageSource/ImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/ImageSourceServiceTests.Android.cs
@@ -140,17 +140,13 @@ namespace Microsoft.Maui.DeviceTests
 			result2.Dispose();
 		}
 
-		static async Task<bool> TryCollectFile(string bitmapFile)
+		async Task<bool> TryCollectFile(string bitmapFile)
 		{
 			var collected = false;
 
 			for (var i = 0; i < GCCollectRetries && !collected; i++)
 			{
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-				await Task.Delay(10);
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
+				await WaitForGC();
 
 				try
 				{

--- a/src/Core/tests/DeviceTests/TestBase.cs
+++ b/src/Core/tests/DeviceTests/TestBase.cs
@@ -18,5 +18,14 @@ namespace Microsoft.Maui.DeviceTests
 
 		public Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> func) =>
 			TestDispatcher.Current.DispatchAsync(func);
+
+		protected async Task WaitForGC()
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			await Task.Delay(10);
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
 	}
 }

--- a/src/TestUtils/src/DeviceTests/RepeatAttribute.cs
+++ b/src/TestUtils/src/DeviceTests/RepeatAttribute.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	/// <summary>	
+	/// Usage Example
+	/// [Theory]
+	/// [Repeat(100)]
+	/// public async Task TheSameImageSourceReturnsTheSameBitmap(int _)
+	/// </summary>
+	public sealed class RepeatAttribute : Xunit.Sdk.DataAttribute
+	{
+		private readonly int count;
+
+		public RepeatAttribute(int count)
+		{
+			if (count < 1)
+			{
+				throw new System.ArgumentOutOfRangeException(
+					paramName: nameof(count),
+					message: "Repeat count must be greater than 0."
+					);
+			}
+			this.count = count;
+		}
+
+		public override System.Collections.Generic.IEnumerable<object[]> GetData(System.Reflection.MethodInfo testMethod)
+		{
+			foreach (var iterationNumber in Enumerable.Range(start: 1, count: this.count))
+			{
+				yield return new object[] { iterationNumber };
+			}
+		}
+	}
+}

--- a/src/TestUtils/src/DeviceTests/RepeatAttribute.cs
+++ b/src/TestUtils/src/DeviceTests/RepeatAttribute.cs
@@ -12,25 +12,18 @@ namespace Microsoft.Maui.DeviceTests
 	/// [Repeat(100)]
 	/// public async Task TheSameImageSourceReturnsTheSameBitmap(int _)
 	/// </summary>
-	public sealed class RepeatAttribute : Xunit.Sdk.DataAttribute
+	public sealed class RepeatAttribute : DataAttribute
 	{
-		private readonly int count;
+		readonly int _count;
 
 		public RepeatAttribute(int count)
 		{
-			if (count < 1)
-			{
-				throw new System.ArgumentOutOfRangeException(
-					paramName: nameof(count),
-					message: "Repeat count must be greater than 0."
-					);
-			}
-			this.count = count;
+			this._count = count;
 		}
 
-		public override System.Collections.Generic.IEnumerable<object[]> GetData(System.Reflection.MethodInfo testMethod)
+		public override IEnumerable<object[]> GetData(MethodInfo testMethod)
 		{
-			foreach (var iterationNumber in Enumerable.Range(start: 1, count: this.count))
+			foreach (var iterationNumber in Enumerable.Range(start: 1, count: this._count))
 			{
 				yield return new object[] { iterationNumber };
 			}


### PR DESCRIPTION
### Description of Change ###

https://github.com/dotnet/maui/pull/3671 broke our `Core.DeviceTests`

- Inside our `DataFetcher` code we were just disposing on Cleanup but this doesn't really do anything useful. It just disconnects the managed peer from the unmanaged peer.  This code changes that to close the model if it's an InputStream. The only other type here that we use is a `FontImageSourceModel` that doesn't have any resources that need to be cleaned up
- It looks like the use of a RequestBuilder causes the cached `Bitmap` to survive a bit longer so this adds some additional code that tries harder to collect and wait
- The exception thrown from retrieving a no longer cached image is no longer wrapped inside of an `ExecutionExceptionEngine` exception
- Added a RepeatAttribute for xUnit

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
