### PR TITLE
[iOS] Replace UIDevice.CheckSystemVersion checks

### DIFF
--- a/src/Compatibility/Core/src/Handlers/ListView/iOS/CellRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/ListView/iOS/CellRenderer.cs
@@ -105,9 +105,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				if (cell.GetIsGroupHeader<ItemsView<Cell>, Cell>())
 				{
-					if (!UIDevice.CurrentDevice.CheckSystemVersion(7, 0))
-						return;
-
 					uiBgColor = Controls.Compatibility.Platform.iOS.ColorExtensions.GroupedBackground;
 				}
 				else

--- a/src/Compatibility/Core/src/Handlers/ListView/iOS/ContextActionCell.cs
+++ b/src/Compatibility/Core/src/Handlers/ListView/iOS/ContextActionCell.cs
@@ -242,19 +242,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				var b = _buttons[i];
 				totalWidth += b.Frame.Width;
-
-				if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-					_scroller.AddSubview(b);
-				else
-				{
-					if (container == null)
-					{
-						container = new iOS7ButtonContainer(b.Frame.Width);
-						_scroller.InsertSubview(container, 0);
-					}
-
-					container.AddSubview(b);
-				}
+				_scroller.AddSubview(b);
 			}
 
 			_scroller.Delegate = new ContextScrollViewDelegate(container, _buttons, isOpen);
@@ -331,71 +319,43 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var path = _tableView.IndexPathForCell(this);
 			var rowPosition = _tableView.RectForRowAtIndexPath(path);
 			var sourceRect = new RectangleF(x, rowPosition.Y, rowPosition.Width, rowPosition.Height);
+			var actionSheet = new MoreActionSheetController();
 
-			if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
+			for (var i = 0; i < _cell.ContextActions.Count; i++)
 			{
-				var actionSheet = new MoreActionSheetController();
+				if (displayed.Contains(i))
+					continue;
 
-				for (var i = 0; i < _cell.ContextActions.Count; i++)
+				var item = _cell.ContextActions[i];
+				var weakItem = new WeakReference<MenuItem>(item);
+				var action = UIAlertAction.Create(item.Text, UIAlertActionStyle.Default, a =>
 				{
-					if (displayed.Contains(i))
-						continue;
+					if (_scroller == null)
+						return;
 
-					var item = _cell.ContextActions[i];
-					var weakItem = new WeakReference<MenuItem>(item);
-					var action = UIAlertAction.Create(item.Text, UIAlertActionStyle.Default, a =>
-					{
-						if (_scroller == null)
-							return;
+					_scroller.SetContentOffset(new PointF(0, 0), true);
+					if (weakItem.TryGetTarget(out MenuItem mi))
+						((IMenuItemController)mi).Activate();
+				});
+				actionSheet.AddAction(action);
+			}
 
-						_scroller.SetContentOffset(new PointF(0, 0), true);
-						if (weakItem.TryGetTarget(out MenuItem mi))
-							((IMenuItemController)mi).Activate();
-					});
-					actionSheet.AddAction(action);
-				}
+			var controller = GetController();
+			if (controller == null)
+				throw new InvalidOperationException("No UIViewController found to present.");
 
-				var controller = GetController();
-				if (controller == null)
-					throw new InvalidOperationException("No UIViewController found to present.");
-
-				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
-				{
-					var cancel = UIAlertAction.Create(StringResources.Cancel, UIAlertActionStyle.Cancel, null);
-					actionSheet.AddAction(cancel);
-				}
-				else
-				{
-					actionSheet.PopoverPresentationController.SourceView = _tableView;
-					actionSheet.PopoverPresentationController.SourceRect = sourceRect;
-				}
-
-				controller.PresentViewController(actionSheet, true, null);
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
+			{
+				var cancel = UIAlertAction.Create(StringResources.Cancel, UIAlertActionStyle.Cancel, null);
+				actionSheet.AddAction(cancel);
 			}
 			else
 			{
-				var d = new MoreActionSheetDelegate { Scroller = _scroller, Items = new List<MenuItem>() };
-
-				var actionSheet = new UIActionSheet(null, (IUIActionSheetDelegate)d);
-
-				for (var i = 0; i < _cell.ContextActions.Count; i++)
-				{
-					if (displayed.Contains(i))
-						continue;
-
-					var item = _cell.ContextActions[i];
-					d.Items.Add(item);
-					actionSheet.AddButton(item.Text);
-				}
-
-				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
-				{
-					var index = actionSheet.AddButton(StringResources.Cancel);
-					actionSheet.CancelButtonIndex = index;
-				}
-
-				actionSheet.ShowFrom(sourceRect, _tableView, true);
+				actionSheet.PopoverPresentationController.SourceView = _tableView;
+				actionSheet.PopoverPresentationController.SourceRect = sourceRect;
 			}
+
+			controller.PresentViewController(actionSheet, true, null);
 		}
 
 		void CullButtons(nfloat acceptableTotalWidth, ref bool needMoreButton, ref nfloat largestButtonWidth)
@@ -632,11 +592,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				}
 
 				var offset = (n + 1) * largestWidth;
