### PR TITLE
Refactor AppInfo into interface

### DIFF
--- a/src/Essentials/src/AppInfo/AppInfo.android.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.android.cs
@@ -5,7 +5,7 @@ using Android.Content.Res;
 using Android.Provider;
 using AndroidX.Core.Content.PM;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class AppInfoImplementation : IAppInfo
 	{

--- a/src/Essentials/src/AppInfo/AppInfo.android.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.android.cs
@@ -7,51 +7,62 @@ using AndroidX.Core.Content.PM;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class AppInfo
+	public class AppInfoImplementation : IAppInfo
 	{
-		static string PlatformGetPackageName() => Platform.AppContext.PackageName;
+		public string PackageName => Platform.AppContext.PackageName;
 
-		static string PlatformGetName()
+		public string Name
 		{
-			var applicationInfo = Platform.AppContext.ApplicationInfo;
-			var packageManager = Platform.AppContext.PackageManager;
-			return applicationInfo.LoadLabel(packageManager);
-		}
-
-		static string PlatformGetVersionString()
-		{
-			var pm = Platform.AppContext.PackageManager;
-			var packageName = Platform.AppContext.PackageName;
-			using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
+			get
 			{
-				return info.VersionName;
+				var applicationInfo = Platform.AppContext.ApplicationInfo;
+				var packageManager = Platform.AppContext.PackageManager;
+				return applicationInfo.LoadLabel(packageManager);
 			}
 		}
 
-		static string PlatformGetBuild()
+		public System.Version Version => Utils.ParseVersion(VersionString);
+
+		public string VersionString
 		{
-			var pm = Platform.AppContext.PackageManager;
-			var packageName = Platform.AppContext.PackageName;
-			using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
+			get
 			{
+				var pm = Platform.AppContext.PackageManager;
+				var packageName = Platform.AppContext.PackageName;
+				using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
+				{
+					return info.VersionName;
+				}
+			}
+		}
+
+		public string BuildString
+		{
+			get
+			{
+				var pm = Platform.AppContext.PackageManager;
+				var packageName = Platform.AppContext.PackageName;
+				using (var info = pm.GetPackageInfo(packageName, PackageInfoFlags.MetaData))
+				{
 #if __ANDROID_28__
-				return PackageInfoCompat.GetLongVersionCode(info).ToString(CultureInfo.InvariantCulture);
+					return PackageInfoCompat.GetLongVersionCode(info).ToString(CultureInfo.InvariantCulture);
 #else
 #pragma warning disable CS0618 // Type or member is obsolete
 				return info.VersionCode.ToString(CultureInfo.InvariantCulture);
 #pragma warning restore CS0618 // Type or member is obsolete
 #endif
+				}
 			}
 		}
 
-		static void PlatformShowSettingsUI()
+		public void ShowSettingsUI()
 		{
 			var context = Platform.GetCurrentActivity(false) ?? Platform.AppContext;
 
 			var settingsIntent = new Intent();
 			settingsIntent.SetAction(global::Android.Provider.Settings.ActionApplicationDetailsSettings);
 			settingsIntent.AddCategory(Intent.CategoryDefault);
-			settingsIntent.SetData(global::Android.Net.Uri.Parse("package:" + PlatformGetPackageName()));
+			settingsIntent.SetData(global::Android.Net.Uri.Parse("package:" + PackageName));
 
 			var flags = ActivityFlags.NewTask | ActivityFlags.NoHistory | ActivityFlags.ExcludeFromRecents;
 
@@ -64,14 +75,12 @@ namespace Microsoft.Maui.Essentials
 			context.StartActivity(settingsIntent);
 		}
 
-		static AppTheme PlatformRequestedTheme()
-		{
-			return (Platform.AppContext.Resources.Configuration.UiMode & UiMode.NightMask) switch
+		public AppTheme RequestedTheme
+			=> (Platform.AppContext.Resources.Configuration.UiMode & UiMode.NightMask) switch
 			{
 				UiMode.NightYes => AppTheme.Dark,
 				UiMode.NightNo => AppTheme.Light,
 				_ => AppTheme.Unspecified
 			};
-		}
 	}
 }

