### PR TITLE
Run BlazorWebView tests only on Android API level 28+

### DIFF
--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -20,30 +20,30 @@ stages:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.android, '') }}:
           - ${{ each api in parameters.androidApiLevels }}:
-            - job: android_device_tests_${{ project.name }}_${{ api }}
-              condition: ${{ or(eq(project.androidApiLevels, ''), containsValue(project.androidApiLevels, api)) }}
-              workspace:
-                clean: all
-              displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
-              pool:
-                name: ${{ parameters.androidVmPool }}
-                vmImage: ${{ parameters.androidVmImage }}
-                ${{ if startsWith(parameters.androidVmPool, 'VSEng-VSMac-Xamarin-Shared') }}:
-                  demands:
-                    - macOS.Name -equals BigSur
-                    - macOS.Architecture -equals x64
-              variables:
-                ${{ if ge(api, 24) }}:
-                  ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
-                ${{ if lt(api, 24) }}:
-                  ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
-                REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
-              steps:
-                - template: device-tests-steps.yml
-                  parameters:
-                    platform: android
-                    path: ${{ project.android }}
-                    device: android-emulator-32_${{ api }}
+            - ${{ if or(eq(project.androidApiLevels, ''), containsValue(project.androidApiLevels, api)) }}:
+              - job: android_device_tests_${{ project.name }}_${{ api }}
+                workspace:
+                  clean: all
+                displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
+                pool:
+                  name: ${{ parameters.androidVmPool }}
+                  vmImage: ${{ parameters.androidVmImage }}
+                  ${{ if startsWith(parameters.androidVmPool, 'VSEng-VSMac-Xamarin-Shared') }}:
+                    demands:
+                      - macOS.Name -equals BigSur
+                      - macOS.Architecture -equals x64
+                variables:
+                  ${{ if ge(api, 24) }}:
+                    ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"
+                  ${{ if lt(api, 24) }}:
+                    ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis;x86"
+                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
+                steps:
+                  - template: device-tests-steps.yml
+                    parameters:
+                      platform: android
+                      path: ${{ project.android }}
+                      device: android-emulator-32_${{ api }}
 
   - stage: ios_device_tests
     displayName: iOS Device Tests
@@ -52,26 +52,26 @@ stages:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
           - ${{ each version in parameters.iosVersions }}:
-            - job: ios_device_tests_${{ project.name }}_${{ replace(version, '.', '_') }}
-              condition: ${{ or(eq(project.iosVersions, ''), containsValue(project.iosVersions, version)) }}
-              workspace:
-                clean: all
-              displayName: ${{ coalesce(project.desc, project.name) }} (v${{ version }})
-              pool:
-                name: ${{ parameters.iosVmPool }}
-                vmImage: ${{ parameters.iosVmImage }}
-                ${{ if startsWith(parameters.iosVmPool, 'VSEng-VSMac-Xamarin-Shared') }}:
-                  demands:
-                    - macOS.Name -equals BigSur
-                    - macOS.Architecture -equals x64
-              variables:
-                REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
-              steps:
-                - template: device-tests-steps.yml
-                  parameters:
-                    platform: ios
-                    path: ${{ project.ios }}
-                    ${{ if eq(version, 'latest') }}:
-                      device: ios-simulator-64
-                    ${{ if ne(version, 'latest') }}:
-                      device: ios-simulator-64_${{ version }}
+            - ${{ if or(eq(project.iosVersions, ''), containsValue(project.iosVersions, version)) }}:
+              - job: ios_device_tests_${{ project.name }}_${{ replace(version, '.', '_') }}
+                workspace:
+                  clean: all
+                displayName: ${{ coalesce(project.desc, project.name) }} (v${{ version }})
+                pool:
+                  name: ${{ parameters.iosVmPool }}
+                  vmImage: ${{ parameters.iosVmImage }}
+                  ${{ if startsWith(parameters.iosVmPool, 'VSEng-VSMac-Xamarin-Shared') }}:
+                    demands:
+                      - macOS.Name -equals BigSur
+                      - macOS.Architecture -equals x64
+                variables:
+                  REQUIRED_XCODE: $(DEVICETESTS_REQUIRED_XCODE)
+                steps:
+                  - template: device-tests-steps.yml
+                    parameters:
+                      platform: ios
+                      path: ${{ project.ios }}
+                      ${{ if eq(version, 'latest') }}:
+                        device: ios-simulator-64
+                      ${{ if ne(version, 'latest') }}:
+                        device: ios-simulator-64_${{ version }}

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -21,6 +21,7 @@ stages:
         - ${{ if ne(project.android, '') }}:
           - ${{ each api in parameters.androidApiLevels }}:
             - job: android_device_tests_${{ project.name }}_${{ api }}
