### PR TITLE
Remove IToolbar from IStackNavigationView

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/NavigationPageRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/NavigationPageRenderer.cs
@@ -917,7 +917,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 
 		protected virtual void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
 		{
-			ToolbarExtensions.UpdateMenuItemIcon(Element.FindMauiContext(), menuItem, toolBarItem, null);
+			Element.FindMauiContext().UpdateMenuItemIcon(menuItem, toolBarItem, null);
 		}
 
 		void UpdateToolbar()

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -107,34 +107,31 @@ namespace Microsoft.Maui.Controls
 		}
 
 
-		IToolbar IStackNavigation.Toolbar
+		internal IToolbar FindMyToolbar()
 		{
-			get
+			if (this.Toolbar != null)
+				return Toolbar;
+
+			var rootPage = this.FindParentWith(x => (x is IWindow te || Navigation.ModalStack.Contains(x)), true);
+			if (this.FindParentWith(x => (x is IToolbarElement te && te.Toolbar != null), false) is IToolbarElement te)
 			{
-				if (this.Toolbar != null)
-					return Toolbar;
+				// This means I'm inside a Modal Page so we shouldn't return the Toolbar from the window
+				if (rootPage is not IWindow && te is IWindow)
+					return null;
 
-				var rootPage = this.FindParentWith(x => (x is IWindow te || Navigation.ModalStack.Contains(x)), true);
-				if (this.FindParentWith(x => (x is IToolbarElement te && te.Toolbar != null), false) is IToolbarElement te)
-				{
-					// This means I'm inside a Modal Page so we shouldn't return the Toolbar from the window
-					if (rootPage is not IWindow && te is IWindow)
-						return null;
-
-					return te.Toolbar;
-				}
-
-				return null;
+				return te.Toolbar;
 			}
+
+			return null;
 		}
 
 		void OnNavigatingFrom(object sender, EventArgs e)
 		{
 			// Update the Container level Toolbar with my Toolbar information
-			if (this is IStackNavigation te && te.Toolbar is NavigationPageToolbar ct)
+			if (FindMyToolbar() is NavigationPageToolbar ct)
 			{
 				// If the root page is being covered by a Modal Page then we don't worry about hiding the nav bar
-				bool coveredByModal = te.Toolbar.Parent is Window && Navigation.ModalStack.Count > 0;
+				bool coveredByModal = ct.Parent is Window && Navigation.ModalStack.Count > 0;
 				ct.ApplyNavigationPage(this, coveredByModal);
 			}
 		}