--- a/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
@@ -9,7 +9,7 @@ using UIKit;
 using AppKit;
 #endif
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class AppInfoImplementation : IAppInfo
 	{

--- a/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
@@ -11,24 +11,26 @@ using AppKit;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class AppInfo
+	public class AppInfoImplementation : IAppInfo
 	{
-		static string PlatformGetPackageName() => GetBundleValue("CFBundleIdentifier");
+		public string PackageName => GetBundleValue("CFBundleIdentifier");
 
-		static string PlatformGetName() => GetBundleValue("CFBundleDisplayName") ?? GetBundleValue("CFBundleName");
+		public string Name => GetBundleValue("CFBundleDisplayName") ?? GetBundleValue("CFBundleName");
 
-		static string PlatformGetVersionString() => GetBundleValue("CFBundleShortVersionString");
+		public Version Version => Utils.ParseVersion(VersionString);
 
-		static string PlatformGetBuild() => GetBundleValue("CFBundleVersion");
+		public string VersionString => GetBundleValue("CFBundleShortVersionString");
 
-		static string GetBundleValue(string key)
+		public string BuildString => GetBundleValue("CFBundleVersion");
+
+		string GetBundleValue(string key)
 		   => NSBundle.MainBundle.ObjectForInfoDictionary(key)?.ToString();
 
 #if __IOS__ || __TVOS__
-		static async void PlatformShowSettingsUI()
+		public async void ShowSettingsUI()
 			=> await Launcher.OpenAsync(UIApplication.OpenSettingsUrlString);
 #elif __MACOS__
-        static void PlatformShowSettingsUI()
+        public void ShowSettingsUI()
         {
             MainThread.BeginInvokeOnMainThread(() =>
             {
@@ -38,47 +40,53 @@ namespace Microsoft.Maui.Essentials
             });
         }
 #else
-		static void PlatformShowSettingsUI() =>
+		public void ShowSettingsUI() =>
 			throw new FeatureNotSupportedException();
 #endif
 
 #if __IOS__ || __TVOS__
-		static AppTheme PlatformRequestedTheme()
+		public AppTheme RequestedTheme
 		{
-			if (!Platform.HasOSVersion(13, 0))
-				return AppTheme.Unspecified;
-
-			var uiStyle = Platform.GetCurrentUIViewController()?.TraitCollection?.UserInterfaceStyle ??
-				UITraitCollection.CurrentTraitCollection.UserInterfaceStyle;
-
-			return uiStyle switch
+			get
 			{
-				UIUserInterfaceStyle.Light => AppTheme.Light,
-				UIUserInterfaceStyle.Dark => AppTheme.Dark,
-				_ => AppTheme.Unspecified
-			};
+				if (!Platform.HasOSVersion(13, 0))
+					return AppTheme.Unspecified;
+
+				var uiStyle = Platform.GetCurrentUIViewController()?.TraitCollection?.UserInterfaceStyle ??
+					UITraitCollection.CurrentTraitCollection.UserInterfaceStyle;
+
+				return uiStyle switch
+				{
+					UIUserInterfaceStyle.Light => AppTheme.Light,
+					UIUserInterfaceStyle.Dark => AppTheme.Dark,
+					_ => AppTheme.Unspecified
+				};
+			}
 		}
 #elif __MACOS__
-        static AppTheme PlatformRequestedTheme()
+        public AppTheme RequestedTheme
         {
-            if (DeviceInfo.Version >= new Version(10, 14))
-            {
-                var app = NSAppearance.CurrentAppearance?.FindBestMatch(new string[]
-                {
-                    NSAppearance.NameAqua,
-                    NSAppearance.NameDarkAqua
-                });
+			get
+			{
+				if (DeviceInfo.Version >= new Version(10, 14))
+				{
+					var app = NSAppearance.CurrentAppearance?.FindBestMatch(new string[]
+					{
+						NSAppearance.NameAqua,
+						NSAppearance.NameDarkAqua
+					});
 
-                if (string.IsNullOrEmpty(app))
-                    return AppTheme.Unspecified;
+					if (string.IsNullOrEmpty(app))
+						return AppTheme.Unspecified;
 
-                if (app == NSAppearance.NameDarkAqua)
-                    return AppTheme.Dark;
-            }
-            return AppTheme.Light;
+					if (app == NSAppearance.NameDarkAqua)
+						return AppTheme.Dark;
+				}
+				return AppTheme.Light;
+			}
         }
 #else
-		static AppTheme PlatformRequestedTheme() =>
+		public AppTheme RequestedTheme =>
 			AppTheme.Unspecified;
 #endif
 

--- a/src/Essentials/src/AppInfo/AppInfo.netstandard.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.netstandard.cs
@@ -1,18 +1,20 @@
 namespace Microsoft.Maui.Essentials
 {
 	/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="Type[@FullName='Microsoft.Maui.Essentials.AppInfo']/Docs" />
-	public static partial class AppInfo
+	public class AppInfoImplementation : IAppInfo
 	{
-		static string PlatformGetPackageName() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public string PackageName => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		static string PlatformGetName() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public string Name => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		static string PlatformGetVersionString() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public System.Version Version => Utils.ParseVersion(VersionString);
 
-		static string PlatformGetBuild() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public string VersionString => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		static void PlatformShowSettingsUI() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public string BuildString => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		static AppTheme PlatformRequestedTheme() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public void ShowSettingsUI() => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+		public AppTheme RequestedTheme => throw ExceptionUtils.NotSupportedOrImplementedException;
 	}
 }

--- a/src/Essentials/src/AppInfo/AppInfo.netstandard.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.netstandard.cs
@@ -1,4 +1,4 @@
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="Type[@FullName='Microsoft.Maui.Essentials.AppInfo']/Docs" />
 	public class AppInfoImplementation : IAppInfo

--- a/src/Essentials/src/AppInfo/AppInfo.shared.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.shared.cs
@@ -2,28 +2,50 @@ using System;
 
 namespace Microsoft.Maui.Essentials
 {
+	public interface IAppInfo
+	{
+		string PackageName { get; }
+
+		string Name { get; }
+
+		string VersionString { get; }
+
+		Version Version { get; }
+
+		string BuildString { get; }
+
+		void ShowSettingsUI();
+
+		AppTheme RequestedTheme { get; }
+	}
+
 	/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="Type[@FullName='Microsoft.Maui.Essentials.AppInfo']/Docs" />
-	public static partial class AppInfo
+	public static class AppInfo
 	{
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='PackageName']/Docs" />
-		public static string PackageName => PlatformGetPackageName();
+		public static string PackageName => Default.PackageName;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='Name']/Docs" />
-		public static string Name => PlatformGetName();
+		public static string Name => Default.Name;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='VersionString']/Docs" />
-		public static string VersionString => PlatformGetVersionString();
+		public static string VersionString => Default.VersionString;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='Version']/Docs" />
-		public static Version Version => Utils.ParseVersion(VersionString);
+		public static Version Version => Default.Version;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='BuildString']/Docs" />
-		public static string BuildString => PlatformGetBuild();
+		public static string BuildString => Default.BuildString;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='ShowSettingsUI']/Docs" />
-		public static void ShowSettingsUI() => PlatformShowSettingsUI();
+		public static void ShowSettingsUI() => Default.ShowSettingsUI();
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='RequestedTheme']/Docs" />
-		public static AppTheme RequestedTheme => PlatformRequestedTheme();
+		public static AppTheme RequestedTheme => Default.RequestedTheme;
+
+
+		static Lazy<IAppInfo> current = new Lazy<IAppInfo>(() => new AppInfoImplementation());
+
+		public static IAppInfo Current => current.Value;
 	}
 }

