### PR TITLE
Remove Material Visual marker

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/PropagateCodeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/PropagateCodeGallery.cs
@@ -19,8 +19,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Star }
 				},
-				FlowDirection = FlowDirection.RightToLeft,
-				Visual = VisualMarker.Material
+				FlowDirection = FlowDirection.RightToLeft
 			};
 
 			var itemTemplate = ExampleTemplates.PropagationTemplate();

--- a/src/Controls/src/Core.Design/VisualDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/VisualDesignTypeConverter.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Maui.Controls.Design
 		}
 
 		protected override string[] KnownValues
-			=> new string[] { "Default", "Material" };
+			=> new string[] { "Default" /*, "Material" */ };
 	}
 }

--- a/src/Controls/src/Core/EffectiveVisualExtensions.cs
+++ b/src/Controls/src/Core/EffectiveVisualExtensions.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/EffectiveVisualExtensions.xml" path="//Member[@MemberName='IsMatchParent']/Docs" />
 		public static bool IsMatchParent(this IVisual visual) => visual == VisualMarker.MatchParent;
 		/// <include file="../../docs/Microsoft.Maui.Controls/EffectiveVisualExtensions.xml" path="//Member[@MemberName='IsMaterial']/Docs" />
-		public static bool IsMaterial(this IVisual visual) => visual == VisualMarker.Material;
+		public static bool IsMaterial(this IVisual visual) => false; // visual == VisualMarker.Material;
 	}
 }

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Internals
 	{
 		readonly Dictionary<Type, Dictionary<Type, (Type target, short priority)>> _handlers = new Dictionary<Type, Dictionary<Type, (Type target, short priority)>>();
 		static Type _defaultVisualType = typeof(VisualMarker.DefaultVisual);
-		static Type _materialVisualType = typeof(VisualMarker.MaterialVisual);
+		//static Type _materialVisualType = typeof(VisualMarker.MaterialVisual);
 
 		static Type[] _defaultVisualRenderers = new[] { _defaultVisualType };
 
@@ -157,8 +157,8 @@ namespace Microsoft.Maui.Controls.Internals
 			if (_handlers.TryGetValue(viewType, out Dictionary<Type, (Type target, short priority)> visualRenderers))
 				if (visualRenderers.TryGetValue(visualType, out (Type target, short priority) specificTypeRenderer))
 					return specificTypeRenderer.target;
-				else if (visualType == _materialVisualType)
-					VisualMarker.MaterialCheck();
+				//else if (visualType == _materialVisualType)
+				//	VisualMarker.MaterialCheck();
 
 			if (visualType != _defaultVisualType && visualRenderers != null)
 				if (visualRenderers.TryGetValue(_defaultVisualType, out (Type target, short priority) specificTypeRenderer))

--- a/src/Controls/src/Core/Visuals/VisualMarker.cs
+++ b/src/Controls/src/Core/Visuals/VisualMarker.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls
 		public static IVisual Default { get; } = new DefaultVisual();
 		
 		// /// <include file="../../../docs/Microsoft.Maui.Controls/VisualMarker.xml" path="//Member[@MemberName='Material']/Docs" />
-		//public static IVisual Material { get; } = new MaterialVisual();
+		internal static IVisual Material { get; } = new MaterialVisual();
 
 		internal static void RegisterMaterial() => _isMaterialRegistered = true;
 		internal static void MaterialCheck()
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls
 				logger?.LogWarning("Material is currently not support on {RuntimePlatform}.", DeviceInfo.Platform);
 		}
 
-		// public sealed class MaterialVisual : IVisual { public MaterialVisual() { } }
+		internal sealed class MaterialVisual : IVisual { public MaterialVisual() { } }
 		public sealed class DefaultVisual : IVisual { public DefaultVisual() { } }
 		internal sealed class MatchParentVisual : IVisual { public MatchParentVisual() { } }
 	}

--- a/src/Controls/src/Core/Visuals/VisualMarker.cs
+++ b/src/Controls/src/Core/Visuals/VisualMarker.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Maui.Controls
 		public static IVisual MatchParent { get; } = new MatchParentVisual();
 		/// <include file="../../../docs/Microsoft.Maui.Controls/VisualMarker.xml" path="//Member[@MemberName='Default']/Docs" />
 		public static IVisual Default { get; } = new DefaultVisual();
-		/// <include file="../../../docs/Microsoft.Maui.Controls/VisualMarker.xml" path="//Member[@MemberName='Material']/Docs" />
-		public static IVisual Material { get; } = new MaterialVisual();
+		
+		// /// <include file="../../../docs/Microsoft.Maui.Controls/VisualMarker.xml" path="//Member[@MemberName='Material']/Docs" />
+		//public static IVisual Material { get; } = new MaterialVisual();
 
 		internal static void RegisterMaterial() => _isMaterialRegistered = true;
 		internal static void MaterialCheck()
@@ -32,7 +33,7 @@ namespace Microsoft.Maui.Controls
 				logger?.LogWarning("Material is currently not support on {RuntimePlatform}.", DeviceInfo.Platform);
 		}
 
-		public sealed class MaterialVisual : IVisual { public MaterialVisual() { } }
+		// public sealed class MaterialVisual : IVisual { public MaterialVisual() { } }
 		public sealed class DefaultVisual : IVisual { public DefaultVisual() { } }
 		internal sealed class MatchParentVisual : IVisual { public MatchParentVisual() { } }
 	}

--- a/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
+++ b/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
@@ -173,6 +173,9 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/VisualTypeConverter.xml" path="//Member[@MemberName='GetStandardValues']/Docs" />
 		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
-			=> new(new[] { "Default", "Material" });
+			=> new(new[] { 
+				nameof(VisualMarker.Default), 
+				// nameof(VisualMarker.Material)
+			});
 	}
 }


### PR DESCRIPTION
Material is unsupported for .NET 6 MAUI. Google's Material Design for iOS library which Xamarin.Forms used is no longer supported. https://github.com/material-components/material-components-ios/

Experiments for different visuals in MAUI are being explored in [dotnet/Microsoft.Maui.Graphics.Controls](https://github.com/dotnet/Microsoft.Maui.Graphics.Controls).

This PR removes the old `Material` as an option for `Visual`.