### PR TITLE
[X] remove RegisterSourceInfo from Xamlc

### DIFF
--- a/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
+++ b/src/Controls/src/Build.Tasks/CreateObjectVisitor.cs
@@ -89,7 +89,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 						node.SkipProperties.Add(prop.Key);
 				node.CollectionItems.Clear();
 
-				Context.IL.Append(RegisterSourceInfo(Context, node));
 				return;
 			}
 
@@ -242,11 +241,9 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 						if (!node.SkipProperties.Contains(prop.Key))
 							node.SkipProperties.Add(prop.Key);
 					node.CollectionItems.Clear();
-					Context.IL.Append(RegisterSourceInfo(Context, node));
 
 					return;
 				}
-				Context.IL.Append(RegisterSourceInfo(Context, node));
 			}
 		}
 
@@ -263,7 +260,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			Context.Body.Variables.Add(vardef);
 			Context.IL.Emit(OpCodes.Ldarg_0);
 			Context.IL.Emit(OpCodes.Stloc, vardef);
-			Context.IL.Append(RegisterSourceInfo(Context, node));
 		}
 
 		public void Visit(ListNode node, INode parentNode)
@@ -574,54 +570,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					}
 					break;
 			}
-		}
-
-		internal static IEnumerable<Instruction> RegisterSourceInfo(ILContext context, INode valueNode)
-		{
-			if (!context.DefineDebug)
-				yield break;
-			if (!(valueNode is IXmlLineInfo lineInfo))
-				yield break;
-			if (!(valueNode is IElementNode elementNode))
-				yield break;
-			if (context.Variables[elementNode].VariableType.IsValueType)
-				yield break;
-
-			var module = context.Body.Method.Module;
-
-			yield return Create(Ldloc, context.Variables[elementNode]);     //target
-
-			yield return Create(Ldstr, context.XamlFilePath);
-			yield return Create(Ldstr, ";assembly=");
-			yield return Create(Ldstr, context.Module.Assembly.Name.Name);
-			yield return Create(Call, module.ImportMethodReference(("mscorlib", "System", "String"),
-																   methodName: "Concat",
-																   parameterTypes: new[] {
-																	   ("mscorlib", "System", "String"),
-																	   ("mscorlib", "System", "String"),
-																	   ("mscorlib", "System", "String"),
-																   },
-																   isStatic: true));
-
-
-			yield return Create(Ldc_I4, (int)UriKind.RelativeOrAbsolute);
-			yield return Create(Newobj, module.ImportCtorReference(("System", "System", "Uri"),
-																   parameterTypes: new[] {
-																	   ("mscorlib", "System", "String"),
-																	   ("System", "System", "UriKind"),
-																   }));     //uri
-
-			yield return Create(Ldc_I4, lineInfo.LineNumber);               //lineNumber
-			yield return Create(Ldc_I4, lineInfo.LinePosition);             //linePosition
-
-			yield return Create(Call, module.ImportMethodReference(("Microsoft.Maui", "Microsoft.Maui", "VisualDiagnostics"),
-																   methodName: "RegisterSourceInfo",
-																   parameterTypes: new[] {
-																	   ("mscorlib", "System", "Object"),
-																	   ("System", "System", "Uri"),
-																	   ("mscorlib", "System", "Int32"),
-																	   ("mscorlib", "System", "Int32")},
-																   isStatic: true));
 		}
 	}
 }

--- a/src/Controls/src/Build.Tasks/ILContext.cs
+++ b/src/Controls/src/Build.Tasks/ILContext.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 		public MethodBody Body { get; private set; }
 
 		public ModuleDefinition Module { get; private set; }
-		public bool DefineDebug { get; internal set; }
 		public string XamlFilePath { get; internal set; }
 	}
 }

--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -1576,7 +1576,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 			var templateContext = new ILContext(templateIl, loadTemplate.Body, module, parentValues)
 			{
 				Root = root,
-				DefineDebug = parentContext.DefineDebug,
 				XamlFilePath = parentContext.XamlFilePath,
 			};
 			node.Accept(new CreateObjectVisitor(templateContext), null);

--- a/src/Controls/src/Build.Tasks/XamlCTask.cs
+++ b/src/Controls/src/Build.Tasks/XamlCTask.cs
@@ -288,7 +288,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 
 				var visitorContext = new ILContext(il, body, module)
 				{
-					DefineDebug = DebugSymbols || (!string.IsNullOrEmpty(DebugType) && DebugType.ToLowerInvariant() != "none"),
 					XamlFilePath = xamlFilePath
 				};
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh10803.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh10803.xaml.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			}
 
 			[Test]
-			public void SourceInfoForElementsInDT([Values(false, true)] bool useCompiledXaml)
+			public void SourceInfoForElementsInDT([Values(false)] bool useCompiledXaml)
 			{
 				var layout = new Gh10803(useCompiledXaml);
 				var listview = layout.listview;


### PR DESCRIPTION
As XamlC is only used for Release builds nowadays, and not the
instrumented ones, we can safely remove calls to RegisterSourceInfo

- fixes #4642



<!-- 

We are currently only accepting Pull Requests for .NET MAUI issues in our [Handler Property Backlog](https://github.com/dotnet/maui/projects/4). We will continue to update this repository over the next couple of months as we begin to accept more types of PRs.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
          - If the issue you're working on has a milestone, target the corresponding branch.
          - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
               See [Contributing](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md) for more tips!

```
 PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
```
 -->
### Description of Change ###

<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implements #

### Additions made ###
<!-- List all the additions made here, example:

- Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for WinUI, Android, and iOS
- Adds extension methods to apply Padding on WinUI/Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on WinUI, iOS, and Android

 -->

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
