### PR TITLE
WinUI TabbedPage Tests/Cleanup/BarBackground

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGallery.xaml
@@ -4,12 +4,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.TabbedPageGallery"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
-    Title="Tabbed Page">
+    Title="Tabbed Page"
+    BarBackground="Purple">
     <ContentPage Title="Tab 1">
         <VerticalStackLayout>
             <Button Text="Set Tabbed Page as Root" Clicked="OnTabbedPageAsRoot"></Button>
             <Button Text="Toggle Bottom Tabs (Android)" Clicked="OnSetToBottomTabs"></Button>
             <Button Text="Change Tab Index" Clicked="OnChangeTabIndex"></Button>
+            <Button Text="Toggle TabBar Background Color" Clicked="OnToggleTabBar"></Button>
         </VerticalStackLayout>
     </ContentPage>
 </TabbedPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGallery.xaml.cs
@@ -52,5 +52,13 @@ namespace Maui.Controls.Sample.Pages
 		{
 			CurrentPage = Children[1];
 		}
+
+		void OnToggleTabBar(object sender, EventArgs e)
+		{
+			if(this.BarBackground == SolidColorBrush.Purple)
+				this.BarBackground = null;
+			else
+				this.BarBackground = SolidColorBrush.Purple;
+		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/TabbedPageGallery.xaml.cs
@@ -55,8 +55,8 @@ namespace Maui.Controls.Sample.Pages
 
 		void OnToggleTabBar(object sender, EventArgs e)
 		{
-			if(this.BarBackground == SolidColorBrush.Purple)
-				this.BarBackground = null;
+			if ((this.BarBackground as SolidColorBrush)?.Color == SolidColorBrush.Purple.Color)
+				this.BarBackground = SolidColorBrush.Black;
 			else
 				this.BarBackground = SolidColorBrush.Purple;
 		}

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Windows.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Maui.Controls
 				panel.Children.Clear();
 				panel.Children.Add(nativeContent);
 
+				if (view.VisualDiagnosticsOverlay != null)
+					view.VisualDiagnosticsOverlay.Initialize();
+
 			}
 
 		}

--- a/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
@@ -64,9 +64,17 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		private protected override void OnDisconnectHandler(FrameworkElement nativeView)
 		{
-			((WFrame)NativeView).Navigated -= OnNavigated;
+			((WFrame)nativeView).Navigated -= OnNavigated;
 			VirtualView.Appearing -= OnTabbedPageAppearing;
 			VirtualView.Disappearing -= OnTabbedPageDisappearing;
+			if (_navigationView != null)
+				_navigationView.SelectionChanged -= OnSelectedMenuItemChanged;
+
+			_navigationView = null;
+			_navigationRootManager = null;
+			_previousView = null;
+			_navigationFrame = null;
+
 			base.OnDisconnectHandler(nativeView);
 		}
 
@@ -107,15 +115,17 @@ namespace Microsoft.Maui.Controls.Handlers
 			_navigationRootManager = MauiContext?.GetNavigationRootManager();
 
 			if (_navigationView == null)
+			{
 				_navigationView = (_navigationRootManager?.RootView as NavigationRootView)?.NavigationViewControl;
 
-			if (_navigationView != null)
-			{
-				_navigationView.PaneDisplayMode = NavigationViewPaneDisplayMode.Top;
-				_navigationView.MenuItemsSource = VirtualView.Children;
-				_navigationView.MenuItemTemplate = (UI.Xaml.DataTemplate)WApp.Current.Resources["TabBarNavigationViewMenuItem"];
-				_navigationView.SelectionChanged += OnSelectedMenuItemChanged;
-				_navigationView.SelectedItem = VirtualView.CurrentPage;
+				if (_navigationView != null)
+				{
+					_navigationView.PaneDisplayMode = NavigationViewPaneDisplayMode.Top;
+					_navigationView.MenuItemsSource = VirtualView.Children;
+					_navigationView.MenuItemTemplate = (UI.Xaml.DataTemplate)WApp.Current.Resources["TabBarNavigationViewMenuItem"];
+					_navigationView.SelectionChanged += OnSelectedMenuItemChanged;
+					_navigationView.SelectedItem = VirtualView.CurrentPage;
+				}
 			}
 		}
 

--- a/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
@@ -37,8 +37,6 @@ namespace Microsoft.Maui.Controls.Handlers
 					IsPaneToggleButtonVisible = false
 				};
 
-				_navigationView.OnApplyTemplateFinished += OnApplyTemplateFinished;
-
 				// Unset styles set by parent NavigationView
 				_navigationView.UpdateResourceToApplicationDefault("NavigationViewContentMargin", null);
 				_navigationView.UpdateResourceToApplicationDefault("NavigationViewMinimalHeaderMargin", null);
@@ -62,6 +60,10 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_navigationView == null)
 			{
 				SetupNavigationLocals();
+			}
+			else
+			{
+				SetupNavigationView();
 			}
 
 			if(_navigationView == null && _navigationRootManager?.RootView is WindowRootView wrv)
@@ -157,7 +159,11 @@ namespace Microsoft.Maui.Controls.Handlers
 			UpdateValue(nameof(TabbedPage.ItemsSource));
 
 			_navigationView.SelectionChanged += OnSelectedMenuItemChanged;
-			_navigationView.SelectedItem = VirtualView.CurrentPage;
+
+			if (_navigationView.SelectedItem != VirtualView.CurrentPage)
+				_navigationView.SelectedItem = VirtualView.CurrentPage;
+			else
+				NavigateToPage(VirtualView.CurrentPage);
 		}
 
 		void OnSelectedMenuItemChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)

--- a/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Maui.Controls.Handlers
 				};
 
 				// Unset styles set by parent NavigationView
-				_navigationView.Resources["NavigationViewContentMargin"] = new WThickness(0, 0, 0, 0);
-				_navigationView.Resources["NavigationViewMinimalHeaderMargin"] = new WThickness(-24, 44, 0, 0);
-				_navigationView.Resources["NavigationViewHeaderMargin"] = new WThickness(56, 44, 0, 0);
-				_navigationView.Resources["NavigationViewMinimalContentGridBorderThickness"] = new WThickness(0, 1, 0, 0);
+				_navigationView.UpdateThemeDictionaries("NavigationViewContentMargin", null);
+				_navigationView.UpdateThemeDictionaries("NavigationViewMinimalHeaderMargin", null);
+				_navigationView.UpdateThemeDictionaries("NavigationViewHeaderMargin", null);
+				_navigationView.UpdateThemeDictionaries("NavigationViewMinimalContentGridBorderThickness", null);
 
 				return _navigationView;
 			}
@@ -189,10 +189,12 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapBarBackground(TabbedPageHandler handler, TabbedPage view)
 		{
+			handler._navigationView?.UpdateTopNavAreaBackground(view.BarBackground ?? view.BarBackgroundColor?.AsPaint());
 		}
 
 		public static void MapBarBackgroundColor(TabbedPageHandler handler, TabbedPage view)
 		{
+			MapBarBackground(handler, view);
 		}
 
 		public static void MapBarTextColor(TabbedPageHandler handler, TabbedPage view)

--- a/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Maui.Controls.Handlers
 				_navigationView.UpdateResourceToApplicationDefault("NavigationViewHeaderMargin", null);
 				_navigationView.UpdateResourceToApplicationDefault("NavigationViewMinimalContentGridBorderThickness", null);
 
-				SetupNavigationView();
 				return _navigationView;
 			}
 
@@ -61,6 +60,22 @@ namespace Microsoft.Maui.Controls.Handlers
 			// If CreateNativeView didn't set the NavigationView then that means we are using the
 			// WindowRootView for our tabs
 			if (_navigationView == null)
