### PR TITLE
Remove all GetAssemblies() implementations

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/Startup.cs
+++ b/src/Compatibility/ControlGallery/src/Core/Startup.cs
@@ -23,22 +23,22 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 				.UseMauiApp<App>()
 				.ConfigureMauiHandlers(handlers =>
 				{
-					handlers.AddCompatibilityRenderers(Device.GetAssemblies());
+					handlers.AddCompatibilityRenderers(AppDomain.CurrentDomain.GetAssemblies());
 				})
 				.ConfigureImageSources(sources =>
 				{
-					sources.AddCompatibilityServices(Device.GetAssemblies());
+					sources.AddCompatibilityServices(AppDomain.CurrentDomain.GetAssemblies());
 				})
 				.ConfigureFonts(fonts =>
 				{
-					fonts.AddCompatibilityFonts(new FontRegistrar(new EmbeddedFontLoader()), Device.GetAssemblies());
+					fonts.AddCompatibilityFonts(new FontRegistrar(new EmbeddedFontLoader()), AppDomain.CurrentDomain.GetAssemblies());
 				})
 				.ConfigureEffects(effects =>
 				{
-					effects.AddCompatibilityEffects(Device.GetAssemblies());
+					effects.AddCompatibilityEffects(AppDomain.CurrentDomain.GetAssemblies());
 				});
 
-			DependencyService.Register(Device.GetAssemblies());
+			DependencyService.Register(AppDomain.CurrentDomain.GetAssemblies());
 
 			return builder;
 		}

--- a/src/Compatibility/ControlGallery/src/Core/Startup.cs
+++ b/src/Compatibility/ControlGallery/src/Core/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls.Compatibility;
 using Microsoft.Maui.Controls.Hosting;

--- a/src/Compatibility/Core/src/Android/Forms.cs
+++ b/src/Compatibility/Core/src/Android/Forms.cs
@@ -336,11 +336,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 				_context = context;
 			}
 
-			public Assembly[] GetAssemblies()
-			{
-				return AppDomain.CurrentDomain.GetAssemblies();
-			}
-
 			public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 			{
 				if (_smallSize == 0)

--- a/src/Compatibility/Core/src/GTK/GtkPlatformServices.cs
+++ b/src/Compatibility/Core/src/GTK/GtkPlatformServices.cs
@@ -25,11 +25,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.GTK
 			return new GtkTicker();
 		}
 
-		public Assembly[] GetAssemblies()
-		{
-			return AppDomain.CurrentDomain.GetAssemblies();
-		}
-
 		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 		{
 			switch (size)

--- a/src/Compatibility/Core/src/Tizen/TizenPlatformServices.cs
+++ b/src/Compatibility/Core/src/Tizen/TizenPlatformServices.cs
@@ -129,11 +129,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 				return await response.Content.ReadAsStreamAsync();
 		}
 
-		public Assembly[] GetAssemblies()
-		{
-			return AppDomain.CurrentDomain.GetAssemblies();
-		}
-
 		public IIsolatedStorageFile GetUserStoreForApplication()
 		{
 			return new TizenIsolatedStorageFile();

--- a/src/Compatibility/Core/src/WPF/WPFPlatformServices.cs
+++ b/src/Compatibility/Core/src/WPF/WPFPlatformServices.cs
@@ -31,11 +31,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.WPF
 			return new WPFTicker();
 		}
 
-		public Assembly[] GetAssemblies()
-		{
-			return AppDomain.CurrentDomain.GetAssemblies();
-		}
-
 		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 		{
 			switch (size)

--- a/src/Compatibility/Core/src/Windows/WindowsPlatformServices.cs
+++ b/src/Compatibility/Core/src/Windows/WindowsPlatformServices.cs
@@ -27,67 +27,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			_uiSettings.ColorValuesChanged += UISettingsColorValuesChanged;
 		}
 
-		public virtual Assembly[] GetAssemblies()
-		{
-			var options = new QueryOptions { FileTypeFilter = { ".exe", ".dll" } };
-
-			StorageFileQueryResult query = Package.Current.InstalledLocation.CreateFileQueryWithOptions(options);
-			IReadOnlyList<StorageFile> files = query.GetFilesAsync().AsTask().Result;
-
-			var assemblies = new List<Assembly>(files.Count);
-
-			LoadAllAssemblies(AppDomain.CurrentDomain.GetAssemblies(), assemblies);
-
-			Assembly thisAssembly = GetType().GetTypeInfo().Assembly;
-			// this happens with .NET Native
-			if (!assemblies.Contains(thisAssembly))
-				assemblies.Add(thisAssembly);
-
-			Assembly coreAssembly = typeof(Microsoft.Maui.Controls.Label).GetTypeInfo().Assembly;
-			if (!assemblies.Contains(coreAssembly))
-				assemblies.Add(coreAssembly);
-
-			Assembly xamlAssembly = typeof(Microsoft.Maui.Controls.Xaml.Extensions).GetTypeInfo().Assembly;
-			if (!assemblies.Contains(xamlAssembly))
-				assemblies.Add(xamlAssembly);
-
-			return assemblies.ToArray();
-		}
-
-		void LoadAllAssemblies(Assembly[] files, List<Assembly> loaded)
-		{
-			for (var i = 0; i < files.Length; i++)
-			{
-				var asm = files[i];
-				if (!loaded.Contains(asm))
-				{
-					loaded.Add(asm);
-				}
-			}
-		}
-
-		void LoadAllAssemblies(AssemblyName[] files, List<Assembly> loaded)
-		{
-			for (var i = 0; i < files.Length; i++)
-			{
-				try
-				{
-					var asm = Assembly.Load(files[i]);
-					if (!loaded.Contains(asm))
-					{
-						loaded.Add(asm);
-						LoadAllAssemblies(asm.GetReferencedAssemblies(), loaded);
-					}
-				}
-				catch (IOException)
-				{
-				}
-				catch (BadImageFormatException)
-				{
-				}
-			}
-		}
-
 		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 		{
 			return size.GetFontSize();

--- a/src/Compatibility/Core/src/iOS/Forms.cs
+++ b/src/Compatibility/Core/src/iOS/Forms.cs
@@ -293,11 +293,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 #endif
 			}
 
