### PR TITLE
Fix iOS CollectionView update when not visible

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -623,6 +623,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				if (CollectionView.Hidden)
 				{
+					CollectionView.ReloadData();
 					CollectionView.Hidden = false;
 					Layout.InvalidateLayout();
 					CollectionView.LayoutIfNeeded();

--- a/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ObservableItemsSource.cs
@@ -125,7 +125,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
 			// Force UICollectionView to get the internal accounting straight
-			CollectionView.NumberOfItemsInSection(_section);
+			if (!CollectionView.Hidden)
+				CollectionView.NumberOfItemsInSection(_section);
 
 			switch (args.Action)
 			{


### PR DESCRIPTION
### Description of Change

Port for [this fix](https://github.com/xamarin/Xamarin.Forms/pull/14384) in Xamarin.Forms

> If a CollectionView is not visible and an ObservableCollection notifies about changes the CollectionView doesn't react.
Also, after changing the CollectionView's visibility to visible and making any changes in the ObservableCollection we can get exceptions like this: https://github.com/xamarin/Xamarin.Forms/issues/14045#issuecomment-869204559

### Issues Fixed

N/A original Forms issue: https://github.com/xamarin/Xamarin.Forms/issues/14045
