### PR TITLE
Remove GetNative and wrapped overload

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Windows/ViewToHandlerConverter.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ViewToHandlerConverter.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls.Platform
 				_view = view;
 				_view.MeasureInvalidated += OnMeasureInvalidated;
 
-				FrameworkElement = view.ToNative(view.FindMauiContext()!, true);
+				FrameworkElement = view.ToNative(view.FindMauiContext()!);
 				Children.Add(FrameworkElement);
 
 				// make sure we re-measure once the template is applied

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Controls.Platform
 					?.MauiContext
 					?.GetNavigationRootManager()
 					.RootView ??
-					CurrentPage.GetNative(true) ??
+					CurrentPage.ToNative() ??
 					throw new InvalidOperationException("Current Root View cannot be null");
 		}
 

--- a/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
+++ b/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
@@ -120,11 +120,11 @@ namespace Microsoft.Maui
 			var visualElements = new List<IVisualTreeElement>();
 			if (visualElement is IWindow window)
 			{
-				uiElement = window.Content.GetNative(true);
+				uiElement = window.Content.ToNative();
 			}
 			else if (visualElement is IView view)
 			{
-				uiElement = view.GetNative(true);
+				uiElement = view.ToNative();
 			}
 
 			if (uiElement != null)
@@ -136,7 +136,7 @@ namespace Microsoft.Maui
 				}
 
 				var uniqueElements = uiElements.Distinct();
-				var viewTree = visualElement.GetVisualTreeDescendants().Where(n => n is IView).Select(n => new Tuple<IView, object?>((IView)n, ((IView)n).GetNative(true)));
+				var viewTree = visualElement.GetVisualTreeDescendants().Where(n => n is IView).Select(n => new Tuple<IView, object?>((IView)n, ((IView)n).ToNative()));
 				var testList = viewTree.Where(n => uniqueElements.Contains(n.Item2)).Select(n => n.Item1);
 				if (testList != null && testList.Any())
 					visualElements.AddRange(testList.Select(n => (IVisualTreeElement)n));

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Handlers
 		void UpdateDetailsFragmentView()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			var newDetailsView = VirtualView.Detail?.ToNative(MauiContext, true);
+			var newDetailsView = VirtualView.Detail?.ToNative(MauiContext);
 
 			if (_detailView == newDetailsView)
 				return;
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 			_ = VirtualView.Flyout.ToNative(MauiContext);
 
-			var newFlyoutView = VirtualView.Flyout.GetNative(true);
+			var newFlyoutView = VirtualView.Flyout.ToNative();
 			if (_flyoutView == newFlyoutView)
 				return;
 

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Windows.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 			_ = VirtualView.Detail.ToNative(MauiContext);
 
-			NativeView.Content = VirtualView.Detail.GetNative(true);
+			NativeView.Content = VirtualView.Detail.ToNative();
 		}
 
 		void UpdateFlyout()
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Handlers
 
 			_flyoutPanel.Children.Clear();
 
-			if (VirtualView.Flyout.GetNative(true) is UIElement element)
+			if (VirtualView.Flyout.ToNative() is UIElement element)
 				_flyoutPanel.Children.Add(element);
 		}
 

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Handlers
 
 			foreach (var child in VirtualView.OrderByZIndex())
 			{
-				NativeView.AddView(child.ToNative(MauiContext, true));
+				NativeView.AddView(child.ToNative(MauiContext));
 			}
 		}
 
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			NativeView.AddView(child.ToNative(MauiContext, true), targetIndex);
+			NativeView.AddView(child.ToNative(MauiContext), targetIndex);
 		}
 
 		public void Remove(IView child)
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child?.GetNative(true) is View view)
+			if (child?.ToNative() is View view)
 			{
 				NativeView.RemoveView(view);
 			}
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			NativeView.AddView(child.ToNative(MauiContext, true), targetIndex);
+			NativeView.AddView(child.ToNative(MauiContext), targetIndex);
 		}
 
 		public void Update(int index, IView child)
