### PR TITLE
Add more APIs to IDispatcher

### DIFF
--- a/src/Compatibility/Core/src/Android/Forms.cs
+++ b/src/Compatibility/Core/src/Android/Forms.cs
@@ -327,19 +327,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 				_context = context;
 			}
 
-			public void StartTimer(TimeSpan interval, Func<bool> callback)
-			{
-				var handler = new Handler(Looper.MainLooper);
-				handler.PostDelayed(() =>
-				{
-					if (callback())
-						StartTimer(interval, callback);
-
-					handler.Dispose();
-					handler = null;
-				}, (long)interval.TotalMilliseconds);
-			}
-
 			public OSAppTheme RequestedTheme
 			{
 				get

--- a/src/Compatibility/Core/src/Windows/WindowsPlatformServices.cs
+++ b/src/Compatibility/Core/src/Windows/WindowsPlatformServices.cs
@@ -27,25 +27,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			_uiSettings.ColorValuesChanged += UISettingsColorValuesChanged;
 		}
 
-		public void StartTimer(TimeSpan interval, Func<bool> callback)
-		{
-			var timerTick = 0L;
-			var stopWatch = new Stopwatch();
-			stopWatch.Start();
-			void renderingFrameEventHandler(object sender, object args)
-			{
-				var newTimerTick = stopWatch.ElapsedMilliseconds / (long)interval.TotalMilliseconds;
-				if (newTimerTick == timerTick)
-					return;
-				timerTick = newTimerTick;
-				bool result = callback();
-				if (result)
-					return;
-				CompositionTarget.Rendering -= renderingFrameEventHandler;
-			}
-			CompositionTarget.Rendering += renderingFrameEventHandler;
-		}
-
 		void UISettingsColorValuesChanged(UISettings sender, object args)
 		{
 			Application.Current.Dispatcher.DispatchIfRequired(() =>

--- a/src/Compatibility/Core/src/iOS/Forms.cs
+++ b/src/Compatibility/Core/src/iOS/Forms.cs
@@ -237,28 +237,6 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		class IOSPlatformServices : IPlatformServices
 		{
-			public void StartTimer(TimeSpan interval, Func<bool> callback)
-			{
-				NSTimer timer = NSTimer.CreateRepeatingTimer(interval, t =>
-				{
-					if (!callback())
-						t.Invalidate();
-				});
-				NSRunLoop.Main.AddTimer(timer, NSRunLoopMode.Common);
-			}
-
-			HttpClient GetHttpClient()
-			{
-				var proxy = CoreFoundation.CFNetwork.GetSystemProxySettings();
-				var handler = new HttpClientHandler();
-				if (!string.IsNullOrEmpty(proxy.HTTPProxy))
-				{
-					handler.Proxy = CoreFoundation.CFNetwork.GetDefaultProxy();
-					handler.UseProxy = true;
-				}
-				return new HttpClient(handler);
-			}
-
 			public OSAppTheme RequestedTheme
 			{
 				get

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml
@@ -24,6 +24,11 @@
             <Button Text="3 Second Timer (Start/Stop)" Clicked="OnTimerClicked" />
             <Label x:Name="timerLabel" Text="..." />
 
+            <Label Text="OBSOLETE ZONE ALERT!" />
+            <Label Text="Some old code still works:" />
+            <Button Text="Device.StartTimer(3s)  (Start/Stop)" Clicked="OnObsoleteClicked" />
+            <Label x:Name="obsoleteLabel" Text="..." />
+
         </StackLayout>
     </ScrollView>
 

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.DispatcherPage"
+    xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base">
+
+    <ScrollView>
+        <StackLayout Padding="20" Spacing="10">
+
+            <Label Text="Watch the machines complain about accessing the UI thread from the background:" />
+            <Button Text="Fail Access" Clicked="OnFailAccessClicked" />
+            <Label x:Name="failLabel" Text="..." />
+
+            <Label Text="Now observe the happy machines when using a dispatcher:" />
+            <Button Text="Access" Clicked="OnAccessClicked" />
+            <Label x:Name="happyLabel" Text="..." />
+
+            <Label Text="Maybe you want something to happen in a few seconds:" />
+            <Button Text="3 Seconds Later" Clicked="OnLaterClicked" />
+            <Label x:Name="laterLabel" Text="..." />
+
+            <Label Text="Or, you might want something to repeat like a timer:" />
+            <Button Text="3 Second Timer (Start/Stop)" Clicked="OnTimerClicked" />
+            <Label x:Name="timerLabel" Text="..." />
+
+        </StackLayout>
+    </ScrollView>
+
+</views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
@@ -13,35 +13,35 @@ namespace Maui.Controls.Sample.Pages
 
 		async void OnFailAccessClicked(object sender, EventArgs e)
 		{
-			await Task.Run(async () =>
+			try
 			{
-				try
+				await Task.Run(() =>
 				{
-					failLabel.Text = "This was a fail!";
-				}
-				catch (Exception ex)
-				{
-					await DisplayAlert("EXCEPTION", ex.Message, "OK");
-				}
-			});
+					failLabel.Text = "Oops!";
+				});
+			}
+			catch (Exception ex)
+			{
+				await DisplayAlert("EXCEPTION", ex.Message, "OK");
+			}
 		}
 
 		async void OnAccessClicked(object sender, EventArgs e)
 		{
-			await Task.Run(async () =>
+			try
 			{
-				await happyLabel.Dispatcher.DispatchAsync(async () =>
+				await Task.Run(async () =>
 				{
-					try
+					await happyLabel.Dispatcher.DispatchAsync(() =>
 					{
 						happyLabel.Text = "This was a success!";
-					}
-					catch (Exception ex)
-					{
-						await DisplayAlert("EXCEPTION", ex.Message, "OK");
-					}
+					});
 				});
-			});
+			}
+			catch (Exception ex)
+			{
+				await DisplayAlert("EXCEPTION", ex.Message, "OK");
+			}
 		}
 
 		void OnLaterClicked(object sender, EventArgs e)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Dispatching;
 
 namespace Maui.Controls.Sample.Pages
@@ -84,6 +85,39 @@ namespace Maui.Controls.Sample.Pages
 				counter++;
 				timerLabel.Text = $"I am on a 3 second timer! {counter} ticks => {later - now}";
 			};
