### PR TITLE
Skip some mappings when using formatted text

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.iOS.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Maui.Controls
 
 		public static void MapTextDecorations(LabelHandler handler, Label label)
 		{
+			if (label?.HasFormattedTextSpans ?? false)
+				return;
+
 			if (label?.TextType == TextType.Html)
 			{
 				return;
@@ -26,6 +29,9 @@ namespace Microsoft.Maui.Controls
 
 		public static void MapCharacterSpacing(LabelHandler handler, Label label)
 		{
+			if (label?.HasFormattedTextSpans ?? false)
+				return;
+
 			if (label?.TextType == TextType.Html)
 			{
 				return;
@@ -36,6 +42,9 @@ namespace Microsoft.Maui.Controls
 
 		public static void MapLineHeight(LabelHandler handler, Label label)
 		{
+			if (label?.HasFormattedTextSpans ?? false)
+				return;
+
 			if (label?.TextType == TextType.Html)
 			{
 				return;
@@ -46,6 +55,9 @@ namespace Microsoft.Maui.Controls
 
 		public static void MapFont(LabelHandler handler, Label label)
 		{
+			if (label?.HasFormattedTextSpans ?? false)
+				return;
+
 			if (label?.TextType == TextType.Html)
 			{
 				return;
@@ -56,6 +68,9 @@ namespace Microsoft.Maui.Controls
 
 		public static void MapTextColor(LabelHandler handler, Label label)
 		{
+			if (label?.HasFormattedTextSpans ?? false)
+				return;
+
 			if (label?.TextType == TextType.Html)
 			{
 				return;

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -350,6 +350,8 @@ namespace Microsoft.Maui.Controls
 			InvalidateMeasure();
 		}
 
+		internal bool HasFormattedTextSpans
+			=> (FormattedText?.Spans?.Count ?? 0) > 0;
 
 		public override IList<GestureElement> GetChildElements(Point point)
 		{


### PR DESCRIPTION
On iOS, we have more mappings registered and they fire _after_ the mapper that fires for FormattedText.  Since these other ones also set the AttributedString on the platform control, they override what was in FormattedText.

This changes it so they do not, and FormattedText always takes priority.

Fixes #4172 

<img width="810" alt="image" src="https://user-images.githubusercontent.com/271950/149846875-5c0351b2-7fd3-4bd2-84b5-966d9219e476.png">
