### PR TITLE
[Essentials] Fix maciOS version checks

### DIFF
--- a/src/Compatibility/Core/src/iOS/Forms.cs
+++ b/src/Compatibility/Core/src/iOS/Forms.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS11OrNewer.HasValue)
-					s_isiOS11OrNewer = OperatingSystem.IsIOSVersionAtLeast(11, 0);
+					s_isiOS11OrNewer = OperatingSystem.IsIOSVersionAtLeast(11, 0) || OperatingSystem.IsTvOSVersionAtLeast(11, 0);
 				return s_isiOS11OrNewer.Value;
 			}
 		}
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS12OrNewer.HasValue)
-					s_isiOS12OrNewer = OperatingSystem.IsIOSVersionAtLeast(12, 0);
+					s_isiOS12OrNewer = OperatingSystem.IsIOSVersionAtLeast(12, 0) || OperatingSystem.IsTvOSVersionAtLeast(12, 0);
 				return s_isiOS12OrNewer.Value;
 			}
 		}
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS13OrNewer.HasValue)
-					s_isiOS13OrNewer = OperatingSystem.IsIOSVersionAtLeast(13, 0);
+					s_isiOS13OrNewer = OperatingSystem.IsIOSVersionAtLeast(13, 0) || OperatingSystem.IsTvOSVersionAtLeast(13, 0);
 				return s_isiOS13OrNewer.Value;
 			}
 		}
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS14OrNewer.HasValue)
-					s_isiOS14OrNewer = OperatingSystem.IsIOSVersionAtLeast(14, 0);
+					s_isiOS14OrNewer = OperatingSystem.IsIOSVersionAtLeast(14, 0) || OperatingSystem.IsTvOSVersionAtLeast(14, 0);
 				return s_isiOS14OrNewer.Value;
 			}
 		}
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 			get
 			{
 				if (!s_isiOS15OrNewer.HasValue)
-					s_isiOS15OrNewer = OperatingSystem.IsIOSVersionAtLeast(15, 0);
+					s_isiOS15OrNewer = OperatingSystem.IsIOSVersionAtLeast(15, 0) || OperatingSystem.IsTvOSVersionAtLeast(15, 0);
 				return s_isiOS15OrNewer.Value;
 			}
 		}

--- a/src/Core/src/Platform/iOS/ElementExtensions.cs
+++ b/src/Core/src/Platform/iOS/ElementExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Platform
 		// If < iOS 13 or the Info.plist does not have a scene manifest entry we need to assume no multi window, and no UISceneDelegate.
 		// We cannot check for iPads/Mac because even on the iPhone it uses the scene delegate if one is specified in the manifest.
 		public static bool HasSceneManifest(this IUIApplicationDelegate platformApplication) =>
-			OperatingSystem.IsIOSVersionAtLeast(13, 0) &&
+			(OperatingSystem.IsIOSVersionAtLeast(13, 0) || OperatingSystem.IsTvOSVersionAtLeast(13,0)) &&
 			NSBundle.MainBundle.InfoDictionary.ContainsKey(new NSString(UIApplicationSceneManifestKey));
 	}
 }