-
-				var x = width - offset;
-				if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-					x += totalWidth;
-
+				var x = width - offset + totalWidth;
 				b.Frame = new RectangleF(x, 0, largestWidth, height);
 				if (resize)
 					b.TitleLabel.AdjustsFontSizeToFitWidth = true;
@@ -710,24 +666,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)
 			{
 				DismissViewController(false, null);
-			}
-		}
-
-		class MoreActionSheetDelegate : UIActionSheetDelegate
-		{
-			public List<MenuItem> Items;
-			public UIScrollView Scroller;
-
-			public override void Clicked(UIActionSheet actionSheet, nint buttonIndex)
-			{
-				if (buttonIndex == Items.Count)
-					return; // Cancel button
-
-				Scroller.SetContentOffset(new PointF(0, 0), true);
-
-				// do not activate a -1 index when dismissing by clicking outside the popover
-				if (buttonIndex >= 0)
-					((IMenuItemController)Items[(int)buttonIndex]).Activate();
 			}
 		}
 	}

--- a/src/Compatibility/Core/src/Handlers/ListView/iOS/ContextScrollViewDelegate.cs
+++ b/src/Compatibility/Core/src/Handlers/ListView/iOS/ContextScrollViewDelegate.cs
@@ -101,22 +101,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			var width = _finalButtonSize;
 			var count = _buttons.Count;
+			var ioffset = scrollView.ContentOffset.X / (float)count;
 
-			if (!UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-				_container.Frame = new RectangleF(scrollView.Frame.Width, 0, scrollView.ContentOffset.X, scrollView.Frame.Height);
-			else
+			if (ioffset > width)
+				width = ioffset + 1;
+
+			for (var i = count - 1; i >= 0; i--)
 			{
-				var ioffset = scrollView.ContentOffset.X / (float)count;
-
-				if (ioffset > width)
-					width = ioffset + 1;
-
-				for (var i = count - 1; i >= 0; i--)
-				{
-					var b = _buttons[i];
-					var rect = b.Frame;
-					b.Frame = new RectangleF(scrollView.Frame.Width + (count - (i + 1)) * ioffset, 0, width, rect.Height);
-				}
+				var b = _buttons[i];
+				var rect = b.Frame;
+				b.Frame = new RectangleF(scrollView.Frame.Width + (count - (i + 1)) * ioffset, 0, width, rect.Height);
 			}
 
 			if (scrollView.ContentOffset.X == 0)
@@ -165,9 +159,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 							ContextActionsCell contentCell = GetContextCell(scrollView);
 							NSAction close = () =>
 							{
-								if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-									RestoreHighlight(scrollView);
-
+								RestoreHighlight(scrollView);
 								IsOpen = false;
 								scrollView.SetContentOffset(new PointF(0, 0), true);
 								ClearCloserRecognizer(contentCell);
@@ -191,9 +183,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 				IsOpen = false;
 				targetContentOffset = new PointF(0, 0);
-
-				if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-					RestoreHighlight(scrollView);
+				RestoreHighlight(scrollView);
 			}
 		}
 

--- a/src/Compatibility/Core/src/iOS/Cells/CellRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Cells/CellRenderer.cs
@@ -88,9 +88,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			{
 				if (cell.GetIsGroupHeader<ItemsView<Cell>, Cell>())
 				{
-					if (!UIDevice.CurrentDevice.CheckSystemVersion(7, 0))
-						return;
-
 					uiBgColor = ColorExtensions.GroupedBackground;
 				}
 				else

--- a/src/Compatibility/Core/src/iOS/ContextActionCell.cs
+++ b/src/Compatibility/Core/src/iOS/ContextActionCell.cs
@@ -243,19 +243,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			{
 				var b = _buttons[i];
 				totalWidth += b.Frame.Width;
-
-				if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-					_scroller.AddSubview(b);
-				else
-				{
-					if (container == null)
-					{
-						container = new iOS7ButtonContainer(b.Frame.Width);
-						_scroller.InsertSubview(container, 0);
-					}
-
-					container.AddSubview(b);
-				}
+				_scroller.AddSubview(b);
 			}
 
 			_scroller.Delegate = new ContextScrollViewDelegate(container, _buttons, isOpen);
@@ -332,71 +320,43 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			var path = _tableView.IndexPathForCell(this);
 			var rowPosition = _tableView.RectForRowAtIndexPath(path);
 			var sourceRect = new RectangleF(x, rowPosition.Y, rowPosition.Width, rowPosition.Height);
+			var actionSheet = new MoreActionSheetController();
 
-			if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
+			for (var i = 0; i < _cell.ContextActions.Count; i++)
 			{
-				var actionSheet = new MoreActionSheetController();
+				if (displayed.Contains(i))
+					continue;
 
-				for (var i = 0; i < _cell.ContextActions.Count; i++)
+				var item = _cell.ContextActions[i];
+				var weakItem = new WeakReference<MenuItem>(item);
+				var action = UIAlertAction.Create(item.Text, UIAlertActionStyle.Default, a =>
 				{
-					if (displayed.Contains(i))
-						continue;
+					if (_scroller == null)
+						return;
 
-					var item = _cell.ContextActions[i];
-					var weakItem = new WeakReference<MenuItem>(item);
-					var action = UIAlertAction.Create(item.Text, UIAlertActionStyle.Default, a =>
-					{
-						if (_scroller == null)
-							return;
+					_scroller.SetContentOffset(new PointF(0, 0), true);
+					if (weakItem.TryGetTarget(out MenuItem mi))
+						((IMenuItemController)mi).Activate();
+				});
+				actionSheet.AddAction(action);
+			}
 
-						_scroller.SetContentOffset(new PointF(0, 0), true);
-						if (weakItem.TryGetTarget(out MenuItem mi))
-							((IMenuItemController)mi).Activate();
-					});
-					actionSheet.AddAction(action);
-				}
+			var controller = GetController();
+			if (controller == null)
+				throw new InvalidOperationException("No UIViewController found to present.");
 
