### PR TITLE
[android] stop using Build.VERSION.SdkInt

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/ButtonRenderer.cs
@@ -187,11 +187,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				NativeButton.LetterSpacing = Element.CharacterSpacing.ToEm();
-			}
-
+			NativeButton.LetterSpacing = Element.CharacterSpacing.ToEm();
 		}
 
 		void IOnClickListener.OnClick(AView v) => ButtonElementManager.OnClick(Element, Element, v);

--- a/src/Compatibility/Core/src/Android/AppCompat/FormsAppCompatActivity.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/FormsAppCompatActivity.cs
@@ -93,10 +93,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		public void SetStatusBarColor(AColor color)
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				Window.SetStatusBarColor(color);
-			}
+			Window.SetStatusBarColor(color);
 		}
 
 		static void RegisterHandler(Type target, Type handler, Type filter)
@@ -247,15 +244,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			OnStateChanged();
 
-			Profile.FramePartition("Forms.IsLollipopOrNewer");
-			if (Forms.IsLollipopOrNewer)
+			// Allow for the status bar color to be changed
+			if ((flags & ActivationFlags.DisableSetStatusBarColor) == 0)
 			{
-				// Allow for the status bar color to be changed
-				if ((flags & ActivationFlags.DisableSetStatusBarColor) == 0)
-				{
-					Profile.FramePartition("Set DrawsSysBarBkgrnds");
-					Window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
-				}
+				Profile.FramePartition("Set DrawsSysBarBkgrnds");
+				Window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
 			}
 
 			Profile.FrameEnd();

--- a/src/Compatibility/Core/src/Android/AppCompat/ImageButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/ImageButtonRenderer.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			if (Drawable != null)
 			{
-				if ((int)Forms.SdkInt >= 18 && backgroundDrawable != null)
+				if (backgroundDrawable != null)
 				{
 					var outlineBounds = backgroundDrawable.GetPaddingBounds(canvas.Width, canvas.Height);
 					var width = (float)canvas.Width;

--- a/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
@@ -166,10 +166,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 		[PortHandler]
 		protected void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
-			}
+			EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
 		}
 
 		[PortHandler("Partially ported, still missing code related to TitleColor, etc.")]

--- a/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/Platform.cs
@@ -695,23 +695,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			}
 		}
 
-		internal static int GenerateViewId()
-		{
-			// getting unique Id's is an art, and I consider myself the Jackson Pollock of the field
-			if ((int)Forms.SdkInt >= 17)
-				return global::Android.Views.View.GenerateViewId();
-
-			// Numbers higher than this range reserved for xml
-			// If we roll over, it can be exceptionally problematic for the user if they are still retaining things, android's internal implementation is
-			// basically identical to this except they do a lot of locking we don't have to because we know we only do this
-			// from the UI thread
-			if (s_id >= 0x00ffffff)
-				s_id = 0x00000400;
-
-			return s_id++;
-		}
-
-		static int s_id = 0x00000400;
+		internal static int GenerateViewId() => global::Android.Views.View.GenerateViewId();
 
 		#region Statics
 

--- a/src/Compatibility/Core/src/Android/AppCompat/TabbedPageRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/TabbedPageRenderer.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 #pragma warning restore CS0618 // Type or member is obsolete
 		ViewPager.IOnPageChangeListener, IManageFragments, NavigationBarView.IOnItemSelectedListener
 	{
-		Drawable _backgroundDrawable;
-		Drawable _wrappedBackgroundDrawable;
 		ColorStateList _originalTabTextColors;
 		ColorStateList _orignalTabIconColors;
 
@@ -416,11 +414,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 
 				if (tabs.Visibility != ViewStates.Gone)
 				{
-					//MinimumHeight is only available on API 16+
-					if ((int)Forms.SdkInt >= 16)
-						tabsHeight = Math.Min(height, Math.Max(tabs.MeasuredHeight, tabs.MinimumHeight));
-					else
-						tabsHeight = Math.Min(height, tabs.MeasuredHeight);
+					tabsHeight = Math.Min(height, Math.Max(tabs.MeasuredHeight, tabs.MinimumHeight));
 				}
 
 				pager.Measure(MeasureSpecFactory.MakeMeasureSpec(width, MeasureSpecMode.AtMost), MeasureSpecFactory.MakeMeasureSpec(height, MeasureSpecMode.AtMost));
@@ -728,36 +722,14 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 			{
 				Color tintColor = Element.BarBackgroundColor;
 
-				if (Forms.IsLollipopOrNewer)
+				if (tintColor == null)
 				{
-					if (tintColor == null)
-						_tabLayout.BackgroundTintMode = null;
-					else
-					{
-						_tabLayout.BackgroundTintMode = PorterDuff.Mode.Src;
-						_tabLayout.BackgroundTintList = ColorStateList.ValueOf(tintColor.ToAndroid());
-					}
+					_tabLayout.BackgroundTintMode = null;
 				}
 				else
 				{
-					if (tintColor == null && _backgroundDrawable != null)
-						_tabLayout.SetBackground(_backgroundDrawable);
-					else if (tintColor != null)
-					{
-						// if you don't create a new drawable then SetBackgroundColor
-						// just sets the color on the background drawable that's saved
-						// it doesn't create a new one
-						if (_backgroundDrawable == null && _tabLayout.Background != null)
-						{
-							_backgroundDrawable = _tabLayout.Background;
-							_wrappedBackgroundDrawable = ADrawableCompat.Wrap(_tabLayout.Background).Mutate();
-						}
-
-						if (_wrappedBackgroundDrawable != null)
-							_tabLayout.Background = _wrappedBackgroundDrawable;
-
-						_tabLayout.SetBackgroundColor(tintColor.ToAndroid());
-					}
+					_tabLayout.BackgroundTintMode = PorterDuff.Mode.Src;
+					_tabLayout.BackgroundTintList = ColorStateList.ValueOf(tintColor.ToAndroid());
 				}
 			}
 		}

--- a/src/Compatibility/Core/src/Android/BorderBackgroundManager.cs
+++ b/src/Compatibility/Core/src/Android/BorderBackgroundManager.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					shadowDx = 0;
 					shadowColor = _backgroundDrawable.PressedBackgroundColor.ToAndroid();
 				}
-				// Otherwise get values from the control (but only for supported APIs)
-				else if ((int)Forms.SdkInt >= 16)
+				// Otherwise get values from the control
+				else
 				{
 					shadowRadius = _renderer.ShadowRadius;
 					shadowDy = _renderer.ShadowDy;
@@ -151,16 +151,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 				if (!backgroundColorIsDefault || _drawOutlineWithBackground)
 				{
-					if (Forms.IsLollipopOrNewer)
-					{
-						var rippleColor = _backgroundDrawable.PressedBackgroundColor.ToAndroid();
-						_rippleDrawable = new RippleDrawable(ColorStateList.ValueOf(rippleColor), _backgroundDrawable, null);
-						Control.SetBackground(_rippleDrawable);
-					}
-					else
-					{
-						Control.SetBackground(_backgroundDrawable);
-					}
+					var rippleColor = _backgroundDrawable.PressedBackgroundColor.ToAndroid();
+					_rippleDrawable = new RippleDrawable(ColorStateList.ValueOf(rippleColor), _backgroundDrawable, null);
+					Control.SetBackground(_rippleDrawable);
 				}
 
 				_drawableEnabled = true;

--- a/src/Compatibility/Core/src/Android/Cells/BaseCellView.cs
+++ b/src/Compatibility/Core/src/Android/Cells/BaseCellView.cs
@@ -77,12 +77,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			SetMinimumHeight((int)context.ToPixels(DefaultMinHeight));
 			_androidDefaultTextColor = Color.FromUint((uint)_mainText.CurrentTextColor);
-
-			if ((int)Forms.SdkInt > 16)
-			{
-				_mainText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
-				_detailText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
-			}
+			_mainText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
+			_detailText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
 		}
 
 		public AView AccessoryView { get; private set; }

--- a/src/Compatibility/Core/src/Android/Cells/SwitchCellRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Cells/SwitchCellRenderer.cs
@@ -97,10 +97,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					}
 					else
 					{
-						if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
-						{
-							aSwitch.TrackDrawable.SetColorFilter(switchCell.OnColor, FilterMode.Multiply);
-						}
+						aSwitch.TrackDrawable.SetColorFilter(switchCell.OnColor, FilterMode.Multiply);
 					}
 				}
 				else