+			{
+				SetupNavigationLocals();
+			}
+
+			if(_navigationView == null && _navigationRootManager?.RootView is WindowRootView wrv)
+			{
+				wrv.ContentChanged += OnContentChanged;
+
+				void OnContentChanged(object? sender, EventArgs e)
+				{
+					wrv.ContentChanged -= OnContentChanged;
+					SetupNavigationLocals();
+				}
+			}
+
+			void SetupNavigationLocals()
 			{
 				_navigationRootManager = MauiContext?.GetNavigationRootManager();
 				_navigationView = (_navigationRootManager?.RootView as WindowRootView)?.NavigationViewControl;

--- a/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
@@ -116,8 +116,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		void OnApplyTemplateFinished(object? sender, EventArgs e)
 		{
-			UpdateValue(nameof(TabbedPage.BarBackground));
-			UpdateValue(nameof(TabbedPage.ItemsSource));
+			UpdateValuesWaitingForNavigationView();
 		}
 
 		void SetupNavigationView()
@@ -127,8 +126,22 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			_navigationView.PaneDisplayMode = NavigationViewPaneDisplayMode.Top;
 			_navigationView.MenuItemTemplate = (UI.Xaml.DataTemplate)WApp.Current.Resources["TabBarNavigationViewMenuItem"];
+
+			if (_navigationView.TopNavArea != null)
+				UpdateValuesWaitingForNavigationView();
+			else
+				_navigationView.OnApplyTemplateFinished += OnApplyTemplateFinished;
+		}
+
+		void UpdateValuesWaitingForNavigationView()
+		{
+			if (_navigationView == null)
+				return;
+
+			UpdateValue(nameof(TabbedPage.BarBackground));
+			UpdateValue(nameof(TabbedPage.ItemsSource));
+
 			_navigationView.SelectionChanged += OnSelectedMenuItemChanged;
-			_navigationView.OnApplyTemplateFinished += OnApplyTemplateFinished;
 			_navigationView.SelectedItem = VirtualView.CurrentPage;
 		}
 

--- a/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_navigationView != null)
 				_navigationView.OnApplyTemplateFinished -= OnApplyTemplateFinished;
 
-			((WFrame)NativeView).Navigated -= OnNavigated;
+			((WFrame)nativeView).Navigated -= OnNavigated;
 			VirtualView.Appearing -= OnTabbedPageAppearing;
 			VirtualView.Disappearing -= OnTabbedPageDisappearing;
 			if (_navigationView != null)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.Platform
 					previousPage
 						.FindMauiContext()
 						?.GetNavigationRootManager()
-						?.Disconnect(previousPage);
+						?.Disconnect();
 
 					previousPage.Handler = null;
 					// Un-parent the page; otherwise the Resources Changed Listeners won't be unhooked and the 

--- a/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		public static IEnumerable<Run> ToRuns(this FormattedString formattedString, double defaultLineHeight = 0d, TextAlignment defaultHorizontalAlignment = TextAlignment.Start, Font? defaultFont = null, Color? defaultColor = null, TextTransform defaultTextTransform = TextTransform.Default)
+		public static IEnumerable<Run> ToRuns(this FormattedString formattedString, double defaultLineHeight = 0d, TextAlignment defaultHorizontalAlignment = TextAlignment.Start, Font? defaultFont = null, Color? defaultColor = null, TextTransform defaultTextTransform = TextTransform.Default, IFontManager? fontManager = null)
 		{
 			var runs = new List<Run>();
 
 			if (formattedString != null && formattedString.Spans != null)
 			{
-				var fontManager = formattedString.RequireFontManager();
+				fontManager = fontManager ?? formattedString.RequireFontManager();
 
 				for (var i = 0; i < formattedString.Spans.Count; i++)
 				{

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Windows.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using WPanel = Microsoft.UI.Xaml.Controls.Panel;
+using WFrameworkElement = Microsoft.UI.Xaml.FrameworkElement;
+using WWindow = Microsoft.UI.Xaml.Window;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.FlyoutPage)]
+	public partial class FlyoutPageTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+					handlers.AddHandler(typeof(Controls.Window), typeof(WindowHandler));
+					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler<Page, PageHandler>();
+				});
+			});
+		}
+
+		[Fact(DisplayName = "FlyoutPage Initializes with PaneFooter Set")]
+		public async Task TabbedPageHandlerDisconnects()
+		{
+			SetupBuilder();
+			var flyoutPage = CreateBasicFlyoutPage();
+
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, (handler) =>
+			{
+				Assert.NotNull(handler.NativeView.PaneFooter);
+				return Task.CompletedTask;
+			});
+		}
+
+		FlyoutPage CreateBasicFlyoutPage()
+		{
+			return new FlyoutPage()
+			{
+				Detail = new NavigationPage(new ContentPage() { Title = "Detail" }) { Title = "NavigationPage Detail" },
+				Flyout = new ContentPage() { Title = "Flyout" }
+			};
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Windows.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
+					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
 					handlers.AddHandler(typeof(Controls.Window), typeof(WindowHandler));
 					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
@@ -35,15 +36,18 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "FlyoutPage Initializes with PaneFooter Set")]
-		public async Task TabbedPageHandlerDisconnects()
+		public async Task FlyoutPageInitializesWithPaneFooterSet()
 		{
 			SetupBuilder();
 			var flyoutPage = CreateBasicFlyoutPage();
 
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, (handler) =>
+			await InvokeOnMainThreadAsync(async () =>
 			{
-				Assert.NotNull(handler.NativeView.PaneFooter);
-				return Task.CompletedTask;
+				await CreateHandlerAndAddToWindow<WindowHandler>(new Window(flyoutPage), (handler) =>
+				{
+					Assert.NotNull(((FlyoutViewHandler)flyoutPage.Handler).NativeView.PaneFooter);
+					return Task.CompletedTask;
+				});
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/FormattedStringTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FormattedStringTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				result = spannable.ToString();
 #elif WINDOWS
-				var runs = formattedString.ToRuns();
+				var runs = formattedString.ToRuns(fontManager: fontManager);
 
 				foreach (var r in runs)
 					result += r.Text;

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using WPanel = Microsoft.UI.Xaml.Controls.Panel;
+using WFrameworkElement = Microsoft.UI.Xaml.FrameworkElement;
+using WWindow = Microsoft.UI.Xaml.Window;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Handlers;
+using WAppBarButton = Microsoft.UI.Xaml.Controls.AppBarButton;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.NavigationPage)]
+	public partial class NavigationPageTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Controls.Window), typeof(WindowHandler));
+					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler<Page, PageHandler>();
+				});
+			});
+		}
+
+		[Fact(DisplayName = "Back Button Visibility Changes with push/pop")]
+		public async Task TabbedPageHandlerDisconnects()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandler>(new Window(navPage), async (handler) =>
+			{
+				var navView = GetMauiNavigationView(handler.MauiContext);
+				Assert.Equal(UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed, navView.IsBackButtonVisible);
+				await navPage.PushAsync(new ContentPage());
+				Assert.Equal(UI.Xaml.Controls.NavigationViewBackButtonVisible.Visible, navView.IsBackButtonVisible);
+				await navPage.PopAsync();
+				Assert.Equal(UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed, navView.IsBackButtonVisible);
+			});
+		}
+
+		[Fact(DisplayName = "Toolbar Items Map Correctly")]
+		public async Task ToolbarItemsMapCorrectly()
+		{
+			SetupBuilder();
+			var toolbarItem = new ToolbarItem() { Text = "Toolbar Item 1" };
+			var navPage = new NavigationPage(new ContentPage()
+			{
+				ToolbarItems =
+				{
+					toolbarItem
+				}
+			});
+
+			await CreateHandlerAndAddToWindow<WindowHandler>(new Window(navPage), (handler) =>
+			{
+				var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
+				WindowHeader windowHeader = (WindowHeader)navView.HeaderControl;
+				var primaryCommand = ((WAppBarButton)windowHeader.CommandBar.PrimaryCommands[0]);
+
+				Assert.Equal(toolbarItem, primaryCommand.DataContext);
+				return Task.CompletedTask;
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.TabbedPage)]
 	public partial class TabbedPageTests : HandlerTestBase
 	{
-		void SetupTabbedPageHandler()
+		void SetupBuilder()
 		{
 			EnsureHandlerCreated(builder =>
 			{
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Swapping Root Window Content for New Tabbed Page")]
 		public async Task SwapWindowContentForNewTabbedPage()
 		{
-			SetupTabbedPageHandler();
+			SetupBuilder();
 			var window = new Window()
 			{
 				Page = CreateBasicTabbedPage()

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -12,8 +12,10 @@ using Xunit;
 using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 using WFrameworkElement = Microsoft.UI.Xaml.FrameworkElement;
 using WWindow = Microsoft.UI.Xaml.Window;
+using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -42,6 +44,22 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				// Validate that no exceptions are thrown
 				((IElementHandler)handler).DisconnectHandler();
+				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "BarBackground Color")]
+		public async Task BarBackgroundColor()
+		{
+			SetupBuilder();
+			var tabbedPage = CreateBasicTabbedPage();
+			tabbedPage.BarBackground = SolidColorBrush.Purple;
+
+			await CreateHandlerAndAddToWindow<WindowHandler>(new Window(tabbedPage), (handler) =>
+			{
+				var navView = GetMauiNavigationView(tabbedPage.Handler.MauiContext);
+				var platformBrush = (WSolidColorBrush)((Paint)tabbedPage.BarBackground).ToNative();
+				Assert.Equal(platformBrush.Color, ((WSolidColorBrush)navView.TopNavArea.Background).Color);
 				return Task.CompletedTask;
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using WPanel = Microsoft.UI.Xaml.Controls.Panel;
+using WFrameworkElement = Microsoft.UI.Xaml.FrameworkElement;
+using WWindow = Microsoft.UI.Xaml.Window;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.TabbedPage)]
+	public partial class TabbedPageTests : HandlerTestBase
+	{
+		void SetupTabbedPageHandler()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedPageHandler));
+					handlers.AddHandler(typeof(Controls.Window), typeof(WindowHandler));
+					handlers.AddHandler<Page, PageHandler>();
+				});
+			});
+		}
+
+		[Fact(DisplayName = "TabbedPage Disconnects")]
+		public async Task TabbedPageHandlerDisconnects()
+		{
+			var tabbedPage = CreateBasicTabbedPage();
+
+			await CreateHandlerAndAddToWindow<TabbedPageHandler>(tabbedPage, (handler) =>
+			{
+				// Validate that no exceptions are thrown
+				((IElementHandler)handler).DisconnectHandler();
+				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "Swapping Root Window Content for New Tabbed Page")]
+		public async Task SwapWindowContentForNewTabbedPage()
+		{
+			SetupTabbedPageHandler();
+			var window = new Window()
+			{
+				Page = CreateBasicTabbedPage()
+			};
+
+			await CreateHandlerAndAddToWindow<WindowHandler>(window, async windowHandler =>
+			{
+				window.Page.Handler.DisconnectHandler();
+
+				// Swap out main page 
+				window.Page = CreateBasicTabbedPage();
+
+				// wait for new handler to finish loading
+				await ((INativeViewHandler)window.Page.Handler).NativeView.LoadedAsync();
+				var navView = GetMauiNavigationView(window.Page.Handler.MauiContext);
+
+				// make sure root view is displaying as top tabs
+				Assert.Equal(UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top, navView.PaneDisplayMode);
+			});
+		}
+
+		TabbedPage CreateBasicTabbedPage()
+		{
+			return new TabbedPage()
+			{
+				Children =
+					{
+						new ContentPage()
+					}
+			};
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Maui.DeviceTests
 					var content = (WPanel)MauiProgram.CurrentWindow.Content;
 					navigationRootManager = mauiContext.GetNavigationRootManager();
 					await content.LoadedAsync();
+					await Task.Delay(10);
 					await action((WindowHandler)newWindowHandler);
 				}
 				finally
@@ -56,6 +57,7 @@ namespace Microsoft.Maui.DeviceTests
 					{
 						MauiProgram.CurrentWindow.Content = testingRootPanel;
 						await testingRootPanel.LoadedAsync();
+						await Task.Delay(10);
 					}
 				}
 			});
