### PR TITLE
[ci] Provisionator channel as a parameter on the pipeline

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -3,6 +3,7 @@ parameters:
   path: '' # path to csproj
   device: '' # the xharness device to use
   cakeArgs: '' # additional cake args
+  provisionatorChannel: 'latest'
 
 steps:
   - template: agent-cleanser/v1.yml@xamarin-templates
@@ -15,6 +16,7 @@ steps:
     parameters:
       platform: macos
       skipXcode: ${{ eq(parameters.platform, 'android') }}
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
     displayName: 'Install .NET'

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -33,6 +33,8 @@ stages:
                     demands:
                       - macOS.Name -equals BigSur
                       - macOS.Architecture -equals x64
+                      - Agent.HasDevices -equals False
+                      - Agent.IsPaired -equals False
                 variables:
                   ${{ if ge(api, 24) }}:
                     ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
@@ -66,6 +68,8 @@ stages:
                     demands:
                       - macOS.Name -equals BigSur
                       - macOS.Architecture -equals x64
+                      - Agent.HasDevices -equals False
+                      - Agent.IsPaired -equals False
                 variables:
                   REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
                 steps:

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -5,6 +5,7 @@ parameters:
   iosVmImage: '$(iosTestsVmImage)'
   androidApiLevels: [ 30 ]
   iosVersions: [ 'latest' ]
+  provisionatorChannel: 'latest'
   projects:
     - name: name
       desc: Human Description
@@ -44,6 +45,7 @@ stages:
                       platform: android
                       path: ${{ project.android }}
                       device: android-emulator-32_${{ api }}
+                      provisionatorChannel: ${{ parameters.provisionatorChannel }}
 
   - stage: ios_device_tests
     displayName: iOS Device Tests
@@ -75,3 +77,4 @@ stages:
                         device: ios-simulator-64
                       ${{ if ne(version, 'latest') }}:
                         device: ios-simulator-64_${{ version }}
+                      provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -26,6 +26,7 @@ steps:
           provisioning_script: $(provisionator.xcode)
           provisioning_extra_args: $(provisionator.extraArguments)
         env:
+          PROVISIONATOR_CHANNEL: $(PROVISIONATOR_CHANNEL)
           AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
     # Provision Additional Software
     - task: xamops.azdevex.provisionator-task.provisionator@1
@@ -35,7 +36,9 @@ steps:
         provisioning_script: $(provisionator.path)
         provisioning_extra_args: $(provisionator.extraArguments)
       env:
+        PROVISIONATOR_CHANNEL: $(PROVISIONATOR_CHANNEL)
         AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
+
     # Setup SDK Paths
     - bash: |
         echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"
@@ -94,6 +97,9 @@ steps:
       condition: eq(variables['provisioningVS'], 'true')
       inputs:
         provisioning_script: $(provisionator.vs)
+      env:
+        PROVISIONATOR_CHANNEL: $(PROVISIONATOR_CHANNEL)
+
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -2,6 +2,7 @@ parameters:
   platform : ''
   skipXcode: false
   poolName: ''
+  provisionatorChannel: 'latest'
 
 steps:
   - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
@@ -26,7 +27,7 @@ steps:
           provisioning_script: $(provisionator.xcode)
           provisioning_extra_args: $(provisionator.extraArguments)
         env:
-          PROVISIONATOR_CHANNEL: $(PROVISIONATOR_CHANNEL)
+          PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
           AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
     # Provision Additional Software
     - task: xamops.azdevex.provisionator-task.provisionator@1
@@ -36,7 +37,7 @@ steps:
         provisioning_script: $(provisionator.path)
         provisioning_extra_args: $(provisionator.extraArguments)
       env:
-        PROVISIONATOR_CHANNEL: $(PROVISIONATOR_CHANNEL)
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
         AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
     # Setup SDK Paths
@@ -98,7 +99,7 @@ steps:
       inputs:
         provisioning_script: $(provisionator.vs)
       env:
-        PROVISIONATOR_CHANNEL: $(PROVISIONATOR_CHANNEL)
+        PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
 
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -30,8 +30,6 @@ variables:
   value: $(Build.ArtifactStagingDirectory)/logs
 - name: TestResultsDirectory
   value: $(Build.ArtifactStagingDirectory)/test-results
