### PR TITLE
Remove dead code from MauiFactory

### DIFF
--- a/src/Core/src/Hosting/ImageSources/ImageSourceServiceProvider.cs
+++ b/src/Core/src/Hosting/ImageSources/ImageSourceServiceProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Hosting.Internal;
 
 namespace Microsoft.Maui.Hosting
 {
-	class ImageSourceServiceProvider : MauiFactory, IImageSourceServiceProvider
+	sealed class ImageSourceServiceProvider : MauiFactory, IImageSourceServiceProvider
 	{
 		static readonly string ImageSourceInterface = typeof(IImageSource).FullName!;
 		static readonly Type ImageSourceServiceType = typeof(IImageSourceService<>);
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Hosting
 		readonly ConcurrentDictionary<Type, Type> _serviceCache = new ConcurrentDictionary<Type, Type>();
 
 		public ImageSourceServiceProvider(IImageSourceServiceCollection collection, IServiceProvider hostServiceProvider)
-			: base(collection, false)
+			: base(collection)
 		{
 			HostServiceProvider = hostServiceProvider;
 		}

--- a/src/Core/src/Hosting/Internal/MauiFactory.cs
+++ b/src/Core/src/Hosting/Internal/MauiFactory.cs
@@ -3,30 +3,25 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Hosting.Internal
 {
 	class MauiFactory : IMauiFactory
 	{
-		static readonly Type ServiceProviderType = typeof(IServiceProvider);
 		static readonly Type EnumerableType = typeof(IEnumerable<>);
 		static readonly Type ListType = typeof(List<>);
 
 		readonly IMauiServiceCollection _collection;
-		readonly bool _constructorInjection;
 
 		protected IMauiServiceCollection InternalCollection => _collection;
 
 		// TODO: do this properly and support scopes
 		readonly IDictionary<ServiceDescriptor, object?> _singletons;
 
-		public MauiFactory(IMauiServiceCollection collection, bool constructorInjection)
+		public MauiFactory(IMauiServiceCollection collection)
 		{
 			_collection = collection ?? throw new ArgumentNullException(nameof(collection));
-			_constructorInjection = constructorInjection;
 			_singletons = new ConcurrentDictionary<ServiceDescriptor, object?>();
 
 			// to make things easier, just add the provider
@@ -164,10 +159,7 @@ namespace Microsoft.Maui.Hosting.Internal
 		{
 			if (item.ImplementationType != null)
 			{
-				if (_constructorInjection)
-					return CreateInstance(item.ImplementationType);
-				else
-					return Activator.CreateInstance(item.ImplementationType);
+				return Activator.CreateInstance(item.ImplementationType);
 			}
 
 			if (item.ImplementationInstance != null)
@@ -177,82 +169,6 @@ namespace Microsoft.Maui.Hosting.Internal
 				return item.ImplementationFactory(this);
 
 			throw new InvalidOperationException($"You need to provide an {nameof(item.ImplementationType)}, an {nameof(item.ImplementationFactory)} or an {nameof(item.ImplementationInstance)}.");
-		}
-
-		object? CreateInstance(
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
-		{
-			// get constructors ordered by parameter count
-			var constructors = implementationType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-			var matches = new (ConstructorInfo? Constructor, ParameterInfo[]? Parameters)[constructors.Length];
-			var matchesCounts = new int[constructors.Length];
-			var found = false;
-			for (var i = 0; i < constructors.Length; i++)
-			{
-				var ctor = constructors[i];
-				if (!ctor.IsFamily && !ctor.IsPrivate)
-				{
-					var parameters = ctor.GetParameters();
-					matchesCounts[i] = parameters.Length;
-					matches[i] = (ctor, parameters);
-					found = true;
-				}
-			}
-			Array.Sort(matchesCounts, matches);
-
-			if (!found)
-				throw new InvalidOperationException($"The type '{implementationType.Name}' did not have any public or internal constructors.");
-
-			// go through in reverse order
-			for (var m = matches.Length - 1; m >= 0; m--)
-			{
-				var (constructor, parameters) = matches[m];
-				if (constructor != null && parameters != null)
-				{
-					var paramCount = parameters.Length;
-
-					// we are at a ctor that has no params, so just use that
-					if (paramCount == 0)
-						return constructor.Invoke(null);
-
-					// try find a ctor that matches what we have in the service collection
-					var validConstructor = true;
-					var paramDescriptors = new (Type ServiceType, ServiceDescriptor? Single, IEnumerable<ServiceDescriptor>? Enumerable, object? Value)[paramCount];
-					for (var i = 0; i < paramCount; i++)
-					{
-						var param = parameters[i];
-						var paramType = param.ParameterType;
-
-						var isValid = TryGetServiceDescriptors(ref paramType, out var single, out var enumerable);
-						if (isValid)
-							paramDescriptors[i] = (paramType, single, enumerable, null);
-						else if (param.HasDefaultValue)
-							paramDescriptors[i] = (paramType, null, null, param.DefaultValue);
-						else
-						{
-							validConstructor = false;
-							break;
-						}
-					}
-
-					// we found something, so now inflate
-					if (validConstructor)
-					{
-						var paramValues = new object?[paramCount];
-						for (var i = 0; i < paramCount; i++)
-						{
-							var descriptor = paramDescriptors[i];
-							if (descriptor.Single != null || descriptor.Enumerable != null)
-								paramValues[i] = GetService(descriptor.ServiceType, descriptor.Single, descriptor.Enumerable);
-							else
-								paramValues[i] = descriptor.Value;
-						}
-						return constructor.Invoke(paramValues);
-					}
-				}
-			}
-
-			throw new InvalidOperationException($"Could not match any constructors for '{implementationType.Name}'.");
 		}
 	}
 }

--- a/src/Core/src/Hosting/Internal/MauiHandlersFactory.cs
+++ b/src/Core/src/Hosting/Internal/MauiHandlersFactory.cs
@@ -5,10 +5,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Hosting.Internal
 {
-	class MauiHandlersFactory : MauiFactory, IMauiHandlersFactory
+	sealed class MauiHandlersFactory : MauiFactory, IMauiHandlersFactory
 	{
 		public MauiHandlersFactory(IEnumerable<HandlerMauiAppBuilderExtensions.HandlerRegistration> registrationActions) :
-			base(CreateHandlerCollection(registrationActions), constructorInjection: false)
+			base(CreateHandlerCollection(registrationActions))
 		{
 		}
 

--- a/src/Core/tests/UnitTests/AbstractViewHandlerTests.cs
+++ b/src/Core/tests/UnitTests/AbstractViewHandlerTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.UnitTests
 			collection.TryAddSingleton<IMauiHandlersFactory>(new MauiHandlersFactory(null));
 			collection.TryAddSingleton<IFooService, FooService>();
 
-			var provider = new MauiFactory(collection, false);
+			var provider = new MauiFactory(collection);
 
 			handlerStub.SetMauiContext(new HandlersContextStub(provider));
 

--- a/src/Core/tests/UnitTests/MauiContextTests.cs
+++ b/src/Core/tests/UnitTests/MauiContextTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.UnitTests
 
 			var collection = new MauiServiceCollection();
 			collection.AddSingleton(obj);
-			var services = new MauiFactory(collection, false);
+			var services = new MauiFactory(collection);
 
 			var first = new MauiContext(services);
 			var second = new MauiContext(first.Services);
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.UnitTests
 
 			var collection = new MauiServiceCollection();
 			collection.AddSingleton(baseObj);
-			var services = new MauiFactory(collection, false);
+			var services = new MauiFactory(collection);
 
 			var specificObj = new TestThing();
 			var context = new MauiContext(services);
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.UnitTests
 		public void AddSpecificIsNotWeak()
 		{
 			var collection = new MauiServiceCollection();
-			var services = new MauiFactory(collection, false);
+			var services = new MauiFactory(collection);
 			var context = new MauiContext(services);
 
 			DoAdd(context);
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.UnitTests
 		public void AddWeakSpecificIsWeak()
 		{
 			var collection = new MauiServiceCollection();
-			var services = new MauiFactory(collection, false);
+			var services = new MauiFactory(collection);
 			var context = new MauiContext(services);
 
 			DoAdd(context);
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.UnitTests
 
 			var collection = new MauiServiceCollection();
 			collection.AddSingleton(obj);
-			var services = new MauiFactory(collection, false);
+			var services = new MauiFactory(collection);
 
 			var first = new MauiContext(services);
 


### PR DESCRIPTION
`_constructorInjection` is only ever set to `false`. The dead code has ILLink warnings in it, since it is trying to find non-public ctors, but the types passed in are only annotated to preserve public ctors.

Removing the dead code resolves the ILLink warning.

I also added `sealed` to the internal classes that inherit from MauiFactory. This is good practice, so the runtime can devirtualize calls when able.