### PR TITLE
iOS TabbedPage and NavigationPage measuring fixes

### DIFF
--- a/src/Compatibility/Core/src/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -70,38 +70,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			double width = Bounds.Width;
 			if (_headerRenderer != null)
 			{
-				// Time for another story with Jason. Gather round children because the following Math.Ceiling will look like it's completely useless.
-				// You will remove it and test and find everything is fiiiiiine, but it is not fine, no it is far from fine. See iOS, or at least iOS 8
-				// has an issue where-by if the TableHeaderView happens to NOT be an integer height, it will add padding to the space between the content
-				// of the UITableView and the TableHeaderView to the tune of the difference between Math.Ceiling (height) - height. Now this seems fine
-				// and when you test it will be, EXCEPT that it does this every time you toggle the visibility of the UITableView causing the spacing to
-				// grow a little each time, which you weren't testing at all were you? So there you have it, the stupid reason we integer align here.
-				//
-				// The same technically applies to the footer, though that could hardly matter less. We just do it for fun.
-				var e = _headerRenderer.VirtualView;
-				var request = e.Measure(width, double.PositiveInfinity);
-				e.Frame = new Rectangle(0, 0, request.Width, request.Height);
-				e.Arrange(e.Frame);
-
-				Device.BeginInvokeOnMainThread(() =>
-				{
-					if (_headerRenderer != null)
-						Control.TableHeaderView = _headerRenderer.NativeView;
-				});
+				UpdateHeaderMeasure();
 			}
 
 			if (_footerRenderer != null)
 			{
-				var e = _footerRenderer.VirtualView;
-				var request = e.Measure(width, height);
-				e.Frame = new Rectangle(0, 0, request.Width, request.Height);
-				e.Arrange(e.Frame);
-
-				Device.BeginInvokeOnMainThread(() =>
-				{
-					if (_footerRenderer != null)
-						Control.TableFooterView = _footerRenderer.NativeView;
-				});
+				UpdateFooterMeasure();
 			}
 
 			if (_requestedScroll != null && Superview != null)
@@ -155,92 +129,71 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		//void DisposeSubviews(UIView view)
-		//{
-		//	var ver = view as IVisualElementRenderer;
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
 
-		//	if (ver == null)
-		//	{
-		//		// VisualElementRenderers should implement their own dispose methods that will appropriately dispose and remove their child views.
-		//		// Attempting to do this work twice could cause a SIGSEGV (only observed in iOS8), so don't do this work here.
-		//		// Non-renderer views, such as separator lines, etc., can be removed here.
-		//		foreach (UIView subView in view.Subviews)
-		//			DisposeSubviews(subView);
+			if (disposing)
+			{
+				if (_insetTracker != null)
+				{
+					_insetTracker.Dispose();
+					_insetTracker = null;
+				}
 
-		//		view.RemoveFromSuperview();
-		//	}
+				if (Element != null)
+				{
+					var templatedItems = TemplatedItemsView.TemplatedItems;
+					templatedItems.CollectionChanged -= OnCollectionChanged;
+					templatedItems.GroupedCollectionChanged -= OnGroupedCollectionChanged;
+				}
 
-		//	view.Dispose();
-		//}
+				if (_dataSource != null)
+				{
+					_dataSource.Dispose();
+					_dataSource = null;
+				}
 
-		//protected override void Dispose(bool disposing)
-		//{
-		//	if (_disposed)
-		//		return;
+				if (_tableViewController != null)
+				{
+					_tableViewController.Dispose();
+					_tableViewController = null;
+				}
 
-		//	if (disposing)
-		//	{
-		//		if (_insetTracker != null)
-		//		{
-		//			_insetTracker.Dispose();
-		//			_insetTracker = null;
-		//		}
+				if (_headerRenderer != null)
+				{
+					_headerRenderer.VirtualView?.DisposeModalAndChildHandlers();
+					_headerRenderer = null;
+				}
+				if (_footerRenderer != null)
+				{
+					_footerRenderer.VirtualView?.DisposeModalAndChildHandlers();
+					_footerRenderer = null;
+				}
 
-		//		foreach (UIView subview in Subviews)
-		//			DisposeSubviews(subview);
+				if (_backgroundUIView != null)
+				{
+					_backgroundUIView.Dispose();
+					_backgroundUIView = null;
+				}
 
-		//		if (Element != null)
-		//		{
-		//			var templatedItems = TemplatedItemsView.TemplatedItems;
-		//			templatedItems.CollectionChanged -= OnCollectionChanged;
-		//			templatedItems.GroupedCollectionChanged -= OnGroupedCollectionChanged;
-		//		}
+				var headerView = ListView?.HeaderElement as VisualElement;
+				if (headerView != null)
+					headerView.MeasureInvalidated -= OnHeaderMeasureInvalidated;
+				Control?.TableHeaderView?.Dispose();
 
-		//		if (_dataSource != null)
-		//		{
-		//			_dataSource.Dispose();
-		//			_dataSource = null;
-		//		}
+				var footerView = ListView?.FooterElement as VisualElement;
+				if (footerView != null)
+					footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
+				Control?.TableFooterView?.Dispose();
+			}
 
