### PR TITLE
Make sure StrokeDashArray property invalidate the Shape.

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Shape/Shape.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shape/Shape.Android.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Shapes
+{
+	public partial class Shape
+	{
+		public static void MapStrokeDashArray(IShapeViewHandler handler, IShapeView shapeView)
+		{
+			handler.PlatformView?.InvalidateShape(shapeView);
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Shape/Shape.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shape/Shape.Impl.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Shapes
+{
+	public partial class Shape
+	{
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Shape/Shape.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shape/Shape.Standard.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Shapes
+{
+	public partial class Shape
+	{
+		public static void MapStrokeDashArray(IShapeViewHandler handler, IShapeView shapeView) { }
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Shape/Shape.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shape/Shape.Windows.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Shapes
+{
+	public partial class Shape
+	{
+		public static void MapStrokeDashArray(IShapeViewHandler handler, IShapeView shapeView)
+		{
+			handler.PlatformView?.InvalidateShape(shapeView);
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Shape/Shape.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shape/Shape.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Shapes
+{
+	public partial class Shape
+	{
+		public static IPropertyMapper<IShapeView, IShapeViewHandler> ControlsShapeViewMapper = new PropertyMapper<IShapeView, IShapeViewHandler>(ShapeViewHandler.Mapper)
+		{
+			[nameof(StrokeDashArray)] = MapStrokeDashArray,
+		};
+
+		internal new static void RemapForControls()
+		{
+			ShapeViewHandler.Mapper = ControlsShapeViewMapper;
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Shape/Shape.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shape/Shape.iOS.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Shapes
+{
+	public partial class Shape
+	{
+		public static void MapStrokeDashArray(IShapeViewHandler handler, IShapeView shapeView)
+		{
+			handler.PlatformView?.InvalidateShape(shapeView);
+		}
+	}
+}

--- a/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/AppHostBuilderExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 
@@ -109,6 +110,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			SearchBar.RemapForControls();
 			TabbedPage.RemapForControls();
 			Layout.RemapForControls();
+			Shape.RemapForControls();
 
 			return builder;
 		}

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Standard.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapAspect(IShapeViewHandler handler, IShapeView shapeView) { }
 		public static void MapFill(IShapeViewHandler handler, IShapeView shapeView) { }
 		public static void MapStroke(IShapeViewHandler handler, IShapeView shapeView) { }
-		public static void MapStrokeThickness(IShapeViewHandler handler, IShapeView shapeView) { }
+		public static void MapStrokeThickness(IShapeViewHandler handler, IShapeView shapeView) { }		
 		public static void MapStrokeDashPattern(IShapeViewHandler handler, IShapeView shapeView) { }
 		public static void MapStrokeLineCap(IShapeViewHandler handler, IShapeView shapeView) { }
 		public static void MapStrokeLineJoin(IShapeViewHandler handler, IShapeView shapeView) { }


### PR DESCRIPTION
### Description of Change

A PropertyMapper entry for `StrokeDashArray` is missing, that is why the UI does not update when `StrokeDashArray` is changed. The property is defined in `Core.Controls`, so I introduced this new `RemapForControls` pattern to handle it there.

### Issues Fixed

Fixes #4566