### PR TITLE
Don't set the text on android if value matches

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -7,17 +7,30 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public static void UpdateText(this EditText editText, InputView inputView)
 		{
+			// Is UpdateText being called only to transform the text
+			// that's already set on the platform element?
+			// If so then we want to retain the cursor position
+			bool transformingPlatformText =
+				(editText.Text == inputView.Text);
+
 			var value = TextTransformUtilites.GetTransformedText(inputView.Text, inputView.TextTransform);
 
-			// Setting the text causes the cursor to reset to position zero
-			// so if we are transforming the text and then setting it to a 
-			// new value then we need to retain the cursor position
-			if (value == editText.Text)
-				return;
+			if (!transformingPlatformText)
+			{
+				editText.Text = value;
+			}
+			else
+			{
+				// Setting the text causes the cursor to reset to position zero
+				// so if we are transforming the text and then setting it to a 
+				// new value then we need to retain the cursor position
+				if (value == editText.Text)
+					return;
 
-			int selectionStart = editText.SelectionStart;
-			editText.Text = value;
-			editText.SetSelection(selectionStart);
+				int selectionStart = editText.SelectionStart;
+				editText.Text = value;
+				editText.SetSelection(selectionStart);
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Platform
 			// Setting the text causes the cursor to reset to position zero
 			// so if we are transforming the text and then setting it to a 
 			// new value then we need to retain the cursor position
-			if (value == inputView.Text)
+			if (value == editText.Text)
 				return;
 
 			int selectionStart = 0;

--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Platform
 			// This means the user is typing at the end of the string
 			if (selectionStart == value.Length)
 				selectionStart = value.Length;
-			// Users is typing at the start/middle of the string
+			// User is typing at the start/middle of the string
 			else
 				selectionStart = editText.SelectionStart;
 

--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -15,15 +15,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (value == editText.Text)
 				return;
 
-			int selectionStart = 0;
-
-			// This means the user is typing at the end of the string
-			if (selectionStart == value.Length)
-				selectionStart = value.Length;
-			// User is typing at the start/middle of the string
-			else
-				selectionStart = editText.SelectionStart;
-
+			int selectionStart = editText.SelectionStart;
 			editText.Text = value;
 			editText.SetSelection(selectionStart);
 		}

--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -7,7 +7,14 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public static void UpdateText(this EditText editText, InputView inputView)
 		{
-			editText.Text = TextTransformUtilites.GetTransformedText(inputView.Text, inputView.TextTransform);
+			var value = TextTransformUtilites.GetTransformedText(inputView.Text, inputView.TextTransform);
+
+			// Setting the text causes the cursor to reset to position zero
+			// Therefore if:
+			// User Types => VirtualView Updated => Triggers Native Update
+			// Then it will cause the cursor to reset to position zero as the user typed
+			if (value != editText.Text)
+				editText.Text = value;
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -10,11 +10,22 @@ namespace Microsoft.Maui.Controls.Platform
 			var value = TextTransformUtilites.GetTransformedText(inputView.Text, inputView.TextTransform);
 
 			// Setting the text causes the cursor to reset to position zero
-			// Therefore if:
-			// User Types => VirtualView Updated => Triggers Native Update
-			// Then it will cause the cursor to reset to position zero as the user typed
-			if (value != editText.Text)
-				editText.Text = value;
+			// so if we are transforming the text and then setting it to a 
+			// new value then we need to retain the cursor position
+			if (value == inputView.Text)
+				return;
+
+			int selectionStart = 0;
+
+			// This means the user is typing at the end of the string
+			if (selectionStart == value.Length)
+				selectionStart = value.Length;
+			// Users is typing at the start/middle of the string
+			else
+				selectionStart = editText.SelectionStart;
+
+			editText.Text = value;
+			editText.SetSelection(selectionStart);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
@@ -13,5 +13,17 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() => GetPlatformControl(handler).Text);
 		}
+
+		int GetCursorStartPosition(EntryHandler entryHandler)
+		{
+			var control = GetPlatformControl(entryHandler);
+			return control.SelectionStart;
+		}
+
+		void UpdateCursorStartPosition(EntryHandler entryHandler, int position)
+		{
+			var control = GetPlatformControl(entryHandler);
+			control.SetSelection(position);
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Windows.cs
@@ -14,5 +14,17 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() => GetPlatformControl(handler).Text);
 		}