-		//		if (_tableViewController != null)
-		//		{
-		//			_tableViewController.Dispose();
-		//			_tableViewController = null;
-		//		}
+			_disposed = true;
 
-		//		if (_headerRenderer != null)
-		//		{
-		//			_headerRenderer.VirtualView?.DisposeModalAndChildHandlers();
-		//			_headerRenderer = null;
-		//		}
-		//		if (_footerRenderer != null)
-		//		{
-		//			_footerRenderer.VirtualView?.DisposeModalAndChildHandlers();
-		//			_footerRenderer = null;
-		//		}
-
-		//		if (_backgroundUIView != null)
-		//		{
-		//			_backgroundUIView.Dispose();
-		//			_backgroundUIView = null;
-		//		}
-
-		//		var headerView = ListView?.HeaderElement as VisualElement;
-		//		if (headerView != null)
-		//			headerView.MeasureInvalidated -= OnHeaderMeasureInvalidated;
-		//		Control?.TableHeaderView?.Dispose();
-
-		//		var footerView = ListView?.FooterElement as VisualElement;
-		//		if (footerView != null)
-		//			footerView.MeasureInvalidated -= OnFooterMeasureInvalidated;
-		//		Control?.TableFooterView?.Dispose();
-		//	}
-
-		//	_disposed = true;
-
-		//	base.Dispose(disposing);
-		//}
-
+			base.Dispose(disposing);
+		}
+		bool _disposed = false;
 		protected override void OnElementChanged(ElementChangedEventArgs<ListView> e)
 		{
 			_requestedScroll = null;
@@ -390,18 +343,54 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			UpdateItems(e, 0, true);
 		}
 
-		void OnFooterMeasureInvalidated(object sender, EventArgs eventArgs)
+		void UpdateFooterMeasure()
 		{
-			double width = Bounds.Width;
-			if (width == 0)
+			Control.TableFooterView = null;
+			if (Bounds.Width * Bounds.Height == 0)
 				return;
 
-			var footerView = (IView)sender;
-			var request = footerView.Measure(width, double.PositiveInfinity);
-			// Todo MAUI
-			//Layout.LayoutChildIntoBoundingRegion(footerView, new Rectangle(0, 0, width, request.Request.Height));
+			var size = _footerRenderer.VirtualView.Measure(Bounds.Width, double.PositiveInfinity);
+			var platformFrame = new RectangleF(0, 0, size.Width, size.Height);
+			_footerRenderer.NativeView.Frame = platformFrame;
+			_footerRenderer.VirtualView.Arrange(platformFrame.ToRectangle());
+			Device.BeginInvokeOnMainThread(() =>
+			{
+				if (_headerRenderer != null)
+					Control.TableFooterView = _footerRenderer.NativeView;
+			});
+		}
 
