### PR TITLE
[android] compute HasRtlSupport once on startup

### DIFF
--- a/src/Compatibility/Core/src/Android/Cells/EntryCellRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Cells/EntryCellRenderer.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		void UpdateHorizontalTextAlignment()
 		{
 			var entryCell = (EntryCell)Cell;
-			_view.EditText.UpdateHorizontalAlignment(entryCell.HorizontalTextAlignment, _view.Context.HasRtlSupport());
+			_view.EditText.UpdateHorizontalAlignment(entryCell.HorizontalTextAlignment);
 		}
 
 		void UpdateVerticalTextAlignment()

--- a/src/Compatibility/Core/src/Android/Extensions/TextAlignmentExtensions.cs
+++ b/src/Compatibility/Core/src/Android/Extensions/TextAlignmentExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		internal static void UpdateTextAlignment(this EditText view, TextAlignment horizontal, TextAlignment vertical)
 		{
-			if (!view.Context.HasRtlSupport())
+			if (!Rtl.IsSupported)
 			{
 				view.Gravity = vertical.ToVerticalGravityFlags() | horizontal.ToHorizontalGravityFlags();
 			}

--- a/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			if (_editText == null)
 				return;
 
-			_editText.UpdateHorizontalAlignment(Element.HorizontalTextAlignment, Context.HasRtlSupport(), Microsoft.Maui.TextAlignment.Center.ToVerticalGravityFlags());
+			_editText.UpdateHorizontalAlignment(Element.HorizontalTextAlignment, Microsoft.Maui.TextAlignment.Center.ToVerticalGravityFlags());
 		}
 
 		[PortHandler]

--- a/src/Compatibility/Core/tests/Android/Issues.cs
+++ b/src/Compatibility/Core/tests/Android/Issues.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		[Issue(IssueTracker.Github, 8137, "[Bug] XF 4.3 Entry HorizontalTextAlignment display wrong position")]
 		public async Task EntryHorizontalAlignmentCenterInRenderer()
 		{
-			bool supportsRTL = Context.HasRtlSupport();
+			bool supportsRTL = IsRTLSupported;
 
 			try
 			{
 				// Test with RTL support off 
-				ToggleRTLSupport(Context, false);
+				SetIsRTLSupported(false);
 
 				await Device.InvokeOnMainThreadAsync(() =>
 				{
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 					}
 
 					// Now turn it back on and verify it works
-					ToggleRTLSupport(Context, true);
+					SetIsRTLSupported(true);
 
 					var entry2 = new Entry { Text = "foo", HorizontalTextAlignment = TextAlignment.Center };
 					using (var editText = GetNativeControl(entry2))
@@ -47,8 +47,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 			}
 			finally
 			{
-				// If something went wrong, make sure we leave the Context as it was when we started
-				ToggleRTLSupport(Context, supportsRTL);
+				// If something went wrong, make sure we leave the value as it was when we started
+				SetIsRTLSupported(supportsRTL);
 			}
 		}
 

--- a/src/Compatibility/Core/tests/Android/PlatformTestFixture.cs
+++ b/src/Compatibility/Core/tests/Android/PlatformTestFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Android.Content;
 using Android.Content.PM;
@@ -95,12 +96,16 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 
 		}
 
-		protected static void ToggleRTLSupport(Context context, bool enabled)
-		{
-			context.ApplicationInfo.Flags = enabled
-				? context.ApplicationInfo.Flags | ApplicationInfoFlags.SupportsRtl
-				: context.ApplicationInfo.Flags & ~ApplicationInfoFlags.SupportsRtl;
-		}
+		static readonly Lazy<FieldInfo> isSupported = new Lazy<FieldInfo>(() => {
+			var type = Type.GetType("Microsoft.Maui.Platform.Rtl, Microsoft.Maui", throwOnError: true);
+			var field = type.GetField("IsSupported");
+			Assert.IsNotNull(field, "Microsoft.Maui.Platform.Rtl.IsSupported not found!");
+			return field;
+		});
+
+		protected static bool IsRTLSupported => (bool)isSupported.Value.GetValue(null);
+
+		protected static void SetIsRTLSupported(bool value) => isSupported.Value.SetValue(null, value);
 
 		protected IVisualElementRenderer GetRenderer(VisualElement element)
 		{

--- a/src/Controls/src/Core/Platform/Android/Shell/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/SearchHandlerAppearanceTracker.cs
@@ -136,12 +136,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 		void UpdateHorizontalTextAlignment()
 		{
-			_editText.UpdateHorizontalAlignment(_searchHandler.HorizontalTextAlignment, _control.Context.HasRtlSupport(), Microsoft.Maui.TextAlignment.Center.ToVerticalGravityFlags());
+			_editText.UpdateHorizontalAlignment(_searchHandler.HorizontalTextAlignment, TextAlignment.Center.ToVerticalGravityFlags());
 		}
 
 		void UpdateVerticalTextAlignment()
 		{
-			_editText.UpdateVerticalAlignment(_searchHandler.VerticalTextAlignment, Microsoft.Maui.TextAlignment.Center.ToVerticalGravityFlags());
+			_editText.UpdateVerticalAlignment(_searchHandler.VerticalTextAlignment, TextAlignment.Center.ToVerticalGravityFlags());
 		}
 
 		void UpdateTextTransform()

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -80,9 +80,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker picker)
 		{
-			var nativePicker = handler.NativeView;
-			var hasRtlSupport = nativePicker?.Context!.HasRtlSupport() ?? false;
-			nativePicker?.UpdateHorizontalAlignment(picker.HorizontalTextAlignment, hasRtlSupport);
+			handler.NativeView?.UpdateHorizontalAlignment(picker.HorizontalTextAlignment);
 		}
 
 		public static void MapTextColor(PickerHandler handler, IPicker picker)

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -71,14 +71,6 @@ namespace Microsoft.Maui.Platform
 			);
 		}
 
