### PR TITLE
[Windows] Detect when image failed to load in Windows ImageButton

### DIFF
--- a/src/Compatibility/Core/src/Windows/ImageButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ImageButtonRenderer.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			await ImageElementManager.UpdateSource(this).ConfigureAwait(false);
 		}
 
-
+		[PortHandler]
 		void OnImageOpened(object sender, RoutedEventArgs routedEventArgs)
 		{
 			if (_measured)
@@ -162,6 +162,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			Element?.SetIsLoading(false);
 		}
 
+		[PortHandler]
 		protected virtual void OnImageFailed(object sender, ExceptionRoutedEventArgs exceptionRoutedEventArgs)
 		{
 			Application.Current?.FindMauiContext()?.CreateLogger<ImageButtonRenderer>()?.LogWarning("Image failed to load: {exceptionRoutedEventArgs.ErrorMessage}", exceptionRoutedEventArgs.ErrorMessage);

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
@@ -7,24 +8,35 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ImageButtonHandler : ViewHandler<IImageButton, Button>
 	{
+		Image _image;
+
 		PointerEventHandler? _pointerPressedHandler;
 
-		protected override Button CreatePlatformView() =>
-			new Button
+		protected override Button CreatePlatformView()
+		{
+			_image = new Image
+			{
+				VerticalAlignment = VerticalAlignment.Center,
+				HorizontalAlignment = HorizontalAlignment.Center,
+				Stretch = Stretch.Uniform,
+			};
+
+			var platformImageButton = new Button
 			{
 				VerticalAlignment = VerticalAlignment.Stretch,
 				HorizontalAlignment = HorizontalAlignment.Stretch,
-				Content = new Image
-				{
-					VerticalAlignment = VerticalAlignment.Center,
-					HorizontalAlignment = HorizontalAlignment.Center,
-					Stretch = Stretch.Uniform,
-				}
+				Content = _image
 			};
+
+			return platformImageButton;
+		}
 
 		protected override void ConnectHandler(Button platformView)
 		{
 			_pointerPressedHandler = new PointerEventHandler(OnPointerPressed);
+
+			_image.ImageOpened += OnImageOpened;
+			_image.ImageFailed += OnImageFailed;
 
 			platformView.Click += OnClick;
 			platformView.AddHandler(UIElement.PointerPressedEvent, _pointerPressedHandler, true);
@@ -34,6 +46,9 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(Button platformView)
 		{
+			_image.ImageOpened -= OnImageOpened;
+			_image.ImageFailed -= OnImageFailed;
+
 			platformView.Click -= OnClick;
 			platformView.RemoveHandler(UIElement.PointerPressedEvent, _pointerPressedHandler);
 
@@ -78,6 +93,17 @@ namespace Microsoft.Maui.Handlers
 		void OnPointerPressed(object sender, PointerRoutedEventArgs e)
 		{
 			VirtualView?.Pressed();
+		}
+
+		void OnImageOpened(object sender, RoutedEventArgs routedEventArgs)
+		{
+			VirtualView?.UpdateIsLoading(false);
+		}
+
+		protected virtual void OnImageFailed(object sender, ExceptionRoutedEventArgs exceptionRoutedEventArgs)
+		{
+			MauiContext?.CreateLogger<ImageButtonHandler>()?.LogWarning("Image failed to load: {exceptionRoutedEventArgs.ErrorMessage}", exceptionRoutedEventArgs.ErrorMessage);
+			VirtualView?.UpdateIsLoading(false);
 		}
 	}
 }

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Windows.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ImageButtonHandler : ViewHandler<IImageButton, Button>
 	{
-		Image _image;
+		Image? _image;
 
 		PointerEventHandler? _pointerPressedHandler;
 
@@ -35,8 +35,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			_pointerPressedHandler = new PointerEventHandler(OnPointerPressed);
 
-			_image.ImageOpened += OnImageOpened;
-			_image.ImageFailed += OnImageFailed;
+			if (_image != null)
+			{
+				_image.ImageOpened += OnImageOpened;
+				_image.ImageFailed += OnImageFailed;
+			}
 
 			platformView.Click += OnClick;
 			platformView.AddHandler(UIElement.PointerPressedEvent, _pointerPressedHandler, true);
@@ -46,8 +49,11 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(Button platformView)
 		{
-			_image.ImageOpened -= OnImageOpened;
-			_image.ImageFailed -= OnImageFailed;
+			if (_image != null)
+			{
+				_image.ImageOpened -= OnImageOpened;
+				_image.ImageFailed -= OnImageFailed;
+			}
 
 			platformView.Click -= OnClick;
 			platformView.RemoveHandler(UIElement.PointerPressedEvent, _pointerPressedHandler);


### PR DESCRIPTION
### Description of Change ###

Detect when image failed to load in Windows **ImageButton** to update the IsLoading property.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No