### PR TITLE
Clip layouts to bounds

### DIFF
--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
@@ -56,6 +56,23 @@
     <MauiSplashScreen Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Pages\Controls\SwipeViewGalleries\" />
+    <MauiXaml Update="Pages\Layouts\ClippingPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <Compile Update="Pages\Layouts\ClippingPage.xaml.cs">
+      <DependentUpon>ClippingPage.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <MauiXaml Update="Pages\Compatibility\AndExpandPage.xaml">
+      <Generator></Generator>
+    </MauiXaml>
+    
+  </ItemGroup>
+
   <Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\..\BlazorWebView\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.targets" />
 
 </Project>

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ClippingPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ClippingPage.xaml
@@ -1,0 +1,54 @@
+﻿<views:BasePage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.ClippingPage"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+    Title="Clipping" Background="Orange">
+    <views:BasePage.Content>
+
+        <VerticalStackLayout Spacing="5">
+
+            <Label Text="Not clipping" x:Name="Status" Margin="10"/>
+
+            <Button GridLayout.ColumnSpan="2" HorizontalOptions="Center" Margin="5" 
+                    Text="Toggle clipping on horizontal stack layouts" x:Name="ToggleClip"/>
+            
+            <Grid WidthRequest="400" HeightRequest="200">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="0.5*"/>
+                    <ColumnDefinition Width="0.5*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackLayout Orientation="Horizontal" x:Name="Layout1">
+                    <Button Text="1" Margin="1" HeightRequest="50"/>
+                    <Button Text="2" Margin="1" HeightRequest="50"/>
+                    <Button Text="3" Margin="1" HeightRequest="50"/>
+                    <Button Text="4" Margin="1" HeightRequest="50"/>
+                    <Button Text="5" Margin="1" HeightRequest="50"/>
+                    <Button Text="6" Margin="1" HeightRequest="50"/>
+                    <Button Text="7" Margin="1" HeightRequest="50"/>
+                    <Button Text="8" Margin="1" HeightRequest="50"/>
+                </StackLayout>
+                <BoxView GridLayout.Column="1" Background="Red" Opacity="0.5"/>
+            </Grid>
+
+            <HorizontalStackLayout Background="LightBlue" WidthRequest="100" Padding="10" x:Name="Layout2">
+
+                <Button Text="Hey" WidthRequest="50" HeightRequest="50" Background="Purple"/>
+                <Button Text="Hey" WidthRequest="50" HeightRequest="50" Background="Purple"/>
+                <Button Text="Hey" WidthRequest="50" HeightRequest="50" Background="Purple"/>
+                <Button Text="Hey" WidthRequest="50" HeightRequest="50" Background="Purple"/>
+
+            </HorizontalStackLayout>
+
+            <HorizontalStackLayout Background="LightBlue" HeightRequest="30" Padding="3" x:Name="Layout3">
+
+                <Image Source="coffee.png" WidthRequest="50" HeightRequest="50" />
+                <Image Source="coffee.png" WidthRequest="50" HeightRequest="50" Margin="0,20,0,0" />
+
+            </HorizontalStackLayout>
+
+        </VerticalStackLayout>
+
+    </views:BasePage.Content>
+</views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ClippingPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ClippingPage.xaml.cs
@@ -1,0 +1,19 @@
+﻿namespace Maui.Controls.Sample.Pages
+{
+	public partial class ClippingPage
+	{
+		public ClippingPage()
+		{
+			InitializeComponent();
+
+			ToggleClip.Clicked += (sender, args) =>
+			{
+				Layout1.IsClippedToBounds = !Layout1.IsClippedToBounds;
+				Layout2.IsClippedToBounds = !Layout2.IsClippedToBounds;
+				Layout3.IsClippedToBounds = !Layout3.IsClippedToBounds;
+
+				Status.Text = Layout1.IsClippedToBounds ? "Clipping" : "Not clipping";
+			};
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/ViewModels/LayoutsViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/LayoutsViewModel.cs
@@ -9,9 +9,6 @@ namespace Maui.Controls.Sample.ViewModels
 	{
 		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
-			new SectionModel(typeof(ClippingPage), "Clipping",
-				"Layouts clip"),
-
 			new SectionModel(typeof(AbsoluteLayoutPage), "AbsoluteLayout",
 				"An AbsoluteLayout is used to position and size children using explicit values. The position is specified by the upper-left corner of the child relative to the upper-left corner of the AbsoluteLayout, in device-independent units."),
 
@@ -48,7 +45,8 @@ namespace Maui.Controls.Sample.ViewModels
 			new SectionModel(typeof(ZIndexPage), "Z-Index",
 				"Demonstrations of the ZIndex property"),
 
-			
+			new SectionModel(typeof(ClippingPage), "Clipping",
+				"Demonstrations of layout clipping"),
 		};
 	}
 }

--- a/src/Controls/samples/Controls.Sample/ViewModels/LayoutsViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/LayoutsViewModel.cs
@@ -9,6 +9,9 @@ namespace Maui.Controls.Sample.ViewModels
 	{
 		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
+			new SectionModel(typeof(ClippingPage), "Clipping",
+				"Layouts clip"),
+
 			new SectionModel(typeof(AbsoluteLayoutPage), "AbsoluteLayout",
 				"An AbsoluteLayout is used to position and size children using explicit values. The position is specified by the upper-left corner of the child relative to the upper-left corner of the AbsoluteLayout, in device-independent units."),
 
@@ -44,6 +47,8 @@ namespace Maui.Controls.Sample.ViewModels
 
 			new SectionModel(typeof(ZIndexPage), "Z-Index",
 				"Demonstrations of the ZIndex property"),
+
+			
 		};
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout.Impl.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Maui.Controls.Compatibility
 		bool ICollection<IView>.IsReadOnly => ((ICollection<IView>)_children).IsReadOnly;
 		public IView this[int index] { get => _children[index]; set => _children[index] = (T)value; }
 
+		bool Maui.ILayout.ClipsToBounds => IsClippedToBounds;
+
 		void ICollection<IView>.Add(IView child)
 		{
 			if (child is T view)

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -65,7 +65,8 @@ namespace Microsoft.Maui.Controls.Compatibility
 	public abstract class Layout : View, ILayout, ILayoutController, IPaddingElement, IView, IVisualTreeElement
 	{
 		public static readonly BindableProperty IsClippedToBoundsProperty =
-			BindableProperty.Create(nameof(IsClippedToBounds), typeof(bool), typeof(Layout), false);
+			BindableProperty.Create(nameof(IsClippedToBounds), typeof(bool), typeof(Layout), false, 
+				propertyChanged: IsClippedToBoundsPropertyChanged);
 
 		public static readonly BindableProperty CascadeInputTransparentProperty =
 			BindableProperty.Create(nameof(CascadeInputTransparent), typeof(bool), typeof(Layout), true);
@@ -107,6 +108,14 @@ namespace Microsoft.Maui.Controls.Compatibility
 		Thickness IPaddingElement.PaddingDefaultValueCreator() => default(Thickness);
 
 		void IPaddingElement.OnPaddingPropertyChanged(Thickness oldValue, Thickness newValue) => InvalidateLayout();
+
+		static void IsClippedToBoundsPropertyChanged(BindableObject bindableObject, object oldValue, object newValue) 
+		{
+			if (bindableObject is IView view)
+			{
+				view.Handler?.UpdateValue(nameof(Maui.ILayout.ClipsToBounds));
+			}
+		}
 
 		internal ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -60,6 +60,26 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		public static readonly BindableProperty IsClippedToBoundsProperty =
+			BindableProperty.Create(nameof(IsClippedToBounds), typeof(bool), typeof(Layout), false,
+				propertyChanged: IsClippedToBoundsPropertyChanged);
+
+		public bool IsClippedToBounds
+		{
+			get => (bool)GetValue(IsClippedToBoundsProperty);
+			set => SetValue(IsClippedToBoundsProperty, value);
+		}
+
+		static void IsClippedToBoundsPropertyChanged(BindableObject bindableObject, object oldValue, object newValue)
+		{
+			if (bindableObject is IView view)
+			{
+				view.Handler?.UpdateValue(nameof(Maui.ILayout.ClipsToBounds));
+			}
+		}
+
+		bool Maui.ILayout.ClipsToBounds => IsClippedToBounds;
+
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
 		public Thickness Padding
@@ -69,7 +89,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		public bool IgnoreSafeArea { get; set; }
-
+		
 		protected abstract ILayoutManager CreateLayoutManager();
 
 		public IEnumerator<IView> GetEnumerator() => _children.GetEnumerator();

--- a/src/Core/src/Core/ILayout.cs
+++ b/src/Core/src/Core/ILayout.cs
@@ -22,5 +22,10 @@ namespace Microsoft.Maui
 		/// <param name="bounds">The bounds in which the ILayout's children should be arranged.</param>
 		/// <returns>The actual size of the arranged ILayout.</returns>
 		Size CrossPlatformArrange(Rectangle bounds);
+
+		/// <summary>
+		/// Specifies whether the ILayout clips its content to its boundaries.
+		/// </summary>
+		bool ClipsToBounds { get; }
 	}
 }

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.Android.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Maui.Handlers
 				CrossPlatformArrange = VirtualView.CrossPlatformArrange
 			};
 
