### PR TITLE
Better BlazorWebView Custom IFileProvider design

### DIFF
--- a/src/BlazorWebView/samples/BlazorWinFormsApp/CustomFilesBlazorWebView.cs
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/CustomFilesBlazorWebView.cs
@@ -19,7 +19,8 @@ namespace BlazorWpfApp
 				},
 				// The contentRoot is ignored here because in WinForms it would include the absolute physical path to the app's content, which this provider doesn't care about
 				contentRoot: null);
-			return inMemoryFiles;
+
+			return new CompositeFileProvider(inMemoryFiles, base.CreateFileProvider(contentRootDir));
 		}
 	}
 }

--- a/src/BlazorWebView/samples/BlazorWpfApp/CustomFilesBlazorWebView.cs
+++ b/src/BlazorWebView/samples/BlazorWpfApp/CustomFilesBlazorWebView.cs
@@ -19,7 +19,8 @@ namespace BlazorWpfApp
 				},
 				// The contentRoot is ignored here because in WPF it would include the absolute physical path to the app's content, which this provider doesn't care about
 				contentRoot: null);
-			return inMemoryFiles;
+
+			return new CompositeFileProvider(inMemoryFiles, base.CreateFileProvider(contentRootDir));
 		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -92,11 +92,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			var contentRootDir = Path.GetDirectoryName(HostPage!) ?? string.Empty;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage!);
 
-			var customFileProvider = VirtualView.CreateFileProvider(contentRootDir);
-			var mauiAssetFileProvider = new AndroidMauiAssetFileProvider(Context.Assets, contentRootDir);
-			IFileProvider fileProvider = customFileProvider == null
-				? mauiAssetFileProvider
-				: new CompositeFileProvider(customFileProvider, mauiAssetFileProvider);
+			var fileProvider = VirtualView.CreateFileProvider(contentRootDir);
 
 			_webviewManager = new AndroidWebKitWebViewManager(this, NativeView, Services!, ComponentsDispatcher, fileProvider, VirtualView.JSComponents, hostPageRelativePath);
 
@@ -110,6 +106,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 
 			_webviewManager.Navigate("/");
+		}
+
+		internal IFileProvider CreateFileProvider(string contentRootDir)
+		{
+			return new AndroidMauiAssetFileProvider(Context.Assets, contentRootDir);
 		}
 
 		protected virtual WebViewClient GetWebViewClient() =>

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components.Web;
+﻿using System;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -19,9 +20,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		public RootComponentsCollection RootComponents { get; }
 
 		/// <inheritdoc/>
-		public virtual IFileProvider? CreateFileProvider(string contentRootDir)
+		public virtual IFileProvider CreateFileProvider(string contentRootDir)
 		{
-			return null;
+			// Call into the platform-specific code to get that platform's asset file provider
+			return ((BlazorWebViewHandler)(Handler!)).CreateFileProvider(contentRootDir);
 		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -11,11 +11,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		JSComponentConfigurationStore JSComponents { get; }
 
 		/// <summary>
-		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. Override
-		/// this method to return a custom <see cref="IFileProvider"/> to serve assets such as <c>wwwroot/index.html</c>.
+		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. The default implementation
+		/// serves files from a platform-specific location. Override this method to return a custom <see cref="IFileProvider"/> to serve assets such
+		/// as <c>wwwroot/index.html</c>. Call the base method and combine its return value with a <see cref="CompositeFileProvider"/>
+		/// to use both custom assets and default assets.
 		/// </summary>
 		/// <param name="contentRootDir">The base directory to use for all requested assets, such as <c>wwwroot</c>.</param>
-		/// <returns>Returns a <see cref="IFileProvider"/> for static assets, or <c>null</c> if there is no custom provider.</returns>
-		public IFileProvider? CreateFileProvider(string contentRootDir);
+		/// <returns>Returns a <see cref="IFileProvider"/> for static assets.</returns>
+		public IFileProvider CreateFileProvider(string contentRootDir);
 	}
 }

--- a/src/BlazorWebView/src/Maui/Standard/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/Standard/BlazorWebViewHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -6,5 +7,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	public partial class BlazorWebViewHandler : ViewHandler<IBlazorWebView, object>
 	{
 		protected override object CreateNativeView() => throw new NotImplementedException();
+
+		public virtual IFileProvider CreateFileProvider(string contentRootDir) => throw new NotImplementedException();
 	}
 }

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -56,12 +56,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			var contentRootDir = Path.GetDirectoryName(HostPage!) ?? string.Empty;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage!);
 
-			// On WinUI we override HandleWebResourceRequest in WinUIWebViewManager so that loading static assets is done entirely there in an async manner.
-			// This allows the code to be async because in WinUI all the file storage APIs are async-only, but IFileProvider is sync-only and we need to control
-			// the precedence of which files are loaded from where.
-			var customFileProvider = VirtualView.CreateFileProvider(contentRootDir) ?? new NullFileProvider();
+			var fileProvider = VirtualView.CreateFileProvider(contentRootDir);
 
-			_webviewManager = new WinUIWebViewManager(NativeView, Services!, ComponentsDispatcher, customFileProvider, VirtualView.JSComponents, hostPageRelativePath, contentRootDir);
+			_webviewManager = new WinUIWebViewManager(NativeView, Services!, ComponentsDispatcher, fileProvider, VirtualView.JSComponents, hostPageRelativePath, contentRootDir);
 
 			if (RootComponents != null)
 			{
@@ -72,6 +69,14 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				}
 			}
 			_webviewManager.Navigate("/");
