### PR TITLE
Switch to dispatcher so Dispose is called after DestroyView

### DIFF
--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFragmentContainer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFragmentContainer.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		public override AView OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 		{
 			_page = ((IShellContentController)ShellContentTab).GetOrCreateContent();
-			
+
 			var pageMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
-			
+
 			return new ShellPageContainer(RequireContext(), (IPlatformViewHandler)_page.ToHandler(pageMauiContext), true)
 			{
 				LayoutParameters = new LP(LP.MatchParent, LP.MatchParent)
@@ -40,7 +40,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public override void OnDestroy()
 		{
-			Activity.RunOnUiThread(Dispose);
+			_mauiContext
+				.GetDispatcher()
+				.Dispatch(Dispose);
 
 			base.OnDestroy();
 		}

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual void OnShellSectionChanged()
 		{
-			HandleFragmentUpdate(ShellNavigationSource.ShellSectionChanged, ShellSection, null, false);
+			HandleFragmentUpdate(ShellNavigationSource.ShellSectionChanged, ShellSection, null, false).FireAndForget();
 		}
 
 		protected virtual void OnDisplayedPageChanged(Page newPage, Page oldPage)

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellBasicNavigationTestCases.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellBasicNavigationTestCases.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public class ShellBasicNavigationTestCases : IEnumerable<object[]>
+	{
+		public IEnumerator<object[]> GetEnumerator()
+		{
+			var page1 = new ContentPage();
+			var page2 = new ContentPage();
+
+			yield return new object[] { new ShellItem[]
+				{
+					new ShellItem() { Items = { page1 }, Route = "page1" },
+					new ShellItem() { Items = { page2 }, Route = "page2" }
+				} };
+
+			yield return new object[] {new ShellItem[]
+				{
+					new ShellSection() { Items = { page1 }, Route = "page1" },
+					new ShellSection() { Items = { page2 }, Route = "page2" }
+				} };
+
+			yield return new object[] { new ShellItem[]
+				{
+					new ShellContent() { Content = page1, Route = "page1" },
+					new ShellContent() { Content = page2, Route = "page2" }
+				} };
+
+			yield return new object[] { new ShellItem[]
+				{
+					new FlyoutItem()
+					{
+						Items =
+						{
+							new ShellContent() { Content = page1, Route = "page1" },
+							new ShellContent() { Content = page2, Route = "page2" },
+							new ShellContent() { Content = new ContentPage(), Route = "page3" },
+						}
+					}
+				} };
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -50,20 +50,46 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			SetupBuilder();
 
-			var shell = await InvokeOnMainThreadAsync<Shell>(() => {
+			var shell = await InvokeOnMainThreadAsync<Shell>(() =>
+			{
 				return new Shell()
-					{
-						Items =
+				{
+					Items =
 						{
 							new ContentPage()
 						}
-					};
+				};
 			});
 
-			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
 			{
+				// TODO MAUI Fix this 
+				await Task.Delay(100);
 				Assert.NotNull(shell.Handler);
-				return Task.CompletedTask;
+			});
+		}
+
+
+		[Theory]
+		[ClassData(typeof(ShellBasicNavigationTestCases))]
+		public async Task BasicShellNavigationStructurePermutations(ShellItem[] shellItems)
+		{
+			SetupBuilder();
+			var shell = await InvokeOnMainThreadAsync<Shell>(() =>
+			{
+				var value = new Shell();
+				foreach (var item in shellItems)
+					value.Items.Add(item);
+
+				return value;
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				// TODO MAUI Fix this 
+				await Task.Delay(100);
+				await shell.GoToAsync("//page2");
+				await Task.Delay(100);
 			});
 		}
 #endif


### PR DESCRIPTION
### Description of Change

`Activity.RunOnUIThread` will execute the delegate immediately if you are on the UIThread. So, we need to change the `dispose` call back to just using the dispatcher so that it's always queue'd and called after `DestroyView` is called

### Issues Fixed
Fixes #5062
