### PR TITLE
[build] don't edit global.json during the build

### DIFF
--- a/eng/package.ps1
+++ b/eng/package.ps1
@@ -40,15 +40,6 @@ if ($IsWindows)
         Write-Host "Found MSBuild at ${msbuild}"
     }
 
-    # Modify global.json, so the IDE can load
-    $globaljson = Join-Path $PSScriptRoot ../global.json
-    [xml] $xml = Get-Content (Join-Path $PSScriptRoot Versions.props)
-    $jsonBackup = Get-Content $globaljson
-    $json = Get-Content $globaljson | ConvertFrom-Json
-    $json | Add-Member sdk (New-Object -TypeName PSObject) -Force
-    $json.sdk | Add-Member version ([string]$xml.Project.PropertyGroup.MicrosoftDotnetSdkInternalPackageVersion).Trim() -Force
-    $json | ConvertTo-Json | Set-Content $globaljson
-
     # NOTE: I've not found a better way to do this
     # see: https://github.com/PowerShell/PowerShell/issues/3316
     $oldDOTNET_INSTALL_DIR=$env:DOTNET_INSTALL_DIR

--- a/eng/package.ps1
+++ b/eng/package.ps1
@@ -93,7 +93,6 @@ if ($IsWindows)
         $env:DOTNET_MULTILEVEL_LOOKUP=$oldDOTNET_MULTILEVEL_LOOKUP
         $env:MSBuildEnableWorkloadResolver=$oldMSBuildEnableWorkloadResolver
         $env:PATH=$oldPATH
-        $jsonBackup | Set-Content $globaljson
     }
 }
 else


### PR DESCRIPTION
### Description of Change ###

Early on, we had a need when building the .NET MAUI workload for
`global.json` to be filled with the exact version of .NET used when
deploying a WinUI project inside Visual Studio. Otherwise, WinUI
projects would give a build error about the version of .NET it didn't
know about.

This is somewhat annoying that the `global.json` file changes locally,
and then if you want to run your system-wide .NET to do `dotnet cake`
later, you have to discard the change for it to work.

Let's remove this, as @PureWeen verified that working on WinUI seems
to work now without this.
