### PR TITLE
Annotate web Content items to avoid workarounds in Xamarin and iOS SDKs

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -12,6 +12,20 @@
     <RazorComponent Include="**\*.razor" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      Web assets (js, css, etc under wwwroot) and .razor files are represented as Content items in the Razor SDK, but run foul of
+      checks in the Android and iOS SDK. This annotates these items with metadata that prevents them from being bundled / examined.
+    -->
+    <Content Update="@(Content->HasMetadata('WebContentItem')->WithMetadataValue('WebContentItem', 'true'))"
+      ExcludeFromContentCheck="true"
+      PublishFolderType="None" />
+
+    <Content Update="@(Content->WithMetadataValue('Extension', '.razor'))"
+      ExcludeFromContentCheck="true"
+      PublishFolderType="None" />
+  </ItemGroup>
+
   <PropertyGroup>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
     <StaticWebAssetProjectMode>Root</StaticWebAssetProjectMode>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -17,7 +17,7 @@
       Web assets (js, css, etc under wwwroot) and .razor files are represented as Content items in the Razor SDK, but run foul of
       checks in the Android and iOS SDK. This annotates these items with metadata that prevents them from being bundled / examined.
     -->
-    <Content Update="@(Content->HasMetadata('WebContentItem')->WithMetadataValue('WebContentItem', 'true'))"
+    <Content Update="@(Content->WithMetadataValue('WebContentItem', 'true'))"
       ExcludeFromContentCheck="true"
       PublishFolderType="None" />
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/maui/issues/791

This is wave 1 of PRs that updates special content items with new metadata that the iOS and Android SDKs support. Once all the changes have converged, we can remove the workaround targets from this repo. Related PRs:

* https://github.com/dotnet/sdk/pull/23973
* https://github.com/xamarin/xamarin-android/pull/6771/files
