### PR TITLE
[X] Identify Setter property target in VSG case

### DIFF
--- a/src/Controls/src/Core/BindablePropertyConverter.cs
+++ b/src/Controls/src/Core/BindablePropertyConverter.cs
@@ -122,10 +122,9 @@ namespace Microsoft.Maui.Controls
 				throw new XamlParseException($"Expected {nameof(VisualStateGroup)} but found {parents[2]}.", lineInfo);
 			}
 
-			var vsTarget = parents[3];
 
 			// Are these Visual States directly on a VisualElement?
-			if (vsTarget is VisualElement)
+			if (parents[3] is VisualElement vsTarget)
 			{
 				return vsTarget.GetType();
 			}
@@ -133,6 +132,11 @@ namespace Microsoft.Maui.Controls
 			if (!(parents[3] is VisualStateGroupList))
 			{
 				throw new XamlParseException($"Expected {nameof(VisualStateGroupList)} but found {parents[3]}.", lineInfo);
+			}
+
+			if (parents[4] is VisualElement veTarget)
+			{
+				return veTarget.GetType();
 			}
 
 			if (!(parents[4] is Setter))

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3793.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3793.xaml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui3793">
+    <ContentPage.Resources>
+                <ControlTemplate x:Key="CalendarRadioTemplate">
+            <Frame BorderColor="#F3F2F1" BackgroundColor="#F3F2F1" HasShadow="False" 
+                   HeightRequest="100" WidthRequest="100" HorizontalOptions="Start" VerticalOptions="Start" Padding="0">
+
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroupList>
+                        <VisualStateGroup x:Name="CheckedStates">
+
+                            <VisualState x:Name="Checked">
+                                <VisualState.Setters>
+                                    <Setter Property="BorderColor" Value="#FF3300"/>
+                                    <Setter TargetName="Check" Property="Opacity" Value="1"/>
+                                </VisualState.Setters>
+                            </VisualState>
+                            
+                            <VisualState x:Name="Unchecked">
+                                <VisualState.Setters>
+                                    <Setter Property="BackgroundColor" Value="#f3f2f1"/>
+                                    <Setter Property="BorderColor" Value="#f3f2f1"/>
+                                    <Setter TargetName="Check" Property="Opacity" Value="0"/>
+                                </VisualState.Setters>
+                            </VisualState>
+                            
+                        </VisualStateGroup>
+                    </VisualStateGroupList>
+                </VisualStateManager.VisualStateGroups>
+
+                <Grid Margin="4" WidthRequest="100">
+                    <Grid WidthRequest="18" HeightRequest="18" HorizontalOptions="End" VerticalOptions="Start">
+                        <Ellipse Stroke="Blue" WidthRequest="16" HeightRequest="16" StrokeThickness="0.5" VerticalOptions="Center" HorizontalOptions="Center" Fill="White" />
+                        <Ellipse x:Name="Check" WidthRequest="8" HeightRequest="8" Fill="Blue" VerticalOptions="Center" HorizontalOptions="Center" />
+                    </Grid>
+                    <ContentPresenter></ContentPresenter>
+                </Grid>
+            </Frame>
+        </ControlTemplate>
+
+            <Style TargetType="RadioButton">
+                <Setter Property="ControlTemplate" Value="{StaticResource CalendarRadioTemplate}"/>
+            </Style>
+        </ContentPage.Resources>
+        <StackLayout>
+            <RadioButton GroupName="A" Content="A"/>
+            <RadioButton GroupName="A" Content="B"/>
+            <RadioButton GroupName="A" Content="C"/>
+        </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui3793.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui3793.xaml.cs
@@ -1,0 +1,28 @@
+using Microsoft.Maui.Controls.Core.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Maui3793 : ContentPage
+	{
+		public Maui3793() => InitializeComponent();
+		public Maui3793(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void ControlTemplateFromStyle([Values(false, true)] bool useCompiledXaml)
+			{
+				Maui3793 page;
+				Assert.DoesNotThrow(() => page = new Maui3793(useCompiledXaml));
+			}
+		}
+	}
+}


### PR DESCRIPTION
There was an untested (and thus incorrect) case for non-compiled Xaml
where we have a VSM inside a style for a control template. This adds a
unit-test and a solution for this.

- fixes #3793



<!-- 

We are currently only accepting Pull Requests for .NET MAUI issues in our [Handler Property Backlog](https://github.com/dotnet/maui/projects/4). We will continue to update this repository over the next couple of months as we begin to accept more types of PRs.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
          - If the issue you're working on has a milestone, target the corresponding branch.
          - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
               See [Contributing](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md) for more tips!

```
 PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
```
 -->
### Description of Change ###

<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implements #

### Additions made ###
<!-- List all the additions made here, example:

- Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for WinUI, Android, and iOS
- Adds extension methods to apply Padding on WinUI/Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on WinUI, iOS, and Android

 -->

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
