### PR TITLE
Disable BlazorWebView zoom behavior by default

### DIFF
--- a/src/Templates/src/templates/maui-blazor/wwwroot/index.html
+++ b/src/Templates/src/templates/maui-blazor/wwwroot/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<title>MauiApp.1</title>
 	<base href="/" />
 	<link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />


### PR DESCRIPTION
### Description of Change

Adds a meta tag to the default .NET MAUI Blazor templates so zooming by double tapping or pinch to zoom is disabled by default. This behavior can easily be changed by the developer by tweaking this tag if desired.

### Issues Fixed

Fixes #4996