+		}
+
+		bool keepRunning;
+
+		void OnObsoleteClicked(object sender, EventArgs e)
+		{
+			if (keepRunning)
+			{
+				keepRunning = false;
+				obsoleteLabel.Text = "Stopping!";
+				return;
+			}
+
+			var now = DateTime.Now;
+			var counter = 0;
+
+			keepRunning = true;
+			Device.StartTimer(TimeSpan.FromSeconds(3), () =>
+			{
+				if (!keepRunning)
+				{
+					obsoleteLabel.Text = "Stopped!";
+					return false;
+				}
+
+				var later = DateTime.Now;
+				counter++;
+				obsoleteLabel.Text = $"I am on a 3 second timer! {counter} ticks => {later - now}";
+
+				return true;
+			});
+
+			obsoleteLabel.Text = "Started!";
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/DispatcherPage.xaml.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Dispatching;
+
+namespace Maui.Controls.Sample.Pages
+{
+	public partial class DispatcherPage
+	{
+		public DispatcherPage()
+		{
+			InitializeComponent();
+		}
+
+		async void OnFailAccessClicked(object sender, EventArgs e)
+		{
+			await Task.Run(async () =>
+			{
+				try
+				{
+					failLabel.Text = "This was a fail!";
+				}
+				catch (Exception ex)
+				{
+					await DisplayAlert("EXCEPTION", ex.Message, "OK");
+				}
+			});
+		}
+
+		async void OnAccessClicked(object sender, EventArgs e)
+		{
+			await Task.Run(async () =>
+			{
+				await happyLabel.Dispatcher.DispatchAsync(async () =>
+				{
+					try
+					{
+						happyLabel.Text = "This was a success!";
+					}
+					catch (Exception ex)
+					{
+						await DisplayAlert("EXCEPTION", ex.Message, "OK");
+					}
+				});
+			});
+		}
+
+		void OnLaterClicked(object sender, EventArgs e)
+		{
+			var now = DateTime.Now;
+			laterLabel.Dispatcher.DispatchDelayed(TimeSpan.FromSeconds(3), () =>
+			{
+				var later = DateTime.Now;
+				laterLabel.Text = "I happened 3 seconds later! " + (later - now);
+			});
+			laterLabel.Text = "Started!";
+		}
+
+		IDispatcherTimer _timer;
+
+		void OnTimerClicked(object sender, EventArgs e)
+		{
+			if (_timer != null)
+			{
+				_timer.Stop();
+				_timer = null;
+				timerLabel.Text = "Stopped!";
+				return;
+			}
+
+			var now = DateTime.Now;
+			var counter = 0;
+
+			_timer = timerLabel.Dispatcher.CreateTimer();
+
+			_timer.Interval = TimeSpan.FromSeconds(3);
+			_timer.IsRepeating = true;
+			_timer.Start();
+
+			timerLabel.Text = "Started!";
+
+			_timer.Tick += (_, _) =>
+			{
+				var later = DateTime.Now;
+				counter++;
+				timerLabel.Text = $"I am on a 3 second timer! {counter} ticks => {later - now}";
+			};
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/ViewModels/CoreViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/CoreViewModel.cs
@@ -27,6 +27,9 @@ namespace Maui.Controls.Sample.ViewModels
 			new SectionModel(typeof(ClipPage), "Clip",
 				"Defines the outline of the contents of an element."),
 
+			new SectionModel(typeof(DispatcherPage), "Dispatcher",
+				"Managing UI thread access with dispatchers and timers."),
+
 			new SectionModel(typeof(EffectsPage), "Effects",
 				"Apply Effects to a View."),
 

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Maui.Controls
 			StartTimer(dispatcher, interval, callback);
 		}
 
-		private static void StartTimer(IDispatcher dispatcher, TimeSpan interval, Func<bool> callback)
+		internal static void StartTimer(IDispatcher dispatcher, TimeSpan interval, Func<bool> callback)
 		{
 			_ = callback ?? throw new ArgumentNullException(nameof(callback));
 

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -127,7 +127,31 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='StartTimer']/Docs" />
 		public static void StartTimer(TimeSpan interval, Func<bool> callback)
 		{
-			PlatformServices.StartTimer(interval, callback);
+			_ = callback ?? throw new ArgumentNullException(nameof(callback));
+
+			var dispatcher = Application.Current.FindDispatcher();
+
+			StartTimer(dispatcher, interval, callback);
+		}
+
+		private static void StartTimer(IDispatcher dispatcher, TimeSpan interval, Func<bool> callback)
+		{
+			_ = callback ?? throw new ArgumentNullException(nameof(callback));
+
+			var timer = dispatcher.CreateTimer();
+			timer.Interval = interval;
+			timer.IsRepeating = true;
+			timer.Tick += OnTick;
+			timer.Start();
+
+			void OnTick(object sender, EventArgs e)
+			{
+				if (!callback())
+				{
+					timer.Tick -= OnTick;
+					timer.Stop();
+				}
+			}
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][2]/Docs" />

--- a/src/Controls/src/Core/IPlatformServices.cs
+++ b/src/Controls/src/Core/IPlatformServices.cs
@@ -13,7 +13,5 @@ namespace Microsoft.Maui.Controls.Internals
 	internal interface IPlatformServices
 	{
 		OSAppTheme RequestedTheme { get; }
-
-		void StartTimer(TimeSpan interval, Func<bool> callback);
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/MarshalingObservableCollectionTests.cs
+++ b/src/Controls/tests/Core.UnitTests/MarshalingObservableCollectionTests.cs
@@ -310,6 +310,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					_todo.Enqueue(action);
 					return true;
 				}
+
+				public bool DispatchDelayed(TimeSpan delay, Action action) =>
+					throw new NotImplementedException();
+
+				public IDispatcherTimer CreateTimer() =>
+					throw new NotImplementedException();
 			}
 		}
 	}

