### PR TITLE
Refactor DeviceInfo to use an interface

### DIFF
--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.android.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.android.cs
@@ -111,19 +111,19 @@ namespace Microsoft.Maui.Essentials.Implementations
 				return null;
 			}
 		}
-	}
 
-	class Listener : OrientationEventListener
-	{
-		readonly Action onChanged;
-
-		internal Listener(Context context, Action handler)
-			: base(context) => onChanged = handler;
-
-		public override async void OnOrientationChanged(int orientation)
+		class Listener : OrientationEventListener
 		{
-			await Task.Delay(500);
-			onChanged();
+			readonly Action onChanged;
+
+			internal Listener(Context context, Action handler)
+				: base(context) => onChanged = handler;
+
+			public override async void OnOrientationChanged(int orientation)
+			{
+				await Task.Delay(500);
+				onChanged();
+			}
 		}
 	}
 }

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.android.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.android.cs
@@ -9,7 +9,7 @@ using Android.Runtime;
 using Android.Util;
 using Android.Views;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceDisplayImplementation : IDeviceDisplay
 	{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.android.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.android.cs
@@ -11,7 +11,7 @@ using Android.Views;
 
 namespace Microsoft.Maui.Essentials
 {
-	partial class DeviceDisplayImplementation : IDeviceDisplay
+	public class DeviceDisplayImplementation : IDeviceDisplay
 	{
 		OrientationEventListener? orientationListener;
 

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -6,7 +6,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Essentials
 {
-	partial class DeviceDisplayImplementation : IDeviceDisplay
+	public class DeviceDisplayImplementation : IDeviceDisplay
 	{
 		NSObject? observer;
 

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -4,7 +4,7 @@ using Foundation;
 using ObjCRuntime;
 using UIKit;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceDisplayImplementation : IDeviceDisplay
 	{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.macos.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.macos.cs
@@ -4,7 +4,7 @@ using AppKit;
 using CoreVideo;
 using Foundation;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceDisplayImplementation : IDeviceDisplay
 	{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.macos.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.macos.cs
@@ -6,7 +6,7 @@ using Foundation;
 
 namespace Microsoft.Maui.Essentials
 {
-	partial class DeviceDisplayImplementation : IDeviceDisplay
+	public class DeviceDisplayImplementation : IDeviceDisplay
 	{
 		uint keepScreenOnId = 0;
 		NSObject? screenMetricsObserver;

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.netstandard.tvos.watchos.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.netstandard.tvos.watchos.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Microsoft.Maui.Essentials
 {
-	partial class DeviceDisplayImplementation : IDeviceDisplay
+	public class DeviceDisplayImplementation : IDeviceDisplay
 	{
 		public event EventHandler<DisplayInfoChangedEventArgs>? MainDisplayInfoChanged
 		{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.netstandard.tvos.watchos.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.netstandard.tvos.watchos.cs
@@ -1,7 +1,7 @@
 #nullable enable
 using System;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceDisplayImplementation : IDeviceDisplay
 	{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.shared.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.shared.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.ComponentModel;
+using Microsoft.Maui.Essentials.Implementations;
 
 namespace Microsoft.Maui.Essentials
 {

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.tizen.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.tizen.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceDisplayImplementation : IDeviceDisplay
 	{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.tizen.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.tizen.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Maui.Essentials
 {
-	partial class DeviceDisplayImplementation : IDeviceDisplay
+	public class DeviceDisplayImplementation : IDeviceDisplay
 	{
 		[DllImport("libcapi-system-device.so.0", EntryPoint = "device_power_request_lock")]
 		static extern void RequestKeepScreenOn(int type = 1, int timeout = 0);

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
@@ -6,7 +6,7 @@ using Windows.Graphics.Display;
 using Windows.Graphics.Display.Core;
 using Windows.System.Display;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceDisplayImplementation : IDeviceDisplay
 	{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
@@ -8,7 +8,7 @@ using Windows.System.Display;
 
 namespace Microsoft.Maui.Essentials
 {
-	partial class DeviceDisplayImplementation : IDeviceDisplay
+	public class DeviceDisplayImplementation : IDeviceDisplay
 	{
 		readonly object locker = new object();
 		DisplayRequest? displayRequest;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Maui.Essentials.Implementations
 
 		public string VersionString => Build.VERSION.Release;
 
+		public Version Version => Utils.ParseVersion(VersionString);
+
 		public DevicePlatform Platform => DevicePlatform.Android;
 
 		public DeviceIdiom Idiom

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		DeviceIdiom DetectIdiom(UiMode uiMode)
+		static DeviceIdiom DetectIdiom(UiMode uiMode)
 		{
 			if (uiMode == UiMode.TypeNormal)
 				return DeviceIdiom.Unknown;
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		string GetSystemSetting(string name, bool isGlobal = false)
+		static string GetSystemSetting(string name, bool isGlobal = false)
 		{
 			if (isGlobal && Essentials.Platform.HasApiLevelNMr1)
 				return Settings.Global.GetString(Essentials.Platform.AppContext.ContentResolver, name);

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
@@ -6,73 +6,79 @@ using Android.Provider;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class DeviceInfo
+	public class DeviceInfoImplementation : IDeviceInfo
 	{
 		const int tabletCrossover = 600;
 
-		static string GetModel() => Build.Model;
+		public string Model => Build.Model;
 
-		static string GetManufacturer() => Build.Manufacturer;
+		public string Manufacturer => Build.Manufacturer;
 
-		static string GetDeviceName()
+		public string Name
 		{
-			// DEVICE_NAME added in System.Global in API level 25
-			// https://developer.android.com/reference/android/provider/Settings.Global#DEVICE_NAME
-			var name = GetSystemSetting("device_name", true);
-			if (string.IsNullOrWhiteSpace(name))
-				name = Model;
-			return name;
+			get
+			{
+				// DEVICE_NAME added in System.Global in API level 25
+				// https://developer.android.com/reference/android/provider/Settings.Global#DEVICE_NAME
+				var name = GetSystemSetting("device_name", true);
+				if (string.IsNullOrWhiteSpace(name))
+					name = Model;
+				return name;
+			}
 		}
 
-		static string GetVersionString() => Build.VERSION.Release;
+		public string VersionString => Build.VERSION.Release;
 
-		static DevicePlatform GetPlatform() => DevicePlatform.Android;
+		public DevicePlatform Platform => DevicePlatform.Android;
 
-		static DeviceIdiom GetIdiom()
+		public DeviceIdiom Idiom
 		{
-			var currentIdiom = DeviceIdiom.Unknown;
-
-			// first try UIModeManager
-			using var uiModeManager = UiModeManager.FromContext(Essentials.Platform.AppContext);
-
-			try
+			get
 			{
-				var uiMode = uiModeManager?.CurrentModeType ?? UiMode.TypeUndefined;
-				currentIdiom = DetectIdiom(uiMode);
-			}
-			catch (Exception ex)
-			{
-				System.Diagnostics.Debug.WriteLine($"Unable to detect using UiModeManager: {ex.Message}");
-			}
+				var currentIdiom = DeviceIdiom.Unknown;
 
-			// then try Configuration
-			if (currentIdiom == DeviceIdiom.Unknown)
-			{
-				var configuration = Essentials.Platform.AppContext.Resources?.Configuration;
-				if (configuration != null)
+				// first try UIModeManager
+				using var uiModeManager = UiModeManager.FromContext(Essentials.Platform.AppContext);
+
+				try
 				{
-					var minWidth = configuration.SmallestScreenWidthDp;
-					var isWide = minWidth >= tabletCrossover;
-					currentIdiom = isWide ? DeviceIdiom.Tablet : DeviceIdiom.Phone;
+					var uiMode = uiModeManager?.CurrentModeType ?? UiMode.TypeUndefined;
+					currentIdiom = DetectIdiom(uiMode);
 				}
-				else
+				catch (Exception ex)
 				{
-					// start clutching at straws
-					using var metrics = Essentials.Platform.AppContext.Resources?.DisplayMetrics;
-					if (metrics != null)
+					System.Diagnostics.Debug.WriteLine($"Unable to detect using UiModeManager: {ex.Message}");
+				}
+
+				// then try Configuration
+				if (currentIdiom == DeviceIdiom.Unknown)
+				{
+					var configuration = Essentials.Platform.AppContext.Resources?.Configuration;
+					if (configuration != null)
 					{
-						var minSize = Math.Min(metrics.WidthPixels, metrics.HeightPixels);
-						var isWide = minSize * metrics.Density >= tabletCrossover;
+						var minWidth = configuration.SmallestScreenWidthDp;
+						var isWide = minWidth >= tabletCrossover;
 						currentIdiom = isWide ? DeviceIdiom.Tablet : DeviceIdiom.Phone;
 					}
+					else
+					{
+						// start clutching at straws
+						using var metrics = Essentials.Platform.AppContext.Resources?.DisplayMetrics;
+						if (metrics != null)
+						{
+							var minSize = Math.Min(metrics.WidthPixels, metrics.HeightPixels);
+							var isWide = minSize * metrics.Density >= tabletCrossover;
+							currentIdiom = isWide ? DeviceIdiom.Tablet : DeviceIdiom.Phone;
+						}
+					}
 				}
-			}
 
-			// hope we got it somewhere
-			return currentIdiom;
+				// hope we got it somewhere
+				return currentIdiom;
+			}
 		}
 
-		static DeviceIdiom DetectIdiom(UiMode uiMode)
+		DeviceIdiom DetectIdiom(UiMode uiMode)
 		{
 			if (uiMode == UiMode.TypeNormal)
 				return DeviceIdiom.Unknown;
@@ -86,34 +92,37 @@ namespace Microsoft.Maui.Essentials
 			return DeviceIdiom.Unknown;
 		}
 
-		static DeviceType GetDeviceType()
+		public DeviceType DeviceType
 		{
-			var isEmulator =
-				(Build.Brand.StartsWith("generic", StringComparison.InvariantCulture) && Build.Device.StartsWith("generic", StringComparison.InvariantCulture)) ||
-				Build.Fingerprint.StartsWith("generic", StringComparison.InvariantCulture) ||
-				Build.Fingerprint.StartsWith("unknown", StringComparison.InvariantCulture) ||
-				Build.Hardware.Contains("goldfish") ||
-				Build.Hardware.Contains("ranchu") ||
-				Build.Model.Contains("google_sdk") ||
-				Build.Model.Contains("Emulator") ||
-				Build.Model.Contains("Android SDK built for x86") ||
-				Build.Manufacturer.Contains("Genymotion") ||
-				Build.Manufacturer.Contains("VS Emulator") ||
-				Build.Product.Contains("emulator") ||
-				Build.Product.Contains("google_sdk") ||
-				Build.Product.Contains("sdk") ||
-				Build.Product.Contains("sdk_google") ||
-				Build.Product.Contains("sdk_x86") ||
-				Build.Product.Contains("simulator") ||
-				Build.Product.Contains("vbox86p");
+			get
+			{
+				var isEmulator =
+					(Build.Brand.StartsWith("generic", StringComparison.InvariantCulture) && Build.Device.StartsWith("generic", StringComparison.InvariantCulture)) ||
+					Build.Fingerprint.StartsWith("generic", StringComparison.InvariantCulture) ||
+					Build.Fingerprint.StartsWith("unknown", StringComparison.InvariantCulture) ||
+					Build.Hardware.Contains("goldfish") ||
+					Build.Hardware.Contains("ranchu") ||
+					Build.Model.Contains("google_sdk") ||
+					Build.Model.Contains("Emulator") ||
+					Build.Model.Contains("Android SDK built for x86") ||
+					Build.Manufacturer.Contains("Genymotion") ||
+					Build.Manufacturer.Contains("VS Emulator") ||
+					Build.Product.Contains("emulator") ||
+					Build.Product.Contains("google_sdk") ||
+					Build.Product.Contains("sdk") ||
+					Build.Product.Contains("sdk_google") ||
+					Build.Product.Contains("sdk_x86") ||
+					Build.Product.Contains("simulator") ||
+					Build.Product.Contains("vbox86p");
 
-			if (isEmulator)
-				return DeviceType.Virtual;
+				if (isEmulator)
+					return DeviceType.Virtual;
 
-			return DeviceType.Physical;
+				return DeviceType.Physical;
+			}
 		}
 
-		static string GetSystemSetting(string name, bool isGlobal = false)
+		string GetSystemSetting(string name, bool isGlobal = false)
 		{
 			if (isGlobal && Essentials.Platform.HasApiLevelNMr1)
 				return Settings.Global.GetString(Essentials.Platform.AppContext.ContentResolver, name);

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
@@ -4,7 +4,7 @@ using Android.Content.Res;
 using Android.OS;
 using Android.Provider;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceInfoImplementation : IDeviceInfo
 	{

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Maui.Essentials.Implementations
 
 		public string VersionString => UIDevice.CurrentDevice.SystemVersion;
 
+		public Version Version => Utils.ParseVersion(VersionString);
+
 		public DevicePlatform Platform =>
 #if MACCATALYST
 			DevicePlatform.MacCatalyst;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
@@ -9,7 +9,7 @@ using UIKit;
 
 using ObjCRuntime;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceInfoImplementation : IDeviceInfo
 	{

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.ios.tvos.watchos.cs
@@ -11,66 +11,72 @@ using ObjCRuntime;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class DeviceInfo
+	public class DeviceInfoImplementation : IDeviceInfo
 	{
-		static string GetModel()
+		public string Model
 		{
-			try
+			get
 			{
-				return Essentials.Platform.GetSystemLibraryProperty("hw.machine");
+				try
+				{
+					return Essentials.Platform.GetSystemLibraryProperty("hw.machine");
+				}
+				catch (Exception)
+				{
+					Debug.WriteLine("Unable to query hardware model, returning current device model.");
+				}
+				return UIDevice.CurrentDevice.Model;
 			}
-			catch (Exception)
-			{
-				Debug.WriteLine("Unable to query hardware model, returning current device model.");
-			}
-			return UIDevice.CurrentDevice.Model;
 		}
 
-		static string GetManufacturer() => "Apple";
+		public string Manufacturer => "Apple";
 
-		static string GetDeviceName() => UIDevice.CurrentDevice.Name;
+		public string Name => UIDevice.CurrentDevice.Name;
 
-		static string GetVersionString() => UIDevice.CurrentDevice.SystemVersion;
+		public string VersionString => UIDevice.CurrentDevice.SystemVersion;
 
-		static DevicePlatform GetPlatform() =>
-#if __MACCATALYST__ || MACCATALYST
+		public DevicePlatform Platform =>
+#if MACCATALYST
 			DevicePlatform.MacCatalyst;
-#elif __IOS__ || IOS
+#elif IOS
 			DevicePlatform.iOS;
 #elif __TVOS__
-            DevicePlatform.tvOS;
+			DevicePlatform.tvOS;
 #elif __WATCHOS__
-            DevicePlatform.watchOS;
+			DevicePlatform.watchOS;
 #endif
 
-		static DeviceIdiom GetIdiom()
+		public DeviceIdiom Idiom
 		{
+			get
+			{
 #if __WATCHOS__
-            return DeviceIdiom.Watch;
-#elif MACCATALYST || __MACCATALYST__
+			return DeviceIdiom.Watch;
+#elif MACCATALYST
 			return DeviceIdiom.Desktop;
 #else
-			switch (UIDevice.CurrentDevice.UserInterfaceIdiom)
-			{
-				case UIUserInterfaceIdiom.Pad:
-					return DeviceIdiom.Tablet;
-				case UIUserInterfaceIdiom.Phone:
-					return DeviceIdiom.Phone;
-				case UIUserInterfaceIdiom.TV:
-					return DeviceIdiom.TV;
-				case UIUserInterfaceIdiom.CarPlay:
-				case UIUserInterfaceIdiom.Unspecified:
-				default:
-					return DeviceIdiom.Unknown;
-			}
+				switch (UIDevice.CurrentDevice.UserInterfaceIdiom)
+				{
+					case UIUserInterfaceIdiom.Pad:
+						return DeviceIdiom.Tablet;
+					case UIUserInterfaceIdiom.Phone:
+						return DeviceIdiom.Phone;
+					case UIUserInterfaceIdiom.TV:
+						return DeviceIdiom.TV;
+					case UIUserInterfaceIdiom.CarPlay:
+					case UIUserInterfaceIdiom.Unspecified:
+					default:
+						return DeviceIdiom.Unknown;
+				}
 #endif
+			}
 		}
 
-		static DeviceType GetDeviceType() =>
-#if !(__MACCATALYST__ || MACCATALYST || MACOS)
-			Runtime.Arch == Arch.DEVICE ? DeviceType.Physical : DeviceType.Virtual;
-#else
+		public DeviceType DeviceType =>
+#if MACCATALYST || MACOS
 			DeviceType.Physical;
+#else
+			Runtime.Arch == Arch.DEVICE ? DeviceType.Physical : DeviceType.Virtual;
 #endif
 	}
 }

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.macos.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.macos.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using Foundation;
 using ObjCRuntime;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceInfoImplementation : IDeviceInfo
 	{

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.macos.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.macos.cs
@@ -5,7 +5,7 @@ using ObjCRuntime;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class DeviceInfo
+	public class DeviceInfoImplementation : IDeviceInfo
 	{
 		[DllImport(Constants.SystemConfigurationLibrary)]
 		static extern IntPtr SCDynamicStoreCopyComputerName(IntPtr store, IntPtr encoding);
@@ -13,40 +13,46 @@ namespace Microsoft.Maui.Essentials
 		[DllImport(Constants.CoreFoundationLibrary)]
 		static extern void CFRelease(IntPtr cf);
 
-		static string GetModel() =>
+		public string Model =>
 			IOKit.GetPlatformExpertPropertyValue<NSData>("model")?.ToString() ?? string.Empty;
 
-		static string GetManufacturer() => "Apple";
+		public string Manufacturer => "Apple";
 
-		static string GetDeviceName()
+		public string Name
 		{
-			var computerNameHandle = SCDynamicStoreCopyComputerName(IntPtr.Zero, IntPtr.Zero);
-
-			if (computerNameHandle == IntPtr.Zero)
-				return null;
-
-			try
+			get
 			{
+				var computerNameHandle = SCDynamicStoreCopyComputerName(IntPtr.Zero, IntPtr.Zero);
+
+				if (computerNameHandle == IntPtr.Zero)
+					return null;
+
+				try
+				{
 #pragma warning disable CS0618 // Type or member is obsolete
-				return NSString.FromHandle(computerNameHandle);
+					return NSString.FromHandle(computerNameHandle);
 #pragma warning restore CS0618 // Type or member is obsolete
-			}
-			finally
-			{
-				CFRelease(computerNameHandle);
+				}
+				finally
+				{
+					CFRelease(computerNameHandle);
+				}
 			}
 		}
 
-		static string GetVersionString()
+		public string VersionString
 		{
-			using var info = new NSProcessInfo();
-			return info.OperatingSystemVersion.ToString();
+			get
+			{
+				using var info = new NSProcessInfo();
+				return info.OperatingSystemVersion.ToString();
+			}
 		}
 
-		static DevicePlatform GetPlatform() => DevicePlatform.macOS;
+		public DevicePlatform Platform => DevicePlatform.macOS;
 
-		static DeviceIdiom GetIdiom() => DeviceIdiom.Desktop;
+		public DeviceIdiom Idiom => DeviceIdiom.Desktop;
 
-		static DeviceType GetDeviceType() => DeviceType.Physical;
+		public DeviceType DeviceType => DeviceType.Physical;
 	}
 }

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.macos.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.macos.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
+		public Version Version => Utils.ParseVersion(VersionString);
+
 		public DevicePlatform Platform => DevicePlatform.macOS;
 
 		public DeviceIdiom Idiom => DeviceIdiom.Desktop;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.netstandard.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.netstandard.cs
@@ -1,20 +1,19 @@
 namespace Microsoft.Maui.Essentials
 {
-	/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="Type[@FullName='Microsoft.Maui.Essentials.DeviceInfo']/Docs" />
-	public static partial class DeviceInfo
+	public class DeviceInfoImplementation : IDeviceInfo
 	{
-		static string GetModel() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public string Model => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		static string GetManufacturer() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public string Manufacturer => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		static string GetDeviceName() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public string Name => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		static string GetVersionString() => throw ExceptionUtils.NotSupportedOrImplementedException;
+		public string VersionString => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		static DevicePlatform GetPlatform() => DevicePlatform.Unknown;
+		public DevicePlatform Platform => DevicePlatform.Unknown;
 
-		static DeviceIdiom GetIdiom() => DeviceIdiom.Unknown;
+		public DeviceIdiom Idiom => DeviceIdiom.Unknown;
 
-		static DeviceType GetDeviceType() => DeviceType.Unknown;
+		public DeviceType DeviceType => DeviceType.Unknown;
 	}
 }

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.netstandard.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.netstandard.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceInfoImplementation : IDeviceInfo
@@ -9,6 +11,8 @@ namespace Microsoft.Maui.Essentials.Implementations
 		public string Name => throw ExceptionUtils.NotSupportedOrImplementedException;
 
 		public string VersionString => throw ExceptionUtils.NotSupportedOrImplementedException;
+
+		public Version Version => throw ExceptionUtils.NotSupportedOrImplementedException;
 
 		public DevicePlatform Platform => DevicePlatform.Unknown;
 

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.netstandard.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.netstandard.cs
@@ -1,4 +1,4 @@
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceInfoImplementation : IDeviceInfo
 	{

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.ComponentModel;
+using Microsoft.Maui.Essentials.Implementations;
 
 namespace Microsoft.Maui.Essentials
 {

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Essentials
 		public static string VersionString => Current.VersionString;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='Version']/Docs" />
-		public static Version Version => Utils.ParseVersion(VersionString);
+		public static Version Version => Current.Version;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='Platform']/Docs" />
 		public static DevicePlatform Platform => Current.Platform;
@@ -65,6 +65,8 @@ namespace Microsoft.Maui.Essentials
 		string Name { get; }
 
 		string VersionString { get; }
+
+		Version Version { get; }
 
 		DevicePlatform Platform { get; }
 

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Maui.Essentials
 		Virtual = 2
 	}
 
-	/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="Type[@FullName='Microsoft.Maui.Essentials.DeviceInfo']/Docs" />
 	public interface IDeviceInfo
 	{
 		string Model { get; }

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.shared.cs
@@ -1,33 +1,46 @@
+#nullable enable
 using System;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.Essentials
 {
 	/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="Type[@FullName='Microsoft.Maui.Essentials.DeviceInfo']/Docs" />
-	public static partial class DeviceInfo
+	public static class DeviceInfo
 	{
+		static IDeviceInfo? currentImplementation;
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static IDeviceInfo Current =>
+			currentImplementation ??= new DeviceInfoImplementation();
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetCurrent(IDeviceInfo? implementation) =>
+			currentImplementation = implementation;
+
+
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='Model']/Docs" />
-		public static string Model => GetModel();
+		public static string Model => Current.Model;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='Manufacturer']/Docs" />
-		public static string Manufacturer => GetManufacturer();
+		public static string Manufacturer => Current.Manufacturer;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='Name']/Docs" />
-		public static string Name => GetDeviceName();
+		public static string Name => Current.Name;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='VersionString']/Docs" />
-		public static string VersionString => GetVersionString();
+		public static string VersionString => Current.VersionString;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='Version']/Docs" />
 		public static Version Version => Utils.ParseVersion(VersionString);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='Platform']/Docs" />
-		public static DevicePlatform Platform => GetPlatform();
+		public static DevicePlatform Platform => Current.Platform;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='Idiom']/Docs" />
-		public static DeviceIdiom Idiom => GetIdiom();
+		public static DeviceIdiom Idiom => Current.Idiom;
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="//Member[@MemberName='DeviceType']/Docs" />
-		public static DeviceType DeviceType => GetDeviceType();
+		public static DeviceType DeviceType => Current.DeviceType;
 	}
 
 	/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceType.xml" path="Type[@FullName='Microsoft.Maui.Essentials.DeviceType']/Docs" />
@@ -39,5 +52,23 @@ namespace Microsoft.Maui.Essentials
 		Physical = 1,
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceType.xml" path="//Member[@MemberName='Virtual']/Docs" />
 		Virtual = 2
+	}
+
+	/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceInfo.xml" path="Type[@FullName='Microsoft.Maui.Essentials.DeviceInfo']/Docs" />
+	public interface IDeviceInfo
+	{
+		string Model { get; }
+
+		string Manufacturer { get; }
+
+		string Name { get; }
+
+		string VersionString { get; }
+
+		DevicePlatform Platform { get; }
+
+		DeviceIdiom Idiom { get; }
+
+		DeviceType DeviceType { get; }
 	}
 }

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.tizen.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.tizen.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui.Essentials.Implementations
 		public string VersionString
 			=> Plat.GetFeatureInfo("platform.version");
 
+		public Version Version => Utils.ParseVersion(VersionString);
+
 		public DevicePlatform Platform
 			=> DevicePlatform.Tizen;
 

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.tizen.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.tizen.cs
@@ -1,6 +1,6 @@
 using Plat = Microsoft.Maui.Essentials.Platform;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceInfoImplementation : IDeviceInfo
 	{

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.tizen.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.tizen.cs
@@ -2,52 +2,58 @@ using Plat = Microsoft.Maui.Essentials.Platform;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class DeviceInfo
+	public class DeviceInfoImplementation : IDeviceInfo
 	{
-		static string GetModel()
-		   => Plat.GetSystemInfo("model_name");
+		public string Model
+			=> Plat.GetSystemInfo("model_name");
 
-		static string GetManufacturer()
+		public string Manufacturer
 			=> Plat.GetSystemInfo("manufacturer");
 
-		static string GetDeviceName()
+		public string Name
 			=> Plat.GetSystemInfo("device_name");
 
-		static string GetVersionString()
+		public string VersionString
 			=> Plat.GetFeatureInfo("platform.version");
 
-		static DevicePlatform GetPlatform()
+		public DevicePlatform Platform
 			=> DevicePlatform.Tizen;
 
-		static DeviceIdiom GetIdiom()
+		public DeviceIdiom Idiom
 		{
-			var profile = Plat.GetFeatureInfo("profile")?.ToUpperInvariant();
+			get
+			{
+				var profile = Plat.GetFeatureInfo("profile")?.ToUpperInvariant();
 
-			if (profile == null)
-				return DeviceIdiom.Unknown;
+				if (profile == null)
+					return DeviceIdiom.Unknown;
 
-			if (profile.StartsWith("M"))
-				return DeviceIdiom.Phone;
-			else if (profile.StartsWith("W"))
-				return DeviceIdiom.Watch;
-			else if (profile.StartsWith("T"))
-				return DeviceIdiom.TV;
-			else
-				return DeviceIdiom.Unknown;
+				if (profile.StartsWith("M"))
+					return DeviceIdiom.Phone;
+				else if (profile.StartsWith("W"))
+					return DeviceIdiom.Watch;
+				else if (profile.StartsWith("T"))
+					return DeviceIdiom.TV;
+				else
+					return DeviceIdiom.Unknown;
+			}
 		}
 
-		static DeviceType GetDeviceType()
+		public DeviceType DeviceType
 		{
-			var arch = Plat.GetFeatureInfo("platform.core.cpu.arch");
-			var armv7 = Plat.GetFeatureInfo<bool>("platform.core.cpu.arch.armv7");
-			var x86 = Plat.GetFeatureInfo<bool>("platform.core.cpu.arch.x86");
+			get
+			{
+				var arch = Plat.GetFeatureInfo("platform.core.cpu.arch");
+				var armv7 = Plat.GetFeatureInfo<bool>("platform.core.cpu.arch.armv7");
+				var x86 = Plat.GetFeatureInfo<bool>("platform.core.cpu.arch.x86");
 
-			if (arch != null && arch.Equals("armv7") && armv7 && !x86)
-				return DeviceType.Physical;
-			else if (arch != null && arch.Equals("x86") && !armv7 && x86)
-				return DeviceType.Virtual;
-			else
-				return DeviceType.Unknown;
+				if (arch != null && arch.Equals("armv7") && armv7 && !x86)
+					return DeviceType.Physical;
+				else if (arch != null && arch.Equals("x86") && !armv7 && x86)
+					return DeviceType.Virtual;
+				else
+					return DeviceType.Unknown;
+			}
 		}
 	}
 }

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
+		public Version Version => Utils.ParseVersion(VersionString);
+
 		public DevicePlatform Platform => DevicePlatform.UWP;
 
 		public DeviceIdiom Idiom

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
@@ -6,14 +6,14 @@ using Windows.UI.ViewManagement;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class DeviceInfo
+	public class DeviceInfoImplementation : IDeviceInfo
 	{
-		static readonly EasClientDeviceInformation deviceInfo;
-		static DeviceIdiom currentIdiom;
-		static DeviceType currentType = DeviceType.Unknown;
-		static string systemProductName;
+		readonly EasClientDeviceInformation deviceInfo;
+		DeviceIdiom currentIdiom;
+		DeviceType currentType = DeviceType.Unknown;
+		string systemProductName;
 
-		static DeviceInfo()
+		public DeviceInfoImplementation()
 		{
 			deviceInfo = new EasClientDeviceInformation();
 			currentIdiom = DeviceIdiom.Unknown;
@@ -27,85 +27,94 @@ namespace Microsoft.Maui.Essentials
 			}
 		}
 
-		static string GetModel() => deviceInfo.SystemProductName;
+		public string Model => deviceInfo.SystemProductName;
 
-		static string GetManufacturer() => deviceInfo.SystemManufacturer;
+		public string Manufacturer => deviceInfo.SystemManufacturer;
 
-		static string GetDeviceName() => deviceInfo.FriendlyName;
+		public string Name => deviceInfo.FriendlyName;
 
-		static string GetVersionString()
+		public string VersionString
 		{
-			var version = AnalyticsInfo.VersionInfo.DeviceFamilyVersion;
-
-			if (ulong.TryParse(version, out var v))
+			get
 			{
-				var v1 = (v & 0xFFFF000000000000L) >> 48;
-				var v2 = (v & 0x0000FFFF00000000L) >> 32;
-				var v3 = (v & 0x00000000FFFF0000L) >> 16;
-				var v4 = v & 0x000000000000FFFFL;
-				return $"{v1}.{v2}.{v3}.{v4}";
-			}
+				var version = AnalyticsInfo.VersionInfo.DeviceFamilyVersion;
 
-			return version;
+				if (ulong.TryParse(version, out var v))
+				{
+					var v1 = (v & 0xFFFF000000000000L) >> 48;
+					var v2 = (v & 0x0000FFFF00000000L) >> 32;
+					var v3 = (v & 0x00000000FFFF0000L) >> 16;
+					var v4 = v & 0x000000000000FFFFL;
+					return $"{v1}.{v2}.{v3}.{v4}";
+				}
+
+				return version;
+			}
 		}
 
-		static DevicePlatform GetPlatform() => DevicePlatform.UWP;
+		public DevicePlatform Platform => DevicePlatform.UWP;
 
-		static DeviceIdiom GetIdiom()
+		public DeviceIdiom Idiom
 		{
-			switch (AnalyticsInfo.VersionInfo.DeviceFamily)
+			get
 			{
-				case "Windows.Mobile":
-					currentIdiom = DeviceIdiom.Phone;
-					break;
-				case "Windows.Universal":
-				case "Windows.Desktop":
-					{
-						try
+				switch (AnalyticsInfo.VersionInfo.DeviceFamily)
+				{
+					case "Windows.Mobile":
+						currentIdiom = DeviceIdiom.Phone;
+						break;
+					case "Windows.Universal":
+					case "Windows.Desktop":
 						{
-							var currentHandle = Essentials.Platform.CurrentWindowHandle;
-							var settings = UIViewSettingsInterop.GetForWindow(currentHandle);
-							var uiMode = settings.UserInteractionMode;
-							currentIdiom = uiMode == UserInteractionMode.Mouse ? DeviceIdiom.Desktop : DeviceIdiom.Tablet;
+							try
+							{
+								var currentHandle = Essentials.Platform.CurrentWindowHandle;
+								var settings = UIViewSettingsInterop.GetForWindow(currentHandle);
+								var uiMode = settings.UserInteractionMode;
+								currentIdiom = uiMode == UserInteractionMode.Mouse ? DeviceIdiom.Desktop : DeviceIdiom.Tablet;
+							}
+							catch (Exception ex)
+							{
+								Debug.WriteLine($"Unable to get device . {ex.Message}");
+							}
 						}
-						catch (Exception ex)
-						{
-							Debug.WriteLine($"Unable to get device . {ex.Message}");
-						}
-					}
-					break;
-				case "Windows.Xbox":
-				case "Windows.Team":
-					currentIdiom = DeviceIdiom.TV;
-					break;
-				case "Windows.IoT":
-				default:
-					currentIdiom = DeviceIdiom.Unknown;
-					break;
-			}
+						break;
+					case "Windows.Xbox":
+					case "Windows.Team":
+						currentIdiom = DeviceIdiom.TV;
+						break;
+					case "Windows.IoT":
+					default:
+						currentIdiom = DeviceIdiom.Unknown;
+						break;
+				}
 
-			return currentIdiom;
+				return currentIdiom;
+			}
 		}
 
-		static DeviceType GetDeviceType()
+		public DeviceType DeviceType
 		{
-			if (currentType != DeviceType.Unknown)
+			get
+			{
+				if (currentType != DeviceType.Unknown)
+					return currentType;
+
+				try
+				{
+					if (string.IsNullOrWhiteSpace(systemProductName))
+						systemProductName = deviceInfo.SystemProductName;
+
+					var isVirtual = systemProductName.Contains("Virtual") || systemProductName == "HMV domU";
+
+					currentType = isVirtual ? DeviceType.Virtual : DeviceType.Physical;
+				}
+				catch (Exception ex)
+				{
+					Debug.WriteLine($"Unable to get device type. {ex.Message}");
+				}
 				return currentType;
-
-			try
-			{
-				if (string.IsNullOrWhiteSpace(systemProductName))
-					systemProductName = deviceInfo.SystemProductName;
-
-				var isVirtual = systemProductName.Contains("Virtual") || systemProductName == "HMV domU";
-
-				currentType = isVirtual ? DeviceType.Virtual : DeviceType.Physical;
 			}
-			catch (Exception ex)
-			{
-				Debug.WriteLine($"Unable to get device type. {ex.Message}");
-			}
-			return currentType;
 		}
 	}
 }

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
@@ -4,7 +4,7 @@ using Windows.Security.ExchangeActiveSyncProvisioning;
 using Windows.System.Profile;
 using Windows.UI.ViewManagement;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public class DeviceInfoImplementation : IDeviceInfo
 	{


### PR DESCRIPTION
### Description of Change ###

Use a lazy interface.

Required for https://github.com/dotnet/maui/issues/1965

### Additions made ###

```cs
public interface IDeviceInfo
{
	string Model { get; }
	string Manufacturer { get; }
	string Name { get; }
	string VersionString { get; }
	Version Version { get; }
	DevicePlatform Platform { get; }
	DeviceIdiom Idiom { get; }
	DeviceType DeviceType { get; }
}
```