-				var controller = GetController();
-				if (controller == null)
-					throw new InvalidOperationException("No UIViewController found to present.");
-
-				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
-				{
-					var cancel = UIAlertAction.Create(StringResources.Cancel, UIAlertActionStyle.Cancel, null);
-					actionSheet.AddAction(cancel);
-				}
-				else
-				{
-					actionSheet.PopoverPresentationController.SourceView = _tableView;
-					actionSheet.PopoverPresentationController.SourceRect = sourceRect;
-				}
-
-				controller.PresentViewController(actionSheet, true, null);
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
+			{
+				var cancel = UIAlertAction.Create(StringResources.Cancel, UIAlertActionStyle.Cancel, null);
+				actionSheet.AddAction(cancel);
 			}
 			else
 			{
-				var d = new MoreActionSheetDelegate { Scroller = _scroller, Items = new List<MenuItem>() };
-
-				var actionSheet = new UIActionSheet(null, (IUIActionSheetDelegate)d);
-
-				for (var i = 0; i < _cell.ContextActions.Count; i++)
-				{
-					if (displayed.Contains(i))
-						continue;
-
-					var item = _cell.ContextActions[i];
-					d.Items.Add(item);
-					actionSheet.AddButton(item.Text);
-				}
-
-				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
-				{
-					var index = actionSheet.AddButton(StringResources.Cancel);
-					actionSheet.CancelButtonIndex = index;
-				}
-
-				actionSheet.ShowFrom(sourceRect, _tableView, true);
+				actionSheet.PopoverPresentationController.SourceView = _tableView;
+				actionSheet.PopoverPresentationController.SourceRect = sourceRect;
 			}
+
+			controller.PresentViewController(actionSheet, true, null);
 		}
 
 		void CullButtons(nfloat acceptableTotalWidth, ref bool needMoreButton, ref nfloat largestButtonWidth)
@@ -633,11 +593,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				}
 
 				var offset = (n + 1) * largestWidth;
-
-				var x = width - offset;
-				if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-					x += totalWidth;
-
+				var x = width - offset + totalWidth;
 				b.Frame = new RectangleF(x, 0, largestWidth, height);
 				if (resize)
 					b.TitleLabel.AdjustsFontSizeToFitWidth = true;
@@ -711,24 +667,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)
 			{
 				DismissViewController(false, null);
-			}
-		}
-
-		class MoreActionSheetDelegate : UIActionSheetDelegate
-		{
-			public List<MenuItem> Items;
-			public UIScrollView Scroller;
-
-			public override void Clicked(UIActionSheet actionSheet, nint buttonIndex)
-			{
-				if (buttonIndex == Items.Count)
-					return; // Cancel button
-
-				Scroller.SetContentOffset(new PointF(0, 0), true);
-
-				// do not activate a -1 index when dismissing by clicking outside the popover
-				if (buttonIndex >= 0)
-					((IMenuItemController)Items[(int)buttonIndex]).Activate();
 			}
 		}
 	}

--- a/src/Compatibility/Core/src/iOS/ContextScrollViewDelegate.cs
+++ b/src/Compatibility/Core/src/iOS/ContextScrollViewDelegate.cs
@@ -102,22 +102,16 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			var width = _finalButtonSize;
 			var count = _buttons.Count;
+			var ioffset = scrollView.ContentOffset.X / (float)count;
 
-			if (!UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-				_container.Frame = new RectangleF(scrollView.Frame.Width, 0, scrollView.ContentOffset.X, scrollView.Frame.Height);
-			else
+			if (ioffset > width)
+				width = ioffset + 1;
+
+			for (var i = count - 1; i >= 0; i--)
 			{
-				var ioffset = scrollView.ContentOffset.X / (float)count;
-
-				if (ioffset > width)
-					width = ioffset + 1;
-
-				for (var i = count - 1; i >= 0; i--)
-				{
-					var b = _buttons[i];
-					var rect = b.Frame;
-					b.Frame = new RectangleF(scrollView.Frame.Width + (count - (i + 1)) * ioffset, 0, width, rect.Height);
-				}
+				var b = _buttons[i];
+				var rect = b.Frame;
+				b.Frame = new RectangleF(scrollView.Frame.Width + (count - (i + 1)) * ioffset, 0, width, rect.Height);
 			}
 
 			if (scrollView.ContentOffset.X == 0)
@@ -166,9 +160,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 							ContextActionsCell contentCell = GetContextCell(scrollView);
 							NSAction close = () =>
 							{
-								if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-									RestoreHighlight(scrollView);
-
+								RestoreHighlight(scrollView);
 								IsOpen = false;
 								scrollView.SetContentOffset(new PointF(0, 0), true);
 								ClearCloserRecognizer(contentCell);
@@ -192,9 +184,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 				IsOpen = false;
 				targetContentOffset = new PointF(0, 0);
-
-				if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
-					RestoreHighlight(scrollView);
+				RestoreHighlight(scrollView);
 			}
 		}
 