@@ -142,7 +139,7 @@ namespace Microsoft.Maui.Controls
 		void OnAppearing(object sender, EventArgs e)
 		{
 			// Update the Container level Toolbar with my Toolbar information
-			if (this is IStackNavigation te && te.Toolbar is NavigationPageToolbar ct)
+			if (FindMyToolbar() is NavigationPageToolbar ct)
 			{
 				ct.ApplyNavigationPage(this, HasAppeared);
 			}
@@ -271,7 +268,7 @@ namespace Microsoft.Maui.Controls
 		{
 			base.OnHandlerChangedCore();
 
-			if (Handler == null && (this as IStackNavigation).Toolbar is IToolbar tb)
+			if (Handler == null && FindMyToolbar() is IToolbar tb)
 			{
 				tb.Handler = null;
 				if (tb.Parent is Window w)

--- a/src/Controls/src/Core/HandlerImpl/ShellSection.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ShellSection.Impl.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class ShellSection : IStackNavigation
 	{
-		IToolbar IStackNavigation.Toolbar { get; }
-
 		// This code only runs for shell bits that are running through a proper
 		// ShellHandler
 		TaskCompletionSource<object>? _handlerBasedNavigationCompletionSource;

--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls
 		void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
 		{
 			_ = MauiContext ?? throw new ArgumentNullException(nameof(MauiContext));
-			ToolbarExtensions.UpdateMenuItemIcon(MauiContext, menuItem, toolBarItem, null);
+			MauiContext.UpdateMenuItemIcon(menuItem, toolBarItem, null);
 		}
 
 		void UpdateMenu()

--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Windows.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls
 
 		internal void UpdateMenu()
 		{
-			if (Handler.NativeView is not WindowHeader wh)
+			if (Handler.NativeView is not MauiToolbar wh)
 				return;
 
 			var commandBar = wh.CommandBar;
@@ -107,11 +107,6 @@ namespace Microsoft.Maui.Controls
 		public static void MapToolbarItems(ToolbarHandler arg1, Toolbar arg2)
 		{
 			arg2.UpdateMenu();
-		}
-
-		public static void MapTitle(ToolbarHandler arg1, Toolbar arg2)
-		{
-			arg1.NativeView.UpdateTitle(arg2);
 		}
 
 		public static void MapIconColor(ToolbarHandler arg1, Toolbar arg2)

--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Maui.Controls
 				   [nameof(Toolbar.TitleIcon)] = MapTitleIcon,
 				   [nameof(Toolbar.TitleView)] = MapTitleView,
 				   [nameof(Toolbar.IconColor)] = MapIconColor,
-				   [nameof(Toolbar.Title)] = MapTitle,
 				   [nameof(Toolbar.ToolbarItems)] = MapToolbarItems,
 				   [nameof(Toolbar.BackButtonTitle)] = MapBackButtonTitle,
 				   [nameof(Toolbar.BarBackgroundColor)] = MapBarBackgroundColor,

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -6,7 +6,6 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
 using Android.Graphics.Drawables;
-#nullable enable
 using Android.Text;
 using Android.Text.Style;
 using Android.Views;
@@ -134,11 +133,6 @@ namespace Microsoft.Maui.Controls.Platform
 			var navIconColor = toolbar.IconColor;
 			if (navIconColor != null && nativeToolbar.NavigationIcon != null)
 				nativeToolbar.NavigationIcon.SetColorFilter(navIconColor, FilterMode.SrcAtop);
-		}
-
-		public static void UpdateTitle(this AToolbar nativeToolbar, Toolbar toolbar)
-		{
-			nativeToolbar.Title = toolbar?.Title ?? string.Empty;
 		}
 
 		public static void UpdateBarTextColor(this AToolbar nativeToolbar, Toolbar toolbar)
@@ -317,7 +311,7 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		internal static void UpdateMenuItemIcon(IMauiContext mauiContext, IMenuItem menuItem, ToolbarItem toolBarItem, Color? tintColor)
+		internal static void UpdateMenuItemIcon(this IMauiContext mauiContext, IMenuItem menuItem, ToolbarItem toolBarItem, Color? tintColor)
 		{
 			toolBarItem.IconImageSource.LoadImage(mauiContext, result =>
 			{

--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal static class ToolbarExtensions
 	{
-		public static void UpdateIsVisible(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateIsVisible(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			nativeToolbar.Visibility = (toolbar.IsVisible) ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
 		}
 
-		public static void UpdateTitleIcon(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateTitleIcon(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			_ = toolbar?.Handler?.MauiContext ?? throw new ArgumentNullException(nameof(toolbar.Handler.MauiContext));
 			toolbar.TitleIcon.LoadImage(toolbar.Handler.MauiContext, (result) =>
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls.Platform
 			});
 		}
 
-		public static void UpdateBackButton(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateBackButton(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			nativeToolbar
 				.IsBackButtonVisible = (toolbar.BackButtonVisible) ? NavigationViewBackButtonVisible.Visible : NavigationViewBackButtonVisible.Collapsed;
@@ -39,12 +39,12 @@ namespace Microsoft.Maui.Controls.Platform
 			toolbar.Handler?.UpdateValue(nameof(Toolbar.BarBackground));
 		}
 
-		public static void UpdateBarBackgroundColor(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateBarBackgroundColor(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			UpdateBarBackground(nativeToolbar, toolbar);
 		}
 
-		public static void UpdateBarBackground(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateBarBackground(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			var barBackground = toolbar.BarBackground?.ToBrush() ?? 
 				toolbar.BarBackgroundColor?.ToNative();
@@ -52,30 +52,30 @@ namespace Microsoft.Maui.Controls.Platform
 			nativeToolbar.Background = barBackground;
 		}
 
-		public static void UpdateTitleView(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateTitleView(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			_ = toolbar.Handler?.MauiContext ?? throw new ArgumentNullException(nameof(toolbar.Handler.MauiContext));
 
 			nativeToolbar.TitleView = toolbar.TitleView?.ToPlatform(toolbar.Handler.MauiContext);
 		}
 
-		public static void UpdateIconColor(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateIconColor(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			// This property wasn't wired up in Controls
 		}
 
-		public static void UpdateTitle(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateTitle(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			nativeToolbar.Title = toolbar.Title;
 		}
 
-		public static void UpdateBarTextColor(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateBarTextColor(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			if (toolbar.BarTextColor != null)
 				nativeToolbar.TitleColor = toolbar.BarTextColor.ToNative();
 		}
 
-		public static void UpdateToolbarDynamicOverflowEnabled(this WindowHeader nativeToolbar, Toolbar toolbar)
+		public static void UpdateToolbarDynamicOverflowEnabled(this MauiToolbar nativeToolbar, Toolbar toolbar)
 		{
 			if (nativeToolbar.CommandBar == null)
 				return;

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Platform;
+using Xunit;
+using Google.Android.Material.AppBar;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.NavigationPage)]
+	public partial class NavigationPageTests : HandlerTestBase
+	{
+		MaterialToolbar GetPlatformToolbar(IElementHandler handler) =>
+			GetPlatformToolbar(handler.MauiContext);
+
+		MaterialToolbar GetPlatformToolbar(IMauiContext mauiContext)
+		{
+			var navManager = mauiContext.GetNavigationRootManager();
+			return navManager.ToolbarElement.Toolbar.Handler.NativeView as
+				MaterialToolbar;
+		}
+
+		public bool IsBackButtonVisible(IElementHandler handler) =>
+			IsBackButtonVisible(handler.MauiContext);
+
+		public bool IsBackButtonVisible(IMauiContext mauiContext)
+		{
+			return GetPlatformToolbar(mauiContext).NavigationIcon != null;
+		}
+
+		public bool IsNavigationBarVisible(IElementHandler handler) =>
+			IsNavigationBarVisible(handler.MauiContext);
+
+		public bool IsNavigationBarVisible(IMauiContext mauiContext)
+		{
+			return GetPlatformToolbar(mauiContext)
+					.LayoutParameters.Height > 0;
+		}
+
+		public bool ToolbarItemsMatch(
+			IElementHandler handler,
+			params ToolbarItem[] toolbarItems)
+		{
+			var toolbar = GetPlatformToolbar(handler);
+			var menu = toolbar.Menu;
+
+			Assert.Equal(toolbarItems.Length, menu.Size());
+
+			for (var i = 0; i < toolbarItems.Length; i++)
+			{
+				ToolbarItem toolbarItem = toolbarItems[i];
+				var primaryCommand = menu.GetItem(i);
+				Assert.Equal(toolbarItem.Text, $"{primaryCommand.TitleFormatted}");
+			}
+
+			return true;
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -60,5 +60,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			return true;
 		}
+
+		string GetToolbarTitle(IElementHandler handler) =>
+			GetPlatformToolbar(handler).Title;
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
@@ -21,94 +21,41 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.NavigationPage)]
 	public partial class NavigationPageTests : HandlerTestBase
 	{
-		void SetupBuilder()
+		public bool IsBackButtonVisible(IElementHandler handler) =>
+			IsBackButtonVisible(handler.MauiContext);
+
+		public bool IsBackButtonVisible(IMauiContext mauiContext)
 		{
-			EnsureHandlerCreated(builder =>
-			{
-				builder.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
-					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
-					handlers.AddHandler<Page, PageHandler>();
-				});
-			});
+			var navView = GetMauiNavigationView(mauiContext);
+			return navView.IsBackButtonVisible == UI.Xaml.Controls.NavigationViewBackButtonVisible.Visible;
 		}
 
-		[Fact(DisplayName = "Back Button Visibility Changes with push/pop")]
-		public async Task TabbedPageHandlerDisconnects()
-		{
-			SetupBuilder();
-			var navPage = new NavigationPage(new ContentPage());
+		public bool IsNavigationBarVisible(IElementHandler handler) =>
+			IsNavigationBarVisible(handler.MauiContext);
 
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
-			{
-				var navView = GetMauiNavigationView(handler.MauiContext);
-				Assert.Equal(UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed, navView.IsBackButtonVisible);
-				await navPage.PushAsync(new ContentPage());
-				Assert.Equal(UI.Xaml.Controls.NavigationViewBackButtonVisible.Visible, navView.IsBackButtonVisible);
-				await navPage.PopAsync();
-				Assert.Equal(UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed, navView.IsBackButtonVisible);
-			});
+		public bool IsNavigationBarVisible(IMauiContext mauiContext)
+		{
+			var navView = GetMauiNavigationView(mauiContext);
+			var header = navView.Header as WFrameworkElement;
+			return header.Visibility == UI.Xaml.Visibility.Visible;
 		}
 
-		[Fact(DisplayName = "Set Has Back Button")]
-		public async Task SetHasBackButton()
+		public bool ToolbarItemsMatch(
+			IElementHandler handler,
+			params ToolbarItem[] toolbarItems)
 		{
-			SetupBuilder();
-			var navPage = new NavigationPage(new ContentPage());
+			var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
+			WindowHeader windowHeader = (WindowHeader)navView.Header;
 
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			Assert.Equal(toolbarItems.Length, windowHeader.CommandBar.PrimaryCommands.Count);
+			for (var i = 0; i < toolbarItems.Length; i++)
 			{
-				var navView = GetMauiNavigationView(handler.MauiContext);
-				await navPage.PushAsync(new ContentPage());
-				NavigationPage.SetHasBackButton(navPage.CurrentPage, false);
-				Assert.Equal(UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed, navView.IsBackButtonVisible);
-				NavigationPage.SetHasBackButton(navPage.CurrentPage, true);
-				Assert.Equal(UI.Xaml.Controls.NavigationViewBackButtonVisible.Visible, navView.IsBackButtonVisible);
-			});
-		}
-
-		[Fact(DisplayName = "Set Has Navigation Bar")]
-		public async Task SettHasNavigationBar()
-		{
-			SetupBuilder();
-			var navPage = new NavigationPage(new ContentPage());
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
-			{
-				var navView = GetMauiNavigationView(handler.MauiContext);
-				var header = navView.Header as WFrameworkElement;
-				Assert.True(header.Visibility == UI.Xaml.Visibility.Visible);
-				NavigationPage.SetHasNavigationBar(navPage.CurrentPage, false);
-				Assert.True(header.Visibility == UI.Xaml.Visibility.Collapsed);
-				NavigationPage.SetHasNavigationBar(navPage.CurrentPage, true);
-				Assert.True(header.Visibility == UI.Xaml.Visibility.Visible);
-				return Task.CompletedTask;
-			});
-		}
-
-		[Fact(DisplayName = "Toolbar Items Map Correctly")]
-		public async Task ToolbarItemsMapCorrectly()
-		{
-			SetupBuilder();
-			var toolbarItem = new ToolbarItem() { Text = "Toolbar Item 1" };
-			var navPage = new NavigationPage(new ContentPage()
-			{
-				ToolbarItems =
-				{
-					toolbarItem
-				}
-			});
-
-			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
-			{
-				var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
-				WindowHeader windowHeader = (WindowHeader)navView.Header;
-				var primaryCommand = ((WAppBarButton)windowHeader.CommandBar.PrimaryCommands[0]);
-
+				ToolbarItem toolbarItem = toolbarItems[i];
+				var primaryCommand = ((WAppBarButton)windowHeader.CommandBar.PrimaryCommands[i]);
 				Assert.Equal(toolbarItem, primaryCommand.DataContext);
-				return Task.CompletedTask;
-			});
+			}
+
+			return true;
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.DeviceTests
 			params ToolbarItem[] toolbarItems)
 		{
 			var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
-			WindowHeader windowHeader = (WindowHeader)navView.Header;
+			MauiToolbar windowHeader = (MauiToolbar)navView.Header;
 
 			Assert.Equal(toolbarItems.Length, windowHeader.CommandBar.PrimaryCommands.Count);
 			for (var i = 0; i < toolbarItems.Length; i++)
@@ -57,5 +57,15 @@ namespace Microsoft.Maui.DeviceTests
 
 			return true;
 		}
+
+		MauiToolbar GetPlatformToolbar(IElementHandler handler)
+		{
+			var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
+			MauiToolbar windowHeader = (MauiToolbar)navView.Header;
+			return windowHeader;
+		}
+
+		string GetToolbarTitle(IElementHandler handler) =>
+			GetPlatformToolbar(handler).Title;
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -97,6 +97,22 @@ namespace Microsoft.Maui.DeviceTests
 				return Task.CompletedTask;
 			});
 		}
+
+		[Fact(DisplayName = "Toolbar Title")]
+		public async Task ToolbarTitle()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage()
+			{
+				Title = "Page Title"
+			});
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
+			{
+				string title = GetToolbarTitle(handler);
+				Assert.Equal("Page Title", title);
+			});
+		}
 	}
 }
 #endif

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -1,0 +1,102 @@
+﻿#if !IOS
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.NavigationPage)]
+	public partial class NavigationPageTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Window, WindowHandlerStub>();
+				});
+			});
+		}
+
+
+		[Fact(DisplayName = "Back Button Visibility Changes with push/pop")]
+		public async Task BackButtonVisibilityChangesWithPushPop()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				Assert.False(IsBackButtonVisible(handler.MauiContext));
+				await navPage.PushAsync(new ContentPage());
+				Assert.True(IsBackButtonVisible(handler.MauiContext));
+				await navPage.PopAsync();
+				Assert.False(IsBackButtonVisible(handler.MauiContext));
+			});
+		}
+
+		[Fact(DisplayName = "Set Has Back Button")]
+		public async Task SetHasBackButton()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				await navPage.PushAsync(new ContentPage());
+				NavigationPage.SetHasBackButton(navPage.CurrentPage, false);
+				Assert.False(IsBackButtonVisible(handler.MauiContext));
+				NavigationPage.SetHasBackButton(navPage.CurrentPage, true);
+				Assert.True(IsBackButtonVisible(handler.MauiContext));
+			});
+		}
+
+		[Fact(DisplayName = "Set Has Navigation Bar")]
+		public async Task SettHasNavigationBar()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
+			{
+				Assert.True(IsNavigationBarVisible(handler));
+				NavigationPage.SetHasNavigationBar(navPage.CurrentPage, false);
+				Assert.False(IsNavigationBarVisible(handler));
+				NavigationPage.SetHasNavigationBar(navPage.CurrentPage, true);
+				Assert.True(IsNavigationBarVisible(handler));
+				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "Toolbar Items Map Correctly")]
+		public async Task ToolbarItemsMapCorrectly()
+		{
+			SetupBuilder();
+			var toolbarItem = new ToolbarItem() { Text = "Toolbar Item 1" };
+			var navPage = new NavigationPage(new ContentPage()
+			{
+				ToolbarItems =
+				{
+					toolbarItem
+				}
+			});
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), (handler) =>
+			{
+				ToolbarItemsMatch(handler, toolbarItem);
+				return Task.CompletedTask;
+			});
+		}
+	}
+}
+#endif

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Maui.DeviceTests
 				finally
 				{
 					if (window.Handler != null)
+					{
 						window.Handler.DisconnectHandler();
+					}
 
 					rootView.RemoveView(linearLayoutCompat);
 
@@ -68,6 +70,10 @@ namespace Microsoft.Maui.DeviceTests
 						.BeginTransaction()
 						.Remove(viewFragment)
 						.Commit();
+
+					await linearLayoutCompat.OnUnloadedAsync();
+					if (viewFragment.View != null)
+						await viewFragment.View.OnUnloadedAsync();
 				}
 			});
 		}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -121,6 +121,15 @@ namespace Microsoft.Maui.DeviceTests
 				return func(handler);
 			});
 		}