--- a/src/Controls/tests/Core.UnitTests/MockPlatformServices.cs
+++ b/src/Controls/tests/Core.UnitTests/MockPlatformServices.cs
@@ -19,26 +19,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	internal class MockPlatformServices : Internals.IPlatformServices
 	{
-		readonly IDispatcher _dispatcher;
-
-		public MockPlatformServices(IDispatcher dispatcher = null)
-		{
-			_dispatcher = dispatcher ?? new MockDispatcher();
-		}
-
-		public void StartTimer(TimeSpan interval, Func<bool> callback)
-		{
-			Timer timer = null;
-			TimerCallback onTimeout = o => _dispatcher.Dispatch(() =>
-			{
-				if (callback())
-					return;
-
-				timer.Dispose();
-			});
-			timer = new Timer(onTimeout, null, interval, interval);
-		}
-
 		public OSAppTheme RequestedTheme { get; set; }
 	}
 
@@ -147,6 +127,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			action();
 			return true;
 		}
+
+		public bool DispatchDelayed(TimeSpan delay, Action action) =>
+			throw new NotImplementedException();
+
+		public IDispatcherTimer CreateTimer() =>
+			throw new NotImplementedException();
 	}
 
 	class MockDeviceInfo : IDeviceInfo

--- a/src/Core/src/Dispatching/Dispatcher.Android.cs
+++ b/src/Core/src/Dispatching/Dispatcher.Android.cs
@@ -19,6 +19,63 @@ namespace Microsoft.Maui.Dispatching
 
 		bool DispatchImplementation(Action action) =>
 			_handler.Post(() => action());
