### PR TITLE
[templates] define a %(BaseSize) for images

### DIFF
--- a/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+++ b/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <MauiImage Include="Resources\Images\*" />
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
-    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" />
+    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">

--- a/src/Controls/samples/Controls.Sample.Profiling/Maui.Controls.Sample.Profiling.csproj
+++ b/src/Controls/samples/Controls.Sample.Profiling/Maui.Controls.Sample.Profiling.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <MauiIcon Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" Color="#512BD4" />
-    <MauiSplashScreen Include="Resources\AppIcons\appicon_foreground.svg" Color="#512BD4" />
+    <MauiSplashScreen Include="Resources\AppIcons\appicon_foreground.svg" Color="#512BD4" BaseSize="128,128" />
     <MauiImage Include="Resources\Images\*" />
     <MauiFont Include="Resources\Fonts\*" />
   </ItemGroup>

--- a/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
-    <MauiSplashScreen Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" />
+    <MauiSplashScreen Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" BaseSize="168,208" />
   </ItemGroup>
 
 </Project>

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -53,7 +53,7 @@
     <MauiImage Update="Resources\Images\*.gif" Resize="false" />
     <MauiIcon Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" />
     <MauiFont Include="Resources\Fonts\*" />
-    <MauiSplashScreen Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" />
+    <MauiSplashScreen Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" BaseSize="168,208" />
   </ItemGroup>
 
   <Import Condition=" '$(UseMaui)' != 'true' " Project="..\..\..\BlazorWebView\src\Maui\build\Microsoft.AspNetCore.Components.WebView.Maui.targets" />

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <MauiImage Include="Resources\Images\*" />
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
-    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" />
+    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
-    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" />
+    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
     <MauiImage Include="Resources\Images\*" />
     <MauiFont Include="Resources\Fonts\*" />
     <MauiImage Update="Resources\Images\*.gif" Resize="false" />

--- a/src/Essentials/samples/Samples/Essentials.Sample.csproj
+++ b/src/Essentials/samples/Samples/Essentials.Sample.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <MauiImage Include="Resources\Images\*" />
     <MauiIcon Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appiconfg.svg" Color="#512BD4" />
-    <MauiSplashScreen Include="Resources\AppIcons\appiconfg.svg" Color="#512BD4" />
+    <MauiSplashScreen Include="Resources\AppIcons\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
+++ b/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
-    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" />
+    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
     <MauiImage Include="Resources\Images\*" />
     <MauiFont Include="Resources\Fonts\*" />
     <MauiImage Update="Resources\Images\*.gif" Resize="false" />

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -38,10 +38,11 @@
 			Color="#512BD4" />
 
 		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" />
+		<MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
+		<MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
 		<!-- Custom Fonts -->
 		<MauiFont Include="Resources\Fonts\*" />

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -34,10 +34,11 @@
 		<MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
 
 		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" />
+		<MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
+		<MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
 		<!-- Custom Fonts -->
 		<MauiFont Include="Resources\Fonts\*" />

--- a/src/TestUtils/samples/DeviceTests.Sample/TestUtils.DeviceTests.Sample.csproj
+++ b/src/TestUtils/samples/DeviceTests.Sample/TestUtils.DeviceTests.Sample.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
-    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" />
+    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">


### PR DESCRIPTION
### Description of Change ###

Reviewing `dotnet trace` output for a `dotnet new maui` project on Android:

    106.07ms Mono.Android!Android.Content.Context.GetDrawable

This is the time spent literally loading 1 image:

https://github.com/dotnet/maui/blob/8ae34d460a1ff526d08dbe9d031ea2403d90d11a/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.Android.cs#L31

Reviewing the build output at:

    obj\Release\net6.0-android\resizetizer\r\mipmap-xxxhdpi\
        appiconfg.png = 1824x1824
        dotnet_bot.png = 1676x2076

Ok, those images are enormous!

Let's modify the template, so that we declare a `%(BaseSize)` for
each:

    <!-- Splash Screen -->
    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
    <!-- Images -->
    <MauiImage Include="Resources\Images\*" />
    <MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />

This changes the images to:

    obj\Release\net6.0-android\resizetizer\r\mipmap-xxxhdpi\
        appiconfg.png = 512x512
        dotnet_bot.png = 672x832

The images look "the same" to me, they don't appear smaller on a Pixel
5 device.

![screencap](https://user-images.githubusercontent.com/840039/154538011-a733b4e7-103f-46bc-8915-1ce762c26858.png)

I updated a couple other uses of `@(MauiSplashScreen)` in other samples.

### Results

Building a `Release` app (defaults to Profiled AOT) with
xamarin-android/main + dotnet/maui/main the average of 10 runs on a
Pixel 5:

    Before:
    02-17 10:44:34.992  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +494ms
    02-17 10:44:36.203  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +522ms
    02-17 10:44:37.372  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +491ms
    02-17 10:44:38.614  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +508ms
    02-17 10:44:39.823  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +521ms
    02-17 10:44:41.015  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +513ms
    02-17 10:44:42.207  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +484ms
    02-17 10:44:43.411  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +494ms
    02-17 10:44:44.615  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +501ms
    02-17 10:44:45.829  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +511ms
    Average(ms): 503.9
    Std Err(ms): 4.13239236601108
    Std Dev(ms): 13.0677720620872

    After:
    02-17 10:55:42.512  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +462ms
    02-17 10:55:43.732  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +481ms
    02-17 10:55:44.911  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +482ms
    02-17 10:55:46.186  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +491ms
    02-17 10:55:47.389  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +469ms
    02-17 10:55:48.545  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +463ms
    02-17 10:55:49.757  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +461ms
    02-17 10:55:50.964  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +473ms
    02-17 10:55:52.163  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +478ms
    02-17 10:55:53.356  1980  2259 I ActivityTaskManager: Displayed com.companyname.foo/crc64808a40cc7e533249.MainActivity: +466ms
    Average(ms): 472.6
    Std Err(ms): 3.20138858761146
    Std Dev(ms): 10.1236796121217

This saves ~30ms of startup time on the template!

### PR Checklist ###

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?

No