### PR TITLE
[Housekeeping] Update the Gallery with more focus samples

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EditorPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EditorPage.xaml
@@ -49,6 +49,16 @@
                     Text="I am read only" 
                     IsReadOnly="True"/>
                 <Label
+                    Text="Focus"
+                    Style="{StaticResource Headline}" />
+                <Editor 
+                    Focused="OnEditorFocused"/>
+                <Label
+                    Text="Unfocus"
+                    Style="{StaticResource Headline}" />
+                <Editor 
+                    Unfocused="OnEditorUnfocused"/>
+                <Label
                     Text="Completed"
                     Style="{StaticResource Headline}" />
                 <Editor 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EditorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EditorPage.xaml.cs
@@ -15,5 +15,17 @@ namespace Maui.Controls.Sample.Pages
 			var text = ((Editor)sender).Text;
 			DisplayAlert("Completed", text, "Ok");
 		}
+
+		void OnEditorFocused(object sender, FocusEventArgs e)
+		{
+			var text = ((Editor)sender).Text;
+			DisplayAlert("Focused", text, "Ok");
+		}
+
+		void OnEditorUnfocused(object sender, FocusEventArgs e)
+		{
+			var text = ((Editor)sender).Text;
+			DisplayAlert("Unfocused", text, "Ok");
+		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
@@ -80,6 +80,16 @@
                     ReturnCommand="{Binding ReturnCommand}"
                     ReturnCommandParameter="ReturnCommandParameter"/>
                 <Label
+                    Text="Focus"
+                    Style="{StaticResource Headline}" />
+                <Entry 
+                    Focused="OnEntryFocused"/>
+                <Label
+                    Text="Unfocus"
+                    Style="{StaticResource Headline}" />
+                <Entry 
+                    Unfocused="OnEntryUnfocused"/>
+                <Label
                     Text="Completed"
                     Style="{StaticResource Headline}" />
                 <Entry 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml.cs
@@ -47,5 +47,17 @@ namespace Maui.Controls.Sample.Pages
 			var text = ((Entry)sender).Text;
 			DisplayAlert("Completed", text, "Ok");
 		}
+
+		void OnEntryFocused(object sender, FocusEventArgs e)
+		{
+			var text = ((Entry)sender).Text;
+			DisplayAlert("Focused", text, "Ok");
+		}
+
+		void OnEntryUnfocused(object sender, FocusEventArgs e)
+		{
+			var text = ((Entry)sender).Text;
+			DisplayAlert("Unfocused", text, "Ok");
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Update the Gallery with more focus samples in the Entry and Editor pages to validate the issues #5126 and #5124.
The issues are filled using Preview 13 and focus management is implemented in Preview 14. This PR only includes more samples.

![editor-entry-focus](https://user-images.githubusercontent.com/6755973/157246273-5c2862b0-079b-4dfc-85cb-ac3c089863e3.gif)

### Issues Fixed

Fixes #5126 and #5124
