### PR TITLE
Remove assembly scanning from VisualTypeConverter

### DIFF
--- a/src/Compatibility/Core/src/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/Hosting/AppHostBuilderExtensions.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Hosting;
+
+namespace Microsoft.Maui.Controls.Compatibility.Hosting
+{
+	public static class MauiAppBuilderExtensions
+	{
+		public static MauiAppBuilder AddVisual<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TVisualType>(this MauiAppBuilder builder)
+		=> AddVisual(builder, typeof(TVisualType));
+
+		public static MauiAppBuilder AddVisual(this MauiAppBuilder builder, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type TVisualType)
+		{
+			Internals.Registrar.Registered.RegisterVisual(TVisualType);
+			return builder;
+		}
+	}
+}

--- a/src/Compatibility/Core/src/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/Hosting/AppHostBuilderExtensions.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 {
 	public static class MauiAppBuilderExtensions
 	{
-		public static MauiAppBuilder AddVisual<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TVisualType>(this MauiAppBuilder builder)
-		=> AddVisual(builder, typeof(TVisualType));
+		public static MauiAppBuilder RegisterVisual<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TVisualType>(this MauiAppBuilder builder)
+		=> RegisterVisual(builder, typeof(TVisualType));
 
-		public static MauiAppBuilder AddVisual(this MauiAppBuilder builder, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type TVisualType)
+		public static MauiAppBuilder RegisterVisual(this MauiAppBuilder builder, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type TVisualType)
 		{
 			Internals.Registrar.Registered.RegisterVisual(TVisualType);
 			return builder;

--- a/src/Controls/src/Core/HandlerAttribute.cs
+++ b/src/Controls/src/Core/HandlerAttribute.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls
 {
@@ -24,7 +23,6 @@ namespace Microsoft.Maui.Controls
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public short Priority { get; set; }
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		internal Type[] SupportedVisuals { get; private set; }
 
 		internal Type HandlerType { get; private set; }

--- a/src/Controls/src/Core/HandlerAttribute.cs
+++ b/src/Controls/src/Core/HandlerAttribute.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls
 {
@@ -22,7 +23,10 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/HandlerAttribute.xml" path="//Member[@MemberName='Priority']/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public short Priority { get; set; }
+
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		internal Type[] SupportedVisuals { get; private set; }
+
 		internal Type HandlerType { get; private set; }
 
 		internal Type TargetType { get; private set; }

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -55,6 +55,9 @@ namespace Microsoft.Maui.Controls.Internals
 				}
 				else
 					visualRenderers[supportedVisuals[i]] = (trender, priority);
+
+				if (!_registeredVisuals.Contains(supportedVisuals[i]))
+					_registeredVisuals.Add(supportedVisuals[i]);
 			}
 
 			// This registers a factory into the Handler version of the registrar.
@@ -80,32 +83,18 @@ namespace Microsoft.Maui.Controls.Internals
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
 		public void Register(Type tview, Type trender) => Register(tview, trender, _defaultVisualRenderers);
 
-
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		HashSet<Type> _registeredVisuals = new HashSet<Type>();
+
 		internal void RegisterVisual([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type registeredVisual)
 		{
 			if (!_registeredVisuals.Contains(registeredVisual))
 				_registeredVisuals.Add(registeredVisual);
 		}
 
-		internal IEnumerable<Type> VisualTypes
-		{
-			get
-			{
-				HashSet<Type> visualTypes = new HashSet<Type>(_registeredVisuals);
-
-				foreach (var item in _handlers)
-				{
-					foreach (var visualType in item.Value.Keys)
-					{
-						if (!visualTypes.Contains(visualType))
-							visualTypes.Add(visualType);
-					}
-				}
-
-				return visualTypes;
-			}
-		}
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		internal HashSet<Type> VisualTypes =>
+			_registeredVisuals;
 
 		internal TRegistrable GetHandler(Type type) => GetHandler(type, _defaultVisualType);
 
@@ -317,7 +306,8 @@ namespace Microsoft.Maui.Controls.Internals
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='ExtraAssemblies']/Docs" />
 		public static IEnumerable<Assembly> ExtraAssemblies { get; set; }
 
-		internal static IEnumerable<Type> VisualTypes
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		internal static HashSet<Type> VisualTypes
 		{
 			get => Registered.VisualTypes;
 		}

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -84,11 +84,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 		HashSet<Type> _registeredVisuals = new HashSet<Type>();
 
-		internal void RegisterVisual([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type registeredVisual)
-		{
-			if (!_registeredVisuals.Contains(registeredVisual))
-				_registeredVisuals.Add(registeredVisual);
-		}
+		internal void RegisterVisual([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type registeredVisual) => _registeredVisuals.Add(registeredVisual);
 
 		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		internal Type GetVisual(string visualName)

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -56,8 +56,7 @@ namespace Microsoft.Maui.Controls.Internals
 				else
 					visualRenderers[supportedVisuals[i]] = (trender, priority);
 
-				if (!_registeredVisuals.Contains(supportedVisuals[i]))
-					_registeredVisuals.Add(supportedVisuals[i]);
+				RegisterVisual(supportedVisuals[i]);
 			}
 
 			// This registers a factory into the Handler version of the registrar.
@@ -83,7 +82,6 @@ namespace Microsoft.Maui.Controls.Internals
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
 		public void Register(Type tview, Type trender) => Register(tview, trender, _defaultVisualRenderers);
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		HashSet<Type> _registeredVisuals = new HashSet<Type>();
 
 		internal void RegisterVisual([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type registeredVisual)
@@ -306,7 +304,6 @@ namespace Microsoft.Maui.Controls.Internals
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='ExtraAssemblies']/Docs" />
 		public static IEnumerable<Assembly> ExtraAssemblies { get; set; }
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		internal static HashSet<Type> VisualTypes
 		{
 			get => Registered.VisualTypes;

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -27,15 +27,17 @@ namespace Microsoft.Maui.Controls.Internals
 	public class Registrar<TRegistrable> where TRegistrable : class
 	{
 		readonly Dictionary<Type, Dictionary<Type, (Type target, short priority)>> _handlers = new Dictionary<Type, Dictionary<Type, (Type target, short priority)>>();
+
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		static Type _defaultVisualType = typeof(VisualMarker.DefaultVisual);
+
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		static Type _materialVisualType = typeof(VisualMarker.MaterialVisual);
 
-		static Type[] _defaultVisualRenderers = new[] { _defaultVisualType };
-
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
-		public void Register(Type tview, Type trender, Type[] supportedVisuals, short priority)
+		public void Register(Type tview, Type trender, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type[] supportedVisuals, short priority)
 		{
-			supportedVisuals = supportedVisuals ?? _defaultVisualRenderers;
+			supportedVisuals = supportedVisuals ?? new[] { _defaultVisualType };
 			//avoid caching null renderers
 			if (trender == null)
 				return;
@@ -77,10 +79,10 @@ namespace Microsoft.Maui.Controls.Internals
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
-		public void Register(Type tview, Type trender, Type[] supportedVisual) => Register(tview, trender, supportedVisual, 0);
+		public void Register(Type tview, Type trender, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type[] supportedVisual) => Register(tview, trender, supportedVisual, 0);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
-		public void Register(Type tview, Type trender) => Register(tview, trender, _defaultVisualRenderers);
+		public void Register(Type tview, Type trender) => Register(tview, trender, new[] { _defaultVisualType });
 
 		HashSet<Type> _registeredVisuals = new HashSet<Type>();
 
@@ -115,7 +117,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 		internal TRegistrable GetHandler(Type type) => GetHandler(type, _defaultVisualType);
 
-		internal TRegistrable GetHandler(Type type, Type visualType)
+		internal TRegistrable GetHandler(Type type, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type visualType)
 		{
 			Type handlerType = GetHandlerType(type, visualType ?? _defaultVisualType);
 			if (handlerType == null)
@@ -126,7 +128,7 @@ namespace Microsoft.Maui.Controls.Internals
 			return (TRegistrable)handler;
 		}
 
-		internal TRegistrable GetHandler(Type type, object source, IVisual visual, params object[] args)
+		internal TRegistrable GetHandler(Type type, object source, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] IVisual visual, params object[] args)
 		{
 			TRegistrable returnValue = default(TRegistrable);
 			if (args.Length == 0)
@@ -183,7 +185,7 @@ namespace Microsoft.Maui.Controls.Internals
 		public Type GetHandlerType(Type viewType) => GetHandlerType(viewType, _defaultVisualType);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType']/Docs" />
-		public Type GetHandlerType(Type viewType, Type visualType)
+		public Type GetHandlerType(Type viewType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type visualType)
 		{
 			visualType = visualType ?? _defaultVisualType;
 
@@ -240,7 +242,7 @@ namespace Microsoft.Maui.Controls.Internals
 			return false;
 		}
 
-		void RegisterRenderWithTypes(Type viewType, Type visualType)
+		void RegisterRenderWithTypes(Type viewType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type visualType)
 		{
 			visualType = visualType ?? _defaultVisualType;
 

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -28,14 +28,12 @@ namespace Microsoft.Maui.Controls.Internals
 	{
 		readonly Dictionary<Type, Dictionary<Type, (Type target, short priority)>> _handlers = new Dictionary<Type, Dictionary<Type, (Type target, short priority)>>();
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		static Type _defaultVisualType = typeof(VisualMarker.DefaultVisual);
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		static Type _materialVisualType = typeof(VisualMarker.MaterialVisual);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
-		public void Register(Type tview, Type trender, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type[] supportedVisuals, short priority)
+		public void Register(Type tview, Type trender, Type[] supportedVisuals, short priority)
 		{
 			supportedVisuals = supportedVisuals ?? new[] { _defaultVisualType };
 			//avoid caching null renderers
@@ -79,7 +77,7 @@ namespace Microsoft.Maui.Controls.Internals
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
-		public void Register(Type tview, Type trender, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type[] supportedVisual) => Register(tview, trender, supportedVisual, 0);
+		public void Register(Type tview, Type trender, Type[] supportedVisual) => Register(tview, trender, supportedVisual, 0);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
 		public void Register(Type tview, Type trender) => Register(tview, trender, new[] { _defaultVisualType });
@@ -128,7 +126,7 @@ namespace Microsoft.Maui.Controls.Internals
 			return (TRegistrable)handler;
 		}
 
-		internal TRegistrable GetHandler(Type type, object source, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] IVisual visual, params object[] args)
+		internal TRegistrable GetHandler(Type type, object source, IVisual visual, params object[] args)
 		{
 			TRegistrable returnValue = default(TRegistrable);
 			if (args.Length == 0)

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -90,9 +90,32 @@ namespace Microsoft.Maui.Controls.Internals
 				_registeredVisuals.Add(registeredVisual);
 		}
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-		internal HashSet<Type> VisualTypes =>
-			_registeredVisuals;
+		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		internal Type GetVisual(string visualName)
+		{
+			foreach (var visualType in _registeredVisuals)
+			{
+				string name = visualType.Name;
+				string fullName = visualType.FullName;
+
+				if (name.EndsWith("Visual", StringComparison.OrdinalIgnoreCase))
+				{
+					name = name.Substring(0, name.Length - 6);
+					fullName = fullName.Substring(0, fullName.Length - 6);
+				}
+
+				if (visualName == name ||
+					visualName == fullName ||
+					visualName == $"{name}Visual" ||
+					visualName == $"{fullName}Visual")
+				{
+					return visualType;
+				}
+
+			}
+
+			return null;
+		}
 
 		internal TRegistrable GetHandler(Type type) => GetHandler(type, _defaultVisualType);
 
@@ -303,11 +326,6 @@ namespace Microsoft.Maui.Controls.Internals
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='ExtraAssemblies']/Docs" />
 		public static IEnumerable<Assembly> ExtraAssemblies { get; set; }
-
-		internal static HashSet<Type> VisualTypes
-		{
-			get => Registered.VisualTypes;
-		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Registered']/Docs" />
 		public static Registrar<IRegisterable> Registered { get; internal set; }

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.StyleSheets;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls
 {
@@ -78,6 +79,33 @@ namespace Microsoft.Maui.Controls.Internals
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
 		public void Register(Type tview, Type trender) => Register(tview, trender, _defaultVisualRenderers);
+
+
+		HashSet<Type> _registeredVisuals = new HashSet<Type>();
+		internal void RegisterVisual([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type registeredVisual)
+		{
+			if (!_registeredVisuals.Contains(registeredVisual))
+				_registeredVisuals.Add(registeredVisual);
+		}
+
+		internal IEnumerable<Type> VisualTypes
+		{
+			get
+			{
+				HashSet<Type> visualTypes = new HashSet<Type>(_registeredVisuals);
+
+				foreach (var item in _handlers)
+				{
+					foreach (var visualType in item.Value.Keys)
+					{
+						if (!visualTypes.Contains(visualType))
+							visualTypes.Add(visualType);
+					}
+				}
+
+				return visualTypes;
+			}
+		}
 
 		internal TRegistrable GetHandler(Type type) => GetHandler(type, _defaultVisualType);
 
@@ -288,6 +316,11 @@ namespace Microsoft.Maui.Controls.Internals
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='ExtraAssemblies']/Docs" />
 		public static IEnumerable<Assembly> ExtraAssemblies { get; set; }
+
+		internal static IEnumerable<Type> VisualTypes
+		{
+			get => Registered.VisualTypes;
+		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Registered']/Docs" />
 		public static Registrar<IRegisterable> Registered { get; internal set; }

--- a/src/Controls/src/Core/Visuals/VisualMarker.cs
+++ b/src/Controls/src/Core/Visuals/VisualMarker.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Essentials;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls
 {
@@ -33,13 +32,8 @@ namespace Microsoft.Maui.Controls
 				logger?.LogWarning("Material is currently not support on {RuntimePlatform}.", DeviceInfo.Platform);
 		}
 
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		public sealed class MaterialVisual : IVisual { public MaterialVisual() { } }
-
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		public sealed class DefaultVisual : IVisual { public DefaultVisual() { } }
-
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		internal sealed class MatchParentVisual : IVisual { public MatchParentVisual() { } }
 	}
 }

--- a/src/Controls/src/Core/Visuals/VisualMarker.cs
+++ b/src/Controls/src/Core/Visuals/VisualMarker.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Essentials;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Controls
 {
@@ -32,8 +33,13 @@ namespace Microsoft.Maui.Controls
 				logger?.LogWarning("Material is currently not support on {RuntimePlatform}.", DeviceInfo.Platform);
 		}
 
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		public sealed class MaterialVisual : IVisual { public MaterialVisual() { } }
+
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		public sealed class DefaultVisual : IVisual { public DefaultVisual() { } }
+
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		internal sealed class MatchParentVisual : IVisual { public MatchParentVisual() { } }
 	}
 }

--- a/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
+++ b/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui.Controls
 		void InitMappings()
 		{
 			var mappings = new Dictionary<string, IVisual>(StringComparer.OrdinalIgnoreCase);
+
 			foreach (var visual in Internals.Registrar.VisualTypes)
 				Register(visual, mappings);
 

--- a/src/Controls/tests/Core.UnitTests/VisualTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualTests.cs
@@ -470,6 +470,32 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(Maui.Controls.VisualMarker.MatchParent, ((View)view).Visual);
 		}
 
+		[Test]
+		public void RegisteredVisualWorksWithTypeConverter()
+		{
+			Registrar.Registered.RegisterVisual(typeof(VisualTypeConverterTestVisual));
+			VisualTypeConverter visualTypeConverter = new VisualTypeConverter();
+
+			Assert.AreEqual(typeof(VisualTypeConverterTestVisual), visualTypeConverter.ConvertFrom("VisualTypeConverterTestVisual").GetType());
+
+			Assert.AreEqual(typeof(VisualTypeConverterTestVisual), visualTypeConverter.ConvertFrom("VisualTypeConverterTest").GetType());
+		}
+
+		[Test]
+		public void RegisteredVisualOnViewWorksWithTypeConverter()
+		{
+			Registrar.Registered.Register(
+				typeof(VisualTypeConverterTestButton),
+				typeof(VisualTypeConverterTestButtonRenderer),
+				new[] { typeof(VisualTypeConverterTestButtonVisual) });
+
+			VisualTypeConverter visualTypeConverter = new VisualTypeConverter();
+
+			Assert.AreEqual(typeof(VisualTypeConverterTestButtonVisual), visualTypeConverter.ConvertFrom("VisualTypeConverterTestButtonVisual").GetType());
+
+			Assert.AreEqual(typeof(VisualTypeConverterTestButtonVisual), visualTypeConverter.ConvertFrom("VisualTypeConverterTestButton").GetType());
+		}
+
 		static void AddExplicitLTRToScrollView(ScrollView parent, View child)
 		{
 			parent.Content = child;
@@ -620,6 +646,26 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assume.That(((View)view).Visual == Maui.Controls.VisualMarker.MatchParent, "New view Visual should be MatchParent");
 
 			return view;
+		}
+
+		class VisualTypeConverterTestButton : Button
+		{
+			public VisualTypeConverterTestButton() { }
+		}
+
+		class VisualTypeConverterTestButtonRenderer : IRegisterable
+		{
+			public VisualTypeConverterTestButtonRenderer() { }
+		}
+
+		class VisualTypeConverterTestButtonVisual : IVisual
+		{
+			public VisualTypeConverterTestButtonVisual() { }
+		}
+
+		class VisualTypeConverterTestVisual : IVisual
+		{
+			public VisualTypeConverterTestVisual() { }
 		}
 
 		class PropertyWatchingView : View

--- a/src/Controls/tests/Xaml.UnitTests/VisualTypeConverterTests.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/VisualTypeConverterTests.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.VisualTypeConverterTests"
+             Visual="VisualTypeConverterTests">
+	<StackLayout>
+	</StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/VisualTypeConverterTests.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/VisualTypeConverterTests.xaml.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class VisualTypeConverterTests : ContentPage
+	{
+		public VisualTypeConverterTests()
+		{
+			InitializeComponent();
+		}
+
+		public VisualTypeConverterTests(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		public class Tests
+		{
+			[TestCase(false)]
+			[TestCase(true)]
+			public void VisualAreConverted(bool useCompiledXaml)
+			{
+				Controls.Internals.Registrar.Registered.RegisterVisual(typeof(VisualTypeConverterTestsVisual));
+
+				var page = new VisualTypeConverterTests(useCompiledXaml);
+				Assert.That(page.Visual, Is.TypeOf<VisualTypeConverterTestsVisual>());
+			}
+		}
+
+		public class VisualTypeConverterTestsVisual : IVisual
+		{
+			public VisualTypeConverterTestsVisual() { }
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change
- Remove Assembly Scanning from VisualTypeConverter
- Leave attribute registration in place
- The Converter now reads from the Registrar from any registered Visual Types. This means if the user has opted for assembly scanning with legacy renderers those will get picked up.
- Adds `builder.RegisterVisual` inside the `Microsoft.Maui.Controls.Compatibility.Hosting` namespace so 3rd party libraries can register visuals as part of their builder code

### Issues Fixed
Fixes #4937
