### PR TITLE
Fix SwipeView Handler on iOS

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/BasicSwipeGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/BasicSwipeGallery.xaml.cs
@@ -13,9 +13,9 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 		}
 
-		private void OnInvoked(object sender, EventArgs e)
+		async void OnInvoked(object sender, EventArgs e)
 		{
-			DisplayAlert("SwipeView", "Delete Invoked", "OK");
+			await DisplayAlert("SwipeView", "Delete Invoked", "OK");
 		}
 	}
 }

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -57,20 +57,20 @@ namespace Microsoft.Maui.Controls.Hosting
 			handlersCollection.AddHandler<ImageButton, ImageButtonHandler>();
 			handlersCollection.AddHandler<IndicatorView, IndicatorViewHandler>();
 			handlersCollection.AddHandler<RadioButton, RadioButtonHandler>();
+			handlersCollection.AddHandler<SwipeView, SwipeViewHandler>();
+			handlersCollection.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();
 #if __ANDROID__ || __IOS__
 			handlersCollection.AddHandler<RefreshView, RefreshViewHandler>();
+			handlersCollection.AddHandler<SwipeItemView, SwipeItemViewHandler>();
 			
 #endif
 #if WINDOWS || ANDROID
 			handlersCollection.AddHandler<NavigationPage, NavigationViewHandler>();
 			handlersCollection.AddHandler<Toolbar, ToolbarHandler>();
-			handlersCollection.AddHandler<SwipeView, SwipeViewHandler>();
-			handlersCollection.AddHandler<SwipeItem, SwipeItemMenuItemHandler>();
 			handlersCollection.AddHandler<FlyoutPage, FlyoutViewHandler>();
 #endif
 #if ANDROID
 			handlersCollection.AddHandler<TabbedPage, Controls.Handlers.TabbedPageHandler>();
-			handlersCollection.AddHandler<SwipeItemView, SwipeItemViewHandler>();
 #endif
 			return handlersCollection;
 		}

--- a/src/Core/src/Handlers/SwipeView/SwipeViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/SwipeView/SwipeViewHandler.iOS.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapIsEnabled(ISwipeViewHandler handler, ISwipeView swipeView)
 		{
-			handler.TypedNativeView.UpdateIsEnabled(swipeView);
+			handler.TypedNativeView.UpdateIsSwipeEnabled(swipeView);
 			ViewHandler.MapIsEnabled(handler, swipeView);
 		}
 		

--- a/src/Core/src/Platform/iOS/MauiSwipeView.cs
+++ b/src/Core/src/Platform/iOS/MauiSwipeView.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Maui.Platform
 
 		void UpdateSwipeItems()
 		{
-			if (_contentView == null || _actionView != null || Element?.Handler?.MauiContext == null)
+			if (_contentView == null || Element?.Handler?.MauiContext == null)
 				return;
 
 			ISwipeItems? items = Element.GetSwipeItemsByDirection(_swipeDirection);


### PR DESCRIPTION
### Description of Change ###

- Fix call to correct IsEnabled method on `MauiView`
- Fix SwipeView registration for iOS
- Fixed incorrect null check when creating action views

When testing the Swipe gallery you won't see any alerts displayed because DisplayAlert is currently broken on iOS
