### PR TITLE
product name / terminology corrections

### DIFF
--- a/src/Compatibility/ControlGallery/src/Xamarin.Forms.ControlGallery.MacOS/RegistrarValidationService.cs
+++ b/src/Compatibility/ControlGallery/src/Xamarin.Forms.ControlGallery.MacOS/RegistrarValidationService.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.ControlGallery.MacOS
 				|| renderer.GetType().Name == "DefaultRenderer"
 				)
 			{
-				message = $"Failed to load proper MacOS renderer for {element.GetType().Name}";
+				message = $"Failed to load proper macOS renderer for {element.GetType().Name}";
 				return false;
 			}
 

--- a/src/Compatibility/Core/src/GTK/Renderers/OpenGLViewRenderer.cs
+++ b/src/Compatibility/Core/src/GTK/Renderers/OpenGLViewRenderer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.GTK.Renderers
 			if (e.NewElement != null)
 			{
 				// The Open Toolkit library is a low-level C# binding for OpenGL, OpenGL ES and OpenAL. 
-				// Runs on Linux, MacOS and Windows with GTK# (and more platforms).
+				// Runs on Linux, macOS and Windows with GTK# (and more platforms).
 				_openGlView = new Controls.OpenGLView();
 				SetNativeControl(_openGlView);
 

--- a/src/Compatibility/Core/src/GTK/Renderers/WebViewRenderer.cs
+++ b/src/Compatibility/Core/src/GTK/Renderers/WebViewRenderer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.GTK.Renderers
 				{
 					try
 					{
-						// On Linux and MacOS use C#/CLI bindings to WebKit/Gtk+: https://github.com/mono/webkit-sharp
+						// On Linux and macOS use C#/CLI bindings to WebKit/Gtk+: https://github.com/mono/webkit-sharp
 						// On Windows, use the WebBrowser class from System.Windows.Forms.
 						Control = new Controls.WebView();
 					}

--- a/src/Compatibility/Core/src/MacOS/Controls/FormsNSSlider.cs
+++ b/src/Compatibility/Core/src/MacOS/Controls/FormsNSSlider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.macOS.Controls
 			Continuous = true;
 			SizeToFit();
 			var size = Bounds.Size;
-			// This size will be set as default for horizontal NSSlider, if you try to create it via XCode (drag and drope)
+			// This size will be set as default for horizontal NSSlider, if you try to create it via Xcode (drag and drope)
 			// See this screenshot: https://user-images.githubusercontent.com/10124814/52661252-aecb8100-2f12-11e9-8f45-c0dab8bc8ffc.png
 			_fitSize = size.Width > 0 && size.Height > 0 ? size : new CGSize(96, 21);
 		}

--- a/src/Compatibility/Core/src/MacOS/Controls/MacOSOpenGLView.cs
+++ b/src/Compatibility/Core/src/MacOS/Controls/MacOSOpenGLView.cs
@@ -2,7 +2,7 @@ using AppKit;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 {
-	//TODO: Still not implemented on MacOS
+	//TODO: Still not implemented on macOS
 	public class MacOSOpenGLView : NSView
 	{
 		public MacOSOpenGLView()

--- a/src/Compatibility/Core/src/MacOS/PlatformNavigation.cs
+++ b/src/Compatibility/Core/src/MacOS/PlatformNavigation.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 		Task<Page> INavigation.PopAsync(bool animated)
 		{
-			throw new InvalidOperationException("PopAsync is not supported globally on MacOS, please use a NavigationPage.");
+			throw new InvalidOperationException("PopAsync is not supported globally on macOS, please use a NavigationPage.");
 		}
 
 		Task INavigation.PopToRootAsync()
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 		Task INavigation.PopToRootAsync(bool animated)
 		{
-			throw new InvalidOperationException("PopToRootAsync is not supported globally on MacOS, please use a NavigationPage.");
+			throw new InvalidOperationException("PopToRootAsync is not supported globally on macOS, please use a NavigationPage.");
 		}
 
 		Task INavigation.PushAsync(Page root)
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 		Task INavigation.PushAsync(Page root, bool animated)
 		{
-			throw new InvalidOperationException("PushAsync is not supported globally on MacOS, please use a NavigationPage.");
+			throw new InvalidOperationException("PushAsync is not supported globally on macOS, please use a NavigationPage.");
 		}
 
 		Task INavigation.PushModalAsync(Page modal)

--- a/src/Compatibility/Core/src/MacOS/Renderers/LayoutRenderer.cs
+++ b/src/Compatibility/Core/src/MacOS/Renderers/LayoutRenderer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			_bounds = Bounds;
 
 			//when the layout changes we might need to update  the children position based in our new size,
-			//this is only needed in MacOS because of the inversion of the Y coordinate. 
+			//this is only needed in macOS because of the inversion of the Y coordinate. 
 			//Forms layout system doesn't know we need to relayout the other items ,(first ones for example)
 			//so we do it here 
 			for (int i = 0; i < Subviews.Length; i++)

--- a/src/Compatibility/Core/src/WPF/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/src/Compatibility/Core/src/WPF/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Windows.Shell
 			[SecurityCritical]
 			get
 			{
-				// We're only detecting this state to work around .Net 3.5 issues.
+				// We're only detecting this state to work around .NET 3.5 issues.
 				// This logic won't work correctly when those issues are fixed.
 				Assert.IsTrue(IsPresentationFrameworkVersionLessThan4);
 
@@ -1069,7 +1069,7 @@ namespace Microsoft.Windows.Shell
 		[SecurityCritical]
 		private IntPtr _HandleEnterSizeMove(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled)
 		{
-			// This is only intercepted to deal with bugs in Window in .Net 3.5 and below.
+			// This is only intercepted to deal with bugs in Window in .NET 3.5 and below.
 			Assert.IsTrue(IsPresentationFrameworkVersionLessThan4);
 
 			_isUserResizing = true;
@@ -1182,7 +1182,7 @@ namespace Microsoft.Windows.Shell
 
 		private IntPtr _HandleExitSizeMove(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled)
 		{
-			// This is only intercepted to deal with bugs in Window in .Net 3.5 and below.
+			// This is only intercepted to deal with bugs in Window in .NET 3.5 and below.
 			Assert.IsTrue(IsPresentationFrameworkVersionLessThan4);
 
 			_isUserResizing = false;
@@ -1202,7 +1202,7 @@ namespace Microsoft.Windows.Shell
 
 		private IntPtr _HandleMove(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled)
 		{
-			// This is only intercepted to deal with bugs in Window in .Net 3.5 and below.
+			// This is only intercepted to deal with bugs in Window in .NET 3.5 and below.
 			Assert.IsTrue(IsPresentationFrameworkVersionLessThan4);
 
 			if (_isUserResizing)

--- a/src/Core/src/Fonts/FontRegistrar.iOS.cs
+++ b/src/Core/src/Fonts/FontRegistrar.iOS.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui
 			var mainBundlePath = Foundation.NSBundle.MainBundle.BundlePath;
 
 #if MACCATALYST
-			// MacOS Apps have Contents folder in the bundle root, iOS does not
+			// macOS Apps have Contents folder in the bundle root, iOS does not
 			mainBundlePath = Path.Combine(mainBundlePath, "Contents");
 #endif
 


### PR DESCRIPTION
grammar corrections to product names: 'macOS', 'Xcode', '.NET'