### PR TITLE
Add a PropertyMapper for FormattedText

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Label/Label.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.Controls
 		{
 			[nameof(TextType)] = MapTextType,
 			[nameof(Text)] = MapText,
+			[nameof(FormattedText)] = MapText,
 			[nameof(TextTransform)] = MapText,
 #if __IOS__
 			[nameof(TextDecorations)] = MapTextDecorations,


### PR DESCRIPTION
### Description of Change

Adding the missed `PropertyMapper` for `FormattedText` on `Label`.

### Issues Fixed

Fixes #4765
