### PR TITLE
Fix Blazor Hybrid page reloading

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -94,6 +94,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			base.OnPageFinished(view, url);
 
+			// TODO: How do we know this runs only once?
 			if (view != null && IsAppOriginPageUri(url))
 			{
 				RunBlazorStartupScripts(view);

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -97,6 +97,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			// TODO: How do we know this runs only once?
 			if (view != null && IsAppOriginPageUri(url))
 			{
+				// Startup scripts must run in OnPageFinished. If scripts are run earlier they will have no lasting
+				// effect because once the page content loads all the document state gets reset.
 				RunBlazorStartupScripts(view);
 			}
 		}

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		// we intercept all the requests within this origin.
 		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
 
+		private static readonly Uri AppOriginUri = new(AppOrigin);
+
 		private readonly BlazorWebViewHandler? _webViewHandler;
 
 		public WebKitWebViewClient(BlazorWebViewHandler webViewHandler!!)
@@ -171,10 +173,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				return false;
 			}
 
-			var appBaseUri = new Uri(AppOrigin);
 			var requestUri = new Uri(requestUriString);
-
-			if (!appBaseUri.IsBaseOf(requestUri))
+			if (!AppOriginUri.IsBaseOf(requestUri))
 			{
 				return false;
 			}

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -87,7 +87,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				if (new Uri(AppOrigin).IsBaseOf(uri))
 				{
 					var relativePath = new Uri(AppOrigin).MakeRelativeUri(uri).ToString();
-					if (allowFallbackOnHostPage && string.IsNullOrEmpty(relativePath))
+
+					// If the path does not end in a file extension (or is empty), it's most likely referring to a page,
+					// in which case we should allow falling back on the host page.
+					if (allowFallbackOnHostPage && !Path.HasExtension(relativePath))
 					{
 						relativePath = _hostPageRelativePath;
 					}


### PR DESCRIPTION
### Description of Change

This PR resolves an issue where non-root pages cannot be loaded on some platforms in Blazor Hybrid applications. This behavior was initially observed in Android, but I was able to reproduce it in WinUI. It may be worthwhile to also check if the buggy reloading behavior exists in iOS.

### Issues Fixed

This PR fixes page reloading issues for both WinUI and Android platforms.

Fixes #5136