@@ -92,12 +94,17 @@ namespace Microsoft.Maui.DeviceTests
 					frameworkElement = (WFrameworkElement)handler.NativeView;
 					content.Children.Add(frameworkElement);
 					await frameworkElement.LoadedAsync();
+					await Task.Delay(10);
 					await action(handler);
 				}
 				finally
 				{
 					if (frameworkElement != null)
+					{
 						content.Children.Remove(frameworkElement);
+						await frameworkElement.UnloadedAsync();
+						await Task.Delay(10);
+					}
 				}
 			});
 		}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -1,6 +1,18 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using NativeAutomationProperties = Microsoft.UI.Xaml.Automation.AutomationProperties;
+using WPanel = Microsoft.UI.Xaml.Controls.Panel;
+using WFrameworkElement = Microsoft.UI.Xaml.FrameworkElement;
+using WWindow = Microsoft.UI.Xaml.Window;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Platform;
+using System.Threading.Tasks;
+using System;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -9,5 +21,84 @@ namespace Microsoft.Maui.DeviceTests
 		protected bool GetIsAccessibilityElement(IViewHandler viewHandler) =>
 			((AccessibilityView)((DependencyObject)viewHandler.NativeView).GetValue(NativeAutomationProperties.AccessibilityViewProperty)) 
 			== AccessibilityView.Content;
