### PR TITLE
[Housekeeping] Add pending events in iOS DatePickerHandler and TimePickerHandler

### DIFF
--- a/src/Compatibility/Core/src/iOS/Renderers/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/DatePickerRenderer.cs
@@ -158,11 +158,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			}
 		}
 
+		[PortHandler]
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 
+		[PortHandler]
 		void OnStarted(object sender, EventArgs eventArgs)
 		{
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);

--- a/src/Compatibility/Core/src/iOS/Renderers/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/TimePickerRenderer.cs
@@ -156,16 +156,19 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				UpdateFlowDirection();
 		}
 
+		[PortHandler]
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 
+		[PortHandler]
 		void OnStarted(object sender, EventArgs eventArgs)
 		{
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 		}
 
+		[PortHandler]
 		void OnValueChanged(object sender, EventArgs e)
 		{
 			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.Immediately)

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
@@ -52,7 +52,11 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiDatePicker nativeView)
 		{
 			if (_picker != null)
+			{
+				_picker.EditingDidBegin += OnStarted;
+				_picker.EditingDidEnd += OnEnded;
 				_picker.ValueChanged += OnValueChanged;
+			}
 
 			base.ConnectHandler(nativeView);
 		}
@@ -60,7 +64,11 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(MauiDatePicker nativeView)
 		{
 			if (_picker != null)
+			{
+				_picker.EditingDidBegin -= OnStarted;
+				_picker.EditingDidEnd -= OnEnded;
 				_picker.ValueChanged -= OnValueChanged;
+			}
 
 			base.DisconnectHandler(nativeView);
 		}
@@ -105,6 +113,16 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextColor(DatePickerHandler handler, IDatePicker datePicker)
 		{
 			handler.NativeView?.UpdateTextColor(datePicker, handler._defaultTextColor);
+		}
+
+		void OnStarted(object? sender, EventArgs eventArgs)
+		{
+			// TODO: Update IsFocused property
+		}
+
+		void OnEnded(object? sender, EventArgs eventArgs)
+		{
+			// TODO: Update IsFocused property
 		}
 
 		void OnValueChanged(object? sender, EventArgs? e)

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
@@ -22,7 +22,11 @@ namespace Microsoft.Maui.Handlers
 			base.ConnectHandler(nativeView);
 
 			if (nativeView != null)
+			{
+				nativeView.EditingDidBegin += OnStarted;
+				nativeView.EditingDidEnd += OnEnded;
 				nativeView.ValueChanged += OnValueChanged;
+			}
 		}
 
 		protected override void DisconnectHandler(MauiTimePicker nativeView)
@@ -32,6 +36,8 @@ namespace Microsoft.Maui.Handlers
 			if (nativeView != null)
 			{
 				nativeView.RemoveFromSuperview();
+				nativeView.EditingDidBegin -= OnStarted;
+				nativeView.EditingDidEnd -= OnEnded;
 				nativeView.ValueChanged -= OnValueChanged;
 				nativeView.Dispose();
 			}
@@ -67,6 +73,16 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextColor(TimePickerHandler handler, ITimePicker timePicker)
 		{
 			handler.NativeView?.UpdateTextColor(timePicker, DefaultTextColor);
+		}
+
+		void OnStarted(object? sender, EventArgs eventArgs)
+		{
+			// TODO: Update IsFocused property
+		}
+
+		void OnEnded(object? sender, EventArgs eventArgs)
+		{
+			// TODO: Update IsFocused property
 		}
 
 		void OnValueChanged(object? sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

Add pending events in DatePickerHandler and TimePickerHandler. The main goal is to have TODOs to take into account after implementing the IsFocused property. 

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No