### PR TITLE
Mark all the Device [Obsolete]

### DIFF
--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -9,7 +9,7 @@
     <Nullable>disable</Nullable>
     <!--<DefineConstants>$(DefineConstants);HAVE_OPENTK</DefineConstants>-->
     <AndroidLinkMode>None</AndroidLinkMode>
-    <NoWarn>IL2036;0618</NoWarn>
+    <NoWarn>IL2036;0618;0612</NoWarn>
   </PropertyGroup>
 
     <!--

--- a/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core.csproj
+++ b/src/Compatibility/ControlGallery/src/Core/Compatibility.ControlGallery.Core.csproj
@@ -11,13 +11,13 @@
     <DefineConstants>TRACE;DEBUG;PERF;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618</NoWarn>
+    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618;0612</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DefineConstants>TRACE;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618</NoWarn>
+    <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429;0618;0612</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap10.0'))">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>

--- a/src/Compatibility/ControlGallery/src/WinUI/Compatibility.ControlGallery.WinUI.csproj
+++ b/src/Compatibility/ControlGallery/src/WinUI/Compatibility.ControlGallery.WinUI.csproj
@@ -8,7 +8,7 @@
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <RootNamespace>Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <NoWarn>1701;1702;CS8305;8305;CA1416</NoWarn>
+    <NoWarn>1701;1702;CS8305;8305;CA1416;0612</NoWarn>
     <EnableDefaultPageItems>true</EnableDefaultPageItems>
     <EnableDefaultXamlItems>false</EnableDefaultXamlItems>
 

--- a/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
+++ b/src/Compatibility/ControlGallery/src/iOS/Compatibility.ControlGallery.iOS.csproj
@@ -10,6 +10,7 @@
     <!--<DefineConstants>$(DefineConstants);HAVE_OPENTK</DefineConstants>-->
     <!--<MtouchLink Condition="'$(CI)' == 'true'">Full</MtouchLink>-->
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+    <NoWarn>0612</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/Android.UITests/Compatibility.ControlGallery.Android.UITests.csproj
@@ -7,14 +7,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <DefineConstants>$(DefineConstants);__ANDROID__;UITEST;__SHELL__</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;0618</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;0618</NoWarn>
+    <NoWarn>1701;1702;0618;0612</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/WinUI.UITests/WinUI.UITests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <DefineConstants>$(DefineConstants);WINDOWS;UITEST</DefineConstants>
-    <NoWarn>0114;0108;4014;0649;0169;0168;0219;0618</NoWarn>
+    <NoWarn>0114;0108;4014;0649;0169;0168;0219;0618;0612</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
+++ b/src/Compatibility/ControlGallery/test/iOS.UITests/Compatibility.ControlGallery.iOS.UITests.csproj
@@ -7,14 +7,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <DefineConstants>$(DefineConstants);__IOS__;UITEST;__SHELL__</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;0618</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;0618</NoWarn>
+    <NoWarn>1701;1702;0618;0612</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compatibility/Core/src/Windows/ButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ButtonRenderer.cs
@@ -304,7 +304,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (textStyle.Font == Font.Default && !_fontApplied)
 				return;
 
-			Font fontToApply = textStyle.Font == Font.Default ? Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Medium, Element.GetType(), false)) : textStyle.Font;
+			Font fontToApply = textStyle.Font == Font.Default
+#pragma warning disable CS0612 // Type or member is obsolete
+				? Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Medium, Element.GetType(), false))
+#pragma warning restore CS0612 // Type or member is obsolete
+				: textStyle.Font;
 
 			Control.ApplyFont(fontToApply, Element.RequireFontManager());
 			_fontApplied = true;

--- a/src/Compatibility/Core/src/Windows/DatePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/DatePickerRenderer.cs
@@ -255,7 +255,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (datePicker == null)
 				return;
 
-			bool datePickerIsDefault = datePicker.FontFamily == null && datePicker.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(DatePicker), true) && datePicker.FontAttributes == FontAttributes.None;
+			bool datePickerIsDefault =
+				datePicker.FontFamily == null &&
+#pragma warning disable CS0612 // Type or member is obsolete
+				datePicker.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(DatePicker), true) &&
+#pragma warning restore CS0612 // Type or member is obsolete
+				datePicker.FontAttributes == FontAttributes.None;
 
 			if (datePickerIsDefault && !_fontApplied)
 				return;

--- a/src/Compatibility/Core/src/Windows/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/EditorRenderer.cs
@@ -224,7 +224,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				return;
 
 			bool editorIsDefault = editor.FontFamily == null &&
