### PR TITLE
Execute Screenshot tests on the main thread

### DIFF
--- a/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
@@ -11,7 +11,19 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Fact]
 		public async Task GetPngScreenshot()
 		{
-			var mediaFile = await Screenshot.CaptureAsync();
+			ScreenshotResult mediaFile = null;
+
+			for (int i = 0; i < 2; i++)
+			{
+				try
+				{
+					mediaFile = await Screenshot.CaptureAsync();
+					break;
+				}
+				catch { }
+				await Task.Delay(1000);
+			}
+
 			var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Png);
 			Assert.True(png.Length > 0);
 		}
@@ -19,7 +31,19 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Fact]
 		public async Task GetJpegScreenshot()
 		{
-			var mediaFile = await Screenshot.CaptureAsync();
+			ScreenshotResult mediaFile = null;
+
+			for (int i = 0; i < 2; i++)
+			{
+				try
+				{
+					mediaFile = await Screenshot.CaptureAsync();
+					break;
+				}
+				catch { }
+				await Task.Delay(1000);
+			}
+
 			var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Jpeg);
 			Assert.True(png.Length > 0);
 		}

--- a/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			return Utils.OnMainThread(async () =>
 			{
+				await Task.Delay(500);
 				ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
 				var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Png);
 				Assert.True(png.Length > 0);
@@ -24,6 +25,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			return Utils.OnMainThread(async () =>
 			{
+				await Task.Delay(500);
 				ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
 				var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Jpeg);
 				Assert.True(png.Length > 0);

--- a/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			return Utils.OnMainThread(async () =>
 			{
-				await Task.Delay(500);
+				await Task.Delay(100);
 				ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
 				var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Png);
 				Assert.True(png.Length > 0);
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			return Utils.OnMainThread(async () =>
 			{
-				await Task.Delay(500);
+				await Task.Delay(100);
 				ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
 				var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Jpeg);
 				Assert.True(png.Length > 0);

--- a/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
@@ -9,43 +9,25 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 	public class Screenshot_Tests
 	{
 		[Fact]
-		public async Task GetPngScreenshot()
+		public Task GetPngScreenshot()
 		{
-			ScreenshotResult mediaFile = null;
-
-			for (int i = 0; i < 2; i++)
+			return Utils.OnMainThread(async () =>
 			{
-				try
-				{
-					mediaFile = await Screenshot.CaptureAsync();
-					break;
-				}
-				catch { }
-				await Task.Delay(1000);
-			}
-
-			var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Png);
-			Assert.True(png.Length > 0);
+				ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
+				var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Png);
+				Assert.True(png.Length > 0);
+			});
 		}
 
 		[Fact]
-		public async Task GetJpegScreenshot()
+		public Task GetJpegScreenshot()
 		{
-			ScreenshotResult mediaFile = null;
-
-			for (int i = 0; i < 2; i++)
+			return Utils.OnMainThread(async () =>
 			{
-				try
-				{
-					mediaFile = await Screenshot.CaptureAsync();
-					break;
-				}
-				catch { }
-				await Task.Delay(1000);
-			}
-
-			var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Jpeg);
-			Assert.True(png.Length > 0);
+				ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
+				var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Jpeg);
+				Assert.True(png.Length > 0);
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

There appears to be a timing issue with the screen shot tests where they are running before the scene/view is ready. This changes them to marshal to the main thread so that they will "hopefully" execute in a consistently passing way