--- a/src/Compatibility/Core/src/Android/Extensions/FlowDirectionExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Extensions/FlowDirectionExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 	{
 		internal static void UpdateFlowDirection(this AView view, IVisualElementController controller)
 		{
-			if (view == null || controller == null || (int)Forms.SdkInt < 17)
+			if (view == null || controller == null)
 				return;
 
 			if (controller is IView v)
@@ -18,7 +18,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				return;
 			}
 
-			// if android:targetSdkVersion < 17 setting these has no effect
 			if (controller.EffectiveFlowDirection.IsRightToLeft())
 			{
 				view.LayoutDirection = ALayoutDirection.Rtl;

--- a/src/Compatibility/Core/src/Android/Extensions/ScrollViewExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Extensions/ScrollViewExtensions.cs
@@ -16,9 +16,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 	{
 		internal static void HandleScrollBarVisibilityChange(this IScrollView scrollView)
 		{
-			if (Forms.SdkInt <= BuildVersionCodes.Kitkat)
-				return;
-
 			// According to the Android Documentation
 			// * <p>AwakenScrollBars method should be invoked every time a subclass directly updates
 			// *the scroll parameters.</ p >

--- a/src/Compatibility/Core/src/Android/Extensions/TextAlignmentExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Extensions/TextAlignmentExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 	{
 		internal static void UpdateHorizontalAlignment(this EditText view, TextAlignment alignment, bool hasRtlSupport, AGravityFlags orMask = AGravityFlags.NoGravity)
 		{
-			if ((int)Build.VERSION.SdkInt < 17 || !hasRtlSupport)
+			if (!hasRtlSupport)
 				view.Gravity = alignment.ToHorizontalGravityFlags() | orMask;
 			else
 				view.TextAlignment = alignment.ToTextAlignment();
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		internal static void UpdateTextAlignment(this EditText view, TextAlignment horizontal, TextAlignment vertical)
 		{
-			if ((int)Build.VERSION.SdkInt < 17 || !view.Context.HasRtlSupport())
+			if (!view.Context.HasRtlSupport())
 			{
 				view.Gravity = vertical.ToVerticalGravityFlags() | horizontal.ToHorizontalGravityFlags();
 			}

--- a/src/Compatibility/Core/src/Android/FastRenderers/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/ButtonRenderer.cs
@@ -364,10 +364,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				LetterSpacing = Button.CharacterSpacing.ToEm();
-			}
+			LetterSpacing = Button.CharacterSpacing.ToEm();
 		}
 
 		float IBorderVisualElementRenderer.ShadowRadius => ShadowRadius;

--- a/src/Compatibility/Core/src/Android/FastRenderers/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/LabelRenderer.cs
@@ -361,10 +361,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				LetterSpacing = Element.CharacterSpacing.ToEm();
-			}
+			LetterSpacing = Element.CharacterSpacing.ToEm();
 		}
 
 		[PortHandler]

--- a/src/Compatibility/Core/src/Android/Forms.cs
+++ b/src/Compatibility/Core/src/Android/Forms.cs
@@ -54,15 +54,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 	{
 		const int TabletCrossover = 600;
 
-		static BuildVersionCodes? s_sdkInt;
-		static bool? s_is29OrNewer;
-		static bool? s_isJellyBeanMr1OrNewer;
-		static bool? s_isLollipopOrNewer;
-		static bool? s_isMarshmallowOrNewer;
-		static bool? s_isNougatOrNewer;
-		static bool? s_isOreoOrNewer;
-		static bool? s_isPieOrNewer;
-
 		// One per process; does not change, suitable for loading resources (e.g., ResourceProvider)
 		internal static Context ApplicationContext { get; private set; } = global::Android.App.Application.Context;
 		internal static IMauiContext MauiContext { get; private set; }
@@ -73,91 +64,13 @@ namespace Microsoft.Maui.Controls.Compatibility
 		static Color _ColorButtonNormal = null;
 		public static Color ColorButtonNormalOverride { get; set; }
 
-		internal static BuildVersionCodes SdkInt
-		{
-			get
-			{
-				if (!s_sdkInt.HasValue)
-					s_sdkInt = Build.VERSION.SdkInt;
-				return (BuildVersionCodes)s_sdkInt;
-			}
-		}
+		internal static readonly bool IsMarshmallowOrNewer = OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.M);
 
-		internal static bool Is29OrNewer
-		{
-			get
-			{
-				if (!s_is29OrNewer.HasValue)
-					s_is29OrNewer = (int)SdkInt >= 29;
-				return s_is29OrNewer.Value;
-			}
-		}
-
-		internal static bool IsJellyBeanMr1OrNewer
-		{
-			get
-			{
-				if (!s_isJellyBeanMr1OrNewer.HasValue)
-					s_isJellyBeanMr1OrNewer = SdkInt >= BuildVersionCodes.JellyBeanMr1;
-				return s_isJellyBeanMr1OrNewer.Value;
-			}
-		}
-
-		internal static bool IsLollipopOrNewer
-		{
-			get
-			{
-				if (!s_isLollipopOrNewer.HasValue)
-					s_isLollipopOrNewer = SdkInt >= BuildVersionCodes.Lollipop;
-				return s_isLollipopOrNewer.Value;
-			}
-		}
-
-		internal static bool IsMarshmallowOrNewer
-		{
-			get
-			{
-				if (!s_isMarshmallowOrNewer.HasValue)
-					s_isMarshmallowOrNewer = SdkInt >= BuildVersionCodes.M;
-				return s_isMarshmallowOrNewer.Value;
-			}
-		}
-
-		internal static bool IsNougatOrNewer
-		{
-			get
-			{
-				if (!s_isNougatOrNewer.HasValue)
-					s_isNougatOrNewer = SdkInt >= BuildVersionCodes.N;
-				return s_isNougatOrNewer.Value;
-			}
-		}
-
-		internal static bool IsOreoOrNewer
-		{
-			get
-			{
-				if (!s_isOreoOrNewer.HasValue)
-					s_isOreoOrNewer = SdkInt >= BuildVersionCodes.O;
-				return s_isOreoOrNewer.Value;
-			}
-		}
-
-		internal static bool IsPieOrNewer
-		{
-			get
-			{
-				if (!s_isPieOrNewer.HasValue)
-					s_isPieOrNewer = SdkInt >= BuildVersionCodes.P;
-				return s_isPieOrNewer.Value;
-			}
-		}
+		internal static readonly bool IsNougatOrNewer = OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.N);
 
 		public static float GetFontSizeNormal(Context context)
 		{
 			float size = 50;
-			if (!IsLollipopOrNewer)
-				return size;
 
 			// Android 5.0+
 			//this doesn't seem to work
@@ -385,7 +298,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 				returnValue = TargetIdiom.TV;
 			else if (uiMode == UiMode.TypeDesk)
 				returnValue = TargetIdiom.Desktop;
-			else if (SdkInt >= BuildVersionCodes.KitkatWatch && uiMode == UiMode.TypeWatch)
+			else if (uiMode == UiMode.TypeWatch)
 				returnValue = TargetIdiom.Watch;
 
 			Device.SetIdiom(returnValue);
@@ -397,7 +310,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			Color rc;
 			using (var value = new TypedValue())
 			{
-				if (context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorAccent, value, true) && Forms.IsLollipopOrNewer) // Android 5.0+
+				if (context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorAccent, value, true)) // Android 5.0+
 				{
 					rc = Color.FromUint((uint)value.Data);
 				}
@@ -407,19 +320,9 @@ namespace Microsoft.Maui.Controls.Compatibility
 				}
 				else                    // fallback to old code if nothing works (don't know if that ever happens)
 				{
-					// Detect if legacy device and use appropriate accent color
 					// Hardcoded because could not get color from the theme drawable
-					var sdkVersion = (int)SdkInt;
-					if (sdkVersion <= 10)
-					{
-						// legacy theme button pressed color
-						rc = Color.FromArgb("#fffeaa0c");
-					}
-					else
-					{
-						// Holo dark light blue
-						rc = Color.FromArgb("#ff33b5e5");
-					}
+					// Holo dark light blue
+					rc = Color.FromArgb("#ff33b5e5");
 				}
 			}
 			return rc;