+#pragma warning disable CS0612 // Type or member is obsolete
 								   editor.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Editor), true) &&
+#pragma warning restore CS0612 // Type or member is obsolete
 								   editor.FontAttributes == FontAttributes.None;
 
 			if (editorIsDefault && !_fontApplied)

--- a/src/Compatibility/Core/src/Windows/EntryRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/EntryRenderer.cs
@@ -220,7 +220,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (entry == null)
 				return;
 
-			bool entryIsDefault = entry.FontFamily == null && entry.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Entry), true) && entry.FontAttributes == FontAttributes.None;
+			bool entryIsDefault =
+				entry.FontFamily == null &&
+#pragma warning disable CS0612 // Type or member is obsolete
+				entry.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Entry), true) &&
+#pragma warning restore CS0612 // Type or member is obsolete
+				entry.FontAttributes == FontAttributes.None;
 
 			if (entryIsDefault && !_fontApplied)
 				return;

--- a/src/Compatibility/Core/src/Windows/LabelRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/LabelRenderer.cs
@@ -274,7 +274,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				return;
 
 			if (isLabelDefault && _isInitiallyDefault)
+#pragma warning disable CS0612 // Type or member is obsolete
 				textBlock.ApplyFont(Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Medium, Element.GetType(), false)), Element.RequireFontManager());
+#pragma warning restore CS0612 // Type or member is obsolete
 			else
 				textBlock.ApplyFont(label.ToFont(), Element.RequireFontManager());
 

--- a/src/Compatibility/Core/src/Windows/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/PickerRenderer.cs
@@ -191,7 +191,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (picker == null)
 				return;
 
-			bool pickerIsDefault = picker.FontFamily == null && picker.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Picker), true) && picker.FontAttributes == FontAttributes.None;
+			bool pickerIsDefault =
+				picker.FontFamily == null &&
+#pragma warning disable CS0612 // Type or member is obsolete
+				picker.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(Picker), true) &&
+#pragma warning restore CS0612 // Type or member is obsolete
+				picker.FontAttributes == FontAttributes.None;
 
 			if (pickerIsDefault && !_fontApplied)
 				return;

--- a/src/Compatibility/Core/src/Windows/RadioButtonRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/RadioButtonRenderer.cs
@@ -192,7 +192,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (font == Font.Default && !_fontApplied)
 				return;
 
-			Font fontToApply = font == Font.Default ? Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Medium, Element.GetType(), false)) : font;
+			Font fontToApply = font == Font.Default
+#pragma warning disable CS0612 // Type or member is obsolete
+				? Font.SystemFontOfSize(Device.GetNamedSize(NamedSize.Medium, Element.GetType(), false))
+#pragma warning restore CS0612 // Type or member is obsolete
+				: font;
 
 			Control.ApplyFont(fontToApply, Element.RequireFontManager());
 			_fontApplied = true;

--- a/src/Compatibility/Core/src/Windows/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/SearchBarRenderer.cs
@@ -207,7 +207,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (searchBar == null)
 				return;
 
-			bool searchBarIsDefault = searchBar.FontFamily == null && searchBar.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(SearchBar), true) && searchBar.FontAttributes == FontAttributes.None;
+			bool searchBarIsDefault =
+				searchBar.FontFamily == null &&
+#pragma warning disable CS0612 // Type or member is obsolete
+				searchBar.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(SearchBar), true) &&
+#pragma warning restore CS0612 // Type or member is obsolete
+				searchBar.FontAttributes == FontAttributes.None;
 
 			if (searchBarIsDefault && !_fontApplied)
 				return;

--- a/src/Compatibility/Core/src/Windows/TimePickerRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/TimePickerRenderer.cs
@@ -141,7 +141,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (timePicker == null)
 				return;
 
-			bool timePickerIsDefault = timePicker.FontFamily == null && timePicker.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(TimePicker), true) && timePicker.FontAttributes == FontAttributes.None;
+			bool timePickerIsDefault =
+				timePicker.FontFamily == null &&
+#pragma warning disable CS0612 // Type or member is obsolete
+				timePicker.FontSize == Device.GetNamedSize(NamedSize.Default, typeof(TimePicker), true) &&
+#pragma warning restore CS0612 // Type or member is obsolete
+				timePicker.FontAttributes == FontAttributes.None;
 
 			if (timePickerIsDefault && !_fontApplied)
 				return;

--- a/src/Compatibility/Core/tests/Android/CollectionViewTests.cs
+++ b/src/Compatibility/Core/tests/Android/CollectionViewTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Dispatching;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
@@ -20,7 +21,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 			cv.ItemsLayout = itemsLayout;
 
 			// Creating the renderer is enough to cause the ClassNotFoundException on older APIs
