### PR TITLE
Fix Razor compilation when running inside WPF's GenerateTemporaryTargetAssembly sub-build

### DIFF
--- a/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml.cs
+++ b/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml.cs
@@ -45,8 +45,4 @@ namespace BlazorWpfApp
 			blazorWebView1.WebView.CoreWebView2.ExecuteScriptAsync("alert('hello from native UI')");
 		}
 	}
-
-	// Workaround for compiler error "error MC3050: Cannot find the type 'local:Main'"
-	// It seems that, although WPF's design-time build can see Razor components, its runtime build cannot.
-	public partial class Main { }
 }

--- a/src/BlazorWebView/src/Wpf/build/Microsoft.AspNetCore.Components.WebView.Wpf.targets
+++ b/src/BlazorWebView/src/Wpf/build/Microsoft.AspNetCore.Components.WebView.Wpf.targets
@@ -6,7 +6,7 @@
     <CoreCompileDependsOn Condition="'$(PublishProtocol)' == 'ClickOnce' or '$(PublishProtocol)' == 'FileSystem'">$(CoreCompileDependsOn);StaticWebAssetsPrepareForRun</CoreCompileDependsOn>
 
     <!-- Workaround for https://github.com/dotnet/wpf/issues/5697 (fixes https://github.com/dotnet/maui/issues/3526) -->
-    <RootNamespace Condition="$(UseWPF) == 'true' AND $(RootNamespace.EndsWith('_wpftmp'))">$(_TargetAssemblyProjectName)</RootNamespace>
+    <RootNamespace Condition="'$(UseWPF)' == 'true' AND $(RootNamespace.EndsWith('_wpftmp'))">$(_TargetAssemblyProjectName)</RootNamespace>
   </PropertyGroup>
 
   <Target Name="AddStaticWebAssetsForClickOnce" AfterTargets="ComputeFilesToPublish" Condition="'$(PublishProtocol)' == 'ClickOnce'">

--- a/src/BlazorWebView/src/Wpf/build/Microsoft.AspNetCore.Components.WebView.Wpf.targets
+++ b/src/BlazorWebView/src/Wpf/build/Microsoft.AspNetCore.Components.WebView.Wpf.targets
@@ -4,6 +4,9 @@
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
     <StaticWebAssetProjectMode>Root</StaticWebAssetProjectMode>
     <CoreCompileDependsOn Condition="'$(PublishProtocol)' == 'ClickOnce' or '$(PublishProtocol)' == 'FileSystem'">$(CoreCompileDependsOn);StaticWebAssetsPrepareForRun</CoreCompileDependsOn>
+
+    <!-- Workaround for https://github.com/dotnet/wpf/issues/5697 (fixes https://github.com/dotnet/maui/issues/3526) -->
+    <RootNamespace Condition="$(UseWPF) == 'true' AND $(RootNamespace.EndsWith('_wpftmp'))">$(_TargetAssemblyProjectName)</RootNamespace>
   </PropertyGroup>
 
   <Target Name="AddStaticWebAssetsForClickOnce" AfterTargets="ComputeFilesToPublish" Condition="'$(PublishProtocol)' == 'ClickOnce'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/3526

The issue is that WPF's build targets perform a sub-build called `GenerateTemporaryTargetAssembly` using an auto-generated random project name. The Razor compiler by default uses the project name as the root namespace for components, so you end up compiling components with names like `MyProject_du828d5_wpftmp.Shared.SurveyPrompt`, hence a line in `_Imports.razor` like `@using MyProject.Shared` results in a compiler error complaining that `MyProject.Shared` doesn't exist (whereas `MyProject_du828d5_wpftmp.Shared` actually does).

This is a known problem with WPF compilation: https://github.com/dotnet/wpf/issues/5697. This might get fixed externally eventually, but in the meantime, we can use a pretty simple fix by setting `RootNamespace` ourselves explicitly in this particular case.

One could argue that the fix isn't specific to Blazor Hybrid and could go into the Razor SDK itself, since theoretically someone might try to use the Razor SDK in a non-Blazor-Hybrid WPF project. However I don't think we should go looking for broader problems to solve here. A targeted workaround is less likely to cause any unwanted side-effects, and is safer to remove in the future if the external issue does get resolved.