### PR TITLE
Add provisionator to windows

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -91,14 +91,14 @@ steps:
       displayName: 'Install PowerShell Core'
     - task: xamops.azdevex.provisionator-task.provisionator@1
       displayName: 'Provision Visual Studio'
-      condition: eq(variables['provisioningVS'], 'true')
+      condition: eq(variables['usevs'], 'true')
       inputs:
         provisioning_script: $(provisionator.vs)
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"
       displayName: 'Setup MSBuild Paths'
-      condition: eq(variables['provisioningVS'], 'true')
+      condition: eq(variables['usevs'], 'true')
 
   # Prepare Both
   - pwsh: ./build.ps1 --target provision

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -84,16 +84,6 @@ steps:
     #       msiexec.exe /package $output /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
     #     }
     #   displayName: 'Install PowerShell Core'
-    - task: xamops.azdevex.provisionator-task.provisionator@1
-      displayName: 'Provision Visual Studio'
-      condition: eq(variables['provisioningVS'], 'true')
-      inputs:
-        provisioning_script: $(provisionator.vs)
-    - pwsh: |
-        $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
-        echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"
-      displayName: 'Setup MSBuild Paths'
-      condition: eq(variables['provisioningVS'], 'true')
 
     # Provision Additional Software
     - task: xamops.azdevex.provisionator-task.provisionator@1
@@ -104,6 +94,19 @@ steps:
         provisioning_extra_args: $(provisionator.extraArguments)
       env:
         AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
+
+    - task: xamops.azdevex.provisionator-task.provisionator@1
+      displayName: 'Provision Visual Studio'
+      condition: eq(variables['provisioningVS'], 'true')
+      inputs:
+        provisioning_script: $(provisionator.vs)
+
+    - pwsh: |
+        $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
+        echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"
+      displayName: 'Setup MSBuild Paths'
+      condition: eq(variables['provisioningVS'], 'true')
+      
   # Prepare Both
   - pwsh: ./build.ps1 --target provision
     displayName: 'Cake Provision'

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -75,15 +75,15 @@ steps:
 
   # Prepare Windows
   - ${{ if eq(parameters.platform, 'windows') }}:
-    - powershell: |
-        if (-not $(where.exe pwsh)) {
-          $url = "https://github.com/PowerShell/PowerShell/releases/download/v$env:POWERSHELL_VERSION/PowerShell-$env:POWERSHELL_VERSION-win-x64.msi"
-          $output = "$env:TEMP\PowerShell.msi"
-          Remove-Item -Force $output -ErrorAction Ignore
-          Invoke-WebRequest -Uri $url -OutFile $output
-          msiexec.exe /package $output /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
-        }
-      displayName: 'Install PowerShell Core'
+    # - powershell: |
+    #     if (-not $(where.exe pwsh)) {
+    #       $url = "https://github.com/PowerShell/PowerShell/releases/download/v$env:POWERSHELL_VERSION/PowerShell-$env:POWERSHELL_VERSION-win-x64.msi"
+    #       $output = "$env:TEMP\PowerShell.msi"
+    #       Remove-Item -Force $output -ErrorAction Ignore
+    #       Invoke-WebRequest -Uri $url -OutFile $output
+    #       msiexec.exe /package $output /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
+    #     }
+    #   displayName: 'Install PowerShell Core'
     - task: xamops.azdevex.provisionator-task.provisionator@1
       displayName: 'Provision Visual Studio'
       condition: eq(variables['provisioningVS'], 'true')

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -91,14 +91,14 @@ steps:
       displayName: 'Install PowerShell Core'
     - task: xamops.azdevex.provisionator-task.provisionator@1
       displayName: 'Provision Visual Studio'
-      condition: eq(variables['usevs'], 'true')
+      condition: eq(variables['provisioningvs'], 'true')
       inputs:
         provisioning_script: $(provisionator.vs)
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"
       displayName: 'Setup MSBuild Paths'
-      condition: eq(variables['usevs'], 'true')
+      condition: eq(variables['provisioningvs'], 'true')
 
   # Prepare Both
   - pwsh: ./build.ps1 --target provision

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -91,15 +91,24 @@ steps:
       displayName: 'Install PowerShell Core'
     - task: xamops.azdevex.provisionator-task.provisionator@1
       displayName: 'Provision Visual Studio'
-      condition: eq(variables['provisioningvs'], 'true')
+      condition: eq(variables['provisioningVS'], 'true')
       inputs:
         provisioning_script: $(provisionator.vs)
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"
       displayName: 'Setup MSBuild Paths'
-      condition: eq(variables['provisioningvs'], 'true')
+      condition: eq(variables['provisioningVS'], 'true')
 
+    # Provision Additional Software
+    - task: xamops.azdevex.provisionator-task.provisionator@1
+      displayName: 'Provision Additional Software'
+      condition: eq(variables['provisioning'], 'true')
+      inputs:
+        provisioning_script: $(provisionator.path)
+        provisioning_extra_args: $(provisionator.extraArguments)
+      env:
+        AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
   # Prepare Both
   - pwsh: ./build.ps1 --target provision
     displayName: 'Cake Provision'

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -10,11 +10,6 @@ steps:
       packageType: sdk
       version: 6.0.x
 
-  - pwsh: |
-      dotnet --version
-      dotnet --list-sdks
-    displayName: 'Show .NET SDK info'
-
   # Prepare macOS
   - ${{ if eq(parameters.platform, 'macos') }}:
     # Provision Xcode

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -30,8 +30,6 @@ variables:
   value: $(Build.ArtifactStagingDirectory)/logs
 - name: TestResultsDirectory
   value: $(Build.ArtifactStagingDirectory)/test-results
-- name: provisioningVS
-  value: true
 - name: provisionator.xcode
   value: '$(System.DefaultWorkingDirectory)/eng/provisioning/xcode.csx'
 - name: provisionator.path

--- a/eng/provisioning/provisioning.csx
+++ b/eng/provisioning/provisioning.csx
@@ -1,3 +1,7 @@
+MicrosoftOpenJdk ("17.0.1.12.1");
+
+string releaseChannel = Environment.GetEnvironmentVariable ("CHANNEL");
+
 if (IsMac)
 {
 	System.Net.Http.HttpClient client = new System.Net.Http.HttpClient (new System.Net.Http.HttpClientHandler { AllowAutoRedirect = true });
@@ -7,9 +11,8 @@ if (IsMac)
  			.Source (_ => "https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.107.macos10.xamarin.universal.pkg");
  	}
 	ForceJavaCleanup();
-	MicrosoftOpenJdk ("11.0.13.8.1");
 
-	string releaseChannel = Environment.GetEnvironmentVariable ("CHANNEL");
+
 	Console.WriteLine ("ANDROID_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC"));
 	Console.WriteLine ("IOS_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
 	Console.WriteLine ("MONO_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("MONO_SDK_MAC"));

--- a/eng/provisioning/provisioning.csx
+++ b/eng/provisioning/provisioning.csx
@@ -1,3 +1,7 @@
+Item ("PowerShell", "7.2.0")
+  .Condition (ps => Exec ("pwsh", "--version")[0] != $"PowerShell {ps.Version}")
+  .Source (ps => $"https://github.com/PowerShell/PowerShell/releases/download/v{ps.Version}/powershell-{ps.Version}-osx-x64.pkg");
+
 MicrosoftOpenJdk ("17.0.1.12.1");
 
 string releaseChannel = Environment.GetEnvironmentVariable ("CHANNEL");


### PR DESCRIPTION
Cake is not able to install the sdks, but seems provisionator can

Implements #

### Additions made ###

None

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
