### PR TITLE
Improve consistency with resizetizer

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -279,12 +279,14 @@
 
     <Target Name="ProcessMauiAssets">
         <PropertyGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWindowsAppSdk)' == 'True'">
-            <_MauiAssetFolderName>Assets</_MauiAssetFolderName>
             <_MauiAssetItemMetadata>TargetPath</_MauiAssetItemMetadata>
         </PropertyGroup>
+        <ItemGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWindowsAppSdk)' == 'True'">
+            <!-- Windows does not recognize %(LogicalName), so we must copy it to %(Link) -->
+            <MauiAsset Update="@(MauiAsset)" Link="%(MauiAsset.LogicalName)" Condition="'%(MauiAsset.Link)' == '' And '%(MauiAsset.LogicalName)' != ''" />
+        </ItemGroup>
         <GetMauiAssetPath
             ProjectDirectory="$(MSBuildProjectDirectory)"
-            FolderName="$(_MauiAssetFolderName)"
             ItemMetadata="$(_MauiAssetItemMetadata)"
             Input="@(MauiAsset)">
             <Output ItemName="AndroidAsset"          TaskParameter="Output" Condition="'$(_ResizetizerIsAndroidApp)' == 'True'" />
@@ -341,7 +343,7 @@
         <ItemGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWindowsAppSdk)' == 'True'">
             <_MauiSplashAssets Include="$(_MauiIntermediateSplashScreen)**\*" />
             <ContentWithTargetPath Include="@(_MauiSplashAssets)">
-                <TargetPath>Assets\%(_MauiSplashAssets.Filename)%(_MauiSplashAssets.Extension)</TargetPath>
+                <TargetPath>%(_MauiSplashAssets.Filename)%(_MauiSplashAssets.Extension)</TargetPath>
             </ContentWithTargetPath>
             <FileWrites Include="@(_MauiSplashAssets)" />
         </ItemGroup>
@@ -410,7 +412,7 @@
         <ItemGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWindowsAppSdk)' == 'True'">
 
             <ContentWithTargetPath Include="@(_MauiFontCopied)" Condition="'@(_MauiFontCopied)' != ''">
-                <TargetPath>Assets\$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</TargetPath>
+                <TargetPath>$([System.IO.Path]::GetFileName(%(_MauiFontCopied.Identity)))</TargetPath>
             </ContentWithTargetPath>
 
         </ItemGroup>
@@ -521,7 +523,7 @@
         <!-- UWP / WinUI -->
         <ItemGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWindowsAppSdk)' == 'True'">
             <ContentWithTargetPath Include="@(_ResizetizerCollectedImages)">
-                <TargetPath>Assets\%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)</TargetPath>
+                <TargetPath>%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)</TargetPath>
             </ContentWithTargetPath>
 
             <FileWrites Include="@(_ResizetizerCollectedImages)" />

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					{
 						relativePath = _hostPageRelativePath;
 					}
-					relativePath = Path.Combine("Assets", _contentRootDir, relativePath.Replace("/", "\\"));
+					relativePath = Path.Combine(_contentRootDir, relativePath.Replace("/", "\\"));
 
 					var winUIItem = await Package.Current.InstalledLocation.TryGetItemAsync(relativePath);
 					if (winUIItem != null)

--- a/src/BlazorWebView/tests/MauiDeviceTests/Platforms/Windows/Package.appxmanifest
+++ b/src/BlazorWebView/tests/MauiDeviceTests/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>MAUI BlazorWebView Tests</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName="Core Tests"
         Description="Core Tests"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="Core Tests">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
+        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/Controls/samples/Controls.Sample.Profiling/App.xaml
+++ b/src/Controls/samples/Controls.Sample.Profiling/App.xaml
@@ -1,8 +1,6 @@
 ﻿<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:windows="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;assembly=Microsoft.Maui.Controls"
-             x:Class="Maui.Controls.Sample.Profiling.App"
-             windows:Application.ImageDirectory="Assets">
+             x:Class="Maui.Controls.Sample.Profiling.App">
     <Application.Resources>
         <ResourceDictionary>
 

