### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,62 +1,10 @@
 
-
-<!-- 
-
-We are currently only accepting Pull Requests for .NET MAUI issues in our [Handler Property Backlog](https://github.com/dotnet/maui/projects/4). We will continue to update this repository over the next couple of months as we begin to accept more types of PRs.
-
-Before you submit this PR, make sure you're building on and targeting the right branch!
-     - If this is an enhancement or contains API changes or breaking changes, target main.
-          - If the issue you're working on has a milestone, target the corresponding branch.
-          - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
-               See [Contributing](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md) for more tips!
-
-```
- PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
-```
- -->
 ### Description of Change ###
 
-<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->
+<!-- Enter description of the fix in this section -->
 
-Implements #
+### Issues Fixed ###
 
-### Additions made ###
-<!-- List all the additions made here, example:
+<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->
 
-- Adds `Thickness Padding { get; }` to the `ILabel` interface
-- Adds Padding property map to LabelHandler
-- Adds Padding mapping methods to LabelHandler for WinUI, Android, and iOS
-- Adds extension methods to apply Padding on WinUI/Android/iOS
-- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
-- Adds DeviceTests for initial Padding values on WinUI, iOS, and Android
-
- -->
-
-* Adds 
-
-### PR Checklist ###
-
-<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->
-
-- [ ] Targets the correct branch 
-- [ ] Tests are passing (or failures are unrelated)
-- [ ] Targets a single property for a single control (or intertwined few properties)
-- [ ] Adds the property to the appropriate interface
-- [ ] Avoids any changes not essential to the handler property
-- [ ] Adds the mapping to the PropertyMapper in the handler
-- [ ] Adds the mapping method to the WinUI, Android, iOS, and Standard aspects of the handler
-- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
-- [ ] Tags ported renderer methods with [PortHandler]
-- [ ] Adds an example of the property to the sample project (MainPage)
-- [ ] Adds the property to the stub class
-- [ ] Implements basic property tests in DeviceTests
-
-#### Does this PR touch anything that might affect accessibility?
-- [ ] Does this PR introduce a new control? (If yes, add an example using SemanticProperties to the SemanticsPage)
-- [ ] APIs that modify focusability?
-- [ ] APIs that modify any text property on a control?
-- [ ] Does this PR modify view nesting or view arrangement in anyway?
-- [ ] Is there the smallest possibility that your PR will change accessibility? 
-- [ ] I'm not sure, please help me
-
-If any of the above checkboxes apply to your PR, then the PR will need to provide testing to demonstrate that accessibility still works. 
+Fixes #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 
-### Description of Change ###
+### Description of Change
 
 <!-- Enter description of the fix in this section -->
 
-### Issues Fixed ###
+### Issues Fixed
 
 <!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->
 


### PR DESCRIPTION
The PR template seems to be woefully out-of-date and contains many items that are no longer necessary or relevant. My own preference is that less is more. If the template is too long, it'll just get ignored anyway (which I think is already largely true).

Also, I changed the template to use the `Fixes #12345` pattern so that GitHub can auto-close associated issues when the PR is merged (that is one of the "well-known" patterns that GitHub detects).