-			Control.TableFooterView = _footerRenderer.NativeView;
+		void UpdateHeaderMeasure()
+		{
+			Control.TableHeaderView = null;
+
+			if (Bounds.Width * Bounds.Height == 0)
+				return;
+
+			var size = _headerRenderer.VirtualView.Measure(Bounds.Width, double.PositiveInfinity);
+			var platformFrame = new RectangleF(0, 0, size.Width, size.Height);
+			_headerRenderer.NativeView.Frame = platformFrame;
+			_headerRenderer.VirtualView.Arrange(platformFrame.ToRectangle());
+			Control.TableHeaderView = _headerRenderer.NativeView;
+
+			// Time for another story with Jason. Gather round children because the following Math.Ceiling will look like it's completely useless.
+			// You will remove it and test and find everything is fiiiiiine, but it is not fine, no it is far from fine. See iOS, or at least iOS 8
+			// has an issue where-by if the TableHeaderView happens to NOT be an integer height, it will add padding to the space between the content
+			// of the UITableView and the TableHeaderView to the tune of the difference between Math.Ceiling (height) - height. Now this seems fine
+			// and when you test it will be, EXCEPT that it does this every time you toggle the visibility of the UITableView causing the spacing to
+			// grow a little each time, which you weren't testing at all were you? So there you have it, the stupid reason we integer align here.
+			//
+			// The same technically applies to the footer, though that could hardly matter less. We just do it for fun.
+			Device.BeginInvokeOnMainThread(() =>
+			{
+				if (_headerRenderer != null)
+					Control.TableHeaderView = _headerRenderer.NativeView;
+			});
+		}
+
+		void OnFooterMeasureInvalidated(object sender, EventArgs eventArgs)
+		{
+			UpdateFooterMeasure();
 		}
 
 		void OnGroupedCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -415,17 +404,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void OnHeaderMeasureInvalidated(object sender, EventArgs eventArgs)
 		{
-			double width = Bounds.Width;
-			if (width == 0)
-				return;
-
-			var headerView = (IView)sender;
-			var request = headerView.Measure(width, double.PositiveInfinity);
-
-			// TODO MAUI
-			//Layout.LayoutChildIntoBoundingRegion(headerView, new Rectangle(0, 0, width, request.Request.Height));
-
-			Control.TableHeaderView = _headerRenderer.NativeView;
+			UpdateHeaderMeasure();
 		}
 
 		void OnScrollToRequested(object sender, ScrollToRequestedEventArgs e)
@@ -489,14 +468,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 
 				_footerRenderer = footerView.ToHandler(MauiContext);
-
-				double width = Bounds.Width;
-				// TODO MAUI
-				//var request = footerView.Measure(width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-				//Layout.LayoutChildIntoBoundingRegion(footerView, new Rectangle(0, 0, width, request.Request.Height));
-
-				Control.TableFooterView = _footerRenderer.NativeView;
 				footerView.MeasureInvalidated += OnFooterMeasureInvalidated;
+				UpdateFooterMeasure();
 			}
 			else if (_footerRenderer != null)
 			{
@@ -531,18 +504,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					_headerRenderer.VirtualView?.DisposeModalAndChildHandlers();
 					_headerRenderer?.DisconnectHandler();
 				}
-
-				// This will force measure to invalidate, which we haven't hooked up to yet because we are smarter!
+				
 				_headerRenderer = headerView.ToHandler(MauiContext);
-
-				double width = Bounds.Width;
-
-				// TODO MAUI
-				//var request = headerView.Measure(width, double.PositiveInfinity);
-				//Layout.LayoutChildIntoBoundingRegion(headerView, new Rectangle(0, 0, width, request.Request.Height));
-
-				Control.TableHeaderView = _headerRenderer.NativeView;
 				headerView.MeasureInvalidated += OnHeaderMeasureInvalidated;
+				UpdateHeaderMeasure();
 			}
 			else if (_headerRenderer != null)
 			{

--- a/src/Compatibility/Core/src/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
-using ObjCRuntime;
 using UIKit;
 using static Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page;
 using PageUIStatusBarAnimation = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation;
@@ -24,8 +23,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		UIColor _defaultBarColor;
 		bool _defaultBarColorSet;
 		bool? _defaultBarTranslucent;
-		bool _loaded;
-		Size _queuedSize;
 		IMauiContext _mauiContext;
 		IMauiContext MauiContext => _mauiContext;
 		public static IPropertyMapper<TabbedPage, TabbedRenderer> Mapper = new PropertyMapper<TabbedPage, TabbedRenderer>(ViewHandler.ViewMapper);
@@ -86,14 +83,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			UpdateBarTranslucent();
 		}
 
