### PR TITLE
[Android] Implement RadioButton Border properties

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/RadioButtonGalleries/RadioButtonBorder.xaml
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/RadioButtonGalleries/RadioButtonBorder.xaml
@@ -8,18 +8,18 @@
         <StackLayout>
             <Label Text="RadioButton with Border" />
             <RadioButton 
-                Content="Cat" 
+                Content="Option 1" 
                 BackgroundColor="Yellow"
                 BorderColor="Red" 
                 BorderWidth="4" 
                 CornerRadius="12" />
             <RadioButton 
-                Content="Dog"
+                Content="Option 2"
                 BackgroundColor="Yellow" />
             <RadioButton 
-                Content="Elephant" />
+                Content="Option 3" />
             <RadioButton 
-                Content="Monkey"
+                Content="Option 4"
                 BorderColor="Green"
                 BorderWidth="4" 
                 CornerRadius="12"

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/RadioButtonGalleries/RadioButtonBorder.xaml
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/RadioButtonGalleries/RadioButtonBorder.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.RadioButtonGalleries.RadioButtonBorder"
+    Title="RadioButton Border">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="RadioButton with Border" />
+            <RadioButton 
+                Content="Cat" 
+                BackgroundColor="Yellow"
+                BorderColor="Red" 
+                BorderWidth="4" 
+                CornerRadius="12" />
+            <RadioButton 
+                Content="Dog"
+                BackgroundColor="Yellow" />
+            <RadioButton 
+                Content="Elephant" />
+            <RadioButton 
+                Content="Monkey"
+                BorderColor="Green"
+                BorderWidth="4" 
+                CornerRadius="12"
+                IsChecked="true" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/RadioButtonGalleries/RadioButtonBorder.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/RadioButtonGalleries/RadioButtonBorder.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.RadioButtonGalleries
+{
+	public partial class RadioButtonBorder 
+	{
+		public RadioButtonBorder()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/RadioButtonGalleries/RadioButtonGalleries.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/RadioButtonGalleries/RadioButtonGalleries.cs
@@ -28,8 +28,10 @@
 							new RadioButtonContentGallery(), Navigation),
 						GalleryBuilder.NavButton("RadioButton Content Properties", () =>
 							new ContentProperties(), Navigation),
-							GalleryBuilder.NavButton("RadioButton Template from Style", () =>
+						GalleryBuilder.NavButton("RadioButton Template from Style", () =>
 							new TemplateFromStyle(), Navigation),
+						GalleryBuilder.NavButton("RadioButton Border", () =>
+							new RadioButtonBorder(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonBorder.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonBorder.xaml
@@ -8,18 +8,18 @@
         <StackLayout>
             <Label Text="RadioButton with Border" />
             <RadioButton 
-                Content="Cat" 
+                Content="Option 1" 
                 BackgroundColor="Yellow"
                 BorderColor="Red" 
                 BorderWidth="4" 
                 CornerRadius="12" />
             <RadioButton 
-                Content="Dog"
+                Content="Option 2"
                 BackgroundColor="Yellow" />
             <RadioButton 
-                Content="Elephant" />
+                Content="Option 3" />
             <RadioButton 
-                Content="Monkey"
+                Content="Option 4"
                 BorderColor="Green"
                 BorderWidth="4" 
                 CornerRadius="12"

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonBorder.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonBorder.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.RadioButtonGalleries.RadioButtonBorder"
+    Title="RadioButton Border">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="RadioButton with Border" />
+            <RadioButton 
+                Content="Cat" 
+                BackgroundColor="Yellow"
+                BorderColor="Red" 
+                BorderWidth="4" 
+                CornerRadius="12" />
+            <RadioButton 
+                Content="Dog"
+                BackgroundColor="Yellow" />
+            <RadioButton 
+                Content="Elephant" />
+            <RadioButton 
+                Content="Monkey"
+                BorderColor="Green"
+                BorderWidth="4" 
+                CornerRadius="12"
+                IsChecked="true" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonBorder.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonBorder.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Maui.Controls.Sample.Pages.RadioButtonGalleries
+{
+	public partial class RadioButtonBorder 
+	{
+		public RadioButtonBorder()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonGalleries.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonGalleries.cs
@@ -31,8 +31,10 @@ namespace Maui.Controls.Sample.Pages.RadioButtonGalleries
 							new RadioButtonContentGallery(), Navigation),
 						GalleryBuilder.NavButton("RadioButton Content Properties", () =>
 							new ContentProperties(), Navigation),
-							GalleryBuilder.NavButton("RadioButton Template from Style", () =>
+						GalleryBuilder.NavButton("RadioButton Template from Style", () =>
 							new TemplateFromStyle(), Navigation),
+						GalleryBuilder.NavButton("RadioButton Border", () =>
+							new RadioButtonBorder(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/samples/Controls.Sample/ViewModels/ControlsViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/ControlsViewModel.cs
@@ -55,7 +55,7 @@ namespace Maui.Controls.Sample.ViewModels
 				"The ProgressBar control visually represents progress as a horizontal bar that is filled to a percentage represented by a float value."),
 
 			new SectionModel(typeof(Pages.RadioButtonGalleries.RadioButtonGalleries), "RadioButton",
-				"The Xamarin.Forms RadioButton is a type of button that allows users to select one option from a set. Each option is represented by one radio button, and you can only select one radio button in a group."),
+				"The RadioButton is a type of button that allows users to select one option from a set. Each option is represented by one radio button, and you can only select one radio button in a group."),
 
 			new SectionModel(typeof(RefreshViewPage), "RefreshView",
 				"RefreshView is a container control that provides pull-to-refresh functionality for scrollable content."),

--- a/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Impl.cs
@@ -37,5 +37,11 @@ namespace Microsoft.Maui.Controls
 		}
 
 		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? (Content as IView);
+
+		double IButtonStroke.StrokeThickness => (double)GetValue(BorderWidthProperty);
+
+		Color IButtonStroke.StrokeColor => (Color)GetValue(BorderColorProperty);
+
+		int IButtonStroke.CornerRadius => (int)GetValue(CornerRadiusProperty);
 	}
 }

--- a/src/Core/src/Core/IRadioButton.cs
+++ b/src/Core/src/Core/IRadioButton.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Represents a View that provides a toggled value.
 	/// </summary>
-	public interface IRadioButton : IView, ITextStyle, IContentView
+	public interface IRadioButton : IView, ITextStyle, IContentView, IButtonStroke
 	{
 		/// <summary>
 		/// Gets or sets a Boolean value that indicates whether this RadioButton is checked.

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Android.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Maui.Handlers
 				PlatformRadioButton.CheckedChange -= OnCheckChanged;
 		}
 
+		public static void MapBackground(RadioButtonHandler handler, IRadioButton radioButton)
+		{
+			handler.PlatformRadioButton?.UpdateBackground(radioButton);
+		}
+
 		public static void MapIsChecked(RadioButtonHandler handler, IRadioButton radioButton)
 		{
 			handler.PlatformRadioButton?.UpdateIsChecked(radioButton);
@@ -53,6 +58,21 @@ namespace Microsoft.Maui.Handlers
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
 			handler.PlatformRadioButton?.UpdateFont(textStyle, fontManager);
+		}
+
+		public static void MapStrokeColor(RadioButtonHandler handler, IRadioButton radioButton)
+		{ 
+			handler.PlatformRadioButton?.UpdateStrokeColor(radioButton); 
+		}
+
+		public static void MapStrokeThickness(RadioButtonHandler handler, IRadioButton radioButton)
+		{ 
+			handler.PlatformRadioButton?.UpdateStrokeThickness(radioButton);
+		}
+
+		public static void MapCornerRadius(RadioButtonHandler handler, IRadioButton radioButton)
+		{ 
+			handler.PlatformRadioButton?.UpdateCornerRadius(radioButton); 
 		}
 
 		void OnCheckChanged(object? sender, CompoundButton.CheckedChangeEventArgs e)

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Standard.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Standard.cs
@@ -5,24 +5,14 @@ namespace Microsoft.Maui.Handlers
 	public partial class RadioButtonHandler : ViewHandler<IRadioButton, object>
 	{
 		protected override object CreateNativeView() => throw new NotImplementedException();
-		public static void MapIsChecked(RadioButtonHandler handler, IRadioButton radioButton)
-		{
-		}
 
-		public static void MapContent(RadioButtonHandler handler, IRadioButton radioButton)
-		{
-		}
-
-		public static void MapTextColor(RadioButtonHandler handler, ITextStyle textStyle)
-		{
-		}
-
-		public static void MapCharacterSpacing(RadioButtonHandler handler, ITextStyle textStyle)
-		{
-		}
-
-		public static void MapFont(RadioButtonHandler handler, ITextStyle textStyle)
-		{
-		}
+		public static void MapIsChecked(RadioButtonHandler handler, IRadioButton radioButton) { }
+		public static void MapContent(RadioButtonHandler handler, IRadioButton radioButton) { }
+		public static void MapTextColor(RadioButtonHandler handler, ITextStyle textStyle) { }
+		public static void MapCharacterSpacing(RadioButtonHandler handler, ITextStyle textStyle) { }
+		public static void MapFont(RadioButtonHandler handler, ITextStyle textStyle) { }
+		public static void MapStrokeColor(RadioButtonHandler handler, IRadioButton radioButton) { }
+		public static void MapStrokeThickness(RadioButtonHandler handler, IRadioButton radioButton) { }
+		public static void MapCornerRadius(RadioButtonHandler handler, IRadioButton radioButton) { }
 	}
 }

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Windows.cs
@@ -25,5 +25,14 @@ namespace Microsoft.Maui.Handlers
 			var fontManager = handler.GetRequiredService<IFontManager>();
 			handler.NativeView?.UpdateFont(button, fontManager);
 		}
+
+		[MissingMapper]
+		public static void MapStrokeColor(RadioButtonHandler handler, IRadioButton radioButton) { }
+
+		[MissingMapper]
+		public static void MapStrokeThickness(RadioButtonHandler handler, IRadioButton radioButton) { }
+
+		[MissingMapper]
+		public static void MapCornerRadius(RadioButtonHandler handler, IRadioButton radioButton) { }
 	}
 }

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
@@ -4,11 +4,17 @@
 	{
 		public static IPropertyMapper<IRadioButton, RadioButtonHandler> Mapper = new PropertyMapper<IRadioButton, RadioButtonHandler>(ViewHandler.ViewMapper)
 		{
+#if ANDROID
+			[nameof(IRadioButton.Background)] = MapBackground,
+#endif
 			[nameof(IRadioButton.IsChecked)] = MapIsChecked,
 			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(ITextStyle.Font)] = MapFont,
 			[nameof(ITextStyle.TextColor)] = MapTextColor,
 			[nameof(IRadioButton.Content)] = MapContent,
+			[nameof(IRadioButton.StrokeColor)] = MapStrokeColor,
+			[nameof(IRadioButton.StrokeThickness)] = MapStrokeThickness,
+			[nameof(IRadioButton.CornerRadius)] = MapCornerRadius,
 		};
 
 		public RadioButtonHandler() : base(Mapper)

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.iOS.cs
@@ -46,20 +46,25 @@ namespace Microsoft.Maui.Handlers
 			handler.UpdateContent();
 		}
 