--- a/src/Controls/samples/Controls.Sample.Sandbox/Platforms/Windows/Package.appxmanifest
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>.NET MAUI Controls</DisplayName>
     <PublisherDisplayName>.NET Foundation</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName=".NET MAUI Controls"
         Description=".NET MAUI Controls sample application"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="Single Project">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\dotnet_botSplashScreen.png" />
+        <uap:SplashScreen Image="dotnet_botSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/Controls/samples/Controls.Sample.SingleProject/Platforms/Windows/Package.appxmanifest
+++ b/src/Controls/samples/Controls.Sample.SingleProject/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>.NET MAUI Controls</DisplayName>
     <PublisherDisplayName>.NET Foundation</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName=".NET MAUI Controls"
         Description=".NET MAUI Controls sample application"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="Single Project">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\dotnet_botSplashScreen.png" />
+        <uap:SplashScreen Image="dotnet_botSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/Controls/samples/Controls.Sample/Resources/Raw/RawAsset.txt
+++ b/src/Controls/samples/Controls.Sample/Resources/Raw/RawAsset.txt
@@ -1,0 +1,1 @@
+﻿This is a raw MauiAsset file.

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml
@@ -2,10 +2,8 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:Maui.Controls.Sample"
-    xmlns:windows="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;assembly=Microsoft.Maui.Controls"
     xmlns:converters="clr-namespace:Controls.Sample.Converters"
-    x:Class="Maui.Controls.Sample.XamlApp"
-    windows:Application.ImageDirectory="Assets">
+    x:Class="Maui.Controls.Sample.XamlApp">
     <Application.Resources>
         <ResourceDictionary>
 

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using Maui.Controls.Sample.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Essentials;
 
 namespace Maui.Controls.Sample
 {
@@ -22,6 +24,23 @@ namespace Maui.Controls.Sample
 				// Respond to the theme change
 				Debug.WriteLine($"Requested theme changed: {args.RequestedTheme}");
 			};
+
+			LoadAsset();
+		}
+
+		async void LoadAsset()
+		{
+			try
+			{
+				using var stream = await FileSystem.OpenAppPackageFileAsync("RawAsset.txt");
+				using var reader = new StreamReader(stream);
+
+				Debug.WriteLine($"The raw Maui asset contents: '{reader.ReadToEnd().Trim()}'");
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Error loading the raw Maui asset contents: {ex}");
+			}
 		}
 
 		// Must not use MainPage for multi-window

--- a/src/Controls/tests/DeviceTests/Platforms/Windows/Package.appxmanifest
+++ b/src/Controls/tests/DeviceTests/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>Controls Tests</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName="Core Tests"
         Description="Core Tests"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="Core Tests">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