+
+		bool DispatchDelayedImplementation(TimeSpan delay, Action action) =>
+			_handler.PostDelayed(() => action(), (long)delay.TotalMilliseconds);
+
+		IDispatcherTimer CreateTimerImplementation()
+		{
+			return new DispatcherTimer(_handler);
+		}
+	}
+
+	partial class DispatcherTimer : IDispatcherTimer
+	{
+		readonly Handler _handler;
+
+		public DispatcherTimer(Handler handler)
+		{
+			_handler = handler;
+		}
+
+		public TimeSpan Interval { get; set; }
+
+		public bool IsRepeating { get; set; }
+
+		public bool IsRunning { get; private set; }
+
+		public event EventHandler? Tick;
+
+		public void Start()
+		{
+			if (IsRunning)
+				return;
+
+			IsRunning = true;
+
+			_handler.PostDelayed(OnTimerTick, (long)Interval.TotalMilliseconds);
+		}
+
+		public void Stop()
+		{
+			if (!IsRunning)
+				return;
+
+			IsRunning = false;
+
+			_handler.RemoveCallbacks(OnTimerTick);
+		}
+
+		void OnTimerTick()
+		{
+			if (!IsRunning)
+				return;
+
+			Tick?.Invoke(this, EventArgs.Empty);
+
+			if (IsRepeating)
+				_handler.PostDelayed(OnTimerTick, (long)Interval.TotalMilliseconds);
+		}
 	}
 
 	public partial class DispatcherProvider

--- a/src/Core/src/Dispatching/Dispatcher.Standard.cs
+++ b/src/Core/src/Dispatching/Dispatcher.Standard.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Maui.Dispatching
 
 		bool DispatchImplementation(Action action) =>
 			throw new NotImplementedException();
+
+		bool DispatchDelayedImplementation(TimeSpan delay, Action action) =>
+			throw new NotImplementedException();
+
+		IDispatcherTimer CreateTimerImplementation() =>
+			throw new NotImplementedException();
 	}
 
 	public partial class DispatcherProvider

