### PR TITLE
[Windows] WebView not loading HtmlWebViewSource 

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
@@ -9,6 +9,29 @@
             <VerticalStackLayout    
                 Margin="12">
                 <Label
+                    Text="HtmlWebViewSource"
+                    Style="{StaticResource Headline}"/>
+                <WebView 
+                    HeightRequest="150"
+                    HorizontalOptions="FillAndExpand">
+                    <WebView.Source>
+                        <HtmlWebViewSource>
+                            <HtmlWebViewSource.Html>
+                                <![CDATA[
+                                <html>
+                                <head>
+                                </head>
+                                <body>
+                                <h1>.NET MAUI</h1>
+                                <p>This is a local html source.</p>
+                                </body>
+                                </html>                    
+                                ]]>
+                            </HtmlWebViewSource.Html>
+                        </HtmlWebViewSource>
+                    </WebView.Source>
+                </WebView>
+                <Label
                     Text="UrlWebViewSource"
                     Style="{StaticResource Headline}"/>
                 <WebView 


### PR DESCRIPTION
### Description of Change

Added **HtmlWebViewSource** sample in the .NET MAUI Gallery and is working. However, reviewing the sample from the issue #5098 doesn't set the height on the WebView. 

While on other platforms the content is displayed, on Windows you need to set the WebView size. We also have the same behavior in Xamarin.Forms. The key question is, should we autoresize the WebView if it doesn't have the height set?.  If it's not something we want for GA, merge this PR to add the sample but keep the issue open, and if we want to change the behavior we can apply the changes directly in this PR. 

Something like:

```
var heightString = await webView.ExecuteScriptAsync("(function(){return document.body.scrollHeight;})()");

if (int.TryParse(heightString, out var height))
{
    webView.Height = height;
}
```

### Issues Fixed

Fixes #5098
