### PR TITLE
[WinUI] Fix Flyout Background Color and Locked Flyout Margins

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -71,7 +71,10 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapFlyoutBackground(ShellHandler handler, Shell view)
 		{
-			handler.NativeView.UpdatePaneBackground(view.FlyoutBackground ?? view.FlyoutBackgroundColor?.AsPaint());
+			handler.NativeView.UpdatePaneBackground(
+				!Brush.IsNullOrEmpty(view.FlyoutBackground) ?
+					view.FlyoutBackground :
+					view.FlyoutBackgroundColor?.AsPaint());
 		}
 
 		public static void MapFlyoutVerticalScrollMode(ShellHandler handler, Shell view)

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellFlyoutTemplatedContentView.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellFlyoutTemplatedContentView.cs
@@ -60,8 +60,8 @@ namespace Microsoft.Maui.Controls.Platform
 			Profile.FrameBegin();
 
 			var context = shellContext.AndroidContext;
-
-			var coordinator = (ViewGroup)LayoutInflater.FromContext(context).Inflate(Resource.Layout.flyoutcontent, null);
+			var layoutInflator = shellContext.Shell.FindMauiContext().GetLayoutInflater();
+			var coordinator = (ViewGroup)layoutInflator.Inflate(Resource.Layout.flyoutcontent, null);
 
 			Profile.FramePartition("Find AppBar");
 			_appBar = coordinator.FindViewById<AppBarLayout>(Resource.Id.flyoutcontent_appbar);

--- a/src/Controls/src/Core/Platform/Android/Shell/ShellView.cs
+++ b/src/Controls/src/Core/Platform/Android/Shell/ShellView.cs
@@ -122,7 +122,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 		protected Context AndroidContext { get; }
 		protected Shell Element { get; private set; }
-		FragmentManager FragmentManager => AndroidContext.GetFragmentManager();
+		FragmentManager FragmentManager => 
+			Element.FindMauiContext().GetFragmentManager();
 
 		protected virtual IShellObservableFragment CreateFragmentForPage(Page page)
 		{

--- a/src/Controls/src/Core/ToolbarTracker.cs
+++ b/src/Controls/src/Core/ToolbarTracker.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Maui.Controls
 			else if (page is IPageContainer<Page>)
 			{
 				var container = (IPageContainer<Page>)page;
-				if (container.CurrentPage != null)
+				if (container.CurrentPage != null && container.CurrentPage != container)
 					result.AddRange(GetCurrentToolbarItems(container.CurrentPage));
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Windows.cs
@@ -26,13 +26,11 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			SetupBuilder();
 			var flyoutPage = CreateBasicFlyoutPage();
-			await InvokeOnMainThreadAsync(async () =>
+
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, (handler) =>
 			{
-				await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, (handler) =>
-				{
-					Assert.NotNull(handler.NativeView.PaneFooter);
-					return Task.CompletedTask;
-				});
+				Assert.NotNull(handler.NativeView.PaneFooter);
+				return Task.CompletedTask;
 			});
 		}
 
@@ -43,16 +41,42 @@ namespace Microsoft.Maui.DeviceTests
 			SetupBuilder();
 			var flyoutPage = CreateBasicFlyoutPage();
 
-			await InvokeOnMainThreadAsync(async () =>
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(flyoutPage), (handler) =>
 			{
-				await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(flyoutPage), (handler) =>
-				{
-					var navView = GetMauiNavigationView(handler.MauiContext);
-					Assert.NotNull(navView.Header);
-					return Task.CompletedTask;
-				});
+				var navView = GetMauiNavigationView(handler.MauiContext);
+				Assert.NotNull(navView.Header);
+				return Task.CompletedTask;
 			});
 		}
