### PR TITLE
Put BoundsConverter on accessor in AbsoluteLayout

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/AbsoluteLayoutPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/AbsoluteLayoutPage.xaml
@@ -24,7 +24,16 @@
                 AbsoluteLayout.LayoutFlags="PositionProportional" />
             <Label 
                 Text="Centered text"
+                HorizontalTextAlignment="Center"
                 AbsoluteLayout.LayoutBounds="0.5,0.5,110,25"
+                AbsoluteLayout.LayoutFlags="PositionProportional" />
+
+            <Label 
+                Text="AutoSized"
+                TextColor="White"
+                Background="Blue"
+                HorizontalOptions="Center"
+                AbsoluteLayout.LayoutBounds="0.2,0.7,AutoSize,AutoSize"
                 AbsoluteLayout.LayoutFlags="PositionProportional" />
         </AbsoluteLayout>
     </views:BasePage.Content>

--- a/src/Controls/src/Core/Layout/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/Layout/AbsoluteLayout.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty LayoutBoundsProperty = BindableProperty.CreateAttached("LayoutBounds",
 			typeof(Rectangle), typeof(AbsoluteLayout), new Rectangle(0, 0, AutoSize, AutoSize), propertyChanged: LayoutBoundsPropertyChanged);
 
-		private static void LayoutBoundsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		static void LayoutBoundsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			if (bindable is View view && view.Parent is Maui.ILayout layout)
 			{
@@ -37,6 +37,7 @@ namespace Microsoft.Maui.Controls
 			return (AbsoluteLayoutFlags)bindable.GetValue(LayoutFlagsProperty);
 		}
 
+		[System.ComponentModel.TypeConverter(typeof(BoundsTypeConverter))]
 		public static Rectangle GetLayoutBounds(BindableObject bindable)
 		{
 			return (Rectangle)bindable.GetValue(LayoutBoundsProperty);
@@ -62,7 +63,7 @@ namespace Microsoft.Maui.Controls
 				_ => _viewInfo[view].LayoutFlags,
 			};
 		}
-
+		
 		public Rectangle GetLayoutBounds(IView view)
 		{
 			return view switch

--- a/src/Controls/src/Core/Layout/BoundsTypeConverter.cs
+++ b/src/Controls/src/Core/Layout/BoundsTypeConverter.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 using System.Globalization;
 using Microsoft.Maui.Graphics;
 
-namespace Microsoft.Maui.Controls.Compatibility
+namespace Microsoft.Maui.Controls
 {
 	[Xaml.ProvideCompiled("Microsoft.Maui.Controls.XamlC.BoundsTypeConverter")]
 	public sealed class BoundsTypeConverter : TypeConverter

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported002.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported002.xaml
@@ -3,6 +3,10 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Unreported002">
-	<Label x:Name="label"
+    <StackLayout>
+        <Label x:Name="label"
 		   cmp:AbsoluteLayout.LayoutBounds="0.5,0.5,1,AutoSize" />
+        <Label x:Name="label2"
+		   AbsoluteLayout.LayoutBounds="0.7,0.7,0.9,AutoSize" />
+    </StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Unreported002.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Unreported002.xaml.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
-	using AbsoluteLayout = Microsoft.Maui.Controls.Compatibility.AbsoluteLayout;
+	using AbsoluteLayoutCompat = Microsoft.Maui.Controls.Compatibility.AbsoluteLayout;
 
 	public partial class Unreported002 : ContentPage
 	{
@@ -28,7 +28,8 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void TypeConvertersOnAttachedBP(bool useCompiledXaml)
 			{
 				var p = new Unreported002(useCompiledXaml);
-				Assert.AreEqual(new Rectangle(0.5, 0.5, 1, -1), AbsoluteLayout.GetLayoutBounds(p.label));
+				Assert.AreEqual(new Rectangle(0.5, 0.5, 1, -1), AbsoluteLayoutCompat.GetLayoutBounds(p.label));
+				Assert.AreEqual(new Rectangle(0.7, 0.7, 0.9, -1), Microsoft.Maui.Controls.AbsoluteLayout.GetLayoutBounds(p.label2));
 			}
 		}
 	}


### PR DESCRIPTION
Puts missing converter on the GetLayoutBounds accessor, and moves converter into the Controls namespace. 
Also adds a check for this conversion to the automated test.

Fixes #3632
