### PR TITLE
[workload] add missing Microsoft.Maui.Controls.Build.Tasks.pdb

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -26,6 +26,7 @@
     <_Files Include="$(PkgMono_Cecil)\lib\netstandard2.0\Mono.Cecil.Rocks.pdb" />
     <_Files Include="$(PkgSystem_CodeDom)\lib\netstandard2.0\System.CodeDom.dll" />
     <_Files Include="$(MauiRootDirectory)src\Controls\src\Build.Tasks\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.Controls.Build.Tasks.dll" />
+    <_Files Include="$(MauiRootDirectory)src\Controls\src\Build.Tasks\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.Controls.Build.Tasks.pdb" />
     <_Files Include="$(MauiRootDirectory)src\Controls\src\Build.Tasks\bin\$(Configuration)\netstandard2.0\*\Microsoft.Maui.Controls.Build.Tasks.resources.dll" />
     <_Files Include="$(MauiRootDirectory)src\Controls\src\Core\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.dll" />
     <_Files Include="$(MauiRootDirectory)src\Controls\src\Core\bin\$(Configuration)\netstandard2.0\Microsoft.Maui.pdb" />


### PR DESCRIPTION
### Description of Change ###

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1464998/

SymbolCheck found that I missed a file in 1bc403e4.

Previously it was:

    <None Include="$(OutputPath)$(AssemblyName).dll" Visible="false" Pack="true" PackagePath="build" />
    <None Include="$(OutputPath)$(AssemblyName).pdb" Visible="false" Pack="true" PackagePath="build" />

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No