### PR TITLE
Remove unused ExportFontAttribute.EmbeddedFontResourceId property

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls/ExportFontAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ExportFontAttribute.xml
@@ -62,25 +62,6 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="EmbeddedFontResourceId">
-      <MemberSignature Language="C#" Value="public string EmbeddedFontResourceId { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance string EmbeddedFontResourceId" />
-      <MemberSignature Language="DocId" Value="P:Microsoft.Maui.Controls.ExportFontAttribute.EmbeddedFontResourceId" />
-      <MemberSignature Language="F#" Value="member this.EmbeddedFontResourceId : string with get, set" Usage="Microsoft.Maui.Controls.ExportFontAttribute.EmbeddedFontResourceId" />
-      <MemberType>Property</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>Microsoft.Maui.Controls.Core</AssemblyName>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <ReturnValue>
-        <ReturnType>System.String</ReturnType>
-      </ReturnValue>
-      <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName="FontFileName">
       <MemberSignature Language="C#" Value="public string FontFileName { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string FontFileName" />

--- a/src/Controls/src/Core/ExportFontAttribute.cs
+++ b/src/Controls/src/Core/ExportFontAttribute.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Maui.Controls
 			FontFileName = fontFileName;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ExportFontAttribute.xml" path="//Member[@MemberName='EmbeddedFontResourceId']/Docs" />
-		public string EmbeddedFontResourceId { get; set; }
 		/// <include file="../../docs/Microsoft.Maui.Controls/ExportFontAttribute.xml" path="//Member[@MemberName='FontFileName']/Docs" />
 		public string FontFileName { get; }
 	}


### PR DESCRIPTION
### Description of Change

Porting [this fix](https://github.com/xamarin/Xamarin.Forms/pull/14666) over from Xamarin.Forms

> Removed unused property in ExportFontAttribute.

### Issues Fixed

N/A original link to Forms issue: https://github.com/xamarin/Xamarin.Forms/issues/10183
