### PR TITLE
[Android, iOS] Implement IsTextPredictionEnabled property in SearchBar

### DIFF
--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -91,8 +91,10 @@ namespace Microsoft.Maui.Handlers
 			handler.QueryEditor?.UpdateTextColor(searchBar);
 		}
 
-		[MissingMapper]
-		public static void MapIsTextPredictionEnabled(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapIsTextPredictionEnabled(SearchBarHandler handler, ISearchBar searchBar)
+		{ 
+			handler.NativeView?.UpdateIsTextPredictionEnabled(searchBar, handler.QueryEditor);
+		}
 
 		public static void MapMaxLength(SearchBarHandler handler, ISearchBar searchBar)
 		{

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Drawing;
 using Foundation;
-using Microsoft.Extensions.DependencyInjection;
-using ObjCRuntime;
 using UIKit;
 
 namespace Microsoft.Maui.Handlers
@@ -37,6 +34,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.SearchButtonClicked += OnSearchButtonClicked;
 			nativeView.TextPropertySet += OnTextPropertySet;
 			nativeView.ShouldChangeTextInRange += ShouldChangeText;
+
 			base.ConnectHandler(nativeView);
 			SetupDefaults(nativeView);
 		}
@@ -47,6 +45,7 @@ namespace Microsoft.Maui.Handlers
 			nativeView.SearchButtonClicked -= OnSearchButtonClicked;
 			nativeView.TextPropertySet -= OnTextPropertySet;
 			nativeView.ShouldChangeTextInRange -= ShouldChangeText;
+
 			base.DisconnectHandler(nativeView);
 		}
 
@@ -62,8 +61,6 @@ namespace Microsoft.Maui.Handlers
 				_cancelButtonTextColorDefaultHighlighted = cancelButton.TitleColor(UIControlState.Highlighted);
 				_cancelButtonTextColorDefaultDisabled = cancelButton.TitleColor(UIControlState.Disabled);
 			}
-
-
 		}
 
 		public static void MapText(SearchBarHandler handler, ISearchBar searchBar)
@@ -124,8 +121,10 @@ namespace Microsoft.Maui.Handlers
 			handler.QueryEditor?.UpdateTextColor(searchBar, handler._defaultTextColor);
 		}
 
-		[MissingMapper]
-		public static void MapIsTextPredictionEnabled(IViewHandler handler, ISearchBar searchBar) { }
+		public static void MapIsTextPredictionEnabled(SearchBarHandler handler, ISearchBar searchBar)
+		{
+			handler.NativeView?.UpdateIsTextPredictionEnabled(searchBar, handler?._editor);
+		}
 
 		public static void MapMaxLength(SearchBarHandler handler, ISearchBar searchBar)
 		{

--- a/src/Core/src/Platform/Android/SearchViewExtensions.cs
+++ b/src/Core/src/Platform/Android/SearchViewExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Content.Res;
+using Android.Text;
 using Android.Widget;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
 
@@ -107,6 +108,19 @@ namespace Microsoft.Maui.Platform
 						image.Drawable.ClearColorFilter();
 				}
 			}
+		}
+
+		public static void UpdateIsTextPredictionEnabled(this SearchView searchView, ISearchBar searchBar, EditText? editText = null)
+		{
+			editText ??= searchView.GetFirstChildOfType<EditText>();
+
+			if (editText == null)
+				return;
+
+			if (searchBar.IsTextPredictionEnabled)
+				editText.InputType &= ~InputTypes.TextFlagNoSuggestions;
+			else
+				editText.InputType |= InputTypes.TextFlagNoSuggestions;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -97,5 +97,18 @@ namespace Microsoft.Maui.Platform
 				cancelButton.SetTitleColor(searchBar.CancelButtonColor.ToNative(), UIControlState.Disabled);
 			}
 		}
+
+		public static void UpdateIsTextPredictionEnabled(this UISearchBar uiSearchBar, ISearchBar searchBar, UITextField? textField)
+		{
+			textField ??= uiSearchBar.FindDescendantView<UITextField>();
+
+			if (textField == null)
+				return;
+
+			if (searchBar.IsTextPredictionEnabled)
+				textField.AutocorrectionType = UITextAutocorrectionType.Yes;
+			else
+				textField.AutocorrectionType = UITextAutocorrectionType.No;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Implement **IsTextPredictionEnabled** property in SearchBar on Android and iOS.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No