+			viewGroup.SetClipChildren(false);
+
 			return viewGroup;
 		}
 

--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -18,6 +18,13 @@ namespace Microsoft.Maui.Handlers
 			handler.GetWrappedNativeView()?.UpdateBackground(label);
 		}
 
+		public static void MapOpacity(LabelHandler handler, ILabel label)
+		{
+			handler.UpdateValue(nameof(IViewHandler.ContainerView));
+			handler.NativeView.UpdateOpacity(label);
+			handler.GetWrappedNativeView()?.UpdateOpacity(label);
+		}
+
 		public static void MapText(LabelHandler handler, ILabel label) =>
 			handler.NativeView?.UpdateText(label);
 

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Handlers
 		{
 #if WINDOWS || __IOS__
 			[nameof(ILabel.Background)] = MapBackground,
+			[nameof(ILabel.Opacity)] = MapOpacity,
 #endif
 			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(ITextStyle.Font)] = MapFont,

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -1,10 +1,10 @@
 #nullable enable
 #if __IOS__ || MACCATALYST
-using NativeView = UIKit.UIView;
+using NativeView = Microsoft.Maui.Platform.LayoutView;
 #elif __ANDROID__
-using NativeView = Android.Views.View;
+using NativeView = Microsoft.Maui.Platform.LayoutViewGroup;
 #elif WINDOWS
