### PR TITLE
[iOS] Add AutoresizingMask to WindowOverlay GraphicsView

### DIFF
--- a/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui
 		PassthroughView? _passthroughView;
 		IDisposable? _frameObserver;
 		NativeGraphicsView? _graphicsView;
+		UIWindow? _uiWindow;
 
 		public virtual bool Initialize()
 		{
@@ -23,6 +24,8 @@ namespace Microsoft.Maui
 			if (nativeLayer is not UIWindow nativeWindow)
 				return false;
 
+			_uiWindow = nativeWindow;
+
 			if (nativeWindow?.RootViewController?.View == null)
 				return false;
 
@@ -30,6 +33,8 @@ namespace Microsoft.Maui
 			_passthroughView = new PassthroughView(this, nativeWindow.RootViewController.View.Frame);
 
 			_graphicsView = new NativeGraphicsView(_passthroughView.Frame, this, new DirectRenderer());
+			_graphicsView.AutoresizingMask = UIViewAutoresizing.All;
+
 			_passthroughView.AddSubview(_graphicsView);
 
 			if (_graphicsView == null)
@@ -79,6 +84,12 @@ namespace Microsoft.Maui
 
 		void FrameAction(Foundation.NSObservedChange obj)
 		{
+			//if (this._passthroughView != null && this._uiWindow?.RootViewController?.View != null)
+			//	this._passthroughView.Frame = this._uiWindow.RootViewController.View.Frame;
+
+			//if (this._graphicsView != null && this._uiWindow?.RootViewController?.View != null)
+			//	this._graphicsView.Frame = this._uiWindow.RootViewController.View.Frame;
+
 			HandleUIChange();
 			Invalidate();
 		}
@@ -101,6 +112,9 @@ namespace Microsoft.Maui
 				: base(frame)
 			{
 				overlay = windowOverlay;
+				//AutoresizingMask = UIViewAutoresizing.All;
+				//AutosizesSubviews = true;
+				//TranslatesAutoresizingMaskIntoConstraints = true;
 			}
 
 			public override bool PointInside(CGPoint point, UIEvent? uievent)

--- a/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Maui
 		PassthroughView? _passthroughView;
 		IDisposable? _frameObserver;
 		NativeGraphicsView? _graphicsView;
-		UIWindow? _uiWindow;
 
 		public virtual bool Initialize()
 		{
@@ -23,8 +22,6 @@ namespace Microsoft.Maui
 			var nativeLayer = Window?.GetNative(true);
 			if (nativeLayer is not UIWindow nativeWindow)
 				return false;
-
-			_uiWindow = nativeWindow;
 
 			if (nativeWindow?.RootViewController?.View == null)
 				return false;
@@ -84,12 +81,6 @@ namespace Microsoft.Maui
 
 		void FrameAction(Foundation.NSObservedChange obj)
 		{
-			//if (this._passthroughView != null && this._uiWindow?.RootViewController?.View != null)
-			//	this._passthroughView.Frame = this._uiWindow.RootViewController.View.Frame;
-
-			//if (this._graphicsView != null && this._uiWindow?.RootViewController?.View != null)
-			//	this._graphicsView.Frame = this._uiWindow.RootViewController.View.Frame;
-
 			HandleUIChange();
 			Invalidate();
 		}
@@ -112,9 +103,6 @@ namespace Microsoft.Maui
 				: base(frame)
 			{
 				overlay = windowOverlay;
-				//AutoresizingMask = UIViewAutoresizing.All;
-				//AutosizesSubviews = true;
-				//TranslatesAutoresizingMaskIntoConstraints = true;
 			}
 
 			public override bool PointInside(CGPoint point, UIEvent? uievent)


### PR DESCRIPTION
https://user-images.githubusercontent.com/898335/146629903-f7d8954b-593d-4b39-a9fe-f3fadb1407f9.mov

When setting up the graphics view for the WindowOverlay, we need to also set the AutoresizingMask flag to make sure that the view gets updated frame constraints. Otherwise, it will only get the initial constraint when the view is created.

This only affects people using the WindowOverlay with their own drawn elements, the default Adorners get the view positions from where the elements are located, which ignores the default "dirtyRect" to get its calculations.