--- a/src/Core/src/Dispatching/Dispatcher.Windows.cs
+++ b/src/Core/src/Dispatching/Dispatcher.Windows.cs
@@ -17,6 +17,71 @@ namespace Microsoft.Maui.Dispatching
 
 		bool DispatchImplementation(Action action) =>
 			_dispatcherQueue.TryEnqueue(() => action());
+
+		bool DispatchDelayedImplementation(TimeSpan delay, Action action)
+		{
+			var timer = _dispatcherQueue.CreateTimer();
+			timer.Interval = delay;
+			timer.Tick += OnTimerTick;
+			timer.Start();
+			return true;
+
+			void OnTimerTick(DispatcherQueueTimer sender, object args)
+			{
+				action();
+				timer.Tick -= OnTimerTick;
+			}
+		}
+
+		IDispatcherTimer CreateTimerImplementation()
+		{
+			return new DispatcherTimer(_dispatcherQueue.CreateTimer());
+		}
+	}
+
+	partial class DispatcherTimer : IDispatcherTimer
+	{
+		readonly DispatcherQueueTimer _timer;
+
+		public DispatcherTimer(DispatcherQueueTimer timer)
+		{
+			_timer = timer;
+		}
+
+		public TimeSpan Interval
+		{
+			get => _timer.Interval;
+			set => _timer.Interval = value;
+		}
+
+		public bool IsRepeating
+		{
+			get => _timer.IsRepeating;
+			set => _timer.IsRepeating = value;
+		}
+
+		public bool IsRunning => _timer.IsRunning;
+
+		public event EventHandler? Tick;
+
+		public void Start()
+		{
+			if (IsRunning)
+				return;
+
+			_timer.Tick += OnTimerTick;
+		}
+
+		public void Stop()
+		{
+			if (!IsRunning)
+				return;
+
+			_timer.Tick += OnTimerTick;
+		}
+
+		void OnTimerTick(DispatcherQueueTimer sender, object args) =>
+			Tick?.Invoke(this, EventArgs.Empty);
 	}
 
 	public partial class DispatcherProvider

--- a/src/Core/src/Dispatching/Dispatcher.Windows.cs
+++ b/src/Core/src/Dispatching/Dispatcher.Windows.cs
@@ -70,6 +70,8 @@ namespace Microsoft.Maui.Dispatching
 				return;
 
 			_timer.Tick += OnTimerTick;
+
+			_timer.Start();
 		}
 
 		public void Stop()
@@ -77,7 +79,9 @@ namespace Microsoft.Maui.Dispatching
 			if (!IsRunning)
 				return;
 
-			_timer.Tick += OnTimerTick;
+			_timer.Tick -= OnTimerTick;
+
+			_timer.Stop();
 		}
 
 		void OnTimerTick(DispatcherQueueTimer sender, object args) =>

--- a/src/Core/src/Dispatching/Dispatcher.cs
+++ b/src/Core/src/Dispatching/Dispatcher.cs
@@ -16,5 +16,17 @@ namespace Microsoft.Maui.Dispatching
 
 			return DispatchImplementation(action);
 		}
+
+		public bool DispatchDelayed(TimeSpan delay, Action action)
+		{
+			_ = action ?? throw new ArgumentNullException(nameof(action));
+
+			return DispatchDelayedImplementation(delay, action);
+		}
+
+		public IDispatcherTimer CreateTimer()
+		{
+			return CreateTimerImplementation();
+		}
 	}
 }

--- a/src/Core/src/Dispatching/IDispatcher.cs
+++ b/src/Core/src/Dispatching/IDispatcher.cs
@@ -6,6 +6,25 @@ namespace Microsoft.Maui.Dispatching
 	{
 		bool Dispatch(Action action);
 
+		bool DispatchDelayed(TimeSpan delay, Action action);
+
+		IDispatcherTimer CreateTimer();
+
 		bool IsDispatchRequired { get; }
+	}
+
+	public interface IDispatcherTimer
+	{
+		TimeSpan Interval { get; set; }
+
+		bool IsRepeating { get; set; }
+
+		bool IsRunning { get; }
+
+		event EventHandler Tick;
+
+		void Start();
+
+		void Stop();
 	}
 }

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -11,6 +11,7 @@
 		public const string Button = "Button";
 		public const string CheckBox = "CheckBox";
 		public const string DatePicker = "DatePicker";
