### PR TITLE
Ensure that using the AndExpand Grid hack doesn't null out BindingContext

### DIFF
--- a/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
+++ b/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
@@ -102,6 +102,11 @@ namespace Microsoft.Maui.Controls
 			{
 				// We don't want to actually re-parent the stuff we add to this			
 			}
+
+			protected override void OnChildRemoved(Element child, int oldLogicalIndex)
+			{
+				// Don't do anything here; the base methods will null out Parents, etc.
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
+++ b/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls
 
 			protected override void OnChildRemoved(Element child, int oldLogicalIndex)
 			{
-				// Don't do anything here; the base methods will null out Parents, etc.
+				// Don't do anything here; the base methods will null out Parents, etc., and we don't want that
 			}
 		}
 	}

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -137,8 +137,7 @@ namespace Microsoft.Maui.Controls
 			{
 				if (this[index] is Element element)
 				{
-					element.Parent = null;
-					VisualDiagnostics.OnChildRemoved(this, element, index);
+					OnChildRemoved(element, index);
 				}
 			}
 

--- a/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 				VerticalOptions = LayoutOptions.FillAndExpand
 			};
 
-			view0.SetBinding(Button.TextProperty, new Binding(nameof(ViewModel.Text));
+			view0.SetBinding(Button.TextProperty, new Binding(nameof(ViewModel.Text)));
 
 			var stackLayout = SetUpTestLayout(StackOrientation.Vertical, view0);
 			stackLayout.BindingContext = vm;

--- a/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
@@ -33,13 +33,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 				layout.Add(view);
 			}
 
+			MeasureAndArrange(layout as Maui.ILayout);
+
+			return layout;
+		}
+
+		static void MeasureAndArrange(Maui.ILayout layout) 
+		{
 			var layoutSize = new Size(TestAreaWidth, TestAreaHeight);
 			var rect = new Rectangle(Point.Zero, layoutSize);
 
 			(layout as Maui.ILayout).CrossPlatformMeasure(layoutSize.Width, layoutSize.Height);
 			(layout as Maui.ILayout).CrossPlatformArrange(rect);
-
-			return layout;
 		}
 
 		[Test]
@@ -280,6 +285,42 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 
 			Assert.AreEqual(0, view2.Bounds.X);
 			Assert.AreEqual(2 * (TestAreaHeight / 3), view2.Bounds.Y);
+		}
+
+		class ViewModel
+		{
+			public string Text { get; }
+
+			public ViewModel(string text) 
+			{
+				Text = text;
+			}
+		}
+
+		[Test]
+		public void AndExpandDoesNotInterfereWithBindingContext()
+		{
+			const string testText = "test text";
+
+			var vm =  new ViewModel(testText);
+
+			var view0 = new TestView
+			{
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			view0.SetBinding(Button.TextProperty, new Binding(nameof(ViewModel.Text));
+
+			var stackLayout = SetUpTestLayout(StackOrientation.Vertical, view0);
+			stackLayout.BindingContext = vm;
+
+			Assert.AreEqual(testText, view0.Text);
+			Assert.AreEqual(vm, view0.BindingContext);
+
+			MeasureAndArrange(stackLayout as Maui.ILayout);
+
+			Assert.AreEqual(testText, view0.Text);
+			Assert.AreEqual(vm, view0.BindingContext);
 		}
 	}
 }


### PR DESCRIPTION
The AndExpandLayoutManager is de-parenting child controls each time it measures/lays out the children after the first pass.

These changes modify the `AndExpandGrid` to avoid de-parenting the controls during the `Clear()` operation.

Fixes #3970