### PR TITLE
Modify existing rectangle rather than creating a new one

### DIFF
--- a/src/Core/src/Layouts/AbsoluteLayoutManager.cs
+++ b/src/Core/src/Layouts/AbsoluteLayoutManager.cs
@@ -93,7 +93,10 @@ namespace Microsoft.Maui.Layouts
 					destination.Y = (availableHeight - destination.Height) * destination.Y;
 				}
 
-				child.Arrange(destination.Offset(left, top));
+				destination.X += left;
+				destination.Y += top;
+
+				child.Arrange(destination);
 			}
 
 			return new Size(availableWidth, availableHeight);


### PR DESCRIPTION
Very, very minor performance improvement. 
We already have a destination Rectangle to use for arranging the AbsoluteLayout child; just modify and use it rather than creating a new Rectangle via .Offset().