--- a/src/Compatibility/Core/src/iOS/Extensions/FlowDirectionExtensions.cs
+++ b/src/Compatibility/Core/src/iOS/Extensions/FlowDirectionExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 	{
 		internal static bool UpdateFlowDirection(this UIView view, IVisualElementController controller)
 		{
-			if (controller == null || view == null || !Forms.IsiOS9OrNewer)
+			if (controller == null || view == null)
 				return false;
 
 			if (controller is IView v)

--- a/src/Compatibility/Core/src/iOS/Forms.cs
+++ b/src/Compatibility/Core/src/iOS/Forms.cs
@@ -43,8 +43,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 		public static bool IsInitialized { get; private set; }
 
 #if __MOBILE__
-		static bool? s_isiOS9OrNewer;
-		static bool? s_isiOS10OrNewer;
 		static bool? s_isiOS11OrNewer;
 		static bool? s_isiOS12OrNewer;
 		static bool? s_isiOS13OrNewer;
@@ -52,33 +50,12 @@ namespace Microsoft.Maui.Controls.Compatibility
 		static bool? s_isiOS15OrNewer;
 		static bool? s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden;
 
-		internal static bool IsiOS9OrNewer
-		{
-			get
-			{
-				if (!s_isiOS9OrNewer.HasValue)
-					s_isiOS9OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(9, 0);
-				return s_isiOS9OrNewer.Value;
-			}
-		}
-
-
-		internal static bool IsiOS10OrNewer
-		{
-			get
-			{
-				if (!s_isiOS10OrNewer.HasValue)
-					s_isiOS10OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(10, 0);
-				return s_isiOS10OrNewer.Value;
-			}
-		}
-
 		internal static bool IsiOS11OrNewer
 		{
 			get
 			{
 				if (!s_isiOS11OrNewer.HasValue)
-					s_isiOS11OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(11, 0);
+					s_isiOS11OrNewer = OperatingSystem.IsIOSVersionAtLeast(11, 0);
 				return s_isiOS11OrNewer.Value;
 			}
 		}
@@ -88,7 +65,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS12OrNewer.HasValue)
-					s_isiOS12OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(12, 0);
+					s_isiOS12OrNewer = OperatingSystem.IsIOSVersionAtLeast(12, 0);
 				return s_isiOS12OrNewer.Value;
 			}
 		}
@@ -98,7 +75,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS13OrNewer.HasValue)
-					s_isiOS13OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
+					s_isiOS13OrNewer = OperatingSystem.IsIOSVersionAtLeast(13, 0);
 				return s_isiOS13OrNewer.Value;
 			}
 		}
@@ -108,7 +85,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS14OrNewer.HasValue)
-					s_isiOS14OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(14, 0);
+					s_isiOS14OrNewer = OperatingSystem.IsIOSVersionAtLeast(14, 0);
 				return s_isiOS14OrNewer.Value;
 			}
 		}
@@ -118,7 +95,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS15OrNewer.HasValue)
-					s_isiOS15OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(15, 0);
+					s_isiOS15OrNewer = OperatingSystem.IsIOSVersionAtLeast(15, 0);
 				return s_isiOS15OrNewer.Value;
 			}
 		}

--- a/src/Compatibility/Core/src/iOS/Platform.cs
+++ b/src/Compatibility/Core/src/iOS/Platform.cs
@@ -521,12 +521,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
 			}
 
-			if (!Forms.IsiOS9OrNewer)
-			{
-				// For iOS 8, we need to explicitly set the size of the window
-				window.Frame = new CGRect(0, 0, UIScreen.MainScreen.Bounds.Width, UIScreen.MainScreen.Bounds.Height);
-			}
-
 			window.RootViewController.PresentViewController(alert, true, null);
 		}
 

