### PR TITLE
[Android] Changes to reduce unnecessary layout requests

### DIFF
--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -105,10 +105,6 @@ namespace Microsoft.Maui.Controls
 		protected override void InvalidateMeasureOverride()
 		{
 			base.InvalidateMeasureOverride();
-			foreach (var child in Children)
-			{
-				child.InvalidateMeasure();
-			}
 		}
 
 		public void Add(IView child)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -32,14 +32,18 @@ namespace Microsoft.Maui.Handlers
 			nativeView.ScrollChange -= ScrollChange;
 		}
 
+		Size _previousDesiredSize;
+
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
 
-			if (FindInsetPanel(this) == null)
+			if (result != _previousDesiredSize && FindInsetPanel(this) == null)
 			{
 				VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
 			}
+			
+			_previousDesiredSize = result;
 
 			return result;
 		}

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -32,18 +32,14 @@ namespace Microsoft.Maui.Handlers
 			nativeView.ScrollChange -= ScrollChange;
 		}
 
-		Size _previousDesiredSize;
-
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
 
-			if (result != _previousDesiredSize && FindInsetPanel(this) == null)
+			if (FindInsetPanel(this) == null)
 			{
 				VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
 			}
-			
-			_previousDesiredSize = result;
 
 			return result;
 		}

--- a/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Maui
 
 			var Context = viewHandler.MauiContext?.Context;
 			var MauiContext = viewHandler.MauiContext;
-			var VirtualView = viewHandler.VirtualView;
 
 			if (nativeView == null || MauiContext == null || Context == null)
 			{

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void InvalidateMeasure(this AView nativeView, IView view)
 		{
-			nativeView.RequestLayout();
+			ViewHelper.RequestLayoutIfNeeded(nativeView);
 		}
 
 		public static void UpdateWidth(this AView nativeView, IView view)


### PR DESCRIPTION
### Description of Change ###

Changes to RequestLayout in Layouts only when needed.

Testing with:
[PerfTests.zip](https://github.com/dotnet/maui/files/7904745/PerfTests.zip)

Before:
![perf01](https://user-images.githubusercontent.com/6755973/150332072-f15f35f5-d0a6-4904-a0f0-132d9491e8a3.gif)

After:
![perf02](https://user-images.githubusercontent.com/6755973/150332082-8e95221d-09e2-48c0-a647-d865cdb77943.gif)

Notice that the onLayout and onMeasure time (green light color) has been greatly reduced.

_NOTE: the gifs have been optimized to have a small size, the quality is low._

@hartez Could we take a look to this together?

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No