@@ -433,7 +336,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			{
 				using (var value = new TypedValue())
 				{
-					if (context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorButtonNormal, value, true) && Forms.IsLollipopOrNewer) // Android 5.0+
+					if (context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorButtonNormal, value, true)) // Android 5.0+
 					{
 						rc = Color.FromUint((uint)value.Data);
 					}

--- a/src/Compatibility/Core/src/Android/Renderers/AndroidGIFImageParser.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/AndroidGIFImageParser.cs
@@ -49,9 +49,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public FormsAnimationDrawable()
 		{
 			RepeatCount = 1;
-
-			if (!Forms.IsLollipopOrNewer)
-				base.SetVisible(false, true);
 		}
 
 		public int RepeatCount { get; set; }
@@ -79,9 +76,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			base.Start();
 
-			if (!Forms.IsLollipopOrNewer)
-				base.SetVisible(true, true);
-
 			_isRunning = true;
 			AnimationStarted?.Invoke(this, null);
 		}
@@ -89,9 +83,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public override void Stop()
 		{
 			base.Stop();
-
-			if (!Forms.IsLollipopOrNewer)
-				base.SetVisible(false, true);
 
 			_isRunning = false;
 			AnimationStopped?.Invoke(this, new FormsAnimationDrawableStateEventArgs(_finished));

--- a/src/Compatibility/Core/src/Android/Renderers/CircularProgress.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/CircularProgress.cs
@@ -44,15 +44,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public void SetColor(Color color)
 		{
 			var progress = color?.ToAndroid() ?? DefaultColor;
-
-			if (Forms.IsLollipopOrNewer)
-			{
-				IndeterminateTintList = ColorStateList.ValueOf(progress);
-			}
-			else
-			{
-				(Indeterminate ? IndeterminateDrawable : ProgressDrawable).SetColorFilter(color.ToAndroid(), FilterMode.SrcIn);
-			}
+			IndeterminateTintList = ColorStateList.ValueOf(progress);
 		}
 
 		public void SetBackground(Color color, Brush brush)
@@ -101,7 +93,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			l += (width - squareSize) / 2;
 			t += (height - squareSize) / 2;
 			int strokeWidth;
-			if (Forms.SdkInt < BuildVersionCodes.N)
+			if (!Forms.IsNougatOrNewer)
 				strokeWidth = squareSize / _paddingRatio23;
 			else
 				strokeWidth = squareSize / _paddingRatio;

--- a/src/Compatibility/Core/src/Android/Renderers/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/DatePickerRenderer.cs
@@ -21,23 +21,19 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public DatePickerRendererBase(Context context) : base(context)
 		{
 			AutoPackage = false;
-			if (Forms.IsLollipopOrNewer)
-				DeviceDisplay.MainDisplayInfoChanged += DeviceInfoPropertyChanged;
+			DeviceDisplay.MainDisplayInfoChanged += DeviceInfoPropertyChanged;
 		}
 
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing && !_disposed)
 			{
-				if (Forms.IsLollipopOrNewer)
-					DeviceDisplay.MainDisplayInfoChanged -= DeviceInfoPropertyChanged;
+				DeviceDisplay.MainDisplayInfoChanged -= DeviceInfoPropertyChanged;
 
 				_disposed = true;
 				if (_dialog != null)
 				{
-					if (Forms.IsLollipopOrNewer)
-						_dialog.CancelEvent -= OnCancelButtonClicked;
-
+					_dialog.CancelEvent -= OnCancelButtonClicked;
 					_dialog.Hide();
 					_dialog.Dispose();
 					_dialog = null;
@@ -99,10 +95,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			{
 				_dialog.Hide();
 				((IElementController)Element).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
-
-				if (Forms.IsLollipopOrNewer)
-					_dialog.CancelEvent -= OnCancelButtonClicked;
-
+				_dialog.CancelEvent -= OnCancelButtonClicked;
 				_dialog = null;
 			}
 		}
@@ -125,8 +118,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			if (currentDialog != null && currentDialog.IsShowing)
 			{
 				currentDialog.Dismiss();
-				if (Forms.IsLollipopOrNewer)
-					currentDialog.CancelEvent -= OnCancelButtonClicked;
+				currentDialog.CancelEvent -= OnCancelButtonClicked;
 
 				ShowPickerDialog(currentDialog.DatePicker.Year, currentDialog.DatePicker.Month, currentDialog.DatePicker.DayOfMonth);
 			}
@@ -151,8 +143,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			UpdateMinimumDate();
 			UpdateMaximumDate();
-			if (Forms.IsLollipopOrNewer)
-				_dialog.CancelEvent += OnCancelButtonClicked;
+			_dialog.CancelEvent += OnCancelButtonClicked;
 
 			_dialog.Show();
 		}
@@ -181,10 +172,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
-			}
+			EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
 		}
 
 		[PortHandler]

--- a/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
@@ -122,8 +122,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			EditText.SetSingleLine(false);
 			EditText.Gravity = GravityFlags.Top;
-			if ((int)Forms.SdkInt > 16)
-				EditText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
+			EditText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
 			EditText.SetHorizontallyScrolling(false);
 
 			UpdateText();
@@ -251,10 +250,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
-			}
+			EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
 		}
 
 		[PortHandler]

--- a/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
@@ -400,10 +400,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
-			}
+			EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
 		}
 
 		[PortHandler]

--- a/src/Compatibility/Core/src/Android/Renderers/FormattedStringExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormattedStringExtensions.cs
@@ -77,10 +77,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			{
 				Font = font;
 				TextView = view;
-				if (Forms.IsLollipopOrNewer)
-				{
-					CharacterSpacing = characterSpacing;
-				}
+				CharacterSpacing = characterSpacing;
 			}
 
 			public Font Font { get; }
@@ -108,10 +105,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					Font.AutoScalingEnabled ? ComplexUnitType.Sp : ComplexUnitType.Dip,
 					value, TextView.Resources.DisplayMetrics);
 
-				if (Forms.IsLollipopOrNewer)
-				{
-					paint.LetterSpacing = CharacterSpacing;
-				}
+				paint.LetterSpacing = CharacterSpacing;
 			}
 		}
 

--- a/src/Compatibility/Core/src/Android/Renderers/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/LabelRenderer.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		}
 		void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer && Control is TextView textControl)
+			if (Control is TextView textControl)
 			{
 				textControl.LetterSpacing = Element.CharacterSpacing.ToEm();
 			}

--- a/src/Compatibility/Core/src/Android/Renderers/ListViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ListViewRenderer.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		{
 			base.OnAttachedToWindow();
 
-			if (Forms.IsLollipopOrNewer && Control != null)
+			if (Control != null)
 				Control.NestedScrollingEnabled = (Parent.GetParentOfType<NestedScrollView>() != null);
 
 			_isAttached = true;

--- a/src/Compatibility/Core/src/Android/Renderers/ProgressBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ProgressBarRenderer.cs
@@ -69,19 +69,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			}
 			else
 			{
-				if (Forms.SdkInt < BuildVersionCodes.Lollipop)
-				{
-					(Control.Indeterminate ? Control.IndeterminateDrawable :
-						Control.ProgressDrawable).SetColorFilter(color, FilterMode.SrcIn);
-				}
+				var tintList = ColorStateList.ValueOf(color.ToAndroid());
+				if (Control.Indeterminate)
+					Control.IndeterminateTintList = tintList;
 				else
-				{
-					var tintList = ColorStateList.ValueOf(color.ToAndroid());
-					if (Control.Indeterminate)
-						Control.IndeterminateTintList = tintList;
-					else
-						Control.ProgressTintList = tintList;
-				}
+					Control.ProgressTintList = tintList;
 			}
 		}
 

--- a/src/Compatibility/Core/src/Android/Renderers/RefreshViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/RefreshViewRenderer.cs
@@ -148,9 +148,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			if (!(view is ViewGroup viewGroup))
 				return base.CanChildScrollUp();
 
-			if (Forms.SdkInt < BuildVersionCodes.JellyBean && viewGroup.IsScrollContainer)
-				return base.CanChildScrollUp();
-
 			if (!CanScrollUpViewByType(view))
 				return false;
 