--- a/src/Essentials/src/AppInfo/AppInfo.shared.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.shared.cs
@@ -1,4 +1,7 @@
+#nullable enable
 using System;
+using System.ComponentModel;
+using Microsoft.Maui.Essentials.Implementations;
 
 namespace Microsoft.Maui.Essentials
 {
@@ -23,29 +26,35 @@ namespace Microsoft.Maui.Essentials
 	public static class AppInfo
 	{
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='PackageName']/Docs" />
-		public static string PackageName => Default.PackageName;
+		public static string PackageName => Current.PackageName;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='Name']/Docs" />
-		public static string Name => Default.Name;
+		public static string Name => Current.Name;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='VersionString']/Docs" />
-		public static string VersionString => Default.VersionString;
+		public static string VersionString => Current.VersionString;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='Version']/Docs" />
-		public static Version Version => Default.Version;
+		public static Version Version => Current.Version;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='BuildString']/Docs" />
-		public static string BuildString => Default.BuildString;
+		public static string BuildString => Current.BuildString;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='ShowSettingsUI']/Docs" />
-		public static void ShowSettingsUI() => Default.ShowSettingsUI();
+		public static void ShowSettingsUI() => Current.ShowSettingsUI();
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AppInfo.xml" path="//Member[@MemberName='RequestedTheme']/Docs" />
-		public static AppTheme RequestedTheme => Default.RequestedTheme;
+		public static AppTheme RequestedTheme => Current.RequestedTheme;
 
 
-		static Lazy<IAppInfo> current = new Lazy<IAppInfo>(() => new AppInfoImplementation());
+		static IAppInfo? currentImplementation;
 
-		public static IAppInfo Current => current.Value;
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static IAppInfo Current =>
+			currentImplementation ??= new AppInfoImplementation();
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetCurrent(IAppInfo? implementation) =>
+			currentImplementation = implementation;
 	}
 }

