### PR TITLE
[Windows] Avoid crash using DisconnectHandler method with Layouts

### DIFF
--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(LayoutPanel nativeView)
 		{
 			// If we're being disconnected from the xplat element, then we should no longer be managing its children
-			Clear();
+			nativeView.Children.Clear();
 			base.DisconnectHandler(nativeView);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Avoid crash using DisconnectHandler method with Layouts on Windows. The changes are mostly clear the layout childrens using the NativeView passed as parameter. Before the changes, invoking the Layout DisconnectHandler method https://github.com/dotnet/maui/blob/dcc4cf0f1437f544dcf09f666b342f2e511b4504/src/Core/src/Handlers/Element/ElementHandler.cs#L125 was invoking the Clear method in the Latout thar try to access to the NativeView (LayoutPanel) that is already null and throw an exception.

Fix https://github.com/dotnet/maui/issues/3787

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No