### PR TITLE
Multiple DispatcherProviders are being created

### DIFF
--- a/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/Dispatching/AppHostBuilderExtensions.cs
@@ -10,7 +10,11 @@ namespace Microsoft.Maui.Hosting
 	{
 		public static MauiAppBuilder ConfigureDispatching(this MauiAppBuilder builder)
 		{
-			builder.Services.TryAddSingleton<IDispatcherProvider>(svc => new DispatcherProvider());
+			builder.Services.TryAddSingleton<IDispatcherProvider>(svc =>
+				// the DispatcherProvider might have already been initialized, so ensure that we are grabbing the
+				// Current and putting it in the DI container.
+				DispatcherProvider.Current);
+
 			builder.Services.TryAddScoped(svc =>
 			{
 				var provider = svc.GetRequiredService<IDispatcherProvider>();


### PR DESCRIPTION
We are getting into a state where multiple instances of DispatcherProvider are getting created. This in turn is logging a warning on every Maui app startup.

The reason this happen is because a BindableObject is getting created during static constructors (for example a static Brush is getting created). Creating a BindableObject is grabbing the current static Dispatcher, which initializes a DispatcherProvider. Later when building the DI container, we inject a new DispatcherProvider instance into the DI container. Then when code tries getting a Dispatcher from DI, we are logging a warning because the Current isn't the same instance as what is in DI.

Changing the DI code to use Current instead. That way only one instance is created.