--- a/src/Essentials/src/AppInfo/AppInfo.tizen.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.tizen.cs
@@ -3,29 +3,29 @@ using Tizen.Applications;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class AppInfo
+	public class AppInfoImplementation
 	{
-		static string PlatformGetPackageName()
+		public string PackageName
 			=> Application.Current.ApplicationInfo.PackageId;
 
-		static string PlatformGetName()
+		public string Name
 			=> Application.Current.ApplicationInfo.Label;
 
-		static string PlatformGetVersionString()
+		public System.Version Version => Utils.ParseVersion(VersionString);
+
+		public string VersionString
 			=> Platform.CurrentPackage.Version;
 
-		static string PlatformGetBuild()
+		public string BuildString
 			=> Version.Build.ToString(CultureInfo.InvariantCulture);
 
-		static void PlatformShowSettingsUI()
+		public void PlatformShowSettingsUI()
 		{
 			Permissions.EnsureDeclared<Permissions.LaunchApp>();
 			AppControl.SendLaunchRequest(new AppControl() { Operation = AppControlOperations.Setting });
 		}
 
-		static AppTheme PlatformRequestedTheme()
-		{
-			return AppTheme.Unspecified;
-		}
+		public AppTheme RequestedTheme
+			=> AppTheme.Unspecified;
 	}
 }

--- a/src/Essentials/src/AppInfo/AppInfo.tizen.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.tizen.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using Tizen.Applications;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class AppInfoImplementation
 	{

--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -8,25 +8,27 @@ using Windows.UI.Xaml;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class AppInfo
+	public class AppInfoImplementation : IAppInfo
 	{
-		static string PlatformGetPackageName() => Package.Current.Id.Name;
+		public string PackageName => Package.Current.Id.Name;
 
-		static string PlatformGetName() => Package.Current.DisplayName;
+		public string Name => Package.Current.DisplayName;
 
-		static string PlatformGetVersionString()
+		public System.Version Version => Utils.ParseVersion(VersionString);
+
+		public string VersionString
 		{
 			var version = Package.Current.Id.Version;
 			return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
 		}
 
-		static string PlatformGetBuild() =>
+		public string BuildString =>
 			Package.Current.Id.Version.Build.ToString(CultureInfo.InvariantCulture);
 
-		static void PlatformShowSettingsUI() =>
+		public void ShowSettingsUI() =>
 			global::Windows.System.Launcher.LaunchUriAsync(new global::System.Uri("ms-settings:appsfeatures-app")).WatchForError();
 
-		static AppTheme PlatformRequestedTheme() =>
+		public AppTheme RequestedTheme =>
 			Application.Current.RequestedTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light;
 	}
 }

--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -6,7 +6,7 @@ using Microsoft.UI.Xaml;
 using Windows.UI.Xaml;
 #endif
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class AppInfoImplementation : IAppInfo
 	{

--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -18,8 +18,11 @@ namespace Microsoft.Maui.Essentials.Implementations
 
 		public string VersionString
 		{
-			var version = Package.Current.Id.Version;
-			return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
+			get
+			{
+				var version = Package.Current.Id.Version;
+				return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
+			}
 		}
 
 		public string BuildString =>

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -11,6 +11,7 @@ using SafariServices;
 using ObjCRuntime;
 using UIKit;
 using WebKit;
+using Microsoft.Maui.Essentials.Implementations;
 
 namespace Microsoft.Maui.Essentials
 {

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Maui.Essentials
 			if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
 				return true;
 
-			return AppInfo.VerifyHasUrlScheme(scheme);
+			return AppInfoImplementation.VerifyHasUrlScheme(scheme);
 		}
 
 #if __IOS__


### PR DESCRIPTION
Adds `Current` lazy instance, and keeps the static methods on `AppInfo`, but now `IAppInfo` is an interface with `AppInfoImplementation` available to use.



<!-- 

We are currently only accepting Pull Requests for .NET MAUI issues in our [Handler Property Backlog](https://github.com/dotnet/maui/projects/4). We will continue to update this repository over the next couple of months as we begin to accept more types of PRs.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
          - If the issue you're working on has a milestone, target the corresponding branch.
          - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
               See [Contributing](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md) for more tips!

```
 PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
```
 -->
### Description of Change ###

<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implements #

### Additions made ###
<!-- List all the additions made here, example:

- Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for WinUI, Android, and iOS
- Adds extension methods to apply Padding on WinUI/Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on WinUI, iOS, and Android

 -->

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
