### PR TITLE
Enable File Picker in Blazor Android WebView

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebChromeClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebChromeClient.cs
@@ -1,8 +1,14 @@
 ﻿
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Android.Content;
 using Android.Net;
 using Android.OS;
 using Android.Webkit;
+using Microsoft.Maui.Essentials;
+using File = Java.IO.File;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
@@ -21,6 +27,82 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			// We don't actually want to create a new WebView window so we just return false 
 			return false;
+		}
+
+		public override bool OnShowFileChooser(Android.Webkit.WebView? view, IValueCallback? filePathCallback, FileChooserParams? fileChooserParams)
+		{
+			if (filePathCallback is null)
+			{
+				return base.OnShowFileChooser(view, filePathCallback, fileChooserParams);
+			}
+
+			_ = CallFilePickerAsync(filePathCallback, fileChooserParams);
+			return true;
+		}
+
+		private static async Task CallFilePickerAsync(IValueCallback filePathCallback, FileChooserParams? fileChooserParams)
+		{
+			var pickOptions = GetPickOptions(fileChooserParams);
+
+			if (fileChooserParams?.Mode == ChromeFileChooserMode.OpenMultiple)
+			{
+				var files = await FilePicker.PickMultipleAsync(pickOptions);
+				if (files is null)
+				{
+					// Task was cancelled, return null to original callback
+					filePathCallback.OnReceiveValue(null);
+					return;
+				}
+
+				var androidUris = files!
+					.Where(f => f is not null)
+					.Select(f => new File(f.FullPath))
+					.Select(Uri.FromFile)
+					.Where(u => u is not null)
+					.Select(u => u!)
+					.ToArray();
+				filePathCallback.OnReceiveValue(androidUris);
+				return;
+			}
+
+			var file = await FilePicker.PickAsync(pickOptions);
+			if (file is null)
+			{
+				// Task was cancelled, return null to original callback
+				filePathCallback.OnReceiveValue(null);
+				return;
+			}
+
+			var androidFile = new File(file!.FullPath);
+			var androidFileUri = Uri.FromFile(androidFile);
+			if (androidFileUri is null)
+			{
+				filePathCallback.OnReceiveValue(null);
+				return;
+			}
+
+			filePathCallback.OnReceiveValue(new Uri[] { androidFileUri! });
+		}
+
+		private static PickOptions? GetPickOptions(FileChooserParams? fileChooserParams)
+		{
+			var acceptedFileTypes = fileChooserParams?.GetAcceptTypes();
+			if (acceptedFileTypes is null ||
+				// When the accept attribute isn't provided GetAcceptTypes returns: [ "" ]
+				// this must be filtered out.
+				(acceptedFileTypes.Length == 1 && string.IsNullOrEmpty(acceptedFileTypes[0])))
+			{
+				return null;
+			}
+
+			var pickOptions = new PickOptions()
+			{
+				FileTypes = new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+				{
+					{ DevicePlatform.Android, acceptedFileTypes }
+				})
+			};
+			return pickOptions;
 		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -15,7 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\SharedSource\**\*.cs" Link="Windows\SharedSource\%(Filename)%(Extension)"/>
+    <Compile Include="..\SharedSource\**\*.cs" Link="Windows\SharedSource\%(Filename)%(Extension)" />
+    <Compile Include="..\..\..\Core\src\TaskExtensions.cs" Link="Utilities\TaskExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorWebView/src/SharedSource/ExternalLinkNavigationEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/ExternalLinkNavigationEventArgs.cs
@@ -3,7 +3,8 @@
 namespace Microsoft.AspNetCore.Components.WebView
 {
 	/// <summary>
-	/// Used to provide information about a link (<![CDATA[<a>]]>) clicked within a Blazor WebView.
+	/// Used to provide information about an external link (<![CDATA[<a>]]>)
+	/// clicked within a Blazor WebView.
 	/// 
 	/// Anchor tags with target="_blank" will always open in the default
 	/// browser and the ExternalNavigationStarting event won't be called.

--- a/src/BlazorWebView/src/SharedSource/ExternalLinkNavigationEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/ExternalLinkNavigationEventArgs.cs
@@ -3,8 +3,7 @@
 namespace Microsoft.AspNetCore.Components.WebView
 {
 	/// <summary>
-	/// Used to provide information about an external link (<![CDATA[<a>]]>)
-	/// clicked within a Blazor WebView.
+	/// Used to provide information about a link (<![CDATA[<a>]]>) clicked within a Blazor WebView.
 	/// 
 	/// Anchor tags with target="_blank" will always open in the default
 	/// browser and the ExternalNavigationStarting event won't be called.

--- a/src/Controls/samples/Controls.Sample.SingleProject/Platforms/Android/AndroidManifest.xml
+++ b/src/Controls/samples/Controls.Sample.SingleProject/Platforms/Android/AndroidManifest.xml
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-	<uses-feature android:name="android.hardware.location" android:required="false" />
-	<uses-feature android:name="android.hardware.location.gps" android:required="false" />
-	<uses-feature android:name="android.hardware.location.network" android:required="false" />
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
+  <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-feature android:name="android.hardware.location" android:required="false" />
+  <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+  <uses-feature android:name="android.hardware.location.network" android:required="false" />
 </manifest>

--- a/src/Core/src/TaskExtensions.cs
+++ b/src/Core/src/TaskExtensions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Maui
 		public static void FireAndForget(this Task task, ILogger? logger, [CallerMemberName] string? callerName = null) =>
 			task.FireAndForget(ex => Log(logger, ex, callerName));
 
+#if !WEBVIEW2_MAUI
 		public static void FireAndForget<T>(this Task task, T? viewHandler, [CallerMemberName] string? callerName = null)
 			where T : IElementHandler
 		{
@@ -55,6 +56,7 @@ namespace Microsoft.Maui
 
 		static ILogger? CreateLogger<T>(this IElementHandler? elementHandler) =>
 			elementHandler?.MauiContext?.Services?.CreateLogger<T>();
+#endif
 
 		static void Log(ILogger? logger, Exception ex, string? callerName) =>
 			logger?.LogError(ex, "Unexpected exception in {Member}.", callerName);


### PR DESCRIPTION
Enables selecting files within the Blazor WebView (includes both `<InputFile />` and `<input type="file">`).

The Blazor Android WebView was updated to utilize the [MAUI Essentials File Picker API](https://docs.microsoft.com/en-us/xamarin/essentials/file-picker?context=xamarin%2Fandroid&tabs=android). Thanks @mattleibow for the tip!

Note, you'll need to add the `READ_EXTERNAL_STORAGE` permission to your `AndroidManifest.xml`:

```xml
<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
```

or update the `AssemblyInfo.cs` with:

```csharp
[assembly: UsesPermission(Android.Manifest.Permission.ReadExternalStorage)]
```

Fixes: https://github.com/dotnet/maui/issues/2678

