### PR TITLE
If handler has a ViewController then return the View for the ViewController when calling ToPlatform

### DIFF
--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -111,6 +111,11 @@ namespace Microsoft.Maui.Platform
 
 			if (view.Handler is IViewHandler viewHandler)
 			{
+#if IOS
+				if (viewHandler is INativeViewHandler nvh && nvh.ViewController?.View != null)
+					return nvh.ViewController.View;
+#endif
+
 				if (viewHandler.ContainerView is NativeView containerView)
 					return containerView;
 

--- a/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Page/PageHandlerTests.iOS.cs
@@ -3,6 +3,7 @@ using Microsoft.Maui.Handlers;
 using ObjCRuntime;
 using UIKit;
 using Xunit;
+using Microsoft.Maui.DeviceTests.Stubs;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -20,6 +21,23 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(1, childCount);
 			return null;
+		}
+
+
+		[Fact(DisplayName = "Page Controller View used for ContainerView")]
+		public async Task AddingPageControllerToParentController()
+		{
+			var slider = new SliderStub();
+			var page = new PageStub
+			{
+				Content = new ButtonStub()
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler(page);
+				Assert.Equal(handler.ViewController.View, handler.ToPlatform());
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Currently the PageHandler view hierarchy on iOS goes

`UIViewController => ControllersView => PageView`

The `PageHandler` currently returns `PageView` for  `handler.NativeView`

This means the following code doesn't really work

`_parentViewController.View.AddSubView(_pageHandler.NativeView)`

This is the reason why the flyout on `FlyoutPage` is currently blank on iOS. Because the `_flyoutPageController` adds the `PageView`. Because iOS just automatically re-parents views this causes the `PageView` to just get removed from its `VC`

This PR doesn't fix `FlyoutPage` on iOS but it does inform the API strategy needed to fix `FlyoutPage`

#### Alternate Idea for this fix

- Should the ContainerView on the `ViewHandler` return the `ViewController.View` ? This gets a little bit awkward because our `ContainerView` has a strong relationship with `WrapperView` specifically 

```C#
	public partial class ViewHandler<TVirtualView, TNativeView> : INativeViewHandler
	{
		UIView? INativeViewHandler.ContainerView
		{
			get => ViewController?.View ?? base.ContainerView;
		}

		bool IViewHandler.HasContainer
		{
			get => (ViewController != null && NativeView != ViewController.View || base.HasContainer);
			set => base.HasContainer = value;
		}
```

- Don't do anything and close the PR. If you're adding a VC to a VC in iOS then you know what you're doing
- Add an extension method

`PlatformView.AddChild(IView view)`

That AddChild will know what to grab and add

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
