### PR TITLE
[ci] Allow to build agains internal sdks (#4591)

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -5,14 +5,22 @@ parameters:
   cakeArgs: '' # additional cake args
 
 steps:
+  - template: agent-cleanser/v1.yml@xamarin-templates
+    parameters:
+      UninstallMono: false
+      UninstallXamarinMac: false
+      CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
 
   - template: provision.yml
     parameters:
       platform: macos
       skipXcode: ${{ eq(parameters.platform, 'android') }}
 
-  - pwsh: ./build.ps1 --target=dotnet --configuration="Release"
+  - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
     displayName: 'Install .NET'
+    env:
+      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+      PRIVATE_BUILD: $(PrivateBuild)
 
   - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
     displayName: 'Add .NET to PATH'

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -27,6 +27,10 @@ stages:
               pool:
                 name: ${{ parameters.androidVmPool }}
                 vmImage: ${{ parameters.androidVmImage }}
+                ${{ if startsWith(parameters.androidVmPool, 'VSEng-VSMac-Xamarin-Shared') }}:
+                  demands:
+                    - macOS.Name -equals BigSur
+                    - macOS.Architecture -equals x64
               variables:
                 ${{ if ge(api, 24) }}:
                   ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
@@ -54,6 +58,10 @@ stages:
               pool:
                 name: ${{ parameters.iosVmPool }}
                 vmImage: ${{ parameters.iosVmImage }}
+                ${{ if startsWith(parameters.iosVmPool, 'VSEng-VSMac-Xamarin-Shared') }}:
+                  demands:
+                    - macOS.Name -equals BigSur
+                    - macOS.Architecture -equals x64
               variables:
                 REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
               steps:

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -104,6 +104,15 @@ steps:
   - pwsh: ./build.ps1 --target provision
     displayName: 'Cake Provision'
     condition: eq(variables['provisioningCake'], 'true')
+
+  - task: PowerShell@2
+    condition: eq(variables['PrivateBuild'], 'true')
+    displayName: Setup Private Feeds Credentials
+    inputs:
+      filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
+      arguments: -ConfigFile $(System.DefaultWorkingDirectory)/NuGet.config -Password $Env:Token
+    env:
+      Token: $(dn-bot-dnceng-artifact-feeds-rw)
   - pwsh: dotnet nuget locals all --clear
     displayName: 'Clear all NuGet caches'
 

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -44,4 +44,14 @@ variables:
   value: Maui
 - name: POWERSHELL_VERSION
   value: 7.1.3
+- ${{ if ne(variables['Build.DefinitionName'], 'MAUI-private') }}:
+  - name: PrivateBuild
+    value: false
+# Variable groups required for private builds
+- ${{ if eq(variables['Build.DefinitionName'], 'MAUI-private') }}:
+  - name: PrivateBuild
+    value: true
+  # For eng/common/SetupNugetSources.ps1
+  - group: DotNetBuilds storage account read tokens
+  - group: AzureDevOps-Artifact-Feeds-Pats
 - group: Xamarin-Secrets

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -48,6 +48,14 @@ parameters:
     type: boolean
     default: false
 
+resources:
+  repositories:
+    - repository: xamarin-templates
+      type: github
+      name: xamarin/yaml-templates
+      endpoint: xamarin
+      ref: refs/heads/main
+      
 stages:
 
   - template: common/device-tests.yml

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -132,12 +132,16 @@ stages:
                   parameters:
                     UninstallMono: false
                     UninstallXamarinMac: false
+                    CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
               - template: common/provision.yml
                 parameters:
                   platform: ${{ BuildPlatform.name }}
                   poolName: ${{ BuildPlatform.poolName }}
               - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Install .NET'
+                env:
+                  DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+                  PRIVATE_BUILD: $(PrivateBuild)
               - pwsh: ./build.ps1 --target=dotnet-build --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET Maui'
               - pwsh: ./build.ps1 --target=dotnet-test --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
@@ -178,12 +182,16 @@ stages:
                 parameters:
                   UninstallMono: false
                   UninstallXamarinMac: false
+                  CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
             - template: common/provision.yml
               parameters:
                 platform: ${{ BuildPlatform.name }}
                 poolName: ${{ BuildPlatform.poolName }}
             - pwsh: ./build.ps1 --target=dotnet-pack --configuration="Release" --verbosity=diagnostic
               displayName: 'Pack .NET Maui'
+              env:
+                DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+                PRIVATE_BUILD: $(PrivateBuild)
             - ${{ if eq(BuildPlatform.name, 'Windows') }}:
               - pwsh: ./build.ps1 --target=dotnet-diff --configuration="Release" --verbosity=diagnostic
                 displayName: 'Diff .NET Maui artifacts with NuGet'
@@ -251,6 +259,7 @@ stages:
                   parameters:
                     UninstallMono: false
                     UninstallXamarinMac: false
+                    CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
               - template: common/provision.yml
                 parameters:
                   platform: ${{ BuildPlatform.name }}
@@ -265,6 +274,10 @@ stages:
                 displayName: Move the downloaded artifacts
               - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Install .NET (Local Workloads)'
+                
+                env:
+                  DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+                  PRIVATE_BUILD: $(PrivateBuild)
               - pwsh: ./build.ps1 --target=dotnet-samples --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET 6 Samples'
               - task: PublishBuildArtifacts@1
@@ -303,6 +316,7 @@ stages:
                   parameters:
                     UninstallMono: false
                     UninstallXamarinMac: false
+                    CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
               - template: common/provision.yml
                 parameters:
                   platform: ${{ BuildPlatform.name }}
@@ -317,6 +331,9 @@ stages:
                 displayName: Move the downloaded artifacts
               - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Install .NET (Local Workloads)'
+                env:
+                  DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+                  PRIVATE_BUILD: $(PrivateBuild)
               - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET 6 Templates'
               - task: PublishBuildArtifacts@1

--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+  "tools": {
+    "dotnet": "6.0.100-rc.2.21478.25"
+  },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.23",
     "Microsoft.Build.NoTargets": "2.0.1"

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -3,20 +3,25 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <InstallWorkloadPacks Condition=" '$(InstallWorkloadPacks)' == '' ">true</InstallWorkloadPacks>
+    <InternalAzureFeed>https://dotnetbuilds.blob.core.windows.net/internal</InternalAzureFeed>
     <DotNetFeedUrl>https://dotnetbuilds.blob.core.windows.net/public</DotNetFeedUrl>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <DotNetInstallScriptUrl>https://dot.net/v1/dotnet-install.ps1</DotNetInstallScriptUrl>
     <DotNetInstallScriptName>dotnet-install.ps1</DotNetInstallScriptName>
     <DotNetInstallScriptPath>$(DotNetOutputPath)$(DotNetInstallScriptName)</DotNetInstallScriptPath>
-    <DotNetInstallCommand>&amp; '$(DotNetInstallScriptPath)' -Version $(MicrosoftDotnetSdkInternalPackageVersion) -InstallDir '$(DotNetDirectory)' -AzureFeed $(DotNetFeedUrl) -Verbose</DotNetInstallCommand>
-    <DotNetInstallCommand>powershell -ExecutionPolicy ByPass -NoProfile -Command &quot;$(DotNetInstallCommand)&quot;</DotNetInstallCommand>
+    <DotNetInstallCommand>&amp; '$(DotNetInstallScriptPath)' -Version $(MicrosoftDotnetSdkInternalPackageVersion) -InstallDir '$(DotNetDirectory)' -Verbose</DotNetInstallCommand>
+    <DotNetInstallCommand Condition=" '$(PRIVATE_BUILD)' == 'false' ">$(DotNetInstallCommand) -AzureFeed $(DotNetFeedUrl)</DotNetInstallCommand>
+    <DotNetInstallCommand Condition=" '$(PRIVATE_BUILD)' == 'true' ">$(DotNetInstallCommand) -AzureFeed $(InternalAzureFeed) -FeedCredential $env:DOTNET_TOKEN</DotNetInstallCommand> 
+    <DotNetInstallCommand>powershell -Command &quot;$(DotNetInstallCommand)&quot;</DotNetInstallCommand>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('osx'))">
     <DotNetInstallScriptUrl>https://dot.net/v1/dotnet-install.sh</DotNetInstallScriptUrl>
     <DotNetInstallScriptName>dotnet-install.sh</DotNetInstallScriptName>
     <DotNetInstallScriptPath>$(DotNetOutputPath)$(DotNetInstallScriptName)</DotNetInstallScriptPath>