+		public const string Dispatcher = "Dispatcher";
 		public const string Editor = "Editor";
 		public const string Entry = "Entry";
 		public const string FlyoutView = "FlyoutView";

--- a/src/Core/tests/UnitTests/TestClasses/DispatcherStub.cs
+++ b/src/Core/tests/UnitTests/TestClasses/DispatcherStub.cs
@@ -32,6 +32,63 @@ namespace Microsoft.Maui.UnitTests
 				_invokeOnMainThread.Invoke(action);
 			return true;
 		}
+
+		public bool DispatchDelayed(TimeSpan delay, Action action)
+		{
+			Timer? timer = null;
+
+			timer = new Timer(OnTimeout, null, delay, delay);
+
+			return true;
+
+			void OnTimeout(object? state)
+			{
+				Dispatch(action);
+
+				timer?.Dispose();
+			}
+		}
+
+		public IDispatcherTimer CreateTimer()
+		{
+			return new DispatcherTimerStub(this);
+		}
+	}
+
+	class DispatcherTimerStub : IDispatcherTimer
+	{
+		readonly DispatcherStub _dispatcher;
+
+		Timer? _timer;
+
+		public DispatcherTimerStub(DispatcherStub dispatcher)
+		{
+			_dispatcher = dispatcher;
+		}
+
+		public TimeSpan Interval { get; set; }
+
+		public bool IsRepeating { get; set; }
+
+		public bool IsRunning => _timer != null;
+
+		public event EventHandler? Tick;
+
+		public void Start()
+		{
+			_timer = new Timer(OnTimeout, null, Interval, IsRepeating ? Interval : Timeout.InfiniteTimeSpan);
+
+			void OnTimeout(object? state)
+			{
+				_dispatcher.Dispatch(() => Tick?.Invoke(this, EventArgs.Empty));
+			}
+		}
+
+		public void Stop()
+		{
+			_timer?.Dispose();
+			_timer = null;
+		}
 	}
 
 	class DispatcherProviderStub : IDispatcherProvider, IDisposable


### PR DESCRIPTION
### Description of Change ###

Part of #1965
Fixes #3950

This PR copies the API of Windows as that is fairly nice, and adds 2 new APIs:

```diff
public interface IDispatcher
{
+	bool DispatchDelayed(TimeSpan delay, Action action);
+	IDispatcherTimer CreateTimer();
}

+public interface IDispatcherTimer
+{
+	TimeSpan Interval { get; set; }
+	bool IsRepeating { get; set; }
+	bool IsRunning { get; }
+	event EventHandler Tick;
+	void Start();
+	void Stop();
+}
```

We now have a few ways to do timer-y things in Maui:

 - **System Timer objects**  
   These timer objects are using whatever the BCL uses to implement it. This may/may not sync with UI updates and things.
 - **Animations**  
   This is the logic used by our animations API, and is directly tied to the screen refresh rate. This is using the `CADisplayLink` and similar on other platforms.
 - **Dispatcher CreateTimer**  
   This is the new API and is a timer based on the dispatcher availability and frequency.

In order to chose which one to use, there are some simple rules:

 - If you want to trigger some event in some work with relative accuracy, use the system/BCL timers
 - If you want to have something that directly syncs to the screen refresh rate, use the animation APIs
 - If you want to queue something on the UI thread repeatedly, use the dispatcher timers

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests

#### Does this PR touch anything that might affect accessibility?
- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
- [ ] APIs that modify focusability?
- [ ] APIs that modify any text property on a control?
- [ ] Does this PR modify view nesting or view arrangement in anyway?
- [ ] Is there the smallest possibility that your PR will change accessibility? 
- [ ] I'm not sure, please help me

If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
