### PR TITLE
[ios] Fix initial time being wrong for TimePicker

### DIFF
--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.Handlers
 				platformView.EditingDidBegin += OnStarted;
 				platformView.EditingDidEnd += OnEnded;
 				platformView.ValueChanged += OnValueChanged;
+				platformView.UpdateTime(VirtualView.Time);
 			}
 		}
 

--- a/src/Core/src/Platform/iOS/MauiTimePicker.cs
+++ b/src/Core/src/Platform/iOS/MauiTimePicker.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Maui.Platform
 			AccessibilityTraits = UIAccessibilityTrait.Button;
 		}
 
+		public void UpdateTime(TimeSpan time)
+		{
+			_picker.Date = new DateTime(1, 1, 1, time.Hours, time.Minutes, time.Seconds).ToNSDate();
+		}
+
 		public NSDate Date => _picker.Date;
 	}
 }


### PR DESCRIPTION
### Description of Change

Initialize the platform TimePicker input view when connecting the handler

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Partially fixes #3759 