-		public void SetElementSize(Size size)
-		{
-			if (_loaded)
-				Element.Layout(new Rectangle(Element.X, Element.Y, size.Width, size.Height));
-			else
-				_queuedSize = size;
-		}
-
 		public UIViewController ViewController
 		{
 			get { return this; }
@@ -122,28 +111,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			base.ViewDidLayoutSubviews();
 
-			if (Element == null)
-				return;
-
-			if (Element.Parent is BaseShellItem)
-				Element.Layout(View.Bounds.ToRectangle());
-
-			if (!Element.Bounds.IsEmpty)
-			{
-				View.Frame = new System.Drawing.RectangleF((float)Element.X, (float)Element.Y, (float)Element.Width, (float)Element.Height);
-			}
-
-			var frame = View.Frame;
-			var tabBarFrame = TabBar.Frame;
-			Page.ContainerArea = new Rectangle(0, 0, frame.Width, frame.Height - tabBarFrame.Height);
-
-			if (!_queuedSize.IsZero)
-			{
-				Element.Layout(new Rectangle(Element.X, Element.Y, _queuedSize.Width, _queuedSize.Height));
-				_queuedSize = Size.Zero;
-			}
-
-			_loaded = true;
+			if (Element is IView view)
+				view.Arrange(View.Bounds.ToRectangle());
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml
@@ -16,6 +16,7 @@
             <Button Text="Swap Root"  Clicked="SwapRoot" />
             <Button Text="Toggle Navigation Bar"  Clicked="ToggleNavigationBar" />
             <Button Text="Toggle Back Button"  Clicked="ToggleBackButton" />
+            <Button Text="Toggle Secondary Toolbar Item"  Clicked="ToggleSecondaryToolbarItem" />
         </StackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
@@ -58,6 +58,22 @@ namespace Maui.Controls.Sample.Pages
 			NavigationPage.SetHasBackButton(this, !NavigationPage.GetHasBackButton(this));
 		}
 
+		void ToggleSecondaryToolbarItem(object sender, EventArgs e)
+		{
+			if (!this.ToolbarItems.Where(x => x.Order == ToolbarItemOrder.Secondary).Any())
+			{
+				this.ToolbarItems.Add(new ToolbarItem() { Text = "One", Order = ToolbarItemOrder.Secondary });
+				this.ToolbarItems.Add(new ToolbarItem() { Text = "Two", Order = ToolbarItemOrder.Secondary });
+			}
+			else
+			{
+				foreach (var ti in this.ToolbarItems.Where(x => x.Order == ToolbarItemOrder.Secondary).ToList())
+				{
+					this.ToolbarItems.Remove(ti);
+				}
+			}
+		}
+
 
 		void SwapRoot(object sender, EventArgs e)
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Others/LargeTitlesPageiOS.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/LargeTitlesPageiOS.cs
@@ -1,0 +1,90 @@
+﻿using System.Linq;
+using System.Windows.Input;
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using static Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.NavigationPage;
+using static Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page;
+using LargeTitleDisplayMode = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.LargeTitleDisplayMode;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Pages
+{
+	public class LargeTitlesPageiOS : ContentPage
+	{
+		public LargeTitlesPageiOS()
+		{
+			Title = "Large Titles";
+
+			var offscreenPageLimit = new Label();
+			var content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Fill,
+				HorizontalOptions = LayoutOptions.Fill,
+				Children =
+				{
+					new Button
+					{
+						Text = "LargeTitleDisplayMode.Never",
+						Command = new Command(() => On<iOS>().SetLargeTitleDisplay(LargeTitleDisplayMode.Never))
+					},
+					new Button
+					{
+						Text = "LargeTitleDisplayMode.Always",
+						Command = new Command(() => On<iOS>().SetLargeTitleDisplay(LargeTitleDisplayMode.Always))
+					},
+					new Button
+					{
+						Text = "LargeTitleDisplayMode.Automatic -> next page will have same LargeTitleDisplayMode as this one",
+						Command = new Command(async () =>{
+							var page = new ContentPage { Title = "Page Title" };
+							page.On<iOS>().SetLargeTitleDisplay(LargeTitleDisplayMode.Automatic);
+							await Navigation.PushAsync(page);
+						} )
+					},
+					new Button
+					{
+						Text = "Tooggle UseLargeTitles on Navigation",
+						Command = new Command( () =>{
+							var navPage = (Parent as NavigationPage);
+							navPage.On<iOS>().SetPrefersLargeTitles(!navPage.On<iOS>().PrefersLargeTitles());
+						} )
+					},
+
+					new Button
+					{
+						Text = "UseLargeTitles on Navigation with safe Area",
+						Command = new Command( () =>{
+							var navPage = (Parent as NavigationPage);
+							navPage.On<iOS>().SetPrefersLargeTitles(true);
+							var page = new ContentPage { Title = "New Title", BackgroundColor = Colors.Red };
+							page.On<iOS>().SetUseSafeArea(true);
+							var listView = new ListView(ListViewCachingStrategy.RecycleElementAndDataTemplate)
+							{
+								HasUnevenRows = true,
+								VerticalOptions = LayoutOptions.Fill
+							};
+
+							listView.ItemTemplate = new DataTemplate(()=>{
+								var cell = new ViewCell();
+								cell.View = new Label { Text ="Hello", FontSize = 30};
+								return cell;
+							});
+							listView.ItemsSource = Enumerable.Range(1, 40);
+							listView.Header = new Label { BackgroundColor = Colors.Pink , Text = "I'm a header, background is red"};
+							listView.Footer = new Label { BackgroundColor = Colors.Yellow , Text = "I'm a footer, you should see no white below me"};
+							page.Content = listView;
+							navPage.PushAsync(page);
+						} )
+					},
+					offscreenPageLimit
+				}
+			};
+
+			var restoreButton = new Button { Text = "Back To Gallery" };
+			restoreButton.Clicked += async (sender, args) => await Navigation.PopAsync();
+			content.Children.Add(restoreButton);
+
+			Content = content;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/ViewModels/OthersViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/OthersViewModel.cs
@@ -11,8 +11,11 @@ namespace Maui.Controls.Sample.ViewModels
 		{
 			new SectionModel(typeof(GraphicsViewPage), "GraphicsView",
 				"Allow to draw directly in a Canvas. You can combine a canvas and native Views on the same page."),
+			new SectionModel(typeof(LargeTitlesPageiOS), "Large Titles - iOS",
+				"This iOS platform-specific is used to display the page title as a large title on the navigation bar of a NavigationPage, for devices that use iOS 11 or greater."),
 			new SectionModel(typeof(StyleSheetsPage), "StyleSheets",
 				"Demonstrates the usage of CSS in XAML.")
+			
 		};
 	}
 }

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml.cs
@@ -47,6 +47,7 @@ namespace Maui.Controls.Sample
 		protected override Window CreateWindow(IActivationState activationState)
 		{
 			var window = new Window(Services.GetRequiredService<Page>());
+
 			window.Title = ".NET MAUI Samples Gallery";
 			return window;
 		}

