### PR TITLE
Remove storage read from essentials android - file/media picker

### DIFF
--- a/src/Essentials/src/FilePicker/FilePicker.android.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.android.cs
@@ -11,10 +11,6 @@ namespace Microsoft.Maui.Essentials
 	{
 		static async Task<IEnumerable<FileResult>> PlatformPickAsync(PickOptions options, bool allowMultiple = false)
 		{
-			// we only need the permission when accessing the file, but it's more natural
-			// to ask the user first, then show the picker.
-			await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
-
 			// Essentials supports >= API 19 where this action is available
 			var action = Intent.ActionOpenDocument;
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -20,10 +20,6 @@ namespace Microsoft.Maui.Essentials
 
 		static async Task<FileResult> PlatformPickAsync(MediaPickerOptions options, bool photo)
 		{
-			// We only need the permission when accessing the file, but it's more natural
-			// to ask the user first, then show the picker.
-			await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
-
 			var intent = new Intent(Intent.ActionGetContent);
 			intent.SetType(photo ? FileSystem.MimeTypes.ImageAll : FileSystem.MimeTypes.VideoAll);
 


### PR DESCRIPTION
### Description of Change ###

Implements https://github.com/xamarin/Essentials/pull/1968


### PR Checklist ###

- [x] Targets the correct branch 
- [x] Tests are passing (or failures are unrelated)
- [x] Targets a single property for a single control (or intertwined few properties)
- [x] Adds the property to the appropriate interface
- [x] Avoids any changes not essential to the handler property
- [x] Adds the mapping to the PropertyMapper in the handler
- [x] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [x] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [x] Tags ported renderer methods with [PortHandler]
- [x] Adds an example of the property to the sample project (MainPage)
- [x] Adds the property to the stub class
- [x] Implements basic property tests in DeviceTests

