### PR TITLE
Remove `DisableImplicitNamespaceImports` config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,8 +23,6 @@
     <!-- HACK: WinUI seems to have issues without this -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
-    <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <!-- version number information -->


### PR DESCRIPTION
Remove `DisableImplicitNamespaceImports` config since .NET 6 RC 1 `ImplicitUsings` is used and disabled by default