+
+
+		Task RunWindowTest(IWindow window, Func<WindowHandler, Task> action)
+		{
+			return InvokeOnMainThreadAsync(async () =>
+			{
+				var testingRootPanel = (WPanel)MauiProgram.CurrentWindow.Content;
+				IElementHandler newWindowHandler = null;
+				NavigationRootManager navigationRootManager = null;
+				try
+				{
+					var scopedContext = new MauiContext(MauiContext.Services);
+					scopedContext.AddWeakSpecific(MauiProgram.CurrentWindow);
+					var mauiContext = scopedContext.MakeScoped(true);
+
+					// This will swap out the root windows panel with the panel we are going to be testing with
+					newWindowHandler = window.ToHandler(mauiContext);
+					var content = (WPanel)MauiProgram.CurrentWindow.Content;
+					navigationRootManager = mauiContext.GetNavigationRootManager();
+					await content.LoadedAsync();
+					await action((WindowHandler)newWindowHandler);
+				}
+				finally
+				{
+					if (navigationRootManager != null)
+						navigationRootManager.Disconnect();
+
+					if (newWindowHandler != null)
+						newWindowHandler.DisconnectHandler();
+
+					// Set the root window panel back to the testing panel
+					if (testingRootPanel != null)
+					{
+						MauiProgram.CurrentWindow.Content = testingRootPanel;
+						await testingRootPanel.LoadedAsync();
+					}
+				}
+			});
+		}
+
+
+
+		MauiNavigationView GetMauiNavigationView(NavigationRootManager navigationRootManager)
+		{
+			return (navigationRootManager.RootView as NavigationRootView).NavigationViewControl;
+		}
+
+		protected MauiNavigationView GetMauiNavigationView(IMauiContext mauiContext)
+		{
+			return GetMauiNavigationView(mauiContext.GetNavigationRootManager());			
+		}
+
+		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action)
+			where THandler : class, IElementHandler
+		{
+			if(view is IWindow window)
+			{
+				return RunWindowTest(window, (handler) => action(handler as THandler));
+			}
+
+			return InvokeOnMainThreadAsync(async () =>
+			{
+				WFrameworkElement frameworkElement = null;
+				var content = (WPanel)MauiContext.Services.GetService<WWindow>().Content;
+				try
+				{
+					var mauiContext = MauiContext.MakeScoped(true);
+					var handler = CreateHandler<THandler>(view, mauiContext);
+					frameworkElement = (WFrameworkElement)handler.NativeView;
+					content.Children.Add(frameworkElement);
+					await action(handler);
+				}
+				finally
+				{
+					if (frameworkElement != null)
+						content.Children.Remove(frameworkElement);
+				}
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -78,13 +78,14 @@ namespace Microsoft.Maui.DeviceTests
 		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action)
 			where THandler : class, IElementHandler
 		{
-			if(view is IWindow window)
-			{
-				return RunWindowTest(window, (handler) => action(handler as THandler));
-			}
-
 			return InvokeOnMainThreadAsync(async () =>
 			{
+				if (view is IWindow window)
+				{
+					await RunWindowTest(window, (handler) => action(handler as THandler));
+					return;
+				}
+
 				WFrameworkElement frameworkElement = null;
 				var content = (WPanel)MauiContext.Services.GetService<WWindow>().Content;
 				try

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		MauiNavigationView GetMauiNavigationView(NavigationRootManager navigationRootManager)
 		{
-			return (navigationRootManager.RootView as NavigationRootView).NavigationViewControl;
+			return (navigationRootManager.RootView as WindowRootView).NavigationViewControl;
 		}
 
 		protected MauiNavigationView GetMauiNavigationView(IMauiContext mauiContext)
@@ -91,6 +91,7 @@ namespace Microsoft.Maui.DeviceTests
 					var handler = CreateHandler<THandler>(view, mauiContext);
 					frameworkElement = (WFrameworkElement)handler.NativeView;
 					content.Children.Add(frameworkElement);
+					await frameworkElement.LoadedAsync();
 					await action(handler);
 				}
 				finally

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -6,26 +6,63 @@ using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Essentials;
+using Microsoft.Maui.LifecycleEvents;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class HandlerTestBase : TestBase, IDisposable
 	{
+		bool _isCreated;
 		MauiApp _mauiApp;
+		IMauiContext _mauiContext;
 
-		public HandlerTestBase()
+		public void EnsureHandlerCreated(Action<MauiAppBuilder> additionalCreationActions = null)
 		{
-			_mauiApp = MauiApp
+			if (_isCreated)
+			{
+				return;
+			}
+
+			_isCreated = true;
+			var appBuilder = MauiApp
 				.CreateBuilder()
 				.RemapForControls()
+				.ConfigureLifecycleEvents(lifecycle =>
+				{
+#if __IOS__
+					lifecycle
+						.AddiOS(iOS => iOS
+							.OpenUrl((app, url, options) =>
+								Microsoft.Maui.Essentials.Platform.OpenUrl(app, url, options))
+							.ContinueUserActivity((application, userActivity, completionHandler) =>
+								Microsoft.Maui.Essentials.Platform.ContinueUserActivity(application, userActivity, completionHandler))
+							.PerformActionForShortcutItem((application, shortcutItem, completionHandler) =>
+								Microsoft.Maui.Essentials.Platform.PerformActionForShortcutItem(application, shortcutItem, completionHandler)));
+#elif WINDOWS
+					lifecycle
+						.AddWindows(windows =>
+						{
+							windows
+								.OnLaunched((app, e) =>
+									Microsoft.Maui.Essentials.Platform.OnLaunched(e));
+							windows
+								.OnActivated((window, e) =>
+									Microsoft.Maui.Essentials.Platform.OnActivated(window, e));
+						});
+#endif
+				})
 				.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler(typeof(Editor), typeof(EditorHandler));
 					handlers.AddHandler(typeof(VerticalStackLayout), typeof(LayoutHandler));
-				})
-				.Build();
+				});
 
-			MauiContext = new ContextStub(_mauiApp.Services);
+			additionalCreationActions?.Invoke(appBuilder);
+
+			_mauiApp = appBuilder.Build();
+
+			_mauiContext = new ContextStub(_mauiApp.Services);
 		}
 
 		public void Dispose()
@@ -33,31 +70,47 @@ namespace Microsoft.Maui.DeviceTests
 			((IDisposable)_mauiApp).Dispose();
 
 			_mauiApp = null;
-			MauiContext = null;
+			_mauiContext = null;
 		}
 
-		protected IMauiContext MauiContext { get; private set; }
+		protected IMauiContext MauiContext
+		{
+			get
+			{
+				EnsureHandlerCreated();
+				return _mauiContext;
+			}
+		}
 
-		protected THandler CreateHandler<THandler>(IView view)
-			where THandler : IViewHandler
+		protected THandler CreateHandler<THandler>(IElement view)
+			where THandler : IElementHandler
+		{
+			return CreateHandler<THandler>(view, MauiContext);
+		}
+
+		protected THandler CreateHandler<THandler>(IElement element, IMauiContext mauiContext)
+			where THandler : IElementHandler
 		{
 			var handler = Activator.CreateInstance<THandler>();
-			handler.SetMauiContext(MauiContext);
+			handler.SetMauiContext(mauiContext);
 
-			handler.SetVirtualView(view);
-			view.Handler = handler;
+			handler.SetVirtualView(element);
+			element.Handler = handler;
 
-			view.Arrange(new Rectangle(0, 0, view.Width, view.Height));
-			handler.NativeArrange(view.Frame);
+			if (element is IView view && handler is IViewHandler viewHandler)
+			{
+				view.Arrange(new Rectangle(0, 0, view.Width, view.Height));
+				viewHandler.NativeArrange(view.Frame);
+			}
 
 			return handler;
 		}
 
-		protected async Task<THandler> CreateHandlerAsync<THandler>(IView view) where THandler : IViewHandler =>
+		protected async Task<THandler> CreateHandlerAsync<THandler>(IElement view) where THandler : IElementHandler =>
 			await InvokeOnMainThreadAsync(() => CreateHandler<THandler>(view));
 
-		protected Task<TValue> GetValueAsync<TValue, THandler>(IView view, Func<THandler, TValue> func)
-			 where THandler : IViewHandler
+		protected Task<TValue> GetValueAsync<TValue, THandler>(IElement view, Func<THandler, TValue> func)
+			 where THandler : IElementHandler
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{

--- a/src/Controls/tests/DeviceTests/Properties/launchSettings.json
+++ b/src/Controls/tests/DeviceTests/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "Windows Machine": {
-      "commandName": "MsixPackage"
+        "commandName": "MsixPackage",
+        "nativeDebugging": true
     }
   }
 }

--- a/src/Controls/tests/DeviceTests/Startup.cs
+++ b/src/Controls/tests/DeviceTests/Startup.cs
@@ -6,8 +6,10 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public static class MauiProgram
 	{
-#if __ANDROID__
+#if ANDROID
 		public static Android.Content.Context CurrentContext { get; private set; }
+#elif WINDOWS
+		public static Microsoft.UI.Xaml.Window CurrentWindow { get; private set; }
 #endif
 
 		public static MauiApp CreateMauiApp() =>
@@ -15,10 +17,15 @@ namespace Microsoft.Maui.DeviceTests
 				.CreateBuilder()
 				.ConfigureLifecycleEvents(life =>
 				{
-#if __ANDROID__
+#if ANDROID
 					life.AddAndroid(android =>
 					{
 						android.OnCreate((a, b) => CurrentContext = a);
+					});
+#elif WINDOWS
+					life.AddWindows(windows =>
+					{
+						windows.OnWindowCreated(win => CurrentWindow = win);
 					});
 #endif
 				})
@@ -26,7 +33,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					Assemblies =
 					{
-						typeof(MauiProgram).Assembly
+						typeof(MauiProgram).Assembly,
 					},
 				})
 				.UseHeadlessRunner(new HeadlessRunnerOptions

--- a/src/Controls/tests/DeviceTests/Stubs/ContextStub.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/ContextStub.cs
@@ -32,12 +32,15 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 			if (serviceType == typeof(NavigationRootManager))
 				return _windowManager ??= new NavigationRootManager(this);
-#elif __IOS__
+#elif IOS
 			if (serviceType == typeof(UIKit.UIWindow))
 				return UIKit.UIApplication.SharedApplication.KeyWindow;
 #elif WINDOWS
 			if (serviceType == typeof(NavigationRootManager))
 				return _windowManager ??= new NavigationRootManager(this);
+
+			if (serviceType == typeof(UI.Xaml.Window))
+				return MauiProgram.CurrentWindow;
 #endif
 
 			if (serviceType == typeof(IDispatcher))

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -8,6 +8,7 @@
 		public const string FlyoutPage = "FlyoutPage";
 		public const string Gesture = "Gesture";
 		public const string Label = "Label";
+		public const string NavigationPage = "NavigationPage";
 		public const string TabbedPage = "TabbedPage";
 		public const string VisualElement = "VisualElement";
 	}

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -5,6 +5,7 @@
 		public const string Button = "Button";
 		public const string Dispatcher = "Dispatcher";
 		public const string Editor = "Editor";