--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Controls
 
 		Size IContentView.CrossPlatformArrange(Rectangle bounds)
 		{
+			Frame = bounds;
 			this.ArrangeContent(bounds);
 			return bounds.Size;
 		}

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -33,26 +33,10 @@ namespace Microsoft.Maui.Controls
 
 		Thickness IView.Margin => Thickness.Zero;
 
-		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+		protected override void LayoutChildren(double x, double y, double width, double height)
 		{
-			if (Content is IView view)
-			{
-				_ = view.Measure(widthConstraint, heightConstraint);
-			}
-
-			return new Size(widthConstraint, heightConstraint);
-		}
-
-		protected override Size ArrangeOverride(Rectangle bounds)
-		{
-			Frame = this.ComputeFrame(bounds);
-
-			if (Content is IView view)
-			{
-				_ = view.Arrange(Frame);
-			}
-
-			return Frame.Size;
+			// We don't want forcelayout to call the legacy
+			// Page.LayoutChildren code
 		}
 
 		void IStackNavigation.RequestNavigation(NavigationRequest eventArgs)

--- a/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Impl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls
 {
@@ -9,6 +10,12 @@ namespace Microsoft.Maui.Controls
 		private protected override void OnHandlerChangedCore()
 		{
 			base.OnHandlerChangedCore();
+		}
+
+		protected override void LayoutChildren(double x, double y, double width, double height)
+		{
+			// We don't want forcelayout to call the legacy
+			// Page.LayoutChildren code
 		}
 
 		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)

--- a/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/TabbedPage/TabbedPageHandler.Windows.cs
@@ -92,7 +92,10 @@ namespace Microsoft.Maui.Controls.Handlers
 		private protected override void OnDisconnectHandler(FrameworkElement nativeView)
 		{
 			if (_navigationView != null)
+			{
 				_navigationView.OnApplyTemplateFinished -= OnApplyTemplateFinished;
+				_navigationView.SizeChanged -= OnNavigationViewSizeChanged;
+			}
 
 			((WFrame)nativeView).Navigated -= OnNavigated;
 			VirtualView.Appearing -= OnTabbedPageAppearing;
@@ -140,6 +143,12 @@ namespace Microsoft.Maui.Controls.Handlers
 			UpdateValuesWaitingForNavigationView();
 		}
 
+		void OnNavigationViewSizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			if (_navigationView != null)
+				VirtualView.Arrange(_navigationView);
+		}
+
 		void SetupNavigationView()
 		{
 			if (_navigationView == null)
@@ -153,7 +162,10 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_navigationView.TopNavArea != null)
 				UpdateValuesWaitingForNavigationView();
 			else
