### PR TITLE
Fire Navigated After Loaded

### DIFF
--- a/src/Controls/tests/DeviceTests/DispatchingTests.cs
+++ b/src/Controls/tests/DeviceTests/DispatchingTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.DeviceTests
 			bool dispatched = false;
 			await Task.Run(async () =>
 			{
-				var app = new Application(false);
+				var app = await InvokeOnMainThreadAsync(() =>  new Application(false));
 				var handler = new ApplicationHandlerStub();
 				handler.SetMauiContext(MauiContext);
 				app.Handler = handler;

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
@@ -107,6 +107,27 @@ namespace Microsoft.Maui.DeviceTests
 
 #if !IOS
 		[Fact]
+		public async Task NavigatedToFiresAfterLoaded()
+		{
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage());
+			var page = new ContentPage();
+
+			int loaded = 0;
+			bool loadedFired = false;
+
+			page.Loaded += (_, __) => loaded++;
+			page.NavigatedTo += (_, __) => loadedFired = (loaded == 1);
+
+			await CreateHandlerAndAddToWindow<NavigationViewHandler>(navPage, async (handler) =>
+			{
+				await navPage.PushAsync(page);
+				Assert.True(loadedFired);
+			});
+		}
+
+		[Fact]
 		public async Task LoadedFiresOnPushedPage()
 		{
 			SetupBuilder();

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -41,7 +41,12 @@ namespace Microsoft.Maui.DeviceTests
 					navigationRootManager = mauiContext.GetNavigationRootManager();
 					navigationRootManager.UseCustomAppTitleBar = false;
 
-					newWindowHandler = window.ToHandler(mauiContext);
+					MauiContext
+						.Services
+						.GetRequiredService<WWindow>()
+						.SetWindowHandler(window, mauiContext);
+
+					newWindowHandler = window.Handler;
 					var content = window.Content.Handler.ToPlatform();
 					await content.OnLoadedAsync();
 					await Task.Delay(10);

--- a/src/Core/src/Platform/Windows/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Windows/StackNavigationManager.cs
@@ -181,7 +181,15 @@ namespace Microsoft.Maui.Platform
 
 			fe.OnLoaded(() =>
 			{
-				FireNavigationFinished();
+				if (presenter?.Content is not FrameworkElement pc)
+				{
+					FireNavigationFinished();
+				}
+				else
+				{
+					pc.OnLoaded(FireNavigationFinished);
+				}
+
 				if (NavigationView is IView view)
 				{
 					view.Arrange(fe);


### PR DESCRIPTION
### Description of Change

The WinUI test was moving on before the Loaded event had time to fire. This PR changes it so the Navigated event fires after the content of the page fires "Loaded".


