### PR TITLE
Fix Controls.Xaml build error

### DIFF
--- a/src/Controls/src/Xaml/SimplifyOnPlatformVisitor.cs
+++ b/src/Controls/src/Xaml/SimplifyOnPlatformVisitor.cs
@@ -1,4 +1,5 @@
 ﻿#nullable disable
+using System;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
@@ -34,16 +35,15 @@ namespace Microsoft.Maui.Controls.Xaml
 				return;
 
 			string target = null;
-			if (TargetFramework.Contains("-android"))
+			if (TargetFramework.Contains("-android", StringComparison.Ordinal))
 				target = nameof(OnPlatformExtension.Android);
-			if (TargetFramework.Contains("-ios"))
+			else if (TargetFramework.Contains("-ios", StringComparison.Ordinal))
 				target = nameof(OnPlatformExtension.iOS);
-			if (TargetFramework.Contains("-macos"))
+			else if (TargetFramework.Contains("-macos", StringComparison.Ordinal))
 				target = nameof(OnPlatformExtension.macOS);
-			if (TargetFramework.Contains("-maccatalyst"))
+			else if (TargetFramework.Contains("-maccatalyst", StringComparison.Ordinal))
 				target = nameof(OnPlatformExtension.MacCatalyst);
-
-			if (target is null)
+			else if (target is null)
 				return;
 
 			if (   node.Properties.TryGetValue(new XmlName("", target), out INode targetNode)


### PR DESCRIPTION
### Description of Change

Use `StringComparision.Ordinal` in 'Microsoft.Maui.Controls.Xaml.SimplifyOnPlatformVisitor.Visit()` to remove following build error.  (see full log [here](https://dev.azure.com/xamarin/public/_build/results?buildId=56970&view=logs&j=a2b1c795-2687-5fd3-b418-4e4b87c7d580&t=f98b3571-5084-5d4e-0013-9a861ec79559&l=9607))

```sh
 D:\a\_work\1\s\src\Controls\src\Xaml\SimplifyOnPlatformVisitor.cs(37,8): error CA1307: 'string.Contains(string)' has a method overload that takes a 'StringComparison' parameter. Replace this call in 'Microsoft.Maui.Controls.Xaml.SimplifyOnPlatformVisitor.Visit(Microsoft.Maui.Controls.Xaml.ElementNode, Microsoft.Maui.Controls.Xaml.INode)' with a call to 'string.Contains(string, System.StringComparison)' for clarity of intent. [D:\a\_work\1\s\src\Controls\src\Xaml\Controls.Xaml.csproj]
D:\a\_work\1\s\src\Controls\src\Xaml\SimplifyOnPlatformVisitor.cs(39,8): error CA1307: 'string.Contains(string)' has a method overload that takes a 'StringComparison' parameter. Replace this call in 'Microsoft.Maui.Controls.Xaml.SimplifyOnPlatformVisitor.Visit(Microsoft.Maui.Controls.Xaml.ElementNode, Microsoft.Maui.Controls.Xaml.INode)' with a call to 'string.Contains(string, System.StringComparison)' for clarity of intent. [D:\a\_work\1\s\src\Controls\src\Xaml\Controls.Xaml.csproj]
D:\a\_work\1\s\src\Controls\src\Xaml\SimplifyOnPlatformVisitor.cs(41,8): error CA1307: 'string.Contains(string)' has a method overload that takes a 'StringComparison' parameter. Replace this call in 'Microsoft.Maui.Controls.Xaml.SimplifyOnPlatformVisitor.Visit(Microsoft.Maui.Controls.Xaml.ElementNode, Microsoft.Maui.Controls.Xaml.INode)' with a call to 'string.Contains(string, System.StringComparison)' for clarity of intent. [D:\a\_work\1\s\src\Controls\src\Xaml\Controls.Xaml.csproj]
D:\a\_work\1\s\src\Controls\src\Xaml\SimplifyOnPlatformVisitor.cs(43,8): error CA1307: 'string.Contains(string)' has a method overload that takes a 'StringComparison' parameter. Replace this call in 'Microsoft.Maui.Controls.Xaml.SimplifyOnPlatformVisitor.Visit(Microsoft.Maui.Controls.Xaml.ElementNode, Microsoft.Maui.Controls.Xaml.INode)' with a call to 'string.Contains(string, System.StringComparison)' for clarity of intent. [D:\a\_work\1\s\src\Controls\src\Xaml\Controls.Xaml.csproj]
```