+			{
 				_navigationView.OnApplyTemplateFinished += OnApplyTemplateFinished;
+				_navigationView.SizeChanged += OnNavigationViewSizeChanged;
+			}
 		}
 
 		void UpdateValuesWaitingForNavigationView()

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -108,11 +108,13 @@ namespace Microsoft.Maui.Controls.Handlers
 				Element.Appearing -= OnTabbedPageAppearing;
 				Element.Disappearing -= OnTabbedPageDisappearing;
 				RemoveTabs();
+				_viewPager.LayoutChange -= OnLayoutChanged;
 			}
 
 			Element = tabbedPage;
 			if (Element != null)
 			{
+				_viewPager.LayoutChange += OnLayoutChanged;
 				Element.Appearing += OnTabbedPageAppearing;
 				Element.Disappearing += OnTabbedPageDisappearing;
 				_viewPager.Adapter = new MultiPageFragmentStateAdapter<Page>(tabbedPage, FragmentManager, _context) { CountOverride = tabbedPage.Children.Count };
@@ -157,6 +159,11 @@ namespace Microsoft.Maui.Controls.Handlers
 				UpdateOffscreenPageLimit();
 				SetTabLayout();
 			}
+		}
+
+		void OnLayoutChanged(object sender, AView.LayoutChangeEventArgs e)
+		{
+			Element.Arrange(e);
 		}
 
 		void RemoveTabs()

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.DeviceTests
 				flyoutPage.Detail = details2;
 				var detailView2 = details2.ToPlatform();
 
-				await detailView2.LoadedAsync();
+				await detailView2.OnLoadedAsync();
 				dl = FindPlatformFlyoutView(detailView);
 				Assert.Equal(flyoutView, dl);
 			});

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Maui.DeviceTests
 				window.Page = CreateBasicTabbedPage();
 
 				// wait for new handler to finish loading
-				await ((INativeViewHandler)window.Page.Handler).NativeView.LoadedAsync();
+				await ((INativeViewHandler)window.Page.Handler).NativeView.OnLoadedAsync();
 				var navView = GetMauiNavigationView(window.Page.Handler.MauiContext);
 
 				// make sure root view is displaying as top tabs

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.DeviceTests
 
 					newWindowHandler = window.ToHandler(mauiContext);
 					var content = window.Content.Handler.ToPlatform();
-					await content.LoadedAsync();
+					await content.OnLoadedAsync();
 					await Task.Delay(10);
 
 					if (typeof(THandler).IsAssignableFrom(newWindowHandler.GetType()))
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.DeviceTests
 					if (testingRootPanel != null && MauiProgram.CurrentWindow.Content != testingRootPanel)
 					{
 						MauiProgram.CurrentWindow.Content = testingRootPanel;
-						await testingRootPanel.LoadedAsync();
+						await testingRootPanel.OnLoadedAsync();
 						await Task.Delay(10);
 					}
 				}

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Android.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Android.cs
@@ -2,6 +2,7 @@
 using Android.Runtime;
 using Android.Views;
 using AndroidX.Fragment.App;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -22,6 +23,16 @@ namespace Microsoft.Maui.Handlers
 			return view;
 		}
 
+		public override Graphics.Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			return base.GetDesiredSize(widthConstraint, heightConstraint);
+		}
+
+		public override void NativeArrange(Graphics.Rectangle frame)
+		{
+			base.NativeArrange(frame);
+		}
+
 		StackNavigationManager CreateNavigationManager()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
@@ -32,12 +43,19 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.ConnectHandler(nativeView);
 			_stackNavigationManager?.Connect(VirtualView);
+			NativeView.LayoutChange += OnLayoutChanged;
+		}
+
+		void OnLayoutChanged(object? sender, View.LayoutChangeEventArgs e)
+		{
+			VirtualView.Arrange(e);
 		}
 
 		private protected override void OnDisconnectHandler(View nativeView)
 		{
 			_stackNavigationManager?.Disconnect();
 			base.OnDisconnectHandler(nativeView);
+			nativeView.LayoutChange -= OnLayoutChanged;
 		}
 
 		public static void RequestNavigation(NavigationViewHandler arg1, IStackNavigation arg2, object? arg3)

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -400,15 +400,11 @@ namespace Microsoft.Maui.Platform
 		}
 
 
