### PR TITLE
[X] Convert element before adding to collections

### DIFF
--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -141,12 +141,21 @@ namespace Microsoft.Maui.Controls.Xaml
 					return;
 
 				// Collection element, implicit content, or implicit collection element.
-				if (xpe == null && typeof(IEnumerable).IsAssignableFrom(Context.Types[parentElement]) && Context.Types[parentElement].GetRuntimeMethods().Any(mi => mi.Name == "Add" && mi.GetParameters().Length == 1))
+				if (   xpe == null
+					&& typeof(IEnumerable).IsAssignableFrom(Context.Types[parentElement])
+					&& Context.Types[parentElement].GetRuntimeMethods().Any(mi => mi.Name == "Add" && mi.GetParameters().Length == 1))
 				{
 					var addMethod =
 						Context.Types[parentElement].GetRuntimeMethods().First(mi => mi.Name == "Add" && mi.GetParameters().Length == 1);
+					try
+					{
+						addMethod.Invoke(source, new[] { value.ConvertTo(addMethod.GetParameters()[0].ParameterType, (Func<TypeConverter>)null, new XamlServiceProvider(node, Context), out xpe) });
+					}
+					catch (Exception e)
+					{
+						xpe ??= e;
+					}
 
-					addMethod.Invoke(source, new[] { value });
 					return;
 				}
 				if (xpe == null && (contentProperty = GetContentPropertyName(Context.Types[parentElement].GetTypeInfo())) != null)

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui4509.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui4509.xaml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui4509">
+           <StackLayout x:Name="layout">
+             <Label x:Name="label0" />
+             <OnPlatform x:TypeArguments="View">
+               <On Platform="iOS">
+                 <RadioButton />
+               </On>
+             </OnPlatform>
+           </StackLayout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui4509.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui4509.xaml.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Essentials;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Maui4509 : ContentPage
+	{
+		public Maui4509() => InitializeComponent();
+		public Maui4509(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Test
+		{
+			[SetUp] public void Setup() => AppInfo.SetCurrent(new MockAppInfo());
+			[TearDown]
+			public void TearDown()
+			{
+				AppInfo.SetCurrent(null);
+				DeviceInfo.SetCurrent(null);
+			}
+
+			[Test]
+			public void OnPlatformAsCollectionElementiOS([Values(false, true)] bool useCompiledXaml)
+			{
+				DeviceInfo.SetCurrent(new MockDeviceInfo(platform: DevicePlatform.iOS));
+				var page = new Maui4509(useCompiledXaml);
+				Assert.That(page.layout.Children.Count, Is.EqualTo(2));
+			}
+			[Test]
+			public void OnPlatformAsCollectionElementAndroid([Values(false, true)] bool useCompiledXaml)
+			{
+				DeviceInfo.SetCurrent(new MockDeviceInfo(platform: DevicePlatform.Android));
+				var page = new Maui4509(useCompiledXaml);
+				Assert.That(page.layout.Children.Count, Is.EqualTo(1));
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
While adding a collection item, try converting it before adding, like
it's done everywhere else. This allows placing OnPlatform elements as
part of collections.

- fixes #4509
- closes #5073


### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
