### PR TITLE
[shell] minor performance improvements

### DIFF
--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Maui.Controls
 		static int s_routeCount = 0;
 		static Dictionary<string, RouteFactory> s_routes = new Dictionary<string, RouteFactory>();
 		static Dictionary<string, Page> s_implicitPageRoutes = new Dictionary<string, Page>();
+		static HashSet<string> s_routeKeys;
 
 		const string ImplicitPrefix = "IMPL_";
 		const string DefaultPrefix = "D_FAULT_";
@@ -21,13 +22,17 @@ namespace Microsoft.Maui.Controls
 		internal static void ClearImplicitPageRoutes()
 		{
 			s_implicitPageRoutes.Clear();
+			s_routeKeys = null;
 		}
 
 		internal static void RegisterImplicitPageRoute(Page page)
 		{
 			var route = GetRoute(page);
 			if (!IsUserDefined(route))
+			{
 				s_implicitPageRoutes[route] = page;
+				s_routeKeys = null;
+			}
 		}
 
 		// Shell works much better if the entire nav stack can be represented by a string
@@ -109,6 +114,7 @@ namespace Microsoft.Maui.Controls
 		{
 			s_implicitPageRoutes.Clear();
 			s_routes.Clear();
+			s_routeKeys = null;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RouteProperty']/Docs" />
@@ -121,12 +127,22 @@ namespace Microsoft.Maui.Controls
 			return $"{DefaultPrefix}{bindable.GetType().Name}{++s_routeCount}";
 		}
 
-		internal static string[] GetRouteKeys()
+		internal static HashSet<string> GetRouteKeys()
 		{
-			string[] keys = new string[s_routes.Count + s_implicitPageRoutes.Count];
-			s_routes.Keys.CopyTo(keys, 0);
-			s_implicitPageRoutes.Keys.CopyTo(keys, s_routes.Count);
-			return keys;
+			var keys = s_routeKeys;
+			if (keys != null)
+				return keys;
+
+			keys = new HashSet<string>(StringComparer.Ordinal);
+			foreach (var key in s_routes.Keys)
+			{
+				keys.Add(ShellUriHandler.FormatUri(key));
+			}
+			foreach (var key in s_implicitPageRoutes.Keys)
+			{
+				keys.Add(ShellUriHandler.FormatUri(key));
+			}
+			return s_routeKeys = keys;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='GetOrCreateContent']/Docs" />
@@ -201,13 +217,16 @@ namespace Microsoft.Maui.Controls
 			ValidateRoute(route, factory);
 
 			s_routes[route] = factory;
