### PR TITLE
Add microsoft.net.workload.mono.toolchain back into the rollback.json

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
@@ -4,5 +4,6 @@
   "microsoft.net.sdk.maccatalyst": "@MicrosoftMacCatalystSdkPackageVersion@",
   "microsoft.net.sdk.macos": "@MicrosoftmacOSSdkPackageVersion@",
   "microsoft.net.sdk.maui": "@VERSION@",
-  "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@"
+  "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@",
+  "microsoft.net.workload.mono.toolchain": "@MicrosoftNETCoreAppRefPackageVersion@"
 }


### PR DESCRIPTION
### Description of Change ###

When installing from a rollback file, we also want to make sure we install the toolchain: `microsoft.net.workload.mono.toolchain`