+
+		[Fact(DisplayName = "Flyout Locked Offset")]
+		public async Task FlyoutLockedOffset()
+		{
+			SetupBuilder();
+			var flyout = CreateBasicFlyoutPage();
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyout, (handler) =>
+			{
+				flyout.FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
+				var distance = DistanceYFromTheBottomOfTheAppTitleBar(flyout.Flyout);
+				Assert.True(Math.Abs(distance) < 1);
+				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "Flyout Locked Offset from App Title Bar With Pushed Page")]
+		public async Task FlyoutLockedOffsetFromAppTitleBarWithPushedPage()
+		{
+			SetupBuilder();
+			var flyout = CreateBasicFlyoutPage();
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyout, async (handler) =>
+			{
+				flyout.FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
+				await flyout.Detail.Navigation.PushAsync(new ContentPage());
+				var distance = DistanceYFromTheBottomOfTheAppTitleBar(flyout.Flyout);
+				Assert.True(Math.Abs(distance) < 1);
+			});
+		}
+
 		NavigationView FindPlatformFlyoutView(WFrameworkElement aView) =>
 			aView.GetParentOfType<NavigationView>();
 

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -55,8 +55,10 @@ namespace Microsoft.Maui.DeviceTests
 				var detailView2 = details2.ToPlatform();
 
 				await detailView2.OnLoadedAsync();
-				dl = FindPlatformFlyoutView(detailView);
+				await detailView.OnUnloadedAsync();
+				dl = FindPlatformFlyoutView(detailView2);
 				Assert.Equal(flyoutView, dl);
+				Assert.Null(FindPlatformFlyoutView(detailView));
 			});
 		}
 #endif

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	public partial class ShellTests : HandlerTestBase
+	{
+		[Fact(DisplayName = "Flyout Locked Offset")]
+		public async Task FlyoutLockedOffset()
+		{
+			SetupBuilder();
+			var label = new StackLayout()
+			{ 
+				HeightRequest = 10
+			};
+
+			var shell = new Shell()
+			{
+				FlyoutHeader = label,
+				Items =
+				{
+					new ContentPage()
+				},
+				FlyoutBehavior = FlyoutBehavior.Locked
+			};
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			{
+				var rootManager = handler.MauiContext.GetNavigationRootManager();
+				var position = label.GetLocationRelativeTo(rootManager.AppTitleBar);
+				var distance = rootManager.AppTitleBar.Height - position.Value.Y;
+				Assert.True(Math.Abs(distance) < 1);
+				return Task.CompletedTask;
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	public partial class ShellTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+#if WINDOWS || ANDROID
+					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
+#endif
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Toolbar, ToolbarHandler>();
+#if WINDOWS
+					handlers.AddHandler<ShellItem, ShellItemHandler>();
+					handlers.AddHandler<ShellSection, ShellSectionHandler>();
+					handlers.AddHandler<ShellContent, ShellContentHandler>();
+					handlers.AddHandler<Layout, LayoutHandler>();
+					handlers.AddHandler<Image, ImageHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+#endif
+				});
+			});
+		}
+
+#if !IOS
+		[Fact(DisplayName = "Empty Shell")]
+		public async Task DetailsViewUpdates()
+		{
+			SetupBuilder();
+			var shell = new Shell()
+			{
+				Items =
+				{
+					new ContentPage()
+				}
+			};
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			{
+				Assert.NotNull(shell.Handler);
+				return Task.CompletedTask;
+			});
+		}
+#endif
+	}
+}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -68,6 +68,10 @@ namespace Microsoft.Maui.DeviceTests
 						.BeginTransaction()
 						.Remove(viewFragment)
 						.Commit();
+
+					await linearLayoutCompat.OnUnloadedAsync();
+					if (viewFragment.View != null)
+						await viewFragment.View.OnUnloadedAsync();
 				}
 			});
 		}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
