### PR TITLE
Register compatibilty handlers for RelativeLayout and AbsoluteLayout

### DIFF
--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -124,6 +124,10 @@ namespace Microsoft.Maui.Controls.Hosting
 					handlers.TryAddCompatibilityRenderer(typeof(ViewCell), typeof(ViewCellRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(SwitchCell), typeof(SwitchCellRenderer));
 
+
+					handlers.TryAddCompatibilityRenderer(typeof(Microsoft.Maui.Controls.Compatibility.RelativeLayout), typeof(DefaultRenderer));
+					handlers.TryAddCompatibilityRenderer(typeof(Microsoft.Maui.Controls.Compatibility.AbsoluteLayout), typeof(DefaultRenderer));
+
 					// This is for Layouts that currently don't work when assigned to LayoutHandler
 
 					DependencyService.Register<Xaml.ResourcesLoader>();

--- a/src/Controls/src/Core/LegacyLayouts/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/LegacyLayouts/AbsoluteLayout.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 			if (xIsProportional)
 			{
-				result.X = DeviceDisplay.MainDisplayInfo.DisplayRound((region.Width - result.Width) * bounds.X);
+				result.X = Math.Round((region.Width - result.Width) * bounds.X);
 			}
 			else
 			{
@@ -282,7 +282,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 			if (yIsProportional)
 			{
-				result.Y = DeviceDisplay.MainDisplayInfo.DisplayRound((region.Height - result.Height) * bounds.Y);
+				result.Y =Math.Round((region.Height - result.Height) * bounds.Y);
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #3006; 
Fixes #2062;

Also fixes a crash in the compatibility AbsoluteLayout on Windows.