### PR TITLE
[iOS][macOS] Remove more superflous version checks

### DIFF
--- a/src/Compatibility/Core/src/Handlers/ListView/iOS/ListViewRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/ListView/iOS/ListViewRenderer.cs
@@ -1518,8 +1518,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			? UITableViewStyle.Plain
 			  : UITableViewStyle.Grouped)
 		{
-			if (PlatformVersion.IsAtLeast(9))
-				TableView.CellLayoutMarginsFollowReadableWidth = false;
+			TableView.CellLayoutMarginsFollowReadableWidth = false;
 
 			_usingLargeTitles = usingLargeTitles;
 

--- a/src/Compatibility/Core/src/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -153,17 +153,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			// Setting TabBarItem.Title in iOS 10 causes rendering bugs
 			// Work around this by creating a new UITabBarItem on each change
-			if (e.PropertyName == Page.TitleProperty.PropertyName && !PlatformVersion.IsAtLeast(10))
-			{
-				var page = (Page)sender;
-				var renderer = page.ToHandler(_mauiContext);
-				if (renderer == null)
-					return;
-
-				if (renderer.ViewController.TabBarItem != null)
-					renderer.ViewController.TabBarItem.Title = page.Title;
-			}
-			else if (e.PropertyName == Page.IconImageSourceProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName && PlatformVersion.IsAtLeast(10))
+			if (e.PropertyName == Page.IconImageSourceProperty.PropertyName || e.PropertyName == Page.TitleProperty.PropertyName)
 			{
 				var page = (Page)sender;
 
@@ -445,22 +435,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (Tabbed.IsSet(TabbedPage.SelectedTabColorProperty) && Tabbed.SelectedTabColor != null)
 			{
-				if (PlatformVersion.IsAtLeast(10))
-					TabBar.TintColor = Tabbed.SelectedTabColor.ToPlatform();
-				else
-					TabBar.SelectedImageTintColor = Tabbed.SelectedTabColor.ToPlatform();
-
+				TabBar.TintColor = Tabbed.SelectedTabColor.ToPlatform();
 			}
 			else
 			{
-				if (PlatformVersion.IsAtLeast(10))
-					TabBar.TintColor = UITabBar.Appearance.TintColor;
-				else
-					TabBar.SelectedImageTintColor = UITabBar.Appearance.SelectedImageTintColor;
+				TabBar.TintColor = UITabBar.Appearance.TintColor;
 			}
-
-			if (!PlatformVersion.IsAtLeast(10))
-				return;
 
 			if (Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) && Tabbed.UnselectedTabColor != null)
 				TabBar.UnselectedItemTintColor = Tabbed.UnselectedTabColor.ToPlatform();

--- a/src/Compatibility/Core/src/Handlers/TableView/iOS/TableViewRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/TableView/iOS/TableViewRenderer.cs
@@ -89,8 +89,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					_originalBackgroundView = tv.BackgroundView;
 
 					SetNativeControl(tv);
-					if (PlatformVersion.IsAtLeast(9))
-						tv.CellLayoutMarginsFollowReadableWidth = false;
+					tv.CellLayoutMarginsFollowReadableWidth = false;
 
 					_insetTracker = new KeyboardInsetTracker(tv, () => Control.Window, insets => Control.ContentInset = Control.ScrollIndicatorInsets = insets, point =>
 					{

--- a/src/Compatibility/Core/src/iOS/Forms.cs
+++ b/src/Compatibility/Core/src/iOS/Forms.cs
@@ -117,29 +117,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 			}
 		}
 #else
-		static bool? s_isSierraOrNewer;
-
-		internal static bool IsSierraOrNewer
-		{
-			get
-			{
-				if (!s_isSierraOrNewer.HasValue)
-					s_isSierraOrNewer = NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(new NSOperatingSystemVersion(10, 12, 0));
-				return s_isSierraOrNewer.Value;
-			}
-		}
-
-		static bool? s_isHighSierraOrNewer;
-
-		internal static bool IsHighSierraOrNewer
-		{
-			get
-			{
-				if (!s_isHighSierraOrNewer.HasValue)
-					s_isHighSierraOrNewer = NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(new NSOperatingSystemVersion(10, 13, 0));
-				return s_isHighSierraOrNewer.Value;
-			}
-		}
 
 		static bool? s_isMojaveOrNewer;
 
@@ -148,7 +125,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isMojaveOrNewer.HasValue)
-					s_isMojaveOrNewer = NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(new NSOperatingSystemVersion(10, 14, 0));
+					s_isMojaveOrNewer = OperatingSystem.IsMacOSVersionAtLeast (10, 14);
 				return s_isMojaveOrNewer.Value;
 			}
 		}

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -270,19 +270,6 @@ namespace Microsoft.Maui.Platform
 
 		public static UIImage? ConvertToImage(this UIView view)
 		{
-			if (!PlatformVersion.IsAtLeast(10))
-			{
-				UIGraphics.BeginImageContext(view.Frame.Size);
-				view.Layer.RenderInContext(UIGraphics.GetCurrentContext());
-				var image = UIGraphics.GetImageFromCurrentImageContext();
-				UIGraphics.EndImageContext();
-
-				if (image.CGImage == null)
-					return null;
-
-				return new UIImage(image.CGImage);
-			}
-
 			var imageRenderer = new UIGraphicsImageRenderer(view.Bounds.Size);
 
 			return imageRenderer.CreateImage((a) =>


### PR DESCRIPTION
Context: #461

Checks for macOS High Sierra 10.13 and lower have been removed.  The
macOS Mojave check has been updated to use `IsMacOSVersionAtLeast`.

Some other checks for iOS 10 and lower have also been removed as they
should not be needed.