+        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/Core/src/Fonts/FontRegistrar.Windows.cs
+++ b/src/Core/src/Fonts/FontRegistrar.Windows.cs
@@ -9,7 +9,11 @@ namespace Microsoft.Maui
 		{
 			var root = global::Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
 
-			var packagePath = Path.Combine(root, "Assets", filename);
+			var packagePath = Path.Combine(root, filename);
+			if (File.Exists(packagePath))
+				return $"ms-appx:///{filename}";
+
+			packagePath = Path.Combine(root, "Assets", filename);
 			if (File.Exists(packagePath))
 				return $"ms-appx:///Assets/{filename}";
 

--- a/src/Core/src/Platform/Windows/Styles/NavigationRootViewStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/NavigationRootViewStyle.xaml
@@ -35,7 +35,7 @@
                                         x:Name="AppFontIcon"
                                         HorizontalAlignment="Left" 
                                         VerticalAlignment="Center"
-                                        Source="Assets/Square44x44Logo.png" 
+                                        Source="Square44x44Logo.png" 
                                         Width="16" 
                                         Height="16"/>
                                     <TextBlock 

--- a/src/Core/tests/DeviceTests/Platforms/Windows/Package.appxmanifest
+++ b/src/Core/tests/DeviceTests/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>Core Tests</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName="Core Tests"
         Description="Core Tests"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="Core Tests">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
+        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/Essentials/samples/Samples/Platforms/Windows/Package.appxmanifest
+++ b/src/Essentials/samples/Samples/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>Essentials</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName="Essentials"
         Description="Essentials"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="Essentials">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
+        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
         <uap:Extension Category="windows.protocol">

--- a/src/Essentials/src/AppActions/AppActions.uwp.cs
+++ b/src/Essentials/src/AppActions/AppActions.uwp.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Essentials
 	{
 		const string appActionPrefix = "XE_APP_ACTIONS-";
 
-		public static string IconDirectory { get; set; } = "Assets";
+		public static string IconDirectory { get; set; } = "";
 
 		public static string IconExtension { get; set; } = "png";
 
@@ -104,12 +104,14 @@ namespace Microsoft.Maui.Essentials
 			if (!string.IsNullOrEmpty(action.Icon))
 			{
 				var dir = IconDirectory.Trim('/', '\\').Replace('\\', '/');
+				if (!string.IsNullOrEmpty(dir))
+					dir += "/";
 
 				var ext = IconExtension;
 				if (!string.IsNullOrEmpty(ext) && !ext.StartsWith("."))
 					ext = "." + ext;
 
-				item.Logo = new Uri($"ms-appx:///{dir}/{action.Icon}{ext}");
+				item.Logo = new Uri($"ms-appx:///{dir}{action.Icon}{ext}");
 			}
 
 			return item;

--- a/src/Essentials/test/DeviceTests/Platforms/Windows/Package.appxmanifest
+++ b/src/Essentials/test/DeviceTests/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>Essentials Tests</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName="Essentials Tests"
         Description="Essentials Tests"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="Essentials Tests">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
+        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/SingleProject/Resizetizer/src/DpiPath.cs
+++ b/src/SingleProject/Resizetizer/src/DpiPath.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		public static class Windows
 		{
-			public const string OutputPath = "Assets";
+			public const string OutputPath = "";
 
 			public static DpiPath Original =>
 				new DpiPath(OutputPath, 1.0m, null, ".scale-100");

--- a/src/SingleProject/Resizetizer/src/GetMauiAssetPath.cs
+++ b/src/SingleProject/Resizetizer/src/GetMauiAssetPath.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Resizetizer
 		public string ProjectDirectory { get; set; }
 
 		/// <summary>
-		/// On Windows, 'Assets/' is prepended to the path
+		/// The name of any folders to prefix with
 		/// </summary>
 		public string FolderName { get; set; }
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/DpiPathTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/DpiPathTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[Theory]
 			[InlineData("android", "drawable")]
 			[InlineData("ios", "Resources")]
-			[InlineData("uwp", "Assets")]
+			[InlineData("uwp", "")]
 			[InlineData("wpf", "")]
 			public void ReturnsCorrectFolder(string platform, string folder)
 			{

--- a/src/SingleProject/Resizetizer/test/UnitTests/GenerateSplashAssetsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/GenerateSplashAssetsTests.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			var success = task.Execute();
 			Assert.True(success, $"{task.GetType()}.Execute() failed.");
 
-			AssertFile($"Assets/{image}SplashScreen.scale-100.png", 620, 300);
-			AssertFile($"Assets/{image}SplashScreen.scale-125.png", 775, 375);
-			AssertFile($"Assets/{image}SplashScreen.scale-200.png", 1240, 600);
+			AssertFile($"{image}SplashScreen.scale-100.png", 620, 300);
+			AssertFile($"{image}SplashScreen.scale-125.png", 775, 375);
+			AssertFile($"{image}SplashScreen.scale-200.png", 1240, 600);
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -943,8 +943,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success);
 
-				AssertFileSize("Assets/camera.scale-100.png", 1792, 1792);
-				AssertFileSize("Assets/camera.scale-200.png", 3584, 3584);
+				AssertFileSize("camera.scale-100.png", 1792, 1792);
+				AssertFileSize("camera.scale-200.png", 3584, 3584);
 			}
 
 			[Fact]
@@ -960,11 +960,11 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success);
 
-				AssertFileSize("Assets/camera.scale-100.png", 1792, 1792);
-				AssertFileSize("Assets/camera_color.scale-100.png", 256, 256);
+				AssertFileSize("camera.scale-100.png", 1792, 1792);
+				AssertFileSize("camera_color.scale-100.png", 256, 256);
 
-				AssertFileSize("Assets/camera.scale-200.png", 3584, 3584);
-				AssertFileSize("Assets/camera_color.scale-200.png", 512, 512);
+				AssertFileSize("camera.scale-200.png", 3584, 3584);
+				AssertFileSize("camera_color.scale-200.png", 512, 512);
 			}
 
 			[Fact]
