### PR TITLE
EvaluateJavaScriptAsync with CommandMapper

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
@@ -40,6 +40,16 @@
                 <Button
                     Text="Eval"
                     Clicked="OnEvalClicked"/>
+				<Label
+                    Text="Eval Script (async)"
+                    Style="{StaticResource Headline}"/>
+                <Button
+                    Text="Eval Async"
+                    Clicked="OnEvalAsyncClicked"/>
+				<Label
+					x:Name="EvalResultLabel"
+                    Text="..."
+                    Style="{StaticResource Headline}"/>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
@@ -39,5 +39,15 @@ namespace Maui.Controls.Sample.Pages
 		{
 			MauiWebView.Eval("alert('text')");
 		}
+
+		async void OnEvalAsyncClicked(object sender, EventArgs args)
+		{
+			MauiWebView.Eval("alert('text')");
+
+			var result = await MauiWebView.EvaluateJavaScriptAsync(
+				"var test = function(){ return 'This string came from Javascript!'; }; test();");
+
+			EvalResultLabel.Text = result;
+		}
 	}
 }

--- a/src/Controls/src/Core/WebView.cs
+++ b/src/Controls/src/Core/WebView.cs
@@ -111,7 +111,20 @@ namespace Microsoft.Maui.Controls
 				script = "try{JSON.stringify(eval('" + script + "'))}catch(e){'null'};";
 			}
 
-			var result = await _evaluateJavaScriptRequested?.Invoke(script);
+			string result;
+			
+			if (_evaluateJavaScriptRequested?.GetInvocationList().Length == 0)
+			{
+				// This is the WebViewRenderer subscribing to these requests; the handler stuff
+				// doesn't use them.
+				result = await _evaluateJavaScriptRequested?.Invoke(script);
+			}
+			else
+			{
+				// Use the handler command to evaluate the JS
+				result = await Handler.InvokeAsync(nameof(IWebView.EvaluateJavaScriptAsync), 
+					new EvaluateJavaScriptAsyncRequest(script));
+			}
 
 			//if the js function errored or returned null/undefined treat it as null
 			if (result == "null")

--- a/src/Core/src/Core/IWebView.cs
+++ b/src/Core/src/Core/IWebView.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Maui
 {
 	/// <summary>
 	/// Represents a View that presents HTML content.
@@ -40,5 +42,7 @@
 		/// </summary>
 		/// <param name="script">A script to evaluate.</param>
 		void Eval(string script);
+
+		Task<string> EvaluateJavaScriptAsync(string script);
 	}
 }

--- a/src/Core/src/Handlers/ElementHandlerExtensions.cs
+++ b/src/Core/src/Handlers/ElementHandlerExtensions.cs
@@ -10,6 +10,7 @@ using NativeView = System.Object;
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Handlers;
+using System.Threading.Tasks;
 
 namespace Microsoft.Maui
 {
@@ -66,6 +67,20 @@ namespace Microsoft.Maui
 			var service = services.GetRequiredService<T>();
 
 			return service;
+		}
+	
+		public static async Task<T> InvokeAsync<T>(this IElementHandler handler, string commandName,
+			AsyncCommandArguments<T> args)
+		{
+			handler?.Invoke(commandName, args);
+			return await args.Result;
+		}
+
+		public static async Task InvokeAsync(this IElementHandler handler, string commandName,
+			AsyncCommandArguments args)
+		{
+			handler?.Invoke(commandName, args);
+			await args.Task;
 		}
 	}
 }

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -87,5 +87,13 @@ namespace Microsoft.Maui.Handlers
 			IWebViewDelegate? webViewDelegate = handler.NativeView as IWebViewDelegate;
 			handler.NativeView?.UpdateSource(webView, webViewDelegate);
 		}