-		internal static Task LoadedAsync(this AView frameworkElement, TimeSpan? timeOut = null)
+		internal static void OnLoaded(this View frameworkElement, Action action)
 		{
-			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
-			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
-
 			if (frameworkElement.IsAttachedToWindow)
 			{
-				taskCompletionSource.SetResult(true);
-				return taskCompletionSource.Task;
+				action();
 			}
 
 			EventHandler<AView.ViewAttachedToWindowEventArgs>? routedEventHandler = null;
@@ -417,23 +413,17 @@ namespace Microsoft.Maui.Platform
 				if (routedEventHandler != null)
 					frameworkElement.ViewAttachedToWindow -= routedEventHandler;
 
-				taskCompletionSource.SetResult(true);
+				action();
 			};
 
 			frameworkElement.ViewAttachedToWindow += routedEventHandler;
-
-			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 
-		internal static Task UnloadedAsync(this AView frameworkElement, TimeSpan? timeOut = null)
+		internal static void OnUnloaded(this View frameworkElement, Action action)
 		{
-			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
-			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
-
 			if (!frameworkElement.IsAttachedToWindow)
 			{
-				taskCompletionSource.SetResult(true);
-				return taskCompletionSource.Task;
+				action();
 			}
 
 			EventHandler<AView.ViewDetachedFromWindowEventArgs>? routedEventHandler = null;
@@ -442,12 +432,10 @@ namespace Microsoft.Maui.Platform
 				if (routedEventHandler != null)
 					frameworkElement.ViewDetachedFromWindow -= routedEventHandler;
 
-				taskCompletionSource.SetResult(true);
+				action();
 			};
 
 			frameworkElement.ViewDetachedFromWindow += routedEventHandler;
-
-			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 
 		internal static IViewParent? GetParent(this View? view)

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 using System.Threading.Tasks;
+using Android.Content;
 using Android.Graphics.Drawables;
 using Android.Util;
 using Android.Views;
@@ -457,6 +458,46 @@ namespace Microsoft.Maui.Platform
 		internal static IViewParent? GetParent(this IViewParent? view)
 		{
 			return view?.Parent;
+		}
+
+		internal static void Arrange(
+			this IView view, 
+			int left,
+			int top,
+			int right,
+			int bottom,
+			Context context)
+		{
+			var deviceIndependentLeft = context.FromPixels(left);
+			var deviceIndependentTop = context.FromPixels(top);
+			var deviceIndependentRight = context.FromPixels(right);
+			var deviceIndependentBottom = context.FromPixels(bottom);
+			var destination = Rectangle.FromLTRB(0, 0,
+				deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
+
+			if (!view.Frame.Equals(destination))
+				view.Arrange(destination);
+		}
+
+		internal static void Arrange(this IView view, AView.LayoutChangeEventArgs e)
+		{
+			var context = view.Handler?.MauiContext?.Context ??
+				 throw new InvalidOperationException("View is Missing Handler");
+
+			view.Arrange(e.Left, e.Top, e.Right, e.Bottom, context);
+		}
+
+		internal static void Arrange(this IView view, View platformView)
+		{
+			var context = platformView.Context ??
+				 throw new InvalidOperationException("platformView is Missing Context");
+
+			view.Arrange(
+				platformView.Left, 
+				platformView.Top, 
+				platformView.Right, 
+				platformView.Left, 
+				context);
 		}
 	}
 }

--- a/src/Core/src/Platform/ViewExtensions.cs
+++ b/src/Core/src/Platform/ViewExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using Microsoft.Maui.Graphics;
+using System.Threading.Tasks;
 #if NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using INativeViewHandler = Microsoft.Maui.IViewHandler;
 #endif
@@ -79,6 +80,22 @@ namespace Microsoft.Maui
 				return t;
 
 			return view.GetParent()?.GetParentOfType<T>();
+		}
+
+		internal static Task OnUnloadedAsync(this PlatformView platformView, TimeSpan? timeOut = null)
+		{
+			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+			platformView.OnUnloaded(() => taskCompletionSource.SetResult(true));
+			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
+		}
+
+		internal static Task OnLoadedAsync(this PlatformView platformView, TimeSpan? timeOut = null)
+		{
+			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+			platformView.OnLoaded(() => taskCompletionSource.SetResult(true));
+			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 #endif
 

--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -192,15 +192,11 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static Task LoadedAsync(this FrameworkElement frameworkElement, TimeSpan? timeOut = null)
+		internal static void OnLoaded(this FrameworkElement frameworkElement, Action action)
 		{
-			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
-			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
-
 			if (frameworkElement.IsLoaded)
 			{
-				taskCompletionSource.SetResult(true);
-				return taskCompletionSource.Task;
+				action();
 			}
 
 			UI.Xaml.RoutedEventHandler? routedEventHandler = null;
@@ -209,23 +205,28 @@ namespace Microsoft.Maui.Platform
 				if (routedEventHandler != null)
 					frameworkElement.Loaded -= routedEventHandler;
 
-				taskCompletionSource.SetResult(true);
+				action();
 			};
 
 			frameworkElement.Loaded += routedEventHandler;
+		}
 
