### PR TITLE
Set the date after the DatePickerDialog is shown

### DIFF
--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiDatePicker platformView)
 		{
 			base.ConnectHandler(platformView);
-			
+
 			DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
 
 			SetupDefaults(platformView);
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Handlers
 				_dialog.Dispose();
 				_dialog = null;
 			}
-			
+
 			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
 
 			base.DisconnectHandler(platformView);
@@ -139,7 +139,11 @@ namespace Microsoft.Maui.Handlers
 			if (_dialog == null)
 				_dialog = CreateDatePickerDialog(year, month, day);
 			else
-				_dialog.UpdateDate(year, month, day);
+			{
+				EventHandler? setDateLater = null;
+				setDateLater = (sender, e) => { _dialog!.UpdateDate(year, month, day); _dialog.ShowEvent -= setDateLater; };
+				_dialog.ShowEvent += setDateLater;
+			}
 
 			_dialog.CancelEvent += OnCancelButtonClicked;
 


### PR DESCRIPTION
### Description of Change

For Android, the platform`DatePickerDialog` seems to have this weird behavior.

If we show the dialog, the user changed the month by pressing the arrow buttons, and then dismissing the dialog by either ok or cancel, and we show the dialog again, the calendar disappears.

[This](https://github.com/dotnet/maui/pull/5173#issuecomment-1064337775) comment below describes the underlying issue in the Android implementation of `DatePicker`. As @hartez suggested, we can workaround the underlying bug by making sure that we set the date after the UI is shown.

### Issues Fixed

Fixes #3749
