### PR TITLE
Interfaced handlers for ShapeView, Slider, Stepper

### DIFF
--- a/src/Controls/src/Core/Handlers/Shapes/Line/LineHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Line/LineHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class LineHandler : ShapeViewHandler
 	{
-		public static IPropertyMapper<Line, LineHandler> LineMapper = new PropertyMapper<Line, LineHandler>(ShapeViewMapper)
+		public static IPropertyMapper<Line, LineHandler> LineMapper = new PropertyMapper<Line, LineHandler>(Mapper)
 		{
 			[nameof(Line.X1)] = MapX1,
 			[nameof(Line.Y1)] = MapY1,

--- a/src/Controls/src/Core/Handlers/Shapes/Path/PathHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Path/PathHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PathHandler : ShapeViewHandler
 	{
-		public static IPropertyMapper<Path, PathHandler> PathMapper = new PropertyMapper<Path, PathHandler>(ShapeViewMapper)
+		public static IPropertyMapper<Path, PathHandler> PathMapper = new PropertyMapper<Path, PathHandler>(Mapper)
 		{
 			[nameof(Path.Data)] = MapData,
 			[nameof(Path.RenderTransform)] = MapRenderTransform,

--- a/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PolygonHandler : ShapeViewHandler
 	{
-		public static IPropertyMapper<Polygon, PolygonHandler> PolygonMapper = new PropertyMapper<Polygon, PolygonHandler>(ShapeViewMapper)
+		public static IPropertyMapper<Polygon, PolygonHandler> PolygonMapper = new PropertyMapper<Polygon, PolygonHandler>(Mapper)
 		{
 			[nameof(Polygon.Points)] = MapPoints,
 		};

--- a/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PolylineHandler : ShapeViewHandler
 	{
-		public static IPropertyMapper<Polyline, PolylineHandler> PolylineMapper = new PropertyMapper<Polyline, PolylineHandler>(ShapeViewMapper)
+		public static IPropertyMapper<Polyline, PolylineHandler> PolylineMapper = new PropertyMapper<Polyline, PolylineHandler>(Mapper)
 		{
 			[nameof(Polyline.Points)] = MapPoints,
 		};

--- a/src/Controls/src/Core/Handlers/Shapes/Rectangle/RectangleHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Rectangle/RectangleHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class RectangleHandler : ShapeViewHandler
 	{
-		public static IPropertyMapper<Rectangle, RectangleHandler> RectangleMapper = new PropertyMapper<Rectangle, RectangleHandler>(ShapeViewMapper)
+		public static IPropertyMapper<Rectangle, RectangleHandler> RectangleMapper = new PropertyMapper<Rectangle, RectangleHandler>(Mapper)
 		{
 			[nameof(Rectangle.RadiusX)] = MapRadiusX,
 			[nameof(Rectangle.RadiusY)] = MapRadiusY,

--- a/src/Controls/src/Core/Handlers/Shapes/RoundRectangle/RoundRectangleHandler.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/RoundRectangle/RoundRectangleHandler.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class RoundRectangleHandler : ShapeViewHandler
 	{
-		public static IPropertyMapper<RoundRectangle, RoundRectangleHandler> RoundRectangleMapper = new PropertyMapper<RoundRectangle, RoundRectangleHandler>(ShapeViewMapper)
+		public static IPropertyMapper<RoundRectangle, RoundRectangleHandler> RoundRectangleMapper = new PropertyMapper<RoundRectangle, RoundRectangleHandler>(Mapper)
 		{
 			[nameof(RoundRectangle.CornerRadius)] = MapCornerRadius
 		};

--- a/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
@@ -1,0 +1,18 @@
+﻿#if __IOS__ || MACCATALYST
+using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
+#elif MONOANDROID
+using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial interface IShapeViewHandler : IViewHandler
+	{
+		new IShapeView VirtualView { get; }
+		new PlatformView PlatformView { get; }
+	}
+}

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Android.cs
@@ -7,47 +7,47 @@ namespace Microsoft.Maui.Handlers
 		protected override MauiShapeView CreatePlatformView() =>
 			new MauiShapeView(Context);
 
-		public static void MapShape(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapShape(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.UpdateShape(shapeView);
 		}
 
-		public static void MapAspect(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapAspect(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapFill(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapFill(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStroke(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStroke(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeThickness(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeThickness(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeDashPattern(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeDashPattern(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeLineCap(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeLineCap(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeLineJoin(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeLineJoin(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeMiterLimit(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeMiterLimit(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Standard.cs
@@ -7,14 +7,14 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override object CreatePlatformView() => throw new NotImplementedException();
 
-		public static void MapShape(IViewHandler handler, IShapeView shapeView) { }
-		public static void MapAspect(IViewHandler handler, IShapeView shapeView) { }
-		public static void MapFill(IViewHandler handler, IShapeView shapeView) { }
-		public static void MapStroke(IViewHandler handler, IShapeView shapeView) { }
-		public static void MapStrokeThickness(IViewHandler handler, IShapeView shapeView) { }
-		public static void MapStrokeDashPattern(IViewHandler handler, IShapeView shapeView) { }
-		public static void MapStrokeLineCap(IViewHandler handler, IShapeView shapeView) { }
-		public static void MapStrokeLineJoin(IViewHandler handler, IShapeView shapeView) { }
-		public static void MapStrokeMiterLimit(IViewHandler handler, IShapeView shapeView) { }
+		public static void MapShape(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapAspect(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapFill(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapStroke(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapStrokeThickness(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapStrokeDashPattern(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapStrokeLineCap(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapStrokeLineJoin(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapStrokeMiterLimit(IShapeViewHandler handler, IShapeView shapeView) { }
 	}
 }

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Windows.cs
@@ -10,47 +10,47 @@ namespace Microsoft.Maui.Handlers
 			return new W2DGraphicsView();
 		}
 
-		public static void MapShape(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapShape(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.UpdateShape(shapeView);
 		}
 
-		public static void MapAspect(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapAspect(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapFill(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapFill(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStroke(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStroke(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeThickness(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeThickness(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeDashPattern(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeDashPattern(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeLineCap(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeLineCap(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeLineJoin(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeLineJoin(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeMiterLimit(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeMiterLimit(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
@@ -1,10 +1,19 @@
-﻿using Microsoft.Maui.Graphics;
+﻿#if __IOS__ || MACCATALYST
+using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
+#elif MONOANDROID
+using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
+
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ShapeViewHandler
+	public partial class ShapeViewHandler : IShapeViewHandler
 	{
-		public static IPropertyMapper<IShapeView, ShapeViewHandler> ShapeViewMapper = new PropertyMapper<IShapeView, ShapeViewHandler>(ViewHandler.ViewMapper)
+		public static IPropertyMapper<IShapeView, IShapeViewHandler> Mapper = new PropertyMapper<IShapeView, IShapeViewHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(IShapeView.Shape)] = MapShape,
 			[nameof(IShapeView.Aspect)] = MapAspect,
@@ -17,14 +26,20 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IShapeView.StrokeMiterLimit)] = MapStrokeMiterLimit
 		};
 
-		public ShapeViewHandler() : base(ShapeViewMapper)
+		public static CommandMapper<IShapeView, IShapeViewHandler> CommandMapper = new(ViewCommandMapper)
 		{
+		};
 
+		public ShapeViewHandler() : base(Mapper)
+		{
 		}
 
-		public ShapeViewHandler(IPropertyMapper mapper) : base(mapper ?? ShapeViewMapper)
+		public ShapeViewHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
 		{
-
 		}
+
+		IShapeView IShapeViewHandler.VirtualView => VirtualView;
+
+		PlatformView IShapeViewHandler.PlatformView => PlatformView;
 	}
 }

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.iOS.cs
@@ -9,47 +9,47 @@ namespace Microsoft.Maui.Handlers
 			return new MauiShapeView();
 		}
 
-		public static void MapShape(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapShape(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.UpdateShape(shapeView);
 		}
 
-		public static void MapAspect(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapAspect(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapFill(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapFill(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStroke(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStroke(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeThickness(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeThickness(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeDashPattern(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeDashPattern(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeLineCap(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeLineCap(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeLineJoin(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeLineJoin(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
 
-		public static void MapStrokeMiterLimit(ShapeViewHandler handler, IShapeView shapeView)
+		public static void MapStrokeMiterLimit(IShapeViewHandler handler, IShapeView shapeView)
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}

--- a/src/Core/src/Handlers/Slider/ISliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/ISliderHandler.cs
@@ -1,0 +1,18 @@
+﻿#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UISlider;
+#elif MONOANDROID
+using PlatformView = Android.Widget.SeekBar;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Platform.MauiSlider;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial interface ISliderHandler : IViewHandler
+	{
+		new ISlider VirtualView { get; }
+		new PlatformView PlatformView { get; }
+	}
+}

--- a/src/Core/src/Handlers/Slider/SliderHandler.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.Android.cs
@@ -47,37 +47,37 @@ namespace Microsoft.Maui.Handlers
 			DefaultThumb = platformView.Thumb;
 		}
 
-		public static void MapMinimum(SliderHandler handler, ISlider slider)
+		public static void MapMinimum(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMinimum(slider);
 		}
 
-		public static void MapMaximum(SliderHandler handler, ISlider slider)
+		public static void MapMaximum(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMaximum(slider);
 		}
 
-		public static void MapValue(SliderHandler handler, ISlider slider)
+		public static void MapValue(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateValue(slider);
 		}
 
-		public static void MapMinimumTrackColor(SliderHandler handler, ISlider slider)
+		public static void MapMinimumTrackColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMinimumTrackColor(slider, DefaultProgressBackgroundTintList, DefaultProgressBackgroundTintMode);
 		}
 
-		public static void MapMaximumTrackColor(SliderHandler handler, ISlider slider)
+		public static void MapMaximumTrackColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMaximumTrackColor(slider, DefaultProgressTintList, DefaultProgressTintMode);
 		}
 
-		public static void MapThumbColor(SliderHandler handler, ISlider slider)
+		public static void MapThumbColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateThumbColor(slider, DefaultThumbColorFilter);
 		}
 
-		public static void MapThumbImageSource(SliderHandler handler, ISlider slider)
+		public static void MapThumbImageSource(ISliderHandler handler, ISlider slider)
 		{
 			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
 

--- a/src/Core/src/Handlers/Slider/SliderHandler.Windows.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.Windows.cs
@@ -61,37 +61,37 @@ namespace Microsoft.Maui.Handlers
 			DefaultThumbColor = platformView.Thumb?.Background;
 		}
 
-		public static void MapMinimum(SliderHandler handler, ISlider slider)
+		public static void MapMinimum(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMinimum(slider);
 		}
 
-		public static void MapMaximum(SliderHandler handler, ISlider slider)
+		public static void MapMaximum(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMaximum(slider);
 		}
 
-		public static void MapValue(SliderHandler handler, ISlider slider)
+		public static void MapValue(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateValue(slider);
 		}
 
-		public static void MapMinimumTrackColor(SliderHandler handler, ISlider slider)
+		public static void MapMinimumTrackColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMinimumTrackColor(slider, DefaultForegroundColor);
 		}
 
-		public static void MapMaximumTrackColor(SliderHandler handler, ISlider slider)
+		public static void MapMaximumTrackColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMaximumTrackColor(slider, DefaultBackgroundColor);
 		}
 
-		public static void MapThumbColor(SliderHandler handler, ISlider slider)
+		public static void MapThumbColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateThumbColor(slider, DefaultThumbColor);
 		}
 
-		public static void MapThumbImageSource(SliderHandler handler, ISlider slider)
+		public static void MapThumbImageSource(ISliderHandler handler, ISlider slider)
 		{
 			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
 

--- a/src/Core/src/Handlers/Slider/SliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.cs
@@ -1,9 +1,19 @@
 #nullable enable
+#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UISlider;
+#elif MONOANDROID
+using PlatformView = Android.Widget.SeekBar;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Platform.MauiSlider;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
+
 namespace Microsoft.Maui.Handlers
 {
-	public partial class SliderHandler
+	public partial class SliderHandler : ISliderHandler
 	{
-		public static IPropertyMapper<ISlider, SliderHandler> SliderMapper = new PropertyMapper<ISlider, SliderHandler>(ViewHandler.ViewMapper)
+		public static IPropertyMapper<ISlider, ISliderHandler> Mapper = new PropertyMapper<ISlider, ISliderHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(ISlider.Maximum)] = MapMaximum,
 			[nameof(ISlider.MaximumTrackColor)] = MapMaximumTrackColor,
@@ -14,14 +24,20 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ISlider.Value)] = MapValue,
 		};
 
-		public SliderHandler() : base(SliderMapper)
+		public static CommandMapper<ISlider, ISliderHandler> CommandMapper = new(ViewCommandMapper)
 		{
+		};
 
+		public SliderHandler() : base(Mapper)
+		{
 		}
 
-		public SliderHandler(IPropertyMapper? mapper = null) : base(mapper ?? SliderMapper)
+		public SliderHandler(IPropertyMapper? mapper = null) : base(mapper ?? Mapper)
 		{
-
 		}
+
+		ISlider ISliderHandler.VirtualView => VirtualView;
+
+		PlatformView ISliderHandler.PlatformView => PlatformView;
 	}
 }

--- a/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
@@ -37,37 +37,37 @@ namespace Microsoft.Maui.Handlers
 			DefaultThumbColor = platformView.ThumbTintColor;
 		}
 
-		public static void MapMinimum(SliderHandler handler, ISlider slider)
+		public static void MapMinimum(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMinimum(slider);
 		}
 
-		public static void MapMaximum(SliderHandler handler, ISlider slider)
+		public static void MapMaximum(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMaximum(slider);
 		}
 
-		public static void MapValue(SliderHandler handler, ISlider slider)
+		public static void MapValue(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateValue(slider);
 		}
 
-		public static void MapMinimumTrackColor(SliderHandler handler, ISlider slider)
+		public static void MapMinimumTrackColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMinimumTrackColor(slider, DefaultMinTrackColor);
 		}
 
-		public static void MapMaximumTrackColor(SliderHandler handler, ISlider slider)
+		public static void MapMaximumTrackColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateMaximumTrackColor(slider, DefaultMaxTrackColor);
 		}
 
-		public static void MapThumbColor(SliderHandler handler, ISlider slider)
+		public static void MapThumbColor(ISliderHandler handler, ISlider slider)
 		{
 			handler.PlatformView?.UpdateThumbColor(slider, DefaultThumbColor);
 		}
 
-		public static void MapThumbImageSource(SliderHandler handler, ISlider slider)
+		public static void MapThumbImageSource(ISliderHandler handler, ISlider slider)
 		{
 			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
 

--- a/src/Core/src/Handlers/Stepper/IStepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/IStepperHandler.cs
@@ -1,0 +1,18 @@
+﻿#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UIStepper;
+#elif MONOANDROID
+using PlatformView = Android.Widget.LinearLayout;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Platform.MauiStepper;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
+
+namespace Microsoft.Maui.Handlers
+{
+	public partial interface IStepperHandler : IViewHandler
+	{
+		new IStepper VirtualView { get; }
+		new PlatformView PlatformView { get; }
+	}
+}

--- a/src/Core/src/Handlers/Stepper/StepperHandler.Android.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.Android.cs
@@ -6,16 +6,15 @@ using AOrientation = Android.Widget.Orientation;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class StepperHandler : ViewHandler<IStepper, LinearLayout>, IStepperHandler
+	public partial class StepperHandler : ViewHandler<IStepper, LinearLayout>, IAndroidStepperHandler
 	{
 		AButton? _downButton;
 		AButton? _upButton;
 
-		IStepper? IStepperHandler.VirtualView => VirtualView;
 
-		AButton? IStepperHandler.UpButton => _upButton;
+		AButton? IAndroidStepperHandler.UpButton => _upButton;
 
-		AButton? IStepperHandler.DownButton => _downButton;
+		AButton? IAndroidStepperHandler.DownButton => _downButton;
 
 		protected override LinearLayout CreatePlatformView()
 		{
@@ -37,27 +36,27 @@ namespace Microsoft.Maui.Handlers
 			return stepperLayout;
 		}
 
-		public static void MapMinimum(StepperHandler handler, IStepper stepper)
+		public static void MapMinimum(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateMinimum(stepper);
 		}
 
-		public static void MapMaximum(StepperHandler handler, IStepper stepper)
+		public static void MapMaximum(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateMaximum(stepper);
 		}
 
-		public static void MapIncrement(StepperHandler handler, IStepper stepper)
+		public static void MapIncrement(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateIncrement(stepper);
 		}
 
-		public static void MapValue(StepperHandler handler, IStepper stepper)
+		public static void MapValue(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateValue(stepper);
 		}
 
-		AButton IStepperHandler.CreateButton()
+		AButton IAndroidStepperHandler.CreateButton()
 		{
 			if (Context == null)
 				throw new ArgumentException("Context is null or empty", nameof(Context));

--- a/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
@@ -21,28 +21,28 @@ namespace Microsoft.Maui.Handlers
 			base.DisconnectHandler(platformView);
 		}
 
-		public static void MapMinimum(StepperHandler handler, IStepper stepper) 
+		public static void MapMinimum(IStepperHandler handler, IStepper stepper) 
 		{ 
 			handler.PlatformView?.UpdateMinimum(stepper); 
 		}
 
-		public static void MapMaximum(StepperHandler handler, IStepper stepper) 
+		public static void MapMaximum(IStepperHandler handler, IStepper stepper) 
 		{ 
 			handler.PlatformView?.UpdateMaximum(stepper); 
 		}
 
-		public static void MapIncrement(StepperHandler handler, IStepper stepper) 
+		public static void MapIncrement(IStepperHandler handler, IStepper stepper) 
 		{ 
 			handler.PlatformView?.UpdateInterval(stepper); 
 		}
 
-		public static void MapValue(StepperHandler handler, IStepper stepper) 
+		public static void MapValue(IStepperHandler handler, IStepper stepper) 
 		{ 
 			handler.PlatformView?.UpdateValue(stepper); 
 		}
 
 		// This is a Windows-specific mapping
-		public static void MapBackground(StepperHandler handler, IStepper view)
+		public static void MapBackground(IStepperHandler handler, IStepper view)
 		{
 			handler.PlatformView?.UpdateBackground(view);
 		}

--- a/src/Core/src/Handlers/Stepper/StepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.cs
@@ -1,8 +1,18 @@
-﻿namespace Microsoft.Maui.Handlers
+﻿#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UIStepper;
+#elif MONOANDROID
+using PlatformView = Android.Widget.LinearLayout;
+#elif WINDOWS
+using PlatformView = Microsoft.Maui.Platform.MauiStepper;
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+using PlatformView = System.Object;
+#endif
+
+namespace Microsoft.Maui.Handlers
 {
-	public partial class StepperHandler
+	public partial class StepperHandler : IStepperHandler
 	{
-		public static IPropertyMapper<IStepper, StepperHandler> StepperMapper = new PropertyMapper<IStepper, StepperHandler>(ViewHandler.ViewMapper)
+		public static IPropertyMapper<IStepper, IStepperHandler> Mapper = new PropertyMapper<IStepper, StepperHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(IStepper.Interval)] = MapIncrement,
 			[nameof(IStepper.Maximum)] = MapMaximum,
@@ -13,14 +23,20 @@
 #endif
 		};
 
-		public StepperHandler() : base(StepperMapper)
+		public static CommandMapper<IStepper, IStepperHandler> CommandMapper = new(ViewCommandMapper)
 		{
+		};
 
+		public StepperHandler() : base(Mapper)
+		{
 		}
 
-		public StepperHandler(IPropertyMapper mapper) : base(mapper ?? StepperMapper)
+		public StepperHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
 		{
-
 		}
+
+		IStepper IStepperHandler.VirtualView => VirtualView;
+
+		PlatformView IStepperHandler.PlatformView => PlatformView;
 	}
 }

--- a/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.iOS.cs
@@ -26,22 +26,22 @@ namespace Microsoft.Maui.Handlers
 			platformView.ValueChanged -= OnValueChanged;
 		}
 
-		public static void MapMinimum(StepperHandler handler, IStepper stepper)
+		public static void MapMinimum(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateMinimum(stepper);
 		}
 
-		public static void MapMaximum(StepperHandler handler, IStepper stepper)
+		public static void MapMaximum(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateMaximum(stepper);
 		}
 
-		public static void MapIncrement(StepperHandler handler, IStepper stepper)
+		public static void MapIncrement(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateIncrement(stepper);
 		}
 
-		public static void MapValue(StepperHandler handler, IStepper stepper)
+		public static void MapValue(IStepperHandler handler, IStepper stepper)
 		{
 			handler.PlatformView?.UpdateValue(stepper);
 		}

--- a/src/Core/src/Platform/Android/StepperHandlerManager.cs
+++ b/src/Core/src/Platform/Android/StepperHandlerManager.cs
@@ -5,30 +5,28 @@ using AView = Android.Views.View;
 
 namespace Microsoft.Maui.Platform
 {
-	public interface IStepperHandler
+	public interface IAndroidStepperHandler : IStepperHandler
 	{
 		AButton? UpButton { get; }
 
 		AButton? DownButton { get; }
 
 		AButton CreateButton();
-
-		IStepper? VirtualView { get; }
 	}
 
 	public class StepperHandlerHolder : Java.Lang.Object
 	{
-		public StepperHandlerHolder(IStepperHandler handler)
+		public StepperHandlerHolder(IAndroidStepperHandler handler)
 		{
 			StepperHandler = handler;
 		}
 
-		public IStepperHandler StepperHandler { get; set; }
+		public IAndroidStepperHandler StepperHandler { get; set; }
 	}
 
 	public static class StepperHandlerManager
 	{
-		public static void CreateStepperButtons<TButton>(IStepperHandler handler, out TButton? downButton, out TButton? upButton)
+		public static void CreateStepperButtons<TButton>(IAndroidStepperHandler handler, out TButton? downButton, out TButton? upButton)
 			where TButton : AButton
 		{
 			downButton = (TButton)handler.CreateButton();


### PR DESCRIPTION
Contributes to https://github.com/dotnet/maui/issues/4378.

There was an existing `Microsoft.Maui.Platform.IStepperHandler` interface coupled to `Microsoft.Maui.Platform.StepperHandlerManager` for Android. I changed it to be a derived interface `IAndroidStepperHandler : IStepperHandler`.

This PR does not rename the mappers in `Controls.Core/Handlers/Shapes` handlers.