### PR TITLE
Fixes hang waiting for cancelled Essentials TextToSpeech on Android

### DIFF
--- a/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.android.cs
@@ -109,6 +109,8 @@ namespace Microsoft.Maui.Essentials
 			if (tcsUtterances?.Task != null)
 				await tcsUtterances.Task;
 
+			tcsUtterances = new TaskCompletionSource<bool>();
+
 			if (cancelToken != default)
 			{
 				cancelToken.Register(() =>
@@ -150,7 +152,6 @@ namespace Microsoft.Maui.Essentials
 			var parts = text.SplitSpeak(max);
 
 			numExpectedUtterances = parts.Count;
-			tcsUtterances = new TaskCompletionSource<bool>();
 
 			var guid = Guid.NewGuid().ToString();
 


### PR DESCRIPTION
### Description of Change ###

Porting over [this fix](https://github.com/xamarin/Essentials/pull/1895) in Xamarin.Essentials to .NET MAUI Essentials

### Additions made ###
N/A
