### PR TITLE
Switches to UIResponder for App/Scene delegates

### DIFF
--- a/src/Core/src/Handlers/Application/ApplicationHandler.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.cs
@@ -2,7 +2,7 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 #if __IOS__ || MACCATALYST
-using NativeView = UIKit.UIApplicationDelegate;
+using NativeView = UIKit.IUIApplicationDelegate;
 #elif MONOANDROID
 using NativeView = Android.App.Application;
 #elif WINDOWS

--- a/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.iOS.cs
@@ -7,7 +7,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ApplicationHandler : ElementHandler<IApplication, UIApplicationDelegate>
+	public partial class ApplicationHandler : ElementHandler<IApplication, IUIApplicationDelegate>
 	{
 		public static void MapTerminate(ApplicationHandler handler, IApplication application, object? args)
 		{

--- a/src/Core/src/MauiContextExtensions.cs
+++ b/src/Core/src/MauiContextExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Hosting;
 using NativeApplication = Microsoft.UI.Xaml.Application;
 using NativeWindow = Microsoft.UI.Xaml.Window;
 #elif __IOS__ || __MACCATALYST__
-using NativeApplication = UIKit.UIApplicationDelegate;
+using NativeApplication = UIKit.IUIApplicationDelegate;
 using NativeWindow = UIKit.UIWindow;
 #elif __ANDROID__
 using NativeApplication = Android.App.Application;

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 #if __IOS__ || MACCATALYST
 using NativeView = UIKit.UIView;
-using BasePlatformType = Foundation.NSObject;
+using BasePlatformType = ObjCRuntime.INativeObject;
 using PlatformWindow = UIKit.UIWindow;
-using PlatformApplication = UIKit.UIApplicationDelegate;
+using PlatformApplication = UIKit.IUIApplicationDelegate;
 #elif MONOANDROID
 using NativeView = Android.Views.View;
 using BasePlatformType = Android.Content.Context;

--- a/src/Core/src/Platform/iOS/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/iOS/ApplicationExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Platform
 {
 	public static class ApplicationExtensions
 	{
-		public static void RequestNewWindow(this UIApplicationDelegate nativeApplication, IApplication application, OpenWindowRequest? args)
+		public static void RequestNewWindow(this IUIApplicationDelegate nativeApplication, IApplication application, OpenWindowRequest? args)
 		{
 			if (application.Handler?.MauiContext is not IMauiContext applicationContext || args is null)
 				return;
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Platform
 				err => application.Handler?.MauiContext?.CreateLogger<IApplication>()?.LogError(new NSErrorException(err), err.Description));
 		}
 
-		public static void CreateNativeWindow(this UIApplicationDelegate nativeApplication, IApplication application, UIApplication uiApplication, NSDictionary launchOptions)
+		public static void CreateNativeWindow(this IUIApplicationDelegate nativeApplication, IApplication application, UIApplication uiApplication, NSDictionary launchOptions)
 		{
 			// Find any userinfo/dictionaries we might pass into the activation state
 			var dicts = new List<NSDictionary>();
@@ -35,14 +35,14 @@ namespace Microsoft.Maui.Platform
 				dicts.Add(launchOptions);
 
 			var window = CreateNativeWindow(application, null, dicts.ToArray());
-			if (window is not null)
+			if (window is not null && nativeApplication is UIApplicationDelegate nativeAppDelegate)
 			{
-				nativeApplication.Window = window;
-				nativeApplication.Window.MakeKeyAndVisible();
+				nativeAppDelegate.Window = window;
+				nativeAppDelegate.Window?.MakeKeyAndVisible();
 			}
 		}
 
-		public static void CreateNativeWindow(this UIWindowSceneDelegate sceneDelegate, IApplication application, UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
+		public static void CreateNativeWindow(this IUIWindowSceneDelegate sceneDelegate, IApplication application, UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
 		{
 			// Find any userinfo/dictionaries we might pass into the activation state
 			var dicts = new List<NSDictionary>();
@@ -62,10 +62,10 @@ namespace Microsoft.Maui.Platform
 			}
 
 			var window = CreateNativeWindow(application, scene as UIWindowScene, dicts.ToArray());
-			if (window is not null)
+			if (window is not null && sceneDelegate is UIWindowSceneDelegate windowSceneDelegate)
 			{
-				sceneDelegate.Window = window;
-				sceneDelegate.Window.MakeKeyAndVisible();
+				windowSceneDelegate.Window = window;
+				windowSceneDelegate.Window?.MakeKeyAndVisible();
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/iOS/ApplicationExtensions.cs
@@ -35,10 +35,10 @@ namespace Microsoft.Maui.Platform
 				dicts.Add(launchOptions);
 
 			var window = CreateNativeWindow(application, null, dicts.ToArray());
-			if (window is not null && nativeApplication is UIApplicationDelegate nativeAppDelegate)
+			if (window is not null)
 			{
-				nativeAppDelegate.Window = window;
-				nativeAppDelegate.Window?.MakeKeyAndVisible();
+				nativeApplication.SetWindow(window);
+				nativeApplication.GetWindow()?.MakeKeyAndVisible();
 			}
 		}
 
@@ -62,10 +62,10 @@ namespace Microsoft.Maui.Platform
 			}
 
 			var window = CreateNativeWindow(application, scene as UIWindowScene, dicts.ToArray());
-			if (window is not null && sceneDelegate is UIWindowSceneDelegate windowSceneDelegate)
+			if (window is not null)
 			{
-				windowSceneDelegate.Window = window;
-				windowSceneDelegate.Window?.MakeKeyAndVisible();
+				sceneDelegate.SetWindow(window);
+				sceneDelegate.GetWindow()?.MakeKeyAndVisible();
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/ElementExtensions.cs
+++ b/src/Core/src/Platform/iOS/ElementExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Platform
 
 		// If < iOS 13 or the Info.plist does not have a scene manifest entry we need to assume no multi window, and no UISceneDelegate.
 		// We cannot check for iPads/Mac because even on the iPhone it uses the scene delegate if one is specified in the manifest.
-		public static bool HasSceneManifest(this UIApplicationDelegate nativeApplication) =>
+		public static bool HasSceneManifest(this IUIApplicationDelegate nativeApplication) =>
 			UIDevice.CurrentDevice.CheckSystemVersion(13, 0) &&
 			NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString(UIApplicationSceneManifestKey));
 	}

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -8,14 +8,14 @@ using UIKit;
 
 namespace Microsoft.Maui
 {
-	public abstract class MauiUIApplicationDelegate : UIApplicationDelegate, IUIApplicationDelegate, IPlatformApplication
+	public abstract class MauiUIApplicationDelegate : UIResponder, IUIApplicationDelegate, IPlatformApplication
 	{
 		internal const string MauiSceneConfigurationKey = "__MAUI_DEFAULT_SCENE_CONFIGURATION__";
 		internal const string GetConfigurationSelectorName = "application:configurationForConnectingSceneSession:options:";
 
 		IMauiContext _applicationContext = null!;
 
-		protected MauiUIApplicationDelegate()
+		protected MauiUIApplicationDelegate() : base()
 		{
 			Current = this;
 			IPlatformApplication.Current = this;
@@ -23,7 +23,8 @@ namespace Microsoft.Maui
 
 		protected abstract MauiApp CreateMauiApp();
 
-		public override bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions)
+		[Export("application:willFinishLaunchingWithOptions:")]
+		public bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions)
 		{
 			var mauiApp = CreateMauiApp();
 
@@ -38,7 +39,8 @@ namespace Microsoft.Maui
 			return true;
 		}
 
-		public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+		[Export("application:didFinishLaunchingWithOptions:")]
+		public bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 		{
 			Application = Services.GetRequiredService<IApplication>();
 
@@ -62,15 +64,18 @@ namespace Microsoft.Maui
 			return base.RespondsToSelector(sel);
 		}
 
-		public override UISceneConfiguration GetConfiguration(UIApplication application, UISceneSession connectingSceneSession, UISceneConnectionOptions options)
+		[Export("application:configurationForConnectingSceneSession:options:")]
+		public UISceneConfiguration GetConfiguration(UIApplication application, UISceneSession connectingSceneSession, UISceneConnectionOptions options)
 			=> new(MauiUIApplicationDelegate.MauiSceneConfigurationKey, connectingSceneSession.Role);
 
-		public override void PerformActionForShortcutItem(UIApplication application, UIApplicationShortcutItem shortcutItem, UIOperationHandler completionHandler)
+		[Export("application:performActionForShortcutItem:completionHandler:")]
+		public void PerformActionForShortcutItem(UIApplication application, UIApplicationShortcutItem shortcutItem, UIOperationHandler completionHandler)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.PerformActionForShortcutItem>(del => del(application, shortcutItem, completionHandler));
 		}
 
-		public override bool OpenUrl(UIApplication application, NSUrl url, NSDictionary options)
+		[Export("application:openURL:options:")]
+		public bool OpenUrl(UIApplication application, NSUrl url, NSDictionary options)
 		{
 			var wasHandled = false;
 
@@ -79,10 +84,11 @@ namespace Microsoft.Maui
 				wasHandled = del(application, url, options) || wasHandled;
 			});
 
-			return wasHandled || base.OpenUrl(application, url, options);
+			return wasHandled;
 		}
 
-		public override bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler)
+		[Export("application:continueUserActivity:restorationHandler:")]
+		public bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler)
 		{
 			var wasHandled = false;
 
@@ -91,37 +97,43 @@ namespace Microsoft.Maui
 				wasHandled = del(application, userActivity, completionHandler) || wasHandled;
 			});
 