--- a/src/Compatibility/Core/src/Android/Renderers/ScrollViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/ScrollViewRenderer.cs
@@ -273,10 +273,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			// if the target sdk >= 17 then setting the LayoutDirection on the scroll view natively takes care of the scroll
 			if (!_checkedForRtlScroll && _hScrollView != null && Element is IVisualElementController controller && controller.EffectiveFlowDirection.IsRightToLeft())
 			{
-				if (Context.TargetSdkVersion() < 17)
-					_hScrollView.ScrollX = _container.MeasuredWidth - _hScrollView.MeasuredWidth - _hScrollView.ScrollX;
-				else
-					Device.BeginInvokeOnMainThread(() => UpdateScrollPosition(_hScrollView.ScrollX, ScrollY));
+				Device.BeginInvokeOnMainThread(() => UpdateScrollPosition(_hScrollView.ScrollX, ScrollY));
 			}
 
 			_checkedForRtlScroll = true;

--- a/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
 			var sizerequest = base.GetDesiredSize(widthConstraint, heightConstraint);
-			if (Forms.SdkInt == BuildVersionCodes.N && heightConstraint == 0 && sizerequest.Request.Height == 0)
+			if (Forms.IsNougatOrNewer && heightConstraint == 0 && sizerequest.Request.Height == 0)
 			{
 				sizerequest.Request = new Size(sizerequest.Request.Width, _defaultHeight);
 			}
@@ -268,9 +268,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			if (!Forms.IsLollipopOrNewer)
-				return;
-
 			_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
 
 			if (_editText != null)

--- a/src/Compatibility/Core/src/Android/Renderers/SliderRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SliderRenderer.cs
@@ -67,25 +67,19 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				seekBar.Max = 1000;
 				seekBar.SetOnSeekBarChangeListener(this);
 
-				if (Forms.SdkInt > BuildVersionCodes.Kitkat)
-				{
-					defaultthumbcolorfilter = seekBar.Thumb.GetColorFilter();
-					defaultprogresstintmode = seekBar.ProgressTintMode;
-					defaultprogressbackgroundtintmode = seekBar.ProgressBackgroundTintMode;
-					defaultprogresstintlist = seekBar.ProgressTintList;
-					defaultprogressbackgroundtintlist = seekBar.ProgressBackgroundTintList;
-					defaultthumb = seekBar.Thumb;
-				}
+				defaultthumbcolorfilter = seekBar.Thumb.GetColorFilter();
+				defaultprogresstintmode = seekBar.ProgressTintMode;
+				defaultprogressbackgroundtintmode = seekBar.ProgressBackgroundTintMode;
+				defaultprogresstintlist = seekBar.ProgressTintList;
+				defaultprogressbackgroundtintlist = seekBar.ProgressBackgroundTintList;
+				defaultthumb = seekBar.Thumb;
 			}
 
 			Slider slider = e.NewElement;
 			_min = slider.Minimum;
 			_max = slider.Maximum;
 			Value = slider.Value;
-			if (Forms.SdkInt > BuildVersionCodes.Kitkat)
-			{
-				UpdateSliderColors();
-			}
+			UpdateSliderColors();
 		}
 
 		SeekBar NativeSeekbar
@@ -118,17 +112,14 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					break;
 			}
 
-			if (Forms.SdkInt > BuildVersionCodes.Kitkat)
-			{
-				if (e.PropertyName == Slider.MinimumTrackColorProperty.PropertyName)
-					UpdateMinimumTrackColor();
-				else if (e.PropertyName == Slider.MaximumTrackColorProperty.PropertyName)
-					UpdateMaximumTrackColor();
-				else if (e.PropertyName == Slider.ThumbImageSourceProperty.PropertyName)
-					UpdateThumbImage();
-				else if (e.PropertyName == Slider.ThumbColorProperty.PropertyName)
-					UpdateThumbColor();
-			}
+			if (e.PropertyName == Slider.MinimumTrackColorProperty.PropertyName)
+				UpdateMinimumTrackColor();
+			else if (e.PropertyName == Slider.MaximumTrackColorProperty.PropertyName)
+				UpdateMaximumTrackColor();
+			else if (e.PropertyName == Slider.ThumbImageSourceProperty.PropertyName)
+				UpdateThumbImage();
+			else if (e.PropertyName == Slider.ThumbColorProperty.PropertyName)
+				UpdateThumbColor();
 		}
 
 		private void UpdateSliderColors()
@@ -199,10 +190,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			base.OnLayout(changed, l, t, r, b);
-
-			BuildVersionCodes androidVersion = Forms.SdkInt;
-			if (androidVersion < BuildVersionCodes.JellyBean)
-				return;
 
 			// Thumb only supported JellyBean and higher
 

--- a/src/Compatibility/Core/src/Android/Renderers/TableViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/TableViewRenderer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		{
 			base.OnAttachedToWindow();
 
-			if (Forms.IsLollipopOrNewer && Control != null)
+			if (Control != null)
 				Control.NestedScrollingEnabled = (Parent.GetParentOfType<NestedScrollView>() != null);
 		}
 

--- a/src/Compatibility/Core/src/Android/Renderers/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/TimePickerRenderer.cs
@@ -37,9 +37,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			ElementController.SetValueFromRenderer(TimePicker.TimeProperty, new TimeSpan(hourOfDay, minute, 0));
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 
-			if (Forms.IsLollipopOrNewer)
-				_dialog.CancelEvent -= OnCancelButtonClicked;
-
+			_dialog.CancelEvent -= OnCancelButtonClicked;
 			_dialog = null;
 		}
 
@@ -59,8 +57,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			UpdateCharacterSpacing();
 			UpdateFont();
 
-			if ((int)Forms.SdkInt > 16)
-				Control.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
+			Control.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -98,9 +95,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				_dialog.Hide();
 				ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 
-				if (Forms.IsLollipopOrNewer)
-					_dialog.CancelEvent -= OnCancelButtonClicked;
-
+				_dialog.CancelEvent -= OnCancelButtonClicked;
 				_dialog?.Dispose();
 				_dialog = null;
 			}
@@ -109,10 +104,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		protected virtual TimePickerDialog CreateTimePickerDialog(int hours, int minutes)
 		{
 			var dialog = new TimePickerDialog(Context, this, hours, minutes, Is24HourView);
-
-			if (Forms.IsLollipopOrNewer)
-				dialog.CancelEvent += OnCancelButtonClicked;
-
+			dialog.CancelEvent += OnCancelButtonClicked;
 			return dialog;
 		}
 
@@ -127,7 +119,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			if (disposing)
 			{
-				if (Forms.IsLollipopOrNewer && _dialog.IsAlive())
+				if (_dialog.IsAlive())
 					_dialog.CancelEvent -= OnCancelButtonClicked;
 
 				_dialog?.Dispose();
@@ -183,10 +175,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			if (Forms.IsLollipopOrNewer)
-			{
-				EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
-			}
+			EditText.LetterSpacing = Element.CharacterSpacing.ToEm();
 		}
 
 		[PortHandler]

--- a/src/Compatibility/Core/src/Android/Renderers/WebViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/WebViewRenderer.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		void UpdateMixedContentMode()
 		{
-			if (Control != null && ((int)Forms.SdkInt >= 21))
+			if (Control != null)
 			{
 				Control.Settings.MixedContentMode = (MixedContentHandling)Element.OnThisPlatform().MixedContentMode();
 			}

--- a/src/Compatibility/Core/src/Android/VisualElementPackager.cs
+++ b/src/Compatibility/Core/src/Android/VisualElementPackager.cs
@@ -178,19 +178,16 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					IVisualElementRenderer r = Platform.GetRenderer(element);
 					if (r != null)
 					{
-						if (Forms.IsLollipopOrNewer)
+						var elevation = ElevationHelper.GetElevation(r.View) ?? 0;
+						var elementElevation = ElevationHelper.GetElevation(element, r.View.Context);
+
+						if (elementElevation == null)
 						{
-							var elevation = ElevationHelper.GetElevation(r.View) ?? 0;
-							var elementElevation = ElevationHelper.GetElevation(element, r.View.Context);
+							if (elevation > elevationToSet)
+								elevationToSet = elevation;
 
-							if (elementElevation == null)
-							{
-								if (elevation > elevationToSet)
-									elevationToSet = elevation;
-
-								if (r.View.Elevation != elevationToSet)
-									r.View.Elevation = elevationToSet;
-							}
+							if (r.View.Elevation != elevationToSet)
+								r.View.Elevation = elevationToSet;
 						}
 
 						if (!onlyUpdateElevations)
@@ -217,9 +214,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				EnsureChildOrder();
 				return;
 			}
-
-			if (!Forms.IsLollipopOrNewer)
-				return;
 
 			Element previousChild = ElementController.LogicalChildren[itemCount - 2];
 

--- a/src/Compatibility/Core/src/Android/VisualElementTracker.cs
+++ b/src/Compatibility/Core/src/Android/VisualElementTracker.cs
@@ -113,13 +113,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				Performance.Stop(reference, "Layout");
 			}
 