+using WPoint = Windows.Foundation.Point;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -93,6 +94,14 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
+		protected double DistanceYFromTheBottomOfTheAppTitleBar(IElement element)
+		{
+			var handler = element.Handler;
+			var rootManager = handler.MauiContext.GetNavigationRootManager();
+			var position = element.GetLocationRelativeTo(rootManager.AppTitleBar);
+			var distance = rootManager.AppTitleBar.Height - position.Value.Y;
+			return distance;
+		}
 
 		MauiNavigationView GetMauiNavigationView(NavigationRootManager navigationRootManager)
 		{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.DeviceTests
 				.RemapForControls()
 				.ConfigureLifecycleEvents(lifecycle =>
 				{
-#if __IOS__
+#if IOS
 					lifecycle
 						.AddiOS(iOS => iOS
 							.OpenUrl((app, url, options) =>
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					handlers.AddHandler(typeof(Editor), typeof(EditorHandler));
 					handlers.AddHandler(typeof(VerticalStackLayout), typeof(LayoutHandler));
-#if WINDOWS
+#if WINDOWS || ANDROID
 					handlers.AddHandler(typeof(Controls.Window), typeof(WindowHandlerStub));
 #endif
 				});

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -9,6 +9,7 @@
 		public const string Gesture = "Gesture";
 		public const string Label = "Label";
 		public const string NavigationPage = "NavigationPage";
+		public const string Shell = "Shell";
 		public const string TabbedPage = "TabbedPage";
 		public const string VisualElement = "VisualElement";
 	}

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -277,6 +277,10 @@ namespace Microsoft.Maui.Platform
 
 		public virtual void Disconnect()
 		{
+			VirtualView = null;
+			NavigationView = null;
+			_navHost = null;
+			_fragmentNavigator = null;
 		}
 
 		public virtual void Connect(IView navigationView)
@@ -409,6 +413,9 @@ namespace Microsoft.Maui.Platform
 			#region FragmentLifecycleCallbacks
 			public override void OnFragmentResumed(AndroidX.Fragment.App.FragmentManager fm, AndroidX.Fragment.App.Fragment f)
 			{
+				if (_stackNavigationManager.VirtualView == null)
+					return;
+
 				if (f is NavigationViewFragment pf)
 					_stackNavigationManager.OnNavigationViewFragmentResumed(fm, pf);
 

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -439,9 +439,10 @@ namespace Microsoft.Maui.Platform
 				{
 					var q = Looper.MyLooper();
 					if (q != null)
+					{
 						new Handler(q).Post(action);
-
-					return;
+						return;
+					}
 				}
 
 				action();

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Android.Content;
 using Android.Graphics.Drawables;
+using Android.OS;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
@@ -419,9 +420,9 @@ namespace Microsoft.Maui.Platform
 			frameworkElement.ViewAttachedToWindow += routedEventHandler;
 		}
 
-		internal static void OnUnloaded(this View frameworkElement, Action action)
+		internal static void OnUnloaded(this View view, Action action)
 		{
-			if (!frameworkElement.IsAttachedToWindow)
+			if (!view.IsAttachedToWindow)
 			{
 				action();
 			}
@@ -430,12 +431,23 @@ namespace Microsoft.Maui.Platform
 			routedEventHandler = (_, __) =>
 			{
 				if (routedEventHandler != null)
-					frameworkElement.ViewDetachedFromWindow -= routedEventHandler;
+					view.ViewDetachedFromWindow -= routedEventHandler;
+
+				// This event seems to fire prior to the view actually being
+				// detached from the window
+				if (view.IsAttachedToWindow)
+				{
+					var q = Looper.MyLooper();
+					if (q != null)
+						new Handler(q).Post(action);
+
+					return;
+				}
 
 				action();
 			};
 
-			frameworkElement.ViewDetachedFromWindow += routedEventHandler;
+			view.ViewDetachedFromWindow += routedEventHandler;
 		}
 
 		internal static IViewParent? GetParent(this View? view)

--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -11,7 +11,7 @@ using WBinding = Microsoft.UI.Xaml.Data.Binding;
 using WBindingExpression = Microsoft.UI.Xaml.Data.BindingExpression;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using System.Threading.Tasks;
-using System.Threading;
+using WPoint = Windows.Foundation.Point;
 
 namespace Microsoft.Maui.Platform
 {
@@ -257,6 +257,41 @@ namespace Microsoft.Maui.Platform
 			{
 				frameworkElement.Resources[propertyKey] = value;
 			}
+		}
+
+		internal static WPoint? GetLocationOnScreen(this UIElement element)
+		{
+			var ttv = element.TransformToVisual(element.XamlRoot.Content);
+			WPoint screenCoords = ttv.TransformPoint(new WPoint(0, 0));
+			return new WPoint(screenCoords.X, screenCoords.Y);
+		}
+
+		internal static WPoint? GetLocationOnScreen(this IElement element)
+		{
+			if (element.Handler?.MauiContext == null)
+				return null;
+
+			var view = element.ToPlatform();
+			return
+				view.GetLocationRelativeTo(view.XamlRoot.Content);
+		}
+
+		internal static WPoint? GetLocationRelativeTo(this UIElement element, UIElement relativeTo)
+		{
+			var ttv = element.TransformToVisual(relativeTo);
+			WPoint screenCoords = ttv.TransformPoint(new WPoint(0, 0));
+			return new WPoint(screenCoords.X, screenCoords.Y);
+		}
+
+		internal static WPoint? GetLocationRelativeTo(this IElement element, UIElement relativeTo)
+		{
+			if (element.Handler?.MauiContext == null)
+				return null;
+
+			return
+				element
+					.ToPlatform()
+					.GetLocationRelativeTo(relativeTo);
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Maui.Platform
 		internal event EventHandler? OnApplyTemplateFinished;
 		internal SplitView? RootSplitView { get; private set; }
 		internal ScrollViewer? MenuItemsScrollViewer { get; private set; }
+		internal Grid? ContentPaneTopPadding { get; private set; }
+		internal Grid? PaneToggleButtonGrid { get; private set; }
+		internal Grid? ButtonHolderGrid { get; private set; }
 
 		public MauiNavigationView()
 		{
@@ -36,6 +39,9 @@ namespace Microsoft.Maui.Platform
 			RootSplitView = (SplitView)GetTemplateChild("RootSplitView");
 			TopNavArea = ((StackPanel)GetTemplateChild("TopNavArea"));
 			TopNavMenuItemsHost = ((ItemsRepeater)GetTemplateChild("TopNavMenuItemsHost"));
+			ContentPaneTopPadding = (Grid)GetTemplateChild("ContentPaneTopPadding");
+			PaneToggleButtonGrid = (Grid)GetTemplateChild("PaneToggleButtonGrid");
+			ButtonHolderGrid = (Grid)GetTemplateChild("ButtonHolderGrid");
 			OnApplyTemplateCore();
 			OnApplyTemplateFinished?.Invoke(this, EventArgs.Empty);
 		}

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Maui.Platform
 		}
 
 		internal bool UseCustomAppTitleBar { get; set; } = true;
+		internal FrameworkElement? AppTitleBar => _rootView.AppTitleBar;
 
 		void OnApplyTemplateFinished(object? sender, EventArgs e)
 		{

--- a/src/TestUtils/src/DeviceTests.Runners.SourceGen/RunnerGenerator.cs
+++ b/src/TestUtils/src/DeviceTests.Runners.SourceGen/RunnerGenerator.cs
@@ -149,7 +149,7 @@ namespace " + RootNamespace + @"
 {
 	[global::Android.App.Activity(
 		Name = """ + ApplicationId + "." + headlessActivityName + @""",
-		Theme = ""@style/Theme.MaterialComponents"",
+		Theme = ""@style/Maui.MainTheme.NoActionBar"",
 		ConfigurationChanges =
 			global::Android.Content.PM.ConfigChanges.ScreenSize |
 			global::Android.Content.PM.ConfigChanges.Orientation |


### PR DESCRIPTION
### Description of Change ###

- Check if FlyoutBackground Brush is Empty
- Add tests to ensure that you can create an empty shell without any crashes
  - The Android changes in this PR are related to this Unit Test
- Fix the top margin on the WinUI Flyout when the NavigationView is locked   

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
