### PR TITLE
License matches other .NET projects

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,6 @@
-.NET MAUI SDK
-
 The MIT License (MIT)
 
-Copyright (c) .NET Foundation Contributors
+Copyright (c) .NET Foundation and Contributors
 
 All rights reserved.
 


### PR DESCRIPTION
### Description of Change

Currently, GitHub doesn't recognizes the license, which adds friction when newcomers try to identify the license. It can also exclude this project from general searches where there is a filter on the license type.

I also used the copyright as written in other .NET projects (like [aspnetcore](https://github.com/dotnet/aspnetcore/blob/main/LICENSE.txt) or [efcore](https://github.com/dotnet/efcore/blob/main/LICENSE.txt)), and I renamed the file to match them.