-			// If we're running sufficiently new Android, we have to make sure to update the ClipBounds to
-			// match the new size of the ViewGroup
-			if ((int)Forms.SdkInt >= 18)
-			{
-				UpdateClipToBounds();
-			}
-
+			// We have to make sure to update the ClipBounds to match the new size of the ViewGroup
+			UpdateClipToBounds();
 			UpdateClip();
 
 			Performance.Stop(reference);
@@ -296,32 +291,16 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			bool shouldClip = layout.IsClippedToBounds;
 
-			// setClipBounds is only available in API 18 +	
-			if ((int)Forms.SdkInt >= 18)
+			if (!(_renderer.View is ViewGroup viewGroup))
 			{
-				if (!(_renderer.View is ViewGroup viewGroup))
-				{
-					return;
-				}
-
-				// Forms layouts should not impose clipping on their children	
-				viewGroup.SetClipChildren(false);
-
-				// But if IsClippedToBounds is true, they _should_ enforce clipping at their own edges	
-				viewGroup.ClipBounds = shouldClip ? new global::Android.Graphics.Rect(0, 0, viewGroup.Width, viewGroup.Height) : null;
+				return;
 			}
-			else
-			{
-				// For everything in 17 and below, use the setClipChildren method	
-				if (!(_renderer.View.Parent is ViewGroup parent))
-					return;
 
-				if ((int)Forms.SdkInt >= 18 && parent.ClipChildren == shouldClip)
-					return;
+			// Forms layouts should not impose clipping on their children	
+			viewGroup.SetClipChildren(false);
 
-				parent.SetClipChildren(shouldClip);
-				parent.Invalidate();
-			}
+			// But if IsClippedToBounds is true, they _should_ enforce clipping at their own edges	
+			viewGroup.ClipBounds = shouldClip ? new global::Android.Graphics.Rect(0, 0, viewGroup.Width, viewGroup.Height) : null;
 		}
 
 		void UpdateClip()

--- a/src/Compatibility/Material/src/Android/MaterialColors.cs
+++ b/src/Compatibility/Material/src/Android/MaterialColors.cs
@@ -199,23 +199,16 @@ internal static class MaterialColors
 		{
 			seekBar.ApplyProgressBarColors(progressColor, backgroundColor);
 
-			if (Forms.IsLollipopOrNewer)
+			if (thumbColor.IsDefault)
 			{
-				if (thumbColor.IsDefault)
-				{
-					// reset everything to defaults
-					seekBar.ThumbTintList = seekBar.ProgressTintList;
-				}
-				else
-				{
-					// handle the case where the thumb is set
-					var thumb = thumbColor.ToAndroid();
-					seekBar.ThumbTintList = ColorStateList.ValueOf(thumb);
-				}
+				// reset everything to defaults
+				seekBar.ThumbTintList = seekBar.ProgressTintList;
 			}
 			else
 			{
-				seekBar.Thumb.SetColorFilter(thumbColor.ToAndroid(), FilterMode.SrcIn);
+				// handle the case where the thumb is set
+				var thumb = thumbColor.ToAndroid();
+				seekBar.ThumbTintList = ColorStateList.ValueOf(thumb);
 			}
 		}
 
@@ -236,17 +229,11 @@ internal static class MaterialColors
 				if (progressDrawable.GetDrawable(2) is AScaleDrawable layer2)
 					layer2.SetColorFilter(progressColor, FilterMode.SrcIn);
 			}
-			else if (Forms.IsLollipopOrNewer)
+			else
 			{
 				progressBar.ProgressTintList = ColorStateList.ValueOf(progressColor);
 				progressBar.ProgressBackgroundTintList = ColorStateList.ValueOf(backgroundColor);
 				progressBar.ProgressBackgroundTintMode = mode;
-			}
-			else
-			{
-				(progressBar.Indeterminate ? progressBar.IndeterminateDrawable :
-						   progressBar.ProgressDrawable).SetColorFilter(progressColor, FilterMode.SrcIn);
-
 			}
 		}
 

--- a/src/Controls/src/Core/Platform/Android/Extensions/ViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ViewExtensions.cs
@@ -69,11 +69,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal static void MaybeRequestLayout(this AView view)
 		{
-			var isInLayout = false;
-			if ((int)Build.VERSION.SdkInt >= 18)
-				isInLayout = view.IsInLayout;
-
-			if (!isInLayout && !view.IsLayoutRequested)
+			if (!view.IsInLayout && !view.IsLayoutRequested)
 				view.RequestLayout();
 		}
 	}

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -79,11 +79,6 @@ namespace Microsoft.Maui.Platform
 			return (self.ApplicationInfo?.Flags & AApplicationInfoFlags.SupportsRtl) == AApplicationInfoFlags.SupportsRtl;
 		}
 
