### PR TITLE
Fix Visibility of header elements if they have no content

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Shell.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shell.Impl.cs
@@ -12,5 +12,13 @@ namespace Microsoft.Maui.Controls
 		bool IFlyoutView.IsPresented { get => FlyoutIsPresented; set => FlyoutIsPresented = value; }
 
 		bool IFlyoutView.IsGestureEnabled => false;
+
+		FlyoutBehavior IFlyoutView.FlyoutBehavior
+		{
+			get
+			{
+				return GetEffectiveFlyoutBehavior();
+			}
+		}
 	}
 }

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1213,7 +1213,7 @@ namespace Microsoft.Maui.Controls
 					//
 					// This will happen if the user only specifies a
 					// single ContentPage
-					else if (Routing.IsImplicit(rootItem))
+					else if (rootItem != null && Routing.IsImplicit(rootItem))
 					{
 						if (Items.Count <= 1)
 							return FlyoutBehavior.Disabled;

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1207,6 +1207,17 @@ namespace Microsoft.Maui.Controls
 						return FlyoutBehavior.Flyout;
 					else if (rootItem is TabBar)
 						return FlyoutBehavior.Disabled;
+					// This means the user hasn't specified
+					// a ShellItem so we don't want the flyout to show up
+					// if there is only one ShellItem.
+					//
+					// This will happen if the user only specifies a
+					// single ContentPage
+					else if (Routing.IsImplicit(rootItem))
+					{
+						if (Items.Count <= 1)
+							return FlyoutBehavior.Disabled;
+					}
 
 					return FlyoutBehavior;
 				},
@@ -1301,6 +1312,8 @@ namespace Microsoft.Maui.Controls
 			var behavior = GetEffectiveFlyoutBehavior();
 			for (int i = 0; i < _flyoutBehaviorObservers.Count; i++)
 				_flyoutBehaviorObservers[i].OnFlyoutBehaviorChanged(behavior);
+
+			Handler?.UpdateValue(nameof(IFlyoutView.FlyoutBehavior));
 		}
 
 		void OnFlyoutHeaderChanged(object oldVal, object newVal)

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -75,7 +75,6 @@ namespace Microsoft.Maui.Controls
 				previousPage = stack[stack.Count - 1];
 
 			ToolbarItems = _toolbarTracker.ToolbarItems;
-			IsVisible = _shell.GetEffectiveValue<bool>(Shell.NavBarIsVisibleProperty, true);
 			_backButtonBehavior = _shell.GetEffectiveValue<BackButtonBehavior>(Shell.BackButtonBehaviorProperty, null);
 			bool backButtonVisible = true;
 
@@ -86,8 +85,15 @@ namespace Microsoft.Maui.Controls
 
 			BackButtonVisible = backButtonVisible && stack.Count > 1;
 			Title = (!String.IsNullOrWhiteSpace(currentPage.Title)) ? currentPage.Title : _shell.Title;
-
 			TitleView = _shell.GetEffectiveValue<VisualElement>(Shell.TitleViewProperty, null);
+
+			bool showToolBarDefault =
+				BackButtonVisible ||
+				!String.IsNullOrEmpty(Title) ||
+				TitleView != null ||
+				_toolbarTracker.ToolbarItems.Count > 0;
+
+			IsVisible = _shell.GetEffectiveValue<bool>(Shell.NavBarIsVisibleProperty, showToolBarDefault);
 
 			if (currentPage != null)
 				DynamicOverflowEnabled = PlatformConfiguration.WindowsSpecific.Page.GetToolbarDynamicOverflowEnabled(currentPage);

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -1332,5 +1332,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(shellCount.Count, 1);
 			Assert.AreEqual(shellItemCount.Count, 2);
 		}
