### PR TITLE
[ci] .NET step changes to overcome Mac build machine failures 

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -11,7 +11,9 @@ steps:
       version: 6.0.102
 
   - powershell: |
+      Write-Host "dotnet --version"
       dotnet --version
+      Write-Host "dotnet --list-sdks"
       dotnet --list-sdks
     displayName: 'Show .NET SDK info'
 

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -4,11 +4,20 @@ parameters:
   poolName: ''
 
 steps:
+  - ${{ if eq(parameters.platform, 'macos') }}:
+    -pwsh: |
+      $dotnetToolsPath = "$(Agent.ToolsDirectory)/dotnet"
+      if ([IO.Directory]::Exists($dotnetToolsPath))) {
+        Write-Host "Deleting: ${dotnetToolsPath}"
+        [IO.Directory]::Delete($dotnetToolsPath, $true)
+      }
+
   - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
     displayName: 'Use .NET SDK 6'
     inputs:
       packageType: sdk
       version: 6.0.102
+
 
   - pwsh: |
       Write-Host "dotnet --version"

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -10,12 +10,13 @@ steps:
       packageType: sdk
       version: 6.0.102
 
-  - powershell: |
+  - pwsh: |
       Write-Host "dotnet --version"
       dotnet --version
       Write-Host "dotnet --list-sdks"
       dotnet --list-sdks
     displayName: 'Show .NET SDK info'
+    workingDirectory: $(Agent.ToolsDirectory)/dotnet
 
   # Prepare macOS
   - ${{ if eq(parameters.platform, 'macos') }}:

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -10,7 +10,6 @@ steps:
       packageType: sdk
       version: 6.0.x
 
-
   - pwsh: |
       Write-Host "dotnet --version"
       dotnet --version

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
   - ${{ if eq(parameters.platform, 'macos') }}:
-    -pwsh: |
+    - pwsh: |
       $dotnetToolsPath = "$(Agent.ToolsDirectory)/dotnet"
       if ([IO.Directory]::Exists($dotnetToolsPath))) {
         Write-Host "Deleting: ${dotnetToolsPath}"

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -8,7 +8,7 @@ steps:
     displayName: 'Use .NET SDK 6'
     inputs:
       packageType: sdk
-      version: 6.0.x
+      version: 6.0.101
 
   - pwsh: |
       dotnet --version

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -7,7 +7,7 @@ steps:
   - ${{ if eq(parameters.platform, 'macos') }}:
     - pwsh: |
         $dotnetToolsPath = "$(Agent.ToolsDirectory)/dotnet"
-        if ([IO.Directory]::Exists($dotnetToolsPath))) {
+        if ([IO.Directory]::Exists($dotnetToolsPath)) {
           Write-Host "Deleting: ${dotnetToolsPath}"
           [IO.Directory]::Delete($dotnetToolsPath, $true)
         }

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -6,11 +6,12 @@ parameters:
 steps:
   - ${{ if eq(parameters.platform, 'macos') }}:
     - pwsh: |
-      $dotnetToolsPath = "$(Agent.ToolsDirectory)/dotnet"
-      if ([IO.Directory]::Exists($dotnetToolsPath))) {
-        Write-Host "Deleting: ${dotnetToolsPath}"
-        [IO.Directory]::Delete($dotnetToolsPath, $true)
-      }
+        $dotnetToolsPath = "$(Agent.ToolsDirectory)/dotnet"
+        if ([IO.Directory]::Exists($dotnetToolsPath))) {
+          Write-Host "Deleting: ${dotnetToolsPath}"
+          [IO.Directory]::Delete($dotnetToolsPath, $true)
+        }
+      displayName: 'Cleanse .NET from agent tools directory'
 
   - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
     displayName: 'Use .NET SDK 6'

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -8,7 +8,7 @@ steps:
     displayName: 'Use .NET SDK 6'
     inputs:
       packageType: sdk
-      version: 6.0.*
+      version: 6.0.x
 
 
   - pwsh: |

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -9,9 +9,8 @@ steps:
     inputs:
       packageType: sdk
       version: 6.0.102
-      installationPath: /usr/local/share/dotnet/sdk   # Central .NET SDK install location
 
-  - pwsh: |
+  - powershell: |
       dotnet --version
       dotnet --list-sdks
     displayName: 'Show .NET SDK info'

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -17,7 +17,7 @@ steps:
     displayName: 'Use .NET SDK 6'
     inputs:
       packageType: sdk
-      version: 6.0.102
+      version: 6.0.*
 
 
   - pwsh: |

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -8,7 +8,8 @@ steps:
     displayName: 'Use .NET SDK 6'
     inputs:
       packageType: sdk
-      version: 6.0.101
+      version: 6.0.102
+      installationPath: /usr/local/share/dotnet/sdk   # Central .NET SDK install location
 
   - pwsh: |
       dotnet --version

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -4,15 +4,6 @@ parameters:
   poolName: ''
 
 steps:
-  - ${{ if eq(parameters.platform, 'macos') }}:
-    - pwsh: |
-        $dotnetToolsPath = "$(Agent.ToolsDirectory)/dotnet"
-        if ([IO.Directory]::Exists($dotnetToolsPath)) {
-          Write-Host "Deleting: ${dotnetToolsPath}"
-          [IO.Directory]::Delete($dotnetToolsPath, $true)
-        }
-      displayName: 'Cleanse .NET from agent tools directory'
-
   - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
     displayName: 'Use .NET SDK 6'
     inputs:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -115,7 +115,7 @@ stages:
     - job: reproNet6Issue
       displayName: 'Repro .NET 6 multi-install issue'
       pool:
-        vmImage: 'internal-macos-11'
+        vmImage: 'internal-macos-10.15'
       workspace:
         clean: all
       steps:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -99,7 +99,8 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/dev/bond/cleanse-agent-dotnet   # UNDONE: DO NOT MERGE TO MAIN
+      # ref: refs/heads/dev/bond/cleanse-agent-dotnet   # UNDONE: DO NOT MERGE TO MAIN
+      ref: refs/heads/main
     - repository: sdk-insertions
       type: github
       name: xamarin/sdk-insertions

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -115,7 +115,7 @@ stages:
     - job: reproNet6Issue
       displayName: 'Repro .NET 6 multi-install issue'
       pool:
-        vmImage: 'internal-macos-10.15'
+        name: 'XamarinFormsOSX'
       workspace:
         clean: all
       steps:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -119,6 +119,7 @@ stages:
       workspace:
         clean: all
       steps:
+      - checkout: none
       - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
         displayName: 'Use .NET SDK 6 101'
         inputs:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -99,7 +99,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/main # still defaults to master even though main is the main branch
+      ref: refs/heads/dev/bond/cleanse-agent-dotnet   # UNDONE: DO NOT MERGE TO MAIN
     - repository: sdk-insertions
       type: github
       name: xamarin/sdk-insertions

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -99,8 +99,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      # ref: refs/heads/dev/bond/cleanse-agent-dotnet   # UNDONE: DO NOT MERGE TO MAIN
-      ref: refs/heads/main
+      ref: refs/heads/dev/bond/cleanse-agent-dotnet   # UNDONE: DO NOT MERGE TO MAIN
     - repository: sdk-insertions
       type: github
       name: xamarin/sdk-insertions

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -107,6 +107,34 @@ resources:
       endpoint: xamarin
 
 stages:
+  - stage: reproNet6Issue
+    displayName: 'Repro .NET issue'
+    dependsOn: []
+    jobs:
+    - job: reproNet6Issue
+      displayName: 'Repro .NET 6 multi-install issue'
+      pool:
+        vmImage: 'internal-macos-11'
+      workspace:
+        clean: all
+      steps:
+      - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
+        displayName: 'Use .NET SDK 6 101'
+        inputs:
+          packageType: sdk
+          version: 6.0.101
+      - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
+        displayName: 'Use .NET SDK 6 102'
+        inputs:
+          packageType: sdk
+          version: 6.0.102
+      - pwsh: |
+          Write-Host "dotnet --version"
+          dotnet --version
+          Write-Host "dotnet --list-sdks"
+          dotnet --list-sdks
+        displayName: 'Show .NET SDK info'
+        # workingDirectory: $(Agent.ToolsDirectory)/dotnet
 
   - stage: build_net6
     displayName: Build .NET 6

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -99,7 +99,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/dev/bond/cleanse-agent-dotnet   # UNDONE: DO NOT MERGE TO MAIN
+      ref: refs/heads/main
     - repository: sdk-insertions
       type: github
       name: xamarin/sdk-insertions

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -108,36 +108,6 @@ resources:
       endpoint: xamarin
 
 stages:
-  - stage: reproNet6Issue
-    displayName: 'Repro .NET issue'
-    dependsOn: []
-    jobs:
-    - job: reproNet6Issue
-      displayName: 'Repro .NET 6 multi-install issue'
-      pool:
-        name: 'XamarinFormsOSX'
-      workspace:
-        clean: all
-      steps:
-      - checkout: none
-      - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
-        displayName: 'Use .NET SDK 6 101'
-        inputs:
-          packageType: sdk
-          version: 6.0.101
-      - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
-        displayName: 'Use .NET SDK 6 102'
-        inputs:
-          packageType: sdk
-          version: 6.0.102
-      - pwsh: |
-          Write-Host "dotnet --version"
-          dotnet --version
-          Write-Host "dotnet --list-sdks"
-          dotnet --list-sdks
-        displayName: 'Show .NET SDK info'
-        # workingDirectory: $(Agent.ToolsDirectory)/dotnet
-
   - stage: build_net6
     displayName: Build .NET 6
     dependsOn: []


### PR DESCRIPTION
This PR was created to help investigate why builds were failing on the `Show .NET SDK Info` step. The step would fail when attempting to run a simple `dotnet` command such as `dotnet --version`.  A fix has been applied to the Agent-Cleanser shared template with these PRs https://github.com/xamarin/yaml-templates/pull/169, https://github.com/xamarin/yaml-templates/pull/170 and a follow up PR https://github.com/dotnet/maui/pull/4595