### PR TITLE
[ci] Push .NET artifacts to blob storage

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -49,6 +49,7 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - template: templates/common/vs-release-vars.yml@sdk-insertions
 
 parameters:
   - name: BuildEverything
@@ -99,6 +100,11 @@ resources:
       name: xamarin/yaml-templates
       endpoint: xamarin
       ref: refs/heads/main # still defaults to master even though main is the main branch
+    - repository: sdk-insertions
+      type: github
+      name: xamarin/sdk-insertions
+      ref: refs/heads/main
+      endpoint: xamarin
 
 stages:
 
@@ -358,6 +364,53 @@ stages:
             artifactPath: signed
             propsArtifactName: nuget
             signType: Real
+
+        - job: create_artifact_statuses
+          displayName: Create GitHub Artifact Status
+          dependsOn: nuget_convert
+          timeoutInMinutes: 60
+          pool:
+            vmImage: windows-latest
+          steps:
+          - checkout : none
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: nuget
+              downloadPath: $(Build.StagingDirectory)\nuget
+              patterns: |
+                **/signed/*.nupkg
+                **/*.snupkg
+                **/additional-assets.zip
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: vs-msi-nugets
+              downloadPath: $(Build.StagingDirectory)\nuget
+
+          - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+            parameters:
+              githubToken: $(github--pat--vs-mobiletools-engineering-service2)
+              githubContext: $(NupkgCommitStatusName)
+              blobName: $(NupkgCommitStatusName)
+              packagePrefix: maui
+              artifactsPath: $(Build.StagingDirectory)\nuget
+              yamlResourceName: xamarin-templates
+
+          - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+            parameters:
+              githubToken: $(github--pat--vs-mobiletools-engineering-service2)
+              githubContext: $(VSDropCommitStatusName)
+              blobName: $(VSDropCommitStatusName)
+              packagePrefix: maui
+              artifactsPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
+              yamlResourceName: xamarin-templates
+              downloadSteps:
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifactName: vsdrop-signed
+                  downloadPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
+
 
     - template: vs-insertion/stage/v1.yml@xamarin-templates
       parameters:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -352,7 +352,7 @@ stages:
             signedArtifactName: nuget
             signedArtifactPath: signed
             displayName: Sign Phase
-            condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
+            condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/insert-rd'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
 
         - template: nuget-msi-convert/job/v2.yml@xamarin-templates
           parameters:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -372,7 +372,7 @@ stages:
           pool:
             vmImage: windows-latest
           steps:
-          - checkout : none
+          - checkout: self
 
           - task: DownloadPipelineArtifact@2
             inputs:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -352,7 +352,7 @@ stages:
             signedArtifactName: nuget
             signedArtifactPath: signed
             displayName: Sign Phase
-            condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/insert-rd'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
+            condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
 
         - template: nuget-msi-convert/job/v2.yml@xamarin-templates
           parameters:


### PR DESCRIPTION
Context: https://github.com/xamarin/sdk-insertions/blob/1ecc4ae21866d152a9e37465d422de97a8ac1019/templates/common/upload-vs-insertion-artifacts.yml

Pushes our .NET shipping artifacts to blob storage, and uses the
[BuildTasks][0] tooling to create GitHub commit statuses containing
`json` that describes those artifacts.  These commit statuses will be
used by a new VS insertion release pipeline.

[0]: https://github.com/xamarinhq/build-tasks/tree/d058327acdbd2d99e6cf4a9b0895371065cd9b22/BuildTasks