### PR TITLE
[build] don't use intermediate @(_MauiCompileToAdd)

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
@@ -49,23 +49,20 @@
 
   <!-- Removals -->
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' ">
+    <Compile Remove="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
     <!-- Explicitly include the platform code -->
-    <_MauiCompileToAdd
+    <Compile
         Condition=" '$(TargetPlatformIdentifier)' == 'android' and '$(AndroidProjectFolder)' != '' "
         Include="$(AndroidProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-    <_MauiCompileToAdd
+    <Compile
         Condition=" '$(TargetPlatformIdentifier)' == 'ios' and '$(iOSProjectFolder)' != '' "
         Include="$(iOSProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-    <_MauiCompileToAdd
+    <Compile
         Condition=" '$(TargetPlatformIdentifier)' == 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' "
         Include="$(MacCatalystProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-    <_MauiCompileToAdd
+    <Compile
         Condition=" '$(TargetPlatformIdentifier)' == 'windows' and '$(WindowsProjectFolder)' != '' "
         Include="$(WindowsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-    <None Include="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" Exclude="@(_MauiCompileToAdd)" />
-    <Compile Remove="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-    <Compile Include="@(_MauiCompileToAdd)" />
-    <_MauiCompileToAdd Remove="@(_MauiCompileToAdd)" />
 
     <!-- Remove all Windows (WinUI) XAML Files from the Windows folder -->
     <_MauiXamlToRemove


### PR DESCRIPTION
### Description of Change ###

Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1413769
Fixes: https://github.com/dotnet/maui/issues/3967

Adding a new class to `Platforms\Android` results in:

    <ItemGroup>
      <_MauiCompileToAdd Remove="Platforms\Android\AnotherAndroid.cs" />
    </ItemGroup>
    <ItemGroup>
      <None Include="Platforms\Android\AnotherAndroid.cs" />
    </ItemGroup>

That's weird!

There might be an IDE / ProjectSystem issue here, but I think we should
change the MSBuild includes to workaround this problem.

Reviewing the existing `.targets`:

1. We don't need to add `.cs` files to `@(None)`? It doesn't not
   appear that `dotnet new console` adds `.cs` files to `@(None)`.

2. We can completely get rid of `@(_MauiCompileToAdd)` and just add
   files to `@(Compile)` directly.

After these changes, a `dotnet new maui` app still works. And when I
add new `.cs` files in a `Platforms\*\` folder, the `.csproj` file
remains unchanged. Yay!

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No