-		public static void MapIsChecked(RadioButtonHandler handler, IRadioButton radioButton)
-		{
-		}
+		[MissingMapper]
+		public static void MapIsChecked(RadioButtonHandler handler, IRadioButton radioButton) { }
 
-		public static void MapTextColor(RadioButtonHandler handler, ITextStyle textStyle)
-		{
-		}
+		[MissingMapper]
+		public static void MapTextColor(RadioButtonHandler handler, ITextStyle textStyle) { }
 
-		public static void MapCharacterSpacing(RadioButtonHandler handler, ITextStyle textStyle)
-		{
-		}
+		[MissingMapper]
+		public static void MapCharacterSpacing(RadioButtonHandler handler, ITextStyle textStyle) { }
 
-		public static void MapFont(RadioButtonHandler handler, ITextStyle textStyle)
-		{
-		}
+		[MissingMapper]
+		public static void MapFont(RadioButtonHandler handler, ITextStyle textStyle) { }
+
+		[MissingMapper]
+		public static void MapStrokeColor(RadioButtonHandler handler, IRadioButton radioButton) { }
+
+		[MissingMapper]
+		public static void MapStrokeThickness(RadioButtonHandler handler, IRadioButton radioButton) { }
+
+		[MissingMapper]
+		public static void MapCornerRadius(RadioButtonHandler handler, IRadioButton radioButton) { }
 	}
 }