-    <DotNetInstallCommand>sh '$(DotNetInstallScriptPath)' --version $(MicrosoftDotnetSdkInternalPackageVersion) --install-dir '$(DotNetDirectory)' --azure-feed $(DotNetFeedUrl) --verbose</DotNetInstallCommand>
+    <DotNetInstallCommand>sh '$(DotNetInstallScriptPath)' --version $(MicrosoftDotnetSdkInternalPackageVersion) --install-dir '$(DotNetDirectory)' --verbose</DotNetInstallCommand>
+    <DotNetInstallCommand Condition=" '$(PRIVATE_BUILD)' == 'false' ">$(DotNetInstallCommand) --azure-feed $(DotNetFeedUrl)</DotNetInstallCommand>
+    <DotNetInstallCommand Condition=" '$(PRIVATE_BUILD)' == 'true' ">$(DotNetInstallCommand) --azure-feed $(InternalAzureFeed) --feed-credential $DOTNET_TOKEN</DotNetInstallCommand>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -28,12 +33,6 @@
     </_ProvisionDependsOn>
   </PropertyGroup>
 
-  <Target Name="_ReadAllNuGetSources">
-    <XmlPeek XmlInputPath="../../NuGet.config" Query="configuration/packageSources/add[@key!='wasdk-internal']/@value">
-      <Output TaskParameter="Result" ItemName="_AllNuGetSources" />
-    </XmlPeek>
-  </Target>
-
   <!-- Build target provisions ./bin/dotnet/ -->
   <Target Name="_Provision" BeforeTargets="Build" DependsOnTargets="$(_ProvisionDependsOn)" />
 