-			public Assembly[] GetAssemblies()
-			{
-				return AppDomain.CurrentDomain.GetAssemblies();
-			}
-
 			public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 			{
 				// We make these up anyway, so new sizes didn't really change

--- a/src/Controls/DualScreen/test/MockPlatformServices.cs
+++ b/src/Controls/DualScreen/test/MockPlatformServices.cs
@@ -102,11 +102,6 @@ namespace Microsoft.Maui.Controls.DualScreen.UnitTests
 			return getStreamAsync(uri, cancellationToken);
 		}
 
-		public Assembly[] GetAssemblies()
-		{
-			return AppDomain.CurrentDomain.GetAssemblies();
-		}
-
 		public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 		{
 			if (getNativeSizeFunc != null)

--- a/src/Controls/docs/Microsoft.Maui.Controls/Device.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Device.xml
@@ -106,32 +106,6 @@ Device.BeginInvokeOnMainThread (() => {
         </remarks>
       </Docs>
     </Member>
-    <Member MemberName="GetAssemblies">
-      <MemberSignature Language="C#" Value="public static System.Reflection.Assembly[] GetAssemblies ();" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Reflection.Assembly[] GetAssemblies() cil managed" />
-      <MemberSignature Language="DocId" Value="M:Microsoft.Maui.Controls.Device.GetAssemblies" />
-      <MemberSignature Language="F#" Value="static member GetAssemblies : unit -&gt; System.Reflection.Assembly[]" Usage="Microsoft.Maui.Controls.Device.GetAssemblies " />
-      <MemberType>Method</MemberType>
-      <AssemblyInfo>
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <AssemblyName>Microsoft.Maui.Controls.Core</AssemblyName>
-      </AssemblyInfo>
-      <Attributes>
-        <Attribute>
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-      </Attributes>
-      <ReturnValue>
-        <ReturnType>System.Reflection.Assembly[]</ReturnType>
-      </ReturnValue>
-      <Parameters />
-      <Docs>
-        <summary>For internal use by the Microsoft.Maui.Controls platform.</summary>
-        <returns>For internal use by the Microsoft.Maui.Controls platform.</returns>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="GetMainThreadSynchronizationContextAsync">
       <MemberSignature Language="C#" Value="public static System.Threading.Tasks.Task&lt;System.Threading.SynchronizationContext&gt; GetMainThreadSynchronizationContextAsync ();" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Threading.Tasks.Task`1&lt;class System.Threading.SynchronizationContext&gt; GetMainThreadSynchronizationContextAsync() cil managed" />

--- a/src/Controls/src/Core/DependencyService.cs
+++ b/src/Controls/src/Core/DependencyService.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Controls
 				if (s_initialized)
 					return;
 
-				Assembly[] assemblies = Device.GetAssemblies();
+				Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 				if (Internals.Registrar.ExtraAssemblies != null)
 				{
 					assemblies = assemblies.Union(Internals.Registrar.ExtraAssemblies).ToArray();

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -131,13 +131,6 @@ namespace Microsoft.Maui.Controls
 			PlatformServices.StartTimer(interval, callback);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetAssemblies']/Docs" />
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static Assembly[] GetAssemblies()
-		{
-			return AppDomain.CurrentDomain.GetAssemblies();
-		}
-
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Maui.Controls.Internals
 		public static void RegisterAll(Type[] attrTypes, InitializationFlags flags, IFontRegistrar fontRegistrar = null)
 		{
 			RegisterAll(
-				Device.GetAssemblies(),
+				AppDomain.CurrentDomain.GetAssemblies(),
 				Device.PlatformServices.GetType().GetTypeInfo().Assembly,
 				attrTypes,
 				flags,

--- a/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
+++ b/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 		void InitMappings()
 		{
 			var mappings = new Dictionary<string, IVisual>(StringComparer.OrdinalIgnoreCase);
-			Assembly[] assemblies = Device.GetAssemblies();
+			Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
 			// Check for IVisual Types
 			foreach (var assembly in assemblies)


### PR DESCRIPTION
### Description of Change ###

This PR just removes the remaining implementations and also the API from `Device`. The AppDomain is currently being used and this "feature" is not something we want to do going forward. 

The GetAssemblies member on IPlatformServices was removed some time ago.

Part of #1965

### Additions made ###
* Removes the interface implementations for GetAssemblies
* Removes Device.GetAssemblies

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
