### PR TITLE
Fix up tests after Shell runs

### DIFF
--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellContentFragment.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellContentFragment.cs
@@ -133,9 +133,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_root = inflater.Inflate(Controls.Compatibility.Resource.Layout.shellcontent, null).JavaCast<CoordinatorLayout>();
 
+			var shellContentMauiContext = MauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
 			_toolbar = _root.FindViewById<AToolbar>(Controls.Compatibility.Resource.Id.shellcontent_toolbar);
-			_page.ToPlatform(MauiContext);
-			_viewhandler = (IPlatformViewHandler)_page.Handler;
+			_viewhandler = _page.ToHandler(shellContentMauiContext);
 
 			_shellPageContainer = new ShellPageContainer(Context, _viewhandler);
 

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFragmentContainer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFragmentContainer.cs
@@ -22,8 +22,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		public override AView OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 		{
 			_page = ((IShellContentController)ShellContentTab).GetOrCreateContent();
-			_ = _page.ToPlatform(_mauiContext);
-			return new ShellPageContainer(RequireContext(), (IPlatformViewHandler)_page.Handler, true)
+			
+			var pageMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
+			
+			return new ShellPageContainer(RequireContext(), (IPlatformViewHandler)_page.ToHandler(pageMauiContext), true)
 			{
 				LayoutParameters = new LP(LP.MatchParent, LP.MatchParent)
 			};

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (target == _currentFragment)
 				return Task.FromResult(true);
 
-			var t = ChildFragmentManager.BeginTransaction();
+			var t = ChildFragmentManager.BeginTransactionEx();
 
 			if (animated)
 				SetupAnimation(navSource, t, page);

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellRenderer.cs
@@ -314,32 +314,28 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				navigationBarHeight = resources.GetDimensionPixelSize(resourceId);
 			}
-
-			// TODO Previewer Hack
-			if (decorView != null)
+			
+			// we are using the split drawable here to avoid GPU overdraw.
+			// All it really is is a drawable that only draws under the statusbar/bottom bar to make sure
+			// we dont draw over areas we dont need to. This has very limited benefits considering its
+			// only saving us a flat color fill BUT it helps people not freak out about overdraw.
+			AColor color;
+			if (appearance != null)
 			{
-				// we are using the split drawable here to avoid GPU overdraw.
-				// All it really is is a drawable that only draws under the statusbar/bottom bar to make sure
-				// we dont draw over areas we dont need to. This has very limited benefits considering its
-				// only saving us a flat color fill BUT it helps people not freak out about overdraw.
-				AColor color;
-				if (appearance != null)
-				{
-					color = appearance.BackgroundColor.ToPlatform(Color.FromArgb("#03A9F4"));
-				}
-				else
-				{
-					color = Color.FromArgb("#03A9F4").ToPlatform();
-				}
+				color = appearance.BackgroundColor.ToPlatform(Color.FromArgb("#03A9F4"));
+			}
+			else
+			{
+				color = Color.FromArgb("#03A9F4").ToPlatform();
+			}
 
-				if (!(decorView.Background is SplitDrawable splitDrawable) ||
-					splitDrawable.Color != color || splitDrawable.TopSize != statusBarHeight || splitDrawable.BottomSize != navigationBarHeight)
-				{
-					Profile.FramePartition("Create SplitDrawable");
-					var split = new SplitDrawable(color, statusBarHeight, navigationBarHeight);
-					Profile.FramePartition("SetBackground");
-					decorView.SetBackground(split);
-				}
+			if (!(decorView.Background is SplitDrawable splitDrawable) ||
+				splitDrawable.Color != color || splitDrawable.TopSize != statusBarHeight || splitDrawable.BottomSize != navigationBarHeight)
+			{
+				Profile.FramePartition("Create SplitDrawable");
+				var split = new SplitDrawable(color, statusBarHeight, navigationBarHeight);
+				Profile.FramePartition("SetBackground");
+				decorView.SetBackground(split);
 			}
 
 			Profile.FrameEnd("UpdtStatBarClr");

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellSectionRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellSectionRenderer.cs
@@ -147,7 +147,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			//_viewPager.AddOnPageChangeListener(this);
 			_viewPager.Id = AView.GenerateViewId();
 
-			_viewPager.Adapter = new ShellFragmentStateAdapter(shellSection, ChildFragmentManager, MauiContext);
+			var pagerContext = MauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
+			_viewPager.Adapter = new ShellFragmentStateAdapter(shellSection, ChildFragmentManager, pagerContext);
 			_viewPager.OverScrollMode = OverScrollMode.Never;
 
 			new TabLayoutMediator(_tablayout, _viewPager, this)

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -9,6 +10,7 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Editor)]
 	public partial class EditorTests : HandlerTestBase
 	{
+
 #if !IOS
 		// iOS is broken until this point
 		// https://github.com/dotnet/maui/issues/3425
@@ -31,10 +33,8 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			};
 
