### PR TITLE
Remove CarouselPage

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/ControlGalleryPages/FlowDirectionGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/ControlGalleryPages/FlowDirectionGallery.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 		}
 	}
 
-	public class FlowDirectionGalleryCarP : CarouselPage
+	internal class FlowDirectionGalleryCarP : CarouselPage
 	{
 		public FlowDirectionGalleryCarP(FlowDirection direction)
 		{

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/CarouselPageGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/CarouselPageGallery.cs
@@ -8,7 +8,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 {
 
-	public class CarouselPageGallery : CarouselPage
+	internal class CarouselPageGallery : CarouselPage
 	{
 		public CarouselPageGallery()
 		{

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/MacOSTestGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/MacOSTestGallery.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 			return mdp;
 		}
 
-		public static CarouselPage MacDemoCarouselPage()
+		internal static CarouselPage MacDemoCarouselPage()
 		{
 
 			var carouselPage = new CarouselPage { BackgroundColor = Colors.Yellow };

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29257.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla29257.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 			_menu.SelectedItem = null;
 		}
 
-		public class TestPage : CarouselPage
+		internal class TestPage : CarouselPage
 		{
 			public TestPage()
 			{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla30835.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla30835.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 		}
 
 		[Preserve(AllMembers = true)]
-		public class HolderCarouselPages : CarouselPage
+		internal class HolderCarouselPages : CarouselPage
 		{
 			public HolderCarouselPages()
 			{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38658.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38658.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 	[Issue(IssueTracker.Bugzilla, 38658, "Rotation causes app containing CarouselPage to freeze", PlatformAffected.iOS)]
 	public class Bugzilla38658 : TestTabbedPage // or TestFlyoutPage, etc ...
 	{
-		public class TestCarouselPage : CarouselPage
+		internal class TestCarouselPage : CarouselPage
 		{
 			public TestCarouselPage()
 			{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39458.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39458.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 39458, "[UWP/WinRT] Cannot Set CarouselPage.CurrentPage Inside Constructor", PlatformAffected.WinRT)]
-	public class Bugzilla39458 : TestCarouselPage
+	internal class Bugzilla39458 : TestCarouselPage
 	{
 		public class ChildPage : ContentPage
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39624.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla39624.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 39624, "CarouselPage.Children Appear Out of Order", PlatformAffected.WinRT)]
-	public class Bugzilla39624 : TestCarouselPage
+	internal class Bugzilla39624 : TestCarouselPage
 	{
 		protected override void Init()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/CarouselAsync.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/CarouselAsync.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 0, "Carousel Async Add Page Issue", PlatformAffected.All, NavigationBehavior.PushModalAsync)]
-	public class CarouselAsync : TestCarouselPage
+	internal class CarouselAsync : TestCarouselPage
 	{
 		protected override void Init()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/GitHub2598.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/GitHub2598.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2598, "Replacing page in CarouselPage does not work the first time", PlatformAffected.All)]
-	public class GitHub2598 : TestCarouselPage
+	internal class GitHub2598 : TestCarouselPage
 	{
 		private ContentPage CreatePage(string labelText, Color bg)
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1691.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1691.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1691, "CarouselPage iOS CurrentPage bug")]
-	public class Issue1691 : TestCarouselPage
+	internal class Issue1691 : TestCarouselPage
 	{
 		int _currentIndex;
 		int _page = 9;

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4187.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue4187.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 4187, "Picker list shows up, when focus is set on other controls", PlatformAffected.Android)]
-	public class Issue4187 : TestCarouselPage
+	internal class Issue4187 : TestCarouselPage
 	{
 		protected override void Init()
 		{

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
@@ -426,7 +426,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 		protected abstract void Init();
 	}
 
-	public abstract class TestCarouselPage : CarouselPage
+	internal abstract class TestCarouselPage : CarouselPage
 	{
 #if UITEST
 		public IApp RunningApp => AppSetup.RunningApp;

--- a/src/Compatibility/Core/src/Android/AppCompat/CarouselPageRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/CarouselPageRenderer.cs
@@ -10,7 +10,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 {
 
-	public class CarouselPageRenderer : VisualElementRenderer<CarouselPage>, ViewPager.IOnPageChangeListener, IManageFragments
+	internal class CarouselPageRenderer : VisualElementRenderer<CarouselPage>, ViewPager.IOnPageChangeListener, IManageFragments
 	{
 		bool _disposed;
 		FormsViewPager _viewPager;

--- a/src/Compatibility/Core/src/Windows/CarouselPageRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/CarouselPageRenderer.cs
@@ -10,7 +10,7 @@ using Microsoft.Maui.Controls.Platform;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
-	public class CarouselPageRenderer : FlipView, IVisualElementRenderer
+	internal class CarouselPageRenderer : FlipView, IVisualElementRenderer
 	{
 		bool _fromUpdate;
 		bool _disposed;

--- a/src/Compatibility/Core/src/iOS/Renderers/CarouselPageRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/CarouselPageRenderer.cs
@@ -13,7 +13,7 @@ using SizeF = CoreGraphics.CGSize;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {
-	public class CarouselPageRenderer : UIViewController, IVisualElementRenderer
+	internal class CarouselPageRenderer : UIViewController, IVisualElementRenderer
 	{
 		bool _appeared;
 		Dictionary<Page, UIView> _containerMap;

--- a/src/Controls/src/Core/CarouselPage.cs
+++ b/src/Controls/src/Core/CarouselPage.cs
@@ -3,7 +3,7 @@ using System;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Children))]
-	public class CarouselPage : MultiPage<ContentPage>, IElementConfiguration<CarouselPage>
+	internal class CarouselPage : MultiPage<ContentPage>, IElementConfiguration<CarouselPage>
 	{
 		readonly Lazy<PlatformConfigurationRegistry<CarouselPage>> _platformConfigurationRegistry;
 


### PR DESCRIPTION
### Description of Change ###

Set CarouselPage renderers and CarouselPage to internal. Now that we have `CarouselView` there is no longer a need for a `CarouselPage`