@@ -983,11 +983,11 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				Assert.Equal(items.Length * DpiPath.Windows.Image.Length, copied.Length);
 
 				var mdpi = GetCopiedResource(task, "camera.scale-100.png");
-				Assert.Equal("Assets", mdpi.GetMetadata("_ResizetizerDpiPath"));
+				Assert.Equal("", mdpi.GetMetadata("_ResizetizerDpiPath"));
 				Assert.Equal("1.0", mdpi.GetMetadata("_ResizetizerDpiScale"));
 
 				var xhdpi = GetCopiedResource(task, "camera.scale-200.png");
-				Assert.Equal("Assets", xhdpi.GetMetadata("_ResizetizerDpiPath"));
+				Assert.Equal("", xhdpi.GetMetadata("_ResizetizerDpiPath"));
 				Assert.Equal("2.0", xhdpi.GetMetadata("_ResizetizerDpiScale"));
 			}
 
@@ -1008,19 +1008,19 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				Assert.Equal(items.Length * DpiPath.Windows.Image.Length, copied.Length);
 
 				var mdpi = GetCopiedResource(task, "camera.scale-100.png");
-				Assert.Equal("Assets", mdpi.GetMetadata("_ResizetizerDpiPath"));
+				Assert.Equal("", mdpi.GetMetadata("_ResizetizerDpiPath"));
 				Assert.Equal("1.0", mdpi.GetMetadata("_ResizetizerDpiScale"));
 
 				var xhdpi = GetCopiedResource(task, "camera.scale-200.png");
-				Assert.Equal("Assets", xhdpi.GetMetadata("_ResizetizerDpiPath"));
+				Assert.Equal("", xhdpi.GetMetadata("_ResizetizerDpiPath"));
 				Assert.Equal("2.0", xhdpi.GetMetadata("_ResizetizerDpiScale"));
 
 				mdpi = GetCopiedResource(task, "camera_color.scale-100.png");
-				Assert.Equal("Assets", mdpi.GetMetadata("_ResizetizerDpiPath"));
+				Assert.Equal("", mdpi.GetMetadata("_ResizetizerDpiPath"));
 				Assert.Equal("1.0", mdpi.GetMetadata("_ResizetizerDpiScale"));
 
 				xhdpi = GetCopiedResource(task, "camera_color.scale-200.png");
-				Assert.Equal("Assets", xhdpi.GetMetadata("_ResizetizerDpiPath"));
+				Assert.Equal("", xhdpi.GetMetadata("_ResizetizerDpiPath"));
 				Assert.Equal("2.0", xhdpi.GetMetadata("_ResizetizerDpiScale"));
 			}
 
@@ -1048,8 +1048,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success);
 
-				AssertFileSize($"Assets/{outputName}.scale-100.png", 44, 44);
-				AssertFileSize($"Assets/{outputName}.scale-200.png", 88, 88);
+				AssertFileSize($"{outputName}.scale-100.png", 44, 44);
+				AssertFileSize($"{outputName}.scale-200.png", 88, 88);
 			}
 
 			[Theory]
@@ -1084,15 +1084,15 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success);
 
