### PR TITLE
[ios] Fix crash when updating TimePicker

### DIFF
--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
@@ -97,7 +97,8 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null || PlatformView == null)
 				return;
 
-			VirtualView.Time = PlatformView.Date.ToDateTime() - new DateTime(1, 1, 1);
+			var datetime = PlatformView.Date.ToDateTime();
+			VirtualView.Time = new TimeSpan(datetime.Hour, datetime.Minute, 0);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Fix crash when updating TimePicker.Time on iOS. I'm not sure why it was structured the way it was previously (doing some math to get a TimeSpan), but the Android Handler didn't so I assume there was some Xamarin porting differences that led to it.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #4228 