--- a/src/Compatibility/Core/src/iOS/Renderers/ListViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/ListViewRenderer.cs
@@ -1551,8 +1551,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			? UITableViewStyle.Plain
 			  : UITableViewStyle.Grouped)
 		{
-			if (Forms.IsiOS9OrNewer)
-				TableView.CellLayoutMarginsFollowReadableWidth = false;
+			TableView.CellLayoutMarginsFollowReadableWidth = false;
 
 			_usingLargeTitles = usingLargeTitles;
 

--- a/src/Compatibility/Core/src/iOS/Renderers/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/PickerRenderer.cs
@@ -102,12 +102,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 					entry.InputView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
 					entry.InputAccessoryView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
-
-					if (Forms.IsiOS9OrNewer)
-					{
-						entry.InputAssistantItem.LeadingBarButtonGroups = null;
-						entry.InputAssistantItem.TrailingBarButtonGroups = null;
-					}
+					entry.InputAssistantItem.LeadingBarButtonGroups = null;
+					entry.InputAssistantItem.TrailingBarButtonGroups = null;
 
 					_defaultTextColor = entry.TextColor;
 

--- a/src/Compatibility/Core/src/iOS/Renderers/RefreshViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/RefreshViewRenderer.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		bool CanUseRefreshControlProperty()
 		{
-			return Forms.IsiOS10OrNewer && !_usingLargeTitles;
+			return !_usingLargeTitles;
 		}
 
 		void OnRefresh(object sender, EventArgs e)

--- a/src/Compatibility/Core/src/iOS/Renderers/SafeShellTabBarAppearanceTracker.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/SafeShellTabBarAppearanceTracker.cs
@@ -32,17 +32,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			var titleColor = appearanceElement.EffectiveTabBarTitleColor;
 
 			var tabBar = controller.TabBar;
-			bool operatingSystemSupportsUnselectedTint = Forms.IsiOS10OrNewer;
 
 			if (_defaultTint == null)
 			{
 				_defaultBarTint = tabBar.BarTintColor;
 				_defaultTint = tabBar.TintColor;
-
-				if (operatingSystemSupportsUnselectedTint)
-				{
-					_defaultUnselectedTint = tabBar.UnselectedItemTintColor;
-				}
+				_defaultUnselectedTint = tabBar.UnselectedItemTintColor;
 			}
 
 			if (Forms.IsiOS15OrNewer)
@@ -146,14 +141,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				tabBar.BarTintColor = backgroundColor.ToUIColor();
 			if (titleColor.IsDefault != null)
 				tabBar.TintColor = titleColor.ToUIColor();
-
-			bool operatingSystemSupportsUnselectedTint = Forms.IsiOS10OrNewer;
-
-			if (operatingSystemSupportsUnselectedTint)
-			{
-				if (unselectedColor.IsDefault != null)
-					tabBar.UnselectedItemTintColor = unselectedColor.ToUIColor();
-			}
+			if (unselectedColor.IsDefault != null)
+				tabBar.UnselectedItemTintColor = unselectedColor.ToUIColor();
 		}
 	}
 }

--- a/src/Compatibility/Core/src/iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/ShellFlyoutRenderer.cs
@@ -378,76 +378,46 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				_flyoutAnimation = null;
 			}
 
-			if (Forms.IsiOS10OrNewer)
+			if (IsOpen)
+				UpdateTapoffView();
+
+			if (animate && TapoffView != null)
 			{
-				if (IsOpen)
-					UpdateTapoffView();
+				var tapOffViewAnimation = CABasicAnimation.FromKeyPath(@"opacity");
+				tapOffViewAnimation.BeginTime = 0;
+				tapOffViewAnimation.Duration = AnimationDurationInSeconds;
+				tapOffViewAnimation.SetFrom(NSNumber.FromFloat(TapoffView.Layer.Opacity));
+				tapOffViewAnimation.SetTo(NSNumber.FromFloat(IsOpen ? 1 : 0));
+				tapOffViewAnimation.FillMode = CAFillMode.Forwards;
+				tapOffViewAnimation.RemovedOnCompletion = false;
 
-				if (animate && TapoffView != null)
-				{
-					var tapOffViewAnimation = CABasicAnimation.FromKeyPath(@"opacity");
-					tapOffViewAnimation.BeginTime = 0;
-					tapOffViewAnimation.Duration = AnimationDurationInSeconds;
-					tapOffViewAnimation.SetFrom(NSNumber.FromFloat(TapoffView.Layer.Opacity));
-					tapOffViewAnimation.SetTo(NSNumber.FromFloat(IsOpen ? 1 : 0));
-					tapOffViewAnimation.FillMode = CAFillMode.Forwards;
-					tapOffViewAnimation.RemovedOnCompletion = false;
-
-					_flyoutAnimation = new UIViewPropertyAnimator(AnimationDurationInSeconds, UIViewAnimationCurve.EaseOut, () =>
-					{
-						FlyoutTransition.LayoutViews(View.Bounds, IsOpen ? 1 : 0, Flyout.ViewController.View, Detail.View, _flyoutBehavior);
-
-						if (TapoffView != null)
-						{
-							TapoffView.Layer.AddAnimation(tapOffViewAnimation, "opacity");
-						}
-					});
-
-					_flyoutAnimation.AddCompletion((p) =>
-					{
-						if (p == UIViewAnimatingPosition.End)
-						{
-							if (TapoffView != null)
-							{
-								TapoffView.Layer.Opacity = IsOpen ? 1 : 0;
-								TapoffView.Layer.RemoveAllAnimations();
-							}
-
-							UpdateTapoffView();
-							_flyoutAnimation = null;
-						}
-					});
-
-					_flyoutAnimation.StartAnimation();
-					View.LayoutIfNeeded();
-				}
-				else if (_flyoutAnimation == null)
+				_flyoutAnimation = new UIViewPropertyAnimator(AnimationDurationInSeconds, UIViewAnimationCurve.EaseOut, () =>
 				{
 					FlyoutTransition.LayoutViews(View.Bounds, IsOpen ? 1 : 0, Flyout.ViewController.View, Detail.View, _flyoutBehavior);
-					UpdateTapoffView();
 
 					if (TapoffView != null)
 					{
-						TapoffView.Layer.Opacity = IsOpen ? 1 : 0;
+						TapoffView.Layer.AddAnimation(tapOffViewAnimation, "opacity");
 					}
-				}
-			}
-			else
-			{
+				});
 
