### PR TITLE
Remove Removing Adorners when updating Views (All Platforms)

### DIFF
--- a/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Android.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Android.cs
@@ -39,9 +39,6 @@ namespace Microsoft.Maui
 		{
 			base.HandleUIChange();
 
-			if (WindowElements.Count > 0)
-				RemoveAdorners();
-
 			if (GraphicsView != null)
 				Offset = GenerateAdornerOffset(GraphicsView);
 		}

--- a/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Windows.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.Windows.cs
@@ -43,8 +43,7 @@ namespace Microsoft.Maui
 		{
 			base.HandleUIChange();
 
-			if (WindowElements.Count > 0)
-				RemoveAdorners();
+			Invalidate();
 		}
 
 		void OnViewChanging(object? sender, ScrollViewerViewChangingEventArgs e)

--- a/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.iOS.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnosticsOverlay.iOS.cs
@@ -41,9 +41,6 @@ namespace Microsoft.Maui
 
 		void FrameAction(Foundation.NSObservedChange obj)
 		{
-			if (WindowElements.Count > 0)
-				RemoveAdorners();
-
 			Invalidate();
 		}
 	}


### PR DESCRIPTION
Addresses https://github.com/dotnet/maui/issues/5202

We don't need to clear the existing adorners for Android when the layout changes.

https://user-images.githubusercontent.com/898335/157738377-610a1851-e115-48b5-8333-b8547b8e3442.mp4

.