### PR TITLE
Allow non-dot decimal separator in BindingExpression

### DIFF
--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -460,7 +460,7 @@ namespace Microsoft.Maui.Controls
 				var stringValue = value as string ?? string.Empty;
 				// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
 				// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
-				if (stringValue.EndsWith(CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator, StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))
+				if (stringValue.EndsWith(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))
 				{
 					value = original;
 					return false;
@@ -473,7 +473,7 @@ namespace Microsoft.Maui.Controls
 					return false;
 				}
 
-				value = Convert.ChangeType(value, convertTo, CultureInfo.CurrentUICulture);
+				value = Convert.ChangeType(value, convertTo, CultureInfo.CurrentCulture);
 
 				return true;
 			}

--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -460,7 +460,7 @@ namespace Microsoft.Maui.Controls
 				var stringValue = value as string ?? string.Empty;
 				// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
 				// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
-				if (stringValue.EndsWith(".", StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))
+				if (stringValue.EndsWith(CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator, StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))
 				{
 					value = original;
 					return false;
@@ -473,9 +473,8 @@ namespace Microsoft.Maui.Controls
 					return false;
 				}
 
-				convertTo = Nullable.GetUnderlyingType(convertTo) ?? convertTo;
+				value = Convert.ChangeType(value, convertTo, CultureInfo.CurrentUICulture);
 
-				value = Convert.ChangeType(value, convertTo, CultureInfo.InvariantCulture);
 				return true;
 			}
 			catch (Exception ex) when (ex is InvalidCastException || ex is FormatException || ex is InvalidOperationException || ex is OverflowException)

