### PR TITLE
Make sure RadioButtonExtensions.UpdateTextColor applies to RadioButton only

### DIFF
--- a/src/Core/src/Platform/Windows/RadioButtonExtensions.cs
+++ b/src/Core/src/Platform/Windows/RadioButtonExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui
 			platformRadioButton.IsChecked = radioButton.IsChecked;
 		}
 
-		public static void UpdateTextColor(this Button platformButton, ITextStyle button)
+		public static void UpdateTextColor(this Button platformButton, IRadioButton button)
 		{
 			var brush = button.TextColor?.ToPlatform();
 


### PR DESCRIPTION
### Description of Change

Make sure `RadioButtonExtensions.UpdateTextColor(...)` applies to `RadioButton` only.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #4887