+
+		[Test]
+		public void ShellToolbarNotVisibleWithBasicContentPage()
+		{
+			TestShell testShell = new TestShell(new ContentPage());
+			var shellToolBar = testShell.Toolbar;
+			Assert.False(shellToolBar.IsVisible);
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -18,6 +18,97 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests : HandlerTestBase
 	{
+		[Fact(DisplayName = "Shell with Single Content Page Has Panes Disabled")]
+		public async Task BasicShellHasPaneDisplayModeDisabled()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync((shell) => {
+				shell.Items.Add(new ContentPage());
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			{
+				var rootNavView = (handler.PlatformView);
+				var shellItemView = shell.CurrentItem.Handler.PlatformView as UI.Xaml.Controls.NavigationView;
+				var expected = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+
+				Assert.False(rootNavView.IsPaneToggleButtonVisible);
+				Assert.False(shellItemView.IsPaneToggleButtonVisible);
+
+				Assert.Equal(expected, rootNavView.PaneDisplayMode);
+				Assert.Equal(expected, shellItemView.PaneDisplayMode);
+
+				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "Shell With Only Flyout Items")]
+		public async Task ShellWithOnlyFlyoutItems()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync((shell) => {
+				var shellItem1 = new FlyoutItem();
+				shellItem1.Items.Add(new ContentPage());
+
+				var shellItem2 = new FlyoutItem();
+				shellItem2.Items.Add(new ContentPage());
+
+				shell.Items.Add(shellItem1);
+				shell.Items.Add(shellItem2);
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			{
+				var rootNavView = (handler.PlatformView);
+				var shellItemView = shell.CurrentItem.Handler.PlatformView as UI.Xaml.Controls.NavigationView;
+				var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+				var expectedShellItems = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+
+				Assert.True(rootNavView.IsPaneToggleButtonVisible);
+				Assert.False(shellItemView.IsPaneToggleButtonVisible);
+				Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
+				Assert.Equal(expectedShellItems, shellItemView.PaneDisplayMode);
+
+				return Task.CompletedTask;
+			});
+		}
+
+
+		[Fact(DisplayName = "Shell With Only Top Tabs")]
+		public async Task ShellWithOnlyTopTabs()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync((shell) => {
+				var shellItem = new TabBar();
+				var shellSection1 = new ShellSection();
+				shellSection1.Items.Add(new ContentPage());
+
+				var shellSection2 = new ShellSection();
+				shellSection2.Items.Add(new ContentPage());
+
+				shellItem.Items.Add(shellSection1);
+				shellItem.Items.Add(shellSection2);
+
+				shell.Items.Add(shellItem);
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			{
+				var rootNavView = (handler.PlatformView);
+				var shellItemView = shell.CurrentItem.Handler.PlatformView as UI.Xaml.Controls.NavigationView;
+				var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+				var expectedShellItems = UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top;
+
+				Assert.False(rootNavView.IsPaneToggleButtonVisible);
+				Assert.False(shellItemView.IsPaneToggleButtonVisible);
+				Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
+				Assert.Equal(expectedShellItems, shellItemView.PaneDisplayMode);
+
+				return Task.CompletedTask;
+			});
+		}
+
+
 		[Fact(DisplayName = "Flyout Locked Offset")]
 		public async Task FlyoutLockedOffset()
 		{
@@ -27,14 +118,14 @@ namespace Microsoft.Maui.DeviceTests
 				HeightRequest = 10
 			};
 
-			var shell = await InvokeOnMainThreadAsync<Shell>(() => { 
+			var shell = await InvokeOnMainThreadAsync(() => { 
 				return new Shell()
 				{
 					FlyoutHeader = label,
 					Items =
-				{
-					new ContentPage()
-				},
+					{
+						new ContentPage()
+					},
 					FlyoutBehavior = FlyoutBehavior.Locked
 				};
 			});

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -93,5 +93,13 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 #endif
+
+		protected Task<Shell> CreateShellAsync(Action<Shell> action)=>
+			InvokeOnMainThreadAsync(() =>
+			{
+				var value = new Shell();
+				action?.Invoke(value);
+				return value;
+			});
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -21,9 +21,6 @@ namespace Microsoft.Maui.Platform
 			textBlockBorder.Visibility = UI.Xaml.Visibility.Collapsed;
 			menuContent.Visibility = UI.Xaml.Visibility.Collapsed;
 			titleView.Visibility = UI.Xaml.Visibility.Collapsed;
-
-			titleIcon.ImageOpened += OnTitleIconImageOpened;
-			titleIcon.ImageFailed += OnTitleIconImageFailed;
 		}
 
 		internal string? Title
@@ -51,6 +48,11 @@ namespace Microsoft.Maui.Platform
 			set
 			{
 				titleIcon.Source = value;
+
+				if (value != null)
+					titleIcon.Visibility = UI.Xaml.Visibility.Visible;
+				else
+					titleIcon.Visibility = UI.Xaml.Visibility.Collapsed;
 			}
 		}
 
@@ -62,9 +64,9 @@ namespace Microsoft.Maui.Platform
 				titleView.Content = value;
 
 				if (value != null)
-					textBlockBorder.Visibility = UI.Xaml.Visibility.Visible;
+					titleView.Visibility = UI.Xaml.Visibility.Visible;
 				else
-					textBlockBorder.Visibility = UI.Xaml.Visibility.Collapsed;
+					titleView.Visibility = UI.Xaml.Visibility.Collapsed;
 			}
 		}
 
@@ -115,16 +117,6 @@ namespace Microsoft.Maui.Platform
 				menuContent.Visibility = UI.Xaml.Visibility.Collapsed;
 			else
 				menuContent.Visibility = UI.Xaml.Visibility.Visible;
-		}
-
-		void OnTitleIconImageFailed(object sender, ExceptionRoutedEventArgs e)
-		{
-			titleIcon.Visibility = UI.Xaml.Visibility.Collapsed;
-		}
-
-		void OnTitleIconImageOpened(object sender, RoutedEventArgs e)
-		{
-			titleIcon.Visibility = UI.Xaml.Visibility.Visible;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -10,19 +10,34 @@ namespace Microsoft.Maui.Platform
 	public partial class MauiToolbar
 	{
 		public static readonly DependencyProperty IsBackButtonVisibleProperty
-			= DependencyProperty.Register(nameof(IsBackButtonVisible), typeof(NavigationViewBackButtonVisible), typeof(MauiToolbar), 
+			= DependencyProperty.Register(nameof(IsBackButtonVisible), typeof(NavigationViewBackButtonVisible), typeof(MauiToolbar),
 				new PropertyMetadata(NavigationViewBackButtonVisible.Collapsed, OnIsBackButtonVisiblePropertyChanged));
 
 		MenuBar? _menuBar;
 		public MauiToolbar()
 		{
 			InitializeComponent();
+			titleIcon.Visibility = UI.Xaml.Visibility.Collapsed;
+			textBlockBorder.Visibility = UI.Xaml.Visibility.Collapsed;
+			menuContent.Visibility = UI.Xaml.Visibility.Collapsed;
+			titleView.Visibility = UI.Xaml.Visibility.Collapsed;
+
+			titleIcon.ImageOpened += OnTitleIconImageOpened;
+			titleIcon.ImageFailed += OnTitleIconImageFailed;
 		}
 
 		internal string? Title
 		{
 			get => title.Text;
-			set => title.Text = value;
+			set
+			{
+				title.Text = value;
+
+				if (!string.IsNullOrWhiteSpace(value))
+					textBlockBorder.Visibility = UI.Xaml.Visibility.Visible;
+				else
+					textBlockBorder.Visibility = UI.Xaml.Visibility.Collapsed;
+			}
 		}
 
 		internal WImage? TitleIconImage
@@ -33,13 +48,24 @@ namespace Microsoft.Maui.Platform
 		internal WImageSource? TitleIconImageSource
 		{
 			get => titleIcon.Source;
-			set => titleIcon.Source = value;
+			set
+			{
+				titleIcon.Source = value;
+			}
 		}
 
 		internal object? TitleView
 		{
 			get => titleView.Content;
-			set => titleView.Content = value;
+			set
+			{
+				titleView.Content = value;
+
+				if (value != null)
+					textBlockBorder.Visibility = UI.Xaml.Visibility.Visible;
+				else
+					textBlockBorder.Visibility = UI.Xaml.Visibility.Collapsed;
+			}
 		}
 
 		internal WBrush? TitleColor
@@ -50,9 +76,18 @@ namespace Microsoft.Maui.Platform
 
 		internal CommandBar CommandBar => commandBar;
 
-		internal WGrid ContentGrid => contentGrid;
 
-		internal Border TextBlockBorder => textBlockBorder;
+		internal UI.Xaml.Thickness ContentGridMargin
+		{
+			get => contentGrid.Margin;
+			set => contentGrid.Margin = value;
+		}
+
+		internal VerticalAlignment TextBlockBorderVerticalAlignment
+		{
+			get => textBlockBorder.VerticalAlignment;
+			set => textBlockBorder.VerticalAlignment = value;
+		}
 
 		public NavigationViewBackButtonVisible IsBackButtonVisible
 		{
@@ -75,7 +110,21 @@ namespace Microsoft.Maui.Platform
 				return;
 
 			menuContent.Content = _menuBar;
+
+			if (_menuBar == null || _menuBar.Items.Count == 0)
+				menuContent.Visibility = UI.Xaml.Visibility.Collapsed;
+			else
+				menuContent.Visibility = UI.Xaml.Visibility.Visible;
 		}
 
+		void OnTitleIconImageFailed(object sender, ExceptionRoutedEventArgs e)
+		{
+			titleIcon.Visibility = UI.Xaml.Visibility.Collapsed;
+		}
+
+		void OnTitleIconImageOpened(object sender, RoutedEventArgs e)
+		{
+			titleIcon.Visibility = UI.Xaml.Visibility.Visible;
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Maui.Platform
 
 					if (HeaderControl != null)
 					{
-						HeaderControl.ContentGrid.Margin = new UI.Xaml.Thickness(0, 0, 4, 0);
-						HeaderControl.TextBlockBorder.VerticalAlignment = VerticalAlignment.Center;
+						HeaderControl.ContentGridMargin = new UI.Xaml.Thickness(0, 0, 4, 0);
+						HeaderControl.TextBlockBorderVerticalAlignment = VerticalAlignment.Center;
 					}
 				}
 				else if (PaneFooter == HeaderControl || Header == null)
@@ -82,8 +82,8 @@ namespace Microsoft.Maui.Platform
 
 					if (HeaderControl != null)
 					{
-						HeaderControl.ContentGrid.Margin = new UI.Xaml.Thickness(0, 0, 0, 0);
-						HeaderControl.TextBlockBorder.VerticalAlignment = VerticalAlignment.Top;
+						HeaderControl.ContentGridMargin = new UI.Xaml.Thickness(0, 0, 0, 0);
+						HeaderControl.TextBlockBorderVerticalAlignment = VerticalAlignment.Top;
 					}
 				}
 			}

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
@@ -5,6 +5,12 @@ using Microsoft.Maui.Handlers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Xunit;
+using WBrush = Microsoft.UI.Xaml.Media.Brush;
+using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
+using WGrid = Microsoft.UI.Xaml.Controls.Grid;
+using WImage = Microsoft.UI.Xaml.Controls.Image;
+using WBorder = Microsoft.UI.Xaml.Controls.Border;
+using WVisibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -26,6 +32,65 @@ namespace Microsoft.Maui.DeviceTests
 				return Task.CompletedTask;
 			});
 		}
