### PR TITLE
[loc]Add Microsoft.TemplateEngine.Tasks reference

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -16,6 +16,7 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
   </packageSources>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -211,5 +211,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4f567e5ffa4bad5d2cbb5e82470f18534ee02c9f</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-alpha.1.21601.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha />
+    </Dependency>   
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,6 +71,7 @@
     <_SkiaSharpVersion>2.88.0-preview.179</_SkiaSharpVersion>
     <_HarfBuzzSharpVersion>2.8.2-preview.179</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.fffae82cf6ec1c4a6f490ddb780709ce9211725e.179</_SkiaSharpNativeAssetsVersion>
+    <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->

--- a/eng/automation/LocProject.json
+++ b/eng/automation/LocProject.json
@@ -14,6 +14,41 @@
                 "LclFile": "loc\\{Lang}\\src\\Controls\\src\\Build.Tasks\\ErrorMessages.resx.lcl",
                 "CopyOption": "LangIDOnName",
                 "OutputPath": "src\\Controls\\src\\Build.Tasks\\xlf\\"
+            },
+            {
+              "SourceFile": "src\\Templates\\src\\template\\maui-blazor\\.template.config\\localize\\templatestrings.json",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  "src\\Templates\\src\\template\\maui-blazor\\.template.config\\localize\\"
+            },
+            {
+              "SourceFile": "src\\Templates\\src\\template\\maui-contentpage-csharp\\.template.config\\localize\\templatestrings.json",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  "src\\Templates\\src\\template\\maui-contentpage-csharp\\.template.config\\localize\\"
+            },
+            {
+              "SourceFile": "src\\Templates\\src\\template\\maui-contentpage-xaml\\.template.config\\localize\\templatestrings.json",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  "src\\Templates\\src\\template\\maui-contentpage-xaml\\.template.config\\localize\\"
+            },
+            {
+              "SourceFile": "src\\Templates\\src\\template\\maui-contentview-csharp\\.template.config\\localize\\templatestrings.json",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  "src\\Templates\\src\\template\\maui-contentview-csharp\\.template.config\\localize\\"
+            },
+            {
+              "SourceFile": "src\\Templates\\src\\template\\maui-contentview-xaml\\.template.config\\localize\\templatestrings.json",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  "src\\Templates\\src\\template\\maui-contentview-xaml\\.template.config\\localize\\"
+            },
+            {
+              "SourceFile": "src\\Templates\\src\\template\\maui-lib\\.template.config\\localize\\templatestrings.json",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  "src\\Templates\\src\\template\\maui-lib\\.template.config\\localize\\"
+            },
+            {
+              "SourceFile": "src\\Templates\\src\\template\\maui-mobile\\.template.config\\localize\\templatestrings.json",
+              "CopyOption":  "LangIDOnName",
+              "OutputPath":  "src\\Templates\\src\\template\\maui-mobile\\.template.config\\localize\\"
             }
         ],
         "LssFiles": [],

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -64,7 +64,7 @@
     />
   </Target>
 
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">>
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 </Project>

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -10,6 +10,7 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <LocalizeTemplates>true</LocalizeTemplates>
     <IncludeSymbols>false</IncludeSymbols>
     <ContentTargetFolders>content</ContentTargetFolders>
     <!-- This project has no .NET assemblies, so disable the warning for that -->
