### PR TITLE
Fix ArgumentException using OnPlatform with View type

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonGalleries.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonGalleries.cs
@@ -35,6 +35,8 @@ namespace Maui.Controls.Sample.Pages.RadioButtonGalleries
 							new TemplateFromStyle(), Navigation),
 						GalleryBuilder.NavButton("RadioButton Border", () =>
 							new RadioButtonBorder(), Navigation),
+						GalleryBuilder.NavButton("RadioButton View", () =>
+							new RadioButtonView(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonView.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonView.xaml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Pages.RadioButtonGalleries.RadioButtonView"
+             Title="RadioButton Views">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="When RadioButton.Content is a string, it will be translated to text on each platform:" />
+            <RadioButton Content="RadioButton containing a string" />
+
+            <Label Text="When RadioButton.Content is a View, it will be displayed only on supported platforms:" />
+            <OnPlatform x:TypeArguments="RadioButton">
+                <On Platform="iOS,UWP">
+                    <!-- iOS and UWP can assign a View to RadioButton.Content. -->
+                    <RadioButton>
+                        <RadioButton.Content>
+                            <StackLayout Orientation="Horizontal">
+                                <Image Source="mic.png" />
+                                <Label Text="Monkey"
+                                    VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </RadioButton.Content>
+                    </RadioButton>
+                </On>
+                <On Platform="Android">
+                    <RadioButton Content="Android can't assign a View to RadioButton.Content." />
+                </On>
+            </OnPlatform>
+
+            <Label Text="When RadioButton.Content is a View, it will be displayed on supported platforms and will otherwise fallback to a string representation:" />
+            <RadioButton>
+                <RadioButton.Content>
+                    <StackLayout Orientation="Horizontal">
+                        <Image Source="coffee.png"/>
+                    </StackLayout>
+                </RadioButton.Content>
+            </RadioButton>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonView.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/RadioButtonGalleries/RadioButtonView.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Pages.RadioButtonGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class RadioButtonView : ContentPage
+	{
+		public RadioButtonView()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Controls/src/Core/OnPlatform.cs
+++ b/src/Controls/src/Core/OnPlatform.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Maui.Controls
 
 			return onPlatform.hasDefault ? onPlatform.@default : default(T);
 		}
+
+		public T GetValue() => (T)this;
 	}
 
 	/// <include file="../../docs/Microsoft.Maui.Controls/On.xml" path="Type[@FullName='Microsoft.Maui.Controls.On']/Docs" />

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -145,8 +145,16 @@ namespace Microsoft.Maui.Controls.Xaml
 				{
 					var addMethod =
 						Context.Types[parentElement].GetRuntimeMethods().First(mi => mi.Name == "Add" && mi.GetParameters().Length == 1);
-
-					addMethod.Invoke(source, new[] { value });
+					
+					if (node.XmlType.Name == "OnPlatform" && node.XmlType.TypeArguments.Count == 1)
+					{
+						var getValue = Context.Types[node].GetRuntimeMethods().FirstOrDefault(mi => mi.Name == "GetValue" && mi.GetParameters().Length == 0);
+						addMethod.Invoke(source, new[] { getValue.Invoke(value, null) });
+					}
+					else
+					{
+						addMethod.Invoke(source, new[] { value });
+					}
 					return;
 				}
 				if (xpe == null && (contentProperty = GetContentPropertyName(Context.Types[parentElement].GetTypeInfo())) != null)


### PR DESCRIPTION
### Fix #4509 Exception using OnPlatform with View type

While adding a View when the `value` is `OnPlatform<T>` it should pass the T instead of `value` as an argument of `Invoke`:

https://github.com/dotnet/maui/blob/8dd650231fc535f0475699bb2c7eacd3cbc30461/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs#L146-L149

`OnPlatform<T>`  has implicit operator for getting the View for the current Platform, could not call/use that using reflection, so added parameter less `T GetValue()` the get runtime View, used it to get runtime view type and pass as argument of `Invoke`

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes # https://github.com/dotnet/maui/issues/4509