+		public const string FlyoutPage = "FlyoutPage";
 		public const string Gesture = "Gesture";
 		public const string Label = "Label";
 		public const string TabbedPage = "TabbedPage";

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -7,6 +7,7 @@
 		public const string Editor = "Editor";
 		public const string Gesture = "Gesture";
 		public const string Label = "Label";
+		public const string TabbedPage = "TabbedPage";
 		public const string VisualElement = "VisualElement";
 	}
 }

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Windows.cs
@@ -25,12 +25,6 @@ namespace Microsoft.Maui.Handlers
 			nativeView.FlyoutPaneSizeChanged += OnFlyoutPaneSizeChanged;
 			nativeView.PaneOpened += OnPaneOepened;
 			_registerCallbackToken = nativeView.RegisterPropertyChangedCallback(NavigationView.IsBackButtonVisibleProperty, BackButtonVisibleChanged);
-
-			nativeView.RegisterPropertyChangedCallback(NavigationView.PaneDisplayModeProperty, PaneDisplayModeChanged);
-		}
-
-		private void PaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp)
-		{
 		}
 
 		protected override void DisconnectHandler(RootNavigationView nativeView)

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Windows.cs
@@ -6,20 +6,20 @@ using Windows.Foundation;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, MauiNavigationView>
+	public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, RootNavigationView>
 	{
 		readonly FlyoutPanel _flyoutPanel = new FlyoutPanel();
 		long? _registerCallbackToken;
 		NavigationRootManager? _navigationRootManager;
-		protected override MauiNavigationView CreateNativeView()
+		protected override RootNavigationView CreateNativeView()
 		{
-			var navigationView = new MauiNavigationView();
+			var navigationView = new RootNavigationView();
 
 			navigationView.PaneFooter = _flyoutPanel;
 			return navigationView;
 		}
 
-		protected override void ConnectHandler(MauiNavigationView nativeView)
+		protected override void ConnectHandler(RootNavigationView nativeView)
 		{
 			_navigationRootManager = MauiContext?.GetNavigationRootManager();
 			nativeView.FlyoutPaneSizeChanged += OnFlyoutPaneSizeChanged;
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		}
 
-		protected override void DisconnectHandler(MauiNavigationView nativeView)
+		protected override void DisconnectHandler(RootNavigationView nativeView)
 		{
 			nativeView.FlyoutPaneSizeChanged += OnFlyoutPaneSizeChanged;
 			nativeView.PaneOpened -= OnPaneOepened;

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -27,9 +27,10 @@ namespace Microsoft.Maui.Handlers
 		}
 
 		protected override void DisconnectHandler(UI.Xaml.Window nativeView)
-		{
-			var windowManager = MauiContext?.GetNavigationRootManager();
-			windowManager?.Disconnect(VirtualView.Content);
+		{			
+			MauiContext
+				?.GetNavigationRootManager()
+				?.Disconnect();			
 
 			_rootPanel?.Children?.Clear();
 			nativeView.Content = null;

--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -198,19 +198,47 @@ namespace Microsoft.Maui.Platform
 			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
 
 			if (frameworkElement.IsLoaded)
+			{
 				taskCompletionSource.SetResult(true);
+				return taskCompletionSource.Task;
+			}
 
 			UI.Xaml.RoutedEventHandler? routedEventHandler = null;
 			routedEventHandler = (_, __) =>
 			{
-				if(routedEventHandler != null)
+				if (routedEventHandler != null)
 					frameworkElement.Loaded -= routedEventHandler;
 
 				taskCompletionSource.SetResult(true);
 			};
 
 			frameworkElement.Loaded += routedEventHandler;
-						
+
+			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
+		}
+
+		internal static Task UnloadedAsync(this FrameworkElement frameworkElement, TimeSpan? timeOut = null)
+		{
+			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+
+			if (!frameworkElement.IsLoaded)
+			{
+				taskCompletionSource.SetResult(true);
+				return taskCompletionSource.Task;
+			}
+
+			UI.Xaml.RoutedEventHandler? routedEventHandler = null;
+			routedEventHandler = (_, __) =>
+			{
+				if (routedEventHandler != null)
+					frameworkElement.Unloaded -= routedEventHandler;
+
+				taskCompletionSource.SetResult(true);
+			};
+
+			frameworkElement.Unloaded += routedEventHandler;
+
 			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 

--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -215,67 +215,22 @@ namespace Microsoft.Maui.Platform
 		}
 
 
-		internal static void UpdateThemeDictionaries(this FrameworkElement frameworkElement, string propertyKey, object? value)
+		internal static void UpdateResourceToApplicationDefault(this FrameworkElement frameworkElement, string propertyKey, object? value)
 		{
-			bool foundInThemeDict = false;
-			UI.Xaml.Controls.XamlControlsResources? xamlControlDict = null;
-
-			foreach(var dict in Application.Current.Resources.MergedDictionaries)
+			if (value is null)
 			{
-				if (dict is UI.Xaml.Controls.XamlControlsResources xcr)
-					xamlControlDict = xcr;
-			}
-
-			_ = xamlControlDict ?? throw new InvalidOperationException("Unable to find Xaml.Controls.XamlControlsResources");
-
-
-			foreach (var dict in xamlControlDict.ThemeDictionaries)
-			{
-				var appTheme = (ResourceDictionary)dict.Value;
-
-				object? elementDict;
-
-				if (!frameworkElement.Resources.ThemeDictionaries.TryGetValue(dict.Key, out elementDict))
-				{
-					elementDict = new ResourceDictionary();
-					frameworkElement.Resources.ThemeDictionaries.Add(dict.Key, elementDict);
-				}
-
-				if (value != null)
-				{
-					((ResourceDictionary)elementDict)[propertyKey] = value;
-				}
-				else
-				{
-					if (appTheme.TryGetValue(propertyKey, out value))
-					{
-						foundInThemeDict = true;
-						((ResourceDictionary)elementDict)[propertyKey] = value;
-					}
-					else
-					{
-						((ResourceDictionary)elementDict).Remove(propertyKey);
-					}
-				}
-			}
-
-			if(!foundInThemeDict)
-			{
-				if (value is null)
-				{
-					if (Application.Current.Resources.TryGetValue(propertyKey, out value))
-					{
-						frameworkElement.Resources[propertyKey] = value;
-					}
-					else
-					{
-						frameworkElement.Resources.Remove(propertyKey);
-					}
-				}
-				else
+				if (Application.Current.Resources.TryGetValue(propertyKey, out value))
 				{
 					frameworkElement.Resources[propertyKey] = value;
 				}
+				else
+				{
+					frameworkElement.Resources.Remove(propertyKey);
+				}
+			}
+			else
+			{
+				frameworkElement.Resources[propertyKey] = value;
 			}
 		}
 	}

--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -213,5 +213,70 @@ namespace Microsoft.Maui.Platform
 						
 			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
+
+
+		internal static void UpdateThemeDictionaries(this FrameworkElement frameworkElement, string propertyKey, object? value)
+		{
+			bool foundInThemeDict = false;
+			UI.Xaml.Controls.XamlControlsResources? xamlControlDict = null;
+
+			foreach(var dict in Application.Current.Resources.MergedDictionaries)
+			{
+				if (dict is UI.Xaml.Controls.XamlControlsResources xcr)
+					xamlControlDict = xcr;
+			}
+
+			_ = xamlControlDict ?? throw new InvalidOperationException("Unable to find Xaml.Controls.XamlControlsResources");
+
+
+			foreach (var dict in xamlControlDict.ThemeDictionaries)
+			{
+				var appTheme = (ResourceDictionary)dict.Value;
+
+				object? elementDict;
+
+				if (!frameworkElement.Resources.ThemeDictionaries.TryGetValue(dict.Key, out elementDict))
+				{
+					elementDict = new ResourceDictionary();
+					frameworkElement.Resources.ThemeDictionaries.Add(dict.Key, elementDict);
+				}
+
+				if (value != null)
+				{
+					((ResourceDictionary)elementDict)[propertyKey] = value;
+				}
+				else
+				{
+					if (appTheme.TryGetValue(propertyKey, out value))
+					{
+						foundInThemeDict = true;
+						((ResourceDictionary)elementDict)[propertyKey] = value;
+					}
+					else
+					{
+						((ResourceDictionary)elementDict).Remove(propertyKey);
+					}
+				}
+			}
+
+			if(!foundInThemeDict)
+			{
+				if (value is null)
+				{
+					if (Application.Current.Resources.TryGetValue(propertyKey, out value))
+					{
+						frameworkElement.Resources[propertyKey] = value;
+					}
+					else
+					{
+						frameworkElement.Resources.Remove(propertyKey);
+					}
+				}
+				else
+				{
+					frameworkElement.Resources[propertyKey] = value;
+				}
+			}
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -10,6 +10,8 @@ using Microsoft.UI.Xaml.Media;
 using WBinding = Microsoft.UI.Xaml.Data.Binding;
 using WBindingExpression = Microsoft.UI.Xaml.Data.BindingExpression;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Microsoft.Maui.Platform
 {
@@ -188,6 +190,28 @@ namespace Microsoft.Maui.Platform
 						yield return subChild;
 				}
 			}
+		}
+
+		internal static Task LoadedAsync(this FrameworkElement frameworkElement, TimeSpan? timeOut = null)
+		{
+			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+
+			if (frameworkElement.IsLoaded)
+				taskCompletionSource.SetResult(true);
+
+			UI.Xaml.RoutedEventHandler? routedEventHandler = null;
+			routedEventHandler = (_, __) =>
+			{
+				if(routedEventHandler != null)
+					frameworkElement.Loaded -= routedEventHandler;
+
+				taskCompletionSource.SetResult(true);
+			};
+
+			frameworkElement.Loaded += routedEventHandler;
+						
+			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -11,154 +11,28 @@ namespace Microsoft.Maui.Platform
 	[Microsoft.UI.Xaml.Data.Bindable]
 	public class MauiNavigationView : NavigationView
 	{
-		double _paneHeaderContentHeight;
-		private UIElement? _headerControl;
-
-		internal Grid? ItemsContainerGrid { get; private set; }
-		internal FrameworkElement? TopNavArea { get; private set; }
+		internal StackPanel? TopNavArea { get; private set; }
 		internal Grid? PaneContentGrid { get; private set; }
-		internal event EventHandler? FlyoutPaneSizeChanged;
-		internal Size FlyoutPaneSize { get; private set; }
 		internal event EventHandler? OnApplyTemplateFinished;
-		internal UIElement? HeaderControl 
-		{
-			get => _headerControl; 
-			set
-			{
-				_headerControl = value;
-				UpdateTopNavAreaMargin();
-			} 
-		}
 
 		public MauiNavigationView()
 		{
-			IsSettingsVisible = false;
-			MenuItemsSource = null;
-			IsPaneToggleButtonVisible = false;
-			PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
-			IsTitleBarAutoPaddingEnabled = false;
-			IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
-			RegisterPropertyChangedCallback(IsBackButtonVisibleProperty, BackButtonVisibleChanged);
-			RegisterPropertyChangedCallback(OpenPaneLengthProperty, PaneLengthPropertyChanged);
-			RegisterPropertyChangedCallback(HeaderProperty, HeaderPropertyChanged);
-			RegisterPropertyChangedCallback(PaneFooterProperty, HeaderPropertyChanged);
-			RegisterPropertyChangedCallback(PaneDisplayModeProperty, PaneDisplayModeChanged);
-		}
-
-		void PaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			UpdateTopNavAreaMargin();
-		}
-
-		void UpdateTopNavAreaMargin()
-		{
-			if (TopNavArea != null)
-			{
-				if (PaneDisplayMode == NavigationViewPaneDisplayMode.Top)
-				{
-					TopNavArea.Margin = new UI.Xaml.Thickness(0, 48, 0, 0);
-					Header = null;
-					PaneFooter = HeaderControl;
-				}
-				else
-				{
-					TopNavArea.Margin = new UI.Xaml.Thickness(0, 0, 0, 0);
-					PaneFooter = null;
-					Header = HeaderControl;
-				}
-			}
-
-		}
-		void HeaderPropertyChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			Binding isBackButtonVisible = new Binding();
-			isBackButtonVisible.Source = HeaderControl;
-			isBackButtonVisible.Path = new PropertyPath("IsBackButtonVisible");
-			isBackButtonVisible.Mode = BindingMode.OneWay;
-			isBackButtonVisible.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
-			BindingOperations.SetBinding(this, IsBackButtonVisibleProperty, isBackButtonVisible);
-		}
-
-		void PaneLengthPropertyChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			UpdateFlyoutPaneSize();
-		}
-
-		void BackButtonVisibleChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			if (IsBackButtonVisible == NavigationViewBackButtonVisible.Auto)
-				IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
-
-			IsBackEnabled = (IsBackButtonVisible == NavigationViewBackButtonVisible.Visible);
 		}
 
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
 