--- a/src/Core/src/Platform/iOS/PlatformVersion.cs
+++ b/src/Core/src/Platform/iOS/PlatformVersion.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platform
 	{
 		public static bool IsAtLeast(int version)
 		{
-			return OperatingSystem.IsIOSVersionAtLeast(version);
+			return OperatingSystem.IsIOSVersionAtLeast(version) || OperatingSystem.IsTvOSVersionAtLeast(version);
 		}
 
 		private static bool? SetNeedsUpdateOfHomeIndicatorAutoHidden;

--- a/src/Essentials/src/AppActions/AppActions.ios.cs
+++ b/src/Essentials/src/AppActions/AppActions.ios.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 		public string Type => "XE_APP_ACTION_TYPE";
 
 		public bool IsSupported
-			=> Platform.HasOSVersion(9, 0);
+			=> true;
 
 		public Task<IEnumerable<AppAction>> GetAsync()
 		{

--- a/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 		{
 			get
 			{
-				if (!Platform.HasOSVersion(13, 0))
+				if ((OperatingSystem.IsIOS() && !OperatingSystem.IsIOSVersionAtLeast(13, 0)) || (OperatingSystem.IsTvOS() && !OperatingSystem.IsTvOSVersionAtLeast(13, 0)))
 					return AppTheme.Unspecified;
 
 				var uiStyle = Platform.GetCurrentUIViewController()?.TraitCollection?.UserInterfaceStyle ??
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Essentials.Implementations
         {
 			get
 			{
-				if (DeviceInfo.Version >= new Version(10, 14))
+				if (OperatingSystem.IsMacOSVersionAtLeast(10, 14))
 				{
 					var app = NSAppearance.CurrentAppearance?.FindBestMatch(new string[]
 					{

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.ios.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 				density: scale,
 				orientation: CalculateOrientation(),
 				rotation: CalculateRotation(),
-				rate: Platform.HasOSVersion(10, 3) ? UIScreen.MainScreen.MaximumFramesPerSecond : 0);
+				rate: (OperatingSystem.IsIOSVersionAtLeast(10, 3) || OperatingSystem.IsTvOSVersionAtLeast(10, 3)) ? UIScreen.MainScreen.MaximumFramesPerSecond : 0);
 		}
 
 		public void StartScreenMetricsListeners()

--- a/src/Essentials/src/FilePicker/FilePicker.ios.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.ios.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Essentials
 			// Use Open instead of Import so that we can attempt to use the original file.
 			// If the file is from an external provider, then it will be downloaded.
 			using var documentPicker = new UIDocumentPickerViewController(allowedUtis, UIDocumentPickerMode.Open);
-			if (Platform.HasOSVersion(11, 0))
+			if (OperatingSystem.IsIOSVersionAtLeast(11, 0))
 				documentPicker.AllowsMultipleSelection = allowMultiple;
 			documentPicker.Delegate = new PickerDelegate
 			{

--- a/src/Essentials/src/HapticFeedback/HapticFeedback.ios.cs
+++ b/src/Essentials/src/HapticFeedback/HapticFeedback.ios.cs
@@ -24,24 +24,18 @@ namespace Microsoft.Maui.Essentials.Implementations
 
 		void Click()
 		{
-			if (Platform.HasOSVersion(10, 0))
-			{
-				var impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Light);
-				impact.Prepare();
-				impact.ImpactOccurred();
-				impact.Dispose();
-			}
+			var impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Light);
+			impact.Prepare();
+			impact.ImpactOccurred();
+			impact.Dispose();
 		}
 
 		public void LongPress()
 		{
-			if (Platform.HasOSVersion(10, 0))
-			{
-				var impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Medium);
-				impact.Prepare();
-				impact.ImpactOccurred();
-				impact.Dispose();
-			}
+			var impact = new UIImpactFeedbackGenerator(UIImpactFeedbackStyle.Medium);
+			impact.Prepare();
+			impact.ImpactOccurred();
+			impact.Dispose();
 		}
 	}
 }

--- a/src/Essentials/src/Launcher/Launcher.ios.tvos.cs
+++ b/src/Essentials/src/Launcher/Launcher.ios.tvos.cs
@@ -18,9 +18,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			PlatformOpenAsync(WebUtils.GetNativeUrl(uri));
 
 		Task<bool> PlatformOpenAsync(NSUrl nativeUrl) =>
-			Platform.HasOSVersion(10, 0)
-				? UIApplication.SharedApplication.OpenUrlAsync(nativeUrl, new UIApplicationOpenUrlOptions())
-				: Task.FromResult(UIApplication.SharedApplication.OpenUrl(nativeUrl));
+			UIApplication.SharedApplication.OpenUrlAsync(nativeUrl, new UIApplicationOpenUrlOptions());
 
 		Task<bool> PlatformTryOpenAsync(Uri uri)
 		{

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 				await Permissions.EnsureGrantedAsync<Permissions.Microphone>();
 
 			// Check if picking existing or not and ensure permission accordingly as they can be set independently from each other
-			if (pickExisting && !Platform.HasOSVersion(11, 0))
+			if (pickExisting && !OperatingSystem.IsIOSVersionAtLeast(11, 0))
 				await Permissions.EnsureGrantedAsync<Permissions.Photos>();
 
 			if (!pickExisting)
@@ -109,7 +109,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			PHAsset phAsset = null;
 			NSUrl assetUrl = null;
 
-			if (Platform.HasOSVersion(11, 0))
+			if (OperatingSystem.IsIOSVersionAtLeast(11, 0))
 			{
 				assetUrl = info[UIImagePickerController.ImageUrl] as NSUrl;
 
@@ -147,13 +147,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			if (phAsset == null || assetUrl == null)
 				return null;
 
-			string originalFilename;
-
-			if (Platform.HasOSVersion(9, 0))
-				originalFilename = PHAssetResource.GetAssetResources(phAsset).FirstOrDefault()?.OriginalFilename;
-			else
-				originalFilename = phAsset.ValueForKey(new NSString("filename")) as NSString;
-
+			string originalFilename = PHAssetResource.GetAssetResources(phAsset).FirstOrDefault()?.OriginalFilename;
 			return new PHAssetFileResult(assetUrl, phAsset, originalFilename);
 		}
 

--- a/src/Essentials/src/Permissions/Permissions.ios.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.cs
@@ -168,10 +168,6 @@ namespace Microsoft.Maui.Essentials
 
 			internal static PermissionStatus GetMediaPermissionStatus()
 			{
-				// Only available in 9.3+
-				if (!Platform.HasOSVersion(9, 3))
-					return PermissionStatus.Unknown;
-
 				var status = MPMediaLibrary.AuthorizationStatus;
 				return status switch
 				{
@@ -184,10 +180,6 @@ namespace Microsoft.Maui.Essentials
 
 			internal static Task<PermissionStatus> RequestMediaPermission()
 			{
-				// Only available in 9.3+
-				if (!Platform.HasOSVersion(9, 3))
-					return Task.FromResult(PermissionStatus.Unknown);
-
 				var tcs = new TaskCompletionSource<PermissionStatus>();
 
 				MPMediaLibrary.RequestAuthorization(s =>
@@ -278,9 +270,6 @@ namespace Microsoft.Maui.Essentials
 
 			internal static Task<PermissionStatus> RequestSpeechPermission()
 			{
-				if (!Platform.HasOSVersion(10, 0))
-					return Task.FromResult(PermissionStatus.Unknown);
-
 				var tcs = new TaskCompletionSource<PermissionStatus>();
 
 				SFSpeechRecognizer.RequestAuthorization(s =>

--- a/src/Essentials/src/Permissions/Permissions.ios.tvos.macos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.tvos.macos.cs
@@ -92,11 +92,10 @@ namespace Microsoft.Maui.Essentials
 			};
 
 		static bool CheckOSVersionForPhotos()
-#if __MACOS__
-        => Platform.HasOSVersion(11, 0);
-#else
-		=> Platform.HasOSVersion(14, 0);
-#endif
-
+		{
+			return OperatingSystem.IsIOSVersionAtLeast(14, 0) ||
+				OperatingSystem.IsMacOSVersionAtLeast(11, 0) ||
+				OperatingSystem.IsTvOSVersionAtLeast(14, 0);
+		}
 	}
 }

--- a/src/Essentials/src/Permissions/Permissions.ios.watchos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.watchos.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Essentials
 				if (!CMMotionActivityManager.IsActivityAvailable)
 					return PermissionStatus.Disabled;
 
-				if (Platform.HasOSVersion(11, 0))
+				if (OperatingSystem.IsIOSVersionAtLeast(11, 0) || OperatingSystem.IsWatchOSVersionAtLeast(4, 0))
 				{
 					switch (CMMotionActivityManager.AuthorizationStatus)
 					{

--- a/src/Essentials/src/Platform/Platform.ios.tvos.watchos.cs
+++ b/src/Essentials/src/Platform/Platform.ios.tvos.watchos.cs
@@ -69,9 +69,6 @@ namespace Microsoft.Maui.Essentials
 			return returnValue;
 		}
 
-		internal static bool HasOSVersion(int major, int minor) =>
-			OperatingSystem.IsIOSVersionAtLeast(major, minor);
-
 #if __IOS__ || __TVOS__
 
 		static Func<UIViewController> getCurrentController;

--- a/src/Essentials/src/Platform/Platform.macos.cs
+++ b/src/Essentials/src/Platform/Platform.macos.cs
@@ -19,12 +19,6 @@ namespace Microsoft.Maui.Essentials
 
 			return window;
 		}
-
-		internal static bool HasOSVersion(int major, int minor)
-		{
-			using var info = new NSProcessInfo();
-			return info.IsOperatingSystemAtLeastVersion(new NSOperatingSystemVersion(major, minor, 0));
-		}
 	}
 
 	internal static class CoreGraphicsInterop

--- a/src/Essentials/src/Share/Share.ios.cs
+++ b/src/Essentials/src/Share/Share.ios.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundation;
@@ -31,7 +32,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			{
 				activityController.PopoverPresentationController.SourceView = vc.View;
 
-				if (request.PresentationSourceBounds != Rectangle.Zero || Platform.HasOSVersion(13, 0))
+				if (request.PresentationSourceBounds != Rectangle.Zero || OperatingSystem.IsIOSVersionAtLeast(13, 0))
 					activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.AsCGRect();
 			}
 
@@ -60,7 +61,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			{
 				activityController.PopoverPresentationController.SourceView = vc.View;
 
-				if (request.PresentationSourceBounds != Rectangle.Zero || Platform.HasOSVersion(13, 0))
+				if (request.PresentationSourceBounds != Rectangle.Zero || OperatingSystem.IsIOSVersionAtLeast(13, 0))
 					activityController.PopoverPresentationController.SourceRect = request.PresentationSourceBounds.AsCGRect();
 			}
 

--- a/src/Essentials/src/Types/LocationExtensions.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/Types/LocationExtensions.ios.tvos.watchos.macos.cs
@@ -55,13 +55,10 @@ namespace Microsoft.Maui.Essentials
 
 		internal static CLAuthorizationStatus GetAuthorizationStatus(this CLLocationManager locationManager)
 		{
-#if __MACOS__
-            if (DeviceInfo.Version >= new Version(11, 0))
-#elif __WATCHOS__
-            if (Platform.HasOSVersion(7, 0))
-#else
-			if (Platform.HasOSVersion(14, 0))
-#endif
+			if (OperatingSystem.IsIOSVersionAtLeast(14, 0) ||
+				OperatingSystem.IsMacOSVersionAtLeast(11, 0) ||
+				OperatingSystem.IsWatchOSVersionAtLeast(7, 0) ||
+				OperatingSystem.IsTvOSVersionAtLeast(14, 0))
 			{
 				// return locationManager.AuthorizationStatus;
 

--- a/src/Essentials/src/WebAuthenticator/AppleSignInAuthenticator.ios.cs
+++ b/src/Essentials/src/WebAuthenticator/AppleSignInAuthenticator.ios.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 
 		public async Task<WebAuthenticatorResult> AuthenticateAsync(AppleSignInAuthenticator.Options options)
 		{
-			if (DeviceInfo.Version.Major < 13)
+			if (!OperatingSystem.IsIOSVersionAtLeast(13))
 				throw new FeatureNotSupportedException();
 
 			var provider = new ASAuthorizationAppleIdProvider();

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 		static bool VerifyHasUrlSchemeOrDoesntRequire(string scheme)
 		{
 			// iOS11+ uses sfAuthenticationSession which handles its own url routing
-			if (OperatingSystem.IsIOSVersionAtLeast(11, 0))
+			if (OperatingSystem.IsIOSVersionAtLeast(11, 0) || OperatingSystem.IsTvOSVersionAtLeast (11, 0))
 				return true;
 
 			return AppInfoImplementation.VerifyHasUrlScheme(scheme);

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.macos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.macos.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			redirectUri = callbackUrl;
 			var scheme = redirectUri.Scheme;
 
-			if (DeviceInfo.Version >= new Version(10, 15))
+			if (OperatingSystem.IsMacOSVersionAtLeast(10, 15))
 			{
 				static void AuthSessionCallback(NSUrl cbUrl, NSError error)
 				{

--- a/src/Essentials/test/DeviceTests/Tests/AppActions_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/AppActions_Tests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 #if __ANDROID__
 			expectSupported = OperatingSystem.IsAndroidVersionAtLeast(25);
 #elif __IOS__
-			expectSupported = Platform.HasOSVersion(9, 0);
+			expectSupported = true;
 #endif
 
 			Assert.Equal(expectSupported, AppActions.IsSupported);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/461

Commit 158ffbd3 accidentially introduced what was likely a breaking
change in `Platform.ios.tvos.watchos.HasOSVersion`.  The call to
`UIDevice.CurrentDevice.CheckSystemVersion` was replaced by
`OperatingSystem.IsIOSVersionAtLeast`, however `HasOSVersion` was used
on platforms other than iOS.

Fix this oversight by removing `HasOSVersion` entirely, and use the
correct `Is$(Platform)VersionAtLeast` variant at all call sites instead.

`OperatingSystem.IsIOSVersionAtLeast` will work on iOS and MacCatalyst,
but not on tvOS. Additional tvOS checks have been added as needed.

Instances of `DeviceInfo.Version` have also been replaced by
`Is$(Platform)VersionAtLeast` where applicable.