+
+		public static async void MapEvaluateJavaScriptAsync(WebViewHandler handler, IWebView webView, object? arg) 
+		{
+			if (arg is EvaluateJavaScriptAsyncRequest request)
+			{
+				await handler.NativeView.EvaluateJavaScript(request);				
+			}
+		}
 	}
 }

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Standard.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -12,5 +13,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapGoForward(IViewHandler handler, IWebView webView, object? arg) { }
 		public static void MapReload(IViewHandler handler, IWebView webView, object? arg) { }
 		public static void MapEval(IViewHandler handler, IWebView webView, object? arg) { }
+		public static void MapEvaluateJavaScriptAsync(IViewHandler handler, IWebView webView, object? arg) { }
 	}
 }

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Windows.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
+using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -57,6 +59,14 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			handler.NativeView?.Eval(webView, script);
+		}
+
+		public static async void MapEvaluateJavaScriptAsync(WebViewHandler handler, IWebView webView, object? arg) 
+		{
+			if (arg is EvaluateJavaScriptAsyncRequest request)
+			{
+				await handler.NativeView.EvaluateJavaScript(request);
+			}
 		}
 	}
 }

--- a/src/Core/src/Handlers/WebView/WebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IWebView.GoForward)] = MapGoForward,
 			[nameof(IWebView.Reload)] = MapReload,
 			[nameof(IWebView.Eval)] = MapEval,
+			[nameof(IWebView.EvaluateJavaScriptAsync)] = MapEvaluateJavaScriptAsync,
 		};
 
 		public WebViewHandler() : base(WebViewMapper, WebViewCommandMapper)

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -72,5 +72,13 @@ namespace Microsoft.Maui.Handlers
 
 			return size;
 		}
+
+		public static async void MapEvaluateJavaScriptAsync(WebViewHandler handler, IWebView webView, object? arg) 
+		{
+			if (arg is EvaluateJavaScriptAsyncRequest request)
+			{
+				await handler.NativeView.EvaluateJavaScript(request);
+			}
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/WebViewExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Platform
@@ -64,6 +65,12 @@ namespace Microsoft.Maui.Platform
 			{
 				await nativeWebView.ExecuteScriptAsync(script);
 			});
+		}
+
+		public static async Task EvaluateJavaScript(this WebView2 webView, EvaluateJavaScriptAsyncRequest request) 
+		{
+			var result = await webView.ExecuteScriptAsync(request.Script);
+			request.SetResult(result);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/WebViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/WebViewExtensions.cs
@@ -1,4 +1,5 @@
-﻿using WebKit;
+﻿using System.Threading.Tasks;
+using WebKit;
 
 namespace Microsoft.Maui.Platform
 {
@@ -57,6 +58,12 @@ namespace Microsoft.Maui.Platform
 		public static void Eval(this WKWebView nativeWebView, IWebView webView, string script)
 		{
 			nativeWebView.EvaluateJavaScriptAsync(script);
+		}
+
+		public static async Task EvaluateJavaScript(this WKWebView webView, EvaluateJavaScriptAsyncRequest request)
+		{
+			var result = await webView.EvaluateJavaScriptAsync(request.Script);
+			request.SetResult(result?.ToString() ?? "null");
 		}
 	}
 }