+			s_routeKeys = null;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='UnRegisterRoute']/Docs" />
 		public static void UnRegisterRoute(string route)
 		{
-			if (s_routes.TryGetValue(route, out _))
-				s_routes.Remove(route);
+			if (s_routes.Remove(route))
+			{
+				s_routeKeys = null;
+			}
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute'][0]/Docs" />

--- a/src/Controls/src/Core/Shell/RouteRequestBuilder.cs
+++ b/src/Controls/src/Core/Shell/RouteRequestBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 		readonly List<string> _globalRouteMatches = new List<string>();
 		readonly List<string> _matchedSegments = new List<string>();
 		readonly List<string> _fullSegments = new List<string>();
-		readonly string[] _allSegments = null;
+		readonly List<string> _allSegments = null;
 		readonly static string _uriSeparator = "/";
 
 		public Shell Shell { get; private set; }
@@ -22,13 +22,13 @@ namespace Microsoft.Maui.Controls
 		public object LowestChild =>
 			(object)Content ?? (object)Section ?? (object)Item ?? (object)Shell;
 
-		public RouteRequestBuilder(string[] allSegments)
+		public RouteRequestBuilder(List<string> allSegments)
 		{
 			_allSegments = allSegments;
 		}
 
 
-		public RouteRequestBuilder(string shellSegment, string userSegment, object node, string[] allSegments) : this(allSegments)
+		public RouteRequestBuilder(string shellSegment, string userSegment, object node, List<string> allSegments) : this(allSegments)
 		{
 			if (node != null)
 				AddMatch(shellSegment, userSegment, node);
@@ -201,7 +201,7 @@ namespace Microsoft.Maui.Controls
 		string GetNextSegment(IReadOnlyList<string> matchedSegments)
 		{
 			var nextMatch = matchedSegments.Count;
-			if (nextMatch >= _allSegments.Length)
+			if (nextMatch >= _allSegments.Count)
 				return null;
 
 			return _allSegments[nextMatch];
@@ -218,22 +218,22 @@ namespace Microsoft.Maui.Controls
 			get
 			{
 				var nextMatch = _matchedSegments.Count;
-				if (nextMatch >= _allSegments.Length)
+				if (nextMatch >= _allSegments.Count)
 					return null;
 
 				return Routing.FormatRoute(String.Join(_uriSeparator, _allSegments.Skip(nextMatch)));
 			}
 		}
 
-		public string[] RemainingSegments
+		public List<string> RemainingSegments
 		{
 			get
 			{
 				var nextMatch = _matchedSegments.Count;
-				if (nextMatch >= _allSegments.Length)
+				if (nextMatch >= _allSegments.Count)
 					return null;
 
-				return _allSegments.Skip(nextMatch).ToArray();
+				return _allSegments.Skip(nextMatch).ToList();
 			}
 		}
 
@@ -265,7 +265,7 @@ namespace Microsoft.Maui.Controls
 		public string PathNoImplicit => MakeUriString(_matchedSegments);
 		public string PathFull => MakeUriString(_fullSegments);
 
-		public bool IsFullMatch => _matchedSegments.Count == _allSegments.Length;
+		public bool IsFullMatch => _matchedSegments.Count == _allSegments.Count;
 		public List<string> GlobalRouteMatches => _globalRouteMatches;
 		public List<string> SegmentsMatched => _matchedSegments;
 		public IReadOnlyList<string> FullSegments => _fullSegments;

--- a/src/Core/tests/Benchmarks/Benchmarks/ShellBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/ShellBenchmarker.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Handlers.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class ShellBenchmarker
+	{
+		[Benchmark]
+		public async Task GoTo()
+		{
+			var shell = new Shell();
+
+			var one = new ShellItem { Route = "one" };
+			var two = new ShellItem { Route = "two" };
+
+			var section1 = new ShellSection { Route = "tabone", Items = { new ShellContent { Route = "content" } } };
+			one.Items.Add(section1);
+			var section2 = new ShellSection { Route = "tabtwo", Items = { new ShellContent { Route = "content" } } };
+			two.Items.Add(section2);
+
+			shell.Items.Add(one);
+			shell.Items.Add(two);
+
+			await shell.GoToAsync(new ShellNavigationState("//two/tabtwo/content"));
+		}
+	}
+}

--- a/src/Core/tests/Benchmarks/Program.cs
+++ b/src/Core/tests/Benchmarks/Program.cs
@@ -6,8 +6,7 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 	{
 		static void Main(string[] args)
 		{
-			//BenchmarkRunner.Run<MauiServiceProviderBenchmarker>();
-			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).RunAllJoined();
+			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 		}
 	}
 }


### PR DESCRIPTION
Reviewing `dotnet trace` output of the .NET Podcast app:

    54.94ms Microsoft.NetConf2021.Maui!Microsoft.NetConf2021.Maui.Pages.MobileShell.InitializeComponent
    ...
    10.30ms Microsoft.Maui.Controls!Microsoft.Maui.Controls.ShellUriHandler.GetNavigationRequest
     2.73ms System.Linq!Enumerable.ToArray
     1.26ms System.Linq!Enumerable.Skip
     1.24ms Microsoft.Maui.Controls!Microsoft.Maui.Controls.Routing.GetRouteKeys

Reviewing the code, it looks like we can make several low-risk changes:

1. `Routing.GetRouteKeys()` can return a `HashSet<string>` as various
   usage of `keys.Contains()` will be much faster.

2. Cache the result of `Routing.GetRouteKeys()`. The cache is cleared
   when routes change.

3. Create a `List<string>` instead of doing
   `RetrievePaths(localPath).Skip(1).ToArray()`. The list can be used
   throughout instead of the array.

4. Use `Array.Empty<object>()` in a couple places instead of `new
   object[0]`.

Afterwards, `dotnet trace` output looks a bit better:

    7.37ms Microsoft.Maui.Controls!Microsoft.Maui.Controls.ShellUriHandler.GetNavigationRequest

System.Linq calls are gone from the trace. This seems like it would
save ~3ms of startup for MAUI app using shell on a Pixel 5 device.

I also added a benchmark for Shell navigation:

Before:

| Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|-------:|-------:|------:|----------:|
| --GoTo | 75.06 us | 1.063 us | 0.994 us | 7.4463 | 0.6104 |     - |  61.13 KB |
| ++GoTo | 73.21 us | 0.907 us | 0.849 us | 7.3242 | 0.6104 |     - |  60.82 KB |

It appears the changes are faster with less allocations.