-		public static bool HasRtlSupport(this Context self)
-		{
-			if (self == null)
-				return false;
-
-			return (self.ApplicationInfo?.Flags & AApplicationInfoFlags.SupportsRtl) == AApplicationInfoFlags.SupportsRtl;
-		}
-
 		public static double GetThemeAttributeDp(this Context self, int resource)
 		{
 			using (var value = new TypedValue())

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateHorizontalTextAlignment(this EditText editText, ITextAlignment textAlignment)
 		{
-			editText.UpdateHorizontalAlignment(textAlignment.HorizontalTextAlignment, editText.Context != null && editText.Context.HasRtlSupport());
+			editText.UpdateHorizontalAlignment(textAlignment.HorizontalTextAlignment);
 		}
 
 		public static void UpdateVerticalTextAlignment(this EditText editText, ITextAlignment entry)

--- a/src/Core/src/Platform/Android/Rtl.cs
+++ b/src/Core/src/Platform/Android/Rtl.cs
@@ -1,0 +1,14 @@
+﻿using Android.App;
+using Android.Content.PM;
+
+namespace Microsoft.Maui.Platform
+{
+	static class Rtl
+	{
+		/// <summary>
+		/// True if /manifest/application@android:supportsRtl="true"
+		/// </summary>
+		public static readonly bool IsSupported =
+			(Application.Context?.ApplicationInfo?.Flags & ApplicationInfoFlags.SupportsRtl) != 0;
+	}
+}

--- a/src/Core/src/Platform/Android/TextAlignmentExtensions.cs
+++ b/src/Core/src/Platform/Android/TextAlignmentExtensions.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Maui.Platform
 {
 	public static class TextAlignmentExtensions
 	{
-		internal static void UpdateHorizontalAlignment(this EditText view, TextAlignment alignment, bool hasRtlSupport, AGravityFlags orMask = AGravityFlags.NoGravity)
+		internal static void UpdateHorizontalAlignment(this EditText view, TextAlignment alignment, AGravityFlags orMask = AGravityFlags.NoGravity)
 		{
-			if (!hasRtlSupport)
+			if (!Rtl.IsSupported)
 				view.Gravity = alignment.ToHorizontalGravityFlags() | orMask;
 			else
 				view.TextAlignment = alignment.ToTextAlignment();
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateTextAlignment(this EditText view, TextAlignment horizontal, TextAlignment vertical)
 		{
-			if (view.Context != null && !view.Context.HasRtlSupport())
+			if (view.Context != null && !Rtl.IsSupported)
 			{
 				view.Gravity = vertical.ToVerticalGravityFlags() | horizontal.ToHorizontalGravityFlags();
 			}

--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateHorizontalTextAlignment(this TextView textView, ITextAlignment text)
 		{
-			if (textView.Context!.HasRtlSupport())
+			if (Rtl.IsSupported)
 			{
 				// We want to use TextAlignment where possible because it doesn't conflict with the
 				// overall gravity of the underlying control


### PR DESCRIPTION
### Description of Change ###

Previously we were calculating:

    public static bool HasRtlSupport(this Context self)
    {
        if (self == null)
            return false;

        return (self.ApplicationInfo?.Flags & AApplicationInfoFlags.SupportsRtl) == AApplicationInfoFlags.SupportsRtl;
    }

Multiple times for every `Label`, `Entry`, or related controls.
`Context.ApplicationInfo` pulls values from the `AndroidManifest.xml`
for the entire Android application, so this isn't a value that would
not change after startup -- or for different controls.

https://developer.android.com/reference/android/content/pm/ApplicationInfo#flags
https://developer.android.com/reference/android/content/pm/ApplicationInfo#FLAG_SUPPORTS_RTL

Let's move this method to be a `static readonly` field in a new static
class. It will lazily be evaluated when the new class is accessed, and
only once per application run.

### Results ###

Running `ViewHandlerBenchmark` on a Pixel 5 device:

    > .\bin\dotnet\dotnet build .\src\Core\tests\Benchmarks.Droid\Benchmarks.Droid.csproj -t:Benchmark -c Release

| Method |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------- |-----------:|---------:|---------:|-------:|----------:|
| -Label |   527.6 µs |  4.89 µs |  4.57 µs | 0.9766 |      5 KB |
| +Label |   494.9 µs |  5.72 µs |  5.35 µs | 0.9766 |      5 KB |
| -Entry | 1,951.2 µs |  5.02 µs |  4.19 µs |      - |     12 KB |
| +Entry | 1,925.8 µs | 13.24 µs | 11.74 µs |      - |     12 KB |

`-` Using dotnet/maui/main before these changes
`+` Using these changes

I tried a few times, and I'm not sure I'm able to see a measurable
difference launching `Maui.Controls.Sample.SingleProject.csproj` over
and over. But this change seems low risk, worth adding in.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No