-using NativeView = Microsoft.UI.Xaml.FrameworkElement;
+using NativeView = Microsoft.Maui.Platform.LayoutPanel;
 #elif NETSTANDARD
 using NativeView = System.Object;
 #endif
@@ -15,7 +15,8 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<ILayout, ILayoutHandler> LayoutMapper = new PropertyMapper<ILayout, ILayoutHandler>(ViewMapper)
 		{
-			[nameof(ILayout.Background)] = MapBackground
+			[nameof(ILayout.Background)] = MapBackground,
+			[nameof(ILayout.ClipsToBounds)] = MapClipsToBounds,
 		};
 
 		public static CommandMapper<ILayout, ILayoutHandler> LayoutCommandMapper = new(ViewCommandMapper)
@@ -42,6 +43,11 @@ namespace Microsoft.Maui.Handlers
 		public static void MapBackground(ILayoutHandler handler, ILayout layout)
 		{
 			((NativeView?)handler.NativeView)?.UpdateBackground(layout);
+		}
+
+		public static void MapClipsToBounds(ILayoutHandler handler, ILayout layout)
+		{
+			 ((NativeView?)handler.NativeView)?.UpdateClipsToBounds(layout);
 		}
 
 		public static void MapAdd(ILayoutHandler handler, ILayout layout, object? arg)

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -54,22 +54,5 @@ namespace Microsoft.Maui.Handlers
 			else
 				oldParent?.Children.Add(NativeView);
 		}
