### PR TITLE
Introduce IPlatformApplication

### DIFF
--- a/src/Core/src/Core/IPlatformApplication.cs
+++ b/src/Core/src/Core/IPlatformApplication.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Microsoft.Maui
+{
+	/// <summary>
+	/// IPlatformApplication.
+	/// Hosts the platform application.
+	/// </summary>
+	public interface IPlatformApplication
+	{
+		/// <summary>
+		/// Gets the current IPlatformApplication.
+		/// </summary>
+		public static IPlatformApplication? Current { get; }
+
+		/// <summary>
+		/// Gets the Service Provider.
+		/// <see cref="IServiceProvider"/>.
+		/// </summary>
+		public IServiceProvider Services { get; }
+
+		/// <summary>
+		/// Gets the Application.
+		/// <see cref="IApplication"/>.
+		/// </summary>
+		public IApplication Application { get; }
+	}
+}

--- a/src/Core/src/Core/IPlatformApplication.cs
+++ b/src/Core/src/Core/IPlatformApplication.cs
@@ -8,10 +8,15 @@ namespace Microsoft.Maui
 	/// </summary>
 	public interface IPlatformApplication
 	{
+
+#if !NETSTANDARD2_0
 		/// <summary>
 		/// Gets the current IPlatformApplication.
+		/// This must be set in each implementation manually, as we can't
+		/// have a true static be used in the implementation.
 		/// </summary>
-		public static IPlatformApplication? Current { get; }
+		public static IPlatformApplication? Current { get; set; }
+#endif
 
 		/// <summary>
 		/// Gets the Service Provider.

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -10,7 +10,7 @@ using Microsoft.Maui.LifecycleEvents;
 
 namespace Microsoft.Maui
 {
-	public abstract class MauiApplication : Application
+	public abstract class MauiApplication : Application, IPlatformApplication
 	{
 		protected MauiApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
 		{

--- a/src/Core/src/Platform/Android/MauiApplication.cs
+++ b/src/Core/src/Platform/Android/MauiApplication.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Maui
 		protected MauiApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
 		{
 			Current = this;
+			IPlatformApplication.Current = this;
 		}
 
 		protected abstract MauiApp CreateMauiApp();

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Maui;
-using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
-using Microsoft.Maui.Platform;
 
 namespace Microsoft.Maui
 {
-	public abstract class MauiWinUIApplication : UI.Xaml.Application
+	public abstract class MauiWinUIApplication : UI.Xaml.Application, IPlatformApplication
 	{
 		protected abstract MauiApp CreateMauiApp();
 
@@ -21,7 +18,7 @@ namespace Microsoft.Maui
 				Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunched>(del => del(this, args));
 				return;
 			}
-			
+
 			var mauiApp = CreateMauiApp();
 
 			var rootContext = new MauiContext(mauiApp.Services);

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui
 				return;
 			}
 
+			IPlatformApplication.Current = this;
 			var mauiApp = CreateMauiApp();
 
 			var rootContext = new MauiContext(mauiApp.Services);

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui
 		protected MauiUIApplicationDelegate()
 		{
 			Current = this;
+			IPlatformApplication.Current = this;
 		}
 
 		protected abstract MauiApp CreateMauiApp();

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -3,13 +3,12 @@ using Foundation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
-using Microsoft.Maui.Platform;
 using ObjCRuntime;
 using UIKit;
 
 namespace Microsoft.Maui
 {
-	public abstract class MauiUIApplicationDelegate : UIApplicationDelegate, IUIApplicationDelegate
+	public abstract class MauiUIApplicationDelegate : UIApplicationDelegate, IUIApplicationDelegate, IPlatformApplication
 	{
 		internal const string MauiSceneConfigurationKey = "__MAUI_DEFAULT_SCENE_CONFIGURATION__";
 		internal const string GetConfigurationSelectorName = "application:configurationForConnectingSceneSession:options:";

--- a/src/Core/tests/DeviceTests/ApplicationTests.Android.cs
+++ b/src/Core/tests/DeviceTests/ApplicationTests.Android.cs
@@ -1,0 +1,17 @@
+﻿using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Application)]
+	public class ApplicationTests
+	{
+		[Fact(DisplayName = "Verify Application.Current exists on IPlatformApplication")]
+		public void PlatformApplicationCurrentExists()
+		{
+			var platform = Microsoft.Maui.IPlatformApplication.Current;
+			Assert.NotNull(platform);
+			Assert.NotNull(platform.Services);
+			Assert.NotNull(platform.Application);
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -4,6 +4,7 @@
 	{
 		public const string MauiContext = "MauiContext";
 
+		public const string Application = "Application";
 		public const string ActivityIndicator = "ActivityIndicator";
 		public const string Border = "Border";
 		public const string BoxView = "BoxView";


### PR DESCRIPTION
`IPlatformApplication` is a Core interface for the platform level `Application`'s, on the apps that are created to host an MAUI app. 

Currently, XAML Hot Reload uses `Maui.Controls.Application.Current` to get the current Application, which we then use to traverse down the tree for the rest of the app. While that works for MAUI itself, it won't work for anyone who builds on `Core`. By having an interface for the platform specific applications that are built in Core, we can access the static "Current" instance of that, and then get the `IApplication` from that instance.