### PR TITLE
updated Microsoft.TemplateEngine.Tasks version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -211,9 +211,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4f567e5ffa4bad5d2cbb5e82470f18534ee02c9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-alpha.1.21601.1">
+    <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-preview.2.22102.8">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha />
-    </Dependency>   
+      <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
+    </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,7 +71,7 @@
     <_SkiaSharpVersion>2.88.0-preview.179</_SkiaSharpVersion>
     <_HarfBuzzSharpVersion>2.8.2-preview.179</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.fffae82cf6ec1c4a6f490ddb780709ce9211725e.179</_SkiaSharpNativeAssetsVersion>
-    <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
+    <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.2.22102.8</MicrosoftTemplateEngineTasksVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Match the first three version numbers and append 00 -->


### PR DESCRIPTION
### Description of Change ###

updated Microsoft.TemplateEngine.Tasks version, new version fixes null-reference exception during error reporting.
https://github.com/dotnet/templating/pull/4338