-				AssertFileSize($"Assets/{outputName}Logo.scale-100.png", 44, 44);
-				AssertFileSize($"Assets/{outputName}Logo.scale-125.png", 55, 55);
-				AssertFileSize($"Assets/{outputName}Logo.scale-200.png", 88, 88);
+				AssertFileSize($"{outputName}Logo.scale-100.png", 44, 44);
+				AssertFileSize($"{outputName}Logo.scale-125.png", 55, 55);
+				AssertFileSize($"{outputName}Logo.scale-200.png", 88, 88);
 
-				AssertFileSize($"Assets/{outputName}StoreLogo.scale-100.png", 50, 50);
-				AssertFileSize($"Assets/{outputName}StoreLogo.scale-200.png", 100, 100);
+				AssertFileSize($"{outputName}StoreLogo.scale-100.png", 50, 50);
+				AssertFileSize($"{outputName}StoreLogo.scale-200.png", 100, 100);
 
-				AssertFileSize($"Assets/{outputName}MediumTile.scale-100.png", 150, 150);
-				AssertFileSize($"Assets/{outputName}MediumTile.scale-150.png", 225, 225);
+				AssertFileSize($"{outputName}MediumTile.scale-100.png", 150, 150);
+				AssertFileSize($"{outputName}MediumTile.scale-150.png", 225, 225);
 			}
 
 			[Theory]
@@ -1135,15 +1135,15 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success);
 
-				AssertFileSize($"Assets/{outputName}Logo.scale-100.png", 44, 44);
-				AssertFileSize($"Assets/{outputName}Logo.scale-125.png", 55, 55);
-				AssertFileSize($"Assets/{outputName}Logo.scale-200.png", 88, 88);
+				AssertFileSize($"{outputName}Logo.scale-100.png", 44, 44);
+				AssertFileSize($"{outputName}Logo.scale-125.png", 55, 55);
+				AssertFileSize($"{outputName}Logo.scale-200.png", 88, 88);
 
-				AssertFileSize($"Assets/{outputName}StoreLogo.scale-100.png", 50, 50);
-				AssertFileSize($"Assets/{outputName}StoreLogo.scale-200.png", 100, 100);
+				AssertFileSize($"{outputName}StoreLogo.scale-100.png", 50, 50);
+				AssertFileSize($"{outputName}StoreLogo.scale-200.png", 100, 100);
 
-				AssertFileSize($"Assets/{outputName}MediumTile.scale-100.png", 150, 150);
-				AssertFileSize($"Assets/{outputName}MediumTile.scale-150.png", 225, 225);
+				AssertFileSize($"{outputName}MediumTile.scale-100.png", 150, 150);
+				AssertFileSize($"{outputName}MediumTile.scale-150.png", 225, 225);
 			}
 
 			[Theory]
@@ -1164,18 +1164,18 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success);
 
-				AssertFileSize($"Assets/{bg}Logo.scale-100.png", 44, 44);
-				AssertFileSize($"Assets/{bg}Logo.scale-125.png", 55, 55);
-				AssertFileSize($"Assets/{bg}Logo.scale-200.png", 88, 88);
+				AssertFileSize($"{bg}Logo.scale-100.png", 44, 44);
+				AssertFileSize($"{bg}Logo.scale-125.png", 55, 55);
+				AssertFileSize($"{bg}Logo.scale-200.png", 88, 88);
 
-				AssertFileSize($"Assets/{bg}StoreLogo.scale-100.png", 50, 50);
-				AssertFileSize($"Assets/{bg}StoreLogo.scale-200.png", 100, 100);
+				AssertFileSize($"{bg}StoreLogo.scale-100.png", 50, 50);
+				AssertFileSize($"{bg}StoreLogo.scale-200.png", 100, 100);
 
-				AssertFileSize($"Assets/{bg}MediumTile.scale-100.png", 150, 150);
-				AssertFileSize($"Assets/{bg}MediumTile.scale-150.png", 225, 225);
+				AssertFileSize($"{bg}MediumTile.scale-100.png", 150, 150);
+				AssertFileSize($"{bg}MediumTile.scale-150.png", 225, 225);
 
