### PR TITLE
[WinUI] Use XamlRoot for GetViewTransform

### DIFF
--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -277,10 +277,10 @@ namespace Microsoft.Maui.Platform
 
 		internal static Matrix4x4 GetViewTransform(this FrameworkElement element)
 		{
-			var root = element?.Parent as UIElement;
+			var root = element?.XamlRoot;
 			if (root == null)
 				return new Matrix4x4();
-			var offset = element?.TransformToVisual(root) as MatrixTransform;
+			var offset = element?.TransformToVisual(root.Content) as MatrixTransform;
 			if (offset == null)
 				return new Matrix4x4();
 			Matrix matrix = offset.Matrix;


### PR DESCRIPTION
Using the Parent element isn't correct for getting the correct view transform values. To be consistent with the rest of our view transforms, we need to base it on the XamlRoot values. We already do that for the bounding box, and that's producing values we expect.

Addresses https://github.com/dotnet/maui/issues/4690