+
+		int GetCursorStartPosition(EntryHandler entryHandler)
+		{
+			var control = GetPlatformControl(entryHandler);
+			return control.SelectionStart;
+		}
+
+		void UpdateCursorStartPosition(EntryHandler entryHandler, int position)
+		{
+			var control = GetPlatformControl(entryHandler);
+			control.SelectionStart = position;
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -28,5 +28,28 @@ namespace Microsoft.Maui.DeviceTests
 			var platformText = await GetPlatformText(handler);
 			Assert.Equal(expected, platformText);
 		}
+
+
+
+		[Fact]
+		public async Task CursorPositionDoesntResetWhenNativeTextValueChanges()
+		{
+			var textInput = new Entry()
+			{
+				Text = "Hello"
+			};
+
+
+			int cursorPosition = 0;
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<EntryHandler>(textInput);
+				UpdateCursorStartPosition(handler, 5);
+				handler.UpdateValue(nameof(ITextInput.Text));
+				cursorPosition = GetCursorStartPosition(handler);
+			});
+
+			Assert.Equal(5, cursorPosition);
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -68,7 +68,16 @@ namespace Microsoft.Maui.DeviceTests
 				cursorPosition = GetCursorStartPosition(handler);
 			});
 
+			// iOS won't reset your cursor position when changing the value.
+			// We could force iOS to act like winui/android
+			// but that starts to become a rabbit hole.
+			// If the developer cares they can use the cursor APIs
+			// to specifically move the cursor where they want it to be
+#if IOS
+			Assert.Equal(3, cursorPosition);
+#else
 			Assert.Equal(0, cursorPosition);
+#endif
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		public async Task CursorPositionDoesntResetWhenApplyingTransform()
+		public async Task CursorPositionResetsToZeroAfterChangingText()
 		{
 			var textInput = new Entry()
 			{
@@ -64,11 +64,11 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				var handler = CreateHandler<EntryHandler>(textInput);
 				UpdateCursorStartPosition(handler, 5);
-				textInput.TextTransform = TextTransform.Uppercase;
+				textInput.Text = "hel";
 				cursorPosition = GetCursorStartPosition(handler);
 			});
 
-			Assert.Equal(5, cursorPosition);
+			Assert.Equal(0, cursorPosition);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expected, platformText);
 		}
 
-
-
 		[Fact]
 		public async Task CursorPositionDoesntResetWhenNativeTextValueChanges()
 		{
@@ -46,6 +44,27 @@ namespace Microsoft.Maui.DeviceTests
 				var handler = CreateHandler<EntryHandler>(textInput);
 				UpdateCursorStartPosition(handler, 5);
 				handler.UpdateValue(nameof(ITextInput.Text));
+				cursorPosition = GetCursorStartPosition(handler);
+			});
+
+			Assert.Equal(5, cursorPosition);
+		}
+
+		[Fact]
+		public async Task CursorPositionDoesntResetWhenApplyingTransform()
+		{
+			var textInput = new Entry()
+			{
+				Text = "Hello"
+			};
+
+
+			int cursorPosition = 0;
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<EntryHandler>(textInput);
+				UpdateCursorStartPosition(handler, 5);
+				textInput.TextTransform = TextTransform.Uppercase;
 				cursorPosition = GetCursorStartPosition(handler);
 			});
 

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -13,5 +13,18 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() => GetPlatformControl(handler).Text);
 		}
+
+		void UpdateCursorStartPosition(EntryHandler entryHandler, int position)
+		{
+			var control = GetPlatformControl(entryHandler);
+			var endPosition = control.GetPosition(control.BeginningOfDocument, position);
+			control.SelectedTextRange = control.GetTextRange(endPosition, endPosition);
+		}
+
+		int GetCursorStartPosition(EntryHandler entryHandler)
+		{
+			var control = GetPlatformControl(entryHandler);
+			return (int)control.GetOffsetFromPosition(control.BeginningOfDocument, control.SelectedTextRange.Start);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

On android if you set the text to the same value it causes the cursor to reset to the initial position. We fixed this once in `Core` but it broke again with the `TextTransform` changes

`TextTransform` is a little bit trickier to manage because we're modifying the text after it's been set on the platform control. This PR attempts to only restore the cursor for cases where the `TextTransform` is modifying the text. If the user is modifying the text then we just want it to fall back to whatever the default platform behavior is.