-
-		static double AdjustForExplicitSize(double externalConstraint, double explicitValue)
-		{
-			// Even with an explicit value specified, Windows will limit the size of the control to 
-			// the size of the parent's explicit size. Since we want our controls to get their
-			// explicit sizes regardless (and possibly exceed the size of their layouts), we need
-			// to measure them at _at least_ their explicit size.
-			
-			if (double.IsNaN(explicitValue))
-			{
-				// NaN for an explicit height/width on Windows means "unspecified", so we just use the external value
-				return externalConstraint;
-			}
-
-			// If the control's explicit height/width is larger than the containers, use the control's value
-			return Math.Max(externalConstraint, explicitValue);
-		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -52,6 +53,16 @@ namespace Microsoft.Maui.Handlers
 				oldParent?.Children.Insert(idx, NativeView);
 			else
 				oldParent?.Children.Add(NativeView);
+		}
+
+		static double AdjustForExplicitSize(double externalConstraint, double explicitValue)
+		{
+			if (double.IsNaN(explicitValue))
+			{
+				return externalConstraint;
+			}
+
+			return Math.Max(externalConstraint, explicitValue);
 		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -57,11 +57,18 @@ namespace Microsoft.Maui.Handlers
 
 		static double AdjustForExplicitSize(double externalConstraint, double explicitValue)
 		{
+			// Even with an explicit value specified, Windows will limit the size of the control to 
+			// the size of the parent's explicit size. Since we want our controls to get their
+			// explicit sizes regardless (and possibly exceed the size of their layouts), we need
+			// to measure them at _at least_ their explicit size.
+			
 			if (double.IsNaN(explicitValue))
 			{
+				// NaN for an explicit height/width on Windows means "unspecified", so we just use the external value
 				return externalConstraint;
 			}
 
+			// If the control's explicit height/width is larger than the containers, use the control's value
 			return Math.Max(externalConstraint, explicitValue);
 		}
 	}

--- a/src/Core/src/Handlers/ViewHandlerExtensions.Windows.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Windows.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using System;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui
 {
@@ -13,6 +14,9 @@ namespace Microsoft.Maui
 
 			if (widthConstraint < 0 || heightConstraint < 0)
 				return Size.Zero;
+
+			widthConstraint = AdjustForExplicitSize(widthConstraint, nativeView.Width);
+			heightConstraint = AdjustForExplicitSize(heightConstraint, nativeView.Height);
 
 			var measureConstraint = new global::Windows.Foundation.Size(widthConstraint, heightConstraint);
 
@@ -34,6 +38,23 @@ namespace Microsoft.Maui
 			nativeView.Arrange(new global::Windows.Foundation.Rect(rect.X, rect.Y, rect.Width, rect.Height));
 
 			viewHandler.Invoke(nameof(IView.Frame), rect);
+		}
+
+		static double AdjustForExplicitSize(double externalConstraint, double explicitValue)
+		{
+			// Even with an explicit value specified, Windows will limit the size of the control to 
+			// the size of the parent's explicit size. Since we want our controls to get their
+			// explicit sizes regardless (and possibly exceed the size of their layouts), we need
+			// to measure them at _at least_ their explicit size.
+
+			if (double.IsNaN(explicitValue))
+			{
+				// NaN for an explicit height/width on Windows means "unspecified", so we just use the external value
+				return externalConstraint;
+			}
+
+			// If the control's explicit height/width is larger than the containers, use the control's value
+			return Math.Max(externalConstraint, explicitValue);
 		}
 	}
 }

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Layouts
 				stackWidth = ArrangeRightToLeft(height, left, top, Stack.Spacing, Stack);
 			}
 
-			var actual = new Size(height, stackWidth);
+			var actual = new Size(stackWidth, height);
 
 			return actual.AdjustForFill(bounds, Stack);
 		}

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -5,15 +5,16 @@ using Android.Util;
 using Android.Views;
 using Rectangle = Microsoft.Maui.Graphics.Rectangle;
 using Size = Microsoft.Maui.Graphics.Size;
