### PR TITLE
IBorder now works again for iOS/Android

### DIFF
--- a/src/Core/src/Platform/Android/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Android/StrokeExtensions.cs
@@ -5,6 +5,26 @@ namespace Microsoft.Maui.Platform
 {
 	public static class StrokeExtensions
 	{
+		public static void UpdateBorderStroke(this AView platformView, IBorderStroke border)
+		{
+			//Always set the drawable first
+			platformView.UpdateMauiDrawable(border);
+
+			var borderShape = border.Shape;
+			MauiDrawable? mauiDrawable = platformView.Background as MauiDrawable;
+
+			if (mauiDrawable == null && borderShape == null)
+				return;
+			mauiDrawable?.SetBorderBrush(border.Stroke);
+			mauiDrawable?.SetBorderWidth(border.StrokeThickness);
+			platformView.UpdateStrokeDashPattern(border);
+			platformView.UpdateStrokeDashOffset(border);
+			mauiDrawable?.SetBorderMiterLimit(border.StrokeMiterLimit);
+			mauiDrawable?.SetBorderLineCap(border.StrokeLineCap);
+			mauiDrawable?.SetBorderLineJoin(border.StrokeLineJoin);
+
+		}
+
 		public static void UpdateStrokeShape(this AView platformView, IBorderStroke border)
 		{
 			var borderShape = border.Shape;

--- a/src/Core/src/Platform/Android/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Android/StrokeExtensions.cs
@@ -15,13 +15,14 @@ namespace Microsoft.Maui.Platform
 
 			if (mauiDrawable == null && borderShape == null)
 				return;
-			mauiDrawable.SetBorderBrush(border.Stroke);
-			mauiDrawable.SetBorderWidth(border.StrokeThickness);
+			
+			mauiDrawable?.SetBorderBrush(border.Stroke);
+			mauiDrawable?.SetBorderWidth(border.StrokeThickness);
 			platformView.UpdateStrokeDashPattern(border);
 			platformView.UpdateStrokeDashOffset(border);
-			mauiDrawable.SetBorderMiterLimit(border.StrokeMiterLimit);
-			mauiDrawable.SetBorderLineCap(border.StrokeLineCap);
-			mauiDrawable.SetBorderLineJoin(border.StrokeLineJoin);
+			mauiDrawable?.SetBorderMiterLimit(border.StrokeMiterLimit);
+			mauiDrawable?.SetBorderLineCap(border.StrokeLineCap);
+			mauiDrawable?.SetBorderLineJoin(border.StrokeLineJoin);
 
 		}
 

--- a/src/Core/src/Platform/Android/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Android/StrokeExtensions.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Maui.Platform
 
 			if (mauiDrawable == null && borderShape == null)
 				return;
-			mauiDrawable?.SetBorderBrush(border.Stroke);
-			mauiDrawable?.SetBorderWidth(border.StrokeThickness);
+			mauiDrawable.SetBorderBrush(border.Stroke);
+			mauiDrawable.SetBorderWidth(border.StrokeThickness);
 			platformView.UpdateStrokeDashPattern(border);
 			platformView.UpdateStrokeDashOffset(border);
-			mauiDrawable?.SetBorderMiterLimit(border.StrokeMiterLimit);
-			mauiDrawable?.SetBorderLineCap(border.StrokeLineCap);
-			mauiDrawable?.SetBorderLineJoin(border.StrokeLineJoin);
+			mauiDrawable.SetBorderMiterLimit(border.StrokeMiterLimit);
+			mauiDrawable.SetBorderLineCap(border.StrokeLineCap);
+			mauiDrawable.SetBorderLineJoin(border.StrokeLineJoin);
 
 		}
 

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Maui.Platform
 			bool hasBorder = border.Shape != null && border.Stroke != null;
 
 			if (hasBorder)
-				platformView.UpdateMauiDrawable(border);
+				platformView.UpdateBorderStroke(border);
 		}
 
 		public static void UpdateBackground(this AView platformView, IView view, Drawable? defaultBackground = null) =>

--- a/src/Core/src/Platform/Android/WrapperView.cs
+++ b/src/Core/src/Platform/Android/WrapperView.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Platform
 			{
 				this.AddView(BorderView = new AView(Context));
 			}
-			BorderView.UpdateMauiDrawable(Border);
+			BorderView.UpdateBorderStroke(Border);
 		}
 
 		void ClipChild(Canvas canvas)

--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Platform
 				ShadowLayer.Frame = Bounds;
 
 			if (BorderView != null)
-				BringSubviewToFront(BorderView);
+				BorderView.Frame = Bounds;
 
 			SetClip();
 			SetShadow();


### PR DESCRIPTION
On iOS, the overlay view never had it's frame set.

On Android, we were not calling all the correct properties, if it's only an iBorder