### PR TITLE
[WinUI] Allow Hot Reload In-App Selector to work with WindowOverlay

### DIFF
--- a/src/Core/src/WindowOverlay/WindowOverlay.Windows.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Windows.cs
@@ -50,8 +50,10 @@ namespace Microsoft.Maui
 
 			_graphicsView.SetValue(Canvas.ZIndexProperty, 99);
 			_graphicsView.IsHitTestVisible = false;
-			_panel?.Children.Add(_graphicsView);
+			_graphicsView.Visibility = UI.Xaml.Visibility.Collapsed;
 
+			_panel?.Children.Add(_graphicsView);
+			
 			IsNativeViewInitialized = true;
 			return IsNativeViewInitialized;
 		}
@@ -59,7 +61,13 @@ namespace Microsoft.Maui
 		/// <inheritdoc/>
 		public void Invalidate()
 		{
-			_graphicsView?.Invalidate();
+			if (_graphicsView is null)
+				return;
+
+			// Hide the visibility of the graphics view if there are no drawn elements.
+			// This way, the In-App Toolbar will work as expected.
+			_graphicsView.Visibility = WindowElements.Any() ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
+			_graphicsView.Invalidate();
 		}
 
 		/// <summary>


### PR DESCRIPTION
With the visual diagnostics overlay being a native control drawn on the screen, it would break the in-app selector from selecting any elements under it. We can hide the layer until you draw on it, which will then let you use the in-app selector again.

https://user-images.githubusercontent.com/898335/147986771-1d8de980-bd83-443e-82a8-7907360c3448.mp4


