### PR TITLE
[core] remove Try/AddHandlers() APIs for linker-friendliness

### DIFF
--- a/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryServiceBuilder.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/BordelessEntry/BordelessEntryServiceBuilder.cs
@@ -62,7 +62,10 @@ namespace Maui.Controls.Sample.Controls
 
 			if (BordelessEntryServiceBuilder.PendingHandlers.Count > 0)
 			{
-				BordelessEntryServiceBuilder.HandlersCollection.TryAddHandlers(BordelessEntryServiceBuilder.PendingHandlers);
+				foreach (var pair in BordelessEntryServiceBuilder.PendingHandlers)
+				{
+					BordelessEntryServiceBuilder.HandlersCollection.TryAddHandler (pair.Key, pair.Value);
+				}
 				BordelessEntryServiceBuilder.PendingHandlers.Clear();
 			}
 		}

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -10,70 +10,68 @@ namespace Microsoft.Maui.Controls.Hosting
 {
 	public static partial class AppHostBuilderExtensions
 	{
-		static readonly Dictionary<Type, Type> DefaultMauiControlHandlers = new Dictionary<Type, Type>
+		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)
 		{
 #if __IOS__ || __ANDROID__
-			{ typeof(CollectionView), typeof(CollectionViewHandler) },
+			handlersCollection.AddHandler<CollectionView, CollectionViewHandler>();
 #endif
 
 #if WINDOWS
-			{ typeof(CollectionView), typeof(CollectionViewHandler) },
+			handlersCollection.AddHandler<CollectionView, CollectionViewHandler>();
 #endif
 
 #if WINDOWS || __ANDROID__
-			{ typeof(Shell), typeof(ShellHandler) },
+			handlersCollection.AddHandler<Shell, ShellHandler>();
 #endif
-			{ typeof(Application), typeof(ApplicationHandler) },
-			{ typeof(ActivityIndicator), typeof(ActivityIndicatorHandler) },
-			{ typeof(BoxView), typeof(ShapeViewHandler) },
-			{ typeof(Button), typeof(ButtonHandler) },
-			{ typeof(CheckBox), typeof(CheckBoxHandler) },
-			{ typeof(DatePicker), typeof(DatePickerHandler) },
-			{ typeof(Editor), typeof(EditorHandler) },
-			{ typeof(Entry), typeof(EntryHandler) },
-			{ typeof(GraphicsView), typeof(GraphicsViewHandler) },
-			{ typeof(Image), typeof(ImageHandler) },
-			{ typeof(Label), typeof(LabelHandler) },
-			{ typeof(Layout), typeof(LayoutHandler) },
-			{ typeof(Picker), typeof(PickerHandler) },
-			{ typeof(ProgressBar), typeof(ProgressBarHandler) },
-			{ typeof(ScrollView), typeof(ScrollViewHandler) },
-			{ typeof(SearchBar), typeof(SearchBarHandler) },
-			{ typeof(Slider), typeof(SliderHandler) },
-			{ typeof(Stepper), typeof(StepperHandler) },
-			{ typeof(Switch), typeof(SwitchHandler) },
-			{ typeof(TimePicker), typeof(TimePickerHandler) },
-			{ typeof(Page), typeof(PageHandler) },
-			{ typeof(WebView), typeof(WebViewHandler) },
-			{ typeof(Border), typeof(BorderHandler) },
-			{ typeof(IContentView), typeof(ContentViewHandler) },
-			{ typeof(Shapes.Ellipse), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Line), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Path), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Polygon), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Polyline), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.Rectangle), typeof(ShapeViewHandler) },
-			{ typeof(Shapes.RoundRectangle), typeof(ShapeViewHandler) },
-			{ typeof(Window), typeof(WindowHandler) },
-			{ typeof(ImageButton), typeof(ImageButtonHandler) },
-			{ typeof(IndicatorView), typeof(IndicatorViewHandler) },
-			{ typeof(RadioButton), typeof(RadioButtonHandler) },
+			handlersCollection.AddHandler<Application, ApplicationHandler>();
+			handlersCollection.AddHandler<ActivityIndicator, ActivityIndicatorHandler>();
+			handlersCollection.AddHandler<BoxView, ShapeViewHandler>();
+			handlersCollection.AddHandler<Button, ButtonHandler>();
+			handlersCollection.AddHandler<CheckBox, CheckBoxHandler>();
+			handlersCollection.AddHandler<DatePicker, DatePickerHandler>();
+			handlersCollection.AddHandler<Editor, EditorHandler>();
+			handlersCollection.AddHandler<Entry, EntryHandler>();
+			handlersCollection.AddHandler<GraphicsView, GraphicsViewHandler>();
+			handlersCollection.AddHandler<Image, ImageHandler>();
+			handlersCollection.AddHandler<Label, LabelHandler>();
+			handlersCollection.AddHandler<Layout, LayoutHandler>();
+			handlersCollection.AddHandler<Picker, PickerHandler>();
+			handlersCollection.AddHandler<ProgressBar, ProgressBarHandler>();
+			handlersCollection.AddHandler<ScrollView, ScrollViewHandler>();
+			handlersCollection.AddHandler<SearchBar, SearchBarHandler>();
+			handlersCollection.AddHandler<Slider, SliderHandler>();
+			handlersCollection.AddHandler<Stepper, StepperHandler>();
+			handlersCollection.AddHandler<Switch, SwitchHandler>();
+			handlersCollection.AddHandler<TimePicker, TimePickerHandler>();
+			handlersCollection.AddHandler<Page, PageHandler>();
+			handlersCollection.AddHandler<WebView, WebViewHandler>();
+			handlersCollection.AddHandler<Border, BorderHandler>();
+			handlersCollection.AddHandler<IContentView, ContentViewHandler>();
+			handlersCollection.AddHandler<Shapes.Ellipse, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Line, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Path, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Polygon, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Polyline, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.Rectangle, ShapeViewHandler>();
+			handlersCollection.AddHandler<Shapes.RoundRectangle, ShapeViewHandler>();
+			handlersCollection.AddHandler<Window, WindowHandler>();
+			handlersCollection.AddHandler<ImageButton, ImageButtonHandler>();
+			handlersCollection.AddHandler<IndicatorView, IndicatorViewHandler>();
+			handlersCollection.AddHandler<RadioButton, RadioButtonHandler>();
 #if __ANDROID__ || __IOS__