+		}
+
+		internal IFileProvider CreateFileProvider(string contentRootDir)
+		{
+			// On WinUI we override HandleWebResourceRequest in WinUIWebViewManager so that loading static assets is done entirely there in an async manner.
+			// This allows the code to be async because in WinUI all the file storage APIs are async-only, but IFileProvider is sync-only and we need to control
+			// the precedence of which files are loaded from where.
+			return new NullFileProvider();
 		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -113,11 +113,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			var contentRootDir = Path.GetDirectoryName(HostPage!) ?? string.Empty;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDir, HostPage!);
 
-			var customFileProvider = VirtualView.CreateFileProvider(contentRootDir);
-			var mauiAssetFileProvider = new iOSMauiAssetFileProvider(contentRootDir);
-			IFileProvider fileProvider = customFileProvider == null
-				? mauiAssetFileProvider
-				: new CompositeFileProvider(customFileProvider, mauiAssetFileProvider);
+			var fileProvider = VirtualView.CreateFileProvider(contentRootDir);
 
 			_webviewManager = new IOSWebViewManager(this, NativeView, Services!, ComponentsDispatcher, fileProvider, VirtualView.JSComponents, hostPageRelativePath);
 
@@ -131,6 +127,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 
 			_webviewManager.Navigate("/");
+		}
+
+		internal IFileProvider CreateFileProvider(string contentRootDir)
+		{
+			return new iOSMauiAssetFileProvider(contentRootDir);
 		}
 
 		private sealed class WebViewScriptMessageHandler : NSObject, IWKScriptMessageHandler

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -152,11 +152,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath);
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDirFullPath, hostPageFullPath);
 
-			var customFileProvider = CreateFileProvider(contentRootDirFullPath);
-			var assetFileProvider = new PhysicalFileProvider(contentRootDirFullPath);
-			IFileProvider fileProvider = customFileProvider == null
-				? assetFileProvider
-				: new CompositeFileProvider(customFileProvider, assetFileProvider);
+			var fileProvider = CreateFileProvider(contentRootDirFullPath);
 
 			_webviewManager = new WebView2WebViewManager(_webview, Services, ComponentsDispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
 
@@ -193,14 +189,16 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		}
 
 		/// <summary>
-		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. Override
-		/// this method to return a custom <see cref="IFileProvider"/> to serve assets such as <c>wwwroot/index.html</c>.
+		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. The default implementation
+		/// serves files from disk. Override this method to return a custom <see cref="IFileProvider"/> to serve assets such
+		/// as <c>wwwroot/index.html</c>. Call the base method and combine its return value with a <see cref="CompositeFileProvider"/>
+		/// to use both custom assets and default assets.
 		/// </summary>
 		/// <param name="contentRootDir">The base directory to use for all requested assets, such as <c>wwwroot</c>.</param>
-		/// <returns>Returns a <see cref="IFileProvider"/> for static assets, or <c>null</c> if there is no custom provider.</returns>
+		/// <returns>Returns a <see cref="IFileProvider"/> for static assets.</returns>
 		public virtual IFileProvider CreateFileProvider(string contentRootDir)
 		{
-			return null;
+			return new PhysicalFileProvider(contentRootDir);
 		}
 
 		/// <inheritdoc />

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -169,11 +169,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath);
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDirFullPath, hostPageFullPath);
 
-			var customFileProvider = CreateFileProvider(contentRootDirFullPath);
-			var assetFileProvider = new PhysicalFileProvider(contentRootDirFullPath);
-			IFileProvider fileProvider = customFileProvider == null
-				? assetFileProvider
-				: new CompositeFileProvider(customFileProvider, assetFileProvider);
+			var fileProvider = CreateFileProvider(contentRootDirFullPath);
 
 			_webviewManager = new WebView2WebViewManager(_webview, Services, ComponentsDispatcher, fileProvider, RootComponents.JSComponents, hostPageRelativePath);
 			foreach (var rootComponent in RootComponents)
@@ -213,14 +209,16 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		}
 
 		/// <summary>
-		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. Override
-		/// this method to return a custom <see cref="IFileProvider"/> to serve assets such as <c>wwwroot/index.html</c>.
+		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. The default implementation
+		/// serves files from disk. Override this method to return a custom <see cref="IFileProvider"/> to serve assets such
+		/// as <c>wwwroot/index.html</c>. Call the base method and combine its return value with a <see cref="CompositeFileProvider"/>
+		/// to use both custom assets and default assets.
 		/// </summary>
 		/// <param name="contentRootDir">The base directory to use for all requested assets, such as <c>wwwroot</c>.</param>
-		/// <returns>Returns a <see cref="IFileProvider"/> for static assets, or <c>null</c> if there is no custom provider.</returns>
+		/// <returns>Returns a <see cref="IFileProvider"/> for static assets.</returns>
 		public virtual IFileProvider CreateFileProvider(string contentRootDir)
 		{
-			return null;
+			return new PhysicalFileProvider(contentRootDir);
 		}
 
 		private void CheckDisposed()


### PR DESCRIPTION
In the old design the BlazorWebView would have up to two IFileProviders for static assets:

1. The platform-specific provider that is normally used to load static assets
2. Optionally a user-provided `IFileProvider` returned by overriding the virtual `CreateFileProvider` method on the BlazorWebView class

And if (2) is provided, they are combined with a `CompositeFileProvider`.

In the new design, it's an all-in-one by having all the work done in the virtual method `CreateFileProvider`:

1. The platform-specific implementation is in the `BlazorWebView`'s implementation of `CreateFileProvider`
2. The user can override that method and choose whether to call `base.CreateFileProvider()` or not, and whether to combine the result with a `CompositeFileProvider` or not

This is a simpler design that allows greater flexibility, such as the user providing all custom assets and completely avoiding the platform-specific implementation.

@budcribar - would you mind having a look to see if this fits what you're expecting?

Fixes #4058 