-			// We currently use the "PaneFooter" property to set custom content on the flyout
-			// But this content has a top margin of 4 to separate it from the bottom menu items
-			// Because we aren't using bottom menu items we just zero out the margin.
-			// The way we size the flyout content is by retrieving the height/width of the ItemsContainerGrid
-			// Because the FooterContentBorder has a margin the height of the ItemsContainerGrid will increase by four 
-			// everytime you set the PaneFooter Content which will lead to a layout cycle.
-			// TLDR; if you comment this out you'll get a layout cycle crash because of how we're extracting the WxH 
-			// to measure the flyout content
-			((FrameworkElement)GetTemplateChild("FooterContentBorder")).Margin = new UI.Xaml.Thickness(0);
-
-			// This is used to left pad the content/header when the backbutton is visible
-			// Because our backbutton is inside the appbar title we don't care about padding 
-			// the content and header by the size of the backbutton.
-			if (GetTemplateChild("ContentLeftPadding") is Grid g)
-				g.Visibility = UI.Xaml.Visibility.Collapsed;
-
-			var HeaderContent = (ContentControl)GetTemplateChild("HeaderContent");
-			Binding visibilityBinding = new Binding();
-			visibilityBinding.Source = this;
-			visibilityBinding.Path = new PropertyPath("Header.Visibility");
-			visibilityBinding.Mode = BindingMode.TwoWay;
-			visibilityBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
-			BindingOperations.SetBinding(HeaderContent, VisibilityProperty, visibilityBinding);
-
-			Binding backgroundBinding = new Binding();
-			backgroundBinding.Source = this;
-			backgroundBinding.Path = new PropertyPath("Header.Background");
-			backgroundBinding.Mode = BindingMode.TwoWay;
-			backgroundBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
-			BindingOperations.SetBinding(HeaderContent, BackgroundProperty, backgroundBinding);
-
 			PaneContentGrid = (Grid)GetTemplateChild("PaneContentGrid");
-			PaneContentGrid.SizeChanged += OnPaneContentGridSizeChanged;
+			TopNavArea = ((StackPanel)GetTemplateChild("TopNavArea"));
 
-			// The TopNavArea has a background set which makes the window action buttons unclickable
-			// So this offsets the TopNavArea by the size of the AppTitleBar
-			TopNavArea = ((FrameworkElement)GetTemplateChild("TopNavArea"));
-
-			// This is the height taken up by the backbutton/pane toggle button
-			// we use this to offset the height of our flyout content
-			((FrameworkElement)GetTemplateChild("PaneHeaderContentBorder")).SizeChanged += OnPaneHeaderContentBorderSizeChanged;
-			UpdateTopNavAreaMargin();
+			OnApplyTemplateCore();
 			OnApplyTemplateFinished?.Invoke(this, EventArgs.Empty);
 		}
 
-		void OnPaneHeaderContentBorderSizeChanged(object sender, SizeChangedEventArgs e)
+		private protected virtual void OnApplyTemplateCore()
 		{
-			_paneHeaderContentHeight = ((FrameworkElement)sender).ActualHeight;
-			UpdateFlyoutPaneSize();
-		}
 
