### PR TITLE
[essentials] minor perf improvement around app actions

### DIFF
--- a/src/Essentials/src/AppActions/AppActions.android.cs
+++ b/src/Essentials/src/AppActions/AppActions.android.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Android.Content;
 using Android.Content.PM;
 using Android.Graphics.Drawables;
-using Microsoft.Maui.Essentials.Implementations;
+using Android.Runtime;
 
 namespace Microsoft.Maui.Essentials.Implementations
 {
@@ -32,14 +32,15 @@ namespace Microsoft.Maui.Essentials.Implementations
 				throw new FeatureNotSupportedException();
 
 #if __ANDROID_25__
-			Platform.ShortcutManager.SetDynamicShortcuts(actions.Select(a => a.ToShortcutInfo()).ToList());
+			using var list = new JavaList<ShortcutInfo>(actions.Select(a => a.ToShortcutInfo()));
+			Platform.ShortcutManager.SetDynamicShortcuts(list);
 #endif
 			return Task.CompletedTask;
 		}
 
 		public Task SetAsync(params AppAction[] actions)
 		{	
-			return SetAsync(actions.AsEnumerable<AppAction>());
+			return SetAsync(actions);
 		}
 	}
 


### PR DESCRIPTION
The .NET Podcast app is spending this amount of time on startup doing:

    5.36ms Mono.Android!Android.Content.PM.ShortcutManager.SetDynamicShortcuts(System.Collections.Generic.IList`1<Android.Content.PM.ShortcutInfo>)
    1.47ms Mono.Android!Android.Runtime.JavaList<T_REF>.ToLocalJniHandle

The Java binding for this call is:

    // Metadata.xml XPath method reference: path="/api/package[@name='android.content.pm']/class[@name='ShortcutManager']/method[@name='setDynamicShortcuts' and count(parameter)=1 and parameter[1][@type='java.util.List&lt;android.content.pm.ShortcutInfo&gt;']]"
    [global::System.Runtime.Versioning.SupportedOSPlatformAttribute ("android25.0")]
    [Register ("setDynamicShortcuts", "(Ljava/util/List;)Z", "GetSetDynamicShortcuts_Ljava_util_List_Handler", ApiSince = 25)]
    public virtual unsafe bool SetDynamicShortcuts (System.Collections.Generic.IList<Android.Content.PM.ShortcutInfo> shortcutInfoList)
    {
        const string __id = "setDynamicShortcuts.(Ljava/util/List;)Z";
        IntPtr native_shortcutInfoList = Android.Runtime.JavaList<Android.Content.PM.ShortcutInfo>.ToLocalJniHandle (shortcutInfoList);
        try {
            JniArgumentValue* __args = stackalloc JniArgumentValue [1];
            __args [0] = new JniArgumentValue (native_shortcutInfoList);
            var __rm = _members.InstanceMethods.InvokeVirtualBooleanMethod (__id, this, __args);
            return __rm;
        } finally {
            JNIEnv.DeleteLocalRef (native_shortcutInfoList);
            global::System.GC.KeepAlive (shortcutInfoList);
        }
    }

The interesting part being that:

    JavaList<ShortcutInfo>.ToLocalJniHandle()

Internally creates a `JavaList` via:

    public JavaList (IEnumerable items) : this ()
    {
        foreach (var item in items)
            Add (item);
    }

The code in essentials calls System.Linq's `.ToList()`, that we would
`foreach` over and create a new list from. Two lists for one API call?

Refactor to just use `JavaList<T>` directly, which will avoid an
intermediate C# list being created.

We'll do some thinking if there is a more broad approach to improve
calling Java APIs like this in the future.