### PR TITLE
[ios] Fix initial date being wrong for datepicker

### DIFF
--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
@@ -51,11 +51,17 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void ConnectHandler(MauiDatePicker platformView)
 		{
-			if (_picker != null)
+			if (_picker is UIDatePicker picker)
 			{
-				_picker.EditingDidBegin += OnStarted;
-				_picker.EditingDidEnd += OnEnded;
-				_picker.ValueChanged += OnValueChanged;
+				picker.EditingDidBegin += OnStarted;
+				picker.EditingDidEnd += OnEnded;
+				picker.ValueChanged += OnValueChanged;
+
+				var date = VirtualView?.Date;
+				if (date is DateTime dt)
+				{
+					picker.Date = dt.ToNSDate();
+				}
 			}
 
 			base.ConnectHandler(platformView);


### PR DESCRIPTION
### Description of Change

Initialize the platform DatePicker input view when connecting the handler.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Partially fixes #3759 
