### PR TITLE
[Android] Fix the math for GenerateAdornerOffset

### DIFF
--- a/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Android.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Android.cs
@@ -64,10 +64,16 @@ namespace Microsoft.Maui
 			if (nativeActivity.Resources == null || nativeActivity.Resources.DisplayMetrics == null)
 				return new Point();
 
-			float dpi = nativeActivity.Resources.DisplayMetrics.Density;
-			float heightPixels = nativeActivity.Resources.DisplayMetrics.HeightPixels;
+			var decorView = nativeActivity.Window?.DecorView;
+			var rectangle = new Android.Graphics.Rect();
 
-			return new Point(0, -(heightPixels - graphicsView.MeasuredHeight) / dpi);
+			if (decorView is not null)
+			{
+				decorView.GetWindowVisibleDisplayFrame(rectangle);
+			}
+
+			float dpi = nativeActivity.Resources.DisplayMetrics.Density;
+			return new Point(0, -(rectangle.Top / dpi));
 		}
 	}
 }


### PR DESCRIPTION
This switches the math for GenerateAdornerOffset to use the Window DecorView, which should account for Status Bars on all devices.

Addresses https://github.com/dotnet/maui/issues/4675