-				if (animate)
-					UIView.BeginAnimations(FlyoutAnimationName);
-
-				FlyoutTransition.LayoutViews(View.Bounds, IsOpen ? 1 : 0, Flyout.ViewController.View, Detail.View, _flyoutBehavior);
-
-				if (animate)
+				_flyoutAnimation.AddCompletion((p) =>
 				{
-					UIView.SetAnimationCurve(AnimationCurve);
-					UIView.SetAnimationDuration(AnimationDurationInSeconds);
-					UIView.CommitAnimations();
-					View.LayoutIfNeeded();
-				}
-				UpdateTapoffView();
+					if (p == UIViewAnimatingPosition.End)
+					{
+						if (TapoffView != null)
+						{
+							TapoffView.Layer.Opacity = IsOpen ? 1 : 0;
+							TapoffView.Layer.RemoveAllAnimations();
+						}
+
+						UpdateTapoffView();
+						_flyoutAnimation = null;
+					}
+				});
+
+				_flyoutAnimation.StartAnimation();
+				View.LayoutIfNeeded();
 			}
 
 			void UpdateTapoffView()

--- a/src/Compatibility/Core/src/iOS/Renderers/ShellSectionRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/ShellSectionRenderer.cs
@@ -715,10 +715,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				if (coordinator != null && coordinator.IsInteractive)
 				{
 					// handle swipe to dismiss gesture 
-					if (Forms.IsiOS10OrNewer)
-						coordinator.NotifyWhenInteractionChanges(OnInteractionChanged);
-					else
-						coordinator.NotifyWhenInteractionEndsUsingBlock(OnInteractionChanged);
+					coordinator.NotifyWhenInteractionChanges(OnInteractionChanged);
 				}
 			}
 

