### PR TITLE
[Android] Hide Keyboard in Android Entry and Editor when back key is pressed

### DIFF
--- a/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EntryRenderer.cs
@@ -368,6 +368,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		abstract protected void UpdatePlaceholderColor();
 
+		[PortHandler]
 		void OnKeyboardBackPressed(object sender, EventArgs eventArgs)
 		{
 			Control?.ClearFocus();

--- a/src/Compatibility/Core/src/Android/Renderers/FormsEditText.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormsEditText.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		{
 		}
 
-
+		[PortHandler]
 		public override bool OnKeyPreIme(Keycode keyCode, KeyEvent e)
 		{
 			if (keyCode != Keycode.Back || e.Action != KeyEventActions.Down)

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override AppCompatEditText CreatePlatformView()
 		{
-			var editText = new AppCompatEditText(Context)
+			var editText = new MauiEditText(Context)
 			{
 				ImeOptions = ImeAction.Done,
 				Gravity = GravityFlags.Top,

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -1,4 +1,5 @@
-﻿using Android.Content.Res;
+﻿using System;
+using Android.Content.Res;
 using Android.Graphics.Drawables;
 using Android.Runtime;
 using Android.Text;
@@ -19,7 +20,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override AppCompatEditText CreatePlatformView()
 		{
-			var nativeEntry = new AppCompatEditText(Context);
+			var nativeEntry = new MauiEditText(Context);
 			_defaultPlaceholderColors = nativeEntry.HintTextColors;
 			return nativeEntry;
 		}
@@ -34,6 +35,11 @@ namespace Microsoft.Maui.Handlers
 			platformView.FocusChange += OnFocusedChange;
 			platformView.Touch += OnTouch;
 			platformView.EditorAction += OnEditorAction;
+
+			if (platformView is IMauiEditText mauiEditText)
+			{
+				mauiEditText.OnKeyboardBackPressed += OnKeyboardBackPressed;
+			}
 		}
 
 		protected override void DisconnectHandler(AppCompatEditText platformView)
@@ -43,6 +49,11 @@ namespace Microsoft.Maui.Handlers
 			platformView.FocusChange -= OnFocusedChange;
 			platformView.Touch -= OnTouch;
 			platformView.EditorAction -= OnEditorAction;
+
+			if (platformView is IMauiEditText mauiEditText)
+			{
+				mauiEditText.OnKeyboardBackPressed -= OnKeyboardBackPressed;
+			}
 		}
 
 		public static void MapBackground(IEntryHandler handler, IEntry entry) =>
@@ -131,6 +142,11 @@ namespace Microsoft.Maui.Handlers
 			}
 
 			e.Handled = true;
+		}
+
+		void OnKeyboardBackPressed(object? sender, EventArgs eventArgs)
+		{
+			PlatformView?.ClearFocus();
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/IMauiEditText.cs
+++ b/src/Core/src/Platform/Android/IMauiEditText.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Android.Views;
+
+namespace Microsoft.Maui.Platform
+{
+	public interface IMauiEditText
+	{
+		bool OnKeyPreIme(Keycode keyCode, KeyEvent? e); 
+		
+		event EventHandler OnKeyboardBackPressed;
+	}
+}

--- a/src/Core/src/Platform/Android/KeyboardManager.cs
+++ b/src/Core/src/Platform/Android/KeyboardManager.cs
@@ -1,16 +1,17 @@
+﻿#nullable disable
 using System;
-using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Views.InputMethods;
 using Android.Widget;
+using Microsoft.Maui.Essentials;
 using AView = Android.Views.View;
 
-namespace Microsoft.Maui.Controls.Platform
+namespace Microsoft.Maui.Platform
 {
-	internal static class KeyboardManager
+	public static class KeyboardManager
 	{
-		internal static void HideKeyboard(this AView inputView, bool overrideValidation = false)
+		public static void HideKeyboard(this AView inputView, bool overrideValidation = false)
 		{
 			if (inputView == null)
 				throw new ArgumentNullException(nameof(inputView) + " must be set before the keyboard can be hidden.");
@@ -26,7 +27,7 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		internal static void ShowKeyboard(this TextView inputView)
+		public static void ShowKeyboard(this TextView inputView)
 		{
 			if (inputView == null)
 				throw new ArgumentNullException(nameof(inputView) + " must be set before the keyboard can be shown.");
@@ -40,7 +41,7 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		internal static void ShowKeyboard(this SearchView searchView)
+		public static void ShowKeyboard(this SearchView searchView)
 		{
 			if (searchView == null)
 			{
@@ -73,7 +74,7 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		internal static void ShowKeyboard(this AView view)
+		public static void ShowKeyboard(this AView view)
 		{
 			switch (view)
 			{
@@ -100,7 +101,7 @@ namespace Microsoft.Maui.Controls.Platform
 				view.ShowKeyboard();
 			};
 
-			Device.BeginInvokeOnMainThread(ShowKeyboard);
+			MainThread.BeginInvokeOnMainThread(ShowKeyboard);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiEditText.cs
+++ b/src/Core/src/Platform/Android/MauiEditText.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Android.Content;
+using Android.Views;
+using AndroidX.AppCompat.Widget;
+
+namespace Microsoft.Maui.Platform
+{
+	public class MauiEditText : AppCompatEditText, IMauiEditText
+	{
+		event EventHandler? _onKeyboardBackPressed;
+		event EventHandler? IMauiEditText.OnKeyboardBackPressed
+		{
+			add => _onKeyboardBackPressed += value;
+			remove => _onKeyboardBackPressed -= value;
+		}
+
+		public MauiEditText(Context context) : base(context)
+		{
+
+		}
+
+		public override bool OnKeyPreIme(Keycode keyCode, KeyEvent? e)
+		{
+			if (keyCode != Keycode.Back || e?.Action != KeyEventActions.Down)
+			{
+				return base.OnKeyPreIme(keyCode, e);
+			}
+
+			this.HideKeyboard();
+
+			_onKeyboardBackPressed?.Invoke(this, EventArgs.Empty);
+
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Continue implementing peding details from https://github.com/dotnet/maui/issues/4808. Hide Keyboard in Android Entry and Editor when back key is pressed.

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No