### PR TITLE
[core] cleanup PropertyMapper.PopulateKeys()

### DIFF
--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -81,16 +81,14 @@ namespace Microsoft.Maui
 			}
 		}
 
-		protected HashSet<string> PopulateKeys(ref HashSet<string>? returnList)
+		private HashSet<string> PopulateKeys()
 		{
-			_updateKeys = new HashSet<string>();
-
+			var keys = new HashSet<string>(StringComparer.Ordinal);
 			foreach (var key in GetKeys())
 			{
-				_updateKeys.Add(key);
+				keys.Add(key);
 			}
-
-			return returnList ?? new HashSet<string>();
+			return keys;
 		}
 
 		protected virtual void ClearKeyCache()
@@ -98,8 +96,7 @@ namespace Microsoft.Maui
 			_updateKeys = null;
 		}
 
-		public virtual IReadOnlyCollection<string> UpdateKeys =>
-			_updateKeys ?? PopulateKeys(ref _updateKeys);
+		public virtual IReadOnlyCollection<string> UpdateKeys => _updateKeys ??= PopulateKeys();
 
 		public virtual IEnumerable<string> GetKeys()
 		{


### PR DESCRIPTION
### Description of Change ###

I was looking at `PopulateKeys()` and a couple things seemed odd:

1. It is `protected`? It doesn't seem like this should be a "public"
API folks use.

2. It has a `ref returnList` parameter? But doesn't actually use it?

3. It uses the `_updateKeys` member variable, but doesn't return it?

I simplified `PopulateKeys()` and also made use of `StringComparer.Ordinal`:

https://docs.microsoft.com/dotnet/standard/base-types/best-practices-strings#recommendations-for-string-usage

This will have a tiny improvement on performance, but this is more about
cleaning up a "public" API before MAUI goes stable.

### Additions made ###

* Makes `PropertyMapper.PopulateKeys()` `private`. 

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No