@@ -42,7 +41,7 @@
     Running this with ./bin/dotnet/dotnet will work without elevation.
     For a system install, you will need to run this in an admin command-prompt on Windows, or use 'sudo' on Mac.
   -->
-  <Target Name="Install" DependsOnTargets="_ReadAllNuGetSources;SetVersions">
+  <Target Name="Install" DependsOnTargets="SetVersions">
 
     <Error
         Condition=" '$(MSBuildRuntimeType)' != 'Core' "
@@ -73,12 +72,10 @@
     <!-- Run 'dotnet workload install' for the current running 'dotnet' install -->
     <ItemGroup>
       <_WorkloadSource Include="$(PackageOutputPath)" />
-      <_WorkloadSource Include="@(_AllNuGetSources)" />
     </ItemGroup>
-    <Exec
-        Command="&quot;$(MSBuildExtensionsPath)../../dotnet&quot; workload install maui --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; @(_WorkloadSource->'--source &quot;%(Identity)&quot;', ' ')"
-        WorkingDirectory="$(MauiRootDirectory)"
-    />
+    <Copy SourceFiles="$(MauiRootDirectory)NuGet.config" DestinationFolder="$(DotNetTempDirectory)" />
+    <Exec Command="dotnet nuget add source &quot;$(PackageOutputPath)&quot; --name artifacts --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" />
+    <Exec Command="&quot;$(MSBuildExtensionsPath)../../dotnet&quot; workload install maui --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
 
   </Target>
 
@@ -154,10 +151,9 @@
   <Target Name="_InstallWorkloadPacks"
       Condition=" '$(InstallWorkloadPacks)' == 'true' "
       Inputs="$(_Inputs)"
-      Outputs="$(DotNetPacksDirectory).stamp"
-      DependsOnTargets="_ReadAllNuGetSources">
+      Outputs="$(DotNetPacksDirectory).stamp">
     <Exec
-        Command="&quot;$(DotNetToolPath)&quot; workload install %(_WorkloadIds.Identity) --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; @(_AllNuGetSources->'--source &quot;%(Identity)&quot;', ' ')"
+        Command="&quot;$(DotNetToolPath)&quot; workload install %(_WorkloadIds.Identity) --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(MauiRootDirectory)NuGet.config&quot;"
         WorkingDirectory="$(MauiRootDirectory)"
     />
     <Touch Files="$(DotNetPacksDirectory).stamp" AlwaysCreate="true" />