@@ -93,7 +93,7 @@ namespace Microsoft.Maui.Handlers
 
 			NativeView.RemoveViewAt(index);
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			NativeView.AddView(child.ToNative(MauiContext, true), targetIndex);
+			NativeView.AddView(child.ToNative(MauiContext), targetIndex);
 		}
 
 		public void UpdateZIndex(IView child)
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			AView nativeChildView = child.ToNative(MauiContext!, true);
+			AView nativeChildView = child.ToNative(MauiContext!);
 			var currentIndex = IndexOf(NativeView, nativeChildView);
 
 			if (currentIndex == -1)

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			NativeView.Children.Insert(targetIndex, child.ToNative(MauiContext, true));
+			NativeView.Children.Insert(targetIndex, child.ToNative(MauiContext));
 		}
 
 		public override void SetVirtualView(IView view)
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Handlers
 
 			foreach (var child in VirtualView.OrderByZIndex())
 			{
-				NativeView.Children.Add(child.ToNative(MauiContext, true));
+				NativeView.Children.Add(child.ToNative(MauiContext));
 			}
 		}
 
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child?.GetNative(true) is UIElement view)
+			if (child?.ToNative() is UIElement view)
 			{
 				NativeView.Children.Remove(view);
 			}
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			NativeView.Children.Insert(targetIndex, child.ToNative(MauiContext, true));
+			NativeView.Children.Insert(targetIndex, child.ToNative(MauiContext));
 		}
 
 		public void Update(int index, IView child) 
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Handlers
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
-			NativeView.Children[index] = child.ToNative(MauiContext, true);
+			NativeView.Children[index] = child.ToNative(MauiContext);
 			EnsureZIndexOrder(child);
 		}
 
@@ -110,7 +110,7 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			var currentIndex = NativeView.Children.IndexOf(child.ToNative(MauiContext!, true));
+			var currentIndex = NativeView.Children.IndexOf(child.ToNative(MauiContext!));
 
 			if (currentIndex == -1)
 			{

--- a/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.iOS.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Handlers
 
 			foreach (var child in VirtualView.OrderByZIndex())
 			{
-				NativeView.AddSubview(child.ToNative(MauiContext, true));
+				NativeView.AddSubview(child.ToNative(MauiContext));
 			}
 		}
 
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			NativeView.InsertSubview(child.ToNative(MauiContext, true), targetIndex);
+			NativeView.InsertSubview(child.ToNative(MauiContext), targetIndex);
 		}
 
 		public void Remove(IView child)
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Handlers
 			_ = NativeView ?? throw new InvalidOperationException($"{nameof(NativeView)} should have been set by base class.");
 			_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			if (child?.GetNative(true) is NativeView childView)
+			if (child?.ToNative() is NativeView childView)
 			{
 				childView.RemoveFromSuperview();
 			}
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Handlers
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			NativeView.InsertSubview(child.ToNative(MauiContext, true), targetIndex);
+			NativeView.InsertSubview(child.ToNative(MauiContext), targetIndex);
 		}
 
 		public void Update(int index, IView child)
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Handlers
 			var existing = NativeView.Subviews[index];
 			existing.RemoveFromSuperview();
 			var targetIndex = VirtualView.GetLayoutHandlerIndex(child);
-			NativeView.InsertSubview(child.ToNative(MauiContext, true), targetIndex);
+			NativeView.InsertSubview(child.ToNative(MauiContext), targetIndex);
 			NativeView.SetNeedsLayout();
 		}
 
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			NativeView nativeChildView = child.ToNative(MauiContext!, true);
+			NativeView nativeChildView = child.ToNative(MauiContext!);
 			var currentIndex = NativeView.Subviews.IndexOf(nativeChildView);
 
 			if (currentIndex == -1)

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Handlers
 			if (appbarLayout == null)
 				appbarLayout = rootManager?.RootView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar);
 
