### PR TITLE
Added dependency to _CollectHotRestartBundleResources for hiding/unhi…

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -30,7 +30,7 @@
   </Target>
 
   <!-- Targets temporarily remove Content items in various folders so that they don't conflict with iOS/MacCatalyst SDK tasks -->
-  <Target Name="HideContentFromiOSBundleResources" BeforeTargets="_CollectBundleResources">
+  <Target Name="HideContentFromiOSBundleResources" BeforeTargets="_CollectBundleResources;_CollectHotRestartBundleResources">
     <ItemGroup>
       <!-- Find all files outside the wwwroot folder -->
       <_NonWWWRootContent Include="@(Content)" Exclude="wwwroot/**/*" />
@@ -45,7 +45,7 @@
   </Target>
 
   <!-- Restore hidden Content items for iOS/MacCatalyst -->
-  <Target Name="RestoreHiddeniOSContent" AfterTargets="_CollectBundleResources" BeforeTargets="ResolveCurrentProjectStaticWebAssetsInputs">
+  <Target Name="RestoreHiddeniOSContent" AfterTargets="_CollectBundleResources;_CollectHotRestartBundleResources" BeforeTargets="ResolveCurrentProjectStaticWebAssetsInputs">
     <ItemGroup>
       <!-- Restore the previously removed Content items -->
       <Content Include="@(_TemporaryHiddenContent)" />


### PR DESCRIPTION
…ding content items

Only having a dependency to _CollectBundleResources for the targets HideContentFromiOSBundleResources and RestoreHiddeniOSContent let Hot Restart outside the picture, causing MAUI Blazor builds to fail for local devices on VS in Windows

This should fix Bug #1447190 - [XVS][Maui] iOS Hot Restart with an error on Maui Blazor App: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1447190/



<!-- 

We are currently only accepting Pull Requests for .NET MAUI issues in our [Handler Property Backlog](https://github.com/dotnet/maui/projects/4). We will continue to update this repository over the next couple of months as we begin to accept more types of PRs.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
          - If the issue you're working on has a milestone, target the corresponding branch.
          - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
               See [Contributing](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md) for more tips!

```
 PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
```
 -->
### Description of Change ###

<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implements #

### Additions made ###
<!-- List all the additions made here, example:

- Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for WinUI, Android, and iOS
- Adds extension methods to apply Padding on WinUI/Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on WinUI, iOS, and Android

 -->

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
