### PR TITLE
Remove layout resolution

### DIFF
--- a/src/Compatibility/Core/src/Android/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/Android/VisualElementRenderer.cs
@@ -405,15 +405,5 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		void IVisualElementRenderer.SetLabelFor(int? id)
 			=> ViewCompat.SetLabelFor(this, id ?? ViewCompat.GetLabelFor(this));
-
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
-		{
-			if (Element is Layout layout)
-			{
-				layout.ResolveLayoutChanges();
-			}
-
-			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-		}
 	}
 }

--- a/src/Compatibility/Core/src/Windows/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/VisualElementRenderer.cs
@@ -276,11 +276,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (Element == null || availableSize.Width * availableSize.Height == 0)
 				return new global::Windows.Foundation.Size(0, 0);
 
-			if (Element is Layout layout)
-			{
-				layout.ResolveLayoutChanges();
-			}
-
 			Element.IsInNativeLayout = true;
 
 			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)

--- a/src/Compatibility/Core/src/iOS/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/VisualElementRenderer.cs
@@ -236,24 +236,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 #if __MOBILE__
 
-		void ResolveLayoutChanges()
-		{
-			if (Element is Layout layout)
-			{
-				layout.ResolveLayoutChanges();
-			}
-		}
-
 		public override SizeF SizeThatFits(SizeF size)
 		{
-			ResolveLayoutChanges();
 			return new SizeF(0, 0);
 		}
 
 		public override void LayoutSubviews()
 		{
-			ResolveLayoutChanges();
-
 			base.LayoutSubviews();
 
 			if (_blur != null && Superview != null)

--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -104,16 +104,5 @@ namespace Microsoft.Maui.Controls
 
 			return bounds.Size;
 		}
-
-		internal override void QueueLayoutResolution()
-		{
-			if (Handler != null)
-			{
-				// No need to queue up layout changes in ScrollView 
-				return;
-			}
-
-			base.QueueLayoutResolution();
-		}
 	}
 }

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -72,10 +72,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		public static readonly BindableProperty PaddingProperty = PaddingElement.PaddingProperty;
 
-		static IList<KeyValuePair<Layout, int>> s_resolutionList = new List<KeyValuePair<Layout, int>>();
-		static bool s_relayoutInProgress;
-		bool _allocatedFlag;
-
 		bool _hasDoneLayout;
 		Size _lastLayoutSize = new Size(-1, -1);
 
@@ -239,7 +235,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		protected override void OnSizeAllocated(double width, double height)
 		{
-			_allocatedFlag = true;
 			base.OnSizeAllocated(width, height);
 			UpdateChildrenLayout();
 		}
@@ -363,7 +358,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 				}
 			}
 
-			_allocatedFlag = false;
 			if (trigger == InvalidationTrigger.RendererReady)
 			{
 				InvalidateMeasureInternal(InvalidationTrigger.RendererReady);
@@ -371,54 +365,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 			else
 			{
 				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
-			}
-
-			QueueLayoutResolution();
-		}
-
-		internal virtual void QueueLayoutResolution()
-		{
-			s_resolutionList.Add(new KeyValuePair<Layout, int>(this, GetElementDepth(this)));
-
-			if (Device.PlatformInvalidator == null && !s_relayoutInProgress)
-			{
-				// Rather than recomputing the layout for each change as it happens, we accumulate them in
-				// s_resolutionList and schedule a single layout update operation to handle them all at once.
-				// This avoids a lot of unnecessary layout operations if something is triggering many property
-				// changes at once (e.g., a BindingContext change)
-
-				s_relayoutInProgress = true;
-
-				Dispatcher.DispatchIfRequired(ResolveLayoutChanges);
-			}
-			else
-			{
-				// If the platform supports PlatformServices2, queueing is unnecessary; the layout changes
-				// will be handled during the Layout's next Measure/Arrange pass
-				Device.Invalidate(this);
-			}
-		}
-
-		public void ResolveLayoutChanges()
-		{
-			s_relayoutInProgress = false;
-
-			if (s_resolutionList.Count == 0)
-			{
-				return;
-			}
-
-			IList<KeyValuePair<Layout, int>> copy = s_resolutionList;
-			s_resolutionList = new List<KeyValuePair<Layout, int>>();
-
-			foreach (KeyValuePair<Layout, int> kvp in copy)
-			{
-				Layout layout = kvp.Key;
-				double width = layout.Width, height = layout.Height;
-				if (!layout._allocatedFlag && width >= 0 && height >= 0)
-				{
-					layout.SizeAllocated(width, height);
-				}
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlexLayoutTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Threading;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -446,17 +447,34 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 			};
 
+			var handler = Substitute.For<IViewHandler>();
+			layout.Handler = handler;
+
 			layout.Layout(new Rectangle(0, 0, 300, 300));
 			Assert.That(label0.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 20)));
 			Assert.That(label1.Bounds, Is.EqualTo(new Rectangle(0, 20, 300, 20)));
 			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(0, 40, 300, 20)));
 
 			label1.IsVisible = false;