-			var nativeToolBar = te.Toolbar?.ToNative(handler.MauiContext, true);
+			var nativeToolBar = te.Toolbar?.ToNative(handler.MauiContext);
 
 			if (appbarLayout == null || nativeToolBar == null)
 			{
@@ -175,7 +175,7 @@ namespace Microsoft.Maui.Handlers
 			var appbarLayout = nativeView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar) ??
 				rootManager?.RootView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar);
 
-			var nativeToolBar = te.Toolbar?.ToNative(handler.MauiContext, true);
+			var nativeToolBar = te.Toolbar?.ToNative(handler.MauiContext);
 
 			if (appbarLayout == null)
 			{

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.Handlers
 
 			if (toolbarElement.Toolbar != null)
 			{
-				var toolBar = toolbarElement.Toolbar.ToNative(handler.MauiContext, true);
+				var toolBar = toolbarElement.Toolbar.ToNative(handler.MauiContext);
 				handler.MauiContext.GetNavigationRootManager().SetToolbar(toolBar);
 			}
 		}

--- a/src/Core/src/Platform/Android/ContainerView.cs
+++ b/src/Core/src/Platform/Android/ContainerView.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Platform
 			{
 				_ = _context ?? throw new ArgumentNullException(nameof(_context));
 				_ = _view.ToNative(_context);
-				MainView = _view.GetNative(true);
+				MainView = _view.ToNative();
 			}
 		}
 

--- a/src/Core/src/Platform/Android/ContainerView.cs
+++ b/src/Core/src/Platform/Android/ContainerView.cs
@@ -69,8 +69,7 @@ namespace Microsoft.Maui.Platform
 			if (_view != null)
 			{
 				_ = _context ?? throw new ArgumentNullException(nameof(_context));
-				_ = _view.ToNative(_context);
-				MainView = _view.ToNative();
+				MainView = _view.ToNative(_context);
 			}
 		}
 