-				AssertFileSize($"Assets/{bg}WideTile.scale-100.png", 310, 150);
-				AssertFileSize($"Assets/{bg}WideTile.scale-200.png", 620, 300);
+				AssertFileSize($"{bg}WideTile.scale-100.png", 310, 150);
+				AssertFileSize($"{bg}WideTile.scale-200.png", 620, 300);
 			}
 		}
 	}

--- a/src/Templates/src/templates/maui-blazor/App.xaml
+++ b/src/Templates/src/templates/maui-blazor/App.xaml
@@ -1,9 +1,7 @@
 ﻿<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:windows="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;assembly=Microsoft.Maui.Controls"
              xmlns:local="clr-namespace:MauiApp._1"
-             x:Class="MauiApp._1.App"
-             windows:Application.ImageDirectory="Assets">
+             x:Class="MauiApp._1.App">
     <Application.Resources>
         <ResourceDictionary>
 

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -45,6 +45,9 @@
 
 		<!-- Custom Fonts -->
 		<MauiFont Include="Resources\Fonts\*" />
+
+		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">

--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>MauiApp.1</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName="MauiApp.1"
         Description="MauiApp.1"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="MauiApp.1">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
+        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/Templates/src/templates/maui-blazor/Resources/Raw/AboutAssets.txt
+++ b/src/Templates/src/templates/maui-blazor/Resources/Raw/AboutAssets.txt
@@ -1,0 +1,14 @@
+﻿Any raw assets you want to be deployed with your application can be placed in
+this directory (and child directories) and given a Build Action of "MauiAsset":
+
+	<MauiAsset Include="AboutAssets.txt" />
+
+These files will be deployed with you package and will be accessible using Essentials:
+
+	async Task LoadMauiAsset()
+	{
+		using var stream = await FileSystem.OpenAppPackageFileAsync("AboutAssets.txt");
+		using var reader = new StreamReader(stream);
+
+		var contents = reader.ReadToEnd();
+	}

--- a/src/Templates/src/templates/maui-mobile/App.xaml
+++ b/src/Templates/src/templates/maui-mobile/App.xaml
@@ -1,9 +1,7 @@
 ﻿<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:windows="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;assembly=Microsoft.Maui.Controls"
              xmlns:local="clr-namespace:MauiApp._1"
-             x:Class="MauiApp._1.App"
-             windows:Application.ImageDirectory="Assets">
+             x:Class="MauiApp._1.App">
     <Application.Resources>
         <ResourceDictionary>
 

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -9,7 +9,7 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
-    
+
 		<!-- Display name -->
 		<ApplicationTitle>MauiApp.1</ApplicationTitle>
 
@@ -41,6 +41,9 @@
 
 		<!-- Custom Fonts -->
 		<MauiFont Include="Resources\Fonts\*" />
+
+		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>MauiApp.1</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName="MauiApp.1"
         Description="MauiApp.1"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="MauiApp.1">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
+        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/Templates/src/templates/maui-mobile/Resources/Raw/AboutAssets.txt
+++ b/src/Templates/src/templates/maui-mobile/Resources/Raw/AboutAssets.txt
@@ -1,0 +1,14 @@
+﻿Any raw assets you want to be deployed with your application can be placed in
+this directory (and child directories) and given a Build Action of "MauiAsset":
+
+	<MauiAsset Include="AboutAssets.txt" />
+
+These files will be deployed with you package and will be accessible using Essentials:
+
+	async Task LoadMauiAsset()
+	{
+		using var stream = await FileSystem.OpenAppPackageFileAsync("AboutAssets.txt");
+		using var reader = new StreamReader(stream);
+
+		var contents = reader.ReadToEnd();
+	}

--- a/src/TestUtils/samples/DeviceTests.Sample/Platforms/Windows/Package.appxmanifest
+++ b/src/TestUtils/samples/DeviceTests.Sample/Platforms/Windows/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Properties>
     <DisplayName>Tests Sample</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>