-			await Device.InvokeOnMainThreadAsync(() => { GetRenderer(cv).Dispose(); });
+			await cv.Dispatcher.DispatchAsync(() => { GetRenderer(cv).Dispose(); });
 		}
 	}
 }

--- a/src/Compatibility/Core/tests/Android/CornerRadiusTests.cs
+++ b/src/Compatibility/Core/tests/Android/CornerRadiusTests.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Compatibility.Platform.Android;
 using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -76,7 +77,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 
 		public async Task CheckCornerRadius(VisualElement visualElement)
 		{
-			var screenshot = await Device.InvokeOnMainThreadAsync(() =>
+			var screenshot = await visualElement.Dispatcher.DispatchAsync(() =>
 			{
 
 				using (var renderer = GetRenderer(visualElement))

--- a/src/Compatibility/Core/tests/Android/EmbeddingTests.cs
+++ b/src/Compatibility/Core/tests/Android/EmbeddingTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using AndroidX.Fragment.App;
+using Microsoft.Maui.Dispatching;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
@@ -12,7 +13,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		{
 			var contentPage = new ContentPage { Title = "Embedded Page" };
 			contentPage.Parent = Application.Current;
-			await Device.InvokeOnMainThreadAsync(() =>
+			await contentPage.Dispatcher.DispatchAsync(() =>
 			{
 				Fragment fragment = contentPage.CreateSupportFragment(Context);
 			});

--- a/src/Compatibility/Core/tests/Android/IsEnabledTests.cs
+++ b/src/Compatibility/Core/tests/Android/IsEnabledTests.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls.CustomAttributes;
+using Microsoft.Maui.Dispatching;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
@@ -35,7 +36,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		[Description("VisualElement enabled should match renderer enabled")]
 		public async Task EnabledConsistent(VisualElement element)
 		{
-			await Device.InvokeOnMainThreadAsync(() =>
+			await element.Dispatcher.DispatchAsync(() =>
 			{
 				using (var renderer = GetRenderer(element))
 				{

--- a/src/Compatibility/Core/tests/Android/Issues.cs
+++ b/src/Compatibility/Core/tests/Android/Issues.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Android.Views;
 using Microsoft.Maui.Controls.CustomAttributes;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Platform;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -25,7 +26,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 				// Test with RTL support off 
 				SetIsRTLSupported(false);
 
-				await Device.InvokeOnMainThreadAsync(() =>
+				await Application.Current.Dispatcher.DispatchAsync(() =>
 				{
 					var entry1 = new Entry { Text = "foo", HorizontalTextAlignment = TextAlignment.Center };
 					using (var editText = GetNativeControl(entry1))
@@ -70,7 +71,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 
 				var navPage = new NavigationPage(page);
 
-				await Device.InvokeOnMainThreadAsync(() => GetRenderer(navPage));
+				await Application.Current.Dispatcher.DispatchAsync(() => GetRenderer(navPage));
 			}
 			catch (Exception exc)
 			{

--- a/src/Compatibility/Core/tests/Android/PlatformTestFixture.cs
+++ b/src/Compatibility/Core/tests/Android/PlatformTestFixture.cs
@@ -8,6 +8,7 @@ using Android.Views;
 using Android.Widget;
 using AndroidX.AppCompat.Widget;
 using AndroidX.CardView.Widget;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Graphics;
 using NUnit.Framework;
 using AColor = Android.Graphics.Color;
@@ -348,7 +349,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		async Task<TProperty> GetRendererProperty<TProperty>(VisualElement element,
 			Func<IVisualElementRenderer, TProperty> getProperty)
 		{
-			return await Device.InvokeOnMainThreadAsync(() =>
+			return await element.Dispatcher.DispatchAsync(() =>
 			{
 				using (var renderer = GetRenderer(element))
 				{
@@ -360,7 +361,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		async Task<TProperty> GetRendererPropertyWithParent<TProperty>(VisualElement element,
 			Func<IVisualElementRenderer, TProperty> getProperty)
 		{
-			return await Device.InvokeOnMainThreadAsync(() =>
+			return await element.Dispatcher.DispatchAsync(() =>
 			{
 				using (var renderer = GetRenderer(element))
 				{
@@ -375,7 +376,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		async Task<TProperty> GetRendererPropertyWithLayout<TProperty>(VisualElement element,
 			Func<IVisualElementRenderer, TProperty> getProperty)
 		{
-			return await Device.InvokeOnMainThreadAsync(() =>
+			return await element.Dispatcher.DispatchAsync(() =>
 			{
 				using (var renderer = GetRenderer(element))
 				{
@@ -389,7 +390,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		protected async Task<TProperty> GetControlProperty<TProperty>(ImageButton imageButton,
 			Func<AppCompatImageButton, TProperty> getProperty, bool requiresLayout = false)
 		{
-			return await Device.InvokeOnMainThreadAsync(() =>
+			return await imageButton.Dispatcher.DispatchAsync(() =>
 			{
 				using (var control = GetNativeControl(imageButton))
 				{
@@ -406,7 +407,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		protected async Task<TProperty> GetControlProperty<TProperty>(Button button,
 			Func<AppCompatButton, TProperty> getProperty, bool requiresLayout = false)
 		{
-			return await Device.InvokeOnMainThreadAsync(() =>
+			return await button.Dispatcher.DispatchAsync(() =>
 			{
 				using (var control = GetNativeControl(button))
 				{
@@ -438,7 +439,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		protected async Task<TProperty> GetControlProperty<TProperty>(Editor editor,
 			Func<EditText, TProperty> getProperty, bool requiresLayout = false)
 		{
-			return await Device.InvokeOnMainThreadAsync(() =>
+			return await editor.Dispatcher.DispatchAsync(() =>
 			{
 				using (var control = GetNativeControl(editor))
 				{
@@ -455,7 +456,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		protected async Task<TProperty> GetControlProperty<TProperty>(Entry entry,
 			Func<EditText, TProperty> getProperty, bool requiresLayout = false)
 		{
-			return await Device.InvokeOnMainThreadAsync(() =>
+			return await entry.Dispatcher.DispatchAsync(() =>
 			{
 				using (var control = GetNativeControl(entry))
 				{
@@ -472,7 +473,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 		protected async Task<TProperty> GetControlProperty<TProperty>(Label label,
 			Func<TextView, TProperty> getProperty, bool requiresLayout = false)
 		{
-			return await Device.InvokeOnMainThreadAsync(() =>
+			return await label.Dispatcher.DispatchAsync(() =>
 			{
 				using (var control = GetNativeControl(label))
 				{

--- a/src/Compatibility/Core/tests/Android/ShellTests.cs
+++ b/src/Compatibility/Core/tests/Android/ShellTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Maui.Graphics;
 using NUnit.Framework;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Platform.Compatibility;
+using Microsoft.Maui.Dispatching;
 
 [assembly: ExportRenderer(typeof(TestShell), typeof(TestShellRenderer))]
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
@@ -26,7 +27,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 			var initialHeader = new Label() { Text = "Hello" };
 			var newHeader = new Label() { Text = "Hello part 2" };
 			shell.FlyoutHeader = initialHeader;
-			await Device.InvokeOnMainThreadAsync(async () =>
+			await shell.Dispatcher.DispatchAsync(async () =>
 			{
 				TestActivity testSurface = null;
 				try
@@ -36,7 +37,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 					Assert.IsNotNull(addedView);
 					Assert.IsNull(newHeader.GetValue(Platform.RendererProperty));
 					Assert.IsNotNull(initialHeader.GetValue(Platform.RendererProperty));
-					await Device.InvokeOnMainThreadAsync(() => shell.FlyoutHeader = newHeader);
+					await shell.Dispatcher.DispatchAsync(() => shell.FlyoutHeader = newHeader);
 					Assert.IsNotNull(newHeader.GetValue(Platform.RendererProperty), "New Header Not Set Up");
 					Assert.IsNull(initialHeader.GetValue(Platform.RendererProperty), "Old Header Still Set Up");
 				}
@@ -56,7 +57,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 			BottomNavigationView bottomView = new BottomNavigationView(this.Context);
 			bottomView.Menu.Add("test");
 			ColorChangeRevealDrawable ccr =
-				await Device.InvokeOnMainThreadAsync(() =>
+				await shell.Dispatcher.DispatchAsync(() =>
 				{
 					tracker.SetAppearance(bottomView, new ShellAppearanceTest());
 					return (ColorChangeRevealDrawable)bottomView.Background;

--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 		readonly Lazy<PlatformConfigurationRegistry<Application>> _platformConfigurationRegistry;
+
+#pragma warning disable CS0612 // Type or member is obsolete
 		readonly Lazy<IResourceDictionary> _systemResources;
+#pragma warning restore CS0612 // Type or member is obsolete
 
 		IAppIndexingProvider? _appIndexProvider;
 		ReadOnlyCollection<Element>? _logicalChildren;
@@ -38,12 +41,15 @@ namespace Microsoft.Maui.Controls
 			if (setCurrentApplication)
 				SetCurrentApplication(this);
 
+#pragma warning disable CS0612 // Type or member is obsolete
 			_systemResources = new Lazy<IResourceDictionary>(() =>
 			{
 				var systemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
 				systemResources.ValuesChanged += OnParentResourcesChanged;
 				return systemResources;
 			});
+#pragma warning restore CS0612 // Type or member is obsolete
+
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Application>>(() => new PlatformConfigurationRegistry<Application>(this));
 
 			_lastAppTheme = PlatformAppTheme;

--- a/src/Controls/src/Core/Compatibility/Android/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/Android/FontNamedSizeService.cs
@@ -5,10 +5,13 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
 using AndroidResource = Android.Resource;
 
+#pragma warning disable CS0612 // Type or member is obsolete
 [assembly: Microsoft.Maui.Controls.Dependency(typeof(Microsoft.Maui.Controls.Compatibility.Platform.Android.FontNamedSizeService))]
+#pragma warning restore CS0612 // Type or member is obsolete
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
+	[Obsolete]
 	class FontNamedSizeService : IFontNamedSizeService
 	{
 		double _buttonDefaultSize;

--- a/src/Controls/src/Core/Compatibility/Android/ResourcesProvider.cs
+++ b/src/Controls/src/Core/Compatibility/Android/ResourcesProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using Android.Content.Res;
 using Android.Util;
 using Microsoft.Maui.Controls.Internals;
@@ -5,6 +6,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
+	[Obsolete]
 	internal class ResourcesProvider : ISystemResourcesProvider
 	{
 		ResourceDictionary _dictionary;

--- a/src/Controls/src/Core/Compatibility/Windows/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/FontNamedSizeService.cs
@@ -2,10 +2,13 @@ using System;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
 
+#pragma warning disable CS0612 // Type or member is obsolete
 [assembly: Microsoft.Maui.Controls.Dependency(typeof(Microsoft.Maui.Controls.Compatibility.Platform.UWP.FontNamedSizeService))]
+#pragma warning restore CS0612 // Type or member is obsolete
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
+	[Obsolete]
 	class FontNamedSizeService : IFontNamedSizeService
 	{
 		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)

--- a/src/Controls/src/Core/Compatibility/Windows/WindowsResourcesProvider.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/WindowsResourcesProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using Windows.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -8,6 +9,7 @@ using FWeight = Windows.UI.Text.FontWeight;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
+	[Obsolete]
 	internal sealed class WindowsResourcesProvider : ISystemResourcesProvider
 	{
 		public IResourceDictionary GetSystemResources()

--- a/src/Controls/src/Core/Compatibility/iOS/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/FontNamedSizeService.cs
@@ -3,10 +3,13 @@ using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
 using UIKit;
 
+#pragma warning disable CS0612 // Type or member is obsolete
 [assembly: Microsoft.Maui.Controls.Dependency(typeof(Microsoft.Maui.Controls.Compatibility.Platform.iOS.FontNamedSizeService))]
+#pragma warning restore CS0612 // Type or member is obsolete
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 {
+	[Obsolete]
 	class FontNamedSizeService : IFontNamedSizeService
 	{
 		readonly double _fontScalingFactor = 1;

--- a/src/Controls/src/Core/Compatibility/iOS/ResourcesProvider.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/ResourcesProvider.cs
@@ -1,3 +1,4 @@
+using System;
 #if __MOBILE__
 using Microsoft.Maui.Controls.Internals;
 using ObjCRuntime;
@@ -10,6 +11,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 #endif
 {
+	[Obsolete]
 	[Preserve(AllMembers = true)]
 	internal class ResourcesProvider : ISystemResourcesProvider
 	{

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -10,10 +10,11 @@ using Microsoft.Maui.Essentials;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="Type[@FullName='Microsoft.Maui.Controls.Device']/Docs" />
-	//[Obsolete]
+	[Obsolete]
 	public static class Device
 	{
 		// this is just for those cases where the runtime needs to pre-load renderers
+		[Obsolete]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static Assembly DefaultRendererAssembly { get; set; }
 
@@ -70,16 +71,12 @@ namespace Microsoft.Maui.Controls
 		[Obsolete("Use Essentials.DeviceInfo.Platform instead.")]
 		public static string RuntimePlatform => DeviceInfo.Platform.ToString();
 
-		// [Obsolete]
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='FlowDirection']/Docs" />
-		public static FlowDirection FlowDirection
-		{
-			get
-			{
-				return AppInfo.RequestedLayoutDirection == LayoutDirection.RightToLeft
-					? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
-			}
-		}
+		[Obsolete("Use Essentials.AppInfo.RequestedLayoutDirection instead.")]
+		public static FlowDirection FlowDirection =>
+			AppInfo.RequestedLayoutDirection == LayoutDirection.RightToLeft
+				? FlowDirection.RightToLeft
+				: FlowDirection.LeftToRight;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='IsInvokeRequired']/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.IsDispatchRequired instead.")]
@@ -117,19 +114,21 @@ namespace Microsoft.Maui.Controls
 			Application.Current.FindDispatcher().GetSynchronizationContextAsync();
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][2]/Docs" />
+		[Obsolete]
 		public static double GetNamedSize(NamedSize size, Element targetElement)
 		{
 			return GetNamedSize(size, targetElement.GetType());
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][1]/Docs" />
+		[Obsolete]
 		public static double GetNamedSize(NamedSize size, Type targetElementType)
 		{
 			return GetNamedSize(size, targetElementType, false);
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='StartTimer']/Docs" />
-		[Obsolete("Use BindableObject.Dispatcher.StartTimer() instead.")]
+		[Obsolete("Use BindableObject.Dispatcher.StartTimer() or BindableObject.Dispatcher.DispatchDelayed() instead.")]
 		public static void StartTimer(TimeSpan interval, Func<bool> callback)
 		{
 			_ = callback ?? throw new ArgumentNullException(nameof(callback));
@@ -140,11 +139,13 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][3]/Docs" />
+		[Obsolete]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes) =>
 			DependencyService.Get<IFontNamedSizeService>()?.GetNamedSize(size, targetElementType, useOldSizes) ??
 			throw new NotImplementedException("The current platform does not implement the IFontNamedSizeService dependency service.");
 
+		[Obsolete]
 		public static class Styles
 		{
 			public static readonly string TitleStyleKey = "TitleStyle";

--- a/src/Controls/src/Core/DeviceStateTrigger.cs
+++ b/src/Controls/src/Core/DeviceStateTrigger.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/DeviceStateTrigger.xml" path="//Member[@MemberName='DeviceProperty']/Docs" />
 		public static readonly BindableProperty DeviceProperty =
-		BindableProperty.Create(nameof(Device), typeof(string), typeof(DeviceStateTrigger), string.Empty,
-			propertyChanged: OnDeviceChanged);
+			BindableProperty.Create(nameof(Device), typeof(string), typeof(DeviceStateTrigger), string.Empty,
+				propertyChanged: OnDeviceChanged);
 
 		static void OnDeviceChanged(BindableObject bindable, object oldvalue, object newvalue)
 		{
@@ -31,12 +31,10 @@ namespace Microsoft.Maui.Controls
 		void UpdateState()
 		{
 			var device = DevicePlatform.Create(Device);
-			if (device == DevicePlatform.Android)
-				SetActive(DeviceInfo.Platform == DevicePlatform.Android);
-			else if (device == DevicePlatform.iOS)
-				SetActive(DeviceInfo.Platform == DevicePlatform.iOS);
-			else if (device == DevicePlatform.WinUI || device == DevicePlatform.Create("UWP"))
+			if (device == DevicePlatform.Create("UWP"))
 				SetActive(DeviceInfo.Platform == DevicePlatform.WinUI);
+			else
+				SetActive(DeviceInfo.Platform == device);
 		}
 	}
 }

--- a/src/Controls/src/Core/FontSizeConverter.cs
+++ b/src/Controls/src/Core/FontSizeConverter.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Maui.Controls
 				if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out double size))
 					return size;
 
+#pragma warning disable CS0612 // Type or member is obsolete
 				var ignoreCase = (serviceProvider?.GetService(typeof(IConverterOptions)) as IConverterOptions)?.IgnoreCase ?? false;
 				var sc = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 				NamedSize? namedSize = null;
@@ -56,6 +57,7 @@ namespace Microsoft.Maui.Controls
 					var type = serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget valueTargetProvider ? valueTargetProvider.TargetObject.GetType() : typeof(Label);
 					return Device.GetNamedSize(namedSize.Value, type, false);
 				}
+#pragma warning restore CS0612 // Type or member is obsolete
 			}
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(double)));
 		}
@@ -71,6 +73,7 @@ namespace Microsoft.Maui.Controls
 					return size;
 				strValue = strValue.Trim();
 
+#pragma warning disable CS0612 // Type or member is obsolete
 				if (strValue.Equals(nameof(NamedSize.Default), StringComparison.Ordinal))
 					return Device.GetNamedSize(NamedSize.Default, typeof(Label), false);
 				if (strValue.Equals(nameof(NamedSize.Micro), StringComparison.Ordinal))
@@ -93,6 +96,7 @@ namespace Microsoft.Maui.Controls
 					return Device.GetNamedSize(NamedSize.Title, typeof(Label), false);
 				if (Enum.TryParse(strValue, out NamedSize namedSize))
 					return Device.GetNamedSize(namedSize, typeof(Label), false);
+#pragma warning restore CS0612 // Type or member is obsolete
 			}
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", strValue, typeof(double)));
 		}

--- a/src/Controls/src/Core/FontTypeConverter.cs
+++ b/src/Controls/src/Core/FontTypeConverter.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Maui.Controls
 				var bold = false;
 				var italic = false;
 				double size = -1;
+#pragma warning disable CS0612 // Type or member is obsolete
 				NamedSize namedSize = 0;
+#pragma warning restore CS0612 // Type or member is obsolete
 
 				// check if last is a size
 				string last = parts.Last();
@@ -42,11 +44,13 @@ namespace Microsoft.Maui.Controls
 					size = trySize;
 					parts.RemoveAt(parts.Count - 1);
 				}
+#pragma warning disable CS0612 // Type or member is obsolete
 				else if (Enum.TryParse(last, out NamedSize tryNamedSize))
 				{
 					namedSize = tryNamedSize;
 					parts.RemoveAt(parts.Count - 1);
 				}
+#pragma warning restore CS0612 // Type or member is obsolete
 
 				// check if first is a name
 				foreach (string part in parts)
@@ -74,17 +78,25 @@ namespace Microsoft.Maui.Controls
 					attributes |= FontAttributes.Bold;
 				if (italic)
 					attributes |= FontAttributes.Italic;
+
+#pragma warning disable CS0612 // Type or member is obsolete
 				if (size == -1 && namedSize == 0)
 					namedSize = NamedSize.Medium;
+#pragma warning restore CS0612 // Type or member is obsolete
 
 				if (name != null)
 				{
+#pragma warning disable CS0612 // Type or member is obsolete
 					if (size == -1)
 						size = Device.GetNamedSize(namedSize, null, false);
+#pragma warning restore CS0612 // Type or member is obsolete
 					return Font.OfSize(name, size).WithAttributes(attributes);
 				}
+
+#pragma warning disable CS0612 // Type or member is obsolete
 				if (size == -1)
-					return Font.SystemFontOfSize(Device.GetNamedSize(namedSize, null, false)).WithAttributes(attributes);
+					size = Device.GetNamedSize(namedSize, null, false);
+#pragma warning restore CS0612 // Type or member is obsolete
 				return Font.SystemFontOfSize(size).WithAttributes(attributes);
 			}
 

--- a/src/Controls/src/Core/IFontNamedSizeService.cs
+++ b/src/Controls/src/Core/IFontNamedSizeService.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Microsoft.Maui.Controls.Internals
 {
+	[Obsolete]
 	public interface IFontNamedSizeService
 	{
 		double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes);

--- a/src/Controls/src/Core/ISystemResourcesProvider.cs
+++ b/src/Controls/src/Core/ISystemResourcesProvider.cs
@@ -1,7 +1,9 @@
+using System;
 using System.ComponentModel;
 
 namespace Microsoft.Maui.Controls.Internals
 {
+	[Obsolete]
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface ISystemResourcesProvider
 	{

--- a/src/Controls/src/Core/LayoutDirectionExtensions.cs
+++ b/src/Controls/src/Core/LayoutDirectionExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.Maui.Essentials;
+
+namespace Microsoft.Maui.Controls
+{
+	public static class LayoutDirectionExtensions
+	{
+		public static FlowDirection ToFlowDirection(this LayoutDirection layoutDirection) =>
+			layoutDirection == LayoutDirection.RightToLeft
+				? FlowDirection.RightToLeft
+				: FlowDirection.LeftToRight;
+	}
+}

--- a/src/Controls/src/Core/NamedSize.cs
+++ b/src/Controls/src/Core/NamedSize.cs
@@ -1,6 +1,9 @@
+using System;
+
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/NamedSize.xml" path="Type[@FullName='Microsoft.Maui.Controls.NamedSize']/Docs" />
+	[Obsolete]
 	public enum NamedSize
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/NamedSize.xml" path="//Member[@MemberName='Default']/Docs" />

--- a/src/Controls/src/Core/Platform/Windows/Extensions/FontExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FontExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.Platform
 		internal static void ApplyFont<TFontElement>(this UI.Xaml.Documents.TextElement self, TFontElement element) where TFontElement : Element, IFontElement
 			=> self.UpdateFont(element.ToFont(), element.RequireFontManager());
 
+		[Obsolete]
 		internal static double GetFontSize(this NamedSize size) => size switch
 		{
 			NamedSize.Default => (double)UI.Xaml.Application.Current.Resources["ControlContentThemeFontSize"],

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -455,7 +455,7 @@ namespace Microsoft.Maui.Controls
 				}
 				else if (DeviceInfo.Platform == DevicePlatform.iOS)
 				{
-					defaultLabelClass.Setters.Add(new Setter { Property = Label.FontSizeProperty, Value = Device.GetNamedSize(NamedSize.Small, label) });
+					defaultLabelClass.Setters.Add(new Setter { Property = Label.FontSizeProperty, Value = 14 });
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.FontAttributesProperty, Value = FontAttributes.Bold });
 				}
 				else if (DeviceInfo.Platform == DevicePlatform.WinUI)

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -138,10 +138,13 @@ namespace Microsoft.Maui.Controls.Hosting
 			DependencyService.SetToInitialized();
 			DependencyService.Register<Xaml.ResourcesLoader>();
 			DependencyService.Register<Xaml.ValueConverterProvider>();
-			DependencyService.Register<ResourcesProvider>();
 			DependencyService.Register<PlatformSizeService>();
 			DependencyService.Register<PlatformInvalidate>();
+
+#pragma warning disable CS0612 // Type or member is obsolete
+			DependencyService.Register<ResourcesProvider>();
 			DependencyService.Register<FontNamedSizeService>();
+#pragma warning restore CS0612 // Type or member is obsolete
 #endif
 
 			builder.ConfigureImageSourceHandlers();

--- a/src/Controls/tests/Core.UnitTests/MockPlatformServices.cs
+++ b/src/Controls/tests/Core.UnitTests/MockPlatformServices.cs
@@ -10,12 +10,16 @@ using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Essentials;
 using Microsoft.Maui.Graphics;
 
+#pragma warning disable CS0612 // Type or member is obsolete
 [assembly: Dependency(typeof(MockResourcesProvider))]
 [assembly: Dependency(typeof(MockFontNamedSizeService))]
+#pragma warning restore CS0612 // Type or member is obsolete
+
 [assembly: Dependency(typeof(MockPlatformSizeService))]
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
+	[Obsolete]
 	internal class MockResourcesProvider : Internals.ISystemResourcesProvider
 	{
 		public Internals.IResourceDictionary GetSystemResources()
@@ -49,6 +53,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 	}
 
+	[Obsolete]
 	public class MockFontNamedSizeService : IFontNamedSizeService
 	{
 		public double GetNamedSize(NamedSize size, Type targetElement, bool useOldSizes)


### PR DESCRIPTION
### Description of Change

Fixes #4549

Mark `Device` and related obsolete in preparation of a better system:

 - `Device`  
   This is the containing class, and everything it had is now obsolete. Ready for removal in .NET 7!
 - `GetNamedSize`, `NamedSize` and `IFontNamedSizeService`  
   This used to be the only way to get scaled font sizes, but now it is built into Font. If we want to actually expose those values to the user, we can maybe use a "stringly-typed enum" to allow for supporting the other values on the system. We only had `Title1`, but there is also a `Title2` and `Title3`.
 - `Device.Styles` and `ISystemResourcesProvider` ("Device Styles" eg: `{DynamicResource TitleStyle}`)  
   This is the way to get the OS font styles. This may be more popular than I think, but I am just pre-emptively removing it for now.

In both cases (named sizes and device styles), I may be missing the real uses here, so this PR is to show what is going and can start a conversation.

If anything, some things need to be tweaked and not exist only in the `Device` class. 

### Named Sizes

> NOTE: these values appear to be magical and do things, but at XAML parse time, they are translated into a double with no idea that they were special values. Thus, they never did respond to OS changes. Once set, they are just a number and nothing special

For named sizes, we could have `Font` be smarter and actually have the stringly-typed value as a field. For example:

```cs
class Font {
    double Size;
    string NamedSize;
    string Family;
}
```

Then the font manager can do a check like this:

```cs
double realSize;
if (font.NamedSize != null) {
    realSize = GetSizeFromName(font.NamedSize);
} else {
    realSize = font.Size * scalingFactor;
}
```

### Device Styles

And then for the device styles, this can maybe just move to an application level service... Or maybe a Window-service as each window may have different rules? These values may actually change in dark/light modes, so we need to confirm they work. And also verify that accessibility is in place. Some platforms don't seem to have that last part hooked up...