-		void OnPaneContentGridSizeChanged(object sender, SizeChangedEventArgs e)
-		{
-			UpdateFlyoutPaneSize();
-		}
-
-		void UpdateFlyoutPaneSize()
-		{
-			if (PaneContentGrid == null)
-				return;
-
-			FlyoutPaneSize = new Size(OpenPaneLength, PaneContentGrid.ActualHeight - _paneHeaderContentHeight);
-			FlyoutPaneSizeChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Maui.Platform
 
 		public virtual void Connect(IView view)
 		{
+			bool firstConnect = _rootView.Content == null;
 			var nativeView = view.ToNative(_mauiContext);
 
 			NavigationView rootNavigationView;
@@ -56,21 +57,33 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				rootNavigationView = new MauiNavigationView();
+				if(_rootView.Content is MauiNavigationView navView)
+				{
+					rootNavigationView = navView;
+				}
+				else
+				{
+					rootNavigationView = new MauiNavigationView();
+				}
+				
 				rootNavigationView.Content = nativeView;
 				_rootView.Content = rootNavigationView;
 			}
 
-			var nativeWindow = _mauiContext.GetNativeWindow();
-			nativeWindow.Activated += OnWindowActivated;
+			if (firstConnect)
+			{
+				var nativeWindow = _mauiContext.GetNativeWindow();
+				nativeWindow.Activated += OnWindowActivated;
 
-			UpdateAppTitleBar(true);
-			SetWindowTitle(_mauiContext.GetNativeWindow().GetWindow()?.Title);
+				UpdateAppTitleBar(true);
+				SetWindowTitle(_mauiContext.GetNativeWindow().GetWindow()?.Title);
+			}
 		}
 