-			await InvokeOnMainThreadAsync(() =>
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, (_) =>
 			{
-				_ = CreateHandler<LayoutHandler>(layout);
-
 				layout.Arrange(new Graphics.Rectangle(Graphics.Point.Zero, layout.Measure(1000, 1000)));
 				var initialHeight = editor.Height;
 
@@ -45,6 +45,8 @@ namespace Microsoft.Maui.DeviceTests
 					Assert.Equal(initialHeight, editor.Height);
 				else
 					Assert.True(initialHeight < editor.Height);
+
+				return Task.CompletedTask;
 			});
 		}
 #endif
@@ -53,7 +55,7 @@ namespace Microsoft.Maui.DeviceTests
 		[ClassData(typeof(TextTransformCases))]
 		public async Task InitialTextTransformApplied(string text, TextTransform transform, string expected)
 		{
-			var control = new Editor() { Text = text , TextTransform = transform };
+			var control = new Editor() { Text = text, TextTransform = transform };
 			var platformText = await GetPlatformText(await CreateHandlerAsync<EditorHandler>(control));
 			Assert.Equal(expected, platformText);
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Maui.DeviceTests
 				{
 #if WINDOWS || ANDROID
 					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
+					handlers.AddHandler<Layout, LayoutHandler>();
+					handlers.AddHandler<Image, ImageHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
 #endif
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Toolbar, ToolbarHandler>();
@@ -36,9 +39,6 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<ShellItem, ShellItemHandler>();
 					handlers.AddHandler<ShellSection, ShellSectionHandler>();
 					handlers.AddHandler<ShellContent, ShellContentHandler>();
-					handlers.AddHandler<Layout, LayoutHandler>();
-					handlers.AddHandler<Image, ImageHandler>();
-					handlers.AddHandler<Label, LabelHandler>();
 #endif
 				});
 			});

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(async () =>
 			{
 				AViewGroup rootView = MauiContext.Context.GetActivity().Window.DecorView as AViewGroup;
+				var decorBackground = rootView.Background;
 				var linearLayoutCompat = new LinearLayoutCompat(MauiContext.Context);
 
 				var fragmentManager = MauiContext.GetFragmentManager();
@@ -74,6 +75,16 @@ namespace Microsoft.Maui.DeviceTests
 					await linearLayoutCompat.OnUnloadedAsync();
 					if (viewFragment.View != null)
 						await viewFragment.View.OnUnloadedAsync();
+
+					// This is mainly to remove changes to the decor view that shell imposes
+					if (decorBackground != rootView.Background)
+						rootView.Background = decorBackground;
+
+					// Unset the Support Action bar if the calling code has set the support action bar
+					if (MauiContext.Context.GetActivity() is AppCompatActivity aca)
+					{
+						aca.SetSupportActionBar(null);
+					}
 				}
 			});
 		}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(VerticalStackLayout), typeof(LayoutHandler));
 #if WINDOWS || ANDROID
 					handlers.AddHandler(typeof(Controls.Window), typeof(WindowHandlerStub));
+					handlers.AddHandler(typeof(Controls.ContentPage), typeof(PageHandler));
 #endif
 				});
 
@@ -110,11 +111,11 @@ namespace Microsoft.Maui.DeviceTests
 				// which update properties don't crash. 
 
 				var aView = viewHandler.PlatformView as Android.Views.View;
-				if(aView.LayoutParameters == null)
+				if (aView.LayoutParameters == null)
 				{
-					aView.LayoutParameters = 
+					aView.LayoutParameters =
 						new Android.Views.ViewGroup.LayoutParams(
-							Android.Views.ViewGroup.LayoutParams.WrapContent, 
+							Android.Views.ViewGroup.LayoutParams.WrapContent,
 							Android.Views.ViewGroup.LayoutParams.WrapContent);
 				}
 #endif

--- a/src/Core/src/Platform/Android/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Android/MauiContextExtensions.cs
@@ -70,17 +70,9 @@ namespace Microsoft.Maui.Platform
 				if (fragmentManager == null)
 					throw new InvalidOperationException("If you're creating a new Navigation Root you need to use a new Fragment Manager");
 
-				scopedContext.AddWeakSpecific(new NavigationRootManager(scopedContext));
+				scopedContext.AddSpecific(new NavigationRootManager(scopedContext));
 			}
 
-			return scopedContext;
-		}
-
-		public static IMauiContext MakeScopededArgs<TArgs>(this IMauiContext mauiContext, TArgs args)
-			where TArgs : class
-		{
-			var scopedContext = new MauiContext(mauiContext.Services);
-			scopedContext.AddWeakSpecific(args);
 			return scopedContext;
 		}
 


### PR DESCRIPTION
### Description of Change

- Shell sets the background of the decorview to a specialized "splitDrawable" that was breaking the UnitTests after a run. The background now just gets reset to pre-shell state so that tests remain runnable
- The NavigationRootManager was being added to the WrapperView as a WeakReference which means that sometimes it would get cleaned up by the GC since that's the only reference. The NavigationRootManager needs to exist as a strong reference inside the WrappedServiceProvider
   -  This fixed an issue where various tests would occasionally fail with "NavigationRootManager" not found
- Fixed up some fragments inside shell so they create a new scoped MauiContext with the correct inflater/childsupportmanager
- Fixed Editor test on WinUI so that it adds the editor to the VisualTree. This is required in order for the editor field to measure at all

### Testing
- verify tests all run properly in visual runner and that you can run and re-run them
- verify Android Shell still works