-		public static int? TargetSdkVersion(this Context self)
-		{
-			return (int?)self?.ApplicationInfo?.TargetSdkVersion;
-		}
-
 		public static double GetThemeAttributeDp(this Context self, int resource)
 		{
 			using (var value = new TypedValue())
@@ -150,7 +145,7 @@ namespace Microsoft.Maui.Platform
 					{
 						if (context.Resources != null)
 						{
-							if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
+							if (OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.M))
 								return context.Resources.GetColor(mTypedValue.ResourceId, context.Theme);
 							else
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Core/src/Platform/Android/NativeVersion.cs
+++ b/src/Core/src/Platform/Android/NativeVersion.cs
@@ -1,32 +1,19 @@
+using System;
 using Android.OS;
 
 namespace Microsoft.Maui.Platform
 {
 	public static partial class NativeVersion
 	{
-		static readonly BuildVersionCodes BuildVersion = Build.VERSION.SdkInt;
+		public static bool IsAtLeast(BuildVersionCodes buildVersionCode) => OperatingSystem.IsAndroidVersionAtLeast((int)buildVersionCode);
 
-		public static bool IsAtLeast(BuildVersionCodes buildVersionCode)
-		{
-			return buildVersionCode >= BuildVersion;
-		}
+		public static bool IsAtLeast(int apiLevel) => OperatingSystem.IsAndroidVersionAtLeast(apiLevel);
 
-		internal static int ApiLevel { get; } = (int)BuildVersion;
-
-		public static bool IsAtLeast(int apiLevel)
-		{
-			return ApiLevel >= apiLevel;
-		}
-
-		public static bool Supports(int nativeApi)
-		{
-			return IsAtLeast(nativeApi);
-		}
+		public static bool Supports(int nativeApi) => OperatingSystem.IsAndroidVersionAtLeast(nativeApi);
 	}
 
 	public static class NativeApis
 	{
-		public const int PowerSaveMode = 21;
 		public const int BlendModeColorFilter = 29;
 		public const int SeekBarSetMin = 26;
 		public const int LaunchAdjacent = 24;

--- a/src/Essentials/src/Battery/Battery.android.cs
+++ b/src/Essentials/src/Battery/Battery.android.cs
@@ -11,18 +11,12 @@ namespace Microsoft.Maui.Essentials
 
 		static void StartEnergySaverListeners()
 		{
-			if (!Platform.HasApiLevel(BuildVersionCodes.Lollipop))
-				return;
-
 			powerReceiver = new EnergySaverBroadcastReceiver(OnEnergySaverChanged);
 			Platform.AppContext.RegisterReceiver(powerReceiver, new IntentFilter(PowerManager.ActionPowerSaveModeChanged));
 		}
 
 		static void StopEnergySaverListeners()
 		{
-			if (!Platform.HasApiLevel(BuildVersionCodes.Lollipop))
-				return;
-
 			try
 			{
 				Platform.AppContext.UnregisterReceiver(powerReceiver);
@@ -39,10 +33,7 @@ namespace Microsoft.Maui.Essentials
 		{
 			get
 			{
-				var status = false;
-				if (Platform.HasApiLevel(BuildVersionCodes.Lollipop))
-					status = Platform.PowerManager?.IsPowerSaveMode ?? false;
-
+				var status = Platform.PowerManager?.IsPowerSaveMode ?? false;
 				return status ? EnergySaverStatus.On : EnergySaverStatus.Off;
 			}
 		}

--- a/src/Essentials/src/Connectivity/Connectivity.android.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.android.cs
@@ -120,56 +120,49 @@ namespace Microsoft.Maui.Essentials
 					var currentAccess = NetworkAccess.None;
 					var manager = Platform.ConnectivityManager;
 
-					if (Platform.HasApiLevel(BuildVersionCodes.Lollipop))
-					{
 #pragma warning disable CS0618 // Type or member is obsolete
-						var networks = manager.GetAllNetworks();
+					var networks = manager.GetAllNetworks();
 #pragma warning restore CS0618 // Type or member is obsolete
 
-						// some devices running 21 and 22 only use the older api.
-						if (networks.Length == 0 && (int)Build.VERSION.SdkInt < 23)
-						{
-							ProcessAllNetworkInfo();
-							return currentAccess;
-						}
-
-						foreach (var network in networks)
-						{
-							try
-							{
-								var capabilities = manager.GetNetworkCapabilities(network);
-
-								if (capabilities == null)
-									continue;
-
-#pragma warning disable CS0618 // Type or member is obsolete
-								var info = manager.GetNetworkInfo(network);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-#pragma warning disable CS0618 // Type or member is obsolete
-								if (info == null || !info.IsAvailable)
-#pragma warning restore CS0618 // Type or member is obsolete
-									continue;
-
-								// Check to see if it has the internet capability
-								if (!capabilities.HasCapability(NetCapability.Internet))
-								{
-									// Doesn't have internet, but local is possible
-									currentAccess = IsBetterAccess(currentAccess, NetworkAccess.Local);
-									continue;
-								}
-
-								ProcessNetworkInfo(info);
-							}
-							catch
-							{
-								// there is a possibility, but don't worry
-							}
-						}
-					}
-					else
+					// some devices running 21 and 22 only use the older api.
+					if (networks.Length == 0 && !OperatingSystem.IsAndroidVersionAtLeast(23))
 					{
 						ProcessAllNetworkInfo();
+						return currentAccess;
+					}
+
+					foreach (var network in networks)
+					{
+						try
+						{
+							var capabilities = manager.GetNetworkCapabilities(network);
+
+							if (capabilities == null)
+								continue;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+							var info = manager.GetNetworkInfo(network);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+#pragma warning disable CS0618 // Type or member is obsolete
+							if (info == null || !info.IsAvailable)
+#pragma warning restore CS0618 // Type or member is obsolete
+								continue;
+
+							// Check to see if it has the internet capability
+							if (!capabilities.HasCapability(NetCapability.Internet))
+							{
+								// Doesn't have internet, but local is possible
+								currentAccess = IsBetterAccess(currentAccess, NetworkAccess.Local);
+								continue;
+							}
+
+							ProcessNetworkInfo(info);
+						}
+						catch
+						{
+							// there is a possibility, but don't worry
+						}
 					}
 
 					void ProcessAllNetworkInfo()
@@ -211,40 +204,26 @@ namespace Microsoft.Maui.Essentials
 				Permissions.EnsureDeclared<Permissions.NetworkState>();
 
 				var manager = Platform.ConnectivityManager;
-				if (Platform.HasApiLevel(BuildVersionCodes.Lollipop))
+#pragma warning disable CS0618 // Type or member is obsolete
+				var networks = manager.GetAllNetworks();
+#pragma warning restore CS0618 // Type or member is obsolete
+				foreach (var network in networks)
 				{
 #pragma warning disable CS0618 // Type or member is obsolete
-					var networks = manager.GetAllNetworks();
-#pragma warning restore CS0618 // Type or member is obsolete
-					foreach (var network in networks)
+					NetworkInfo info = null;
+					try
 					{
-#pragma warning disable CS0618 // Type or member is obsolete
-						NetworkInfo info = null;
-						try
-						{
-							info = manager.GetNetworkInfo(network);
-						}
-						catch
-						{
-							// there is a possibility, but don't worry about it
-						}
+						info = manager.GetNetworkInfo(network);
+					}
+					catch
+					{
+						// there is a possibility, but don't worry about it
+					}
 #pragma warning restore CS0618 // Type or member is obsolete
 
-						var p = ProcessNetworkInfo(info);
-						if (p.HasValue)
-							yield return p.Value;
-					}
-				}
-				else
-				{
-#pragma warning disable CS0618 // Type or member is obsolete
-					foreach (var info in manager.GetAllNetworkInfo())
-#pragma warning restore CS0618 // Type or member is obsolete
-					{
-						var p = ProcessNetworkInfo(info);
-						if (p.HasValue)
-							yield return p.Value;
-					}
+					var p = ProcessNetworkInfo(info);
+					if (p.HasValue)
+						yield return p.Value;
 				}
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Essentials
 				return DeviceIdiom.TV;
 			else if (uiMode == UiMode.TypeDesk)
 				return DeviceIdiom.Desktop;
-			else if (Essentials.Platform.HasApiLevel(BuildVersionCodes.KitkatWatch) && uiMode == UiMode.TypeWatch)
+			else if (uiMode == UiMode.TypeWatch)
 				return DeviceIdiom.Watch;
 
 			return DeviceIdiom.Unknown;

--- a/src/Essentials/src/FileSystem/FileSystem.android.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.android.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Essentials
 				if (File.Exists(resolved))
 					return resolved;
 			}
-			else if (!requireExtendedAccess || !Platform.HasApiLevel(29))
+			else if (!requireExtendedAccess || !OperatingSystem.IsAndroidVersionAtLeast(29))
 			{
 				// if this is on an older OS version, or we just need it now
 

--- a/src/Essentials/src/Flashlight/Flashlight.android.cs
+++ b/src/Essentials/src/Flashlight/Flashlight.android.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Essentials
 			{
 				lock (locker)
 				{
-					if (Platform.HasApiLevel(BuildVersionCodes.M) && !AlwaysUseCameraApi)
+					if (OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.M) && !AlwaysUseCameraApi)
 					{
 						var cameraManager = Platform.CameraManager;
 						foreach (var id in cameraManager.GetCameraIdList())

--- a/src/Essentials/src/MainThread/MainThread.android.cs
+++ b/src/Essentials/src/MainThread/MainThread.android.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Essentials
 		{
 			get
 			{
-				if (Platform.HasApiLevel(BuildVersionCodes.M))
+				if (OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.M))
 					return Looper.MainLooper.IsCurrentThread;
 
 				return Looper.MyLooper() == Looper.MainLooper;

--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -311,22 +311,17 @@ namespace Microsoft.Maui.Essentials
 						permissions.Add((Manifest.Permission.AddVoicemail, true));
 					if (IsDeclaredInManifest(Manifest.Permission.UseSip))
 						permissions.Add((Manifest.Permission.UseSip, true));
-
-#if __ANDROID_26__
 					if (Platform.HasApiLevelO)
 					{
 						if (IsDeclaredInManifest(Manifest.Permission.AnswerPhoneCalls))
 							permissions.Add((Manifest.Permission.AnswerPhoneCalls, true));
 					}
-#endif
 
 #pragma warning disable CS0618 // Type or member is obsolete
 					if (IsDeclaredInManifest(Manifest.Permission.ProcessOutgoingCalls))
 					{
-#if __ANDROID_29__
-						if (Platform.HasApiLevel(BuildVersionCodes.Q))
+						if (OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.Q))
 							System.Diagnostics.Debug.WriteLine($"{Manifest.Permission.ProcessOutgoingCalls} is deprecated in Android 10");
-#endif
 						permissions.Add((Manifest.Permission.ProcessOutgoingCalls, true));
 					}
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Essentials/src/PhoneDialer/PhoneDialer.android.cs
+++ b/src/Essentials/src/PhoneDialer/PhoneDialer.android.cs
@@ -26,19 +26,10 @@ namespace Microsoft.Maui.Essentials
 			ValidateOpen(number);
 
 			var phoneNumber = string.Empty;
-#if __ANDROID_24__
 			if (Platform.HasApiLevelN)
 				phoneNumber = PhoneNumberUtils.FormatNumber(number, Java.Util.Locale.GetDefault(Java.Util.Locale.Category.Format).Country) ?? phoneNumber;
-			else if (Platform.HasApiLevel(BuildVersionCodes.Lollipop))
-#else
-			if (Platform.HasApiLevel(BuildVersionCodes.Lollipop))
-#endif
-
-				phoneNumber = PhoneNumberUtils.FormatNumber(number, Java.Util.Locale.Default.Country) ?? phoneNumber;
 			else
-#pragma warning disable CS0618
-				phoneNumber = PhoneNumberUtils.FormatNumber(number) ?? phoneNumber;
-#pragma warning restore CS0618
+				phoneNumber = PhoneNumberUtils.FormatNumber(number, Java.Util.Locale.Default.Country) ?? phoneNumber;
 
 			// if we are an extension then we need to encode
 			if (phoneNumber.Contains(',') || phoneNumber.Contains(';'))
@@ -47,10 +38,8 @@ namespace Microsoft.Maui.Essentials
 			var dialIntent = ResolveDialIntent(phoneNumber);
 
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-#if __ANDROID_24__
 			if (Platform.HasApiLevelN)
 				flags |= ActivityFlags.LaunchAdjacent;
-#endif
 			dialIntent.SetFlags(flags);
 
 			Platform.AppContext.StartActivity(dialIntent);

--- a/src/Essentials/src/Platform/Platform.android.cs
+++ b/src/Essentials/src/Platform/Platform.android.cs
@@ -165,28 +165,17 @@ namespace Microsoft.Maui.Essentials
 			return AndroidUri.FromFile(sharedFile);
 		}
 
-		internal static bool HasApiLevelKitKat => HasApiLevel(BuildVersionCodes.Kitkat);
+		internal static readonly bool HasApiLevelKitKat = OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.Kitkat);
 
-		internal static bool HasApiLevelN => HasApiLevel(24);
+		internal static readonly bool HasApiLevelN = OperatingSystem.IsAndroidVersionAtLeast(24);
 
-		internal static bool HasApiLevelS => HasApiLevel(31);
+		internal static readonly bool HasApiLevelS = OperatingSystem.IsAndroidVersionAtLeast(31);
 
-		internal static bool HasApiLevelNMr1 => HasApiLevel(25);
+		internal static readonly bool HasApiLevelNMr1 = OperatingSystem.IsAndroidVersionAtLeast(25);
 
-		internal static bool HasApiLevelO => HasApiLevel(26);
+		internal static readonly bool HasApiLevelO = OperatingSystem.IsAndroidVersionAtLeast(26);
 
-		internal static bool HasApiLevelQ => HasApiLevel(29);
-
-		static int? sdkInt;
-
-		internal static int SdkInt
-			=> sdkInt ??= (int)Build.VERSION.SdkInt;
-
-		internal static bool HasApiLevel(BuildVersionCodes versionCode) =>
-			SdkInt >= (int)versionCode;
-
-		internal static bool HasApiLevel(int apiLevel) =>
-			SdkInt >= apiLevel;
+		internal static readonly bool HasApiLevelQ = OperatingSystem.IsAndroidVersionAtLeast(29);
 
 		internal static CameraManager CameraManager =>
 			AppContext.GetSystemService(Context.CameraService) as CameraManager;

--- a/src/Essentials/src/Sms/Sms.android.cs
+++ b/src/Essentials/src/Sms/Sms.android.cs
@@ -21,10 +21,8 @@ namespace Microsoft.Maui.Essentials
 			var intent = CreateIntent(message?.Body, message?.Recipients);
 
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-#if __ANDROID_24__
 			if (Platform.HasApiLevelN)
 				flags |= ActivityFlags.LaunchAdjacent;
-#endif
 			intent.SetFlags(flags);
 
 			Platform.AppContext.StartActivity(intent);
@@ -38,7 +36,7 @@ namespace Microsoft.Maui.Essentials
 
 			body = body ?? string.Empty;
 
-			if (Platform.HasApiLevel(BuildVersionCodes.Kitkat) && recipients.All(x => string.IsNullOrWhiteSpace(x)))
+			if (recipients.All(x => string.IsNullOrWhiteSpace(x)))
 			{
 				var packageName = Telephony.Sms.GetDefaultSmsPackage(Platform.AppContext);
 				if (!string.IsNullOrWhiteSpace(packageName))

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Essentials
 				throw new PlatformNotSupportedException("Unable to start text-to-speech engine, not supported on device.");
 
 			var max = maxSpeechInputLengthDefault;
-			if (Platform.HasApiLevel(BuildVersionCodes.JellyBeanMr2))
+			if (OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.JellyBeanMr2))
 				max = AndroidTextToSpeech.MaxSpeechInputLength;
 
 			return textToSpeech.SpeakAsync(text, max, options, cancelToken);
@@ -187,16 +187,13 @@ namespace Microsoft.Maui.Essentials
 		{
 			await Initialize();
 
-			if (Platform.HasApiLevel(BuildVersionCodes.Lollipop))
+			try
 			{
-				try
-				{
-					return tts.AvailableLanguages.Select(a => new Locale(a.Language, a.Country, a.DisplayName, string.Empty));
-				}
-				catch (Exception ex)
-				{
-					Debug.WriteLine("Unable to query language on new API, attempting older api: " + ex);
-				}
+				return tts.AvailableLanguages.Select(a => new Locale(a.Language, a.Country, a.DisplayName, string.Empty));
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine("Unable to query language on new API, attempting older api: " + ex);
 			}
 
 			return JavaLocale.GetAvailableLocales()
@@ -233,22 +230,14 @@ namespace Microsoft.Maui.Essentials
 #pragma warning disable 0618
 		void SetDefaultLanguage()
 		{
-			if (Platform.HasApiLevel(BuildVersionCodes.JellyBeanMr2))
+			try
 			{
-				try
-				{
-					if (tts.DefaultLanguage == null && tts.Language != null)
-						tts.SetLanguage(tts.Language);
-					else if (tts.DefaultLanguage != null)
-						tts.SetLanguage(tts.DefaultLanguage);
-				}
-				catch
-				{
-					if (tts.Language != null)
-						tts.SetLanguage(tts.Language);
-				}
+				if (tts.DefaultLanguage == null && tts.Language != null)
+					tts.SetLanguage(tts.Language);
+				else if (tts.DefaultLanguage != null)
+					tts.SetLanguage(tts.DefaultLanguage);
 			}
-			else
+			catch
 			{
 				if (tts.Language != null)
 					tts.SetLanguage(tts.Language);

--- a/src/Essentials/src/Types/FileProvider.android.cs
+++ b/src/Essentials/src/Types/FileProvider.android.cs
@@ -36,19 +36,6 @@ namespace Microsoft.Maui.Essentials
 			// If we explicitly want only external locations we need to do some permissions checking
 			var externalOnly = TemporaryLocation == FileProviderLocation.External;
 
-			// Check to see if we are >= API Level 19 (KitKat) since we don't need to declare the permission on these API levels to save to the external cache/storage
-			// If we're not on 19 or higher we do need to check for permissions, but if we aren't limiting to external only, don't throw an exception if the
-			// permission wasn't declared because we can always fall back to internal cache
-			var hasPermission = Platform.HasApiLevel(BuildVersionCodes.Kitkat);
-
-			if (!hasPermission)
-			{
-				hasPermission = Permissions.IsDeclaredInManifest(global::Android.Manifest.Permission.WriteExternalStorage);
-
-				if (!hasPermission && externalOnly)
-					throw new PermissionException("Cannot access external storage, the explicitly chosen FileProviderLocation.");
-			}
-
 			// make sure the external storage is available
 			var hasExternalMedia = Platform.AppContext.ExternalCacheDir != null && IsMediaMounted(Platform.AppContext.ExternalCacheDir);
 
@@ -62,17 +49,13 @@ namespace Microsoft.Maui.Essentials
 
 			// based on permssions, return the correct directory
 			// if permission were required, then it would have already thrown
-			return hasPermission && hasExternalMedia
+			return hasExternalMedia
 				? Platform.AppContext.ExternalCacheDir
 				: Platform.AppContext.CacheDir;
 		}
 
 		static bool IsMediaMounted(Java.IO.File location) =>
-			Platform.HasApiLevel(BuildVersionCodes.Lollipop)
-				? AndroidEnvironment.GetExternalStorageState(location) == AndroidEnvironment.MediaMounted
-#pragma warning disable CS0618 // Type or member is obsolete
-				: AndroidEnvironment.GetStorageState(location) == AndroidEnvironment.MediaMounted;
-#pragma warning restore CS0618 // Type or member is obsolete
+			AndroidEnvironment.GetExternalStorageState(location) == AndroidEnvironment.MediaMounted;
 
 		internal static bool IsFileInPublicLocation(string filename)
 		{

--- a/src/Essentials/src/Types/LocationExtensions.android.cs
+++ b/src/Essentials/src/Types/LocationExtensions.android.cs
@@ -29,24 +29,15 @@ namespace Microsoft.Maui.Essentials
 				Timestamp = location.GetTimestamp().ToUniversalTime(),
 				Accuracy = location.HasAccuracy ? location.Accuracy : default(float?),
 				VerticalAccuracy =
-#if __ANDROID_26__
 					Platform.HasApiLevelO && location.HasVerticalAccuracy ? location.VerticalAccuracyMeters : default(float?),
-#else
-					default(float?),
-#endif
 				Course = location.HasBearing ? location.Bearing : default(double?),
 				Speed = location.HasSpeed ? location.Speed : default(double?),
-				IsFromMockProvider = Platform.HasApiLevel(global::Android.OS.BuildVersionCodes.JellyBeanMr2)
-					? (
-#if __ANDROID_31__
-						Platform.HasApiLevelS
-							? location.Mock :
-#endif
+				IsFromMockProvider =
+					Platform.HasApiLevelS
+						? location.Mock :
 #pragma warning disable CS0618 // Type or member is obsolete
-							location.IsFromMockProvider
+						location.IsFromMockProvider,
 #pragma warning restore CS0618 // Type or member is obsolete
-						)
-					: false,
 				AltitudeReferenceSystem = AltitudeReferenceSystem.Ellipsoid
 			};
 

--- a/src/Essentials/test/DeviceTests/Startup.cs
+++ b/src/Essentials/test/DeviceTests/Startup.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
 using Microsoft.Maui.TestUtils.DeviceTests.Runners;
@@ -32,7 +33,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 					SkipCategories = Traits
 						.GetSkipTraits()
 #if __ANDROID__
-						.Append($"{Traits.FileProvider}={Traits.FeatureSupport.ToExclude(Platform.HasApiLevel(24))}")
+						.Append($"{Traits.FileProvider}={Traits.FeatureSupport.ToExclude(OperatingSystem.IsAndroidVersionAtLeast(24))}")
 #endif
 						.ToList(),
 				})

--- a/src/Essentials/test/DeviceTests/Tests/Android/FileProvider_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/FileProvider_Tests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 			Assert.Equal("content", shareableUri.Scheme);
 			Assert.Equal("com.microsoft.maui.essentials.devicetests.fileProvider", shareableUri.Authority);
 
-			if (Platform.HasApiLevel(29))
+			if (OperatingSystem.IsAndroidVersionAtLeast(29))
 			{
 #pragma warning disable CS0618 // Type or member is obsolete
 				var externalRoot = AndroidEnvironment.ExternalStorageDirectory.AbsolutePath;

--- a/src/Essentials/test/DeviceTests/Tests/AppActions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/AppActions_Tests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
@@ -12,7 +13,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			var expectSupported = false;
 
 #if __ANDROID__
-			expectSupported = Platform.SdkInt >= 25;
+			expectSupported = OperatingSystem.IsAndroidVersionAtLeast(25);
 #elif __IOS__
 			expectSupported = Platform.HasOSVersion(9, 0);
 #endif

--- a/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/SecureStorage_Tests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task Fix_Corrupt_Data(string key, string data)
 		{
 			// this operation is only available on API level 23+ devices
-			if (!Platform.HasApiLevel(23))
+			if (!OperatingSystem.IsAndroidVersionAtLeast(23))
 				return;
 
 			// set a valid key

--- a/src/Essentials/test/DeviceTests/Tests/Vibration_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Vibration_Tests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 #if __ANDROID__
             // API 23+ we need user interaction for camera permission
             // can't really test so easily on device.
-            if (Platform.HasApiLevel(Android.OS.BuildVersionCodes.M))
+            if (OperatingSystem.IsAndroidVersionAtLeast((int)Android.OS.BuildVersionCodes.M))
                 return;
 #elif __IOS__
             // TODO: remove this as soon as the test harness can filter
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 #if __ANDROID__
             // API 23+ we need user interaction for camera permission
             // can't really test so easily on device.
-            if (Platform.HasApiLevel(Android.OS.BuildVersionCodes.M))
+            if (OperatingSystem.IsAndroidVersionAtLeast((int)Android.OS.BuildVersionCodes.M))
                 return;
 #elif __IOS__
             // TODO: remove this as soon as the test harness can filter

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestInstrumentation.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 			var name = Path.GetFileName(resultsFile);
 
 			string finalPath;
-			if ((int)Build.VERSION.SdkInt < 30)
+			if (!OperatingSystem.IsAndroidVersionAtLeast(30))
 			{
 				var root = Application.Context.GetExternalFilesDir(null)!.AbsolutePath!;
 				var dir = Path.Combine(root, guid);


### PR DESCRIPTION
### Description of Change ###

We have a beautiful .NET 6 API we can use instead, that doesn't call
into Java (no JNI!):

https://docs.microsoft.com/dotnet/api/system.operatingsystem.isandroidversionatleast

Usage of `Build.VERSION.SdkInt` came from both Xamarin.Forms and
Xamarin.Essentials. We were caching the result of the value, but still
doing that work twice.

We can also use the pattern:

    OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.JellyBean)

`BuildVersionCodes` is a regular C# enum, and so the C# compiler will
strip this information away leaving just an integer in the final IL.

I used either an integer or the enum, depending on what the existing
code did.

Additionally, I went through any existing code checking old API levels and removed it.
The minimum API level for .NET 6 (dotnet/runtime & xamarin-android) is 21. So any
code looking for API levels 21 or lower, could just be removed.

I also removed code I found such as:

    public static int? TargetSdkVersion(this Context self)
    {
        return (int?)self?.ApplicationInfo?.TargetSdkVersion;
    }

This was only used in one place, and was checking API 17, so I just
removed it.

### Results ###

Testing a `Release` build of `Maui.Controls.Sample.SingleProject.csproj`
on a Pixel 5 device:

    Before:
    12-16 14:41:19.289  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s739ms
    12-16 14:41:24.468  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s713ms
    12-16 14:41:29.867  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s917ms
    12-16 14:41:34.905  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s765ms
    12-16 14:41:40.132  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s719ms
    12-16 14:41:45.431  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s768ms
    12-16 14:41:50.608  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s716ms
    12-16 14:41:55.878  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s754ms
    12-16 14:42:01.157  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s754ms
    12-16 14:42:06.315  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s713ms
    Average(ms): 1755.8
    Std Err(ms): 19.1803139819046
    Std Dev(ms): 60.6534784199921

    After:
    12-16 14:45:35.208  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s737ms
    12-16 14:45:40.448  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s743ms
    12-16 14:45:45.663  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s715ms
    12-16 14:45:50.931  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s741ms
    12-16 14:45:56.161  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s712ms
    12-16 14:46:01.426  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s768ms
    12-16 14:46:06.574  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s699ms
    12-16 14:46:11.867  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s779ms
    12-16 14:46:16.979  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s694ms
    12-16 14:46:22.229  1741  1935 I ActivityTaskManager: Displayed com.microsoft.maui.sample/crc64dac46b470c4e9200.MainActivity: +1s728ms
    Average(ms): 1731.6
    Std Err(ms): 8.79924239163047
    Std Dev(ms): 27.8256476414596

This appears to maybe save ~24ms on startup for this app?

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No