### PR TITLE
[Android] Update the DatePicker Dialog if the display info changes

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/DatePickerRenderer.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			return dialog;
 		}
 
+		[PortHandler]
 		void DeviceInfoPropertyChanged(object sender, DisplayInfoChangedEventArgs e)
 		{
 			DatePickerDialog currentDialog = _dialog;

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -1,6 +1,8 @@
-﻿using Android.App;
+﻿using System;
+using Android.App;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
+using Microsoft.Maui.Essentials;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -32,6 +34,8 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiDatePicker platformView)
 		{
 			base.ConnectHandler(platformView);
+			
+			DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
 
 			SetupDefaults(platformView);
 		}
@@ -46,10 +50,13 @@ namespace Microsoft.Maui.Handlers
 		{
 			if (_dialog != null)
 			{
+				_dialog.CancelEvent -= OnCancelButtonClicked;
 				_dialog.Hide();
 				_dialog.Dispose();
 				_dialog = null;
 			}
+			
+			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
 
 			base.DisconnectHandler(platformView);
 		}
@@ -134,12 +141,32 @@ namespace Microsoft.Maui.Handlers
 			else
 				_dialog.UpdateDate(year, month, day);
 
+			_dialog.CancelEvent += OnCancelButtonClicked;
+
 			_dialog.Show();
 		}
 
 		void HidePickerDialog()
 		{
 			_dialog?.Hide();
+		}
+
+		void OnMainDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)
+		{
+			DatePickerDialog? currentDialog = _dialog;
+
+			if (currentDialog != null && currentDialog.IsShowing)
+			{
+				currentDialog.Dismiss();
+				currentDialog.CancelEvent -= OnCancelButtonClicked;
+
+				ShowPickerDialog(currentDialog.DatePicker.Year, currentDialog.DatePicker.Month, currentDialog.DatePicker.DayOfMonth);
+			}
+		}
+
+		void OnCancelButtonClicked(object? sender, EventArgs e)
+		{
+			// TODO: Update IsFocused Property
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Update (dimiss and open it again) the DatePicker Dialog if the display info changes.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No