--- a/src/Core/src/Primitives/AsyncCommandArguments.cs
+++ b/src/Core/src/Primitives/AsyncCommandArguments.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui
+{
+	/// <summary>
+	/// Arguments for an asynchronous handler command which returns a value.
+	/// </summary>
+	/// <typeparam name="T">The type of the value to be returned.</typeparam>
+	/// <remarks>
+	/// AsyncCommandArguments are passed to a mapped handler command via the <see cref="Microsoft.Maui.IElementHandler.Invoke(string, object?)" /> method.
+	/// The mapped handler command is responsible for calling the <see cref="SetResult"/> method to 
+	/// signal to the caller that the command has completed. 
+	/// </remarks>
+	public class AsyncCommandArguments<T> 
+	{
+		readonly TaskCompletionSource<T> _taskCompletionSource;
+
+		/// <summary>
+		/// Called by the handler to set the result when available.
+		/// </summary>
+		public Action<T> SetResult { get; }
+
+		/// <summary>
+		/// The task to be awaited by the cross-platform control invoking the command.
+		/// </summary>
+		public Task<T> Result => _taskCompletionSource.Task;
+
+		public AsyncCommandArguments() 
+		{
+			_taskCompletionSource = new TaskCompletionSource<T>();
+			SetResult = _taskCompletionSource.SetResult;
+		}
+	}
+
+	/// <summary>
+	/// Arguments for an asynchronous handler command 
+	/// </summary>
+	/// <remarks>
+	/// AsyncCommandArguments are passed to a mapped handler command via the <see cref="Microsoft.Maui.IElementHandler.Invoke(string, object?)" /> method.
+	/// The mapped handler command is responsible for calling the <see cref="SetComplete"/> method to 
+	/// signal to the caller that the command has completed.
+	/// </remarks>
+	public class AsyncCommandArguments
+	{
+		readonly TaskCompletionSource<object?> _taskCompletionSource;
+
+		/// <summary>
+		/// Called by the handler to signal when the command is complete.
+		/// </summary>
+		public Action SetComplete { get; }
+
+		/// <summary>
+		/// The task to be awaited by the cross-platform control invoking the command.
+		/// </summary>
+		public Task Task => _taskCompletionSource.Task;
+
+		protected AsyncCommandArguments()
+		{
+			_taskCompletionSource = new TaskCompletionSource<object?>();
+			SetComplete = () => _taskCompletionSource.SetResult(null);
+		}
+	}
+}

--- a/src/Core/src/Primitives/AsyncCommandArguments.cs
+++ b/src/Core/src/Primitives/AsyncCommandArguments.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui
 		/// </summary>
 		public Task Task => _taskCompletionSource.Task;
 
-		protected AsyncCommandArguments()
+		public AsyncCommandArguments()
 		{
 			_taskCompletionSource = new TaskCompletionSource<object?>();
 			SetComplete = () => _taskCompletionSource.SetResult(null);

--- a/src/Core/src/Primitives/EvaluateJavaScriptAsyncCommand.cs
+++ b/src/Core/src/Primitives/EvaluateJavaScriptAsyncCommand.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.Maui
+{
+	/// <summary>
+	/// Specifies JavasScript to be evaluated by a platform web view control
+	/// </summary>
+	public class EvaluateJavaScriptAsyncRequest : AsyncCommandArguments<string>
+	{
+		/// <summary>
+		/// The JavaScript to be evaluated.
+		/// </summary>
+		public string Script { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the EvaluateJavaScriptAsyncRequest class.
+		/// </summary>
+		/// <param name="script">The JavaScript to be evaluated.</param>
+		public EvaluateJavaScriptAsyncRequest(string script) : base()
+		{
+			Script = script;
+		}
+	}
+}


### PR DESCRIPTION
Implements the `EvaluateJavaScriptAsync` method for `WebView`; adds support for packing up arguments with a `Task` for communicating async results from a handler back to the cross-platform control. 

API changes:

ElementHandlerExtensions Added:

// Convenience method for invoking a command on a handler and getting back a result
`public static async Task<T> InvokeAsync<T>(this IElementHandler handler, string commandName, AsyncCommandArguments<T> args)`

// Same thing, but without the result
`public static async Task InvokeAsync(this IElementHandler handler, string commandName, AsyncCommandArguments args)`

Primitives Added:

// Contains a Task for returning a value of type T and letting the caller know the operation is finished
`public class AsyncCommandArguments<T>`

// Same thing as above, but no return value
`public class AsyncCommandArguments`

// Can pass in a script to execute and return the result as a string
`public class EvaluateJavaScriptAsyncRequest : AsyncCommandArguments<string>`