### PR TITLE
CarouselView fix measure for CarouselView.Loop

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/CarouselViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/CarouselViewAdapter.cs
@@ -14,8 +14,21 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			CarouselView = itemsView;
 		}
 
-		public override int ItemCount => CarouselView.Loop && !(ItemsSource is EmptySource)
+		internal bool MeasureFirstItemForLooping { get; set; }
+
+		public override int ItemCount
+		{
+			get
+			{
+				if (MeasureFirstItemForLooping && CarouselView.Loop && ItemsSource.Count > 0)
+				{
+					return 1;
+				}
+
+				return (!MeasureFirstItemForLooping) && !(ItemsSource is EmptySource)
 			&& ItemsSource.Count > 0 ? CarouselViewLoopManager.LoopScale : ItemsSource.Count;
+			}
+		}
 
 		public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
 		{

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/CarouselViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/CarouselViewAdapter.cs
@@ -14,21 +14,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			CarouselView = itemsView;
 		}
 
-		internal bool MeasureFirstItemForLooping { get; set; }
-
-		public override int ItemCount
-		{
-			get
-			{
-				if (MeasureFirstItemForLooping && CarouselView.Loop && ItemsSource.Count > 0)
-				{
-					return 1;
-				}
-
-				return (!MeasureFirstItemForLooping) && !(ItemsSource is EmptySource)
+		public override int ItemCount => CarouselView.Loop && !(ItemsSource is EmptySource)
 			&& ItemsSource.Count > 0 ? CarouselViewLoopManager.LoopScale : ItemsSource.Count;
-			}
-		}
 
 		public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
 		{

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/EmptyViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/EmptyViewAdapter.cs
@@ -273,12 +273,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		int GetHeight(ViewGroup parent)
 		{
 			var headerFooterHeight = parent.Context.ToPixels(_headerHeight + _footerHeight);
-			return Math.Abs((int)(parent.Height - headerFooterHeight));
+			return Math.Abs((int)(parent.MeasuredHeight - headerFooterHeight));
 		}
 
 		int GetWidth(ViewGroup parent)
 		{
-			return parent.Width;
+			return parent.MeasuredWidth;
 		}
 
 		void UpdateHeaderFooterHeight(object item, bool isHeader)

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiCarouselRecyclerView.cs
@@ -282,6 +282,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateInitialPosition()
 		{
+			//if we don't have any items don't update position
+			if (ItemsViewAdapter.ItemsSource.Count == 0)
+				return;
+
 			int itemCount = 0;
 			int position;
 

--- a/src/Controls/src/Core/Handlers/Items/Android/SimpleViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SimpleViewHolder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return new SimpleViewHolder(textView, null);
 		}
 
-		public static SimpleViewHolder FromFormsView(View formsView, Context context, Func<int> width, Func<int> height, ItemsView container)
+		public static SimpleViewHolder FromFormsView(View formsView, Context context, Func<double> width, Func<double> height, ItemsView container)
 		{
 			var itemContentControl = new SizedItemContentView(context, width, height);
 

--- a/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using Android.Content;
+using Android.Views;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
 	internal class SizedItemContentView : ItemContentView
 	{
-		readonly Func<int> _width;
-		readonly Func<int> _height;
+		readonly Func<double> _width;
+		readonly Func<double> _height;
 
-		public SizedItemContentView(Context context, Func<int> width, Func<int> height)
+		public SizedItemContentView(Context context, Func<double> width, Func<double> height)
 			: base(context)
 		{
 			_width = width;
@@ -23,13 +24,31 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				return;
 			}
 
-			var targetWidth = _width();
-			var targetHeight = _height();
+			double targetWidth = _width();
+			double targetHeight = _height();
 
-			(Content.VirtualView as View).Measure(Context.FromPixels(targetWidth), Context.FromPixels(targetHeight),
-				MeasureFlags.IncludeMargins);
+			if (!double.IsInfinity(targetWidth))
+				targetWidth = (int)Context.FromPixels(targetWidth);
 
-			SetMeasuredDimension(targetWidth, targetHeight);
+			if (!double.IsInfinity(targetHeight))
+				targetHeight = (int)Context.FromPixels(targetHeight);
+
+			//_ = (Content.VirtualView as IView)
+			//	.Measure(targetWidth, targetHeight);
+
+			if (Content.VirtualView.Handler is IPlatformViewHandler pvh)
+			{
+				var widthSpec = Context.CreateMeasureSpec(targetWidth, 
+					double.IsInfinity(targetWidth) ? double.NaN : targetWidth
+					, targetWidth);
+				var heightSpec = Context.CreateMeasureSpec(targetHeight, double.IsInfinity(targetHeight) ? double.NaN : targetHeight
+					, targetHeight);
+
+				pvh.PlatformView.Measure(widthSpec, heightSpec);
+				SetMeasuredDimension(
+					pvh.PlatformView.MeasuredWidth,
+					pvh.PlatformView.MeasuredHeight);
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
@@ -33,18 +33,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (!double.IsInfinity(targetHeight))
 				targetHeight = (int)Context.FromPixels(targetHeight);
 
-			//_ = (Content.VirtualView as IView)
-			//	.Measure(targetWidth, targetHeight);
-
 			if (Content.VirtualView.Handler is IPlatformViewHandler pvh)
 			{
 				var widthSpec = Context.CreateMeasureSpec(targetWidth, 
 					double.IsInfinity(targetWidth) ? double.NaN : targetWidth
 					, targetWidth);
+					
 				var heightSpec = Context.CreateMeasureSpec(targetHeight, double.IsInfinity(targetHeight) ? double.NaN : targetHeight
 					, targetHeight);
 
 				pvh.PlatformView.Measure(widthSpec, heightSpec);
+				
 				SetMeasuredDimension(
 					pvh.PlatformView.MeasuredWidth,
 					pvh.PlatformView.MeasuredHeight);

--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Android.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			return new CarouselViewAdapter<CarouselView, IItemsViewSource>(VirtualView, (view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
 		}
+
 		protected override RecyclerView CreatePlatformView()
 		{
 			return new MauiCarouselRecyclerView(Context, GetItemsLayout, CreateAdapter);
@@ -53,25 +54,40 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			_widthConstraint = widthConstraint;
 			_heightConstraint = heightConstraint;
+
+			if (!double.IsInfinity(_widthConstraint))
+				_widthConstraint = Context.ToPixels(_widthConstraint);
+
+			if (!double.IsInfinity(_heightConstraint))
+				_heightConstraint = Context.ToPixels(_heightConstraint);
+
 			return base.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 
-		int GetItemWidth()
+		public override void PlatformArrange(Rect frame)
 		{
-			var itemWidth = (int)Context?.ToPixels(_widthConstraint);
+			_widthConstraint = Context.ToPixels(frame.Width);
+			_heightConstraint = Context.ToPixels(frame.Height);
+
+			base.PlatformArrange(frame);
+		}
+
+		double GetItemWidth()
+		{
+			var itemWidth = _widthConstraint;
 
 			if ((PlatformView as IMauiRecyclerView<CarouselView>)?.ItemsLayout is LinearItemsLayout listItemsLayout && listItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
-				itemWidth = (int)(PlatformView.Width - Context?.ToPixels(VirtualView.PeekAreaInsets.Left) - Context?.ToPixels(VirtualView.PeekAreaInsets.Right) - Context?.ToPixels(listItemsLayout.ItemSpacing));
+				itemWidth = (int)(PlatformView.MeasuredWidth - Context?.ToPixels(VirtualView.PeekAreaInsets.Left) - Context?.ToPixels(VirtualView.PeekAreaInsets.Right) - Context?.ToPixels(listItemsLayout.ItemSpacing));
 
 			return itemWidth;
 		}
 
-		int GetItemHeight()
+		double GetItemHeight()
 		{
-			var itemHeight = (int)Context?.ToPixels(_heightConstraint);
+			var itemHeight = _heightConstraint;
 
 			if ((PlatformView as IMauiRecyclerView<CarouselView>)?.ItemsLayout is LinearItemsLayout listItemsLayout && listItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
-				itemHeight = (int)(PlatformView.Height - Context?.ToPixels(VirtualView.PeekAreaInsets.Top) - Context?.ToPixels(VirtualView.PeekAreaInsets.Bottom) - Context?.ToPixels(listItemsLayout.ItemSpacing));
+				itemHeight = (int)(PlatformView.MeasuredHeight - Context?.ToPixels(VirtualView.PeekAreaInsets.Top) - Context?.ToPixels(VirtualView.PeekAreaInsets.Bottom) - Context?.ToPixels(listItemsLayout.ItemSpacing));
 
 			return itemHeight;
 		}

--- a/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Items/CarouselViewHandler.Android.cs
@@ -77,7 +77,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var itemWidth = _widthConstraint;
 
 			if ((PlatformView as IMauiRecyclerView<CarouselView>)?.ItemsLayout is LinearItemsLayout listItemsLayout && listItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
-				itemWidth = (int)(PlatformView.MeasuredWidth - Context?.ToPixels(VirtualView.PeekAreaInsets.Left) - Context?.ToPixels(VirtualView.PeekAreaInsets.Right) - Context?.ToPixels(listItemsLayout.ItemSpacing));
+			{
+				var width = (PlatformView.MeasuredWidth == 0) ? _widthConstraint : PlatformView.MeasuredWidth;
+
+				if (double.IsInfinity(width))
+					return width;
+
+				itemWidth = (int)(width - Context?.ToPixels(VirtualView.PeekAreaInsets.Left) - Context?.ToPixels(VirtualView.PeekAreaInsets.Right) - Context?.ToPixels(listItemsLayout.ItemSpacing));
+			}
 
 			return itemWidth;
 		}
@@ -87,7 +94,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var itemHeight = _heightConstraint;
 
 			if ((PlatformView as IMauiRecyclerView<CarouselView>)?.ItemsLayout is LinearItemsLayout listItemsLayout && listItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
-				itemHeight = (int)(PlatformView.MeasuredHeight - Context?.ToPixels(VirtualView.PeekAreaInsets.Top) - Context?.ToPixels(VirtualView.PeekAreaInsets.Bottom) - Context?.ToPixels(listItemsLayout.ItemSpacing));
+			{
+				var height = (PlatformView.MeasuredHeight == 0) ? _heightConstraint : PlatformView.MeasuredHeight;
+
+				if (double.IsInfinity(height))
+					return height;
+
+				itemHeight = (int)(height - Context?.ToPixels(VirtualView.PeekAreaInsets.Top) - Context?.ToPixels(VirtualView.PeekAreaInsets.Bottom) - Context?.ToPixels(listItemsLayout.ItemSpacing));
+			}
 
 			return itemHeight;
 		}


### PR DESCRIPTION
### Description of Change

 If the height or width are unbounded and the user is set to Loop then the CarouselView tries to create and measure all 16384 items that we virtualize.  Looping works by setting item count to 16384 so if the  CarV has infinite room it'll generate all 16384 items. This PR attempts to detect that condition and then just forces to the CarV to measure with one item and then uses that for the WxH.

There are also various fixes that seemed needed as it related to contraints/px/dp interactions.

I think this PR also breaks margins when set on Items but I'm not too sure how to account for Margins here and make it all work.

- You can test the looping fix just with the first gallery in CarouselViewGallery. That gallery just has 3 items with looping turned on. If you try to load it against this [PR](https://github.com/dotnet/maui/pull/3343) it just locks up trying to load 16384 rows

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #4082
