### PR TITLE
Essentials fix DeviceDisplay and DeviceInfo

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Maui
 
 			NativeMessage?.Invoke(this, args);
 
+			Essentials.Platform.NewWindowProc(hWnd, msg, wParam, lParam);
 			return CallWindowProc(oldWndProc, hWnd, msg, wParam, lParam);
 		}
 

--- a/src/Essentials/samples/Samples/Platforms/Windows/app.manifest
+++ b/src/Essentials/samples/Samples/Platforms/Windows/app.manifest
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+    <assemblyIdentity version="1.0.0.0" name="Microsoft.Maui.Essentials.Sample.app"/>
+
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <!-- The combination of below two tags have the following effect:
+           1) Per-Monitor for >= Windows 10 Anniversary Update
+           2) System < Windows 10 Anniversary Update
+      -->
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+        </windowsSettings>
+    </application>
+</assembly>

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
@@ -49,100 +49,8 @@ namespace Microsoft.Maui.Essentials
 			}
 		}
 
-		public DisplayInfo GetMainDisplayInfo()
+		static DisplayRotation CalculateRotation(DisplayOrientations native, DisplayOrientations current)
 		{
-			var appWindow = GetAppWindowForCurrentWindow();
-			DEVMODE vDevMode = new DEVMODE();
-			EnumDisplaySettings(null!, -1, ref vDevMode);
-
-			var rotation = CalculateRotation(vDevMode);
-			var perpendicular =
-				rotation == DisplayRotation.Rotation90 ||
-				rotation == DisplayRotation.Rotation270;
-
-			var w = appWindow.Size.Width;
-			var h = appWindow.Size.Height;
-
-
-			var hdi = HdmiDisplayInformation.GetForCurrentView();
-			var hdm = hdi?.GetCurrentDisplayMode();
-
-			return new DisplayInfo(
-				width: perpendicular ? h : w,
-				height: perpendicular ? w : h,
-				density: 999,//di.LogicalDpi / 96.0, TODO FIX
-				orientation: GetWindowOrientationWin32() == DisplayOrientations.Landscape ? DisplayOrientation.Landscape : DisplayOrientation.Portrait,
-				rotation: rotation,
-				rate: (float)(hdm?.RefreshRate ?? 0));
-		}
-
-		public void StartScreenMetricsListeners()
-		{
-			MainThread.BeginInvokeOnMainThread(() =>
-			{
-				var di = DisplayInformation.GetForCurrentView();
-
-				di.DpiChanged += OnDisplayInformationChanged;
-				di.OrientationChanged += OnDisplayInformationChanged;
-			});
-		}
-
-		public void StopScreenMetricsListeners()
-		{
-			MainThread.BeginInvokeOnMainThread(() =>
-			{
-				var di = DisplayInformation.GetForCurrentView();
-
-				di.DpiChanged -= OnDisplayInformationChanged;
-				di.OrientationChanged -= OnDisplayInformationChanged;
-			});
-		}
-
-		void OnDisplayInformationChanged(DisplayInformation di, object args)
-		{
-
-			//var metrics = GetMainDisplayInfo(di);
-
-			// TODO this is just so it compiles
-			MainDisplayInfoChanged?.Invoke(this, new DisplayInfoChangedEventArgs(new DisplayInfo()));
-		}
-
-		DisplayOrientation CalculateOrientation(DisplayInformation di)
-		{
-			switch (di.CurrentOrientation)
-			{
-				case DisplayOrientations.Landscape:
-				case DisplayOrientations.LandscapeFlipped:
-					return DisplayOrientation.Landscape;
-				case DisplayOrientations.Portrait:
-				case DisplayOrientations.PortraitFlipped:
-					return DisplayOrientation.Portrait;
-			}
-
-			return DisplayOrientation.Unknown;
-		}
-
-		static DisplayRotation CalculateRotation(DEVMODE devMode)
-		{
-			DisplayOrientations native = DisplayOrientations.Portrait;
-			switch (devMode.dmDisplayOrientation)
-			{
-				case 0:
-					native = DisplayOrientations.Portrait;
-					break;
-				case 1:
-					native = DisplayOrientations.Landscape;
-					break;
-				case 2:
-					native = DisplayOrientations.LandscapeFlipped;
-					break;
-				case 3:
-					native = DisplayOrientations.PortraitFlipped;
-					break;
-			}
-
-			var current = GetWindowOrientationWin32();
-
 			if (native == DisplayOrientations.Portrait)
 			{
 				switch (current)
@@ -175,22 +83,132 @@ namespace Microsoft.Maui.Essentials
 			return DisplayRotation.Unknown;
 		}
 
-		static AppWindow GetAppWindowForCurrentWindow()
+#if WINDOWS
+
+		AppWindow? _currentAppWindowListeningTo;
+		public DisplayInfo GetMainDisplayInfo()
 		{
-			var myWndId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(Essentials.Platform.CurrentWindowHandle);
-			return AppWindow.GetFromWindowId(myWndId);
+			var appWindow = Platform.CurrentAppWindow;
+			var windowHandler = Platform.CurrentWindowHandle;
+			var mi = GetDisplay(windowHandler);
+
+			if (mi == null)
+				return new DisplayInfo();
+
+			DEVMODE vDevMode = new DEVMODE();
+			EnumDisplaySettings(mi.Value.DeviceNameToLPTStr(), -1, ref vDevMode);
+
+			var rotation = CalculateRotation(vDevMode, appWindow);
+			var perpendicular =
+				rotation == DisplayRotation.Rotation90 ||
+				rotation == DisplayRotation.Rotation270;
+
+			var w = vDevMode.dmPelsWidth;
+			var h = vDevMode.dmPelsHeight;
+			var dpi = GetDpiForWindow(windowHandler) / 96.0;
+
+			return new DisplayInfo(
+				width: perpendicular ? h : w,
+				height: perpendicular ? w : h,
+				density: dpi,
+				orientation: GetWindowOrientationWin32(appWindow) == DisplayOrientations.Landscape ? DisplayOrientation.Landscape : DisplayOrientation.Portrait,
+				rotation: rotation,
+				rate: vDevMode.dmDisplayFrequency);
 		}
 
-		[DllImport("User32.dll")]
-		[return: MarshalAs(UnmanagedType.Bool)]
-		internal static extern Boolean EnumDisplaySettings(
-			byte[] lpszDeviceName, 
-			[param: MarshalAs(UnmanagedType.U4)] int iModeNum,
-			[In, Out] ref DEVMODE lpDevMode);
-
-		static DisplayOrientations GetWindowOrientationWin32()
+		static MONITORINFOEX? GetDisplay(IntPtr hwnd)
 		{
-			var appWindow = GetAppWindowForCurrentWindow();
+			IntPtr hMonitor;
+			RECT rc;
+			GetWindowRect(hwnd, out rc);
+			hMonitor = MonitorFromRect(ref rc, MonitorOptions.MONITOR_DEFAULTTONEAREST);
+
+			MONITORINFOEX mi = new MONITORINFOEX();
+			mi.Size = Marshal.SizeOf(mi);
+			bool success = GetMonitorInfo(hMonitor, ref mi);
+			if (success)
+			{
+				return mi;
+			}
+			return null;
+		}
+
+		public void StartScreenMetricsListeners()
+		{
+			MainThread.BeginInvokeOnMainThread(() =>
+			{
+				Platform.CurrentWindowDisplayChanged += OnWindowDisplayChanged;
+				Platform.CurrentWindowChanged += OnCurrentWindowChanged;
+				_currentAppWindowListeningTo = Platform.CurrentAppWindow;
+				_currentAppWindowListeningTo.Changed += OnAppWindowChanged;
+			});
+		}
+
+		public void StopScreenMetricsListeners()
+		{
+			MainThread.BeginInvokeOnMainThread(() =>
+			{
+				Platform.CurrentWindowChanged -= OnCurrentWindowChanged;
+				Platform.CurrentWindowDisplayChanged -= OnWindowDisplayChanged;
+
+				if (_currentAppWindowListeningTo != null)
+					_currentAppWindowListeningTo.Changed -= OnAppWindowChanged;
+
+				_currentAppWindowListeningTo = null;
+			});
+		}
+
+		void OnCurrentWindowChanged(object? sender, EventArgs e)
+		{
+			if (_currentAppWindowListeningTo != null)
+			{
+				_currentAppWindowListeningTo.Changed -= OnAppWindowChanged;
+			}
+
+			_currentAppWindowListeningTo = Platform.CurrentAppWindow;
+			_currentAppWindowListeningTo.Changed += OnAppWindowChanged;
+		}
+
+		void OnWindowDisplayChanged(object? sender, EventArgs e)
+		{
+			WindowDisplayPropertiesChanged();
+		}
+
+		void WindowDisplayPropertiesChanged()
+		{
+			var metrics = GetMainDisplayInfo();
+			MainDisplayInfoChanged?.Invoke(this, new DisplayInfoChangedEventArgs(metrics));
+		}
+
+		void OnAppWindowChanged(AppWindow sender, AppWindowChangedEventArgs args) =>
+			WindowDisplayPropertiesChanged();
+
+		static DisplayRotation CalculateRotation(DEVMODE devMode, AppWindow appWindow)
+		{
+			DisplayOrientations native = DisplayOrientations.Portrait;
+			switch (devMode.dmDisplayOrientation)
+			{
+				case 0:
+					native = DisplayOrientations.Landscape;
+					break;
+				case 1:
+					native = DisplayOrientations.Portrait;
+					break;
+				case 2:
+					native = DisplayOrientations.LandscapeFlipped;
+					break;
+				case 3:
+					native = DisplayOrientations.PortraitFlipped;
+					break;
+			}
+
+			var current = GetWindowOrientationWin32(appWindow);
+			return CalculateRotation(native, current);
+		}
+
+		// https://github.com/marb2000/DesktopWindow/blob/abb21b797767bb24da09c066514117d5f1aabd75/WindowExtensions/DesktopWindow.cs#L407
+		static DisplayOrientations GetWindowOrientationWin32(AppWindow appWindow)
+		{
 			DisplayOrientations orientationEnum;
 			int theScreenWidth = appWindow.Size.Width;
 			int theScreenHeight = appWindow.Size.Height;
@@ -202,7 +220,81 @@ namespace Microsoft.Maui.Essentials
 			return orientationEnum;
 		}
 
-		public struct DEVMODE
+		[DllImport("User32", CharSet = CharSet.Unicode)]
+		static extern int GetDpiForWindow(IntPtr hwnd);
+
+		[DllImport("User32", CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern IntPtr MonitorFromRect(ref RECT lprc, MonitorOptions dwFlags);
+
+		[DllImport("User32", CharSet = CharSet.Unicode, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+		[DllImport("User32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		static extern Boolean EnumDisplaySettings(
+			byte[] lpszDeviceName,
+			[param: MarshalAs(UnmanagedType.U4)] int iModeNum,
+			[In, Out] ref DEVMODE lpDevMode);
+
+		[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+		static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFOEX lpmi);
+
+		[DllImport("user32.dll")]
+		static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, EnumMonitorsDelegate lpfnEnum, IntPtr dwData);
+		delegate bool EnumMonitorsDelegate(IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData);
+
+		static bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData)
+		{
+			MONITORINFOEX mi = new MONITORINFOEX();
+			mi.Size = Marshal.SizeOf(typeof(MONITORINFOEX));
+			if (GetMonitorInfo(hMonitor, ref mi))
+				Console.WriteLine(mi.DeviceName);
+
+			return true;
+		}
+
+		enum MonitorOptions : uint
+		{
+			MONITOR_DEFAULTTONULL,
+			MONITOR_DEFAULTTOPRIMARY,
+			MONITOR_DEFAULTTONEAREST
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		struct RECT
+		{
+			public int Left;
+			public int Top;
+			public int Right;
+			public int Bottom;
+		}
+
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+		struct MONITORINFOEX
+		{
+			public int Size;
+			public RECT Monitor;
+			public RECT WorkArea;
+			public uint Flags;
+			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+			public string DeviceName;
+
+			public byte[] DeviceNameToLPTStr()
+			{
+				var lptArray = new byte[DeviceName.Length + 1];
+
+				var index = 0;
+				foreach (char c in DeviceName.ToCharArray())
+					lptArray[index++] = Convert.ToByte(c);
+
+				lptArray[index] = Convert.ToByte('\0');
+
+				return lptArray;
+			}
+		}
+
+		struct DEVMODE
 		{
 			private const int CCHDEVICENAME = 0x20;
 			private const int CCHFORMNAME = 0x20;
@@ -239,5 +331,85 @@ namespace Microsoft.Maui.Essentials
 			public int dmPanningWidth;
 			public int dmPanningHeight;
 		}
+#elif WINDOWS_UWP
+		public DisplayInfo GetMainDisplayInfo() =>
+			GetMainDisplayInfo(null);
+
+		DisplayInfo GetMainDisplayInfo(DisplayInformation? di = null)
+		{
+			di ??= DisplayInformation.GetForCurrentView();
+
+			var rotation = CalculateRotation(di);
+			var perpendicular =
+				rotation == DisplayRotation.Rotation90 ||
+				rotation == DisplayRotation.Rotation270;
+
+			var w = di.ScreenWidthInRawPixels;
+			var h = di.ScreenHeightInRawPixels;
+
+			var hdi = HdmiDisplayInformation.GetForCurrentView();
+			var hdm = hdi?.GetCurrentDisplayMode();
+
+			return new DisplayInfo(
+				width: perpendicular ? h : w,
+				height: perpendicular ? w : h,
+				density: di.LogicalDpi / 96.0,
+				orientation: CalculateOrientation(di),
+				rotation: rotation,
+				rate: (float)(hdm?.RefreshRate ?? 0));
+		}
+
+		public void StartScreenMetricsListeners()
+		{
+			MainThread.BeginInvokeOnMainThread(() =>
+			{
+				var di = DisplayInformation.GetForCurrentView();
+
+				di.DpiChanged += OnDisplayInformationChanged;
+				di.OrientationChanged += OnDisplayInformationChanged;
+			});
+		}
+
+		public void StopScreenMetricsListeners()
+		{
+			MainThread.BeginInvokeOnMainThread(() =>
+			{
+				var di = DisplayInformation.GetForCurrentView();
+
+				di.DpiChanged -= OnDisplayInformationChanged;
+				di.OrientationChanged -= OnDisplayInformationChanged;
+			});
+		}
+
+		void OnDisplayInformationChanged(DisplayInformation di, object args)
+		{
+			var metrics = GetMainDisplayInfo(di);
+			MainDisplayInfoChanged?.Invoke(this, new DisplayInfoChangedEventArgs(metrics));
+		}
+
+		DisplayOrientation CalculateOrientation(DisplayInformation di)
+		{
+			switch (di.CurrentOrientation)
+			{
+				case DisplayOrientations.Landscape:
+				case DisplayOrientations.LandscapeFlipped:
+					return DisplayOrientation.Landscape;
+				case DisplayOrientations.Portrait:
+				case DisplayOrientations.PortraitFlipped:
+					return DisplayOrientation.Portrait;
+			}
+
+			return DisplayOrientation.Unknown;
+		}
+
+		static DisplayRotation CalculateRotation(DisplayInformation di)
+		{
+			var native = di.NativeOrientation;
+			var current = di.CurrentOrientation;
+
+			return CalculateRotation(native, current);
+		}
+	}
+#endif
 	}
 }

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
@@ -63,7 +63,9 @@ namespace Microsoft.Maui.Essentials
 					{
 						try
 						{
-							var uiMode = UIViewSettings.GetForCurrentView().UserInteractionMode;
+							var currentHandle = Essentials.Platform.CurrentWindowHandle;
+							var settings = UIViewSettingsInterop.GetForWindow(currentHandle);
+							var uiMode = settings.UserInteractionMode;
 							currentIdiom = uiMode == UserInteractionMode.Mouse ? DeviceIdiom.Desktop : DeviceIdiom.Tablet;
 						}
 						catch (Exception ex)

--- a/src/Essentials/src/Platform/Platform.uwp.cs
+++ b/src/Essentials/src/Platform/Platform.uwp.cs
@@ -5,6 +5,7 @@ using Windows.UI.Xaml;
 using WindowActivationState = Windows.UI.Core.CoreWindowActivationState;
 #elif WINDOWS
 using System;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 #endif
 
@@ -12,15 +13,54 @@ namespace Microsoft.Maui.Essentials
 {
 	public static partial class Platform
 	{
+		const uint DISPLAY_CHANGED = 126;
+		const uint DPI_CHANGED = 126;
+
+		static internal event EventHandler CurrentWindowChanged;
+		static internal event EventHandler CurrentWindowDisplayChanged;
+
 		internal static Window CurrentWindow
 		{
 			get => _currentWindow ?? Window.Current;
-			set => _currentWindow = value;
+			set
+			{
+				bool changed = _currentWindow != value;
+				_currentWindow = value;
+
+				if(changed)
+					CurrentWindowChanged?.Invoke(value, EventArgs.Empty);
+			}
 		}
 
 		internal static IntPtr CurrentWindowHandle
 			=> WinRT.Interop.WindowNative.GetWindowHandle(CurrentWindow);
-	
+#if WINDOWS
+		internal static UI.WindowId CurrentWindowId
+			=> UI.Win32Interop.GetWindowIdFromWindow(CurrentWindowHandle);
+
+		internal static AppWindow CurrentAppWindow
+			=> AppWindow.GetFromWindowId(CurrentWindowId);
+
+		// Currently there isn't a way to detect Orientation Changes unless you subclass the WinUI.Window and watch the messages
+		// Maui.Core forwards these messages to here so that WinUI can react accordingly.
+		// This is the "subtlest" way to currently wire this together. 
+		// Hopefully there will be a more public API for this down the road so we can just use that directly from Essentials
+		internal static void NewWindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+		{
+			if (CurrentWindowDisplayChanged == null)
+				return;
+
+			// We only care about orientation or dpi changes
+			if (DISPLAY_CHANGED != msg && DPI_CHANGED != msg)
+				return;
+
+			if (_currentWindow != null && hWnd == CurrentWindowHandle)
+			{
+				CurrentWindowDisplayChanged?.Invoke(CurrentWindow, EventArgs.Empty);
+			}
+		}
+#endif
+
 		internal const string AppManifestFilename = "AppxManifest.xml";
 		internal const string AppManifestXmlns = "http://schemas.microsoft.com/appx/manifest/foundation/windows10";
 		internal const string AppManifestUapXmlns = "http://schemas.microsoft.com/appx/manifest/uap/windows10";
@@ -34,7 +74,9 @@ namespace Microsoft.Maui.Essentials
 		public static void OnActivated(Window window, WindowActivatedEventArgs args)
 		{
 			if (args.WindowActivationState != WindowActivationState.Deactivated)
+			{
 				CurrentWindow = window;
+			}
 		}
 	}
 }

--- a/src/Essentials/src/Platform/Platform.uwp.cs
+++ b/src/Essentials/src/Platform/Platform.uwp.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Essentials
 	public static partial class Platform
 	{
 		const uint DISPLAY_CHANGED = 126;
-		const uint DPI_CHANGED = 126;
+		const uint DPI_CHANGED = 736;
 
 		static internal event EventHandler CurrentWindowChanged;
 		static internal event EventHandler CurrentWindowDisplayChanged;

--- a/src/Essentials/src/Properties/AssemblyInfo.uwp.cs
+++ b/src/Essentials/src/Properties/AssemblyInfo.uwp.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Maui")]


### PR DESCRIPTION
### Description of Change ###

Convert over all of the static UWP static method calls to use PInvoke via the WindowHandle
Most of the code here is taken from

https://github.com/marb2000/DesktopWindow

The one unfortunate part of this code is the additional call from Maui.Core into Essentials through IVT. Taking from @marb2000 's examples the only way to react to the orientationchange/dpi change is by inspecting the windows messages.  You can get pretty close by subscribing to the `Change` event on `AppWindow` but there are some edge cases (landscape to landscae flipped) where it looks like the `Change` event doesn't fire on `AppWindow`.  Hopefully there will be some additional APIs added to WinUI down the road that let us sever this requirement.

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