-			return wasHandled || base.ContinueUserActivity(application, userActivity, completionHandler);
+			return wasHandled;
 		}
 
-		public override void OnActivated(UIApplication application)
+		[Export("applicationDidBecomeActive:")]
+		public void OnActivated(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.OnActivated>(del => del(application));
 		}
 
-		public override void OnResignActivation(UIApplication application)
+		[Export("applicationWillResignActive:")]
+		public void OnResignActivation(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.OnResignActivation>(del => del(application));
 		}
 
-		public override void WillTerminate(UIApplication application)
+		[Export("applicationWillTerminate:")]
+		public void WillTerminate(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.WillTerminate>(del => del(application));
 		}
 
-		public override void DidEnterBackground(UIApplication application)
+		[Export("applicationDidEnterBackground:")]
+		public void DidEnterBackground(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.DidEnterBackground>(del => del(application));
 		}
 
-		public override void WillEnterForeground(UIApplication application)
+		[Export("applicationWillEnterForeground:")]
+		public void WillEnterForeground(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.WillEnterForeground>(del => del(application));
 		}
 
 		public static MauiUIApplicationDelegate Current { get; private set; } = null!;
 
-		public override UIWindow? Window { get; set; }
+		[Export("window")]
+		public UIWindow? Window { get; set; }
 
 		public IServiceProvider Services { get; protected set; } = null!;
 

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui
 		protected abstract MauiApp CreateMauiApp();
 
 		[Export("application:willFinishLaunchingWithOptions:")]
