### PR TITLE
In BlazorWebView WinForms/WPF, don't require wwwroot to exist in bin dir in development

### DIFF
--- a/src/BlazorWebView/samples/BlazorWinFormsApp/BlazorWinFormsApp.csproj
+++ b/src/BlazorWebView/samples/BlazorWinFormsApp/BlazorWinFormsApp.csproj
@@ -15,12 +15,6 @@
     <ProjectReference Include="..\WebViewAppShared\WebViewAppShared.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Update="wwwroot\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
   <Import Project="..\..\src\WindowsForms\build\Microsoft.AspNetCore.Components.WebView.WindowsForms.targets" />
 
 </Project>

--- a/src/BlazorWebView/samples/BlazorWpfApp/BlazorWpfApp.csproj
+++ b/src/BlazorWebView/samples/BlazorWpfApp/BlazorWpfApp.csproj
@@ -15,12 +15,6 @@
     <ProjectReference Include="..\WebViewAppShared\WebViewAppShared.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Update="wwwroot\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
   <Import Project="..\..\src\Wpf\build\Microsoft.AspNetCore.Components.WebView.Wpf.targets" />
 
 </Project>

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -198,7 +198,17 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// <returns>Returns a <see cref="IFileProvider"/> for static assets.</returns>
 		public virtual IFileProvider CreateFileProvider(string contentRootDir)
 		{
-			return new PhysicalFileProvider(contentRootDir);
+			if (Directory.Exists(contentRootDir))
+			{
+				// Typical case after publishing, or if you're copying content to the bin dir in development for some nonstandard reason
+				return new PhysicalFileProvider(contentRootDir);
+			}
+			else
+			{
+				// Typical case in development, as the files come from Microsoft.AspNetCore.Components.WebView.StaticContentProvider
+				// instead and aren't copied to the bin dir
+				return new NullFileProvider();
+			}
 		}
 
 		/// <inheritdoc />

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -218,7 +218,17 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		/// <returns>Returns a <see cref="IFileProvider"/> for static assets.</returns>
 		public virtual IFileProvider CreateFileProvider(string contentRootDir)
 		{
-			return new PhysicalFileProvider(contentRootDir);
+			if (Directory.Exists(contentRootDir))
+			{
+				// Typical case after publishing, or if you're copying content to the bin dir in development for some nonstandard reason
+				return new PhysicalFileProvider(contentRootDir);
+			}
+			else
+			{
+				// Typical case in development, as the files come from Microsoft.AspNetCore.Components.WebView.StaticContentProvider
+				// instead and aren't copied to the bin dir
+				return new NullFileProvider();
+			}
 		}
 
 		private void CheckDisposed()


### PR DESCRIPTION
Fixes #4537

Turns out we were a bit confused about what the problem was. We *thought* the issue was that your csproj needed to copy the content files to output explicitly. However, that's not the case, since:

 * In development, the underlying `BlazorWebView` library code already deals with using the SWA manifest to return the SWA content, without needing it to be copied to the output directory
 * When publishing, the Razor SDK already deals with copying the content into the publish output directory, so it can be supplied by a `PhysicalFileProvider`

The real problem is much simpler. Our code was trying to create a `PhysicalFileProvider` for `$(OutDir)\wwwroot` regardless of the fact that it doesn't need to exist there in development. By skipping doing that if it's not there, everything else just works.

This only affected WinForms and WPF, and not MAUI, because for MAUI we already deal with converting content items into MAUI content items, which then takes care of getting them to the right place for both dev and prod.