-			{ typeof(RefreshView), typeof(RefreshViewHandler) },
+			handlersCollection.AddHandler<RefreshView, RefreshViewHandler>();
 			
 #endif
 #if WINDOWS || ANDROID
-			{ typeof(NavigationPage), typeof(NavigationViewHandler) },
-			{ typeof(Toolbar), typeof(ToolbarHandler) },
+			handlersCollection.AddHandler<NavigationPage, NavigationViewHandler>();
+			handlersCollection.AddHandler<Toolbar, ToolbarHandler>();
 #endif
 #if __ANDROID__
-			{ typeof(TabbedPage), typeof(Controls.Handlers.TabbedPageHandler) },
-			{ typeof(FlyoutPage), typeof(FlyoutViewHandler) },
+			handlersCollection.AddHandler<TabbedPage, Controls.Handlers.TabbedPageHandler>();
+			handlersCollection.AddHandler<FlyoutPage, FlyoutViewHandler>();
 #endif
-		};
-
-		public static IMauiHandlersCollection AddMauiControlsHandlers(this IMauiHandlersCollection handlersCollection)
-			=> handlersCollection.AddHandlers(DefaultMauiControlHandlers);
+			return handlersCollection;
+		}
 
 		internal static MauiAppBuilder ConfigureImageSourceHandlers(this MauiAppBuilder builder)
 		{

--- a/src/Core/src/Hosting/MauiHandlersCollectionExtensions.cs
+++ b/src/Core/src/Hosting/MauiHandlersCollectionExtensions.cs
@@ -7,15 +7,6 @@ namespace Microsoft.Maui.Hosting
 {
 	public static partial class MauiHandlersCollectionExtensions
 	{
-		public static IMauiHandlersCollection AddHandlers(this IMauiHandlersCollection handlersCollection, Dictionary<Type, Type> handlers)
-		{
-			foreach (var handler in handlers)
-			{
-				handlersCollection.AddTransient(handler.Key, handler.Value);
-			}
-			return handlersCollection;
-		}
-
 		public static IMauiHandlersCollection AddHandler(this IMauiHandlersCollection handlersCollection, Type viewType, Type handlerType)
 		{
 			handlersCollection.AddTransient(viewType, handlerType);
@@ -23,19 +14,10 @@ namespace Microsoft.Maui.Hosting
 		}
 
 		public static IMauiHandlersCollection AddHandler<TType, TTypeRender>(this IMauiHandlersCollection handlersCollection)
-			where TType : IView
-			where TTypeRender : IViewHandler
+			where TType : IElement
+			where TTypeRender : IElementHandler
 		{
 			handlersCollection.AddTransient(typeof(TType), typeof(TTypeRender));
-			return handlersCollection;
-		}
-
-		public static IMauiHandlersCollection TryAddHandlers(this IMauiHandlersCollection handlersCollection, Dictionary<Type, Type> handlers)
-		{
-			foreach (var handler in handlers)
-			{
-				handlersCollection.TryAddTransient(handler.Key, handler.Value);
-			}
 			return handlersCollection;
 		}
 

--- a/src/Core/tests/UnitTests/Hosting/HostBuilderHandlerTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/HostBuilderHandlerTests.cs
@@ -70,24 +70,6 @@ namespace Microsoft.Maui.UnitTests.Hosting
 		}
 
 		[Fact]
-		public void CanRegisterAndGetHandlerWithDictionary()
-		{
-			var dic = new Dictionary<Type, Type>
-			{
-				{ typeof(IViewStub), typeof(ViewHandlerStub) }
-			};
-
-			var mauiApp = MauiApp.CreateBuilder()
-				.ConfigureMauiHandlers(handlers => handlers.AddHandlers(dic))
-				.Build();
-
-			var handler = mauiApp.Services.GetRequiredService<IMauiHandlersFactory>().GetHandler(typeof(IViewStub));
-
-			Assert.NotNull(handler);
-			Assert.IsType<ViewHandlerStub>(handler);
-		}
-
-		[Fact]
 		public void CanRegisterAndGetHandlerForConcreteType()
 		{
 			var mauiApp = MauiApp.CreateBuilder()


### PR DESCRIPTION
### Description of Change ###

This is one idea from dotnet/maui#3249, that I abandoned (for now)
because making `Microsoft.Maui.dll` fully trimmable is a larger task
that I realized.

These two APIs are problematic for dotnet/linker to be able to
statically analyze `Microsoft.Maui.dll`:

    public static partial class MauiHandlersCollectionExtensions
    {
        public static IMauiHandlersCollection AddHandlers(this IMauiHandlersCollection handlersCollection, Dictionary<Type, Type> handlers)
        public static IMauiHandlersCollection TryAddHandlers(this IMauiHandlersCollection handlersCollection, Dictionary<Type, Type> handlers)

Usage of this in `AddMauiControlsHandlers` should just call
`AddHandler()` for each type? No need for a `Dictionary`?

I loosened the generic constrains on one other method:

    public static IMauiHandlersCollection AddHandler<TType, TTypeRender>(this IMauiHandlersCollection handlersCollection)
    --    where TType : IView
    --    where TTypeRender : IViewHandler
    ++    where TType : IElement
    ++    where TTypeRender : IElementHandler

This allowed its usage for `Application` and `Window`.

This would probably have a tiny performance improvement, as we no
longer create a `Dictionary<Type,Type>` with 41 elements. This change
is more about changing a public-facing API, before MAUI is stable. It
will help us make `Microsoft.Maui.dll` fully trimmable one day.

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No