### PR TITLE
Enable `InternalsVisibleTo` for `CommunityToolkit.Maui.Core`

### DIFF
--- a/src/Controls/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Core/Properties/AssemblyInfo.cs
@@ -44,6 +44,11 @@ using Compatibility = Microsoft.Maui.Controls.Compatibility;
 [assembly: InternalsVisibleTo("WinUI.UITests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.DeviceTests")]
 
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
 
 [assembly: Preserve]
 

--- a/src/Controls/src/Xaml/Properties/AssemblyInfo.cs
+++ b/src/Controls/src/Xaml/Properties/AssemblyInfo.cs
@@ -11,6 +11,11 @@ using Microsoft.Maui.Controls.Internals;
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.HotReload.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.SourceGen")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Compatibility")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
 [assembly: Preserve]
 
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui", "Microsoft.Maui.Controls.Xaml")]

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -19,6 +19,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Comet")]
 [assembly: InternalsVisibleTo("Comet.Tests")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]

--- a/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
+++ b/src/Essentials/src/AssemblyInfo/AssemblyInfo.shared.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsShared")]
 [assembly: InternalsVisibleTo("EssentialsDeviceTestsiOS")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
+[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]


### PR DESCRIPTION
### Description of Change ###

The .NET MAUI Community Toolkit [recently added a new CSPROJ, `CommunityToolkit.Maui.Core`](https://github.com/CommunityToolkit/Maui/pull/214).

This PR builds on the [previous pull request enabling `InternalsVisibleTo` for the .NET MAUI Toolkit](https://github.com/dotnet/maui/pull/1970), adding `[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]`.

### Additions made ###
Adds `InternalsVisibleTo` for the .NET MAUI Community Toolkit libraries

```csharp
[assembly: InternalsVisibleTo("CommunityToolkit.Maui")]
[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Core")]
[assembly: InternalsVisibleTo("CommunityToolkit.Maui.UnitTests")]
[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup")]
[assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
```