+              condition: ${{ or(eq(project.androidApiLevels, ''), containsValue(project.androidApiLevels, api)) }}
               workspace:
                 clean: all
               displayName: ${{ coalesce(project.desc, project.name) }} (API ${{ api }})
@@ -52,6 +53,7 @@ stages:
         - ${{ if ne(project.ios, '') }}:
           - ${{ each version in parameters.iosVersions }}:
             - job: ios_device_tests_${{ project.name }}_${{ replace(version, '.', '_') }}
+              condition: ${{ or(eq(project.iosVersions, ''), containsValue(project.iosVersions, version)) }}
               workspace:
                 clean: all
               displayName: ${{ coalesce(project.desc, project.name) }} (v${{ version }})

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -20,7 +20,7 @@ stages:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.android, '') }}:
           - ${{ each api in parameters.androidApiLevels }}:
-            - ${{ if or(eq(project.androidApiLevels, ''), containsValue(project.androidApiLevels, api)) }}:
+            - ${{ if not(containsValue(project.androidApiLevelsExclude, api)) }}:
               - job: android_device_tests_${{ project.name }}_${{ api }}
                 workspace:
                   clean: all
@@ -52,7 +52,7 @@ stages:
       - ${{ each project in parameters.projects }}:
         - ${{ if ne(project.ios, '') }}:
           - ${{ each version in parameters.iosVersions }}:
-            - ${{ if or(eq(project.iosVersions, ''), containsValue(project.iosVersions, version)) }}:
+            - ${{ if not(containsValue(project.iosVersionsExclude, version)) }}:
               - job: ios_device_tests_${{ project.name }}_${{ replace(version, '.', '_') }}
                 workspace:
                   clean: all

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -79,6 +79,6 @@ stages:
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
         - name: blazorwebview
           desc: BlazorWebView
-          androidApiLevels: [ 30, 29, 28 ] # BlazorWebView requires a recent version of Chrome
+          androidApiLevelsExclude: [ 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -77,13 +77,8 @@ stages:
           desc: Controls
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
-  - template: common/device-tests.yml
-    parameters:
-      ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
-        androidApiLevels: [ 30, 29, 28  ]
-        iosVersions: [ 'latest', '14.5', '13.7', '12.4', '11.4' ]
-      projects:
         - name: blazorwebview
           desc: BlazorWebView
+          androidApiLevels: [ 30, 29, 28 ] # BlazorWebView requires a recent version of Chrome
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -77,6 +77,12 @@ stages:
           desc: Controls
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+  - template: common/device-tests.yml
+    parameters:
+      ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
+        androidApiLevels: [ 30, 29, 28  ]
+        iosVersions: [ 'latest', '14.5', '13.7', '12.4', '11.4' ]
+      projects:
         - name: blazorwebview
           desc: BlazorWebView
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/4517

Code review suggestion: it's easiest to understand if you see the whitespace-insensitive diff via https://github.com/dotnet/maui/pull/4625/files?w=1. On this view you can see that it just adds an extra "if" test to the Android and iOS test job lists.

Strictly speaking I only needed to do it for Android but added the same filtering capability for iOS for consistency in case this is needed in the future too.