--- a/src/Compatibility/Core/src/iOS/Renderers/TabbedRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/TabbedRenderer.cs
@@ -192,17 +192,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		{
 			// Setting TabBarItem.Title in iOS 10 causes rendering bugs
 			// Work around this by creating a new UITabBarItem on each change
-			if (e.PropertyName == Page.TitleProperty.PropertyName && !Forms.IsiOS10OrNewer)
-			{
-				var page = (Page)sender;
-				var renderer = Platform.GetRenderer(page);
-				if (renderer == null)
-					return;
-
-				if (renderer.ViewController.TabBarItem != null)
-					renderer.ViewController.TabBarItem.Title = page.Title;
-			}
-			else if (e.PropertyName == Page.IconImageSourceProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName && Forms.IsiOS10OrNewer)
+			if (e.PropertyName == Page.IconImageSourceProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName)
 			{
 				var page = (Page)sender;
 
@@ -494,22 +484,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 			if (Tabbed.IsSet(TabbedPage.SelectedTabColorProperty) && Tabbed.SelectedTabColor != null)
 			{
-				if (Forms.IsiOS10OrNewer)
-					TabBar.TintColor = Tabbed.SelectedTabColor.ToUIColor();
-				else
-					TabBar.SelectedImageTintColor = Tabbed.SelectedTabColor.ToUIColor();
-
+				TabBar.TintColor = Tabbed.SelectedTabColor.ToUIColor();
 			}
 			else
 			{
-				if (Forms.IsiOS10OrNewer)
-					TabBar.TintColor = UITabBar.Appearance.TintColor;
-				else
-					TabBar.SelectedImageTintColor = UITabBar.Appearance.SelectedImageTintColor;
+				TabBar.TintColor = UITabBar.Appearance.TintColor;
 			}
-
-			if (!Forms.IsiOS10OrNewer)
-				return;
 
 			if (Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) && Tabbed.UnselectedTabColor != null)
 				TabBar.UnselectedItemTintColor = Tabbed.UnselectedTabColor.ToUIColor();

--- a/src/Compatibility/Core/src/iOS/Renderers/TableViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/TableViewRenderer.cs
@@ -92,8 +92,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 					_originalBackgroundView = tv.BackgroundView;
 
 					SetNativeControl(tv);
-					if (Forms.IsiOS9OrNewer)
-						tv.CellLayoutMarginsFollowReadableWidth = false;
+					tv.CellLayoutMarginsFollowReadableWidth = false;
 
 					_insetTracker = new KeyboardInsetTracker(tv, () => Control.Window, insets => Control.ContentInset = Control.ScrollIndicatorInsets = insets, point =>
 					{

--- a/src/Compatibility/Core/src/iOS/Renderers/TabletFlyoutPageRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/TabletFlyoutPageRenderer.cs
@@ -124,7 +124,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		bool _disposed;
 		EventTracker _events;
-		InnerDelegate _innerDelegate;
 		nfloat _flyoutWidth = 0;
 		EventedViewController _flyoutController;
 		FlyoutPage _flyoutPage;
@@ -213,9 +212,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			Element = element;
 
 			ViewControllers = new[] { _flyoutController = new EventedViewController(), _detailController = new ChildViewController() };
-
-			if (!Forms.IsiOS9OrNewer)
-				Delegate = _innerDelegate = new InnerDelegate(FlyoutPage.FlyoutLayoutBehavior);
 
 			UpdateControllers();
 
@@ -380,27 +376,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		{
 			base.ViewWillLayoutSubviews();
 			_flyoutController.View.BackgroundColor = ColorExtensions.BackgroundColor;
-		}
-
-		public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)
-		{
-			// I tested this code on iOS9+ and it's never called
-			if (!Forms.IsiOS9OrNewer)
-			{
-				if (!FlyoutPageController.ShouldShowSplitMode && IsFlyoutVisible)
-				{
-					FlyoutPageController.CanChangeIsPresented = true;
-					PreferredDisplayMode = UISplitViewControllerDisplayMode.PrimaryHidden;
-					PreferredDisplayMode = UISplitViewControllerDisplayMode.Automatic;
-				}
-
-				FlyoutPage.UpdateFlyoutLayoutBehavior();
-#pragma warning disable CS0618 // Type or member is obsolete
-				MessagingCenter.Send<IVisualElementRenderer>(this, NavigationRenderer.UpdateToolbarButtons);
-#pragma warning restore CS0618 // Type or member is obsolete
-			}
-
-			base.WillRotate(toInterfaceOrientation, duration);
 		}
 
 		public override UIViewController ChildViewControllerForStatusBarHidden()

--- a/src/Compatibility/Maps/src/iOS/FormsMaps.cs
+++ b/src/Compatibility/Maps/src/iOS/FormsMaps.cs
@@ -1,6 +1,4 @@
 #if __MOBILE__
-using ObjCRuntime;
-using UIKit;
 using Microsoft.Maui.Controls.Compatibility.Maps.iOS;
 #else
 using Microsoft.Maui.Controls.Compatibility.Maps.MacOS;
@@ -11,41 +9,7 @@ namespace Microsoft.Maui.Controls
 	public static class FormsMaps
 	{
 		static bool s_isInitialized;
-#if __MOBILE__
-		static bool? s_isiOs8OrNewer;
-		static bool? s_isiOs9OrNewer;
-		static bool? s_isiOs10OrNewer;
 
-		internal static bool IsiOs8OrNewer
-		{
-			get
-			{
-				if (!s_isiOs8OrNewer.HasValue)
-					s_isiOs8OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(8, 0);
-				return s_isiOs8OrNewer.Value;
-			}
-		}
-
-		internal static bool IsiOs9OrNewer
-		{
-			get
-			{
-				if (!s_isiOs9OrNewer.HasValue)
-					s_isiOs9OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(9, 0);
-				return s_isiOs9OrNewer.Value;
-			}
-		}
-
-		internal static bool IsiOs10OrNewer
-		{
-			get
-			{
-				if (!s_isiOs10OrNewer.HasValue)
-					s_isiOs10OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(10, 0);
-				return s_isiOs10OrNewer.Value;
-			}
-		}
-#endif
 		public static void Init()
 		{
 			if (s_isInitialized)

--- a/src/Compatibility/Maps/src/iOS/MapRenderer.cs
+++ b/src/Compatibility/Maps/src/iOS/MapRenderer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.MacOS
 		// For the time being, we don't want ViewRenderer handling disposal of the MKMapView
 		// if we're on iOS 9 or 10; during Dispose we'll be putting the MKMapView in a pool instead
 #if __MOBILE__
-		protected override bool ManageNativeControlLifetime => !FormsMaps.IsiOs9OrNewer;
+		protected override bool ManageNativeControlLifetime => false;
 #endif
 		protected override void Dispose(bool disposing)
 		{
@@ -89,12 +89,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.MacOS
 				_mapClickedGestureRecognizer.Dispose();
 				_mapClickedGestureRecognizer = null;
 
-				if (FormsMaps.IsiOs9OrNewer)
-				{
-					// This renderer is done with the MKMapView; we can put it in the pool
-					// for other rendererers to use in the future
-					MapPool.Add(mkMapView);
-				}
+				// This renderer is done with the MKMapView; we can put it in the pool
+				// for other rendererers to use in the future
+				MapPool.Add(mkMapView);
 #endif
 				// For iOS versions < 9, the MKMapView will be disposed in ViewRenderer's Dispose method
 
@@ -141,11 +138,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.MacOS
 				{
 					MKMapView mapView = null;
 #if __MOBILE__
-					if (FormsMaps.IsiOs9OrNewer)
-					{
-						// See if we've got an MKMapView available in the pool; if so, use it
-						mapView = MapPool.Get();
-					}
+					// See if we've got an MKMapView available in the pool; if so, use it
+					mapView = MapPool.Get();
 #endif
 					if (mapView == null)
 					{
@@ -478,7 +472,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.MacOS
 		void UpdateIsShowingUser()
 		{
 #if __MOBILE__
-			if (FormsMaps.IsiOs8OrNewer && ((Map)Element).IsShowingUser)
+			if (((Map)Element).IsShowingUser)
 			{
 				_locationManager = new CLLocationManager();
 				_locationManager.RequestWhenInUseAuthorization();

--- a/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.iOS.cs
@@ -44,13 +44,8 @@ namespace Microsoft.Maui.Handlers
 
 			nativePicker.InputView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
 			nativePicker.InputAccessoryView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
-
-			if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
-			{
-				nativePicker.InputAssistantItem.LeadingBarButtonGroups = null;
-				nativePicker.InputAssistantItem.TrailingBarButtonGroups = null;
-			}
-
+			nativePicker.InputAssistantItem.LeadingBarButtonGroups = null;
+			nativePicker.InputAssistantItem.TrailingBarButtonGroups = null;
 			nativePicker.AccessibilityTraits = UIAccessibilityTrait.Button;
 
 			_pickerView.Model = new PickerSource(VirtualView);

--- a/src/Core/src/Platform/iOS/ElementExtensions.cs
+++ b/src/Core/src/Platform/iOS/ElementExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Platform
 		// If < iOS 13 or the Info.plist does not have a scene manifest entry we need to assume no multi window, and no UISceneDelegate.
 		// We cannot check for iPads/Mac because even on the iPhone it uses the scene delegate if one is specified in the manifest.
 		public static bool HasSceneManifest(this IUIApplicationDelegate nativeApplication) =>
-			UIDevice.CurrentDevice.CheckSystemVersion(13, 0) &&
+			OperatingSystem.IsIOSVersionAtLeast(13, 0) &&
 			NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString(UIApplicationSceneManifestKey));
 	}
 }

--- a/src/Core/src/Platform/iOS/NativeVersion.cs
+++ b/src/Core/src/Platform/iOS/NativeVersion.cs
@@ -1,3 +1,5 @@
+using System;
+
 using ObjCRuntime;
 using UIKit;
 
@@ -7,7 +9,7 @@ namespace Microsoft.Maui.Platform
 	{
 		public static bool IsAtLeast(int version)
 		{
-			return UIDevice.CurrentDevice.CheckSystemVersion(version, 0);
+			return OperatingSystem.IsIOSVersionAtLeast(version);
 		}
 
 		private static bool? SetNeedsUpdateOfHomeIndicatorAutoHidden;

--- a/src/Essentials/src/Platform/Platform.ios.tvos.watchos.cs
+++ b/src/Essentials/src/Platform/Platform.ios.tvos.watchos.cs
@@ -10,7 +10,6 @@ using UIKit;
 using CoreMotion;
 #elif __WATCHOS__
 using CoreMotion;
-using UIDevice = WatchKit.WKInterfaceDevice;
 #endif
 
 namespace Microsoft.Maui.Essentials
@@ -69,7 +68,7 @@ namespace Microsoft.Maui.Essentials
 		}
 
 		internal static bool HasOSVersion(int major, int minor) =>
-			UIDevice.CurrentDevice.CheckSystemVersion(major, minor);
+			OperatingSystem.IsIOSVersionAtLeast(major, minor);
 
 #if __IOS__ || __TVOS__
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -72,11 +72,11 @@ namespace Microsoft.Maui.Essentials
 				sf = null;
 			}
 
-			if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
+			if (OperatingSystem.IsIOSVersionAtLeast(12, 0))
 			{
 				was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
 
-				if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+				if (OperatingSystem.IsIOSVersionAtLeast(13, 0))
 				{
 					var ctx = new ContextProvider(Platform.GetCurrentWindow());
 					void_objc_msgSend_IntPtr(was.Handle, ObjCRuntime.Selector.GetHandle("setPresentationContextProvider:"), ctx.Handle);
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Essentials
 			if (prefersEphemeralWebBrowserSession)
 				ClearCookies();
 
-			if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+			if (OperatingSystem.IsIOSVersionAtLeast(11, 0))
 			{
 				sf = new SFAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
 				using (sf)
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Essentials
 			NSUrlCache.SharedCache.RemoveAllCachedResponses();
 
 #if __IOS__
-			if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+			if (OperatingSystem.IsIOSVersionAtLeast(11, 0))
 			{
 				WKWebsiteDataStore.DefaultDataStore.HttpCookieStore.GetAllCookies((cookies) =>
 				{
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Essentials
 		static bool VerifyHasUrlSchemeOrDoesntRequire(string scheme)
 		{
 			// iOS11+ uses sfAuthenticationSession which handles its own url routing
-			if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+			if (OperatingSystem.IsIOSVersionAtLeast(11, 0))
 				return true;
 
 			return AppInfoImplementation.VerifyHasUrlScheme(scheme);


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/461

Removes platform version checks for iOS 10 and lower, as only iOS 10 and
above should be supported.

The remaining `UIDevice.CurrentDevice.CheckSystemVersion` calls have
been replaced with `OperatingSystem.IsOSPlatformVersionAtLeast`.