+
+
+		[Theory(DisplayName = "MauiToolbar Control Visibilities Toggle")]
+		[InlineData("titleIcon")]
+		[InlineData("textBlockBorder")]
+		[InlineData("menuContent")]
+		[InlineData("titleView")]
+		public async Task MauiToolbarControlVisibilitiesToggle(string controlName)
+		{
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				MauiToolbar mauiToolbar = new MauiToolbar();
+				var toolbarContent = (DependencyObject)mauiToolbar.Content;
+				var control = toolbarContent.GetDescendantByName<UIElement>(controlName);
+
+				Assert.Equal(WVisibility.Collapsed, control.Visibility);
+
+				switch (controlName)
+				{
+					case "titleIcon":
+						var tcs = new TaskCompletionSource<bool>();
+						var fileImageSource = new Controls.FileImageSource() { File = "black.png" };
+						fileImageSource.LoadImage(MauiContext, (result) =>
+						{
+							mauiToolbar.TitleIconImageSource = result.Value;
+							tcs.SetResult(true);
+						});
+
+						await tcs.Task;
+						Assert.Equal(WVisibility.Visible, control.Visibility);
+						mauiToolbar.TitleIconImageSource = null;
+						Assert.Equal(WVisibility.Collapsed, control.Visibility);
+						break;
+					case "textBlockBorder":
+						mauiToolbar.Title = "text";
+						Assert.Equal(WVisibility.Visible, control.Visibility);
+						mauiToolbar.Title = "";
+						Assert.Equal(WVisibility.Collapsed, control.Visibility);
+						break;
+					case "menuContent":
+						mauiToolbar.SetMenuBar(new MenuBar() { Items = { new MenuBarItem() } });
+						Assert.Equal(WVisibility.Visible, control.Visibility);
+						mauiToolbar.SetMenuBar(new MenuBar());
+						Assert.Equal(WVisibility.Collapsed, control.Visibility);
+						mauiToolbar.SetMenuBar(new MenuBar() { Items = { new MenuBarItem() } });
+						Assert.Equal(WVisibility.Visible, control.Visibility);
+						mauiToolbar.SetMenuBar(null);
+						Assert.Equal(WVisibility.Collapsed, control.Visibility);
+						break;
+					case "titleView":
+						mauiToolbar.TitleView = "text";
+						Assert.Equal(WVisibility.Visible, control.Visibility);
+						mauiToolbar.TitleView = null;
+						Assert.Equal(WVisibility.Collapsed, control.Visibility);
+						break;
+				}
+			});
+		}
+
 
 
 		RootNavigationView GetRootNavigationView(NavigationRootManager navigationRootManager)


### PR DESCRIPTION
### Description of Change

- If the user hasn't added any elements that will display in the toolbar then hide the toolbar
- If the user isn't using any shell structures that need a flyout then disable the flyout
- Hide various elements inside the Shell Header view based on if the user has supplied anything for that element
  - Having these elements visible was breaking narrator

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #5106
