### PR TITLE
[Android] Avoid crash if not set the RefreshColor property 

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/RefreshView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/RefreshView.Impl.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Layouts;
+﻿using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/RefreshView.xml" path="Type[@FullName='Microsoft.Maui.Controls.RefreshView']/Docs" />
 	public partial class RefreshView : IRefreshView
 	{
-		Paint IRefreshView.RefreshColor => RefreshColor.AsPaint();
+		Paint IRefreshView.RefreshColor => RefreshColor?.AsPaint();
 
 		IView IRefreshView.Content => base.Content;
 


### PR DESCRIPTION
### Description of Change

Avoid crash if not set the RefreshColor property on Android.

### Issues Fixed

Fixes #5069 