+		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Action<THandler> action)
+			where THandler : class, IElementHandler
+		{
+			return CreateHandlerAndAddToWindow<THandler>(view, handler =>
+			{
+				action(handler);
+				return Task.CompletedTask;
+			});
+		}
 
 		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action)
 			where THandler : class, IElementHandler

--- a/src/Core/src/Core/IStackNavigation.cs
+++ b/src/Core/src/Core/IStackNavigation.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Maui
 	/// </summary>
 	public interface IStackNavigation
 	{
-		IToolbar Toolbar { get; }
 		void RequestNavigation(NavigationRequest eventArgs);
 		void NavigationFinished(IReadOnlyList<IView> newStack);
 	}

--- a/src/Core/src/Core/IToolbar.cs
+++ b/src/Core/src/Core/IToolbar.cs
@@ -14,5 +14,10 @@
 		///  Gets or sets a value that indicates whether the toolbar is visible or not.
 		/// </summary>
 		bool IsVisible { get; set; }
+
+		/// <summary>
+		/// Gets the title for the Toolbar.
+		/// </summary>
+		string Title { get; }
 	}
 }

--- a/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
@@ -1,0 +1,18 @@
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UINavigationBar;
+#elif MONOANDROID
+using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Platform.WindowHeader;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial interface IToolbarHandler : IElementHandler
+	{
+		new IToolbar VirtualView { get; }
+		new PlatformView NativeView { get; }
+	}
+}