--- a/src/Controls/src/Core/BindingExpression.cs
+++ b/src/Controls/src/Core/BindingExpression.cs
@@ -457,6 +457,8 @@ namespace Microsoft.Maui.Controls
 			object original = value;
 			try
 			{
+				convertTo = Nullable.GetUnderlyingType(convertTo) ?? convertTo;
+
 				var stringValue = value as string ?? string.Empty;
 				// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
 				// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty

--- a/src/Controls/tests/Core.UnitTests/BindingExpressionTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingExpressionTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[TestCaseSource(nameof(TryConvertWithNumbersAndCulturesCases))]
 		public void TryConvertWithNumbersAndCultures(object inputString, CultureInfo culture, object expected)
 		{
-			CultureInfo.CurrentUICulture = culture;
+			CultureInfo.CurrentCulture = culture;
 			BindingExpression.TryConvert(ref inputString, Entry.TextProperty, expected.GetType(), false);
 
 			Assert.AreEqual(expected, inputString);

--- a/src/Controls/tests/Core.UnitTests/BindingExpressionTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingExpressionTests.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Globalization;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -79,6 +76,53 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var binding = new Binding(path);
 			Assert.DoesNotThrow(() => new BindingExpression(binding, path));
+		}
+
+		static object[] TryConvertWithNumbersAndCulturesCases => new object[]
+		{
+			new object[]{ "4.2", new CultureInfo("en"), 4.2m },
+			new object[]{ "4,2", new CultureInfo("de"), 4.2m },
+			new object[]{ "-4.2", new CultureInfo("en"), -4.2m },
+			new object[]{ "-4,2", new CultureInfo("de"), -4.2m },
+
+			new object[]{ "4.2", new CultureInfo("en"), new decimal?(4.2m)},
+			new object[]{ "4,2", new CultureInfo("de"), new decimal?(4.2m) },
+			new object[]{ "-4.2", new CultureInfo("en"), new decimal?(-4.2m)},
+			new object[]{ "-4,2", new CultureInfo("de"), new decimal?(-4.2m) },
+
+			new object[]{ "4.2", new CultureInfo("en"), 4.2d },
+			new object[]{ "4,2", new CultureInfo("de"), 4.2d },
+			new object[]{ "-4.2", new CultureInfo("en"), -4.2d },
+			new object[]{ "-4,2", new CultureInfo("de"), -4.2d },
+
+			new object[]{ "4.2", new CultureInfo("en"), new double?(4.2d)},
+			new object[]{ "4,2", new CultureInfo("de"), new double?(4.2d) },
+			new object[]{ "-4.2", new CultureInfo("en"), new double?(-4.2d)},
+			new object[]{ "-4,2", new CultureInfo("de"), new double?(-4.2d) },
+
+			new object[]{ "4.2", new CultureInfo("en"), 4.2f },
+			new object[]{ "4,2", new CultureInfo("de"), 4.2f },
+			new object[]{ "-4.2", new CultureInfo("en"), -4.2f },
+			new object[]{ "-4,2", new CultureInfo("de"), -4.2f },
+
+			new object[]{ "4.2", new CultureInfo("en"), new float?(4.2f)},
+			new object[]{ "4,2", new CultureInfo("de"), new float?(4.2f) },
+			new object[]{ "-4.2", new CultureInfo("en"), new float?(-4.2f)},
+			new object[]{ "-4,2", new CultureInfo("de"), new float?(-4.2f) },
+
+			new object[]{ "4.", new CultureInfo("en"), "4." },
+			new object[]{ "4,", new CultureInfo("de"), "4," },
+			new object[]{ "-0", new CultureInfo("en"), "-0" },
+			new object[]{ "-0", new CultureInfo("de"), "-0" },
+		};
+
+		[TestCaseSource(nameof(TryConvertWithNumbersAndCulturesCases))]
+		public void TryConvertWithNumbersAndCultures(object inputString, CultureInfo culture, object expected)
+		{
+			CultureInfo.CurrentUICulture = culture;
+			BindingExpression.TryConvert(ref inputString, Entry.TextProperty, expected.GetType(), false);
+
+			Assert.AreEqual(expected, inputString);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -1864,21 +1864,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 #if !WINDOWS_PHONE
-		[TestCase("en-US"), TestCase("pt-PT")]
-		public void ConvertIsCultureInvariant(string culture)
+		[TestCase("en-US", "0.5", 0.5, 0.9, "0.9")]
+		[TestCase("pt-PT", "0,5", 0.5, 0.9, "0,9")]
+		public void ConvertIsCultureInvariant(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
 
 			var slider = new Slider();
-			var vm = new MockViewModel { Text = "0.5" };
+			var vm = new MockViewModel { Text = sliderSetStringValue };
 			slider.BindingContext = vm;
 			slider.SetBinding(Slider.ValueProperty, "Text", BindingMode.TwoWay);
 
-			Assert.That(slider.Value, Is.EqualTo(0.5));
+			Assert.That(slider.Value, Is.EqualTo(sliderExpectedDoubleValue));
 
-			slider.Value = 0.9;
+			slider.Value = sliderSetDoubleValue;
 
-			Assert.That(vm.Text, Is.EqualTo("0.9"));
+			Assert.That(vm.Text, Is.EqualTo(sliderExpectedStringValue));
 		}
 #endif
 

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -1866,7 +1866,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 #if !WINDOWS_PHONE
 		[TestCase("en-US", "0.5", 0.5, 0.9, "0.9")]
 		[TestCase("pt-PT", "0,5", 0.5, 0.9, "0,9")]
-		public void ConvertIsCultureInvariant(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
+		public void ConvertIsCultureAware(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
 

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -1267,21 +1267,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 #if !WINDOWS_PHONE
-		[TestCase("en-US"), TestCase("pt-PT")]
-		public void ConvertIsCultureInvariant(string culture)
+		[TestCase("en-US", "0.5", 0.5, 0.9, "0.9")]
+		[TestCase("pt-PT", "0,5", 0.5, 0.9, "0,9")]
+		public void ConvertIsCultureInvariant(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
+
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
 
 			var slider = new Slider();
-			var vm = new MockViewModel { Text = "0.5" };
+			var vm = new MockViewModel { Text = sliderSetStringValue };
 			slider.BindingContext = vm;
 			slider.SetBinding(Slider.ValueProperty, new TypedBinding<MockViewModel, string>(mvm => (mvm.Text, true), (mvm, s) => mvm.Text = s, null) { Mode = BindingMode.TwoWay });
 
-			Assert.That(slider.Value, Is.EqualTo(0.5));
+			Assert.That(slider.Value, Is.EqualTo(sliderExpectedDoubleValue));
 
-			slider.Value = 0.9;
+			slider.Value = sliderSetDoubleValue;
 
-			Assert.That(vm.Text, Is.EqualTo("0.9"));
+			Assert.That(vm.Text, Is.EqualTo(sliderExpectedStringValue));
 		}
 #endif
 

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -1269,7 +1269,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 #if !WINDOWS_PHONE
 		[TestCase("en-US", "0.5", 0.5, 0.9, "0.9")]
 		[TestCase("pt-PT", "0,5", 0.5, 0.9, "0,9")]
-		public void ConvertIsCultureInvariant(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
+		public void ConvertIsCultureAware(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
 
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);


### PR DESCRIPTION
### Description of Change

Porting [this fix](https://github.com/xamarin/Xamarin.Forms/pull/11815) from Xamarin.Forms to .NET MAUI.

> The input for floating numbers had some errors in different cultures.
> When using german for example, the decimal seperator is a ',' and not a dot.
>
> You can also use Nullable Types now. Before the Decimal Seperator would be cut off for Nullables.

### Issues Fixed
N/A original Forms issue: https://github.com/xamarin/Xamarin.Forms/issues/7996