### PR TITLE
[iOS] Use GetWrappedView to get the native view

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var size = ConstrainedSize == default ? Measure() : ConstrainedSize;
 
 			// Update the size of the root view to accommodate the Forms element
-			var nativeView = NativeHandler.NativeView;
+			var nativeView = NativeHandler.GetWrappedNativeView();
 			nativeView.Frame = new CGRect(CGPoint.Empty, size);
 
 			// Layout the Maui element 
@@ -164,7 +164,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void SetRenderer(INativeViewHandler renderer)
 		{
 			NativeHandler = renderer;
-			var nativeView = NativeHandler.NativeView;
+
+			var nativeView = NativeHandler.GetWrappedNativeView();
 
 			// Clear out any old views if this cell is being reused
 			ClearSubviews();
@@ -176,7 +177,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected void Layout(CGSize constraints)
 		{
-			var nativeView = NativeHandler.NativeView;
+			var nativeView = NativeHandler.GetWrappedNativeView();
 
 			var width = constraints.Width;
 			var height = constraints.Height;


### PR DESCRIPTION
### Description of Change ###

Fixes NRE on some cases using CollectionView. We now are grabbing the NativeView or it's wrapper to add as child of TemplatedCell.

To test use the `TemplateCodeCollectionViewGallery` replace the itemTemplate to be `ExampleTemplates.CarouselTemplate()`, that use a template that uses Frame. 

related #4366 

### Additions made ###

None


### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
