### PR TITLE
Add xplat OpenMauiAsset extension method

### DIFF
--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample-net6.csproj
@@ -48,7 +48,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Embedded\*" />
-    <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+    <MauiAsset Include="MauiResources\**" />
     <MauiImage Include="Resources\Images\*" />
     <MauiImage Update="Resources\Images\*.gif" Resize="false" />
     <MauiIcon Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" />

--- a/src/Controls/samples/Controls.Sample/MauiResources/Special/index.html
+++ b/src/Controls/samples/Controls.Sample/MauiResources/Special/index.html
@@ -1,0 +1,5 @@
+<html>
+ <body>
+   <h1>Hello, this is special embedded web content!</h1>
+ </body>
+</html>

--- a/src/Controls/samples/Controls.Sample/MauiResources/index.html
+++ b/src/Controls/samples/Controls.Sample/MauiResources/index.html
@@ -1,0 +1,5 @@
+<html>
+ <body>
+   <h1>Hello, this is embedded web content!</h1>
+ </body>
+</html>

--- a/src/Controls/samples/Controls.Sample/Resources/Raw/Special/index.html
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/Special/index.html
@@ -1,5 +1,0 @@
-<html>
- <body>
-   <h1>Hello, this is special embedded web content!<h1>
- </body>
-</html>

--- a/src/Controls/samples/Controls.Sample/Resources/Raw/index.html
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/index.html
@@ -1,5 +1,0 @@
-<html>
- <body>
-   <h1>Hello, this is embedded web content!<h1>
- </body>
-</html>

--- a/src/Core/src/MauiAssetsExtensions.Android.cs
+++ b/src/Core/src/MauiAssetsExtensions.Android.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui
+{
+	public static partial class MauiAssetsExtensions
+	{
+		public static Task<Stream?> OpenMauiAsset(this IMauiContext mauiContext!!, string assetPath!!)
+		{
+			if (mauiContext.Context?.Assets == null)
+			{
+				throw new ArgumentException($"The specified {nameof(IMauiContext)} must have its {nameof(IMauiContext.Context)} property set to a valid Android.Content.Context, which then has a valid Android.Content.Res.AssetManager.", nameof(mauiContext));
+			}
+			assetPath = assetPath.Replace('\\', '/');
+
+			try
+			{
+				return Task.FromResult<Stream?>(mauiContext.Context.Assets.Open(assetPath));
+			}
+			catch
+			{
+				return Task.FromResult<Stream?>(null);
+			}
+		}
+	}
+}

--- a/src/Core/src/MauiAssetsExtensions.Standard.cs
+++ b/src/Core/src/MauiAssetsExtensions.Standard.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui
+{
+	public static partial class MauiAssetsExtensions
+	{
+		public static Task<Stream?> OpenMauiAsset(this IMauiContext mauiContext!!, string assetPath!!) => throw new NotImplementedException();
+	}
+}

--- a/src/Core/src/MauiAssetsExtensions.Windows.cs
+++ b/src/Core/src/MauiAssetsExtensions.Windows.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.ApplicationModel;
+
+namespace Microsoft.Maui
+{
+	public static partial class MauiAssetsExtensions
+	{
+		public static async Task<Stream?> OpenMauiAsset(this IMauiContext mauiContext!!, string assetPath!!)
+		{
+			var winUIAssetPath = Path.Combine("Assets", assetPath.Replace('/', '\\'));
+
+			var winUIItem = await Package.Current.InstalledLocation.TryGetItemAsync(winUIAssetPath);
+			if (winUIItem == null)
+			{
+				return null;
+			}
+
+			var winUIFile = await Package.Current.InstalledLocation.GetFileAsync(winUIAssetPath);
+
+			return await winUIFile.OpenStreamForReadAsync();
+		}
+	}
+}

--- a/src/Core/src/MauiAssetsExtensions.iOS.cs
+++ b/src/Core/src/MauiAssetsExtensions.iOS.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui
+{
+	public static partial class MauiAssetsExtensions
+	{
+		public static Task<Stream?> OpenMauiAsset(this IMauiContext mauiContext!!, string assetPath!!) => throw new NotImplementedException();
+	}
+}

--- a/src/Core/src/MauiAssetsExtensions.iOS.cs
+++ b/src/Core/src/MauiAssetsExtensions.iOS.cs
@@ -3,11 +3,24 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Foundation;
 
 namespace Microsoft.Maui
 {
 	public static partial class MauiAssetsExtensions
 	{
-		public static Task<Stream?> OpenMauiAsset(this IMauiContext mauiContext!!, string assetPath!!) => throw new NotImplementedException();
+		public static Task<Stream?> OpenMauiAsset(this IMauiContext mauiContext!!, string assetPath!!)
+		{
+			var iOSResourcePath = Path.Combine(NSBundle.MainBundle.ResourcePath, assetPath.Replace('\\', '/'));
+
+			try
+			{
+				return Task.FromResult<Stream?>(File.OpenRead(iOSResourcePath));
+			}
+			catch
+			{
+				return Task.FromResult<Stream?>(null);
+			}
+		}
 	}
 }


### PR DESCRIPTION
This makes reading MauiAssets a lot easier across platforms.

Example:

```c#
using var stream = await Application.Current.Handler.MauiContext.OpenMauiAsset("Resources/Path/To/File.txt");
```

Fixes #3270

@mattleibow - any thoughts on this? Still a work-in-progress, but at least an initial read.