### PR TITLE
Refactor SemanticScreenReader to use an interface

### DIFF
--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.android.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.android.cs
@@ -1,6 +1,6 @@
 ﻿using Android.Views.Accessibility;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public partial class SemanticScreenReaderImplementation : ISemanticScreenReader
 	{

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.android.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.android.cs
@@ -2,9 +2,9 @@
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class SemanticScreenReader
+	public partial class SemanticScreenReaderImplementation : ISemanticScreenReader
 	{
-		static void PlatformAnnounce(string text)
+		public void Announce(string text)
 		{
 			AccessibilityManager manager = Android.App.Application.Context.GetSystemService(Android.Content.Context.AccessibilityService) as AccessibilityManager;
 			AccessibilityEvent announcement = AccessibilityEvent.Obtain();

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.ios.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.ios.cs
@@ -4,9 +4,9 @@ using UIKit;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class SemanticScreenReader
+	public partial class SemanticScreenReaderImplementation : ISemanticScreenReader
 	{
-		static void PlatformAnnounce(string text)
+		public void Announce(string text)
 		{
 			if (!UIAccessibility.IsVoiceOverRunning)
 				return;

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.ios.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.ios.cs
@@ -2,7 +2,7 @@
 using ObjCRuntime;
 using UIKit;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public partial class SemanticScreenReaderImplementation : ISemanticScreenReader
 	{

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.netstandard.tvos.watchos.macos.tizen.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.netstandard.tvos.watchos.macos.tizen.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public partial class SemanticScreenReaderImplementation : ISemanticScreenReader
 	{

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.netstandard.tvos.watchos.macos.tizen.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.netstandard.tvos.watchos.macos.tizen.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class SemanticScreenReader
+	public partial class SemanticScreenReaderImplementation : ISemanticScreenReader
 	{
-		static void PlatformAnnounce(string text) =>
+		public void Announce(string text) =>
 			throw ExceptionUtils.NotSupportedOrImplementedException;
 	}
 }

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.shared.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.shared.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Microsoft.Maui.Essentials.Implementations;
 
 namespace Microsoft.Maui.Essentials
 {

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.shared.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.shared.cs
@@ -1,12 +1,29 @@
-﻿using System.Threading.Tasks;
+﻿#nullable enable
+using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace Microsoft.Maui.Essentials
 {
+	public interface ISemanticScreenReader
+	{
+		void Announce(string text);
+	}
+
 	public static partial class SemanticScreenReader
 	{
 		public static void Announce(string text)
 		{
-			PlatformAnnounce(text);
+			Current.Announce(text);
 		}
+
+		static ISemanticScreenReader? currentImplementation;
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static ISemanticScreenReader Current =>
+			currentImplementation ??= new SemanticScreenReaderImplementation();
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetCurrent(ISemanticScreenReader? implementation) =>
+			currentImplementation = implementation;
 	}
 }

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.uwp.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.uwp.cs
@@ -14,9 +14,9 @@ using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui.Essentials
 {
-	public static partial class SemanticScreenReader
+	public partial class SemanticScreenReaderImplementation : ISemanticScreenReader
 	{
-		static void PlatformAnnounce(string text)
+		public void Announce(string text)
 		{
 			if (Platform.CurrentWindow == null)
 				return;

--- a/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.uwp.cs
+++ b/src/Essentials/src/SemanticScreenReader/SemanticScreenReader.uwp.cs
@@ -12,7 +12,7 @@ using Microsoft.UI.Xaml.Media;
 
 
 
-namespace Microsoft.Maui.Essentials
+namespace Microsoft.Maui.Essentials.Implementations
 {
 	public partial class SemanticScreenReaderImplementation : ISemanticScreenReader
 	{


### PR DESCRIPTION
## Description of the change

Contributes to #4497.

## Additions made

```C#
public interface ISemanticScreenReader
{
	void Announce(string text);
}

public class SemanticScreenReaderImplementation : ISemanticScreenReader{ /*... */ }
```

This one doesn't have any tests, and it's `SemanticScreenReaderPage` doesn't appear in the samples app, so I wasn't able to validate the change.