### PR TITLE
[build] fix $(PackageVersion) when building locally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,7 +91,7 @@
     <PackageProjectUrl>https://github.com/dotnet/maui</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageVersion>6.0.100-dev</PackageVersion>
+    <PackageVersion>$(DotNetPreviewVersionBand)-dev</PackageVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts</PackageOutputPath>
   </PropertyGroup>
   <!-- This target is replaced by GitInfo when restored. Allows Versions.targets to rely on it before restore. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.fffae82cf6ec1c4a6f490ddb780709ce9211725e.179</_SkiaSharpNativeAssetsVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Trim all characters after first `-` or `+` is encountered. -->
-    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace($(MicrosoftDotnetSdkInternalPackageVersion), `[-+].*$`, ""))</DotNetPreviewVersionBand>
+    <!-- Match the first three version numbers and append 00 -->
+    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</DotNetPreviewVersionBand>
   </PropertyGroup>
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -53,7 +53,7 @@
   <Target Name="_GenerateBundledVersions"
       BeforeTargets="Build;AssignTargetPaths"
       DependsOnTargets="SetVersions"
-      Inputs="$(MSBuildProjectFile);;$(MauiRootDirectory)eng/Versions.props;Sdk/BundledVersions.in.targets"
+      Inputs="$(MSBuildProjectFile);$(MauiRootDirectory)eng/Versions.props;Sdk/BundledVersions.in.targets"
       Outputs="$(IntermediateOutputPath)BundledVersions.targets">
     <ReplaceText
         Input="Sdk/BundledVersions.in.targets"

--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -53,7 +53,7 @@
   <Target Name="_GenerateBundledVersions"
       BeforeTargets="Build;AssignTargetPaths"
       DependsOnTargets="SetVersions"
-      Inputs="$(MSBuildProjectFile);Sdk/BundledVersions.in.targets"
+      Inputs="$(MSBuildProjectFile);;$(MauiRootDirectory)eng/Versions.props;Sdk/BundledVersions.in.targets"
       Outputs="$(IntermediateOutputPath)BundledVersions.targets">
     <ReplaceText
         Input="Sdk/BundledVersions.in.targets"

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -24,7 +24,11 @@
     <_JsonInputFile Include="SdkInstaller.in.json" OutputPath="$(IntermediateOutputPath)SdkInstaller.json" Pack="false" />
   </ItemGroup>
 
-  <Target Name="_GenerateWorkloadManifest" BeforeTargets="Build;AssignTargetPaths" DependsOnTargets="SetVersions" Inputs="$(MSBuildProjectFile);@(_JsonInputFile)" Outputs="@(_JsonInputFile->'%(OutputPath)')">
+  <Target Name="_GenerateWorkloadManifest"
+      BeforeTargets="Build;AssignTargetPaths"
+      DependsOnTargets="SetVersions"
+      Inputs="$(MSBuildProjectFile);$(MauiRootDirectory)eng/Versions.props;@(_JsonInputFile)"
+      Outputs="@(_JsonInputFile->'%(OutputPath)')">
     <ItemGroup>
       <_VersionsToReplace Include="MicrosoftDotnetSdkInternalPackageVersion" />
       <_VersionsToReplace Include="MicrosoftNETCoreAppRefPackageVersion" />


### PR DESCRIPTION
### Description of Change ###

If you build MAUI locally, then try to use `./bin/dotnet/dotnet` you
hit the error:

    Microsoft.Maui.Controls.targets(48,3): error MAUI004: At least version '6.0.200' of the .NET MAUI workload is required to use <MauiVersion>6.0.100-dev</MauiVersion>.

In 1bc403e4, I bumped `$(_MinimumMauiWorkloadVersion)` to 6.0.200. But
the default `$(PackageVersion)` stayed `6.0.100-dev`!

I changed this value to be based on `$(DotNetPreviewVersionBand)`
instead of hardcoding 6.0.100.

I also found a couple of our targets using the `$(PackageVersion)`
needed an `Inputs` for `eng/Versions.props`. Otherwise, you have to
`git clean -dxf` and rebuild for the workload to be populated
correctly.

Lastly, brought over an improvement in calculating version bands:

https://github.com/xamarin/xamarin-android/commit/d91641a462ceba67fe7583db3d9c4c1a740451f7

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No

/cc @eerhardt 