### PR TITLE
Fix cell parenting when using Retain Caching

### DIFF
--- a/src/Compatibility/Core/src/Handlers/ListView/Android/ListViewRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/ListView/Android/ListViewRenderer.cs
@@ -241,7 +241,15 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 							continue;
 						}
 
-						AView listItem = _adapter.GetView(i, null, Control);
+						// If the parent is already set then we'll just pass
+						// that in as the convert view so that GetView doesn't create
+						// an additional ConditionalFocusLayout
+						// We're basically faking re-use to the GetView call
+						AView currentParent = null;
+						if(cell.Handler?.NativeView is AView aView)
+							currentParent = aView.Parent as AView;
+							
+						AView listItem = _adapter.GetView(i, currentParent, Control);
 						int widthSpec;
 
 						if (double.IsInfinity(widthConstraint))


### PR DESCRIPTION
### Description of Change ###

When a ListView on Android is given infinite height we have to measure all of the cells in order to display the entire thing. If you don't do this then the ListView will only display the first cell. As part of this measurement it creates every single cell which was causing the cells to parent improperly on subsequent measure calls or during the final layout. This PR optimizes the cell creation so the same parent will just get reused. 

This issue was manifesting itself on the RadioButtonGalleries => RadioButton Group Gallery Page

