### PR TITLE
Support Blazor Android WebView `Back` Navigation

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebView.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebView.Android.cs
@@ -1,0 +1,24 @@
+using AWebView = Android.Webkit.WebView;
+using Android.Content;
+using Android.Views;
+using Android.Webkit;
+
+namespace Microsoft.AspNetCore.Components.WebView.Maui
+{
+	public class BlazorAndroidWebView : AWebView
+	{
+		public BlazorAndroidWebView(Context context) : base(context)
+		{
+		}
+
+		public override bool OnKeyDown(Keycode keyCode, KeyEvent? e)
+		{
+			if (keyCode == Keycode.Back && CanGoBack() && e?.RepeatCount == 0)
+			{
+				GoBack();
+				return true;
+			}
+			return false;
+		}
+	}
+}

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -4,52 +4,51 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using Android.Webkit;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Maui.Handlers;
+using Android.Webkit;
 using static Android.Views.ViewGroup;
-using AWebView = Android.Webkit.WebView;
 using Path = System.IO.Path;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
-	public partial class BlazorWebViewHandler : ViewHandler<IBlazorWebView, AWebView>
+	public partial class BlazorWebViewHandler : ViewHandler<IBlazorWebView, BlazorAndroidWebView>
 	{
 		private WebViewClient? _webViewClient;
 		private WebChromeClient? _webChromeClient;
 		private AndroidWebKitWebViewManager? _webviewManager;
 		internal AndroidWebKitWebViewManager? WebviewManager => _webviewManager;
 
-		protected override AWebView CreateNativeView()
+		protected override BlazorAndroidWebView CreateNativeView()
 		{
-			var aWebView = new AWebView(Context!)
+			var blazorAndroidWebView = new BlazorAndroidWebView(Context!)
 			{
 #pragma warning disable 618 // This can probably be replaced with LinearLayout(LayoutParams.MatchParent, LayoutParams.MatchParent); just need to test that theory
 				LayoutParameters = new Android.Widget.AbsoluteLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent, 0, 0)
 #pragma warning restore 618
 			};
 
-			AWebView.SetWebContentsDebuggingEnabled(enabled: true);
+			BlazorAndroidWebView.SetWebContentsDebuggingEnabled(enabled: true);
 
-			if (aWebView.Settings != null)
+			if (blazorAndroidWebView.Settings != null)
 			{
-				aWebView.Settings.JavaScriptEnabled = true;
-				aWebView.Settings.DomStorageEnabled = true;
+				blazorAndroidWebView.Settings.JavaScriptEnabled = true;
+				blazorAndroidWebView.Settings.DomStorageEnabled = true;
 			}
 
 			_webViewClient = GetWebViewClient();
-			aWebView.SetWebViewClient(_webViewClient);
+			blazorAndroidWebView.SetWebViewClient(_webViewClient);
 
 			_webChromeClient = GetWebChromeClient();
-			aWebView.SetWebChromeClient(_webChromeClient);
+			blazorAndroidWebView.SetWebChromeClient(_webChromeClient);
 
-			return aWebView;
+			return blazorAndroidWebView;
 		}
 
-		protected override void DisconnectHandler(AWebView nativeView)
+		protected override void DisconnectHandler(BlazorAndroidWebView nativeView)
 		{
 			nativeView.StopLoading();
 


### PR DESCRIPTION
Currently, hitting the Android `Back` button within a WebView will take you back to the main page of the app regardless of how 'deep' you've navigated within the WebView. This change will allow navigation within the WebView stack before returning to the main page of the app.
 

Fixes: #3385