### PR TITLE
iOS WrapperView overlay should not accept touches

### DIFF
--- a/src/Core/src/Platform/iOS/WrapperView.cs
+++ b/src/Core/src/Platform/iOS/WrapperView.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.Platform
 
 			if (BorderView == null)
 			{
-				AddSubview(BorderView = new UIView(Bounds) { BackgroundColor = UIColor.Black });
+				AddSubview(BorderView = new UIView(Bounds) { UserInteractionEnabled = false});
 			}
 
 			BorderView.UpdateMauiCALayer(Border);


### PR DESCRIPTION
### Description of Change

iOS/Mac's overlay view would accept touches, which breaks buttons when you add a Border