+using ARect = Android.Graphics.Rect;
 
 namespace Microsoft.Maui.Platform
 {
 	public class LayoutViewGroup : ViewGroup
 	{
+		readonly ARect _clipRect = new();
+
 		public LayoutViewGroup(Context context) : base(context)
 		{
-			//Maui layouts should not impose clipping on their children
-			SetClipChildren(false);
 		}
 
 		public LayoutViewGroup(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
@@ -31,6 +32,8 @@ namespace Microsoft.Maui.Platform
 		public LayoutViewGroup(Context context, IAttributeSet attrs, int defStyleAttr, int defStyleRes) : base(context, attrs, defStyleAttr, defStyleRes)
 		{
 		}
+
+		public bool ClipsToBounds { get; set; }
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{
@@ -72,6 +75,17 @@ namespace Microsoft.Maui.Platform
 				deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
 
 			CrossPlatformArrange(destination);
+
+			if (ClipsToBounds)
+			{
+				_clipRect.Right = r - l;
+				_clipRect.Bottom = b - t;
+				ClipBounds = _clipRect;
+			}
+			else
+			{
+				ClipBounds = null;
+			}
 		}
 
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }

--- a/src/Core/src/Platform/Android/LayoutViewGroupExtensions.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroupExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Maui.Platform
+{
+	public static class LayoutViewGroupExtensions
+	{
+		public static void UpdateClipsToBounds(this LayoutViewGroup layoutViewGroup, ILayout layout)
+		{
+			layoutViewGroup.ClipsToBounds = layout.ClipsToBounds;
+			layoutViewGroup.RequestLayout();
+		}
+	}
+}

--- a/src/Core/src/Platform/Standard/ViewExtensions.cs
+++ b/src/Core/src/Platform/Standard/ViewExtensions.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateBackground(this object nativeView, IView view) { }
 
+		public static void UpdateClipsToBounds(this object nativeView, IView view) { }
+
 		public static void UpdateAutomationId(this object nativeView, IView view) { }
 
 		public static void UpdateClip(this object nativeView, IView view) { }

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -2,6 +2,9 @@
 using System;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using WSize = global::Windows.Foundation.Size;
+using WRect = global::Windows.Foundation.Rect;
 
 namespace Microsoft.Maui.Platform
 {
@@ -10,7 +13,9 @@ namespace Microsoft.Maui.Platform
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
 		internal Func<Rectangle, Size>? CrossPlatformArrange { get; set; }
 
-		protected override global::Windows.Foundation.Size MeasureOverride(global::Windows.Foundation.Size availableSize)
+		public bool ClipsToBounds { get; set; }
+
+		protected override WSize MeasureOverride(WSize availableSize)
 		{
 			if (CrossPlatformMeasure == null)
 			{
@@ -25,10 +30,10 @@ namespace Microsoft.Maui.Platform
 			width = crossPlatformSize.Width;
 			height = crossPlatformSize.Height;
 
-			return new global::Windows.Foundation.Size(width, height);
+			return new WSize(width, height);
 		}
 
-		protected override global::Windows.Foundation.Size ArrangeOverride(global::Windows.Foundation.Size finalSize)
+		protected override WSize ArrangeOverride(WSize finalSize)
 		{
 			if (CrossPlatformArrange == null)
 			{
@@ -38,9 +43,11 @@ namespace Microsoft.Maui.Platform
 			var width = finalSize.Width;
 			var height = finalSize.Height;
 
-			var actual = CrossPlatformArrange(new Rectangle(0, 0, width, height));
+			CrossPlatformArrange(new Rectangle(0, 0, width, height));
 
-			return new global::Windows.Foundation.Size(actual.Width, actual.Height);
+			Clip = ClipsToBounds ? new RectangleGeometry { Rect = new WRect(0, 0, finalSize.Width, finalSize.Height) } : null;
+
+			return finalSize;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/LayoutPanelExtensions.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanelExtensions.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+
+namespace Microsoft.Maui.Platform
+{
+	public static class LayoutPanelExtensions 
+	{
+		public static void UpdateClipsToBounds(this LayoutPanel layoutPanel, ILayout layout) 
+		{
+			layoutPanel.ClipsToBounds = layout.ClipsToBounds;
+			layoutPanel.InvalidateArrange();
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -1,7 +1,6 @@
 using System;
 using CoreGraphics;
 using Microsoft.Maui.Graphics;
-using ObjCRuntime;
 using UIKit;
 
 namespace Microsoft.Maui.Platform

--- a/src/Core/src/Platform/iOS/LayoutViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/LayoutViewExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Maui.Platform
+{
+	public static class LayoutViewExtensions
+	{
+		public static void UpdateClipsToBounds(this LayoutView layoutView, ILayout layout)
+		{
+			layoutView.ClipsToBounds = layout.ClipsToBounds;
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public bool IgnoreSafeArea => false;
 
+		public bool ClipsToBounds { get; set; }
+
 		public IView this[int index] { get => _children[index]; set => _children[index] = value; }
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		// These tests need a real collection to work with; we can't reasonably use a substitute here
 		class FakeLayout : ILayout, IList<IView>
 		{
+			public bool ClipsToBounds { get; set; }
+
 			#region IView stuff
 
 			public string AutomationId { get; }


### PR DESCRIPTION
Modifies the various layout backing controls to handle clipping their children to bounds when specified. Adds `bool ClipsToBounds { get; }` to the `ILayout` interface in Core. Maps the `IsClippedToBounds` property in Controls to `ClipsToBounds`. 

Fixes #3554.

Also fixes a HorizontalStackLayoutManager bug, a Windows Label Opacity bug, and a Windows measurement bug I came across while fixing this.