### PR TITLE
Force shell creation on UI thread

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -27,15 +27,17 @@ namespace Microsoft.Maui.DeviceTests
 				HeightRequest = 10
 			};
 
-			var shell = new Shell()
-			{
-				FlyoutHeader = label,
-				Items =
+			var shell = await InvokeOnMainThreadAsync<Shell>(() => { 
+				return new Shell()
+				{
+					FlyoutHeader = label,
+					Items =
 				{
 					new ContentPage()
 				},
-				FlyoutBehavior = FlyoutBehavior.Locked
-			};
+					FlyoutBehavior = FlyoutBehavior.Locked
+				};
+			});
 
 			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -46,13 +46,16 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task DetailsViewUpdates()
 		{
 			SetupBuilder();
-			var shell = new Shell()
-			{
-				Items =
-				{
-					new ContentPage()
-				}
-			};
+
+			var shell = await InvokeOnMainThreadAsync<Shell>(() => {
+				return new Shell()
+					{
+						Items =
+						{
+							new ContentPage()
+						}
+					};
+			});
 
 			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
 			{


### PR DESCRIPTION
Because creating the Shell accesses the current application Theme on Windows, it needs to happen on the UI thread. Otherwise, it'll crash with an access violation.