+
+			// Changing the visibility of the label should have triggered a measure invalidation in the layout
+			AssertInvalidated(handler);
+			
+			// Fake a native invalidation
+			layout.ForceLayout();
+
 			Assert.That(label0.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 20)));
 			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(0, 20, 300, 20)));
 
 			label0.IsVisible = false;
 			label1.IsVisible = true;
+
+			// Verify the visibility changes invalidated the layout
+			AssertInvalidated(handler);
+
+			// Fake a native invalidation
+			layout.ForceLayout();
+
 			Assert.That(label1.Bounds, Is.EqualTo(new Rectangle(0, 0, 300, 20)));
 			Assert.That(label2.Bounds, Is.EqualTo(new Rectangle(0, 20, 300, 20)));
 		}
@@ -471,6 +489,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Direction = FlexDirection.Column,
 			};
 
+			var handler = Substitute.For<IViewHandler>();
+			layout.Handler = handler;
+
 			layout.Layout(new Rectangle(0, 0, 300, 300));
 			for (var i = 0; i < 3; i++)
 			{
@@ -481,6 +502,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				layout.Children.Add(box);
 				FlexLayout.SetGrow(box, 1f);
 			}
+			
+			// Verify the changes invalidated the layout
+			AssertInvalidated(handler);
+
+			// Fake a native invalidation
+			layout.ForceLayout();
 
 			Assert.That(layout.Children[2].Frame, Is.EqualTo(new Rectangle(0, 200, 300, 100)));
 		}
@@ -518,6 +545,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			layout.Layout(new Rectangle(0, 0, 500, 300));
 			Assert.That(layout.Children[0].Frame, Is.EqualTo(new Rectangle(20, 10, 100, 20)));
 			Assert.That(layout.Children[2].Frame, Is.EqualTo(new Rectangle(380, 10, 100, 20)));
+		}
+
+		void AssertInvalidated(IViewHandler handler) 
+		{
+			handler.Received().Invoke(Arg.Is(nameof(IView.InvalidateMeasure)), Arg.Any<object>());
+			handler.ClearReceivedCalls();
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/MarginTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MarginTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -96,6 +97,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				IsPlatformEnabled = true,
 			};
 
