### PR TITLE
Update LayoutHandler to use current conventions

### DIFF
--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutTests.cs
@@ -139,8 +139,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 		LayoutHandler CreateLayoutHandler(Action<string, ILayoutHandler, Maui.ILayout, LayoutHandlerUpdate?>? action)
 		{
 			var handler = new NonThrowingLayoutHandler(
-				LayoutHandler.LayoutMapper,
-				new CommandMapper<Maui.ILayout, ILayoutHandler>(LayoutHandler.LayoutCommandMapper)
+				LayoutHandler.Mapper,
+				new CommandMapper<Maui.ILayout, ILayoutHandler>(LayoutHandler.CommandMapper)
 				{
 					[nameof(ILayoutHandler.Add)] = (h, l, a) => action?.Invoke(nameof(ILayoutHandler.Add), h, l, (LayoutHandlerUpdate?)a),
 					[nameof(ILayoutHandler.Remove)] = (h, l, a) => action?.Invoke(nameof(ILayoutHandler.Remove), h, l, (LayoutHandlerUpdate?)a),

--- a/src/Core/src/Handlers/Layout/ILayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/ILayoutHandler.cs
@@ -1,7 +1,20 @@
+#if __IOS__ || MACCATALYST
+using PlatformView = Microsoft.Maui.Platform.LayoutView;
+#elif MONOANDROID
+using PlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Platform.LayoutPanel;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
+
 namespace Microsoft.Maui
 {
 	public interface ILayoutHandler : IViewHandler
 	{
+		new ILayout VirtualView { get; }
+		new PlatformView PlatformView { get; }
+
 		void Add(IView view);
 		void Remove(IView view);
 		void Clear();

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class LayoutHandler : ILayoutHandler
 	{
-		public static IPropertyMapper<ILayout, ILayoutHandler> LayoutMapper = new PropertyMapper<ILayout, ILayoutHandler>(ViewMapper)
+		public static IPropertyMapper<ILayout, ILayoutHandler> Mapper = new PropertyMapper<ILayout, ILayoutHandler>(ViewMapper)
 		{
 			[nameof(ILayout.Background)] = MapBackground,
 			[nameof(ILayout.ClipsToBounds)] = MapClipsToBounds,
 		};
 
-		public static CommandMapper<ILayout, ILayoutHandler> LayoutCommandMapper = new(ViewCommandMapper)
+		public static CommandMapper<ILayout, ILayoutHandler> CommandMapper = new(ViewCommandMapper)
 		{
 			[nameof(ILayoutHandler.Add)] = MapAdd,
 			[nameof(ILayoutHandler.Remove)] = MapRemove,
@@ -29,16 +29,19 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ILayoutHandler.UpdateZIndex)] = MapUpdateZIndex,
 		};
 
-		public LayoutHandler() : base(LayoutMapper, LayoutCommandMapper)
+		public LayoutHandler() : base(Mapper, CommandMapper)
 		{
-
 		}
 
 		public LayoutHandler(IPropertyMapper? mapper = null, CommandMapper? commandMapper = null)
-			: base(mapper ?? LayoutMapper, commandMapper ?? LayoutCommandMapper)
+			: base(mapper ?? Mapper, commandMapper ?? CommandMapper)
 		{
 
 		}
+
+		ILayout ILayoutHandler.VirtualView => VirtualView;
+
+		PlatformView ILayoutHandler.PlatformView => PlatformView;
 
 		public static void MapBackground(ILayoutHandler handler, ILayout layout)
 		{


### PR DESCRIPTION
Rename mappers and extend `ILayoutHandler` like in #4784.

Contributes to #4378. 