### PR TITLE
Shell page dependency injection now uses IServiceProvider.GetService()

### DIFF
--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Maui.Controls
 				{
 					if (services != null)
 					{
-						result = Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(services, type) as Element;
+						result = (services.GetService(type) ?? Activator.CreateInstance(type)) as Element;
 					}
 					else
 					{
@@ -250,7 +250,7 @@ namespace Microsoft.Maui.Controls
 			{
 				if (services != null)
 				{
-					return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(services, _type) as Element;
+					return (services.GetService(_type) ?? Activator.CreateInstance(_type)) as Element;
 				}
 				return Activator.CreateInstance(_type) as Element;
 			}

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Controls
 						var services = Parent?.FindMauiContext()?.Services;
 						if (services != null)
 						{
-							return Extensions.DependencyInjection.ActivatorUtilities.GetServiceOrCreateInstance(services, template.Type);
+							return services.GetService(template.Type) ?? Activator.CreateInstance(template.Type);
 						}
 						return Activator.CreateInstance(template.Type);
 					};

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -624,11 +624,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[TestCase(typeof(PageWithDependency), typeof(PageWithDependency))]
+		[TestCase(typeof(PageWithDependencyAndMultipleConstructors), typeof(PageWithDependencyAndMultipleConstructors))]
 		[TestCase(typeof(PageWithDependency), typeof(Dependency))]
 		public async Task GlobalRouteWithDependencyResolution(Type typeForRouteName, Type type)
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddTransient<Dependency>();
+			serviceCollection.AddTransient<PageWithDependency>();
+			serviceCollection.AddTransient<PageWithDependencyAndMultipleConstructors>();
 			IServiceProvider services = serviceCollection.BuildServiceProvider();
 			var fakeMauiContext = Substitute.For<IMauiContext>();
 			var fakeHandler = Substitute.For<IElementHandler>();
@@ -650,8 +653,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsNotNull(shell.Navigation.NavigationStack);
 			var page = shell.Navigation.NavigationStack[1];
 			Assert.That(page, Is.Not.Null);
-			Assert.IsInstanceOf<PageWithDependency>(page);
-			Assert.That((page as PageWithDependency).TestDependency, Is.Not.Null);
+			if (type == typeof(PageWithDependency) || type == typeof(Dependency))
+			{
+				Assert.IsInstanceOf<PageWithDependency>(page);
+				Assert.That((page as PageWithDependency).TestDependency, Is.Not.Null);
+			}
+			
+			if (type == typeof(PageWithDependencyAndMultipleConstructors))
+			{
+				Assert.IsInstanceOf<PageWithDependencyAndMultipleConstructors>(page);
+				var testPage = page as PageWithDependencyAndMultipleConstructors;
+				Assert.That(testPage.TestDependency, Is.Not.Null);
+				Assert.That(testPage.OtherTestDependency, Is.Null);
+			}
 		}
 
 		[Test]

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -626,6 +626,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[TestCase(typeof(PageWithDependency), typeof(PageWithDependency))]
 		[TestCase(typeof(PageWithDependencyAndMultipleConstructors), typeof(PageWithDependencyAndMultipleConstructors))]
 		[TestCase(typeof(PageWithDependency), typeof(Dependency))]
+		[TestCase(typeof(PageWithUnregisteredDependencyAndParameterlessConstructor), typeof(PageWithUnregisteredDependencyAndParameterlessConstructor))]
 		public async Task GlobalRouteWithDependencyResolution(Type typeForRouteName, Type type)
 		{
 			var serviceCollection = new ServiceCollection();
@@ -665,6 +666,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				var testPage = page as PageWithDependencyAndMultipleConstructors;
 				Assert.That(testPage.TestDependency, Is.Not.Null);
 				Assert.That(testPage.OtherTestDependency, Is.Null);
+			}
+
+			if (type == typeof(PageWithUnregisteredDependencyAndParameterlessConstructor))
+			{
+				Assert.IsInstanceOf<PageWithUnregisteredDependencyAndParameterlessConstructor>(page);
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
@@ -513,6 +513,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 		}
 
+		public class PageWithUnregisteredDependencyAndParameterlessConstructor : ContentPage
+        {
+			public PageWithUnregisteredDependencyAndParameterlessConstructor(UnregisteredDependency dependency)
+			{
+
+			}
+
+			public PageWithUnregisteredDependencyAndParameterlessConstructor()
+			{
+
+			}
+        }
+
 		public class Dependency
 		{
 			public int Test { get; set; }

--- a/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
@@ -492,7 +492,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			}
 		}
 
+		public class PageWithDependencyAndMultipleConstructors : ContentPage
+		{
+			public Dependency TestDependency { get; set; }
+			public UnregisteredDependency OtherTestDependency { get; set; }
+
+			public PageWithDependencyAndMultipleConstructors(Dependency dependency)
+			{
+				TestDependency = dependency;
+			}
+
+			public PageWithDependencyAndMultipleConstructors(Dependency dependency, UnregisteredDependency unregisteredDependency)
+			{
+				OtherTestDependency = unregisteredDependency;
+			}
+
+			public PageWithDependencyAndMultipleConstructors()
+			{
+				// parameterless constructor
+			}
+		}
+
 		public class Dependency
+		{
+			public int Test { get; set; }
+		}
+
+		public class UnregisteredDependency
 		{
 			public int Test { get; set; }
 		}


### PR DESCRIPTION
Implements #4280 

@PureWeen 

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
