### PR TITLE
[Android] Update cursor visibility when IsReadOnly Property changes on Entry

### DIFF
--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -155,6 +155,8 @@ namespace Microsoft.Maui.Platform
 
 			editText.FocusableInTouchMode = isEditable;
 			editText.Focusable = isEditable;
+
+			editText.SetCursorVisible(isEditable);
 		}
 
 		public static void UpdateKeyboard(this EditText editText, IEntry entry)


### PR DESCRIPTION
### Description of Change

 Update cursor visibility when IsReadOnly Property changes on Entry.

Pending change from https://github.com/xamarin/Xamarin.Forms/blob/caab66bcf9614aca0c0805d560a34e176d196e17/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs#L45

### Issues Fixed

Related with a point from https://github.com/dotnet/maui/issues/4808