+			var handler = Substitute.For<IViewHandler>();
+			parent.Handler = handler;
+
 			var child1 = new Button
 			{
 				Text = "Test",
@@ -122,8 +126,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			child1.Margin = new Thickness(10, 20, 30, 40);
 
+			// Verify that the margin change invalidated the layout, and simulate a native layout change
+			AssertInvalidated(handler);
+			parent.ForceLayout();
+
 			Assert.AreEqual(new Rectangle(10, 20, 100, 50), child1.Bounds);
 			Assert.AreEqual(new Rectangle(5, 120, 980, 50), child2.Bounds);
+		}
+
+		void AssertInvalidated(IViewHandler handler)
+		{
+			handler.Received().Invoke(Arg.Is(nameof(IView.InvalidateMeasure)), Arg.Any<object>());
+			handler.ClearReceivedCalls();
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ScrollViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ScrollViewUnitTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui.Graphics;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -77,6 +78,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			View view = new View { IsPlatformEnabled = true, WidthRequest = 100, HeightRequest = 100 };
 
 			ScrollView scroll = new ScrollView { Content = view };
+
+			var handler = Substitute.For<IViewHandler>();
+			scroll.Handler = handler;
+
 			scroll.Layout(new Rectangle(0, 0, 50, 50));
 
 			Assert.AreEqual(new Size(50, 100), scroll.ContentSize);
@@ -94,6 +99,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			view.HeightRequest = 200;
 
+			// Verify that the HeightRequest change invalidated the layout, and simulate a native layout update 
+			AssertInvalidated(handler);
+			scroll.ForceLayout();
+
 			Assert.True(changed);
 			Assert.AreEqual(new Size(50, 200), scroll.ContentSize);
 		}
@@ -104,6 +113,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			View view = new View { IsPlatformEnabled = true, WidthRequest = 100, HeightRequest = 100 };
 
 			ScrollView scroll = new ScrollView { Content = view, Orientation = ScrollOrientation.Both };
+
+			var handler = Substitute.For<IViewHandler>();
+			scroll.Handler = handler;
+
 			scroll.Layout(new Rectangle(0, 0, 50, 50));
 
 			Assert.AreEqual(new Size(100, 100), scroll.ContentSize);
@@ -121,6 +134,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			view.HeightRequest = 200;
 
+			// Verify that the HeightRequest change invalidated the layout, and simulate a native layout update 
+			AssertInvalidated(handler);
+			scroll.ForceLayout();
+
 			Assert.True(changed);
 			Assert.AreEqual(new Size(100, 200), scroll.ContentSize);
 		}
@@ -135,6 +152,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Orientation = ScrollOrientation.Horizontal,
 				Content = view
 			};
+
+			var handler = Substitute.For<IViewHandler>();
+			scroll.Handler = handler;
+
 			scroll.Layout(new Rectangle(0, 0, 50, 50));
 
 			Assert.AreEqual(new Size(100, 50), scroll.ContentSize);
@@ -152,6 +173,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			view.WidthRequest = 200;
 
+			// Verify that the WidthRequest change invalidated the layout, and simulate a native layout update 
+			AssertInvalidated(handler);
+			scroll.ForceLayout();
+
 			Assert.True(changed);
 			Assert.AreEqual(new Size(200, 50), scroll.ContentSize);
 		}
@@ -166,6 +191,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Orientation = ScrollOrientation.Both,
 				Content = view
 			};
+
+			var handler = Substitute.For<IViewHandler>();
+			scroll.Handler = handler;
+
 			scroll.Layout(new Rectangle(0, 0, 50, 50));
 
 			Assert.AreEqual(new Size(100, 100), scroll.ContentSize);
@@ -182,6 +211,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 
 			view.WidthRequest = 200;
+
+			// Verify that the WidthRequest change invalidated the layout, and simulate a native layout update 
+			AssertInvalidated(handler);
+			scroll.ForceLayout();
 
 			Assert.True(changed);
 			Assert.AreEqual(new Size(200, 100), scroll.ContentSize);
@@ -555,6 +588,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			scrollView.ScrollToAsync(0, 100, true);
 			Assert.AreEqual(y100Count, 2);
+		}
+
+		void AssertInvalidated(IViewHandler handler)
+		{
+			handler.Received().Invoke(Arg.Is(nameof(IView.InvalidateMeasure)), Arg.Any<object>());
+			handler.ClearReceivedCalls();
 		}
 	}
 }


### PR DESCRIPTION
Removing the deferred layout resolution hacks from Forms. They're no longer necessary for MAUI; everything should be hooked into the native platform invalidation. 