### PR TITLE
Update api-tools to support roll-forward

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "api-tools": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "commands": [
         "api-tools"
       ]


### PR DESCRIPTION
### Description of Change ###

The old tool did not roll forward to net6, and thus would not run on net6-only machines.