@@ -63,4 +64,7 @@
     />
   </Target>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
 </Project>

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -64,7 +64,7 @@
     />
   </Target>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">>
     <PackageReference Include="Microsoft.TemplateEngine.Tasks" Version="$(MicrosoftTemplateEngineTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 </Project>

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.cs.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.de.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.es.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.fr.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.it.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.ko.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.pl.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.ru.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.tr.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Blazor App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI using Blazor",
+  "postActions/openInEditor/description": "Opens Pages/Index.razor in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -19,16 +19,17 @@
       }
     ],
     "postActions": [
-      {
-        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-        "description": "Opens Pages/Index.razor in the editor.",
-        "manualInstructions": [],
-        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-        "args": {
-          "files": "0"
-        },
-        "continueOnError": true
-      }
+        {
+            "id": "openInEditor",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "description": "Opens Pages/Index.razor in the editor.",
+            "manualInstructions": [],
+            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+            "args": {
+                "files": "0"
+            },
+            "continueOnError": true
+        }
     ],
     "sources": [
       {

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.cs.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.de.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.es.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.fr.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.it.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.ko.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.pl.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.ru.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.tr.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/template.json
@@ -16,16 +16,17 @@
       }
     ],
     "postActions": [
-      {
-        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-        "description": "Opens NewPage1.cs in the editor.",
-        "manualInstructions": [],
-        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-        "args": {
-          "files": "0"
-        },
-        "continueOnError": true
-      }
+        {
+            "id": "openInEditor",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "description": "Opens NewPage1.cs in the editor.",
+            "manualInstructions": [],
+            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+            "args": {
+                "files": "0"
+            },
+            "continueOnError": true
+        }
     ],
     "sourceName": "NewPage1",
     "defaultName": "NewPage1",

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.cs.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.de.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.es.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.fr.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.it.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.ko.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.pl.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.ru.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.tr.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentPage (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewPage1.xaml in the editor.",
+  "symbols/namespace/description": "namespace for the generated code"
+}

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/template.json
@@ -20,16 +20,17 @@
       }
     ],
     "postActions": [
-      {
-        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-        "description": "Opens NewPage1.xaml in the editor.",
-        "manualInstructions": [],
-        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-        "args": {
-          "files": "0"
-        },
-        "continueOnError": true
-      }
+        {
+            "id": "openInEditor",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "description": "Opens NewPage1.xaml in the editor.",
+            "manualInstructions": [],
+            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+            "args": {
+                "files": "0"
+            },
+            "continueOnError": true
+        }
     ],
     "sourceName": "NewPage1",
     "defaultName": "NewPage1",

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.cs.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.de.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.es.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.fr.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.it.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.ko.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.pl.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.ru.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.tr.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (C#) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.cs in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/template.json
@@ -16,16 +16,17 @@
       }
     ],
     "postActions": [
-      {
-        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-        "description": "Opens NewContent1.cs in the editor.",
-        "manualInstructions": [],
-        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-        "args": {
-          "files": "0"
-        },
-        "continueOnError": true
-      }
+        {
+            "id": "openInEditor",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "description": "Opens NewContent1.cs in the editor.",
+            "manualInstructions": [],
+            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+            "args": {
+                "files": "0"
+            },
+            "continueOnError": true
+        }
     ],
     "sourceName": "NewContent1",
     "defaultName": "NewContent1",

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.cs.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.de.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.es.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.fr.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.it.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.ko.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.pl.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.ru.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.tr.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI ContentView (XAML) (Preview)",
+  "postActions/openInEditor/description": "Opens NewContent1.xaml in the editor.",
+  "symbols/namespace/description": "Namespace for the generated code."
+}

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/template.json
@@ -21,14 +21,15 @@
       ],
       "postActions": [
         {
-          "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-          "description": "Opens NewContent1.xaml in the editor.",
-          "manualInstructions": [],
-          "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-          "args": {
-            "files": "0"
-          },
-          "continueOnError": true
+            "id": "openInEditor",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "description": "Opens NewContent1.xaml in the editor.",
+            "manualInstructions": [],
+            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+            "args": {
+                "files": "0"
+            },
+            "continueOnError": true
         }
       ],
     "sourceName": "NewContent1",

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.cs.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.de.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.es.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.fr.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.it.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.ko.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.pl.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.ru.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.tr.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,6 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI Class Library (Preview)",
+  "description": "A project for creating a .NET MAUI class library",
+  "postActions/openInEditor/description": "Opens Class1.cs in the editor."
+}

--- a/src/Templates/src/templates/maui-lib/.template.config/template.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/template.json
@@ -20,16 +20,17 @@
       }
     ],
     "postActions": [
-      {
-        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-        "description": "Opens Class1.cs in the editor.",
-        "manualInstructions": [],
-        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-        "args": {
-          "files": "1"
-        },
-        "continueOnError": true
-      }
+        {
+            "id": "openInEditor",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "description": "Opens Class1.cs in the editor.",
+            "manualInstructions": [],
+            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+            "args": {
+                "files": "1"
+            },
+            "continueOnError": true
+        }
     ],
     "preferNameDirectory": true,
     "symbols": {

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.cs.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.de.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.en.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.es.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.fr.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.it.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.ja.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.ko.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.pl.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.ru.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.tr.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": ".NET MAUI App (Preview)",
+  "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, and WinUI",
+  "postActions/openInEditor/description": "Opens MainPage.xaml in the editor.",
+  "symbols/applicationId/description": "Overrides the $(ApplicationId) in the project"
+}

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -23,16 +23,17 @@
       }
     ],
     "postActions": [
-      {
-        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-        "description": "Opens MainPage.xaml in the editor.",
-        "manualInstructions": [],
-        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-        "args": {
-          "files": "0;1"
-        },
-        "continueOnError": true
-      }
+        {
+            "id": "openInEditor",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "description": "Opens MainPage.xaml in the editor.",
+            "manualInstructions": [],
+            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+            "args": {
+                "files": "0;1"
+            },
+            "continueOnError": true
+        }
     ],
     "sources": [
       {


### PR DESCRIPTION
## Background:
 Template engine (`dotnet new`) added support for template localizations in .NET 6.0. This new system replaces the old way of localizing templates that only worked on Visual Studio and works on both .NET CLI as well as VS.

This PR introduces changes to switch to the new template localization system.

## Summary of the changes
- Adds `<LocalizeTemplates>true</>` to project containing templates.
- Include PackageReference for "Microsoft.TemplateEngine.Tasks" to project containing templates.
- Generates localization files to be translated by loc team

## What to expect after merging
Every time there is a change to one of the templates:
- The dev making the change should build (at the very least) the modified template project. This will update the loc files on the local working copy,
- Push the loc files together with the template modifications. Review & merge.
- OneLocBuild integration will automatically pick up the changes and will send them for translation.
- You will receive a PR containing the translated template loc files when they are ready. Review & merge.