### PR DESCRIPTION
* [ci] setup internal .NET builds

Context: https://github.com/xamarin/xamarin-android-private/commit/5c8a5432fa20e26926caee470ed3391010d33a93

To consume private .NET 6 builds we need two parts:

1. Run `SetupNugetSources.ps1` with credentials to update the
   `NuGet.config` file to private feeds.

2. Run `dotnet-install.ps1/sh` with `--azure-feed` and
   `--feed-credential`.

To do this we need the variable groups:

    # SetupNugetSources
    - group: AzureDevOps-Artifact-Feeds-Pats
    # dotnet-install
    - group: DotNet-MSRC-Storage

* Fix empty parameter

* Bump to .NET SDK 6.0.100-rc.2.21478.25

* Add "tools" to global.json

* Setup dotnet-install.ps1/sh

* Fixes for $DOTNET_TOKEN

* More fixes

* Update DotNet.csproj

* Try script type variable syntax

* Update version

* Bump sdk version

* Update DotNet.csproj

* use dotnetbuilds-internal-container-uri

* Fix variable

* use dotnetbuilds-internal-container-read-token

* Push more changes to $(dotnetbuilds-internal-container-read-token)

* test again

* Remove AOT

* try this

* Revert "Remove AOT"

This reverts commit 28b9e6aca4e232831cc5bc198fd2b5225aaedbd0.

* Update tools.ps1

* Try not use sources

* Update global.json

* Revert "Update global.json"

This reverts commit 1bc350aac6ebd760a14b3799ba133c7c693a4a8d.

* Revert "Try not use sources"

This reverts commit 3528400cd50da602e2d60cf43198baf5cbd15899.

* Skip dotnet6-internal-transport for workload sources

* Revert "Revert "Try not use sources""

This reverts commit 704369edf324696a5122f95b15cfbfa7676dd2e8.

* Remove souces from Install target

* Revert "Remove souces from Install target"

This reverts commit 4337163ee98a315bafade7291e8bc9ee307e3f1e.

* Try speciy packages path on nuget.config

* Don't use full path

* Try use --configfile

* Revert "Try use --configfile"

This reverts commit d4983c021f0166d82a87c9ee27615a00bd4542c9.

* Try add source from exec command

* Fix when no token exists

* Try fix condition to run private build

* Fix yaml

* Revert not needed change

* Copy nuget.config file to other location

* Fix Copy task

* Fix command

* Remove _ReadAllNuGetSources and specify configfile

* [ci] Agent-Cleanser: Ensure .NET cleansing is turned on (#4595)

* Agent-Cleanser: Ensure .NET cleansing is turned on

* Revise Agent-Cleanser comment explaining why CleanseAgentToolsDotNet is being set

* [ci] Add agent cleaner to device tests (#4618)

* [ci] Add agent cleaner to device tests

* Fix yaml

* Add cleanup to device steps

* [ci] Pass variables to dotnet install on device tests

* Fix get pool name

Co-authored-by: Jonathan Peppers <jonathan.peppers@microsoft.com>
Co-authored-by: Peter Collins <pecolli@microsoft.com>
Co-authored-by: Matthew Leibowitz <mattleibow@live.com>
Co-authored-by: Mike Bond <mjbond-msft@outlook.com>



<!-- 

We are currently only accepting Pull Requests for .NET MAUI issues in our [Handler Property Backlog](https://github.com/dotnet/maui/projects/4). We will continue to update this repository over the next couple of months as we begin to accept more types of PRs.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
          - If the issue you're working on has a milestone, target the corresponding branch.
          - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
               See [Contributing](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md) for more tips!

```
 PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
```
 -->
### Description of Change ###

<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implements #

### Additions made ###
<!-- List all the additions made here, example:

- Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for WinUI, Android, and iOS
- Adds extension methods to apply Padding on WinUI/Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on WinUI, iOS, and Android

 -->

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