--- a/src/Core/src/Platform/Android/BorderDrawable.cs
+++ b/src/Core/src/Platform/Android/BorderDrawable.cs
@@ -1,0 +1,519 @@
+﻿using System;
+using Android.Graphics;
+using Android.Graphics.Drawables;
+using Android.Graphics.Drawables.Shapes;
+using Android.Util;
+using AndroidX.Core.Content;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
+using AColor = Android.Graphics.Color;
+using AContext = Android.Content.Context;
+using APaint = Android.Graphics.Paint;
+using ARect = Android.Graphics.Rect;
+using GPaint = Microsoft.Maui.Graphics.Paint;
+
+namespace Microsoft.Maui.Platform
+{
+	public class BorderDrawable : PaintDrawable
+	{
+		readonly AContext? _context;
+		readonly double _density;
+
+		bool _invalidatePath;
+
+		bool _disposed;
+
+		ARect? _bounds;
+		int _width;
+		int _height;
+
+		Path? _clipPath;
+		APaint? _borderPaint;
+
+		GPaint? _background;
+		AColor? _backgroundColor;
+
+		GPaint? _stroke;
+		AColor? _borderColor;
+
+		float _strokeThickness;
+
+		CornerRadius _cornerRadius;
+
+		public BorderDrawable(AContext? context)
+		{
+			Shape = new RectShape();
+
+			_invalidatePath = true;
+
+			_clipPath = new Path();
+
+			_context = context;
+			_density = context?.Resources?.DisplayMetrics?.Density ?? 1.0f;
+		}
+
+		public void SetBackgroundColor(AColor? backgroundColor)
+		{
+			if (_backgroundColor == backgroundColor)
+				return;
+
+			_backgroundColor = backgroundColor;
+
+			InvalidateSelf();
+		}
+
+		public void SetBackground(GPaint? paint)
+		{
+			if (paint is SolidPaint solidPaint)
+				SetBackground(solidPaint);
+			else if (paint is LinearGradientPaint linearGradientPaint)
+				SetBackground(linearGradientPaint);
+			else if (paint is RadialGradientPaint radialGradientPaint)
+				SetBackground(radialGradientPaint);
+			else if (paint is ImagePaint imagePaint)
+				SetBackground(imagePaint);
+			else if (paint is PatternPaint patternPaint)
+				SetBackground(patternPaint);
+			else
+				SetDefaultBackgroundColor();
+		}
+
+		public void SetBackground(SolidPaint solidPaint)
+		{
+			_invalidatePath = true;
+			_backgroundColor = null;
+			_background = null;
+
+			if (solidPaint.Color == null)
+				SetDefaultBackgroundColor();
+			else
+			{
+				var backgroundColor = solidPaint.Color.ToNative();
+				SetBackgroundColor(backgroundColor);
+			}
+		}
+
+		public void SetBackground(LinearGradientPaint linearGradientPaint)
+		{
+			if (_background == linearGradientPaint)
+				return;
+
+			_invalidatePath = true;
+
+			_backgroundColor = null;
+			_background = linearGradientPaint;
+
+			InitializeBorderIfNeeded();
+			InvalidateSelf();
+		}
+
+		public void SetBackground(RadialGradientPaint radialGradientPaint)
+		{
+			if (_background == radialGradientPaint)
+				return;
+
+			_invalidatePath = true;
+
+			_backgroundColor = null;
+			_background = radialGradientPaint;
+
+			InitializeBorderIfNeeded();
+			InvalidateSelf();
+		}
+
+		public void SetBackground(ImagePaint imagePaint)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void SetBackground(PatternPaint patternPaint)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void SetCornerRadius(CornerRadius cornerRadius)
+		{
+			if (_cornerRadius == cornerRadius)
+				return;
+
+			_invalidatePath = true;
+
+			_cornerRadius = cornerRadius;
+
+			InitializeBorderIfNeeded();
+			InvalidateSelf();
+		}
+
+		public void SetBorderColor(AColor? borderColor)
+		{
+			if (_borderColor == borderColor)
+				return;
+
+			_borderColor = borderColor;
+
+			InvalidateSelf();
+		}
+
+		public void SetBorderBrush(GPaint? paint)
+		{
+			if (paint is SolidPaint solidPaint)
+				SetBorderBrush(solidPaint);
+
+			if (paint is LinearGradientPaint linearGradientPaint)
+				SetBorderBrush(linearGradientPaint);
+
+			if (paint is RadialGradientPaint radialGradientPaint)
+				SetBorderBrush(radialGradientPaint);
+
+			if (paint is ImagePaint imagePaint)
+				SetBorderBrush(imagePaint);
+
+			if (paint is PatternPaint patternPaint)
+				SetBorderBrush(patternPaint);
+		}
+
+		public void SetBorderBrush(SolidPaint solidPaint)
+		{
+			_invalidatePath = true;
+			_borderColor = null;
+
+			var borderColor = solidPaint.Color == null
+				? (AColor?)null
+				: solidPaint.Color.ToNative();
+
+			_stroke = null;
+			SetBorderColor(borderColor);
+		}
+
+		public void SetBorderBrush(LinearGradientPaint linearGradientPaint)
+		{
+			if (_stroke == linearGradientPaint)
+				return;
+
+			_invalidatePath = true;
+
+			_borderColor = null;
+			_stroke = linearGradientPaint;
+
+			InitializeBorderIfNeeded();
+			InvalidateSelf();
+		}
+
+		public void SetBorderBrush(RadialGradientPaint radialGradientPaint)
+		{
+			if (_stroke == radialGradientPaint)
+				return;
+
+			_invalidatePath = true;
+
+			_borderColor = null;
+			_stroke = radialGradientPaint;
+
+			InitializeBorderIfNeeded();
+			InvalidateSelf();
+		}
+
+		public void SetBorderBrush(ImagePaint imagePaint)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void SetBorderBrush(PatternPaint patternPaint)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void SetBorderWidth(double strokeWidth)
+		{
+			float strokeThickness = (float)(strokeWidth * _density);
+
+			if (_strokeThickness == strokeThickness)
+				return;
+
+			_invalidatePath = true;
+
+			_strokeThickness = strokeThickness;
+
+			InitializeBorderIfNeeded();
+			InvalidateSelf();
+		}
+
+		protected override void OnBoundsChange(ARect? bounds)
+		{
+			if (_bounds != bounds)
+			{
+				_bounds = bounds;
+
+				if (_bounds != null)
+				{
+					var width = _bounds.Width();
+					var height = _bounds.Height();
+
+					if (_width == width && _height == height)
+						return;
+
+					_invalidatePath = true;
+
+					_width = width;
+					_height = height;
+				}
+			}
+
+			base.OnBoundsChange(bounds);
+		}
+
+		protected override void OnDraw(Shape? shape, Canvas? canvas, APaint? paint)
+		{
+			if (_disposed)
+				return;
+
+			if (HasBorder())
+			{
+				if (Paint != null)
+					SetBackground(Paint);
+
+				if (_borderPaint != null)
+				{
+					_borderPaint.StrokeWidth = _strokeThickness;
+
+					if (_borderColor != null)
+						_borderPaint.Color = _borderColor.Value;
+					else
+					{
+						if (_stroke != null)
+							SetPaint(_borderPaint, _stroke);
+					}
+				}
+
+				if (_invalidatePath)
+				{
+					_invalidatePath = false;
+
+					var path = GetPath(_width, _height, _cornerRadius, _strokeThickness);
+					var clipPath = path?.AsAndroidPath();
+
+					if (clipPath == null)
+						return;
+
+					if (_clipPath != null)
+					{
+						_clipPath.Reset();
+						_clipPath.Set(clipPath);
+					}
+				}
+
+				if (canvas == null)
+					return;
+
+				var saveCount = canvas.SaveLayer(0, 0, _width, _height, null);
+
+				if (_clipPath != null && Paint != null)
+					canvas.DrawPath(_clipPath, Paint);
+
+				if (_clipPath != null && _borderPaint != null)
+					canvas.DrawPath(_clipPath, _borderPaint);
+
+				canvas.RestoreToCount(saveCount);
+			}
+			else
+			{
+				if (paint != null)
+					SetBackground(paint);
+
+				base.OnDraw(shape, canvas, paint);
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				if (_clipPath != null)
+				{
+					_clipPath.Dispose();
+					_clipPath = null;
+				}
+			}
+
+			DisposeBorder(disposing);
+
+			base.Dispose(disposing);
+		}
+
+		protected virtual void DisposeBorder(bool disposing)
+		{
+			if (disposing)
+			{
+				if (_borderPaint != null)
+				{
+					_borderPaint.Dispose();
+					_borderPaint = null;
+				}
+			}
+		}
+
+		bool HasBorder()
+		{
+			InitializeBorderIfNeeded();
+
+			return _stroke != null || _borderColor != null;
+		}
+
+		void InitializeBorderIfNeeded()
+		{
+			if (_strokeThickness == 0)
+			{
+				DisposeBorder(true);
+				return;
+			}
+
+			if (_borderPaint == null)
+			{
+				_borderPaint = new APaint(PaintFlags.AntiAlias);
+				_borderPaint.SetStyle(APaint.Style.Stroke);
+			}
+		}
+
+		void SetDefaultBackgroundColor()
+		{
+			using (var background = new TypedValue())
+			{
+				if (_context == null || _context.Theme == null || _context.Resources == null)
+					return;
+
+				if (_context.Theme.ResolveAttribute(global::Android.Resource.Attribute.WindowBackground, background, true))
+				{
+					var resource = _context.Resources.GetResourceTypeName(background.ResourceId);
+					var type = resource?.ToLower();
+
+					if (type == "color")
+					{
+						var color = new AColor(ContextCompat.GetColor(_context, background.ResourceId));
+						_backgroundColor = color;
+					}
+				}
+			}
+		}
+
+		void SetBackground(APaint nativePaint)
+		{
+			if (nativePaint != null)
+			{
+				if (_backgroundColor != null)
+					nativePaint.Color = _backgroundColor.Value;
+				else
+				{
+					if (_background != null)
+						SetPaint(nativePaint, _background);
+				}
+			}
+		}
+
+		void SetPaint(APaint nativePaint, GPaint paint)
+		{
+			if (paint is LinearGradientPaint linearGradientPaint)
+				SetLinearGradientPaint(nativePaint, linearGradientPaint);
+
+			if (paint is RadialGradientPaint radialGradientPaint)
+				SetRadialGradientPaint(nativePaint, radialGradientPaint);
+		}
+
+		void SetLinearGradientPaint(APaint nativePaint, LinearGradientPaint linearGradientPaint)
+		{
+			var p1 = linearGradientPaint.StartPoint;
+			var x1 = (float)p1.X;
+			var y1 = (float)p1.Y;
+			var p2 = linearGradientPaint.EndPoint;
+			var x2 = (float)p2.X;
+			var y2 = (float)p2.Y;
+
+			var data = GetGradientPaintData(linearGradientPaint);
+			var shader = new LinearGradientData(data.Colors, data.Offsets, x1, y1, x2, y2);
+			if (_width == 0 && _height == 0)
+				return;
+
+			if (shader.Colors == null || shader.Colors.Length < 2)
+				return;
+
+			var linearGradientShader = new LinearGradient(
+				_width * shader.X1,
+				_height * shader.Y1,
+				_width * shader.X2,
+				_height * shader.Y2,
+				shader.Colors,
+				shader.Offsets,
+				Shader.TileMode.Clamp!);
+
+			nativePaint.SetShader(linearGradientShader);
+		}
+
+		public void SetRadialGradientPaint(APaint nativePaint, RadialGradientPaint radialGradientPaint)
+		{
+			var center = radialGradientPaint.Center;
+			float centerX = (float)center.X;
+			float centerY = (float)center.Y;
+			float radius = (float)radialGradientPaint.Radius;
+
+			var gradientData = GetGradientPaintData(radialGradientPaint);
+			var radialGradientData = new RadialGradientData(gradientData.Colors, gradientData.Offsets, centerX, centerY, radius);
+
+			if (_width == 0 && _height == 0)
+				return;
+
+			if (radialGradientData.Colors == null || radialGradientData.Colors.Length < 2)
+				return;
+
+			var radialGradient = new RadialGradient(
+				_width * radialGradientData.CenterX,
+				_height * radialGradientData.CenterY,
+				Math.Max(_height, _width) * radialGradientData.Radius,
+				radialGradientData.Colors,
+				radialGradientData.Offsets,
+				Shader.TileMode.Clamp!);
+
+			nativePaint.SetShader(radialGradient);
+		}
+
+		GradientData GetGradientPaintData(GradientPaint gradientPaint)
+		{
+			var orderStops = gradientPaint.GradientStops;
+
+			var data = new GradientData(orderStops.Length);
+
+			int count = 0;
+			foreach (var orderStop in orderStops)
+			{
+				data.Colors[count] = orderStop.Color.ToNative().ToArgb();
+				data.Offsets[count] = orderStop.Offset;
+				count++;
+			}
+
+			return data;
+		}
+
+		PathF GetPath(float width, float height, CornerRadius cornerRadius, float strokeThickness)
+		{
+			var path = new PathF();
+
+			float x = (float)strokeThickness / 2;
+			float y = (float)strokeThickness / 2;
+
+			float w = (float)(width - strokeThickness);
+			float h = (float)(height - strokeThickness);
+
+			float topLeftCornerRadius = (float)cornerRadius.TopLeft;
+			float topRightCornerRadius = (float)cornerRadius.TopRight;
+			float bottomLeftCornerRadius = (float)cornerRadius.BottomLeft;
+			float bottomRightCornerRadius = (float)cornerRadius.BottomRight;
+
+			path.AppendRoundedRectangle(x, y, w, h, topLeftCornerRadius, topRightCornerRadius, bottomLeftCornerRadius, bottomRightCornerRadius);
+
+			return path;
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/RadioButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/RadioButtonExtensions.cs
@@ -1,9 +1,15 @@
 ﻿using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui
 {
 	public static class RadioButtonExtensions
 	{
+		public static void UpdateBackground(this AppCompatRadioButton nativeRadioButton, IRadioButton radioButton)
+		{
+			nativeRadioButton.UpdateBorderDrawable(radioButton);
+		}
+
 		public static void UpdateIsChecked(this AppCompatRadioButton nativeRadioButton, IRadioButton radioButton)
 		{
 			nativeRadioButton.Checked = radioButton.IsChecked;
@@ -12,6 +18,45 @@ namespace Microsoft.Maui
 		public static void UpdateContent(this AppCompatRadioButton nativeRadioButton, IRadioButton radioButton)
 		{
 			nativeRadioButton.Text = $"{radioButton.Content}";
+		}
+
+		public static void UpdateStrokeColor(this AppCompatRadioButton nativeRadioButton, IRadioButton radioButton)
+		{
+			nativeRadioButton.UpdateBorderDrawable(radioButton);
+		}
+
+		public static void UpdateStrokeThickness(this AppCompatRadioButton nativeRadioButton, IRadioButton radioButton)
+		{
+			nativeRadioButton.UpdateBorderDrawable(radioButton);
+		}
+
+		public static void UpdateCornerRadius(this AppCompatRadioButton nativeRadioButton, IRadioButton radioButton)
+		{
+			nativeRadioButton.UpdateBorderDrawable(radioButton);
+		}
+
+		internal static void UpdateBorderDrawable(this AppCompatRadioButton nativeView, IRadioButton radioButton)
+		{
+			BorderDrawable? mauiDrawable = nativeView.Background as BorderDrawable;
+
+			if (mauiDrawable == null)
+			{
+				mauiDrawable = new BorderDrawable(nativeView.Context);
+
+				nativeView.Background = mauiDrawable;
+			}
+			
+			mauiDrawable.SetBackground(radioButton.Background);
+
+			if (radioButton.StrokeColor != null)
+				mauiDrawable.SetBorderBrush(new SolidPaint { Color = radioButton.StrokeColor });
+			
+			if (radioButton.StrokeThickness > 0)
+				mauiDrawable.SetBorderWidth(radioButton.StrokeThickness);
+
+			if (radioButton.CornerRadius > 0)
+				mauiDrawable.SetCornerRadius(radioButton.CornerRadius);
+
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/RadioButtonStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/RadioButtonStub.cs
@@ -18,6 +18,12 @@
 
 		public Thickness Padding { get; set; }
 
+		public Color StrokeColor { get; set; }
+
+		public double StrokeThickness { get; set; }
+
+		public int CornerRadius { get; set; }
+
 		public Size CrossPlatformArrange(Rectangle bounds)
 		{
 			return bounds.Size;


### PR DESCRIPTION
### Description of Change ###

Implement RadioButton Border properties:
- BorderColor
- BorderWidth
- CornerRadius

```
<StackLayout>
    <Label Text="What's your favorite animal?" />
    <RadioButton Content="Cat" BackgroundColor="Yellow" BorderColor="Red" BorderWidth="4" CornerRadius="12" />
    <RadioButton Content="Dog" BackgroundColor="Yellow" />
    <RadioButton Content="Elephant" />
    <RadioButton Content="Monkey" BorderColor="Green" BorderWidth="4" CornerRadius="12"
                IsChecked="true" />
</StackLayout>
```

![image](https://user-images.githubusercontent.com/6755973/153591180-795469b1-7840-47ec-bfbb-4436384cad06.png)

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No