-		public bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions)
+		public virtual bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions)
 		{
 			var mauiApp = CreateMauiApp();
 
@@ -40,7 +40,7 @@ namespace Microsoft.Maui
 		}
 
 		[Export("application:didFinishLaunchingWithOptions:")]
-		public bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+		public virtual bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 		{
 			Application = Services.GetRequiredService<IApplication>();
 
@@ -65,17 +65,17 @@ namespace Microsoft.Maui
 		}
 
 		[Export("application:configurationForConnectingSceneSession:options:")]
-		public UISceneConfiguration GetConfiguration(UIApplication application, UISceneSession connectingSceneSession, UISceneConnectionOptions options)
+		public virtual UISceneConfiguration GetConfiguration(UIApplication application, UISceneSession connectingSceneSession, UISceneConnectionOptions options)
 			=> new(MauiUIApplicationDelegate.MauiSceneConfigurationKey, connectingSceneSession.Role);
 
 		[Export("application:performActionForShortcutItem:completionHandler:")]
-		public void PerformActionForShortcutItem(UIApplication application, UIApplicationShortcutItem shortcutItem, UIOperationHandler completionHandler)
+		public virtual void PerformActionForShortcutItem(UIApplication application, UIApplicationShortcutItem shortcutItem, UIOperationHandler completionHandler)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.PerformActionForShortcutItem>(del => del(application, shortcutItem, completionHandler));
 		}
 
 		[Export("application:openURL:options:")]
-		public bool OpenUrl(UIApplication application, NSUrl url, NSDictionary options)
+		public virtual bool OpenUrl(UIApplication application, NSUrl url, NSDictionary options)
 		{
 			var wasHandled = false;
 
@@ -88,7 +88,7 @@ namespace Microsoft.Maui
 		}
 
 		[Export("application:continueUserActivity:restorationHandler:")]