-- name: PROVISIONATOR_CHANNEL
-  value: ${{ parameters.provisionatorChannel }}
 - name: provisionator.xcode
   value: '$(System.DefaultWorkingDirectory)/eng/provisioning/xcode.csx'
 - name: provisionator.path

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -30,6 +30,8 @@ variables:
   value: $(Build.ArtifactStagingDirectory)/logs
 - name: TestResultsDirectory
   value: $(Build.ArtifactStagingDirectory)/test-results
+- name: PROVISIONATOR_CHANNEL
+  value: ${{ parameters.provisionatorChannel }}
 - name: provisionator.xcode
   value: '$(System.DefaultWorkingDirectory)/eng/provisioning/xcode.csx'
 - name: provisionator.path

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -44,6 +44,11 @@ variables:
   - template: /eng/pipelines/common/variables.yml
 
 parameters:
+  - name: provisionatorChannel
+    displayName: 'Provisionator channel'
+    type: string
+    default: 'latest'           # Support for launching a build against a Provisionator PR (e.g., pr/[github-account-name]/[pr-number]) as a means to test in-progress Provisionator changes
+
   - name: BuildEverything
     type: boolean
     default: false
@@ -64,6 +69,7 @@ stages:
         androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off
         iosVersions: [ 'latest', '14.5', '13.7', '12.4', '11.4' ]
+        provisionatorChannel: ${{ parameters.provisionatorChannel }}
       projects:
         - name: essentials
           desc: Essentials

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -52,6 +52,11 @@ variables:
   - template: templates/common/vs-release-vars.yml@sdk-insertions
 
 parameters:
+  - name: provisionatorChannel
+    displayName: 'Provisionator channel'
+    type: string
+    default: 'latest'           # Support for launching a build against a Provisionator PR (e.g., pr/[github-account-name]/[pr-number]) as a means to test in-progress Provisionator changes
+
   - name: BuildEverything
     type: boolean
     default: false

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -148,6 +148,7 @@ stages:
                 parameters:
                   platform: ${{ BuildPlatform.name }}
                   poolName: ${{ BuildPlatform.poolName }}
+                  provisionatorChannel: ${{ parameters.provisionatorChannel }}
               - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Install .NET'
                 env:
@@ -198,6 +199,7 @@ stages:
               parameters:
                 platform: ${{ BuildPlatform.name }}
                 poolName: ${{ BuildPlatform.poolName }}
+                provisionatorChannel: ${{ parameters.provisionatorChannel }}
             - pwsh: ./build.ps1 --target=dotnet-pack --configuration="Release" --verbosity=diagnostic
               displayName: 'Pack .NET Maui'
               env:
@@ -275,6 +277,7 @@ stages:
                 parameters:
                   platform: ${{ BuildPlatform.name }}
                   poolName: ${{ BuildPlatform.poolName }}
+                  provisionatorChannel: ${{ parameters.provisionatorChannel }}
               - task: DownloadBuildArtifacts@0
                 displayName: 'Download Packages'
                 inputs:
@@ -332,6 +335,7 @@ stages:
                 parameters:
                   platform: ${{ BuildPlatform.name }}
                   poolName: ${{ BuildPlatform.poolName }}
+                  provisionatorChannel: ${{ parameters.provisionatorChannel }}
               - task: DownloadBuildArtifacts@0
                 displayName: 'Download Packages'
                 inputs:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -462,5 +462,4 @@ stages:
           artifactMap: [ nuget/signed ]                           # Use artifacts that match the filter from the signed directory and not the top-level directory for the nuget artifact
           packageName: 'Maui'
           packageFilter: '*.msi;*.nupkg'
-          GitHub.Token: $(GitHub.Token)
           condition: ${{ variables.signingCondition }}

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -460,6 +460,6 @@ stages:
         parameters:
           artifactNames: [ nuget, vs-msi-nugets, vsdrop-signed ]
           artifactMap: [ nuget/signed ]                           # Use artifacts that match the filter from the signed directory and not the top-level directory for the nuget artifact
-          packageName: 'Maui'
+          packageName: 'Microsoft Maui'
           packageFilter: '*.msi;*.nupkg'
           condition: ${{ variables.signingCondition }}


### PR DESCRIPTION
### Description of Change ###

Related work item: VS #[1476645](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1476645)

Exposes the Provisionator channel as a parameter on the pipeline. Allows for launching manual builds against in-progress Provisionator PR changes


### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