--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Maui.Platform
 
 			foreach (var item in items)
 			{
-				AView swipeItem = item.ToNative(MauiContext, true);
+				AView swipeItem = item.ToNative(MauiContext);
 
 				if (item is ISwipeItemView formsSwipeItemView)
 				{

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Maui.Platform
 
 		public static Task<byte[]?> RenderAsPNG(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 				return Task.FromResult<byte[]?>(null);
 
@@ -287,7 +287,7 @@ namespace Microsoft.Maui.Platform
 
 		public static Task<byte[]?> RenderAsJPEG(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 				return Task.FromResult<byte[]?>(null);
 
@@ -302,7 +302,7 @@ namespace Microsoft.Maui.Platform
 
 		internal static Rectangle GetNativeViewBounds(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView?.Context == null)
 			{
 				return new Rectangle();
@@ -327,7 +327,7 @@ namespace Microsoft.Maui.Platform
 
 		internal static Matrix4x4 GetViewTransform(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 				return new Matrix4x4();
 			return nativeView.GetViewTransform();
@@ -376,7 +376,7 @@ namespace Microsoft.Maui.Platform
 		}
 
 		internal static Graphics.Rectangle GetBoundingBox(this IView view)
-			=> view.GetNative(true).GetBoundingBox();
+			=> view.ToNative().GetBoundingBox();
 
 		internal static Graphics.Rectangle GetBoundingBox(this View? nativeView)
 		{

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -58,6 +58,9 @@ namespace Microsoft.Maui.Platform
 
 		internal static NativeView? ToNative(this IElement view)
 		{
+			if (view is IReplaceableView replaceableView && replaceableView.ReplacedView != view)
+				return replaceableView.ReplacedView.ToNative();
+
 			if (view.Handler == null)
 			{
 				var mauiContext = view.Parent?.Handler?.MauiContext ??
@@ -65,9 +68,6 @@ namespace Microsoft.Maui.Platform
 
 				return view.ToNative(mauiContext);
 			}
-
-			if (view is IReplaceableView replaceableView && replaceableView.ReplacedView != view)
-				return replaceableView.ReplacedView.ToNative();
 
 			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
 				return nativeHandler.NativeView;

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -56,23 +56,23 @@ namespace Microsoft.Maui.Platform
 			return handler;
 		}
 
-		internal static NativeView? GetNative(this IElement view, bool returnWrappedIfPresent)
+		internal static NativeView? ToNative(this IElement view)
 		{
+			if (view.Handler == null)
+			{
+				var mauiContext = view.Parent?.Handler?.MauiContext ??
+					throw new InvalidOperationException($"{nameof(MauiContext)} should have been set on parent.");
+
+				return view.ToNative(mauiContext);
+			}
+
+			if (view is IReplaceableView replaceableView && replaceableView.ReplacedView != view)
+				return replaceableView.ReplacedView.ToNative();
+
 			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
 				return nativeHandler.NativeView;
 
-			return view.Handler?.NativeView as NativeView;
-
-		}
-
-		internal static NativeView ToNative(this IElement view, IMauiContext context, bool returnWrappedIfPresent)
-		{
-			var nativeView = view.ToNative(context);
-
-			if (view.Handler is INativeViewHandler nativeHandler && nativeHandler.NativeView != null)
-				return nativeHandler.NativeView;
-
-			return nativeView;
+			return (view.Handler?.NativeView as NativeView);
 
 		}
 
@@ -84,7 +84,9 @@ namespace Microsoft.Maui.Platform
 			{
 				throw new InvalidOperationException($"Unable to convert {view} to {typeof(NativeView)}");
 			}
-			return result;
+
+			return view.ToNative() ?? throw new InvalidOperationException($"Unable to convert {view} to {typeof(NativeView)}");
+
 		}
 
 		static void SetHandler(this BasePlatformType nativeElement, IElement element, IMauiContext context)

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Platform
 		public virtual void Connect(IView view)
 		{
 			_ = view.ToNative(_mauiContext);
-			var nativeView = view.GetNative(true);
+			var nativeView = view.ToNative();
 
 			NavigationView rootNavigationView;
 			if (nativeView is NavigationView nv)

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -46,8 +46,7 @@ namespace Microsoft.Maui.Platform
 
 		public virtual void Connect(IView view)
 		{
-			_ = view.ToNative(_mauiContext);
-			var nativeView = view.ToNative();
+			var nativeView = view.ToNative(_mauiContext);
 
 			NavigationView rootNavigationView;
 			if (nativeView is NavigationView nv)

--- a/src/Core/src/Platform/Windows/RadioButtonExtensions.cs
+++ b/src/Core/src/Platform/Windows/RadioButtonExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui
 			_ = radioButton.Handler?.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			if (radioButton.Content is IView view)
-				nativeRadioButton.Content = view.ToNative(radioButton.Handler.MauiContext, true);
+				nativeRadioButton.Content = view.ToNative(radioButton.Handler.MauiContext);
 			else
 				nativeRadioButton.Content = $"{radioButton.Content}";
 		}

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Maui.Platform
 
 		public static async Task<byte[]?> RenderAsPNG(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 				return null;
 
@@ -232,7 +232,7 @@ namespace Microsoft.Maui.Platform
 
 		public static async Task<byte[]?> RenderAsJPEG(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 				return null;
 
@@ -245,7 +245,7 @@ namespace Microsoft.Maui.Platform
 
 		internal static Matrix4x4 GetViewTransform(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 				return new Matrix4x4();
 			return GetViewTransform(nativeView);
@@ -272,7 +272,7 @@ namespace Microsoft.Maui.Platform
 
 		internal static Rectangle GetNativeViewBounds(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView != null)
 				return nativeView.GetNativeViewBounds();
 			return new Rectangle();
@@ -292,7 +292,7 @@ namespace Microsoft.Maui.Platform
 		}
 
 		internal static Graphics.Rectangle GetBoundingBox(this IView view) 
-			=> view.GetNative(true).GetBoundingBox();
+			=> view.ToNative().GetBoundingBox();
 
 		internal static Graphics.Rectangle GetBoundingBox(this FrameworkElement? nativeView)
 		{

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Maui.Platform
 
 		static Task<byte[]?> RenderAsImage(this IView view, bool asPng)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 				return Task.FromResult<byte[]?>(null);
 			var skipChildren = !(view is IView && !(view is ILayout));
@@ -352,7 +352,7 @@ namespace Microsoft.Maui.Platform
 
 		internal static Rectangle GetNativeViewBounds(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 			{
 				return new Rectangle();
@@ -385,7 +385,7 @@ namespace Microsoft.Maui.Platform
 
 		internal static Matrix4x4 GetViewTransform(this IView view)
 		{
-			var nativeView = view?.GetNative(true);
+			var nativeView = view?.ToNative();
 			if (nativeView == null)
 				return new Matrix4x4();
 			return nativeView.Layer.GetViewTransform();
@@ -395,7 +395,7 @@ namespace Microsoft.Maui.Platform
 			=> view.Layer.GetViewTransform();
 
 		internal static Graphics.Rectangle GetBoundingBox(this IView view)
-			=> view.GetNative(true).GetBoundingBox();
+			=> view.ToNative().GetBoundingBox();
 
 		internal static Graphics.Rectangle GetBoundingBox(this UIView? nativeView)
 		{

--- a/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Android.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Android.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui
 
 		public void AddScrollableElementHandler(IScrollView scrollBar)
 		{
-			var nativeScroll = scrollBar.GetNative(true);
+			var nativeScroll = scrollBar.ToNative();
 			if (nativeScroll != null)
 			{
 				nativeScroll.ScrollChange += OnScrollChange;

--- a/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Windows.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Windows.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui
 			if (scrollBar == null)
 				return;
 
-			var nativeScroll = scrollBar.GetNative(true);
+			var nativeScroll = scrollBar.ToNative();
 
 			if (nativeScroll != null && nativeScroll is ScrollViewer viewer)
 			{

--- a/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.iOS.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.iOS.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui
 
 		public void AddScrollableElementHandler(IScrollView scrollBar)
 		{
-			var nativeScroll = scrollBar.GetNative(true);
+			var nativeScroll = scrollBar.ToNative();
 			if (nativeScroll != null)
 			{
 				var dispose = nativeScroll.AddObserver(ScrollViewContentOffsetKey, NSKeyValueObservingOptions.New, FrameAction);

--- a/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui
 			if (Window == null)
 				return false;
 
-			var nativeWindow = Window?.Content?.GetNative(true);
+			var nativeWindow = Window?.Content?.ToNative();
 			if (nativeWindow == null)
 				return false;
 

--- a/src/Core/src/WindowOverlay/WindowOverlay.Windows.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Windows.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui
 			if (Window?.Content == null)
 				return false;
 
-			_nativeElement = Window.Content.GetNative(true);
+			_nativeElement = Window.Content.ToNative();
 			if (_nativeElement == null)
 				return false;
 			var handler = Window.Handler as WindowHandler;

--- a/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui
 			if (IsNativeViewInitialized)
 				return true;
 
-			var nativeLayer = Window?.GetNative(true);
+			var nativeLayer = Window?.ToNative();
 			if (nativeLayer is not UIWindow nativeWindow)
 				return false;
 


### PR DESCRIPTION
### Description of Change ###

- Removed `GetNative` because `ToNative` does basically the same thing. `GetNative` is internal so no API's were changed
- Fixed `ToNative` so it checks for `IReplacedView` before processing the passed in view
