### PR TITLE
[core] use StringComparison.Ordinal everywhere

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,10 @@ indent_style = tab
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1416
 dotnet_diagnostic.CA1416.severity = none
 
+# Code analyzers
+dotnet_diagnostic.CA1307.severity = error
+dotnet_diagnostic.CA1309.severity = error
+
 # Modifier preferences
 dotnet_style_require_accessibility_modifiers = never:suggestion
 

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					{
 						relativePath = _hostPageRelativePath;
 					}
-					relativePath = Path.Combine(_contentRootDir, relativePath.Replace("/", "\\"));
+					relativePath = Path.Combine(_contentRootDir, relativePath.Replace('/', '\\'));
 
 					var winUIItem = await Package.Current.InstalledLocation.TryGetItemAsync(relativePath);
 					if (winUIItem != null)

--- a/src/BlazorWebView/src/SharedSource/QueryStringHelper.cs
+++ b/src/BlazorWebView/src/SharedSource/QueryStringHelper.cs
@@ -3,6 +3,8 @@
 
 #nullable enable
 
+using System;
+
 namespace Microsoft.AspNetCore.Components.WebView
 {
 	internal static class QueryStringHelper
@@ -13,7 +15,7 @@ namespace Microsoft.AspNetCore.Components.WebView
 			{
 				return string.Empty;
 			}
-			var indexOfQueryString = url.IndexOf('?');
+			var indexOfQueryString = url.IndexOf('?', StringComparison.Ordinal);
 			return (indexOfQueryString == -1)
 				? url
 				: url.Substring(0, indexOfQueryString);

--- a/src/Compatibility/ControlGallery/src/Android/TestCloudService.cs
+++ b/src/Compatibility/ControlGallery/src/Android/TestCloudService.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Controls.Compatibility.ControlGallery;
 
 namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Android
@@ -8,7 +9,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Android
 		{
 			var isInTestCloud = System.Environment.GetEnvironmentVariable("XAMARIN_TEST_CLOUD");
 
-			return isInTestCloud != null && isInTestCloud.Equals("1");
+			return isInTestCloud != null && isInTestCloud.Equals("1", StringComparison.Ordinal);
 		}
 
 		public string GetTestCloudDeviceName()

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/CollectionViewGalleries/DemoFilteredItemSource.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/CollectionViewGalleries/DemoFilteredItemSource.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.Coll
 		private bool ItemMatches(string filter, CollectionViewGalleryTestItem item)
 		{
 			filter = filter ?? "";
-			return item.Caption.ToLower().Contains(filter?.ToLower());
+			return item.Caption.IndexOf(filter, StringComparison.OrdinalIgnoreCase) != -1;
 		}
 
 		public void FilterItems(string filter)

--- a/src/Compatibility/ControlGallery/src/UITests.Shared/Utilities/ParsingUtils.cs
+++ b/src/Compatibility/ControlGallery/src/UITests.Shared/Utilities/ParsingUtils.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.Compatibility.UITests
 
 			// Logger.LogLine ("TEST PARSING");
 
-			if (font.Contains("font-weight: bold;"))
+			if (font.IndexOf("font-weight: bold;", StringComparison.Ordinal) != -1)
 			{
 				// Logger.LogLine ("Found Bold");
 				fontAttrs = FontAttributes.Bold;

--- a/src/Compatibility/ControlGallery/src/WinUI/WinUIStartup.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/WinUIStartup.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 				.AddWindows(windows => windows
 					.OnLaunching((_, e) =>
 					{
-						if (!string.IsNullOrWhiteSpace(e.Arguments) && e.Arguments.Contains("RunningAsUITests"))
+						if (!string.IsNullOrWhiteSpace(e.Arguments) && e.Arguments.Contains("RunningAsUITests", StringComparison.Ordinal))
 						{
 							App.RunningAsUITests = true;
 							ControlGallery.App.PreloadTestCasesIssuesList = false;

--- a/src/Compatibility/ControlGallery/src/iOS/AppDelegate.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/AppDelegate.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 		{
 			var isInTestCloud = Environment.GetEnvironmentVariable("XAMARIN_TEST_CLOUD");
 
-			return isInTestCloud != null && isInTestCloud.Equals("1");
+			return isInTestCloud != null && isInTestCloud.Equals("1", StringComparison.Ordinal);
 		}
 
 		public string GetTestCloudDeviceName()

--- a/src/Compatibility/Core/src/Android/BorderBackgroundManager.cs
+++ b/src/Compatibility/Core/src/Android/BorderBackgroundManager.cs
@@ -219,17 +219,17 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				return;
 			}
 
-			if (e.PropertyName.Equals(Button.BorderColorProperty.PropertyName) ||
-				e.PropertyName.Equals(Button.BorderWidthProperty.PropertyName) ||
-				e.PropertyName.Equals(Button.CornerRadiusProperty.PropertyName) ||
-				e.PropertyName.Equals(VisualElement.BackgroundColorProperty.PropertyName) ||
-				e.PropertyName.Equals(VisualElement.BackgroundProperty.PropertyName) ||
-				e.PropertyName.Equals(Specifics.Button.UseDefaultPaddingProperty.PropertyName) ||
-				e.PropertyName.Equals(Specifics.Button.UseDefaultShadowProperty.PropertyName) ||
-				e.PropertyName.Equals(Specifics.ImageButton.IsShadowEnabledProperty.PropertyName) ||
-				e.PropertyName.Equals(Specifics.ImageButton.ShadowColorProperty.PropertyName) ||
-				e.PropertyName.Equals(Specifics.ImageButton.ShadowOffsetProperty.PropertyName) ||
-				e.PropertyName.Equals(Specifics.ImageButton.ShadowRadiusProperty.PropertyName))
+			if (e.PropertyName.Equals(Button.BorderColorProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(Button.BorderWidthProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(Button.CornerRadiusProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(VisualElement.BackgroundColorProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(VisualElement.BackgroundProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(Specifics.Button.UseDefaultPaddingProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(Specifics.Button.UseDefaultShadowProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(Specifics.ImageButton.IsShadowEnabledProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(Specifics.ImageButton.ShadowColorProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(Specifics.ImageButton.ShadowOffsetProperty.PropertyName, StringComparison.Ordinal) ||
+				e.PropertyName.Equals(Specifics.ImageButton.ShadowRadiusProperty.PropertyName, StringComparison.Ordinal))
 			{
 				Reset();
 				UpdateDrawable();

--- a/src/Compatibility/Core/src/Android/Renderers/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/DatePickerRenderer.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			{
 				EditText.Text = date.ToShortDateString();
 			}
-			else if (Element.Format.Contains('/'))
+			else if (Element.Format.Contains('/', StringComparison.Ordinal))
 			{
 				EditText.Text = date.ToString(Element.Format, CultureInfo.InvariantCulture);
 			}

--- a/src/Compatibility/Core/src/Android/Renderers/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/TimePickerRenderer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		bool Is24HourView
 		{
-			get => (DateFormat.Is24HourFormat(Context) && Element.Format == (string)TimePicker.FormatProperty.DefaultValue) || Element.Format?.Contains('H') == true;
+			get => (DateFormat.Is24HourFormat(Context) && Element.Format == (string)TimePicker.FormatProperty.DefaultValue) || Element.Format?.Contains('H', StringComparison.Ordinal) == true;
 		}
 
 		public TimePickerRendererBase(Context context) : base(context)

--- a/src/Compatibility/Core/src/Android/ResourceManager.cs
+++ b/src/Compatibility/Core/src/Android/ResourceManager.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			// When searching by reflection you would use a "_" instead of a "."
 			// So this accounts for cases where users were searching with an "_"
-			if ((id = SearchByIdentifier(name.Replace("_", "."), defType, resource, packageName)) > 0)
+			if ((id = SearchByIdentifier(name.Replace("_", ".", StringComparison.Ordinal), defType, resource, packageName)) > 0)
 				return id;
 
 			int SearchByIdentifier(string n, string d, Resources r, string p)

--- a/src/Compatibility/Core/src/Windows/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/DatePickerRenderer.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 		bool CheckDateFormat()
 		{
-			return String.IsNullOrWhiteSpace(Element.Format) || Element.Format.Equals("d");
+			return String.IsNullOrWhiteSpace(Element.Format) || Element.Format.Equals("d", StringComparison.Ordinal);
 		}
 
 		[PortHandler]
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				Control.MonthFormat = "month";
 			}
-			else if (Element.Format.Equals("D"))
+			else if (Element.Format.Equals("D", StringComparison.Ordinal))
 			{
 				Control.MonthFormat = "month.full";
 			}
@@ -191,7 +191,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				Control.DayFormat = "day";
 			}
-			else if (Element.Format.Equals("D"))
+			else if (Element.Format.Equals("D", StringComparison.Ordinal))
 			{
 				Control.DayFormat = "dayofweek.full";
 			}
@@ -217,7 +217,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			{
 				Control.YearFormat = "year";
 			}
-			else if (Element.Format.Equals("D"))
+			else if (Element.Format.Equals("D", StringComparison.Ordinal))
 			{
 				Control.YearFormat = "year.full";
 			}

--- a/src/Compatibility/Core/src/Windows/FileImageSourceHandler.cs
+++ b/src/Compatibility/Core/src/Windows/FileImageSourceHandler.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 				var directory = IOPath.GetDirectoryName(filePath);
 
-				if (string.IsNullOrEmpty(directory) || !IOPath.GetFullPath(directory).Equals(IOPath.GetFullPath(imageDirectory)))
+				if (string.IsNullOrEmpty(directory) || !IOPath.GetFullPath(directory).Equals(IOPath.GetFullPath(imageDirectory), StringComparison.Ordinal))
 				{
 					filePath = IOPath.Combine(imageDirectory, filePath);
 					fileSource.File = filePath;

--- a/src/Compatibility/Core/src/Windows/FontImageSourceHandler.cs
+++ b/src/Compatibility/Core/src/Windows/FontImageSourceHandler.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 				foreach(var family in allFamilies)
 				{
-					if(family.Contains(source))
+					if(family.Contains(source, StringComparison.Ordinal))
 					{
 						fontSource = family;
 						break;

--- a/src/Compatibility/Core/src/Windows/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/TimePickerRenderer.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		void UpdateTime()
 		{
 			Control.Time = Element.Time;
-			if (Element.Format?.Contains('H') == true)
+			if (Element.Format?.Contains('H', StringComparison.Ordinal) == true)
 			{
 				Control.ClockIdentifier = "24HourClock";
 			}

--- a/src/Compatibility/Core/src/Windows/WebViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/WebViewRenderer.cs
@@ -52,7 +52,7 @@ if(bases.length == 0){
 			_internalWebView.NavigationCompleted += async (sender, args) =>
 			{
 				// Generate a version of the <base> script with the correct <base> tag
-				var script = BaseInsertionScript.Replace("baseTag", baseTag);
+				var script = BaseInsertionScript.Replace("baseTag", baseTag, StringComparison.Ordinal);
 
 				// Run it and retrieve the updated HTML from our WebView
 				await sender.ExecuteScriptAsync(script);

--- a/src/Compatibility/Core/src/iOS/NativeViewPropertyListener.cs
+++ b/src/Compatibility/Core/src/iOS/NativeViewPropertyListener.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 
 		public override void ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
 		{
-			if (keyPath.ToString().Equals(TargetProperty, StringComparison.InvariantCultureIgnoreCase))
+			if (keyPath.ToString().Equals(TargetProperty, StringComparison.OrdinalIgnoreCase))
 				PropertyChanged?.Invoke(ofObject, new PropertyChangedEventArgs(TargetProperty));
 			else
 				base.ObserveValue(keyPath, ofObject, change, context);

--- a/src/Compatibility/Core/src/iOS/Renderers/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/DatePickerRenderer.cs
@@ -176,12 +176,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				_picker.SetDate(Element.Date.ToNSDate(), animate);
 
 			// Can't use Element.Format because it won't display the correct format if the region and language are set differently
-			if (string.IsNullOrWhiteSpace(Element.Format) || Element.Format.Equals("d") || Element.Format.Equals("D"))
+			if (string.IsNullOrWhiteSpace(Element.Format) || Element.Format.Equals("d", StringComparison.OrdinalIgnoreCase))
 			{
 				NSDateFormatter dateFormatter = new NSDateFormatter();
 				dateFormatter.TimeZone = NSTimeZone.FromGMT(0);
 
-				if (Element.Format?.Equals("D") == true)
+				if (Element.Format?.Equals("D", StringComparison.Ordinal) == true)
 				{
 					dateFormatter.DateStyle = NSDateFormatterStyle.Long;
 					var strDate = dateFormatter.StringFor(_picker.Date);
@@ -194,7 +194,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 					Control.Text = strDate;
 				}
 			}
-			else if (Element.Format.Contains("/"))
+			else if (Element.Format.Contains('/', StringComparison.Ordinal))
 			{
 				Control.Text = Element.Date.ToString(Element.Format, CultureInfo.InvariantCulture);
 			}

--- a/src/Compatibility/Core/src/iOS/Renderers/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/TimePickerRenderer.cs
@@ -233,13 +233,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 				Control.Text = DateTime.Today.Add(Element.Time).ToString(Element.Format, cultureInfos);
 			}
 
-			if (Element.Format?.Contains('H') == true)
+			if (Element.Format?.Contains('H', StringComparison.Ordinal) == true)
 			{
 				var ci = new System.Globalization.CultureInfo("de-DE");
 				NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
 				_picker.Locale = locale;
 			}
-			else if (Element.Format?.Contains('h') == true)
+			else if (Element.Format?.Contains('h', StringComparison.Ordinal) == true)
 			{
 				var ci = new System.Globalization.CultureInfo("en-US");
 				NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);

--- a/src/Compatibility/Core/src/iOS/Renderers/WkWebViewRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/WkWebViewRenderer.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 			{
 				// we don't care that much about this being accurate
 				// the cookie container will split the cookies up more correctly
-				if (!cookie.Domain.Contains(domain) && !domain.Contains(cookie.Domain))
+				if (!cookie.Domain.Contains(domain, StringComparison.Ordinal) && !domain.Contains(cookie.Domain, StringComparison.Ordinal))
 					continue;
 
 				existingCookies.Add(cookie);
@@ -563,7 +563,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 						foreach (var deleteme in cookies)
 						{
-							if (record.DisplayName.Contains(deleteme.Domain) || deleteme.Domain.Contains(record.DisplayName))
+							if (record.DisplayName.Contains(deleteme.Domain, StringComparison.Ordinal) || deleteme.Domain.Contains(record.DisplayName, StringComparison.Ordinal))
 							{
 								WKWebsiteDataStore.DefaultDataStore.RemoveDataOfTypes(record.DataTypes,
 									  new[] { record }, () => { });

--- a/src/Controls/Maps/src/Pin.cs
+++ b/src/Controls/Maps/src/Pin.cs
@@ -70,10 +70,17 @@ namespace Microsoft.Maui.Controls.Maps
 		{
 			unchecked
 			{
+#if NETSTANDARD2_0
 				int hashCode = Label?.GetHashCode() ?? 0;
 				hashCode = (hashCode * 397) ^ Position.GetHashCode();
 				hashCode = (hashCode * 397) ^ (int)Type;
 				hashCode = (hashCode * 397) ^ (Address?.GetHashCode() ?? 0);
+#else
+				int hashCode = Label?.GetHashCode(StringComparison.Ordinal) ?? 0;
+				hashCode = (hashCode * 397) ^ Position.GetHashCode();
+				hashCode = (hashCode * 397) ^ (int)Type;
+				hashCode = (hashCode * 397) ^ (Address?.GetHashCode(StringComparison.Ordinal) ?? 0);
+#endif
 				return hashCode;
 			}
 		}
@@ -106,7 +113,9 @@ namespace Microsoft.Maui.Controls.Maps
 
 		bool Equals(Pin other)
 		{
-			return string.Equals(Label, other.Label) && Equals(Position, other.Position) && Type == other.Type && string.Equals(Address, other.Address);
+			return string.Equals(Label, other.Label, StringComparison.Ordinal) &&
+				Equals(Position, other.Position) && Type == other.Type &&
+				string.Equals(Address, other.Address, StringComparison.Ordinal);
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DataTemplateSelectorGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DataTemplateSelectorGallery.xaml.cs
@@ -36,7 +36,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 				return true;
 			}
 
-			return item.Date.DayOfWeek.ToString().ToLower().Contains(filter.ToLower());
+			return item.Date.DayOfWeek.ToString().Contains(filter, StringComparison.OrdinalIgnoreCase);
 		}
 	}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DemoFilteredItemSource.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DemoFilteredItemSource.cs
@@ -40,7 +40,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 		private bool ItemMatches(string filter, CollectionViewGalleryTestItem item)
 		{
 			filter = filter ?? "";
-			return item.Caption.ToLower().Contains(filter?.ToLower());
+			return item.Caption.Contains(filter, StringComparison.OrdinalIgnoreCase);
 		}
 
 		public void FilterItems(string filter)

--- a/src/Controls/src/Core/Accelerator.cs
+++ b/src/Controls/src/Core/Accelerator.cs
@@ -49,7 +49,11 @@ namespace Microsoft.Maui.Controls
 						case "fn":
 						case "win":
 							modifiers.Add(modiferMaskLower);
+#if NETSTANDARD2_0
 							text = text.Replace(modifierMask, "");
+#else
+							text = text.Replace(modifierMask, "", StringComparison.Ordinal);
+#endif
 							break;
 					}
 				}
@@ -89,7 +93,11 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/Accelerator.xml" path="//Member[@MemberName='GetHashCode']/Docs" />
 		public override int GetHashCode()
 		{
-			return ToString().GetHashCode();
+#if NETSTANDARD2_0
+			return _text.GetHashCode();
+#else
+			return _text.GetHashCode(StringComparison.Ordinal);
+#endif
 		}
 
 		public static implicit operator Accelerator(string accelerator)

--- a/src/Controls/src/Core/AnimatableKey.cs
+++ b/src/Controls/src/Core/AnimatableKey.cs
@@ -47,18 +47,25 @@ namespace Microsoft.Maui.Controls
 			unchecked
 			{
 				IAnimatable target;
+#if NETSTANDARD2_0
 				if (!Animatable.TryGetTarget(out target))
 				{
 					return Handle?.GetHashCode() ?? 0;
 				}
-
 				return ((target?.GetHashCode() ?? 0) * 397) ^ (Handle?.GetHashCode() ?? 0);
+#else
+				if (!Animatable.TryGetTarget(out target))
+				{
+					return Handle?.GetHashCode(StringComparison.Ordinal) ?? 0;
+				}
+				return ((target?.GetHashCode() ?? 0) * 397) ^ (Handle?.GetHashCode(StringComparison.Ordinal) ?? 0);
+#endif
 			}
 		}
 
 		protected bool Equals(AnimatableKey other)
 		{
-			if (!string.Equals(Handle, other.Handle))
+			if (!string.Equals(Handle, other.Handle, StringComparison.Ordinal))
 			{
 				return false;
 			}

--- a/src/Controls/src/Core/BindablePropertyConverter.cs
+++ b/src/Controls/src/Core/BindablePropertyConverter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls
 
 			if (string.IsNullOrWhiteSpace(strValue))
 				return null;
-			if (strValue.Contains(":"))
+			if (strValue.IndexOf(":", StringComparison.Ordinal) != -1)
 			{
 				Application.Current?.FindMauiContext()?.CreateLogger<BindablePropertyConverter>()?.LogWarning("Can't resolve properties with xml namespace prefix.");
 				return null;

--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Maui.Controls
 
 				BindingExpressionPart indexer = null;
 
-				int lbIndex = part.IndexOf('[');
+				int lbIndex = part.IndexOf("[", StringComparison.Ordinal);
 				if (lbIndex != -1)
 				{
 					int rbIndex = part.LastIndexOf(']');
@@ -745,7 +745,7 @@ namespace Microsoft.Maui.Controls
 				{
 					if (part.IsIndexer)
 					{
-						if (name.Contains("["))
+						if (name.IndexOf("[", StringComparison.Ordinal) != -1)
 						{
 							if (name != string.Format("{0}[{1}]", part.IndexerName, part.Content))
 								return;

--- a/src/Controls/src/Core/BrushTypeConverter.cs
+++ b/src/Controls/src/Core/BrushTypeConverter.cs
@@ -94,7 +94,12 @@ namespace Microsoft.Maui.Controls
 					return _gradient;
 				}
 
-				_parts = css.Replace("\r\n", "").Split(new[] { '(', ')', ',' }, StringSplitOptions.RemoveEmptyEntries);
+#if NETSTANDARD2_0
+				_parts = css.Replace("\r\n", "")
+#else
+				_parts = css.Replace("\r\n", "", StringComparison.Ordinal)
+#endif
+					.Split(new[] { '(', ')', ',' }, StringSplitOptions.RemoveEmptyEntries);
 
 				while (_position < _parts.Length)
 				{
@@ -306,9 +311,7 @@ namespace Microsoft.Maui.Controls
 
 				if (parts.Length > gradientCenterPosition)
 				{
-					var at = parts[gradientCenterPosition].Trim();
-
-					if (at.Contains("at"))
+					if (parts[gradientCenterPosition].IndexOf("at", StringComparison.Ordinal) != -1)
 					{
 						gradientCenterPosition++;
 						var directionX = gradientCenterPosition < parts.Length ? parts[gradientCenterPosition].Trim() : string.Empty;

--- a/src/Controls/src/Core/ExportEffectAttribute.cs
+++ b/src/Controls/src/Core/ExportEffectAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ExportEffectAttribute.xml" path="//Member[@MemberName='.ctor']/Docs" />
 		public ExportEffectAttribute(Type effectType, string uniqueName)
 		{
-			if (uniqueName.Contains("."))
+			if (uniqueName.IndexOf(".", StringComparison.Ordinal) != -1)
 				throw new ArgumentException("uniqueName must not contain a .");
 			Type = effectType;
 			Id = uniqueName;

--- a/src/Controls/src/Core/FontAttributes.cs
+++ b/src/Controls/src/Core/FontAttributes.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls
 
 			FontAttributes attributes = FontAttributes.None;
 			strValue = strValue.Trim();
-			if (strValue.Contains(","))
+			if (strValue.IndexOf(",", StringComparison.Ordinal) != -1)
 			{ //Xaml
 				foreach (var part in strValue.Split(','))
 					attributes |= ParseSingleAttribute(part, strValue);

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -363,7 +363,7 @@ namespace Microsoft.Maui.Controls
 				var rootTargetPath = XamlResourceIdAttribute.GetPathForType(rootObjectType);
 				var assembly = rootObjectType.GetTypeInfo().Assembly;
 
-				if (value.Contains(";assembly="))
+				if (value.IndexOf(";assembly=", StringComparison.Ordinal) != -1)
 				{
 					var parts = value.Split(new[] { ";assembly=" }, StringSplitOptions.RemoveEmptyEntries);
 					value = parts[0];

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Maui.Controls
 				if (!q.Key.StartsWith(prefix, StringComparison.Ordinal))
 					continue;
 				var key = q.Key.Substring(prefix.Length);
-				if (key.Contains("."))
+				if (key.IndexOf(".", StringComparison.Ordinal) != -1)
 					continue;
 				filteredQuery.Add(key, q.Value);
 			}

--- a/src/Controls/src/Core/Shell/ShellNavigationState.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationState.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls
 			uri = ShellUriHandler.FormatUri(uri, null);
 
 			// don't trim relative pushes
-			if (!uri.OriginalString.StartsWith($"{Routing.PathSeparator}{Routing.PathSeparator}"))
+			if (!uri.OriginalString.StartsWith("//", StringComparison.Ordinal))
 				return uri;
 
 			string[] parts = uri.OriginalString.TrimEnd(Routing.PathSeparator[0]).Split(Routing.PathSeparator[0]);

--- a/src/Controls/src/Core/Shell/ShellUriHandler.cs
+++ b/src/Controls/src/Core/Shell/ShellUriHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 
 		internal static Uri FormatUri(Uri path, Shell shell)
 		{
-			if (path.OriginalString.StartsWith("..") && shell?.CurrentState != null)
+			if (path.OriginalString.StartsWith("..", StringComparison.Ordinal) && shell?.CurrentState != null)
 			{
 				var pathAndQueryString = path.OriginalString.Split(new[] { '?' }, 2);
 				string pathPart = pathAndQueryString[0];
@@ -334,7 +334,12 @@ namespace Microsoft.Maui.Controls
 						var uri = ConvertToStandardFormat(shell, CreateUri(route));
 						if (uri.Equals(request))
 						{
-							throw new Exception($"Global routes currently cannot be the only page on the stack, so absolute routing to global routes is not supported. For now, just navigate to: {originalRequest.OriginalString.Replace("//", "")}");
+							#if NETSTANDARD2_0
+							var replaced = originalRequest.OriginalString.Replace("//", "");
+							#else
+							var replaced = originalRequest.OriginalString.Replace("//", "", StringComparison.Ordinal);
+							#endif
+							throw new Exception($"Global routes currently cannot be the only page on the stack, so absolute routing to global routes is not supported. For now, just navigate to: {replaced}");
 						}
 					}
 				}
@@ -535,7 +540,7 @@ namespace Microsoft.Maui.Controls
 				var collapsedRoutes = CollapsePath(routeKey, possibleRoutePath.SegmentsMatched, true);
 				var collapsedRoute = String.Join(_pathSeparator, collapsedRoutes);
 
-				if (routeKey.StartsWith("//"))
+				if (routeKey.StartsWith("//", StringComparison.Ordinal))
 				{
 					var routeKeyPaths =
 						routeKey.Split(_pathSeparators, StringSplitOptions.RemoveEmptyEntries);
@@ -578,7 +583,7 @@ namespace Microsoft.Maui.Controls
 
 						var collapsedLeafRoute = String.Join(_pathSeparator, CollapsePath(routeKey, leafSearch.SegmentsMatched, true));
 
-						if (routeKey.StartsWith("//"))
+						if (routeKey.StartsWith("//", StringComparison.Ordinal))
 							collapsedLeafRoute = "//" + collapsedLeafRoute;
 
 						string segmentMatch = leafSearch.GetNextSegmentMatch(collapsedLeafRoute);

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -174,10 +174,10 @@ namespace Microsoft.Maui.Controls
 			var transforms = ((string)newValue).Split(' ');
 			foreach (var transform in transforms)
 			{
-				if (string.IsNullOrEmpty(transform) || transform.IndexOf('(') < 0 || transform.IndexOf(')') < 0)
+				if (string.IsNullOrEmpty(transform) || transform.IndexOf("(", StringComparison.Ordinal) < 0 || transform.IndexOf(")", StringComparison.Ordinal) < 0)
 					throw new FormatException("Format for transform is 'none | transform(value) [transform(value) ]*'");
-				var transformName = transform.Substring(0, transform.IndexOf('('));
-				var value = transform.Substring(transform.IndexOf('(') + 1, transform.IndexOf(')') - transform.IndexOf('(') - 1);
+				var transformName = transform.Substring(0, transform.IndexOf("(", StringComparison.Ordinal));
+				var value = transform.Substring(transform.IndexOf("(", StringComparison.Ordinal) + 1, transform.IndexOf(")", StringComparison.Ordinal) - transform.IndexOf("(", StringComparison.Ordinal) - 1);
 				double translationX, translationY, scaleX, scaleY, rotateX, rotateY, rotate;
 				if (transformName.StartsWith("translateX", StringComparison.OrdinalIgnoreCase) && double.TryParse(value, out translationX))
 					bindable.SetValue(TranslationXProperty, translationX);

--- a/src/Controls/src/Core/WebView.cs
+++ b/src/Controls/src/Core/WebView.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Maui.Controls
 			if (js == null)
 				return null;
 
-			if (!js.Contains("'"))
+			if (js.IndexOf("'", StringComparison.Ordinal) == -1)
 				return js;
 
 			//get every quote in the string along with all the backslashes preceding it

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		static bool GetRealNameAndType(ref Type elementType, string namespaceURI, ref string localname,
 			object rootElement, IXmlLineInfo lineInfo)
 		{
-			var dotIdx = localname.IndexOf('.');
+			var dotIdx = localname.IndexOf(".", StringComparison.Ordinal);
 			if (dotIdx > 0)
 			{
 				var typename = localname.Substring(0, dotIdx);

--- a/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StaticExtension.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				throw new ArgumentNullException(nameof(serviceProvider));
 			if (!(serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver))
 				throw new ArgumentException("No IXamlTypeResolver in IServiceProvider");
-			if (string.IsNullOrEmpty(Member) || !Member.Contains("."))
+			if (string.IsNullOrEmpty(Member) || Member.IndexOf(".", StringComparison.Ordinal) == -1)
 				throw new XamlParseException("Syntax for x:Static is [Member=][prefix:]typeName.staticMemberName", serviceProvider);
 
 			var dotIdx = Member.LastIndexOf('.');

--- a/src/Controls/src/Xaml/TypeArgumentsParser.cs
+++ b/src/Controls/src/Xaml/TypeArgumentsParser.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using System.Xml;
 
@@ -45,8 +46,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (isGeneric)
 			{
 				typeArguments = ParseExpression(
-					type.Substring(type.IndexOf('(') + 1, type.LastIndexOf(')') - type.IndexOf('(') - 1), resolver, lineinfo);
-				type = type.Substring(0, type.IndexOf('('));
+					type.Substring(type.IndexOf("(", StringComparison.Ordinal) + 1, type.LastIndexOf(")", StringComparison.Ordinal) - type.IndexOf("(", StringComparison.Ordinal) - 1), resolver, lineinfo);
+				type = type.Substring(0, type.IndexOf("(", StringComparison.Ordinal));
 			}
 
 			var split = type.Split(':');

--- a/src/Controls/src/Xaml/XamlLoader.cs
+++ b/src/Controls/src/Xaml/XamlLoader.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 				var pattern = $"x:Class *= *\"{type.FullName}\"";
 				var regex = new Regex(pattern, RegexOptions.ECMAScript);
-				if (regex.IsMatch(xaml) || xaml.Contains($"x:Class=\"{type.FullName}\""))
+				if (regex.IsMatch(xaml) || xaml.IndexOf($"x:Class=\"{type.FullName}\"") != -1)
 					return xaml;
 			}
 			return null;

--- a/src/Controls/src/Xaml/XamlParser.cs
+++ b/src/Controls/src/Xaml/XamlParser.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Controls.Xaml
 						return;
 					case XmlNodeType.Element:
 						// 1. Property Element.
-						if (reader.Name.Contains("."))
+						if (reader.Name.IndexOf(".", StringComparison.Ordinal) != -1)
 						{
 							XmlName name;
 							if (reader.Name.StartsWith(elementName + ".", StringComparison.Ordinal))
@@ -215,7 +215,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				}
 
 				var namespaceUri = reader.NamespaceURI;
-				if (reader.LocalName.Contains(".") && namespaceUri == "")
+				if (reader.LocalName.IndexOf(".", StringComparison.Ordinal) != -1 && namespaceUri == "")
 					namespaceUri = ((IXmlNamespaceResolver)reader).LookupNamespace("");
 				var propertyName = ParsePropertyName(new XmlName(namespaceUri, reader.LocalName));
 

--- a/src/Controls/src/Xaml/XmlName.cs
+++ b/src/Controls/src/Xaml/XmlName.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Diagnostics;
 
 namespace Microsoft.Maui.Controls.Xaml
@@ -42,10 +43,17 @@ namespace Microsoft.Maui.Controls.Xaml
 			unchecked
 			{
 				int hashCode = 0;
+#if NETSTANDARD2_0
 				if (NamespaceURI != null)
 					hashCode = NamespaceURI.GetHashCode();
 				if (LocalName != null)
 					hashCode = (hashCode * 397) ^ LocalName.GetHashCode();
+#else
+				if (NamespaceURI != null)
+					hashCode = NamespaceURI.GetHashCode(StringComparison.Ordinal);
+				if (LocalName != null)
+					hashCode = (hashCode * 397) ^ LocalName.GetHashCode(StringComparison.Ordinal);
+#endif
 				return hashCode;
 			}
 		}

--- a/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
+++ b/src/Controls/src/Xaml/XmlTypeXamlExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			for (var i = 0; i < lookupNames.Count; i++)
 			{
 				var name = lookupNames[i];
-				if (name.Contains(":"))
+				if (name.IndexOf(":", StringComparison.Ordinal) != -1)
 					name = name.Substring(name.LastIndexOf(':') + 1);
 				if (typeArguments != null)
 					name += "`" + typeArguments.Count; //this will return an open generic Type

--- a/src/Controls/tests/Core.UnitTests/HostBuilderAppTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HostBuilderAppTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			using var app = builder.Build();
 
 			// Make sure we don't lose "MemoryConfigurationProvider" from GetDebugView() when wrapping the provider.
-			Assert.True(((IConfigurationRoot)app.Configuration).GetDebugView().Contains("foo=bar (MemoryConfigurationProvider)"));
+			Assert.True(((IConfigurationRoot)app.Configuration).GetDebugView().Contains("foo=bar (MemoryConfigurationProvider)", StringComparison.Ordinal));
 		}
 
 		[Test]

--- a/src/Controls/tests/Core.UnitTests/ShellUriHandlerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellUriHandlerTests.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 				if (!uri.IsAbsoluteUri)
 				{
-					var reverse = new Uri(uri.OriginalString.Replace("/", "\\"), UriKind.Relative);
+					var reverse = new Uri(uri.OriginalString.Replace('/', '\\'), UriKind.Relative);
 					Assert.AreEqual(new Uri("app://shell/IMPL_shell/path"), ShellUriHandler.ConvertToStandardFormat(shell, reverse));
 				}
 

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Bz44216.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Bz44216.xaml.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void DonSetValueOnPrivateBP(bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
-					Assert.Throws(new BuildExceptionConstraint(7, 26, s => s.Contains("No property,")), () => MockCompiler.Compile(typeof(Bz44216)));
+					Assert.Throws(new BuildExceptionConstraint(7, 26, s => s.Contains("No property,", StringComparison.Ordinal)), () => MockCompiler.Compile(typeof(Bz44216)));
 				else
 					Assert.Throws(new XamlParseExceptionConstraint(7, 26, s => s.StartsWith("Cannot assign property", StringComparison.Ordinal)), () => new Bz44216(useCompiledXaml));
 			}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh3539.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh3539.xaml.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 		public bool Equals(Gh3539NamedColor other)
 		{
-			return Name.Equals(other.Name);
+			return Name.Equals(other.Name, StringComparison.Ordinal);
 		}
 
 		public int CompareTo(Gh3539NamedColor other)

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 		public void ValidateOnly_WithErrors()
 		{
 			var project = NewProject();
-			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage.Replace("</ContentPage>", "<NotARealThing/></ContentPage>")));
+			project.Add(AddFile("MainPage.xaml", "MauiXaml", Xaml.MainPage.Replace("</ContentPage>", "<NotARealThing/></ContentPage>", StringComparison.Ordinal)));
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 
@@ -500,7 +500,7 @@ namespace Microsoft.Maui.Controls.MSBuild.UnitTests
 			var projectFile = IOPath.Combine(tempDirectory, "test.csproj");
 			project.Save(projectFile);
 			var log = Build(projectFile, verbosity: "diagnostic");
-			Assert.IsTrue(log.Contains("Target \"XamlC\" skipped"), "XamlC should be skipped if there are no .xaml files.");
+			Assert.IsTrue(log.Contains("Target \"XamlC\" skipped", StringComparison.Ordinal), "XamlC should be skipped if there are no .xaml files.");
 		}
 	}
 }

--- a/src/Controls/tests/Xaml.UnitTests/Validation/TypeMismatch.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Validation/TypeMismatch.xaml.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			public void ThrowsOnMismatchingType([Values(true, false)] bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
-					Assert.Throws(new BuildExceptionConstraint(7, 16, m => m.Contains("No property, BindableProperty")), () => MockCompiler.Compile(typeof(TypeMismatch)));
+					Assert.Throws(new BuildExceptionConstraint(7, 16, m => m.Contains("No property, BindableProperty", StringComparison.Ordinal)), () => MockCompiler.Compile(typeof(TypeMismatch)));
 				else
 					Assert.Throws(new XamlParseExceptionConstraint(7, 16, m => m.StartsWith("Cannot assign property", StringComparison.Ordinal)), () => new TypeMismatch(useCompiledXaml));
 			}

--- a/src/Core/src/Converters/CornerRadiusTypeConverter.cs
+++ b/src/Core/src/Converters/CornerRadiusTypeConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Converters
 			if (strValue != null)
 			{
 				value = strValue.Trim();
-				if (strValue.Contains(","))
+				if (strValue.IndexOf(",", StringComparison.Ordinal) != -1)
 				{ //Xaml
 					var cornerRadius = strValue.Split(',');
 					if (cornerRadius.Length == 4
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Converters
 						&& double.TryParse(cornerRadius[0], NumberStyles.Number, CultureInfo.InvariantCulture, out double l))
 						return new CornerRadius(l);
 				}
-				else if (strValue.Trim().Contains(" "))
+				else if (strValue.Trim().IndexOf(" ", StringComparison.Ordinal) != -1)
 				{ //CSS
 					var cornerRadius = strValue.Split(' ');
 					if (cornerRadius.Length == 2

--- a/src/Core/src/Converters/ThicknessTypeConverter.cs
+++ b/src/Core/src/Converters/ThicknessTypeConverter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Converters
 			if (strValue != null)
 			{
 				strValue = strValue.Trim();
-				if (strValue.Contains(","))
+				if (strValue.IndexOf(",", StringComparison.Ordinal) != -1)
 				{ //Xaml
 					var thickness = strValue.Split(',');
 					switch (thickness.Length)
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Converters
 							break;
 					}
 				}
-				else if (strValue.Contains(" "))
+				else if (strValue.IndexOf(" ", StringComparison.Ordinal) != -1)
 				{ //CSS
 					var thickness = strValue.Split(' ');
 					switch (thickness.Length)

--- a/src/Core/src/Fonts/FontFile.cs
+++ b/src/Core/src/Fonts/FontFile.cs
@@ -33,9 +33,15 @@ namespace Microsoft.Maui
 		{
 			_ = input ?? throw new ArgumentNullException(nameof(input));
 
-			var hashIndex = input.IndexOf("#", global::System.StringComparison.Ordinal);
+			var hashIndex = input.IndexOf("#", StringComparison.Ordinal);
 			//UWP names require Spaces. Sometimes people may use those, "CuteFont-Regular#Cute Font" should be "CuteFont-Regular#CuteFont"
-			var postScriptName = hashIndex > 0 ? input.Substring(hashIndex + 1).Replace(" ", "") : input;
+			var postScriptName = hashIndex > 0 ? input.Substring(hashIndex + 1)
+#if NETSTANDARD2_0
+				.Replace(" ", "")
+#else
+				.Replace(" ", "", StringComparison.Ordinal)
+#endif
+				: input;
 			//Get the fontFamily name;
 			var fontFamilyName = hashIndex > 0 ? input.Substring(0, hashIndex) : input;
 
@@ -62,7 +68,7 @@ namespace Microsoft.Maui
 		{
 			_ = fontFamily ?? throw new ArgumentNullException(nameof(fontFamily));
 
-			if (fontFamily.Contains(" "))
+			if (fontFamily.IndexOf(" ", StringComparison.Ordinal) != -1)
 			{
 				yield return fontFamily;
 				//We are done, they have spaces, they have it handled.

--- a/src/Core/src/Fonts/FontManager.Android.cs
+++ b/src/Core/src/Fonts/FontManager.Android.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Maui
 		{
 			fontFamily ??= string.Empty;
 
-			int hashtagIndex = fontFamily.IndexOf('#');
+			int hashtagIndex = fontFamily.IndexOf("#", StringComparison.Ordinal);
 			if (hashtagIndex >= 0)
 				return fontFamily.Substring(0, hashtagIndex);
 

--- a/src/Core/src/Fonts/FontManager.Windows.cs
+++ b/src/Core/src/Fonts/FontManager.Windows.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui
 			// First check Alias
 			if (_fontRegistrar.GetFont(fontFamily) is string fontPostScriptName)
 			{
-				if (fontPostScriptName!.Contains("://") && fontPostScriptName.Contains("#"))
+				if (fontPostScriptName.Contains("://", StringComparison.Ordinal) && fontPostScriptName.Contains("#", StringComparison.Ordinal))
 				{
 					// The registrar has given us a perfect path, so use it exactly
 					yield return fontPostScriptName;

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -373,7 +373,7 @@ namespace Microsoft.Maui.Handlers
 				{
 					// we don't care that much about this being accurate
 					// the cookie container will split the cookies up more correctly
-					if (!cookie.Domain.Contains(domain) && !domain.Contains(cookie.Domain))
+					if (!cookie.Domain.Contains(domain, StringComparison.Ordinal) && !domain.Contains(cookie.Domain, StringComparison.Ordinal))
 						continue;
 
 					existingCookies.Add(cookie);
@@ -427,7 +427,7 @@ namespace Microsoft.Maui.Handlers
 
 							foreach (var deleteme in cookies)
 							{
-								if (record.DisplayName.Contains(deleteme.Domain) || deleteme.Domain.Contains(record.DisplayName))
+								if (record.DisplayName.Contains(deleteme.Domain, StringComparison.Ordinal) || deleteme.Domain.Contains(record.DisplayName, StringComparison.Ordinal))
 								{
 									WKWebsiteDataStore.DefaultDataStore.RemoveDataOfTypes(record.DataTypes,
 										  new[] { record }, () => { });

--- a/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
+++ b/src/Core/src/ImageSources/FontImageSourceService/FontImageSourceService.Windows.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Maui
 
 				foreach (var family in allFamilies)
 				{
-					if (family.Contains(source))
+					if (family.Contains(source, StringComparison.Ordinal))
 					{
 						fontSource = family;
 						break;

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Platform
 			_internalWebView.NavigationCompleted += async (sender, args) =>
 			{
 				// Generate a version of the <base> script with the correct <base> tag
-				var script = BaseInsertionScript.Replace("baseTag", baseTag);
+				var script = BaseInsertionScript.Replace("baseTag", baseTag, StringComparison.Ordinal);
 
 				// Run it and retrieve the updated HTML from our WebView
 				await sender.ExecuteScriptAsync(script);

--- a/src/Core/src/Platform/Windows/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/TimePickerExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using System;
+using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml.Controls;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
@@ -10,7 +11,7 @@ namespace Microsoft.Maui.Platform
 		{
 			nativeTimePicker.Time = timePicker.Time;
 
-			if (timePicker.Format?.Contains('H') == true)
+			if (timePicker.Format?.Contains('H', StringComparison.Ordinal) == true)
 			{
 				nativeTimePicker.ClockIdentifier = "24HourClock";
 			}

--- a/src/Core/src/Platform/iOS/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/TimePickerExtensions.cs
@@ -43,21 +43,24 @@ namespace Microsoft.Maui.Platform
 
 			mauiTimePicker.Text = time.ToFormattedString(format, cultureInfo);
 
-			if (timePicker.Format?.Contains('H') == true)
+			if (format != null)
 			{
-				var ci = new CultureInfo("de-DE");
-				NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
+				if (format.IndexOf("H", StringComparison.Ordinal) != -1)
+				{
+					var ci = new CultureInfo("de-DE");
+					NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
 
-				if (picker != null)
-					picker.Locale = locale;
-			}
-			else if (timePicker.Format?.Contains('h') == true)
-			{
-				var ci = new CultureInfo("en-US");
-				NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
+					if (picker != null)
+						picker.Locale = locale;
+				}
+				else if (format.IndexOf("h", StringComparison.Ordinal) != -1)
+				{
+					var ci = new CultureInfo("en-US");
+					NSLocale locale = new NSLocale(ci.TwoLetterISOLanguageName);
 
-				if (picker != null)
-					picker.Locale = locale;
+					if (picker != null)
+						picker.Locale = locale;
+				}
 			}
 
 			mauiTimePicker.UpdateCharacterSpacing(timePicker);

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Maui
 
 		bool Equals(Font other)
 		{
-			return string.Equals(Family, other.Family)
+			return string.Equals(Family, other.Family, StringComparison.Ordinal)
 				&& Size.Equals(other.Size)
 				&& Weight == other.Weight
 				&& Slant == other.Slant

--- a/src/Core/tests/DeviceTests/Services/ImageSource/ImageSourceServiceTests.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/ImageSourceServiceTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			var ex = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredImageSourceService(new FileImageSourceStub()));
 
-			Assert.Contains(nameof(IFileImageSource), ex.Message);
+			Assert.Contains(nameof(IFileImageSource), ex.Message, StringComparison.Ordinal);
 		}
 
 		[Fact]
@@ -58,8 +58,8 @@ namespace Microsoft.Maui.DeviceTests
 
 			var ex = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredImageSourceService(new InvalidImageSourceStub()));
 
-			Assert.Contains(nameof(InvalidImageSourceStub), ex.Message);
-			Assert.Contains(nameof(IImageSource), ex.Message);
+			Assert.Contains(nameof(InvalidImageSourceStub), ex.Message, StringComparison.Ordinal);
+			Assert.Contains(nameof(IImageSource), ex.Message, StringComparison.Ordinal);
 		}
 
 		[Fact]

--- a/src/Core/tests/UnitTests/AbstractViewHandlerTests.cs
+++ b/src/Core/tests/UnitTests/AbstractViewHandlerTests.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Maui.UnitTests
 
 			var ex = Assert.Throws<InvalidOperationException>(() => handlerStub.GetRequiredService<IFooService>());
 
-			Assert.Contains("the context", ex.Message);
-			Assert.Contains("MauiContext", ex.Message);
+			Assert.Contains("the context", ex.Message, StringComparison.Ordinal);
+			Assert.Contains("MauiContext", ex.Message, StringComparison.Ordinal);
 		}
 
 		[Fact]
@@ -67,8 +67,8 @@ namespace Microsoft.Maui.UnitTests
 
 			var ex = Assert.Throws<InvalidOperationException>(() => handlerStub.GetRequiredService<IFooService>());
 
-			Assert.Contains("the service provider", ex.Message);
-			Assert.Contains("MauiContext", ex.Message);
+			Assert.Contains("the service provider", ex.Message, StringComparison.Ordinal);
+			Assert.Contains("MauiContext", ex.Message, StringComparison.Ordinal);
 		}
 
 		[Fact]

--- a/src/Core/tests/UnitTests/Hosting/HostBuilderFontsTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/HostBuilderFontsTests.cs
@@ -45,13 +45,13 @@ namespace Microsoft.Maui.UnitTests.Hosting
 
 			var path = registrar.GetFont(filename);
 			Assert.NotNull(path);
-			Assert.StartsWith(root, path);
+			Assert.StartsWith(root, path, StringComparison.Ordinal);
 
 			if (alias != null)
 			{
 				path = registrar.GetFont(alias);
 				Assert.NotNull(path);
-				Assert.StartsWith(root, path);
+				Assert.StartsWith(root, path, StringComparison.Ordinal);
 			}
 
 			Assert.True(File.Exists(Path.Combine(root, filename)));

--- a/src/Core/tests/UnitTests/Hosting/HostBuilderServicesTests.cs
+++ b/src/Core/tests/UnitTests/Hosting/HostBuilderServicesTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.UnitTests.Hosting
 			var mauiApp = builder.Build();
 
 			var ex = Assert.Throws<InvalidOperationException>(() => mauiApp.Services.GetService<IFooService>());
-			Assert.Contains("suitable constructor", ex.Message);
+			Assert.Contains("suitable constructor", ex.Message, StringComparison.Ordinal);
 		}
 
 		[Fact]

--- a/src/Core/tests/UnitTests/PropertyMapperExtensionTests.cs
+++ b/src/Core/tests/UnitTests/PropertyMapperExtensionTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Controls;
+﻿using System;
+using Microsoft.Maui.Controls;
 using Xunit;
 
 namespace Microsoft.Maui.UnitTests
@@ -23,8 +24,8 @@ namespace Microsoft.Maui.UnitTests
 
 			mapper1.UpdateProperties(null, new Button());
 
-			Assert.Contains(msg1, log);
-			Assert.Contains(msg2, log);
+			Assert.Contains(msg1, log, StringComparison.Ordinal);
+			Assert.Contains(msg2, log, StringComparison.Ordinal);
 
 			var originalIndex = log.IndexOf(msg1);
 			var additionalIndex = log.IndexOf(msg2);
@@ -49,8 +50,8 @@ namespace Microsoft.Maui.UnitTests
 
 			mapper1.UpdateProperties(null, new Button());
 
-			Assert.Contains(msg1, log);
-			Assert.Contains(msg2, log);
+			Assert.Contains(msg1, log, StringComparison.Ordinal);
+			Assert.Contains(msg2, log, StringComparison.Ordinal);
 
 			var originalIndex = log.IndexOf(msg1);
 			var additionalIndex = log.IndexOf(msg2);
@@ -75,8 +76,8 @@ namespace Microsoft.Maui.UnitTests
 
 			mapper1.UpdateProperties(null, new Button());
 
-			Assert.DoesNotContain(msg1, log);
-			Assert.Contains(msg2, log);
+			Assert.DoesNotContain(msg1, log, StringComparison.Ordinal);
+			Assert.Contains(msg2, log, StringComparison.Ordinal);
 		}
 	}
 }

--- a/src/Essentials/samples/Samples/View/BasePage.cs
+++ b/src/Essentials/samples/Samples/View/BasePage.cs
@@ -57,7 +57,7 @@ namespace Samples.View
 		Task OnNavigate(BaseViewModel vm, bool showModal)
 		{
 			var name = vm.GetType().Name;
-			name = name.Replace("ViewModel", "Page");
+			name = name.Replace("ViewModel", "Page", StringComparison.Ordinal);
 
 			var ns = GetType().Namespace;
 			var pageType = Type.GetType($"{ns}.{name}");

--- a/src/Essentials/samples/Samples/ViewModel/HomeViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/HomeViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Maui.Essentials;
@@ -285,13 +286,10 @@ namespace Samples.ViewModel
 		{
 			if (!string.IsNullOrWhiteSpace(filterText))
 			{
-				var lower = filterText.ToLowerInvariant();
 				samples = samples.Where(s =>
 				{
-					var tags = s.Tags
-						.Union(new[] { s.Name })
-						.Select(t => t.ToLowerInvariant());
-					return tags.Any(t => t.Contains(lower));
+					var tags = s.Tags.Union(new[] { s.Name });
+					return tags.Any(t => t.Contains(filterText, StringComparison.OrdinalIgnoreCase));
 				});
 			}
 

--- a/src/Essentials/samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/WebAuthenticatorViewModel.cs
@@ -41,7 +41,7 @@ namespace Samples.ViewModel
 			{
 				WebAuthenticatorResult r = null;
 
-				if (scheme.Equals("Apple")
+				if (scheme.Equals("Apple", StringComparison.Ordinal)
 					&& DeviceInfo.Platform == DevicePlatform.iOS
 					&& DeviceInfo.Version.Major >= 13)
 				{

--- a/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.ios.tvos.watchos.macos.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Maui.Essentials.Implementations
 
 		internal static bool VerifyHasUrlScheme(string scheme)
 		{
-			var cleansed = scheme.Replace("://", string.Empty);
+			var cleansed = scheme.Replace("://", string.Empty, StringComparison.Ordinal);
 			var schemes = GetCFBundleURLSchemes().ToList();
-			return schemes.Any(x => x != null && x.Equals(cleansed, StringComparison.InvariantCultureIgnoreCase));
+			return schemes.Any(x => x != null && x.Equals(cleansed, StringComparison.OrdinalIgnoreCase));
 		}
 
 		internal static IEnumerable<string> GetCFBundleURLSchemes()

--- a/src/Essentials/src/Connectivity/Connectivity.android.cs
+++ b/src/Essentials/src/Connectivity/Connectivity.android.cs
@@ -260,20 +260,19 @@ namespace Microsoft.Maui.Essentials.Implementations
 					if (string.IsNullOrWhiteSpace(typeName))
 						return ConnectionProfile.Unknown;
 
-					var typeNameLower = typeName.ToLowerInvariant();
-					if (typeNameLower.Contains("mobile"))
+					if (typeName.Contains("mobile", StringComparison.OrdinalIgnoreCase))
 						return ConnectionProfile.Cellular;
 
-					if (typeNameLower.Contains("wimax"))
+					if (typeName.Contains("wimax", StringComparison.OrdinalIgnoreCase))
 						return ConnectionProfile.Cellular;
 
-					if (typeNameLower.Contains("wifi"))
+					if (typeName.Contains("wifi", StringComparison.OrdinalIgnoreCase))
 						return ConnectionProfile.WiFi;
 
-					if (typeNameLower.Contains("ethernet"))
+					if (typeName.Contains("ethernet", StringComparison.OrdinalIgnoreCase))
 						return ConnectionProfile.Ethernet;
 
-					if (typeNameLower.Contains("bluetooth"))
+					if (typeName.Contains("bluetooth", StringComparison.OrdinalIgnoreCase))
 						return ConnectionProfile.Bluetooth;
 
 					return ConnectionProfile.Unknown;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.android.cs
@@ -99,23 +99,23 @@ namespace Microsoft.Maui.Essentials.Implementations
 			get
 			{
 				var isEmulator =
-					(Build.Brand.StartsWith("generic", StringComparison.InvariantCulture) && Build.Device.StartsWith("generic", StringComparison.InvariantCulture)) ||
-					Build.Fingerprint.StartsWith("generic", StringComparison.InvariantCulture) ||
-					Build.Fingerprint.StartsWith("unknown", StringComparison.InvariantCulture) ||
-					Build.Hardware.Contains("goldfish") ||
-					Build.Hardware.Contains("ranchu") ||
-					Build.Model.Contains("google_sdk") ||
-					Build.Model.Contains("Emulator") ||
-					Build.Model.Contains("Android SDK built for x86") ||
-					Build.Manufacturer.Contains("Genymotion") ||
-					Build.Manufacturer.Contains("VS Emulator") ||
-					Build.Product.Contains("emulator") ||
-					Build.Product.Contains("google_sdk") ||
-					Build.Product.Contains("sdk") ||
-					Build.Product.Contains("sdk_google") ||
-					Build.Product.Contains("sdk_x86") ||
-					Build.Product.Contains("simulator") ||
-					Build.Product.Contains("vbox86p");
+					(Build.Brand.StartsWith("generic", StringComparison.Ordinal) && Build.Device.StartsWith("generic", StringComparison.Ordinal)) ||
+					Build.Fingerprint.StartsWith("generic", StringComparison.Ordinal) ||
+					Build.Fingerprint.StartsWith("unknown", StringComparison.Ordinal) ||
+					Build.Hardware.Contains("goldfish", StringComparison.Ordinal) ||
+					Build.Hardware.Contains("ranchu", StringComparison.Ordinal) ||
+					Build.Model.Contains("google_sdk", StringComparison.Ordinal) ||
+					Build.Model.Contains("Emulator", StringComparison.Ordinal) ||
+					Build.Model.Contains("Android SDK built for x86", StringComparison.Ordinal) ||
+					Build.Manufacturer.Contains("Genymotion", StringComparison.Ordinal) ||
+					Build.Manufacturer.Contains("VS Emulator", StringComparison.Ordinal) ||
+					Build.Product.Contains("emulator", StringComparison.Ordinal) ||
+					Build.Product.Contains("google_sdk", StringComparison.Ordinal) ||
+					Build.Product.Contains("sdk", StringComparison.Ordinal) ||
+					Build.Product.Contains("sdk_google", StringComparison.Ordinal) ||
+					Build.Product.Contains("sdk_x86", StringComparison.Ordinal) ||
+					Build.Product.Contains("simulator", StringComparison.Ordinal) ||
+					Build.Product.Contains("vbox86p", StringComparison.Ordinal);
 
 				if (isEmulator)
 					return DeviceType.Virtual;

--- a/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 					if (string.IsNullOrWhiteSpace(systemProductName))
 						systemProductName = deviceInfo.SystemProductName;
 
-					var isVirtual = systemProductName.Contains("Virtual") || systemProductName == "HMV domU";
+					var isVirtual = systemProductName.Contains("Virtual", StringComparison.Ordinal) || systemProductName == "HMV domU";
 
 					currentType = isVirtual ? DeviceType.Virtual : DeviceType.Physical;
 				}

--- a/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.ios.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 
 				if (assetUrl != null)
 				{
-					if (!assetUrl.Scheme.Equals("assets-library", StringComparison.InvariantCultureIgnoreCase))
+					if (!assetUrl.Scheme.Equals("assets-library", StringComparison.OrdinalIgnoreCase))
 						return new UIDocumentFileResult(assetUrl);
 
 					phAsset = info.ValueForKey(UIImagePickerController.PHAsset) as PHAsset;

--- a/src/Essentials/src/PhoneDialer/PhoneDialer.android.cs
+++ b/src/Essentials/src/PhoneDialer/PhoneDialer.android.cs
@@ -1,3 +1,4 @@
+using System;
 using Android.App;
 using Android.Content;
 using Android.OS;
@@ -32,7 +33,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 				phoneNumber = PhoneNumberUtils.FormatNumber(number, Java.Util.Locale.Default.Country) ?? phoneNumber;
 
 			// if we are an extension then we need to encode
-			if (phoneNumber.Contains(',') || phoneNumber.Contains(';'))
+			if (phoneNumber.Contains(',', StringComparison.Ordinal) || phoneNumber.Contains(';', StringComparison.Ordinal))
 				phoneNumber = URLEncoder.Encode(phoneNumber, "UTF-8") ?? phoneNumber;
 
 			var dialIntent = ResolveDialIntent(phoneNumber);

--- a/src/Essentials/src/Preferences/Preferences.android.cs
+++ b/src/Essentials/src/Preferences/Preferences.android.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 									if (!double.TryParse(savedDouble, NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out var outDouble))
 									{
 										var maxString = Convert.ToString(double.MaxValue, CultureInfo.InvariantCulture);
-										outDouble = savedDouble.Equals(maxString) ? double.MaxValue : double.MinValue;
+										outDouble = savedDouble.Equals(maxString, StringComparison.Ordinal) ? double.MaxValue : double.MinValue;
 									}
 
 									value = outDouble;

--- a/src/Essentials/src/Types/DeviceIdiom.shared.cs
+++ b/src/Essentials/src/Types/DeviceIdiom.shared.cs
@@ -53,7 +53,11 @@ namespace Microsoft.Maui.Essentials
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='GetHashCode']/Docs" />
 		public override int GetHashCode() =>
-			deviceIdiom == null ? 0 : deviceIdiom.GetHashCode();
+			deviceIdiom == null ? 0 : deviceIdiom.GetHashCode(
+					#if !NETSTANDARD2_0
+					StringComparison.Ordinal
+					#endif
+				);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='ToString']/Docs" />
 		public override string ToString() =>

--- a/src/Essentials/src/Types/DevicePlatform.shared.cs
+++ b/src/Essentials/src/Types/DevicePlatform.shared.cs
@@ -61,7 +61,11 @@ namespace Microsoft.Maui.Essentials
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='GetHashCode']/Docs" />
 		public override int GetHashCode() =>
-			devicePlatform == null ? 0 : devicePlatform.GetHashCode();
+			devicePlatform == null ? 0 : devicePlatform.GetHashCode(
+					#if !NETSTANDARD2_0
+					StringComparison.Ordinal
+					#endif
+				);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='ToString']/Docs" />
 		public override string ToString() =>

--- a/src/Essentials/src/Types/Shared/WebUtils.shared.cs
+++ b/src/Essentials/src/Types/Shared/WebUtils.shared.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Maui.Essentials
 		{
 			var d = new Dictionary<string, string>();
 
-			if (string.IsNullOrWhiteSpace(url) || (!url.Contains("?") && !url.Contains("#")))
+			if (string.IsNullOrWhiteSpace(url) || (url.IndexOf("?", StringComparison.Ordinal) == -1 && url.IndexOf("#", StringComparison.Ordinal) == -1))
 				return d;
 
-			var qsStartIndex = url.IndexOf('?');
+			var qsStartIndex = url.IndexOf("?", StringComparison.Ordinal);
 			if (qsStartIndex < 0)
-				qsStartIndex = url.IndexOf('#');
+				qsStartIndex = url.IndexOf("#", StringComparison.Ordinal);
 
 			if (url.Length - 1 < qsStartIndex + 1)
 				return d;

--- a/src/Essentials/test/DeviceTests/Tests/Android/FileProvider_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Android/FileProvider_Tests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 
 				// Make sure the underlying file exists
 				var realPath = Path.Combine(shareableUri.PathSegments.ToArray())
-					.Replace(expectedCache, expectedCacheDir);
+					.Replace(expectedCache, expectedCacheDir, StringComparison.Ordinal);
 				Assert.True(File.Exists(realPath));
 			}
 			finally
@@ -133,7 +133,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 
 			// Make sure the underlying file exists
 			var realPath = Path.Combine(shareableUri.PathSegments.ToArray())
-				.Replace("external_cache", Platform.AppContext.ExternalCacheDir.AbsolutePath);
+				.Replace("external_cache", Platform.AppContext.ExternalCacheDir.AbsolutePath, StringComparison.Ordinal);
 			Assert.True(File.Exists(realPath));
 		}
 
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests.Shared
 #pragma warning restore CS0618 // Type or member is obsolete
 
 				// replace the real root with the providers "root"
-				var segements = Path.Combine(root.Replace(externalRoot, "external_files"), Path.GetFileName(file));
+				var segements = Path.Combine(root.Replace(externalRoot, "external_files", StringComparison.Ordinal), Path.GetFileName(file));
 
 				Assert.Equal(segements.Split(Path.DirectorySeparatorChar), shareableUri.PathSegments);
 			}

--- a/src/Essentials/test/DeviceTests/Tests/DeviceInfo_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/DeviceInfo_Tests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 #if WINDOWS_UWP || WINDOWS
 			Assert.Equal(10, DeviceInfo.Version.Major);
 			Assert.Equal(0, DeviceInfo.Version.Minor);
-			Assert.StartsWith("10.0", DeviceInfo.VersionString);
+			Assert.StartsWith("10.0", DeviceInfo.VersionString, StringComparison.Ordinal);
 #else
 			Assert.True(DeviceInfo.Version.Major > 0);
 #endif
@@ -40,10 +40,10 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			if (DeviceInfo.DeviceType == DeviceType.Virtual)
 			{
 				var isEmulator =
-					DeviceInfo.Model.Contains("sdk_gphone_x86") ||
-					DeviceInfo.Model.Contains("google_sdk") ||
-					DeviceInfo.Model.Contains("Emulator") ||
-					DeviceInfo.Model.Contains("Android SDK built for x86");
+					DeviceInfo.Model.Contains("sdk_gphone_x86", StringComparison.Ordinal) ||
+					DeviceInfo.Model.Contains("google_sdk", StringComparison.Ordinal) ||
+					DeviceInfo.Model.Contains("Emulator", StringComparison.Ordinal) ||
+					DeviceInfo.Model.Contains("Android SDK built for x86", StringComparison.Ordinal);
 
 				Assert.True(isEmulator);
 			}

--- a/src/Essentials/test/DeviceTests/Tests/Geocoding_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Geocoding_Tests.cs
@@ -64,6 +64,6 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		}
 
 		static bool IsEmulatorFailure(Exception ex) =>
-			ex.Message.ToLower().Contains("grpc") || ex.Message.ToLower().Contains("service not available");
+			ex.Message.Contains("grpc", StringComparison.OrdinalIgnoreCase) || ex.Message.Contains("service not available", StringComparison.OrdinalIgnoreCase);
 	}
 }

--- a/src/Essentials/test/DeviceTests/Tests/Launcher_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Launcher_Tests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task CanOpen(string uri)
 		{
 #if __IOS__
-            if (DeviceInfo.DeviceType == DeviceType.Virtual && (uri.Contains("tel:") || uri.Contains("mailto:")))
+            if (DeviceInfo.DeviceType == DeviceType.Virtual && (uri.Contains("tel:", StringComparison.Ordinal) || uri.Contains("mailto:", StringComparison.Ordinal)))
             {
                 Assert.False(await Launcher.CanOpenAsync(uri));
                 return;
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task CanOpenUri(string uri)
 		{
 #if __IOS__
-            if (DeviceInfo.DeviceType == DeviceType.Virtual && (uri.Contains("tel:") || uri.Contains("mailto:")))
+            if (DeviceInfo.DeviceType == DeviceType.Virtual && (uri.Contains("tel:", StringComparison.Ordinal) || uri.Contains("mailto:", StringComparison.Ordinal)))
             {
                 Assert.False(await Launcher.CanOpenAsync(new Uri(uri)));
                 return;
@@ -112,7 +112,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		public async Task TryOpen(string uri)
 		{
 #if __IOS__
-            if (DeviceInfo.DeviceType == DeviceType.Virtual && (uri.Contains("tel:") || uri.Contains("mailto:")))
+            if (DeviceInfo.DeviceType == DeviceType.Virtual && (uri.Contains("tel:", StringComparison.Ordinal) || uri.Contains("mailto:", StringComparison.Ordinal)))
             {
                 Assert.False(await Launcher.TryOpenAsync(uri));
                 return;

--- a/src/SingleProject/Resizetizer/test/UnitTests/DetectInvalidResourceOutputFilenamesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/DetectInvalidResourceOutputFilenamesTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				};
 
 			protected string GetInvalidFilename(DetectInvalidResourceOutputFilenamesTask task, string path) =>
-				task.InvalidItems.Single(c => c.Replace("\\", "/").EndsWith(path));
+				task.InvalidItems.Single(c => c.Replace('\\', '/').EndsWith(path, StringComparison.Ordinal));
 
 			protected void AssertValidFilename(DetectInvalidResourceOutputFilenamesTask task, ITaskItem item)
 				=> Assert.DoesNotContain(task.InvalidItems ?? Enumerable.Empty<string>(), c => c == item.ItemSpec);

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,7 +29,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				};
 
 			protected ITaskItem GetCopiedResource(ResizetizeImages task, string path) =>
-				task.CopiedResources.Single(c => c.ItemSpec.Replace("\\", "/").EndsWith(path));
+				task.CopiedResources.Single(c => c.ItemSpec.Replace('\\', '/').EndsWith(path, StringComparison.Ordinal));
 
 			protected void AssertFileSize(string file, int width, int height)
 			{
@@ -62,7 +63,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var content = File.ReadAllText(file);
 
 				foreach (var snip in snippet)
-					Assert.Contains(snip, content);
+					Assert.Contains(snip, content, StringComparison.Ordinal);
 			}
 		}
 

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DeviceExecutionSink.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Sinks/DeviceExecutionSink.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 			if (!_testCases.TryGetValue(testResult.TestCase, out TestCaseViewModel? testCase))
 			{
 				// no matching reference, search by Unique ID as a fallback
-				testCase = _testCases.FirstOrDefault(kvp => kvp.Key.UniqueID?.Equals(testResult.TestCase.UniqueID) ?? false).Value;
+				testCase = _testCases.FirstOrDefault(kvp => kvp.Key.UniqueID?.Equals(testResult.TestCase.UniqueID, StringComparison.Ordinal) ?? false).Value;
 
 				if (testCase == null)
 					return;

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Utils/TestRunLogger.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Utils/TestRunLogger.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 				if (!string.IsNullOrEmpty(message))
 				{
 					_builder.Append(" : ");
-					_builder.Append(message.Replace("\r", "\\r").Replace("\n", "\\n"));
+					_builder.Append(message.Replace("\r", "\\r", StringComparison.Ordinal).Replace("\n", "\\n", StringComparison.Ordinal));
 				}
 
 				_builder.AppendLine();

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/XamlExtensions/EmbeddedResourceExtension.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/XamlExtensions/EmbeddedResourceExtension.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 			if (Name == null)
 				return null;
 
-			var resourceName = "." + Name.Trim().Replace("/", ".").Replace("\\", ".");
+			var resourceName = "." + Name.Trim().Replace('/', '.').Replace('\\', '.');
 
 			var assembly = typeof(MauiVisualRunnerApp).Assembly;
 			foreach (var name in assembly.GetManifestResourceNames())


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
Context: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
Context: https://github.com/dotnet/runtime/issues/43956

I was reviewing `dotnet trace` output of the .NET Podcast app:

    6.32ms Microsoft.Maui.Controls!Microsoft.Maui.Controls.ShellNavigationManager.GetNavigationState
    3.82ms Microsoft.Maui.Controls!Microsoft.Maui.Controls.ShellUriHandler.FormatUri

The bulk of this time is spent in `string.StartsWith()`, doing a
culture-aware string comparison?

    3.82ms System.Private.CoreLib!System.String.StartsWith
    2.57ms System.Private.CoreLib!System.Globalization.CultureInfo.get_CurrentCulture

This looks to be showing the cost of the 1st culture-aware comparision
plus any time making these slower string comparisons. It would be
ideal if project templates did not even hit
`CultureInfo.get_CurrentCulture`.

To solve this, let's add to the `.editorconfig` file:

    dotnet_diagnostic.CA1307.severity = error
    dotnet_diagnostic.CA1309.severity = error

And then fix all the places errors appear.

There are some complications in projects that use `netstandard2.0`:

1. For `Contains()` use `IndexOf()` instead.

2. Use `#if NETSTANDARD2_0` for `GetHashCode()` or `Replace()`.

3. Generally, `InvariantCulture` should not be used.

After these changes, the `FormatUri` method disappears completely from
the trace, and we instead get:

    2.88ms Microsoft.Maui.Controls!Microsoft.Maui.Controls.ShellNavigationManager.GetNavigationState

I suspect this saves ~3.44ms for any MAUI app startup, and a small
amount more depending on the number of string comparisions happening.