### PR TITLE
Use unelevated button style on Android

### DIFF
--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -28,7 +28,7 @@
     <style name="AppTheme" parent="Maui.MainTheme" />
     <style name="AppTheme.NoActionBar" parent="Maui.MainTheme.NoActionBar" />
 
-    <style name="MauiMaterialButton" parent="Widget.MaterialComponents.Button">
+    <style name="MauiMaterialButton" parent="Widget.MaterialComponents.Button.UnelevatedButton">
       <!-- remove all the min sizes as MAUI manages it -->
       <item name="android:minWidth">0dp</item>
       <item name="android:minHeight">0dp</item>


### PR DESCRIPTION
The default material button style's Elevation usage causes a few problems:

- it adds a default shadow which conflicts with the cross-platform Shadow property
- wrapping the control to provide other properties (e.g., clip shapes) resets the basis for elevation, which causes odd behaviors
- it can cause some odd z-index issues as the elevated button pops through other controls

This change makes the Unelevated button style the default to avoid these issues. 