--- a/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
@@ -3,7 +3,7 @@ using PlatformView = UIKit.UINavigationBar;
 #elif MONOANDROID
 using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.WindowHeader;
+using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Android.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Android.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Maui.Handlers
 			return view;
 		}
 
+		public static void MapTitle(IToolbarHandler arg1, IToolbar arg2)
+		{
+			arg1.NativeView.UpdateTitle(arg2);
+		}
+
 		DrawerLayout? _drawerLayout;
 		NavController? _navController;
 		StackNavigationManager? _stackNavigationManager;

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Standard.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Standard.cs
@@ -5,5 +5,9 @@ namespace Microsoft.Maui.Handlers
 	public partial class ToolbarHandler : ElementHandler<IToolbar, object>
 	{
 		protected override object CreateNativeElement() => throw new NotImplementedException();
+
+		public static void MapTitle(IToolbarHandler arg1, IToolbar arg2)
+		{
+		}
 	}
 }

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Windows.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Windows.cs
@@ -2,11 +2,16 @@
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ToolbarHandler : ElementHandler<IToolbar, WindowHeader>
+	public partial class ToolbarHandler : ElementHandler<IToolbar, MauiToolbar>
 	{
-		protected override WindowHeader CreateNativeElement()
+		protected override MauiToolbar CreateNativeElement()
 		{
-			return new WindowHeader();
+			return new MauiToolbar();
+		}
+
+		public static void MapTitle(IToolbarHandler arg1, IToolbar arg2)
+		{
+			arg1.NativeView.UpdateTitle(arg2);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
@@ -1,22 +1,27 @@
-﻿#nullable enable
-
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Handlers;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UINavigationBar;
+#elif MONOANDROID
+using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Platform.WindowHeader;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ToolbarHandler
+	public partial class ToolbarHandler : IToolbarHandler
 	{
-		public static IPropertyMapper<IToolbar, ToolbarHandler> Mapper =
-			   new PropertyMapper<IToolbar, ToolbarHandler>(ElementMapper);
+		public static IPropertyMapper<IToolbar, IToolbarHandler> Mapper =
+			   new PropertyMapper<IToolbar, IToolbarHandler>(ElementMapper);
 
-		public static CommandMapper<IToolbar, ToolbarHandler> CommandMapper = new();
+		public static CommandMapper<IToolbar, IToolbarHandler> CommandMapper = new();
 
 		public ToolbarHandler() : base(Mapper, CommandMapper)
 		{
 		}
+
+		IToolbar IToolbarHandler.VirtualView => VirtualView;
+		PlatformView IToolbarHandler.NativeView => NativeView;
 	}
 }

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
@@ -3,7 +3,7 @@ using PlatformView = UIKit.UINavigationBar;
 #elif MONOANDROID
 using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.WindowHeader;
+using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
@@ -13,7 +13,10 @@ namespace Microsoft.Maui.Handlers
 	public partial class ToolbarHandler : IToolbarHandler
 	{
 		public static IPropertyMapper<IToolbar, IToolbarHandler> Mapper =
-			   new PropertyMapper<IToolbar, IToolbarHandler>(ElementMapper);
+			   new PropertyMapper<IToolbar, IToolbarHandler>(ElementMapper)
+			   {
+				   [nameof(IToolbar.Title)] = MapTitle,
+			   };
 
 		public static CommandMapper<IToolbar, IToolbarHandler> CommandMapper = new();
 

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.iOS.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.iOS.cs
@@ -9,5 +9,8 @@ namespace Microsoft.Maui.Handlers
 			throw new System.NotImplementedException();
 		}
 
+		public static void MapTitle(IToolbarHandler arg1, IToolbar arg2)
+		{
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Maui.Platform
 
 		internal DrawerLayout? DrawerLayout { get; private set; }
 
+		internal IToolbarElement? ToolbarElement => _toolbarElement;
+
 		public NavigationRootManager(IMauiContext mauiContext)
 		{
 			_mauiContext = mauiContext;

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -45,6 +45,9 @@ namespace Microsoft.Maui.Platform
 
 		public IMauiContext MauiContext { get; }
 
+		internal IToolbarElement? ToolbarElement =>
+			MauiContext.GetNavigationRootManager().ToolbarElement;
+
 		public StackNavigationManager(IMauiContext mauiContext)
 		{
 			var currentInflater = mauiContext.GetLayoutInflater();
@@ -208,9 +211,9 @@ namespace Microsoft.Maui.Platform
 
 			// The NavigationIcon on the toolbar gets set inside the Navigate call so this is the earliest
 			// point in time that we can setup toolbar colors for the incoming page
-			if (NavigationView is IStackNavigation te && te.Toolbar?.Handler != null)
+			if (NavigationView != null)
 			{
-				te.Toolbar.Handler.UpdateValue(nameof(IToolbar.BackButtonVisible));
+				ToolbarElement?.Toolbar?.Handler?.UpdateValue(nameof(IToolbar.BackButtonVisible));
 			}
 		}
 
@@ -277,6 +280,10 @@ namespace Microsoft.Maui.Platform
 
 		public virtual void Disconnect()
 		{
+			VirtualView = null;
+			NavigationView = null;
+			_navHost = null;
+			_fragmentNavigator = null;
 		}
 
 		public virtual void Connect(IView navigationView)
@@ -409,13 +416,16 @@ namespace Microsoft.Maui.Platform
 			#region FragmentLifecycleCallbacks
 			public override void OnFragmentResumed(AndroidX.Fragment.App.FragmentManager fm, AndroidX.Fragment.App.Fragment f)
 			{
+				if (_stackNavigationManager.VirtualView == null)
+					return;
+
 				if (f is NavigationViewFragment pf)
 					_stackNavigationManager.OnNavigationViewFragmentResumed(fm, pf);
 
 				AToolbar? nativeToolbar = null;
 				IToolbar? toolbar = null;
 
-				if (_stackNavigationManager.NavigationView?.Toolbar is IToolbar tb &&
+				if (_stackNavigationManager.ToolbarElement?.Toolbar is IToolbar tb &&
 					tb?.Handler?.NativeView is AToolbar ntb)
 				{
 					nativeToolbar = ntb;

--- a/src/Core/src/Platform/Android/ToolbarExtensions.cs
+++ b/src/Core/src/Platform/Android/ToolbarExtensions.cs
@@ -1,0 +1,12 @@
+﻿using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
+
+namespace Microsoft.Maui.Platform
+{
+	internal static class ToolbarExtensions
+	{
+		public static void UpdateTitle(this AToolbar nativeToolbar, IToolbar toolbar)
+		{
+			nativeToolbar.Title = toolbar?.Title ?? string.Empty;
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml
@@ -1,5 +1,5 @@
 <CommandBar
-    x:Class="Microsoft.Maui.Platform.WindowHeader"
+    x:Class="Microsoft.Maui.Platform.MauiToolbar"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -1,28 +1,19 @@
-#nullable enable
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
-using WVisibility = Microsoft.UI.Xaml.Visibility;
 using WGrid = Microsoft.UI.Xaml.Controls.Grid;
-using Microsoft.UI.Xaml.Media;
 using WImage = Microsoft.UI.Xaml.Controls.Image;
 
 namespace Microsoft.Maui.Platform
 {
-	public partial class WindowHeader
+	public partial class MauiToolbar
 	{
 		public static readonly DependencyProperty IsBackButtonVisibleProperty
-			= DependencyProperty.Register(nameof(IsBackButtonVisible), typeof(NavigationViewBackButtonVisible), typeof(WindowHeader), 
+			= DependencyProperty.Register(nameof(IsBackButtonVisible), typeof(NavigationViewBackButtonVisible), typeof(MauiToolbar), 
 				new PropertyMetadata(NavigationViewBackButtonVisible.Collapsed, OnIsBackButtonVisiblePropertyChanged));
 
-		public WindowHeader()
+		public MauiToolbar()
 		{
 			InitializeComponent();
 		}

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Platform
 	{
 		IMauiContext _mauiContext;
 		WindowRootView _rootView;
-		WindowHeader? _windowHeader;
+		MauiToolbar? _windowHeader;
 
 		public NavigationRootManager(IMauiContext mauiContext)
 		{
@@ -115,7 +115,7 @@ namespace Microsoft.Maui.Platform
 
 		internal void SetToolbar(FrameworkElement toolBar)
 		{
-			_windowHeader = toolBar as WindowHeader;
+			_windowHeader = toolBar as MauiToolbar;
 			if (_rootView.NavigationViewControl != null)
 			{
 				_rootView.NavigationViewControl.HeaderControl = _windowHeader;

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Maui.Platform
 	public class RootNavigationView : MauiNavigationView
 	{
 		double _paneHeaderContentHeight;
-		WindowHeader? _headerControl;
+		MauiToolbar? _headerControl;
 
 		internal Size FlyoutPaneSize { get; private set; }
-		internal WindowHeader? HeaderControl
+		internal MauiToolbar? HeaderControl
 		{
 			get => _headerControl;
 			set

--- a/src/Core/src/Platform/Windows/ToolbarExtensions.cs
+++ b/src/Core/src/Platform/Windows/ToolbarExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Maui.Platform
+{
+	internal static class ToolbarExtensions
+	{
+		public static void UpdateTitle(this MauiToolbar nativeToolbar, IToolbar toolbar)
+		{
+			nativeToolbar.Title = toolbar.Title;
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

`IStackNavigation.Toolbar` was initially just a mechanism for conveying the `Toolbar` that the `StackNavigationHandler` had influence over. The platform can now just depend on the `NavigationRootManager` for retrieving this information so this API isn't really needed anymore. 

- Adds the set of tests already added for `Windows` to `Android`
- Rename `WindowHeader` to `MauiToolbar` on windows
- Move `Title` over to core so it works for core

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
