### PR TITLE
[msbuild] %(MauiXaml.SubType) defaults to Designer

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.DefaultItems.props
+++ b/.nuspec/Microsoft.Maui.Controls.DefaultItems.props
@@ -4,6 +4,12 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <ItemDefinitionGroup>
+    <MauiXaml>
+      <SubType>Designer</SubType>
+    </MauiXaml>
+  </ItemDefinitionGroup>
+
   <ItemGroup Condition="'$(EnableDefaultItems)'=='True' And '$(EnableDefaultXamlItems)'=='True' And '$(EnableDefaultEmbeddedResourceItems)'=='True'">
     <MauiXaml Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)"/>
   </ItemGroup>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.props
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.props
@@ -1,6 +1,12 @@
 <!-- all <ItemGroup/>'s must check if $(EnableDefaultMauiItems) is true -->
 <Project>
 
+  <ItemDefinitionGroup>
+    <MauiXaml>
+      <SubType>Designer</SubType>
+    </MauiXaml>
+  </ItemDefinitionGroup>
+
   <ItemGroup Condition=" '$(UseMaui)' == 'true' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
     <!-- %(Sdk) is only here if something later needs to identify these -->
     <Using Include="Microsoft.Extensions.DependencyInjection" Sdk="Maui" />


### PR DESCRIPTION
When opening .NET MAUI .xaml in Visual Studio, when you right click in
the editor you see:

    View Code
    Quick Actions and Refactorings...

However, `View Markup` is missing. Adding the `SubType=Designer`
item metadata solves this issue.

![image](https://user-images.githubusercontent.com/840039/157554015-c26ae3b4-3fc9-4243-bc25-7d231ee6ddd7.png)

We can define an `<ItemDefinitionGroup>` so this will be applied
automatically for all `@(MauiXaml)` items.

This is the same trick we used for `@(AndroidResource)` here:

https://github.com/xamarin/xamarin-android/blob/58c8d5ec86a42387084f65fffc934676991e77d2/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.AvailableItems.targets#L60-L64