-		public virtual void Disconnect(IView view)
+		public virtual void Disconnect()
 		{
 			_mauiContext.GetNativeWindow().Activated -= OnWindowActivated;
+			_rootView.Content = null;
 		}
 
 		internal void UpdateAppTitleBar(bool isActive)

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Maui.Platform
 	public class NavigationRootManager
 	{
 		IMauiContext _mauiContext;
-		NavigationRootView _rootView;
+		WindowRootView _rootView;
 		WindowHeader? _windowHeader;
 
 		public NavigationRootManager(IMauiContext mauiContext)
 		{
 			_mauiContext = mauiContext;
-			_rootView = new NavigationRootView();
+			_rootView = new WindowRootView();
 			_rootView.BackRequested += OnBackRequested;
 			_rootView.OnApplyTemplateFinished += OnApplyTemplateFinished;
 		}
@@ -57,13 +57,13 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				if(_rootView.Content is MauiNavigationView navView)
+				if(_rootView.Content is RootNavigationView navView)
 				{
 					rootNavigationView = navView;
 				}
 				else
 				{
-					rootNavigationView = new MauiNavigationView();
+					rootNavigationView = new RootNavigationView();
 				}
 				
 				rootNavigationView.Content = nativeView;

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -9,9 +9,12 @@ namespace Microsoft.Maui.Platform
 {
 	public static class NavigationViewExtensions
 	{
-		public static void UpdateTopNavAreaBackground(this NavigationView navigationView, Paint? paint)
+		public static void UpdateTopNavAreaBackground(this MauiNavigationView navigationView, Paint? paint)
 		{
-			navigationView.UpdateThemeDictionaries("NavigationViewTopPaneBackground", paint?.ToNative());
+			// Background property is set via {ThemeResource NavigationViewTopPaneBackground} in the Control Template
+			// AFAICT you can't modify properties set by ThemeResource at runtime so we have to just update this value directly
+			if (paint != null)
+				navigationView.TopNavArea?.UpdateBackground(paint, null);
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Maui.Graphics;
+
+
+namespace Microsoft.Maui.Platform
+{
+	public static class NavigationViewExtensions
+	{
+		public static void UpdateTopNavAreaBackground(this NavigationView navigationView, Paint? paint)
+		{
+			navigationView.UpdateThemeDictionaries("NavigationViewTopPaneBackground", paint?.ToNative());
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -67,7 +67,10 @@ namespace Microsoft.Maui.Platform
 			}
 
 		}
-		void HeaderPropertyChanged(DependencyObject sender, DependencyProperty dp)
+		void HeaderPropertyChanged(DependencyObject sender, DependencyProperty dp) =>
+			UpdateHeaderPropertyBinding();
+
+		void UpdateHeaderPropertyBinding()
 		{
 			Binding isBackButtonVisible = new Binding();
 			isBackButtonVisible.Source = HeaderControl;
@@ -123,6 +126,9 @@ namespace Microsoft.Maui.Platform
 			backgroundBinding.Mode = BindingMode.TwoWay;
 			backgroundBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
 			BindingOperations.SetBinding(HeaderContent, BackgroundProperty, backgroundBinding);
+
+			if (HeaderControl != null)
+				UpdateHeaderPropertyBinding();
 
 			PaneContentGrid!.SizeChanged += OnPaneContentGridSizeChanged;
 

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Platform
 					Header = null;
 					PaneFooter = HeaderControl;
 				}
-				else
+				else if(PaneFooter == HeaderControl)
 				{
 					TopNavArea.Margin = new UI.Xaml.Thickness(0, 0, 0, 0);
 					PaneFooter = null;

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Windows.Foundation;
+
+namespace Microsoft.Maui.Platform
+{
+	// This is needed by WinUI because of 
+	// https://github.com/microsoft/microsoft-ui-xaml/issues/2698#issuecomment-648751713
+	[Microsoft.UI.Xaml.Data.Bindable]
+	public class RootNavigationView : MauiNavigationView
+	{
+		double _paneHeaderContentHeight;
+		UIElement? _headerControl;
+
+		internal event EventHandler? FlyoutPaneSizeChanged;
+		internal Size FlyoutPaneSize { get; private set; }
+		internal UIElement? HeaderControl 
+		{
+			get => _headerControl; 
+			set
+			{
+				_headerControl = value;
+				UpdateTopNavAreaMargin();
+			} 
+		}
+
+		public RootNavigationView()
+		{
+			IsSettingsVisible = false;
+			MenuItemsSource = null;
+			IsPaneToggleButtonVisible = false;
+			PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
+			IsTitleBarAutoPaddingEnabled = false;
+			IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
+			RegisterPropertyChangedCallback(IsBackButtonVisibleProperty, BackButtonVisibleChanged);
+			RegisterPropertyChangedCallback(OpenPaneLengthProperty, PaneLengthPropertyChanged);
+			RegisterPropertyChangedCallback(HeaderProperty, HeaderPropertyChanged);
+			RegisterPropertyChangedCallback(PaneFooterProperty, HeaderPropertyChanged);
+			RegisterPropertyChangedCallback(PaneDisplayModeProperty, PaneDisplayModeChanged);
+		}
+
+		void PaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			UpdateTopNavAreaMargin();
+		}
+
+		void UpdateTopNavAreaMargin()
+		{
+			if (TopNavArea != null)
+			{
+				if (PaneDisplayMode == NavigationViewPaneDisplayMode.Top)
+				{
+					// The TopNavArea has a background set which makes the window action buttons unclickable
+					// So this offsets the TopNavArea by the size of the AppTitleBar
+					TopNavArea.Margin = new UI.Xaml.Thickness(0, 48, 0, 0);
+					Header = null;
+					PaneFooter = HeaderControl;
+				}
+				else
+				{
+					TopNavArea.Margin = new UI.Xaml.Thickness(0, 0, 0, 0);
+					PaneFooter = null;
+					Header = HeaderControl;
+				}
+			}
+
+		}
+		void HeaderPropertyChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			Binding isBackButtonVisible = new Binding();
+			isBackButtonVisible.Source = HeaderControl;
+			isBackButtonVisible.Path = new PropertyPath("IsBackButtonVisible");
+			isBackButtonVisible.Mode = BindingMode.OneWay;
+			isBackButtonVisible.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
+			BindingOperations.SetBinding(this, IsBackButtonVisibleProperty, isBackButtonVisible);
+		}
+
+		void PaneLengthPropertyChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			UpdateFlyoutPaneSize();
+		}
+
+		void BackButtonVisibleChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			if (IsBackButtonVisible == NavigationViewBackButtonVisible.Auto)
+				IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
+
+			IsBackEnabled = (IsBackButtonVisible == NavigationViewBackButtonVisible.Visible);
+		}
+
+
+		private protected override void OnApplyTemplateCore()
+		{
+			// We currently use the "PaneFooter" property to set custom content on the flyout
+			// But this content has a top margin of 4 to separate it from the bottom menu items
+			// Because we aren't using bottom menu items we just zero out the margin.
+			// The way we size the flyout content is by retrieving the height/width of the ItemsContainerGrid
+			// Because the FooterContentBorder has a margin the height of the ItemsContainerGrid will increase by four 
+			// everytime you set the PaneFooter Content which will lead to a layout cycle.
+			// TLDR; if you comment this out you'll get a layout cycle crash because of how we're extracting the WxH 
+			// to measure the flyout content
+			((FrameworkElement)GetTemplateChild("FooterContentBorder")).Margin = new UI.Xaml.Thickness(0);
+
+			// This is used to left pad the content/header when the backbutton is visible
+			// Because our backbutton is inside the appbar title we don't care about padding 
+			// the content and header by the size of the backbutton.
+			if (GetTemplateChild("ContentLeftPadding") is Grid g)
+				g.Visibility = UI.Xaml.Visibility.Collapsed;
+
+			var HeaderContent = (ContentControl)GetTemplateChild("HeaderContent");
+			Binding visibilityBinding = new Binding();
+			visibilityBinding.Source = this;
+			visibilityBinding.Path = new PropertyPath("Header.Visibility");
+			visibilityBinding.Mode = BindingMode.TwoWay;
+			visibilityBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
+			BindingOperations.SetBinding(HeaderContent, VisibilityProperty, visibilityBinding);
+
+			Binding backgroundBinding = new Binding();
+			backgroundBinding.Source = this;
+			backgroundBinding.Path = new PropertyPath("Header.Background");
+			backgroundBinding.Mode = BindingMode.TwoWay;
+			backgroundBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
+			BindingOperations.SetBinding(HeaderContent, BackgroundProperty, backgroundBinding);
+
+			PaneContentGrid!.SizeChanged += OnPaneContentGridSizeChanged;
+
+			// This is the height taken up by the backbutton/pane toggle button
+			// we use this to offset the height of our flyout content
+			((FrameworkElement)GetTemplateChild("PaneHeaderContentBorder")).SizeChanged += OnPaneHeaderContentBorderSizeChanged;
+			UpdateTopNavAreaMargin();
+		}
+
+		void OnPaneHeaderContentBorderSizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			_paneHeaderContentHeight = ((FrameworkElement)sender).ActualHeight;
+			UpdateFlyoutPaneSize();
+		}
+
+		void OnPaneContentGridSizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			UpdateFlyoutPaneSize();
+		}
+
+		void UpdateFlyoutPaneSize()
+		{
+			if (PaneContentGrid == null)
+				return;
+
+			FlyoutPaneSize = new Size(OpenPaneLength, PaneContentGrid.ActualHeight - _paneHeaderContentHeight);
+			FlyoutPaneSizeChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/Styles/Resources.xaml
+++ b/src/Core/src/Platform/Windows/Styles/Resources.xaml
@@ -11,7 +11,7 @@
         <ResourceDictionary Source="MauiComboBoxStyle.xaml" />
         <ResourceDictionary Source="MauiSliderStyle.xaml" />
         <ResourceDictionary Source="MauiStepperStyle.xaml" />
-        <ResourceDictionary Source="NavigationRootViewStyle.xaml" />
+        <ResourceDictionary Source="WindowRootViewStyle.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <x:Boolean x:Key="MicrosoftMauiCoreIncluded">true</x:Boolean>

--- a/src/Core/src/Platform/Windows/Styles/WindowRootViewStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/WindowRootViewStyle.xaml
@@ -2,10 +2,10 @@
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:maui="using:Microsoft.Maui.Platform">
-    <Style TargetType="maui:NavigationRootView">
+    <Style TargetType="maui:WindowRootView">
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="maui:NavigationRootView">
+                <ControlTemplate TargetType="maui:WindowRootView">
                     <Page Margin="0" Padding="0">
                         <Page.Resources>
                             <!--This top margin is the height of the custom TitleBar-->

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -7,15 +7,15 @@ using WThickness = Microsoft.UI.Xaml.Thickness;
 namespace Microsoft.Maui.Platform
 {
 
-	public partial class NavigationRootView : ContentControl
+	public partial class WindowRootView : ContentControl
 	{
-		public NavigationRootView()
+		public WindowRootView()
 		{
 		}
 
 		public Image? AppFontIcon { get; private set; }
 		public TextBlock? AppTitle { get; private set; }
-		public MauiNavigationView? NavigationViewControl { get; private set; }
+		public RootNavigationView? NavigationViewControl { get; private set; }
 		public FrameworkElement? AppTitleBar { get; private set; } 
 		public event TypedEventHandler<NavigationView, NavigationViewBackRequestedEventArgs>? BackRequested;
 		bool _hasTitleBarImage = false;
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Platform
 		protected override void OnContentChanged(object oldContent, object newContent)
 		{
 			base.OnContentChanged(oldContent, newContent);
-			if(newContent is MauiNavigationView mnv)
+			if(newContent is RootNavigationView mnv)
 			{
 				NavigationViewControl = mnv;
 				NavigationViewControl.DisplayModeChanged += OnNavigationViewControlDisplayModeChanged;

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Maui.Platform
 		public event TypedEventHandler<NavigationView, NavigationViewBackRequestedEventArgs>? BackRequested;
 		bool _hasTitleBarImage = false;
 		internal event EventHandler? OnApplyTemplateFinished;
+		internal event EventHandler? ContentChanged;
 		string? _windowTitle;
 
 		protected override void OnApplyTemplate()
@@ -49,6 +50,8 @@ namespace Microsoft.Maui.Platform
 				NavigationViewControl.BackRequested += OnNavigationViewBackRequested;
 				NavigationViewControl.RegisterPropertyChangedCallback(NavigationView.IsBackButtonVisibleProperty, AppBarNavigationIconsChanged);
 				NavigationViewControl.RegisterPropertyChangedCallback(NavigationView.IsPaneToggleButtonVisibleProperty, AppBarNavigationIconsChanged);
+
+				ContentChanged?.Invoke(this, EventArgs.Empty);
 			}
 		}
 

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Maui.DualScreen.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.UnitTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Core.DeviceTests")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.Controls.DeviceTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.Controls.Core.UnitTests")]
 [assembly: InternalsVisibleTo("Comet")]
 [assembly: InternalsVisibleTo("Comet.Tests")]

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
@@ -21,16 +21,16 @@ namespace Microsoft.Maui.DeviceTests
 
 			await RunWindowTest(window, manager =>
 			{
-				var navView = GetMauiNavigationView(manager);
+				var navView = GetRootNavigationView(manager);
 				Assert.Equal(NavigationViewBackButtonVisible.Collapsed, navView.IsBackButtonVisible);
 				return Task.CompletedTask;
 			});
 		}
 
 
-		MauiNavigationView GetMauiNavigationView(NavigationRootManager navigationRootManager)
+		RootNavigationView GetRootNavigationView(NavigationRootManager navigationRootManager)
 		{
-			return (navigationRootManager.RootView as NavigationRootView).NavigationViewControl;
+			return (navigationRootManager.RootView as WindowRootView).NavigationViewControl;
 		}
 
 		Task RunWindowTest(IWindow window, Func<NavigationRootManager, Task> action)

--- a/src/Core/tests/DeviceTests/Stubs/ContextStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ContextStub.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 #elif WINDOWS
 			if (serviceType == typeof(NavigationRootManager))
 				return _windowManager ??= new NavigationRootManager(this);
+
+			if (serviceType == typeof(UI.Xaml.Window))
+				return Platform.DefaultWindow;
 #endif
 
 			return _services.GetService(serviceType);


### PR DESCRIPTION
### Description of Change ###
- Add more UI Tests for TabbedPageHandler
- Fixed an issue when disconnecting and swapping in a new TabbedPageHandler
  -  You can test this by going to the TabbedPage gallery and clicking the button to swap in TabbedPage as root 
- Wired up BarBackground(Color)
- Fixed a few issues with FlyoutPage when used with TabbedPage

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
