### PR TITLE
[Windows] Fix crash using pan gesture with ScrollView

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
@@ -396,19 +396,24 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_isPinching = true;
 
-			global::Windows.Foundation.Point translationPoint = e.Container.TransformToVisual(Container).TransformPoint(e.Position);
-
-			var scaleOriginPoint = new Point(translationPoint.X / view.Width, translationPoint.Y / view.Height);
-			IEnumerable<PinchGestureRecognizer> pinchGestures = view.GestureRecognizers.GetGesturesFor<PinchGestureRecognizer>();
-			foreach (IPinchGestureController recognizer in pinchGestures)
+			if (e.OriginalSource is UIElement container)
 			{
-				if (!_wasPinchGestureStartedSent)
+				global::Windows.Foundation.Point translationPoint = container.TransformToVisual(Container).TransformPoint(e.Position);
+				var scaleOriginPoint = new Point(translationPoint.X / view.Width, translationPoint.Y / view.Height);
+				IEnumerable<PinchGestureRecognizer> pinchGestures = view.GestureRecognizers.GetGesturesFor<PinchGestureRecognizer>();
+				
+				foreach (IPinchGestureController recognizer in pinchGestures)
 				{
-					recognizer.SendPinchStarted(view, scaleOriginPoint);
+					if (!_wasPinchGestureStartedSent)
+					{
+						recognizer.SendPinchStarted(view, scaleOriginPoint);
+					}
+
+					recognizer.SendPinch(view, e.Delta.Scale, scaleOriginPoint);
 				}
-				recognizer.SendPinch(view, e.Delta.Scale, scaleOriginPoint);
+
+				_wasPinchGestureStartedSent = true;
 			}
-			_wasPinchGestureStartedSent = true;
 		}
 
 		void ModelGestureRecognizersOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)


### PR DESCRIPTION
### Description of Change ###

Fix crash using pan gesture with ScrollView. `ManipulationDeltaRoutedEventArgs.Container` could be null. Applied changes to use OriginalSource.

Fix https://github.com/dotnet/maui/issues/3786

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No