-		public bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler)
+		public virtual bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity, UIApplicationRestorationHandler completionHandler)
 		{
 			var wasHandled = false;
 
@@ -101,31 +101,31 @@ namespace Microsoft.Maui
 		}
 
 		[Export("applicationDidBecomeActive:")]
-		public void OnActivated(UIApplication application)
+		public virtual void OnActivated(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.OnActivated>(del => del(application));
 		}
 
 		[Export("applicationWillResignActive:")]
-		public void OnResignActivation(UIApplication application)
+		public virtual void OnResignActivation(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.OnResignActivation>(del => del(application));
 		}
 
 		[Export("applicationWillTerminate:")]
-		public void WillTerminate(UIApplication application)
+		public virtual void WillTerminate(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.WillTerminate>(del => del(application));
 		}
 
 		[Export("applicationDidEnterBackground:")]
-		public void DidEnterBackground(UIApplication application)
+		public virtual void DidEnterBackground(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.DidEnterBackground>(del => del(application));
 		}
 
 		[Export("applicationWillEnterForeground:")]
-		public void WillEnterForeground(UIApplication application)
+		public virtual void WillEnterForeground(UIApplication application)
 		{
 			Services?.InvokeLifecycleEvents<iOSLifecycle.WillEnterForeground>(del => del(application));
 		}
@@ -133,7 +133,7 @@ namespace Microsoft.Maui
 		public static MauiUIApplicationDelegate Current { get; private set; } = null!;
 
 		[Export("window")]
-		public UIWindow? Window { get; set; }
+		public virtual UIWindow? Window { get; set; }
 
 		public IServiceProvider Services { get; protected set; } = null!;
 

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Maui
 	public class MauiUISceneDelegate : UIResponder, IUIWindowSceneDelegate
 	{
 		[Export("window")]
-		public UIWindow? Window { get; set; }
+		public virtual UIWindow? Window { get; set; }
 
 		[Export("scene:willConnectToSession:options:")]
-		public void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
+		public virtual void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
 		{
 			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneWillConnect>(del => del(scene, session, connectionOptions));
 
@@ -23,13 +23,13 @@ namespace Microsoft.Maui
 		}
 
 		[Export("sceneDidDisconnect:")]
-		public void DidDisconnect(UIScene scene)
+		public virtual void DidDisconnect(UIScene scene)
 		{
 			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneDidDisconnect>(del => del(scene));
 		}
 
 		[Export("stateRestorationActivityForScene:")]
-		public NSUserActivity? GetStateRestorationActivity(UIScene scene)
+		public virtual NSUserActivity? GetStateRestorationActivity(UIScene scene)
 		{
 			var window = Window.GetWindow();
 			if (window is null)

--- a/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUISceneDelegate.cs
@@ -6,11 +6,13 @@ using UIKit;
 
 namespace Microsoft.Maui
 {
-	public class MauiUISceneDelegate : UIWindowSceneDelegate
+	public class MauiUISceneDelegate : UIResponder, IUIWindowSceneDelegate
 	{
-		public override UIWindow? Window { get; set; }
+		[Export("window")]
+		public UIWindow? Window { get; set; }
 
-		public override void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
+		[Export("scene:willConnectToSession:options:")]
+		public void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
 		{
 			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneWillConnect>(del => del(scene, session, connectionOptions));
 
@@ -20,12 +22,14 @@ namespace Microsoft.Maui
 			}
 		}
 
-		public override void DidDisconnect(UIScene scene)
+		[Export("sceneDidDisconnect:")]
+		public void DidDisconnect(UIScene scene)
 		{
 			MauiUIApplicationDelegate.Current?.Services?.InvokeLifecycleEvents<iOSLifecycle.SceneDidDisconnect>(del => del(scene));
 		}
 
-		public override NSUserActivity? GetStateRestorationActivity(UIScene scene)
+		[Export("stateRestorationActivityForScene:")]
+		public NSUserActivity? GetStateRestorationActivity(UIScene scene)
 		{
 			var window = Window.GetWindow();
 			if (window is null)


### PR DESCRIPTION
This is the proper inheritence chain and allows us to use things like overriding the BuildMenu method.

This fixes #4390

