### PR TITLE
Fix tests screenshot

### DIFF
--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -29,12 +29,11 @@ stages:
                 pool:
                   name: ${{ parameters.androidVmPool }}
                   vmImage: ${{ parameters.androidVmImage }}
-                  ${{ if startsWith(parameters.androidVmPool, 'VSEng-VSMac-Xamarin-Shared') }}:
-                    demands:
-                      - macOS.Name -equals BigSur
-                      - macOS.Architecture -equals x64
-                      - Agent.HasDevices -equals False
-                      - Agent.IsPaired -equals False
+                  demands:
+                    - macOS.Name -equals BigSur
+                    - macOS.Architecture -equals x64
+                    - Agent.HasDevices -equals False
+                    - Agent.IsPaired -equals False
                 variables:
                   ${{ if ge(api, 24) }}:
                     ANDROID_EMULATORS: "system-images;android-${{ api }};google_apis_playstore;x86"

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -68,7 +68,7 @@ stages:
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off
-        iosVersions: [ 'latest', '14.5', '13.7', '12.4', '11.4' ]
+        iosVersions: [ 'latest', '14.5', '13.7', '12.4' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       projects:
         - name: essentials

--- a/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Maui.Essentials;
+using Microsoft.Maui.Platform;
 using Xunit;
 
 namespace Microsoft.Maui.Essentials.DeviceTests
@@ -13,10 +14,13 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			return Utils.OnMainThread(async () =>
 			{
-				await Task.Delay(100);
-				ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
-				var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Png);
-				Assert.True(png.Length > 0);
+				if (PlatformVersion.IsAtLeast(13))
+				{
+					await Task.Delay(100);
+					ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
+					var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Png);
+					Assert.True(png.Length > 0);
+				}
 			});
 		}
 
@@ -25,10 +29,13 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			return Utils.OnMainThread(async () =>
 			{
-				await Task.Delay(100);
-				ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
-				var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Jpeg);
-				Assert.True(png.Length > 0);
+				if (PlatformVersion.IsAtLeast(13))
+				{
+					await Task.Delay(100);
+					ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
+					var png = await mediaFile.OpenReadAsync(ScreenshotFormat.Jpeg);
+					Assert.True(png.Length > 0);
+				}
 			});
 		}
 	}

--- a/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			return Utils.OnMainThread(async () =>
 			{
-				if (PlatformVersion.IsAtLeast(13))
+				if (CanExecuteTest())
 				{
 					await Task.Delay(100);
 					ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			return Utils.OnMainThread(async () =>
 			{
-				if (PlatformVersion.IsAtLeast(13))
+				if (CanExecuteTest())
 				{
 					await Task.Delay(100);
 					ScreenshotResult mediaFile = await Screenshot.CaptureAsync();
@@ -37,6 +37,15 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 					Assert.True(png.Length > 0);
 				}
 			});
+		}
+
+		static bool CanExecuteTest()
+		{
+#if __IOS__
+			return PlatformVersion.IsAtLeast(13);
+#else
+			return true;
+#endif
 		}
 	}
 }


### PR DESCRIPTION
- Fix some failing tests for IOS12 and iOS11 related with screenshot api
- Remove tests with iOS11 for now since xharness can't install the simulator

Implements #

### Additions made ###
<!-- List all the additions made here, example:

- Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for WinUI, Android, and iOS
- Adds extension methods to apply Padding on WinUI/Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on WinUI, iOS, and Android



### PR Checklist ###


- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
