### PR TITLE
[Housekeeping] Fix incorrect encoding in XAML file templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:b="clr-namespace:Microsoft.AspNetCore.Components.WebView.Maui;assembly=Microsoft.AspNetCore.Components.WebView.Maui"

--- a/src/Templates/src/templates/maui-contentpage-xaml/NewPage1.xaml
+++ b/src/Templates/src/templates/maui-contentpage-xaml/NewPage1.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MauiApp1.NewPage1"

--- a/src/Templates/src/templates/maui-contentview-xaml/NewContent1.xaml
+++ b/src/Templates/src/templates/maui-contentview-xaml/NewContent1.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MauiApp1.NewContent1"

--- a/src/Templates/src/templates/maui-mobile/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/MainPage.xaml
@@ -1,4 +1,4 @@
-<?xml version = "1.0" encoding = "UTF-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MauiApp._1.MainPage"


### PR DESCRIPTION
### Description of Change ###

Fix incorrect encoding in XAML file templates.

Fixes

- https://github.com/dotnet/maui/issues/4848
- https://github.com/dotnet/maui/issues/3891
- https://github.com/dotnet/maui/issues/4420

There were a couple of xaml files in the templates with the wrong encoding. Checked the encoding after the changes:

![image](https://user-images.githubusercontent.com/6755973/155299292-dfe34730-f6e3-43e2-8227-ee4452521c4c.png)
![image](https://user-images.githubusercontent.com/6755973/155299343-00fd8239-25bd-4f4e-b7df-715abd0e3f77.png)

### PR Checklist ###

- [x] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)

#### Does this PR touch anything that might affect accessibility?
- No