+		internal static Task OnLoadedAsync(this FrameworkElement frameworkElement, TimeSpan? timeOut = null)
+		{
+			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+			frameworkElement.OnLoaded(() => taskCompletionSource.SetResult(true));
 			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 
-		internal static Task UnloadedAsync(this FrameworkElement frameworkElement, TimeSpan? timeOut = null)
+		internal static void OnUnloaded(this FrameworkElement frameworkElement, Action action)
 		{
-			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
 			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
 
 			if (!frameworkElement.IsLoaded)
 			{
 				taskCompletionSource.SetResult(true);
-				return taskCompletionSource.Task;
+				action();
 			}
 
 			UI.Xaml.RoutedEventHandler? routedEventHandler = null;
@@ -234,12 +235,24 @@ namespace Microsoft.Maui.Platform
 				if (routedEventHandler != null)
 					frameworkElement.Unloaded -= routedEventHandler;
 
-				taskCompletionSource.SetResult(true);
+				action();
 			};
+		}
 
-			frameworkElement.Unloaded += routedEventHandler;
-
+		internal static Task OnUnloadedAsync(this FrameworkElement frameworkElement, TimeSpan? timeOut = null)
+		{
+			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+			frameworkElement.OnUnloaded(() => taskCompletionSource.SetResult(true));
 			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
+		}
+
+		internal static void Arrange(this IView view, FrameworkElement frameworkElement)
+		{
+			var rect = new Graphics.Rectangle(0, 0, frameworkElement.ActualWidth, frameworkElement.ActualHeight);
+
+			if (!view.Frame.Equals(rect))
+				view.Arrange(rect);
 		}
 
 

--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -211,14 +211,6 @@ namespace Microsoft.Maui.Platform
 			frameworkElement.Loaded += routedEventHandler;
 		}
 
-		internal static Task OnLoadedAsync(this FrameworkElement frameworkElement, TimeSpan? timeOut = null)
-		{
-			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
-			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
-			frameworkElement.OnLoaded(() => taskCompletionSource.SetResult(true));
-			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
-		}
-
 		internal static void OnUnloaded(this FrameworkElement frameworkElement, Action action)
 		{
 			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
@@ -237,14 +229,6 @@ namespace Microsoft.Maui.Platform
 
 				action();
 			};
-		}
-
-		internal static Task OnUnloadedAsync(this FrameworkElement frameworkElement, TimeSpan? timeOut = null)
-		{
-			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
-			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
-			frameworkElement.OnUnloaded(() => taskCompletionSource.SetResult(true));
-			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 
 		internal static void Arrange(this IView view, FrameworkElement frameworkElement)

--- a/src/Core/src/Platform/Windows/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Windows/StackNavigationManager.cs
@@ -179,18 +179,14 @@ namespace Microsoft.Maui.Platform
 				throw;
 			}
 
-			if (fe.IsLoaded)
+			fe.OnLoaded(() =>
 			{
 				FireNavigationFinished();
-				return;
-			}
-
-			fe.Loaded += OnLoaded;
-			void OnLoaded(object sender, RoutedEventArgs e)
-			{
-				fe.Loaded -= OnLoaded;
-				FireNavigationFinished();
-			}
+				if (NavigationView is IView view)
+				{
+					view.Arrange(fe);
+				}
+			});
 		}
 
 		void FireNavigationFinished()


### PR DESCRIPTION
### Description of Change ###

Rework all the measuring/layout code for the iOS TabbedRenderer and NavigationRenderer to follow the layout rules of .NET MAUI

- Added code to all platforms `TabbedHandler`s and `NavigationHandler`s so that the `Frame` on the xplat control gets set
- Added code to `ContentPage.impl.cs` so it's `Frame` always gets set
- Copied over large titles sample
  - It seems like this is working based on the rules of the sample. @rmarinho ?
  - This also involved some fixes to ListViewRenderer to fix some issues with the header/footer not rendering 
  - If you find issues with large titles please just log a bug



### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
