### PR TITLE
iOS NavigationRend-andler

### DIFF
--- a/src/Compatibility/ControlGallery/src/iOS/CustomRenderers.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/CustomRenderers.cs
@@ -587,7 +587,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 		}
 	}
 
-	public class TabbedPageWithCustomBarColorRenderer : TabbedRenderer
+	public class TabbedPageWithCustomBarColorRenderer : Handlers.Compatibility.TabbedRenderer
 	{
 		public TabbedPageWithCustomBarColorRenderer()
 		{

--- a/src/Compatibility/ControlGallery/src/iOS/RegistrarValidationService.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/RegistrarValidationService.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 
 			if (renderer == null
 				|| renderer.GetType().Name == "DefaultRenderer"
-				|| (element is FlyoutPage && Device.Idiom == TargetIdiom.Tablet && !(renderer is TabletFlyoutPageRenderer))
-				|| (element is FlyoutPage && Device.Idiom == TargetIdiom.Phone && !(renderer is PhoneFlyoutPageRenderer))
 				)
 			{
 				message = $"Failed to load proper iOS renderer for {element.GetType().Name}";

--- a/src/Compatibility/ControlGallery/src/iOS/_10337CustomRenderer.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/_10337CustomRenderer.cs
@@ -9,7 +9,7 @@ using UIKit;
 [assembly: ExportRenderer(typeof(Issue10337NavigationPage), typeof(_10337CustomRenderer))]
 namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 {
-	public class _10337CustomRenderer : NavigationRenderer
+	public class _10337CustomRenderer : Handlers.Compatibility.NavigationRenderer
 	{
 		public override void ViewDidLoad()
 		{

--- a/src/Compatibility/ControlGallery/src/iOS/_9767CustomRenderer.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/_9767CustomRenderer.cs
@@ -12,7 +12,7 @@ using UIKit;
 [assembly: ExportRenderer(typeof(Issue9767NavigationPage), typeof(_9767CustomRenderer))]
 namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 {
-	public class _9767CustomRenderer : NavigationRenderer
+	public class _9767CustomRenderer : Handlers.Compatibility.NavigationRenderer
 	{
 		public _9767CustomRenderer() : base()
 		{

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -30,8 +30,6 @@ using DefaultRenderer = Microsoft.Maui.Controls.Compatibility.Platform.UWP.Defau
 #elif __IOS__
 using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
 using WebViewRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.WkWebViewRenderer;
-using TabbedPageRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.TabbedRenderer;
-using FlyoutPageRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.PhoneFlyoutPageRenderer;
 using RadioButtonRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.Platform.DefaultRenderer;
 using DefaultRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.Platform.DefaultRenderer;
 #endif
@@ -116,7 +114,6 @@ namespace Microsoft.Maui.Controls.Hosting
 					handlers.TryAddCompatibilityRenderer(typeof(ScrollView), typeof(ScrollViewRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(ActivityIndicator), typeof(ActivityIndicatorRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(CheckBox), typeof(CheckBoxRenderer));
-					handlers.TryAddCompatibilityRenderer(typeof(TabbedPage), typeof(TabbedPageRenderer));
 #if !WINDOWS
 					handlers.TryAddCompatibilityRenderer(typeof(Shell), typeof(ShellRenderer));
 #if !(MACCATALYST || MACOS)
@@ -127,7 +124,6 @@ namespace Microsoft.Maui.Controls.Hosting
 #endif
 					handlers.TryAddCompatibilityRenderer(typeof(CarouselPage), typeof(CarouselPageRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(Page), typeof(PageRenderer));
-					handlers.TryAddCompatibilityRenderer(typeof(FlyoutPage), typeof(FlyoutPageRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(RefreshView), typeof(RefreshViewRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(NativeViewWrapper), typeof(NativeViewWrapperRenderer));
 
@@ -145,6 +141,8 @@ namespace Microsoft.Maui.Controls.Hosting
 #if IOS || MACCATALYST
 					Internals.Registrar.RegisterEffect("Xamarin", "ShadowEffect", typeof(ShadowEffect));
 					handlers.AddHandler(typeof(NavigationPage), typeof(Handlers.Compatibility.NavigationRenderer));
+					handlers.AddHandler(typeof(TabbedPage), typeof(Handlers.Compatibility.TabbedRenderer));
+					handlers.AddHandler(typeof(FlyoutPage), typeof(Handlers.Compatibility.PhoneFlyoutPageRenderer));
 #endif
 				});
 

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -30,7 +30,6 @@ using DefaultRenderer = Microsoft.Maui.Controls.Compatibility.Platform.UWP.Defau
 #elif __IOS__
 using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
 using WebViewRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.WkWebViewRenderer;
-using NavigationPageRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.NavigationRenderer;
 using TabbedPageRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.TabbedRenderer;
 using FlyoutPageRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.PhoneFlyoutPageRenderer;
 using RadioButtonRenderer = Microsoft.Maui.Controls.Compatibility.Platform.iOS.Platform.DefaultRenderer;
@@ -126,7 +125,6 @@ namespace Microsoft.Maui.Controls.Hosting
 #else
 					handlers.TryAddCompatibilityRenderer(typeof(Layout), typeof(LayoutRenderer));
 #endif
-					handlers.TryAddCompatibilityRenderer(typeof(NavigationPage), typeof(NavigationPageRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(CarouselPage), typeof(CarouselPageRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(Page), typeof(PageRenderer));
 					handlers.TryAddCompatibilityRenderer(typeof(FlyoutPage), typeof(FlyoutPageRenderer));
@@ -144,8 +142,9 @@ namespace Microsoft.Maui.Controls.Hosting
 					Internals.Registrar.Registered.Register(typeof(Microsoft.Maui.EmbeddedFont), typeof(Microsoft.Maui.EmbeddedFontLoader));
 #endif
 
-#if __IOS__ || MACCATALYST
+#if IOS || MACCATALYST
 					Internals.Registrar.RegisterEffect("Xamarin", "ShadowEffect", typeof(ShadowEffect));
+					handlers.AddHandler(typeof(NavigationPage), typeof(Handlers.Compatibility.NavigationRenderer));
 #endif
 				});
 

--- a/src/Compatibility/Core/src/Handlers/Android/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Android/FrameRenderer.cs
@@ -308,6 +308,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var platformView = content.ToPlatform(_mauiContext);
 			AddView(platformView);
 		}
+
 		#region INativeViewHandler
 		bool IViewHandler.HasContainer { get => false; set { } }
 

--- a/src/Compatibility/Core/src/Handlers/Android/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Android/FrameRenderer.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		Size IViewHandler.GetDesiredSize(double widthMeasureSpec, double heightMeasureSpec)
 		{
-			return VisualElementRenderer<Frame>.GetDesiredSize(this, heightMeasureSpec, widthMeasureSpec,
+			return VisualElementRenderer<Frame>.GetDesiredSize(this, widthMeasureSpec, heightMeasureSpec,
 				new Size(20, 20));
 		}
 

--- a/src/Compatibility/Core/src/Handlers/Android/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Android/FrameRenderer.cs
@@ -43,28 +43,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		int _width;
 		readonly Controls.Compatibility.Platform.Android.MotionEventHelper _motionEventHelper = new Controls.Compatibility.Platform.Android.MotionEventHelper();
 		bool _disposed;
-		Frame? _element;
 		GradientDrawable? _backgroundDrawable;
 		private IMauiContext? _mauiContext;
-		protected IPropertyMapper _mapper;
-		protected CommandMapper? _commandMapper;
-		protected readonly IPropertyMapper _defaultMapper;
-
+		ViewHandlerDelegator<Frame> _viewHandlerWrapper;
 		public event EventHandler<VisualElementChangedEventArgs>? ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs>? ElementPropertyChanged;
 
 		public FrameRenderer(Context context) : base(context)
 		{
-			_defaultMapper = Mapper;
-			_mapper = _defaultMapper;
-			_commandMapper = CommandMapper;
+			_viewHandlerWrapper = new ViewHandlerDelegator<Frame>(Mapper, CommandMapper, this);
 		}
 
 		protected CardView Control => this;
 
 		protected Frame? Element
 		{
-			get { return _element; }
+			get { return _viewHandlerWrapper.Element; }
 			set
 			{
 				if (value != null)
@@ -186,7 +180,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 
 			if (Element != null && e.PropertyName != null)
-				_mapper.UpdateProperty(this, Element, e.PropertyName);
+				_viewHandlerWrapper.UpdateProperty(e.PropertyName);
 
 			ElementPropertyChanged?.Invoke(this, e);
 			_motionEventHelper.UpdateElement(Element);
@@ -333,7 +327,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_mauiContext = mauiContext;
 
 		void IElementHandler.SetVirtualView(Maui.IElement view) =>
-			VisualElementRenderer<Frame>.SetVirtualView(view, this, OnElementChanged, ref _element, ref _mapper, _defaultMapper, false);
+			_viewHandlerWrapper.SetVirtualView(view, OnElementChanged, false);
 
 		void IElementHandler.UpdateValue(string property)
 		{
@@ -345,15 +339,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void IElementHandler.Invoke(string command, object? args)
 		{
-			_commandMapper?.Invoke(this, Element, command, args);
+			_viewHandlerWrapper.Invoke(command, args);
 		}
 
 		void IElementHandler.DisconnectHandler()
 		{
-			if (Element?.Handler == (INativeViewHandler)this)
-				Element.Handler = null;
-
-			_element = null;
+			_viewHandlerWrapper.DisconnectHandler();
 		}
 		#endregion
 	}

--- a/src/Compatibility/Core/src/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		NavigationPage NavPage => Element as NavigationPage;
 		INavigationPageController NavPageController => NavPage;
 
-		public VisualElement Element { get => _viewHandlerWrapper.Element;  }
+		public VisualElement Element { get => _viewHandlerWrapper.Element; }
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -809,10 +809,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return;
 			}
 
-
 			FlyoutPage.Flyout.IconImageSource.LoadImage(FlyoutPage.FindMauiContext(), result =>
 			{
-				var icon = result.Value;
+				var icon = result?.Value;
 				if (icon != null)
 				{
 					try
@@ -1311,7 +1310,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				{
 					titleIcon.LoadImage(titleIcon.FindMauiContext(), result =>
 					{
-						var image = result.Value;
+						var image = result?.Value;
 						try
 						{
 							titleViewContainer.Icon = new UIImageView(image);

--- a/src/Compatibility/Core/src/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1571,6 +1571,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 			}
 
+			protected internal MauiControlsNavigationBar(NativeHandle handle) : base(handle)
+			{
+			}
+
 			public RectangleF BackButtonFrameSize { get; private set; }
 			public UILabel NavBarLabel { get; private set; }
 

--- a/src/Compatibility/Core/src/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1,0 +1,1759 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CoreGraphics;
+using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+using Microsoft.Maui.Essentials;
+using Microsoft.Maui.Graphics;
+using ObjCRuntime;
+using UIKit;
+using static Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.NavigationPage;
+using static Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page;
+using PageUIStatusBarAnimation = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation;
+using PointF = CoreGraphics.CGPoint;
+using RectangleF = CoreGraphics.CGRect;
+using SizeF = CoreGraphics.CGSize;
+
+namespace Microsoft.Maui.Controls.Handlers.Compatibility
+{
+	public class NavigationRenderer : UINavigationController, INativeViewHandler
+	{
+		internal const string UpdateToolbarButtons = "Xamarin.UpdateToolbarButtons";
+		bool _appeared;
+		bool _ignorePopCall;
+		bool _loaded;
+		FlyoutPage _parentFlyoutPage;
+		Size _queuedSize;
+		UIViewController[] _removeControllers;
+		UIToolbar _secondaryToolbar;
+		nfloat _navigationBottom = 0;
+		bool _hasNavigationBar;
+		UIImage _defaultNavBarShadowImage;
+		UIImage _defaultNavBarBackImage;
+		bool _disposed;
+		IMauiContext _mauiContext;
+		IMauiContext MauiContext => _mauiContext ?? NavPage.Handler.MauiContext;
+		public static IPropertyMapper<NavigationPage, NavigationRenderer> Mapper = new PropertyMapper<NavigationPage, NavigationRenderer>(ViewHandler.ViewMapper);
+		public static CommandMapper<NavigationPage, NavigationRenderer> CommandMapper = new CommandMapper<NavigationPage, NavigationRenderer>(ViewHandler.ViewCommandMapper);
+
+		[Preserve(Conditional = true)]
+		public NavigationRenderer() : base(typeof(MauiControlsNavigationBar), null)
+		{
+			// TODO MAUI:
+			//MessagingCenter.Subscribe<IVisualElementRenderer>(this, UpdateToolbarButtons, sender =>
+			//{
+			//	if (!ViewControllers.Any())
+			//		return;
+			//	var parentingViewController = GetParentingViewController();
+			//	parentingViewController?.UpdateLeftBarButtonItem();
+			//});
+		}
+
+		Page Current { get; set; }
+
+		IPageController PageController => Element as IPageController;
+
+		NavigationPage NavPage => Element as NavigationPage;
+		INavigationPageController NavPageController => NavPage;
+
+		public VisualElement Element { get; private set; }
+
+		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+
+		public SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			return VisualElementRenderer<NavigationPage>.GetDesiredSize(this, widthConstraint, heightConstraint,
+				new Size(0, 0));
+		}
+
+		public UIView NativeView
+		{
+			get { return View; }
+		}
+
+		public void SetElement(VisualElement element)
+		{
+			(this as IElementHandler).SetVirtualView(element);
+		}
+
+		public void SetElementSize(Size size)
+		{
+			if (_loaded)
+				Element.Layout(new Rectangle(Element.X, Element.Y, size.Width, size.Height));
+			else
+				_queuedSize = size;
+		}
+
+		public UIViewController ViewController
+		{
+			get { return this; }
+		}
+
+		//TODO: this was deprecated in iOS8.0 and is not called in 9.0+
+		public override void DidRotate(UIInterfaceOrientation fromInterfaceOrientation)
+		{
+			base.DidRotate(fromInterfaceOrientation);
+
+			View.SetNeedsLayout();
+
+			var parentingViewController = GetParentingViewController();
+			parentingViewController?.UpdateLeftBarButtonItem();
+		}
+
+		public Task<bool> PopToRootAsync(Page page, bool animated = true)
+		{
+			return OnPopToRoot(page, animated);
+		}
+
+		public override UIViewController[] PopToRootViewController(bool animated)
+		{
+			if (!_ignorePopCall && ViewControllers.Length > 1)
+				RemoveViewControllers(animated);
+
+			return base.PopToRootViewController(animated);
+		}
+
+		public Task<bool> PopViewAsync(Page page, bool animated = true)
+		{
+			return OnPopViewAsync(page, animated);
+		}
+
+		public override UIViewController PopViewController(bool animated)
+		{
+			RemoveViewControllers(animated);
+			return base.PopViewController(animated);
+		}
+
+		public Task<bool> PushPageAsync(Page page, bool animated = true)
+		{
+			return OnPushAsync(page, animated);
+		}
+
+		public override void ViewDidAppear(bool animated)
+		{
+			if (!_appeared)
+			{
+				_appeared = true;
+				PageController?.SendAppearing();
+			}
+
+			base.ViewDidAppear(animated);
+
+			View.SetNeedsLayout();
+		}
+
+		public override void ViewWillAppear(bool animated)
+		{
+			base.ViewWillAppear(animated);
+
+			SetStatusBarStyle();
+		}
+
+		public override void ViewDidDisappear(bool animated)
+		{
+			base.ViewDidDisappear(animated);
+
+			if (!_appeared || Element == null)
+				return;
+
+			_appeared = false;
+			PageController.SendDisappearing();
+		}
+
+		public override void ViewDidLayoutSubviews()
+		{
+			base.ViewDidLayoutSubviews();
+			if (Current == null)
+				return;
+			UpdateToolBarVisible();
+
+			var navBarFrameBottom = Math.Min(NavigationBar.Frame.Bottom, 140);
+			_navigationBottom = (nfloat)navBarFrameBottom;
+			var toolbar = _secondaryToolbar;
+
+			//save the state of the Current page we are calculating, this will fire before Current is updated
+			_hasNavigationBar = NavigationPage.GetHasNavigationBar(Current);
+
+			// Use 0 if the NavBar is hidden or will be hidden
+			var toolbarY = NavigationBarHidden || NavigationBar.Translucent || !_hasNavigationBar ? 0 : navBarFrameBottom;
+			toolbar.Frame = new RectangleF(0, toolbarY, View.Frame.Width, toolbar.Frame.Height);
+
+			double trueBottom = toolbar.Hidden ? toolbarY : toolbar.Frame.Bottom;
+			var modelSize = _queuedSize.IsZero ? Element.Bounds.Size : _queuedSize;
+			PageController.ContainerArea =
+				new Rectangle(0, toolbar.Hidden ? 0 : toolbar.Frame.Height, modelSize.Width, modelSize.Height - trueBottom);
+
+			if (!_queuedSize.IsZero)
+			{
+				Element.Layout(new Rectangle(Element.X, Element.Y, _queuedSize.Width, _queuedSize.Height));
+				_queuedSize = Size.Zero;
+			}
+
+			_loaded = true;
+
+			foreach (var view in View.Subviews)
+			{
+				if (view == NavigationBar || view == _secondaryToolbar)
+					continue;
+				view.Frame = View.Bounds;
+			}
+		}
+
+		public override void ViewDidLoad()
+		{
+			base.ViewDidLoad();
+
+			UpdateTranslucent();
+
+			_secondaryToolbar = new SecondaryToolbar { Frame = new RectangleF(0, 0, 320, 44) };
+			View.Add(_secondaryToolbar);
+			_secondaryToolbar.Hidden = true;
+
+			FindParentFlyoutPage();
+
+			var navPage = NavPage;
+			INavigationPageController navPageController = NavPage;
+			if (navPage.CurrentPage == null)
+			{
+				throw new InvalidOperationException(
+					"NavigationPage must have a root Page before being used. Either call PushAsync with a valid Page, or pass a Page to the constructor before usage.");
+			}
+
+			navPageController.PushRequested += OnPushRequested;
+			navPageController.PopRequested += OnPopRequested;
+			navPageController.PopToRootRequested += OnPopToRootRequested;
+			navPageController.RemovePageRequested += OnRemovedPageRequested;
+			navPageController.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
+
+			UpdateBarBackground();
+			UpdateBarTextColor();
+			UpdateHideNavigationBarSeparator();
+			UpdateUseLargeTitles();
+
+			if (NativeVersion.Supports(NativeApis.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden))
+				SetNeedsUpdateOfHomeIndicatorAutoHidden();
+
+			// If there is already stuff on the stack we need to push it
+			NavPageController.Pages.ForEach(async p => await PushPageAsync(p, false));
+
+			Element.PropertyChanged += HandlePropertyChanged;
+
+			UpdateToolBarVisible();
+			UpdateBackgroundColor();
+			Current = navPage.CurrentPage;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				//Todo: MAUI
+				//MessagingCenter.Unsubscribe<IVisualElementRenderer>(this, UpdateToolbarButtons);
+
+				foreach (var childViewController in ViewControllers)
+					childViewController.Dispose();
+
+				_secondaryToolbar.RemoveFromSuperview();
+				_secondaryToolbar.Dispose();
+				_secondaryToolbar = null;
+
+				_parentFlyoutPage = null;
+				Current = null; // unhooks events
+
+				var navPage = NavPage;
+				INavigationPageController navPageController = NavPage;
+				navPage.PropertyChanged -= HandlePropertyChanged;
+
+				navPageController.PushRequested -= OnPushRequested;
+				navPageController.PopRequested -= OnPopRequested;
+				navPageController.PopToRootRequested -= OnPopToRootRequested;
+				navPageController.RemovePageRequested -= OnRemovedPageRequested;
+				navPageController.InsertPageBeforeRequested -= OnInsertPageBeforeRequested;
+			}
+
+			base.Dispose(disposing);
+
+			if (disposing && _appeared)
+			{
+				PageController.SendDisappearing();
+
+				_appeared = false;
+			}
+		}
+
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
+		{
+			ElementChanged?.Invoke(this, e);
+		}
+
+		protected virtual async Task<bool> OnPopToRoot(Page page, bool animated)
+		{
+			_ignorePopCall = true;
+			_ = page.ToPlatform(MauiContext);
+			var renderer = (INativeViewHandler)page.Handler;
+			if (renderer == null || renderer.ViewController == null)
+				return false;
+
+			var task = GetAppearedOrDisappearedTask(page);
+
+			PopToRootViewController(animated);
+
+			_ignorePopCall = false;
+			var success = !await task;
+
+			UpdateToolBarVisible();
+			return success;
+		}
+
+		protected virtual async Task<bool> OnPopViewAsync(Page page, bool animated)
+		{
+			if (_ignorePopCall)
+				return true;
+
+			_ = page.ToPlatform(MauiContext);
+			var renderer = (INativeViewHandler)page.Handler;
+			if (renderer == null || renderer.ViewController == null)
+				return false;
+
+			if (page != ((ParentingViewController)TopViewController).Child)
+				throw new NotSupportedException("Popped page does not appear on top of current navigation stack, please file a bug.");
+
+			var task = GetAppearedOrDisappearedTask(page);
+
+			UIViewController poppedViewController;
+			_ignorePopCall = true;
+			poppedViewController = base.PopViewController(animated);
+
+			var actuallyRemoved = poppedViewController == null ? true : !await task;
+			_ignorePopCall = false;
+
+			poppedViewController?.Dispose();
+
+			UpdateToolBarVisible();
+			return actuallyRemoved;
+		}
+
+		protected virtual async Task<bool> OnPushAsync(Page page, bool animated)
+		{
+			if (page is FlyoutPage)
+				System.Diagnostics.Trace.WriteLine($"Pushing a {nameof(FlyoutPage)} onto a {nameof(NavigationPage)} is not a supported UI pattern on iOS. " +
+					"Please see https://developer.apple.com/documentation/uikit/uisplitviewcontroller for more details.");
+
+			var pack = CreateViewControllerForPage(page);
+			var task = GetAppearedOrDisappearedTask(page);
+
+			PushViewController(pack, animated);
+
+			var shown = await task;
+			UpdateToolBarVisible();
+			return shown;
+		}
+
+		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+		{
+			base.TraitCollectionDidChange(previousTraitCollection);
+			// Make sure the control adheres to changes in UI theme
+			if (NativeVersion.IsAtLeast(13) && previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+				UpdateBackgroundColor();
+		}
+
+
+		ParentingViewController CreateViewControllerForPage(Page page)
+		{
+			_ = page.ToPlatform(MauiContext);
+
+			// must pack into container so padding can work
+			// otherwise the view controller is forced to 0,0
+			var pack = new ParentingViewController(this) { Child = page };
+
+			pack.UpdateTitleArea(page);
+
+			var pageRenderer = (INativeViewHandler)page.Handler;
+			pack.View.AddSubview(pageRenderer.ViewController.View);
+			pack.AddChildViewController(pageRenderer.ViewController);
+			pageRenderer.ViewController.DidMoveToParentViewController(pack);
+
+			return pack;
+		}
+
+		ParentingViewController GetParentingViewController()
+		{
+			if (!ViewControllers.Any())
+				return null;
+
+			return ViewControllers.Last() as ParentingViewController;
+		}
+
+		void FindParentFlyoutPage()
+		{
+			var page = Element as Page;
+			var parentPages = page.GetParentPages();
+			var flyoutDetail = parentPages.OfType<FlyoutPage>().FirstOrDefault();
+
+			if (flyoutDetail != null && parentPages.Append((Page)Element).Contains(flyoutDetail.Detail))
+				_parentFlyoutPage = flyoutDetail;
+		}
+
+		Task<bool> GetAppearedOrDisappearedTask(Page page)
+		{
+			var tcs = new TaskCompletionSource<bool>();
+
+			_ = page.ToPlatform(MauiContext);
+			var renderer = (INativeViewHandler)page.Handler;
+			var parentViewController = renderer.ViewController.ParentViewController as ParentingViewController;
+			if (parentViewController == null)
+				throw new NotSupportedException("ParentingViewController parent could not be found. Please file a bug.");
+
+			EventHandler appearing = null, disappearing = null;
+			appearing = (s, e) =>
+			{
+				parentViewController.Appearing -= appearing;
+				parentViewController.Disappearing -= disappearing;
+
+				Device.BeginInvokeOnMainThread(() => { tcs.SetResult(true); });
+			};
+
+			disappearing = (s, e) =>
+			{
+				parentViewController.Appearing -= appearing;
+				parentViewController.Disappearing -= disappearing;
+
+				Device.BeginInvokeOnMainThread(() => { tcs.SetResult(false); });
+			};
+
+			parentViewController.Appearing += appearing;
+			parentViewController.Disappearing += disappearing;
+
+			return tcs.Task;
+		}
+
+		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName ||
+				e.PropertyName == NavigationPage.BarBackgroundProperty.PropertyName)
+			{
+				UpdateBarBackground();
+			}
+			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName
+				  || e.PropertyName == StatusBarTextColorModeProperty.PropertyName)
+			{
+				UpdateBarTextColor();
+				SetStatusBarStyle();
+			}
+			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
+			{
+				UpdateBackgroundColor();
+			}
+			else if (e.PropertyName == NavigationPage.CurrentPageProperty.PropertyName)
+			{
+				Current = NavPage?.CurrentPage;
+				ValidateNavbarExists(Current);
+			}
+			else if (e.PropertyName == IsNavigationBarTranslucentProperty.PropertyName)
+			{
+				UpdateTranslucent();
+			}
+			else if (e.PropertyName == PreferredStatusBarUpdateAnimationProperty.PropertyName)
+			{
+				UpdateCurrentPagePreferredStatusBarUpdateAnimation();
+			}
+			else if (e.PropertyName == PrefersLargeTitlesProperty.PropertyName)
+			{
+				UpdateUseLargeTitles();
+			}
+			else if (e.PropertyName == NavigationPage.BackButtonTitleProperty.PropertyName)
+			{
+				var pack = (ParentingViewController)TopViewController;
+				pack?.UpdateTitleArea(pack.Child);
+			}
+			else if (e.PropertyName == HideNavigationBarSeparatorProperty.PropertyName)
+			{
+				UpdateHideNavigationBarSeparator();
+			}
+		}
+
+		void ValidateNavbarExists(Page newCurrentPage)
+		{
+			//if the last time we did ViewDidLayoutSubviews we had other value for _hasNavigationBar
+			//we will need to relayout. This is because Current is updated async of the layout happening
+			if (_hasNavigationBar != NavigationPage.GetHasNavigationBar(newCurrentPage))
+				ViewDidLayoutSubviews();
+		}
+
+		void UpdateHideNavigationBarSeparator()
+		{
+			bool shouldHide = NavPage.OnThisPlatform().HideNavigationBarSeparator();
+
+			// Just setting the ShadowImage is good for iOS11
+			if (_defaultNavBarShadowImage == null)
+				_defaultNavBarShadowImage = NavigationBar.ShadowImage;
+
+			if (NativeVersion.IsAtLeast(13))
+			{
+				if (shouldHide)
+				{
+					NavigationBar.CompactAppearance.ShadowColor = UIColor.Clear;
+					NavigationBar.StandardAppearance.ShadowColor = UIColor.Clear;
+					NavigationBar.ScrollEdgeAppearance.ShadowColor = UIColor.Clear;
+				}
+				else
+				{
+					NavigationBar.CompactAppearance.ShadowColor = UIColor.FromRGBA(0, 0, 0, 76); //default ios13 shadow color
+					NavigationBar.StandardAppearance.ShadowColor = UIColor.FromRGBA(0, 0, 0, 76);
+					NavigationBar.ScrollEdgeAppearance.ShadowColor = UIColor.FromRGBA(0, 0, 0, 76);
+				}
+			}
+			else
+			{
+				if (shouldHide)
+					NavigationBar.ShadowImage = new UIImage();
+				else
+					NavigationBar.ShadowImage = _defaultNavBarShadowImage;
+			}
+
+			if (!NativeVersion.IsAtLeast(11))
+			{
+				// For iOS 10 and lower, you need to set the background image.
+				// If you set this for iOS11, you'll remove the background color.
+				if (_defaultNavBarBackImage == null)
+					_defaultNavBarBackImage = NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
+
+				if (shouldHide)
+					NavigationBar.SetBackgroundImage(new UIImage(), UIBarMetrics.Default);
+				else
+					NavigationBar.SetBackgroundImage(_defaultNavBarBackImage, UIBarMetrics.Default);
+			}
+		}
+
+		void UpdateCurrentPagePreferredStatusBarUpdateAnimation()
+		{
+			// Not using the extension method syntax here because for some reason it confuses the mono compiler
+			// and throws a CS0121 error
+			PageUIStatusBarAnimation animation = PlatformConfiguration.iOSSpecific.Page.PreferredStatusBarUpdateAnimation(((Page)Element).OnThisPlatform());
+			PlatformConfiguration.iOSSpecific.Page.SetPreferredStatusBarUpdateAnimation(Current.OnThisPlatform(), animation);
+		}
+
+		void UpdateUseLargeTitles()
+		{
+			if (NativeVersion.IsAtLeast(11) && NavPage != null)
+				NavigationBar.PrefersLargeTitles = NavPage.OnThisPlatform().PrefersLargeTitles();
+		}
+
+		void UpdateTranslucent()
+		{
+			NavigationBar.Translucent = NavPage.OnThisPlatform().IsNavigationBarTranslucent();
+		}
+
+		void InsertPageBefore(Page page, Page before)
+		{
+			if (before.Handler is not INativeViewHandler nvh)
+				throw new ArgumentNullException("before");
+			if (page == null)
+				throw new ArgumentNullException("page");
+
+			var pageContainer = CreateViewControllerForPage(page);
+			var target = nvh.ViewController.ParentViewController;
+			ViewControllers = ViewControllers.Insert(ViewControllers.IndexOf(target), pageContainer);
+		}
+
+		void OnInsertPageBeforeRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			InsertPageBefore(e.Page, e.BeforePage);
+		}
+
+		void OnPopRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			e.Task = PopViewAsync(e.Page, e.Animated);
+		}
+
+		void OnPopToRootRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			e.Task = PopToRootAsync(e.Page, e.Animated);
+		}
+
+		void OnPushRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			// If any text entry controls have focus, we need to end their editing session
+			// so that they are not the first responder; if we don't some things (like the activity indicator
+			// on pull-to-refresh) will not work correctly.
+			View?.Window?.EndEditing(true);
+
+			e.Task = PushPageAsync(e.Page, e.Animated);
+		}
+
+		void OnRemovedPageRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			RemovePage(e.Page);
+		}
+
+		void RemovePage(Page page)
+		{
+			if (page?.Handler is not INativeViewHandler nvh)
+				throw new ArgumentNullException("page");
+			if (page == Current)
+				throw new NotSupportedException(); // should never happen as NavPage protects against this
+
+			var target = nvh.ViewController.ParentViewController;
+
+			// So the ViewControllers property is not very property like on iOS. Assigning to it doesn't cause it to be
+			// immediately reflected into the property. The change will not be reflected until there has been sufficient time
+			// to process it (it ends up on the event queue). So to resolve this issue we keep our own stack until we
+			// know iOS has processed it, and make sure any updates use that.
+
+			// In the future we may want to make RemovePageAsync and deprecate RemovePage to handle cases where Push/Pop is called
+			// during a remove cycle.
+
+			if (_removeControllers == null)
+			{
+				_removeControllers = ViewControllers.Remove(target);
+				ViewControllers = _removeControllers;
+				Device.BeginInvokeOnMainThread(() => { _removeControllers = null; });
+			}
+			else
+			{
+				_removeControllers = _removeControllers.Remove(target);
+				ViewControllers = _removeControllers;
+			}
+			target.Dispose();
+			var parentingViewController = GetParentingViewController();
+			parentingViewController?.UpdateLeftBarButtonItem(page);
+		}
+
+		void RemoveViewControllers(bool animated)
+		{
+			var controller = TopViewController as ParentingViewController;
+			if (controller == null || controller.Child == null || controller.Child.Handler == null)
+				return;
+
+			// Gesture in progress, lets not be proactive and just wait for it to finish
+			var task = GetAppearedOrDisappearedTask(controller.Child);
+
+			task.ContinueWith(t =>
+			{
+				// task returns true if the user lets go of the page and is not popped
+				// however at this point the renderer is already off the visual stack so we just need to update the NavigationPage
+				// Also worth noting this task returns on the main thread
+				if (t.Result)
+					return;
+				// because we skip the normal pop process we need to dispose ourselves
+				controller?.Dispose();
+			}, TaskScheduler.FromCurrentSynchronizationContext());
+		}
+
+		void UpdateBackgroundColor()
+		{
+			var color = Element.BackgroundColor == null ? Maui.Platform.ColorExtensions.BackgroundColor : Element.BackgroundColor.ToNative();
+			View.BackgroundColor = color;
+		}
+
+		void UpdateBarBackground()
+		{
+			var barBackgroundColor = NavPage.BarBackgroundColor;
+
+			if (NativeVersion.IsAtLeast(13))
+			{
+				var navigationBarAppearance = NavigationBar.StandardAppearance;
+
+				navigationBarAppearance.ConfigureWithOpaqueBackground();
+
+				if (barBackgroundColor == null)
+				{
+					navigationBarAppearance.BackgroundColor = Maui.Platform.ColorExtensions.BackgroundColor;
+
+					var parentingViewController = GetParentingViewController();
+					parentingViewController?.SetupDefaultNavigationBarAppearance();
+				}
+				else
+					navigationBarAppearance.BackgroundColor = barBackgroundColor.ToNative();
+
+				var barBackgroundBrush = NavPage.BarBackground;
+				var backgroundImage = NavigationBar.GetBackgroundImage(barBackgroundBrush);
+				navigationBarAppearance.BackgroundImage = backgroundImage;
+
+				NavigationBar.CompactAppearance = navigationBarAppearance;
+				NavigationBar.StandardAppearance = navigationBarAppearance;
+				NavigationBar.ScrollEdgeAppearance = navigationBarAppearance;
+			}
+			else
+			{
+				// Set navigation bar background color
+				NavigationBar.BarTintColor = barBackgroundColor == null
+					? UINavigationBar.Appearance.BarTintColor
+					: barBackgroundColor.ToNative();
+
+				var barBackgroundBrush = NavPage.BarBackground;
+				var backgroundImage = NavigationBar.GetBackgroundImage(barBackgroundBrush);
+				NavigationBar.SetBackgroundImage(backgroundImage, UIBarMetrics.Default);
+			}
+		}
+
+		void UpdateBarTextColor()
+		{
+			var barTextColor = NavPage.BarTextColor;
+
+			// Determine new title text attributes via global static data
+			var globalTitleTextAttributes = UINavigationBar.Appearance.TitleTextAttributes;
+			var titleTextAttributes = new UIStringAttributes
+			{
+				ForegroundColor = barTextColor == null ? globalTitleTextAttributes?.ForegroundColor : barTextColor.ToNative(),
+				Font = globalTitleTextAttributes?.Font
+			};
+
+			// Determine new large title text attributes via global static data
+			var largeTitleTextAttributes = titleTextAttributes;
+			if (NativeVersion.IsAtLeast(11))
+			{
+				var globalLargeTitleTextAttributes = UINavigationBar.Appearance.LargeTitleTextAttributes;
+
+				largeTitleTextAttributes = new UIStringAttributes
+				{
+					ForegroundColor = barTextColor == null ? globalLargeTitleTextAttributes?.ForegroundColor : barTextColor.ToNative(),
+					Font = globalLargeTitleTextAttributes?.Font
+				};
+			}
+
+			if (NativeVersion.IsAtLeast(13))
+			{
+				NavigationBar.CompactAppearance.TitleTextAttributes = titleTextAttributes;
+				NavigationBar.CompactAppearance.LargeTitleTextAttributes = largeTitleTextAttributes;
+
+				NavigationBar.StandardAppearance.TitleTextAttributes = titleTextAttributes;
+				NavigationBar.StandardAppearance.LargeTitleTextAttributes = largeTitleTextAttributes;
+
+				NavigationBar.ScrollEdgeAppearance.TitleTextAttributes = titleTextAttributes;
+				NavigationBar.ScrollEdgeAppearance.LargeTitleTextAttributes = largeTitleTextAttributes;
+			}
+			else
+			{
+				NavigationBar.TitleTextAttributes = titleTextAttributes;
+
+				if (NativeVersion.IsAtLeast(11))
+					NavigationBar.LargeTitleTextAttributes = largeTitleTextAttributes;
+			}
+
+			// set Tint color (i. e. Back Button arrow and Text)
+			var iconColor = Current != null ? NavigationPage.GetIconColor(Current) : null;
+			if (iconColor == null)
+				iconColor = barTextColor;
+
+			NavigationBar.TintColor = iconColor == null || NavPage.OnThisPlatform().GetStatusBarTextColorMode() == StatusBarTextColorMode.DoNotAdjust
+				? UINavigationBar.Appearance.TintColor
+				: iconColor.ToNative();
+		}
+
+		void SetStatusBarStyle()
+		{
+			var barTextColor = NavPage.BarTextColor;
+			var statusBarColorMode = NavPage.OnThisPlatform().GetStatusBarTextColorMode();
+
+			if (statusBarColorMode == StatusBarTextColorMode.DoNotAdjust || barTextColor?.GetLuminosity() <= 0.5)
+			{
+				// Use dark text color for status bar
+				if (NativeVersion.IsAtLeast(13))
+				{
+					UIApplication.SharedApplication.StatusBarStyle = UIStatusBarStyle.DarkContent;
+				}
+				else
+				{
+					UIApplication.SharedApplication.StatusBarStyle = UIStatusBarStyle.Default;
+				}
+			}
+			else
+			{
+				// Use light text color for status bar
+				UIApplication.SharedApplication.StatusBarStyle = UIStatusBarStyle.LightContent;
+			}
+		}
+
+		void UpdateToolBarVisible()
+		{
+			if (_secondaryToolbar == null)
+				return;
+			if (TopViewController != null && TopViewController.ToolbarItems != null && TopViewController.ToolbarItems.Any())
+			{
+				_secondaryToolbar.Hidden = false;
+				_secondaryToolbar.Items = TopViewController.ToolbarItems;
+			}
+			else
+			{
+				_secondaryToolbar.Hidden = true;
+				//secondaryToolbar.Items = null;
+			}
+
+			TopViewController?.NavigationItem?.TitleView?.SizeToFit();
+			TopViewController?.NavigationItem?.TitleView?.LayoutSubviews();
+		}
+
+		internal async Task UpdateFormsInnerNavigation(Page pageBeingRemoved)
+		{
+			if (NavPage == null)
+				return;
+			if (_ignorePopCall)
+				return;
+
+			_ignorePopCall = true;
+			if (Element.Navigation.NavigationStack.Contains(pageBeingRemoved))
+				await (NavPage as INavigationPageController)?.RemoveAsyncInner(pageBeingRemoved, false, true);
+			_ignorePopCall = false;
+
+		}
+
+		internal static void SetFlyoutLeftBarButton(UIViewController containerController, FlyoutPage FlyoutPage)
+		{
+			if (!FlyoutPage.ShouldShowToolbarButton())
+			{
+				containerController.NavigationItem.LeftBarButtonItem = null;
+				return;
+			}
+
+
+			FlyoutPage.Flyout.IconImageSource.LoadImage(FlyoutPage.FindMauiContext(), result =>
+			{
+				var icon = result.Value;
+				if (icon != null)
+				{
+					try
+					{
+						containerController.NavigationItem.LeftBarButtonItem = new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, OnItemTapped);
+					}
+					catch (Exception)
+					{
+						// Throws Exception otherwise would catch more specific exception type
+					}
+				}
+
+				if (icon == null || containerController.NavigationItem.LeftBarButtonItem == null)
+				{
+					containerController.NavigationItem.LeftBarButtonItem = new UIBarButtonItem(FlyoutPage.Flyout.Title, UIBarButtonItemStyle.Plain, OnItemTapped);
+				}
+
+				if (FlyoutPage != null && !string.IsNullOrEmpty(FlyoutPage.AutomationId))
+					SetAutomationId(containerController.NavigationItem.LeftBarButtonItem, $"btn_{FlyoutPage.AutomationId}");
+
+				containerController.NavigationItem.LeftBarButtonItem.SetAccessibilityHint(FlyoutPage);
+				containerController.NavigationItem.LeftBarButtonItem.SetAccessibilityLabel(FlyoutPage);
+			});
+
+			void OnItemTapped(object sender, EventArgs e)
+			{
+				FlyoutPage.IsPresented = !FlyoutPage.IsPresented;
+			}
+		}
+
+		static void SetAccessibilityHint(UIBarButtonItem uIBarButtonItem, Element element)
+		{
+			if (element == null)
+				return;
+
+			if (_defaultAccessibilityHint == null)
+				_defaultAccessibilityHint = uIBarButtonItem.AccessibilityHint;
+
+			uIBarButtonItem.AccessibilityHint = (string)element.GetValue(AutomationProperties.HelpTextProperty) ?? _defaultAccessibilityHint;
+		}
+
+		static void SetAccessibilityLabel(UIBarButtonItem uIBarButtonItem, Element element)
+		{
+			if (element == null)
+				return;
+
+			if (_defaultAccessibilityLabel == null)
+				_defaultAccessibilityLabel = uIBarButtonItem.AccessibilityLabel;
+
+			uIBarButtonItem.AccessibilityLabel = (string)element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
+		}
+
+		static void SetIsAccessibilityElement(UIBarButtonItem uIBarButtonItem, Element element)
+		{
+			if (element == null)
+				return;
+
+			if (!_defaultIsAccessibilityElement.HasValue)
+				_defaultIsAccessibilityElement = uIBarButtonItem.IsAccessibilityElement;
+
+			uIBarButtonItem.IsAccessibilityElement = (bool)((bool?)element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? _defaultIsAccessibilityElement);
+		}
+
+		static void SetAccessibilityElementsHidden(UIBarButtonItem uIBarButtonItem, Element element)
+		{
+			if (element == null)
+				return;
+
+			if (!_defaultAccessibilityElementsHidden.HasValue)
+				_defaultAccessibilityElementsHidden = uIBarButtonItem.AccessibilityElementsHidden;
+
+			uIBarButtonItem.AccessibilityElementsHidden = (bool)((bool?)element.GetValue(AutomationProperties.ExcludedWithChildrenProperty) ?? _defaultAccessibilityElementsHidden);
+		}
+
+		static void SetAutomationId(UIBarButtonItem uIBarButtonItem, string id)
+		{
+			uIBarButtonItem.AccessibilityIdentifier = id;
+		}
+
+		static string _defaultAccessibilityLabel;
+		static string _defaultAccessibilityHint;
+		static bool? _defaultIsAccessibilityElement;
+		static bool? _defaultAccessibilityElementsHidden;
+
+		internal void ValidateInsets()
+		{
+			nfloat navBottom = NavigationBar.Frame.Bottom;
+
+			if (_navigationBottom != navBottom && Current != null)
+				ViewDidLayoutSubviews();
+		}
+
+		class SecondaryToolbar : UIToolbar
+		{
+			readonly List<UIView> _lines = new List<UIView>();
+
+			public SecondaryToolbar()
+			{
+				TintColor = UIColor.White;
+			}
+
+			public override UIBarButtonItem[] Items
+			{
+				get { return base.Items; }
+				set
+				{
+					base.Items = value;
+					SetupLines();
+				}
+			}
+
+			public override void LayoutSubviews()
+			{
+				base.LayoutSubviews();
+				if (Items == null || Items.Length == 0)
+					return;
+				LayoutToolbarItems(Bounds.Width, Bounds.Height, 0);
+			}
+
+			void LayoutToolbarItems(nfloat toolbarWidth, nfloat toolbarHeight, nfloat padding)
+			{
+				var x = padding;
+				var y = 0;
+				var itemH = toolbarHeight;
+				var itemW = toolbarWidth / Items.Length;
+
+				foreach (var item in Items)
+				{
+					var frame = new RectangleF(x, y, itemW, itemH);
+					if (frame == item.CustomView.Frame)
+						continue;
+					item.CustomView.Frame = frame;
+					x += itemW + padding;
+				}
+
+				x = itemW + padding * 1.5f;
+				y = (int)Bounds.GetMidY();
+				foreach (var l in _lines)
+				{
+					l.Center = new PointF(x, y);
+					x += itemW + padding;
+				}
+			}
+
+			void SetupLines()
+			{
+				_lines.ForEach(l => l.RemoveFromSuperview());
+				_lines.Clear();
+				if (Items == null)
+					return;
+				for (var i = 1; i < Items.Length; i++)
+				{
+					var l = new UIView(new RectangleF(0, 0, 1, 24)) { BackgroundColor = new UIColor(0, 0, 0, 0.2f) };
+					AddSubview(l);
+					_lines.Add(l);
+				}
+			}
+		}
+
+		class ParentingViewController : UIViewController
+		{
+			readonly WeakReference<NavigationRenderer> _navigation;
+
+			Page _child;
+			bool _disposed;
+			ToolbarTracker _tracker = new ToolbarTracker();
+
+			public ParentingViewController(NavigationRenderer navigation)
+			{
+				AutomaticallyAdjustsScrollViewInsets = false;
+
+				_navigation = new WeakReference<NavigationRenderer>(navigation);
+			}
+
+			public Page Child
+			{
+				get { return _child; }
+				set
+				{
+					if (_child == value)
+						return;
+
+					if (_child != null)
+						_child.PropertyChanged -= HandleChildPropertyChanged;
+
+					_child = value;
+
+					if (_child != null)
+						_child.PropertyChanged += HandleChildPropertyChanged;
+
+					UpdateHasBackButton();
+					UpdateLargeTitles();
+					UpdateIconColor();
+				}
+			}
+
+			public event EventHandler Appearing;
+
+			public override void DidRotate(UIInterfaceOrientation fromInterfaceOrientation)
+			{
+				base.DidRotate(fromInterfaceOrientation);
+
+				View.SetNeedsLayout();
+			}
+
+			public event EventHandler Disappearing;
+
+			public override void ViewDidAppear(bool animated)
+			{
+				base.ViewDidAppear(animated);
+
+				Appearing?.Invoke(this, EventArgs.Empty);
+			}
+
+			public override void ViewDidDisappear(bool animated)
+			{
+				base.ViewDidDisappear(animated);
+
+				// force a redraw for right toolbar items by resetting TintColor to prevent
+				// toolbar items being grayed out when canceling swipe to a previous page
+				foreach (var item in NavigationItem?.RightBarButtonItems)
+				{
+					if (item.Image != null)
+						continue;
+
+					var tintColor = item.TintColor;
+					item.TintColor = tintColor == null ? UIColor.Clear : null;
+					item.TintColor = tintColor;
+				}
+
+				Disappearing?.Invoke(this, EventArgs.Empty);
+			}
+
+			public override void ViewWillLayoutSubviews()
+			{
+				base.ViewWillLayoutSubviews();
+
+				NavigationRenderer n;
+				if (_navigation.TryGetTarget(out n))
+					n.ValidateInsets();
+			}
+
+			public override void ViewDidLayoutSubviews()
+			{
+				UIView nativeView;
+				if ((nativeView = Child.ToPlatform()) != null)
+					nativeView.Frame = Child.Bounds.ToCGRect();
+
+				base.ViewDidLayoutSubviews();
+			}
+
+			public override void ViewDidLoad()
+			{
+				base.ViewDidLoad();
+
+				_tracker.Target = Child;
+				_tracker.AdditionalTargets = Child.GetParentPages();
+				_tracker.CollectionChanged += TrackerOnCollectionChanged;
+
+				UpdateToolbarItems();
+			}
+
+			public override void ViewWillAppear(bool animated)
+			{
+				SetupDefaultNavigationBarAppearance();
+				UpdateNavigationBarVisibility(animated);
+
+				NavigationRenderer n;
+				var isTranslucent = false;
+				if (_navigation.TryGetTarget(out n))
+					isTranslucent = n.NavigationBar.Translucent;
+				EdgesForExtendedLayout = isTranslucent ? UIRectEdge.All : UIRectEdge.None;
+
+				base.ViewWillAppear(animated);
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+
+				if (disposing)
+				{
+					if (Child != null)
+					{
+						Child.SendDisappearing();
+						Child.PropertyChanged -= HandleChildPropertyChanged;
+						Child = null;
+					}
+
+					_tracker.Target = null;
+					_tracker.CollectionChanged -= TrackerOnCollectionChanged;
+					_tracker = null;
+
+					if (NavigationItem.TitleView != null)
+					{
+						NavigationItem.TitleView.Dispose();
+						NavigationItem.TitleView = null;
+					}
+
+					if (NavigationItem.RightBarButtonItems != null)
+					{
+						for (var i = 0; i < NavigationItem.RightBarButtonItems.Length; i++)
+							NavigationItem.RightBarButtonItems[i].Dispose();
+					}
+
+					if (ToolbarItems != null)
+					{
+						for (var i = 0; i < ToolbarItems.Length; i++)
+							ToolbarItems[i].Dispose();
+					}
+				}
+
+				base.Dispose(disposing);
+			}
+
+			void HandleChildPropertyChanged(object sender, PropertyChangedEventArgs e)
+			{
+				if (e.PropertyName == NavigationPage.HasNavigationBarProperty.PropertyName)
+					UpdateNavigationBarVisibility(true);
+				else if (e.PropertyName == Page.TitleProperty.PropertyName)
+					NavigationItem.Title = Child.Title;
+				else if (e.PropertyName == NavigationPage.HasBackButtonProperty.PropertyName)
+					UpdateHasBackButton();
+				else if (e.PropertyName == PrefersStatusBarHiddenProperty.PropertyName)
+					UpdatePrefersStatusBarHidden();
+				else if (e.PropertyName == LargeTitleDisplayProperty.PropertyName)
+					UpdateLargeTitles();
+				else if (e.PropertyName == NavigationPage.TitleIconImageSourceProperty.PropertyName ||
+					 e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
+					UpdateTitleArea(Child);
+				else if (e.PropertyName == NavigationPage.IconColorProperty.PropertyName)
+					UpdateIconColor();
+			}
+
+			internal void SetupDefaultNavigationBarAppearance()
+			{
+				if (!NativeVersion.IsAtLeast(13))
+					return;
+
+				if (!_navigation.TryGetTarget(out NavigationRenderer navigationRenderer))
+					return;
+
+				// We will use UINavigationBar.Appareance to infer settings that
+				// were already set to navigation bar in older versions of
+				// iOS.
+				var navBar = navigationRenderer.NavigationBar;
+				var navAppearance = navBar.StandardAppearance;
+
+				if (navAppearance.BackgroundColor == null)
+				{
+					var backgroundColor = navBar.BarTintColor;
+					navBar.CompactAppearance.BackgroundColor = navBar.StandardAppearance.BackgroundColor = navBar.ScrollEdgeAppearance.BackgroundColor = backgroundColor;
+				}
+
+				if (navAppearance.BackgroundImage == null)
+				{
+					var backgroundImage = navBar.GetBackgroundImage(UIBarMetrics.Default);
+					navBar.CompactAppearance.BackgroundImage = navBar.StandardAppearance.BackgroundImage = navBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
+				}
+
+				if (navAppearance.ShadowImage == null)
+				{
+					var shadowImage = navBar.ShadowImage;
+					navBar.CompactAppearance.ShadowImage = navBar.StandardAppearance.ShadowImage = navBar.ScrollEdgeAppearance.ShadowImage = shadowImage;
+
+					if (shadowImage != null && shadowImage.Size == SizeF.Empty)
+						navBar.CompactAppearance.ShadowColor = navBar.StandardAppearance.ShadowColor = navBar.ScrollEdgeAppearance.ShadowColor = UIColor.Clear;
+				}
+
+				UIImage backIndicatorImage = navBar.BackIndicatorImage;
+				UIImage backIndicatorTransitionMaskImage = navBar.BackIndicatorTransitionMaskImage;
+
+				if (backIndicatorImage != null && backIndicatorImage.Size == SizeF.Empty)
+					backIndicatorImage = GetEmptyBackIndicatorImage();
+
+				if (backIndicatorTransitionMaskImage != null && backIndicatorTransitionMaskImage.Size == SizeF.Empty)
+					backIndicatorTransitionMaskImage = GetEmptyBackIndicatorImage();
+
+				navBar.CompactAppearance.SetBackIndicatorImage(backIndicatorImage, backIndicatorTransitionMaskImage);
+				navBar.StandardAppearance.SetBackIndicatorImage(backIndicatorImage, backIndicatorTransitionMaskImage);
+				navBar.ScrollEdgeAppearance.SetBackIndicatorImage(backIndicatorImage, backIndicatorTransitionMaskImage);
+			}
+
+			UIImage GetEmptyBackIndicatorImage()
+			{
+				var rect = RectangleF.Empty;
+				var size = rect.Size;
+
+				UIGraphics.BeginImageContext(size);
+				var context = UIGraphics.GetCurrentContext();
+				context?.SetFillColor(1, 1, 1, 0);
+				context?.FillRect(rect);
+
+				var empty = UIGraphics.GetImageFromCurrentImageContext();
+				context?.Dispose();
+
+				return empty;
+			}
+
+			internal void UpdateLeftBarButtonItem(Page pageBeingRemoved = null)
+			{
+				NavigationRenderer n;
+				if (!_navigation.TryGetTarget(out n))
+					return;
+
+				var currentChild = this.Child;
+				var firstPage = n.NavPageController.Pages.FirstOrDefault();
+
+
+				if (n._parentFlyoutPage == null)
+					return;
+
+				if (firstPage != pageBeingRemoved && currentChild != firstPage && NavigationPage.GetHasBackButton(currentChild))
+				{
+					NavigationItem.LeftBarButtonItem = null;
+					return;
+				}
+
+				SetFlyoutLeftBarButton(this, n._parentFlyoutPage);
+			}
+
+
+			public bool NeedsTitleViewContainer(Page page) => NavigationPage.GetTitleIconImageSource(page) != null || NavigationPage.GetTitleView(page) != null;
+
+			internal void UpdateBackButtonTitle(Page page) => UpdateBackButtonTitle(page.Title, NavigationPage.GetBackButtonTitle(page));
+
+			internal void UpdateBackButtonTitle(string title, string backButtonTitle)
+			{
+				if (!string.IsNullOrWhiteSpace(title))
+					NavigationItem.Title = title;
+
+				if (backButtonTitle != null)
+					// adding a custom event handler to UIBarButtonItem for navigating back seems to be ignored.
+					NavigationItem.BackBarButtonItem = new UIBarButtonItem { Title = backButtonTitle, Style = UIBarButtonItemStyle.Plain };
+				else
+					NavigationItem.BackBarButtonItem = null;
+			}
+
+			internal void UpdateTitleArea(Page page)
+			{
+				if (page == null)
+					return;
+
+				ImageSource titleIcon = NavigationPage.GetTitleIconImageSource(page);
+				View titleView = NavigationPage.GetTitleView(page);
+				bool needContainer = titleView != null || titleIcon != null;
+
+				string backButtonText = NavigationPage.GetBackButtonTitle(page);
+				bool isBackButtonTextSet = page.IsSet(NavigationPage.BackButtonTitleProperty);
+
+				// on iOS 10 if the user hasn't set the back button text
+				// we set it to an empty string so it's consistent with iOS 11
+				if (!NativeVersion.IsAtLeast(11) && !isBackButtonTextSet)
+					backButtonText = "";
+
+				// First page and we have a flyout detail to contend with
+				UpdateLeftBarButtonItem();
+				UpdateBackButtonTitle(page.Title, backButtonText);
+
+				//var hadTitleView = NavigationItem.TitleView != null;
+				ClearTitleViewContainer();
+				if (needContainer)
+				{
+					NavigationRenderer n;
+					if (!_navigation.TryGetTarget(out n))
+						return;
+
+					Container titleViewContainer = new Container(titleView, n.NavigationBar);
+
+					UpdateTitleImage(titleViewContainer, titleIcon);
+					NavigationItem.TitleView = titleViewContainer;
+				}
+			}
+
+			void UpdateIconColor()
+			{
+				if (_navigation.TryGetTarget(out NavigationRenderer navigationRenderer))
+					navigationRenderer.UpdateBarTextColor();
+			}
+
+			void UpdateTitleImage(Container titleViewContainer, ImageSource titleIcon)
+			{
+				if (titleViewContainer == null)
+					return;
+
+				if (titleIcon == null || titleIcon.IsEmpty)
+				{
+					titleViewContainer.Icon = null;
+				}
+				else
+				{
+					titleIcon.LoadImage(titleIcon.FindMauiContext(), result =>
+					{
+						var image = result.Value;
+						try
+						{
+							titleViewContainer.Icon = new UIImageView(image);
+						}
+						catch
+						{
+							//UIImage ctor throws on file not found if MonoTouch.ObjCRuntime.Class.ThrowOnInitFailure is true;
+						}
+					});
+				}
+			}
+
+			void ClearTitleViewContainer()
+			{
+				if (NavigationItem.TitleView != null && NavigationItem.TitleView is Container titleViewContainer)
+				{
+					titleViewContainer.Dispose();
+					titleViewContainer = null;
+					NavigationItem.TitleView = null;
+				}
+			}
+
+			void UpdatePrefersStatusBarHidden()
+			{
+				View.SetNeedsLayout();
+				ParentViewController?.View.SetNeedsLayout();
+			}
+
+			void TrackerOnCollectionChanged(object sender, EventArgs eventArgs)
+			{
+				UpdateToolbarItems();
+			}
+
+			void UpdateHasBackButton()
+			{
+				if (Child == null || NavigationItem.HidesBackButton == !NavigationPage.GetHasBackButton(Child))
+					return;
+
+				NavigationItem.HidesBackButton = !NavigationPage.GetHasBackButton(Child);
+
+				NavigationRenderer n;
+				if (!_navigation.TryGetTarget(out n))
+					return;
+
+				if (!NativeVersion.IsAtLeast(11) || n._parentFlyoutPage != null)
+					UpdateTitleArea(Child);
+			}
+
+			void UpdateNavigationBarVisibility(bool animated)
+			{
+				var current = Child;
+
+				if (current == null || NavigationController == null)
+					return;
+
+				var hasNavBar = NavigationPage.GetHasNavigationBar(current);
+
+				if (NavigationController.NavigationBarHidden == hasNavBar)
+				{
+					// prevent bottom content "jumping"
+					current.IgnoresContainerArea = !hasNavBar;
+					NavigationController.SetNavigationBarHidden(!hasNavBar, animated);
+				}
+			}
+
+			void UpdateToolbarItems()
+			{
+				if (NavigationItem.RightBarButtonItems != null)
+				{
+					for (var i = 0; i < NavigationItem.RightBarButtonItems.Length; i++)
+						NavigationItem.RightBarButtonItems[i].Dispose();
+				}
+				if (ToolbarItems != null)
+				{
+					for (var i = 0; i < ToolbarItems.Length; i++)
+						ToolbarItems[i].Dispose();
+				}
+
+				List<UIBarButtonItem> primaries = null;
+				List<UIBarButtonItem> secondaries = null;
+				var toolbarItems = _tracker.ToolbarItems;
+				foreach (var item in toolbarItems)
+				{
+					if (item.Order == ToolbarItemOrder.Secondary)
+						(secondaries = secondaries ?? new List<UIBarButtonItem>()).Add(item.ToUIBarButtonItem(true));
+					else
+						(primaries = primaries ?? new List<UIBarButtonItem>()).Add(item.ToUIBarButtonItem());
+				}
+
+				if (primaries != null)
+					primaries.Reverse();
+				NavigationItem.SetRightBarButtonItems(primaries == null ? new UIBarButtonItem[0] : primaries.ToArray(), false);
+				ToolbarItems = secondaries == null ? new UIBarButtonItem[0] : secondaries.ToArray();
+
+				NavigationRenderer n;
+				if (_navigation.TryGetTarget(out n))
+					n.UpdateToolBarVisible();
+			}
+
+			void UpdateLargeTitles()
+			{
+				var page = Child;
+				if (page != null && NativeVersion.IsAtLeast(11))
+				{
+					var largeTitleDisplayMode = page.OnThisPlatform().LargeTitleDisplay();
+					switch (largeTitleDisplayMode)
+					{
+						case LargeTitleDisplayMode.Always:
+							NavigationItem.LargeTitleDisplayMode = UINavigationItemLargeTitleDisplayMode.Always;
+							break;
+						case LargeTitleDisplayMode.Automatic:
+							NavigationItem.LargeTitleDisplayMode = UINavigationItemLargeTitleDisplayMode.Automatic;
+							break;
+						case LargeTitleDisplayMode.Never:
+							NavigationItem.LargeTitleDisplayMode = UINavigationItemLargeTitleDisplayMode.Never;
+							break;
+					}
+				}
+			}
+
+			public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
+			{
+				if (Child?.Handler is INativeViewHandler ivh)
+					return ivh.ViewController.GetSupportedInterfaceOrientations();
+				return base.GetSupportedInterfaceOrientations();
+			}
+
+			public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
+			{
+				if (Child?.Handler is INativeViewHandler ivh)
+					return ivh.ViewController.PreferredInterfaceOrientationForPresentation();
+				return base.PreferredInterfaceOrientationForPresentation();
+			}
+
+			public override bool ShouldAutorotate()
+			{
+				if (Child?.Handler is INativeViewHandler ivh)
+					return ivh.ViewController.ShouldAutorotate();
+				return base.ShouldAutorotate();
+			}
+
+			public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
+			{
+				if (Child?.Handler is INativeViewHandler ivh)
+					return ivh.ViewController.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+				return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+			}
+
+			public override bool ShouldAutomaticallyForwardRotationMethods => true;
+
+			public override async void DidMoveToParentViewController(UIViewController parent)
+			{
+				//we are being removed from the UINavigationPage
+				if (parent == null)
+				{
+					NavigationRenderer navRenderer;
+					if (_navigation.TryGetTarget(out navRenderer))
+						await navRenderer.UpdateFormsInnerNavigation(Child);
+				}
+				base.DidMoveToParentViewController(parent);
+			}
+		}
+
+		public override UIViewController ChildViewControllerForStatusBarHidden()
+		{
+			return (Current.Handler as INativeViewHandler)?.ViewController;
+		}
+
+		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden =>
+			ChildViewControllerForStatusBarHidden();
+
+		bool IViewHandler.HasContainer { get => false; set { } }
+
+		object IViewHandler.ContainerView => null;
+
+		IView IViewHandler.VirtualView => Element;
+
+		object IElementHandler.NativeView => NativeView;
+
+		Maui.IElement IElementHandler.VirtualView => Element;
+
+		IMauiContext IElementHandler.MauiContext => _mauiContext;
+
+		UIView INativeViewHandler.NativeView => NativeView;
+
+		UIView INativeViewHandler.ContainerView => null;
+
+		UIViewController INativeViewHandler.ViewController => this;
+
+		Size IViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) =>
+			VisualElementRenderer<NavigationPage>.GetDesiredSize(this, widthConstraint, heightConstraint,
+				new Size(0, 0));
+
+		void IViewHandler.NativeArrange(Rectangle rect) =>
+			this.NativeArrangeHandler(rect);
+
+		void IElementHandler.SetMauiContext(IMauiContext mauiContext)
+		{
+			_mauiContext = mauiContext;
+		}
+
+		void IElementHandler.SetVirtualView(Maui.IElement view)
+		{
+			var oldElement = Element;
+			Element = (VisualElement)view;
+			Mapper.UpdateProperties(this, Element);
+			OnElementChanged(new VisualElementChangedEventArgs(oldElement, Element));
+		}
+
+		void IElementHandler.UpdateValue(string property)
+		{
+			Mapper.UpdateProperty(this, Element, property);
+		}
+
+		void IElementHandler.Invoke(string command, object args)
+		{
+			CommandMapper.Invoke(this, Element, command, args);
+		}
+
+		void IElementHandler.DisconnectHandler()
+		{
+		}
+
+		internal class MauiControlsNavigationBar : UINavigationBar
+		{
+			[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
+			public MauiControlsNavigationBar() : base()
+			{
+			}
+
+			[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
+			public MauiControlsNavigationBar(Foundation.NSCoder coder) : base(coder)
+			{
+			}
+
+			[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
+			protected MauiControlsNavigationBar(Foundation.NSObjectFlag t) : base(t)
+			{
+			}
+
+			[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
+			protected internal MauiControlsNavigationBar(IntPtr handle) : base(handle)
+			{
+			}
+
+			[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
+			public MauiControlsNavigationBar(RectangleF frame) : base(frame)
+			{
+			}
+
+			public RectangleF BackButtonFrameSize { get; private set; }
+			public UILabel NavBarLabel { get; private set; }
+
+			public override void LayoutSubviews()
+			{
+				if (!NativeVersion.IsAtLeast(11))
+				{
+					for (int i = 0; i < this.Subviews.Length; i++)
+					{
+						if (Subviews[i] is UIView view)
+						{
+							if (view.Class.Name == "_UINavigationBarBackIndicatorView")
+							{
+								if (view.Alpha == 0)
+									BackButtonFrameSize = CGRect.Empty;
+								else
+									BackButtonFrameSize = view.Frame;
+
+								break;
+							}
+							else if (view.Class.Name == "UINavigationItemButtonView")
+							{
+								if (view.Subviews.Length == 0)
+									NavBarLabel = null;
+								else if (view.Subviews[0] is UILabel titleLabel)
+									NavBarLabel = titleLabel;
+							}
+						}
+					}
+				}
+
+				base.LayoutSubviews();
+			}
+		}
+
+		class Container : UIView
+		{
+			View _view;
+			MauiControlsNavigationBar _bar;
+			INativeViewHandler _child;
+			UIImageView _icon;
+			bool _disposed;
+
+			public Container(View view, UINavigationBar bar) : base(bar.Bounds)
+			{
+				if (NativeVersion.IsAtLeast(11))
+				{
+					TranslatesAutoresizingMaskIntoConstraints = false;
+				}
+				else
+				{
+					TranslatesAutoresizingMaskIntoConstraints = true;
+					AutoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth;
+				}
+
+				_bar = bar as MauiControlsNavigationBar;
+				if (view != null)
+				{
+					_view = view;
+					var platformView = view.ToPlatform(view.FindMauiContext());
+					_child = (INativeViewHandler)view.Handler;
+					AddSubview(platformView);
+				}
+
+				ClipsToBounds = true;
+			}
+
+			public override CGSize IntrinsicContentSize => UILayoutFittingExpandedSize;
+
+			nfloat IconHeight => _icon?.Frame.Height ?? 0;
+			nfloat IconWidth => _icon?.Frame.Width ?? 0;
+
+			// Navigation bar will not stretch past these values. Prevent content clipping.
+			// iOS11 does this for us automatically, but apparently iOS10 doesn't.
+			nfloat ToolbarHeight
+			{
+				get
+				{
+					if (Superview?.Bounds.Height > 0)
+						return Superview.Bounds.Height;
+
+					return (Device.Idiom == TargetIdiom.Phone && DeviceDisplay.MainDisplayInfo.Orientation.IsLandscape()) ? 32 : 44;
+				}
+			}
+
+			public override CGRect Frame
+			{
+				get => base.Frame;
+				set
+				{
+					if (Superview != null)
+					{
+						if (!NativeVersion.IsAtLeast(11))
+						{
+							value.Y = Superview.Bounds.Y;
+
+							if (_bar != null && String.IsNullOrWhiteSpace(_bar.NavBarLabel?.Text) && _bar.BackButtonFrameSize != RectangleF.Empty)
+							{
+								var xSpace = _bar.BackButtonFrameSize.Width + (_bar.BackButtonFrameSize.X * 2);
+								value.Width = (value.X - xSpace) + value.Width;
+								value.X = xSpace;
+							}
+						};
+
+						value.Height = ToolbarHeight;
+					}
+
+					base.Frame = value;
+				}
+			}
+
+			public UIImageView Icon
+			{
+				set
+				{
+					if (_icon != null)
+						_icon.RemoveFromSuperview();
+
+					_icon = value;
+
+					if (_icon != null)
+						AddSubview(_icon);
+				}
+			}
+
+			public override SizeF SizeThatFits(SizeF size)
+			{
+				return new SizeF(size.Width, ToolbarHeight);
+			}
+
+			public override void LayoutSubviews()
+			{
+				base.LayoutSubviews();
+				if (Frame == CGRect.Empty || Frame.Width >= 10000 || Frame.Height >= 10000)
+					return;
+
+				nfloat toolbarHeight = ToolbarHeight;
+
+				double height = Math.Min(toolbarHeight, Bounds.Height);
+
+				if (_icon != null)
+					_icon.Frame = new RectangleF(0, 0, IconWidth, Math.Min(toolbarHeight, IconHeight));
+
+				if (_child?.VirtualView != null)
+				{
+					Rectangle layoutBounds = new Rectangle(IconWidth, 0, Bounds.Width - IconWidth, height);
+
+					_child.NativeArrangeHandler(layoutBounds);
+				}
+				else if (_icon != null && Superview != null)
+				{
+					_icon.Center = new PointF(Superview.Frame.Width / 2 - Frame.X, Superview.Frame.Height / 2);
+				}
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+
+				if (disposing)
+				{
+
+					if (_child != null)
+					{
+						//_child.VirtualView?.DisposeModalAndChildRenderers();
+						_child.NativeView.RemoveFromSuperview();
+						//_child.Dispose();
+						_child = null;
+					}
+
+					_view = null;
+
+					_icon?.Dispose();
+					_icon = null;
+				}
+
+				base.Dispose(disposing);
+			}
+		}
+	}
+}

--- a/src/Compatibility/Core/src/Handlers/ViewHandlerDelegator.cs
+++ b/src/Compatibility/Core/src/Handlers/ViewHandlerDelegator.cs
@@ -86,6 +86,21 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			VisualElementRenderer<TElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _element, ref _mapper, _defaultMapper, autoPackage);
 #endif
 		}
+
+		public void SetVirtualView(
+			Maui.IElement view,
+			Action<VisualElementChangedEventArgs> onElementChanged,
+			bool autoPackage)
+		{
+			SetVirtualView(view, ElementChanged, false);
+
+			void ElementChanged(ElementChangedEventArgs<TElement> e)
+			{
+				onElementChanged(new VisualElementChangedEventArgs(
+					e.OldElement as VisualElement,
+					e.NewElement as VisualElement));
+			}
+		}
 	}
 }
 #endif

--- a/src/Compatibility/Core/src/Handlers/ViewHandlerDelegator.cs
+++ b/src/Compatibility/Core/src/Handlers/ViewHandlerDelegator.cs
@@ -1,0 +1,91 @@
+﻿#nullable enable
+
+#if WINDOWS || IOS || ANDROID
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls.Handlers.Compatibility
+{
+#if WINDOWS
+	class ViewHandlerDelegator<TElement, TNativeElement>
+		where TElement : VisualElement
+		where TNativeElement : Microsoft.UI.Xaml.FrameworkElement
+#else
+	class ViewHandlerDelegator<TElement>
+		where TElement : Element, IView
+#endif
+	{
+		protected readonly IPropertyMapper _defaultMapper;
+		protected IPropertyMapper _mapper;
+		protected CommandMapper _commandMapper;
+		INativeViewHandler _viewHandler;
+		TElement? _element;
+		public TElement? Element => _element;
+		bool _disposed;
+
+		public ViewHandlerDelegator(
+			IPropertyMapper mapper,
+			CommandMapper commandMapper,
+			INativeViewHandler viewHandler)
+		{
+			_defaultMapper = mapper;
+			_mapper = _defaultMapper;
+			_commandMapper = commandMapper;
+			_viewHandler = viewHandler;
+		}
+
+		public void UpdateProperty(string property)
+		{
+			if (_viewHandler.VirtualView != null)
+				_mapper.UpdateProperty(_viewHandler, _viewHandler.VirtualView, property);
+		}
+
+		public void Invoke(string command, object? args)
+		{
+			_commandMapper.Invoke(_viewHandler, _viewHandler.VirtualView, command, args);
+		}
+
+		public void DisconnectHandler()
+		{
+			if (_element == null)
+				return;
+
+			if (_element.Handler == _viewHandler)
+				_element.Handler = null;
+
+			_element = null;
+
+			if (!_disposed && _viewHandler is IDisposable disposable)
+			{
+				disposable.Dispose();
+				_disposed = true;
+			}
+		}
+
+		public Size GetDesiredSize(double widthConstraint, double heightConstraint, Size? minimumSize = null) =>
+#if WINDOWS
+			VisualElementRenderer<TElement, TNativeElement>.GetDesiredSize(_viewHandler, widthConstraint, heightConstraint, minimumSize);
+#else
+			VisualElementRenderer<TElement>.GetDesiredSize(_viewHandler, widthConstraint, heightConstraint, minimumSize);
+#endif
+
+		public void NativeArrange(Rectangle rect) =>
+			_viewHandler.NativeArrangeHandler(rect);
+
+		public void SetVirtualView(
+			Maui.IElement view,
+			Action<ElementChangedEventArgs<TElement>> onElementChanged,
+			bool autoPackage)
+		{
+#if WINDOWS
+			VisualElementRenderer<TElement, TNativeElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _element, ref _mapper, _defaultMapper, autoPackage);
+#else
+			VisualElementRenderer<TElement>.SetVirtualView(view, _viewHandler, onElementChanged, ref _element, ref _mapper, _defaultMapper, autoPackage);
+#endif
+		}
+	}
+}
+#endif

--- a/src/Compatibility/Core/src/Handlers/VisualElementRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/VisualElementRenderer.cs
@@ -108,17 +108,21 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		}
 
 
-		internal static Size GetDesiredSize(INativeViewHandler handler, double widthConstraint, double heightConstraint, Size minimumSize)
+		internal static Size GetDesiredSize(INativeViewHandler handler, double widthConstraint, double heightConstraint, Size? minimumSize)
 		{
 			var size = handler.GetDesiredSizeFromHandler(widthConstraint, heightConstraint);
-			var minSize = minimumSize;
 
-			if (size.Height < minSize.Height || size.Width < minSize.Width)
+			if (minimumSize != null)
 			{
-				return new Size(
-						size.Width < minSize.Width ? minSize.Width : size.Width,
-						size.Height < minSize.Height ? minSize.Height : size.Height
-					);
+				var minSize = minimumSize.Value;
+
+				if (size.Height < minSize.Height || size.Width < minSize.Width)
+				{
+					return new Size(
+							size.Width < minSize.Width ? minSize.Width : size.Width,
+							size.Height < minSize.Height ? minSize.Height : size.Height
+						);
+				}
 			}
 
 			return size;

--- a/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/NavigationRenderer.cs
@@ -20,6 +20,7 @@ using SizeF = CoreGraphics.CGSize;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {
+	[Obsolete("Use Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer instead")]
 	public class NavigationRenderer : UINavigationController, IVisualElementRenderer, IEffectControlProvider
 	{
 		internal const string UpdateToolbarButtons = "Xamarin.UpdateToolbarButtons";

--- a/src/Compatibility/Core/src/iOS/Renderers/PhoneFlyoutPageRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/PhoneFlyoutPageRenderer.cs
@@ -397,7 +397,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			UIViewController firstPage = detailRenderer?.ViewControllers.FirstOrDefault();
 			if (firstPage != null)
+#pragma warning disable CS0618 // Type or member is obsolete
 				NavigationRenderer.SetFlyoutLeftBarButton(firstPage, FlyoutPage);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void UpdateApplyShadow(bool value)

--- a/src/Compatibility/Core/src/iOS/Renderers/TabletFlyoutPageRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/TabletFlyoutPageRenderer.cs
@@ -9,6 +9,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {
+	[Obsolete]
 	internal class ChildViewController : UIViewController
 	{
 		public override void ViewDidLayoutSubviews()
@@ -18,6 +19,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		}
 	}
 
+	[Obsolete]
 	internal class EventedViewController : ChildViewController
 	{
 		FlyoutView _flyoutView;
@@ -114,6 +116,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		}
 	}
 
+
+	[Obsolete("Use Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer instead")]
 	public class TabletFlyoutPageRenderer : UISplitViewController, IVisualElementRenderer, IEffectControlProvider
 	{
 		UIViewController _detailController;

--- a/src/Compatibility/Core/src/iOS/Renderers/TabletFlyoutPageRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/TabletFlyoutPageRenderer.cs
@@ -391,7 +391,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				}
 
 				FlyoutPage.UpdateFlyoutLayoutBehavior();
+#pragma warning disable CS0618 // Type or member is obsolete
 				MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			base.WillRotate(toInterfaceOrientation, duration);
@@ -449,7 +451,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		void HandleFlyoutPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Page.IconImageSourceProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName)
+#pragma warning disable CS0618 // Type or member is obsolete
 				MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -470,7 +474,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			else if (e.Is(Microsoft.Maui.Controls.FlyoutPage.FlyoutLayoutBehaviorProperty))
 				UpdateFlyoutLayoutBehavior(base.View.Bounds.Size);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -28,8 +28,8 @@ namespace Maui.Controls.Sample
 	{
 		static bool UseMauiGraphicsSkia = false;
 
-		enum PageType { Main, Blazor, Shell, Template, FlyoutPage }
-		readonly static PageType _pageType = PageType.Main;
+		enum PageType { Main, Blazor, Shell, Template, FlyoutPage, TabbedPage }
+		readonly static PageType _pageType = PageType.FlyoutPage;
 
 		public static MauiApp CreateMauiApp()
 		{
@@ -117,6 +117,7 @@ namespace Maui.Controls.Sample
 					PageType.Shell => typeof(AppShell),
 					PageType.Main => typeof(CustomNavigationPage),
 					PageType.FlyoutPage => typeof(CustomFlyoutPage),
+					PageType.TabbedPage => typeof(Pages.TabbedPageGallery),
 					PageType.Blazor =>
 #if NET6_0_OR_GREATER
 						typeof(BlazorPage),

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -29,7 +29,7 @@ namespace Maui.Controls.Sample
 		static bool UseMauiGraphicsSkia = false;
 
 		enum PageType { Main, Blazor, Shell, Template, FlyoutPage, TabbedPage }
-		readonly static PageType _pageType = PageType.FlyoutPage;
+		readonly static PageType _pageType = PageType.Main;
 
 		public static MauiApp CreateMauiApp()
 		{


### PR DESCRIPTION
### Description of Change ###

This converts the legacy NavigationRenderer on iOS to implement `IViewHandler` vs `IVisualElementRenderer` and it fixes all the layout code to be more `ViewHandler` compliant

### Things to note
This PR is mainly about getting the current semi-working implementation moved over to using `IViewHandler`. There are still some measuring behaviors that don't work that will be fixed in layer PRs. 

- FlyoutPage still doesn't work
- TabbedPage still doesn't work when nested inside NavigationPage

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