-    <Logo>Assets\appiconStoreLogo.png</Logo>
+    <Logo>appiconStoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -34,19 +34,19 @@
         DisplayName="Tests Sample"
         Description="Tests Sample"
         BackgroundColor="transparent"
-        Square150x150Logo="Assets\appiconMediumTile.png"
-        Square44x44Logo="Assets\appiconLogo.png">
+        Square150x150Logo="appiconMediumTile.png"
+        Square44x44Logo="appiconLogo.png">
         <uap:DefaultTile
-          Wide310x150Logo="Assets\appiconWideTile.png"
-          Square71x71Logo="Assets\appiconSmallTile.png"
-          Square310x310Logo="Assets\appiconLargeTile.png"
+          Wide310x150Logo="appiconWideTile.png"
+          Square71x71Logo="appiconSmallTile.png"
+          Square310x310Logo="appiconLargeTile.png"
           ShortName="Tests Sample">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
           </uap:ShowNameOnTiles>
         </uap:DefaultTile >
-        <uap:SplashScreen Image="Assets\appiconfgSplashScreen.png" />
+        <uap:SplashScreen Image="appiconfgSplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/MauiVisualRunnerApp.xaml
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/MauiVisualRunnerApp.xaml
@@ -1,9 +1,7 @@
 ﻿<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="using:Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner"
-             xmlns:windows="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;assembly=Microsoft.Maui.Controls"
-             x:Class="Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner.MauiVisualRunnerApp"
-             windows:Application.ImageDirectory="Assets">
+             x:Class="Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner.MauiVisualRunnerApp">
     <Application.Resources>
         <ResourceDictionary>
 


### PR DESCRIPTION
**WINDOWS BREAKING CHANGE** (see below)

### Description of Change ###

Currently, certain parts of resizetizer are inconsistent across platforms, mainly Windows:
 - Windows injects an "Assets" folder in the app package for all resource types
 - Windows does not respect the LogicalName attribute on MauiAssets
 - Accessing the assets via Essentials's `FileSystem.OpenAppPackageFileAsync` still required a `#if WINDOWS` 

This PR attempts to fix #3270

> **WINDOWS BREAKING CHANGE**
> This change _does_ have a breaking change for Windows where all assets are now no longer in the "Assets" folder. This may require XAML, C# and/or logic changes. However, in most cases, this is more to _remove_ special code than to write new code. 

After this PR, you will be able to do this:

Assume there is a asset added:

| .csproj | On Disk | In App |
| :- | :- | :- |
| `<MauiAsset Include="MyAsset.txt" />` | /MyAsset.txt | /MyAsset.txt |
| `<MauiAsset Include="MyAsset.txt" LogicalName="YourAsset.md" />` | /MyAsset.txt | /YourAsset.md |
| `<MauiAsset Include="Resources\MyAsset.txt" LogicalName="YourAsset.md" />` * | /MyAsset.txt | /YourAsset.md |
| `<MauiAsset Include="Assets\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />` ** | /Assets/* | /* |

Notes:

\* Without the LogicalName, this will fail to build on iOS because the "Resources" root folder is illegal
 \** Wildcards can be used to move an entire subfolder to the root of the app package

Since all the files go into predictable locations for all platforms, Essentials can be used to read files:

```cs
async Task LoadMauiAsset()
{
	using var stream = await FileSystem.OpenAppPackageFileAsync("AboutAssets.txt");
	using var reader = new StreamReader(stream);

	var contents = reader.ReadToEnd();
}
```


### Additions made ###

* Assets processed by resizetizer (images, icons, fonts and raw assets) are no longer forced into an "Assets" sub folder in the Windows app package
* The `LogicalName` can *optionally* be used to control where in the app the asset will go  
  One reason for this is that often the folder name of "Resources" is used to contain resources, but this may not be desirable in the app package for a few reasons:
   1. iOS/Mac Catalyst forbids the usage of "Resources" as a root folder name in the app packages
   2. Adding a prefix of "Resources/" to every request for a resource from the resource location is very verbose

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
