### PR TITLE
Lazy Load Shell Flyout and Bottom Tabs

### DIFF
--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -109,75 +109,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			elementHolder.Element = item.Element;
 		}
 
-		class LinearLayoutWithFocus : LinearLayout, ITabStop//, INativeViewHandler
+		class LinearLayoutWithFocus : LinearLayout, ITabStop
 		{
 			public LinearLayoutWithFocus(global::Android.Content.Context context) : base(context)
 			{
 			}
 
 			AView ITabStop.TabStop => this;
-
-			//			#region INativeViewHandler
-
-			//			VisualElement INativeViewHandler.Element => Content?.BindingContext as VisualElement;
-
-			//			VisualElementTracker INativeViewHandler.Tracker => null;
-
-			//			ViewGroup INativeViewHandler.ViewGroup => this;
-
-			//			AView INativeViewHandler.View => this;
-
-			//			SizeRequest INativeViewHandler.GetDesiredSize(int widthConstraint, int heightConstraint) => new SizeRequest(new Size(100, 100));
-
-			//			void INativeViewHandler.SetElement(VisualElement element) { }
-
-			//			void INativeViewHandler.SetLabelFor(int? id) { }
-
-			//			void INativeViewHandler.UpdateLayout() { }
-
-			//#pragma warning disable 67
-			//			public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
-			//			public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;
-			//#pragma warning restore 67
-
-			//			#endregion INativeViewHandler
-
 			internal View Content { get; set; }
-
-
-			// TODO MAUI Is this right for focus order?
-			//	public override AView FocusSearch([GeneratedEnum] FocusSearchDirection direction)
-			//	{
-			//		var element = Content?.BindingContext as ITabStopElement;
-			//		if (element == null)
-			//			return base.FocusSearch(direction);
-
-			//		int maxAttempts = 0;
-			//		var tabIndexes = element?.GetTabIndexesOnParentPage(out maxAttempts);
-			//		if (tabIndexes == null)
-			//			return base.FocusSearch(direction);
-
-			//		// use OS default--there's no need for us to keep going if there's one or fewer tab indexes!
-			//		if (tabIndexes.Count <= 1)
-			//			return base.FocusSearch(direction);
-
-			//		int tabIndex = element.TabIndex;
-			//		AView control = null;
-			//		int attempt = 0;
-			//		bool forwardDirection = !(
-			//			(direction & FocusSearchDirection.Backward) != 0 ||
-			//			(direction & FocusSearchDirection.Left) != 0 ||
-			//			(direction & FocusSearchDirection.Up) != 0);
-
-			//		do
-			//		{
-			//			element = element.FindNextElement(forwardDirection, tabIndexes, ref tabIndex);
-			//			var renderer = (element as BindableObject).GetValue(AppCompat.Platform.RendererProperty);
-			//			control = (renderer as ITabStop)?.TabStop;
-			//		} while (!(control?.Focusable == true || ++attempt >= maxAttempts));
-
-			//		return control?.Focusable == true ? control : null;
-			//	}
 		}
 
 		public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
@@ -299,16 +238,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			AView _itemView;
 			bool _disposed;
 			Shell _shell;
-
-			[Obsolete]
-			public ElementViewHolder(View view, AView itemView, AView bar, Action<Element> selectedCallback) : this(view, itemView, bar, selectedCallback, null)
-			{
-				_itemView = itemView;
-				itemView.Click += OnClicked;
-				View = view;
-				Bar = bar;
-				_selectedCallback = selectedCallback;
-			}
 
 			public ElementViewHolder(View view, AView itemView, AView bar, Action<Element> selectedCallback, Shell shell) : base(itemView)
 			{

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutRenderer.cs
@@ -212,10 +212,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_flyoutWidthDefault = width;
 
-			if (context.Shell is IFlyoutView view)
-				AddFlyoutContentToLayoutIfNeeded(view.FlyoutBehavior);
 
 			AddView(content);
+
+			if (context.Shell is IFlyoutView view)
+				AddFlyoutContentToLayoutIfNeeded(view.FlyoutBehavior);
 
 			((IShellController)context.Shell).AddFlyoutBehaviorObserver(this);
 
@@ -230,7 +231,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (behavior == FlyoutBehavior.Disabled)
 				return;
 
-			if (_flyoutContent == null)
+			if (_flyoutContent == null && ChildCount > 0)
 			{
 				_flyoutContent = _shellContext.CreateShellFlyoutContentRenderer();
 

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -490,10 +490,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				if (View != null && View is ShellFlyoutLayout sfl)
 					sfl.LayoutChanging -= OnFlyoutViewLayoutChanged;
 
-
-				//if (_shellContext.CurrentDrawerLayout != null)
-				//	_shellContext.CurrentDrawerLayout.DrawerStateChanged -= OnFlyoutStateChanging;
-
 				_contentView?.TearDown();
 				_flyoutContentView?.Dispose();
 				_headerView.Dispose();

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -81,7 +81,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_actionBarHeight = context.GetActionBarHeight();
 			UpdateFlyoutHeader();
-			UpdateFlyoutContent();
 
 			var metrics = context.Resources.DisplayMetrics;
 			var width = Math.Min(metrics.WidthPixels, metrics.HeightPixels);

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -79,19 +79,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_appBar.AddOnOffsetChangedListener(this);
 
-			_actionBarHeight = (int)context.ToPixels(56);
+			_actionBarHeight = context.GetActionBarHeight();
 			UpdateFlyoutHeader();
+			UpdateFlyoutContent();
 
 			var metrics = context.Resources.DisplayMetrics;
 			var width = Math.Min(metrics.WidthPixels, metrics.HeightPixels);
-
-			using (TypedValue tv = new TypedValue())
-			{
-				if (context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ActionBarSize, tv, true))
-				{
-					_actionBarHeight = TypedValue.ComplexToDimensionPixelSize(tv.Data, metrics);
-				}
-			}
 
 			width -= _actionBarHeight;
 

--- a/src/Compatibility/Core/src/Handlers/Shell/Android/ShellItemRenderer.cs
+++ b/src/Compatibility/Core/src/Handlers/Shell/Android/ShellItemRenderer.cs
@@ -387,16 +387,19 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual void SetupMenu(IMenu menu, int maxBottomItems, ShellItem shellItem)
 		{
-			var currentIndex = ((IShellItemController)ShellItem).GetItems().IndexOf(ShellSection);
-			var items = CreateTabList(shellItem);
+			if (ShellItemController.ShowTabs)
+			{
+				var currentIndex = ((IShellItemController)ShellItem).GetItems().IndexOf(ShellSection);
+				var items = CreateTabList(shellItem);
 
-			BottomNavigationViewUtils.SetupMenu(
-				menu,
-				maxBottomItems,
-				items,
-				currentIndex,
-				_bottomView,
-				MauiContext);
+				BottomNavigationViewUtils.SetupMenu(
+					menu,
+					maxBottomItems,
+					items,
+					currentIndex,
+					_bottomView,
+					MauiContext);
+			}
 
 			UpdateTabBarVisibility();
 		}

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1321,7 +1321,7 @@ namespace Microsoft.Maui.Controls
 			if (CurrentItem == null || GetVisiblePage() == null)
 				return;
 
-			var behavior = GetEffectiveFlyoutBehavior();
+			var behavior = (this as IFlyoutView).FlyoutBehavior;
 			for (int i = 0; i < _flyoutBehaviorObservers.Count; i++)
 				_flyoutBehaviorObservers[i].OnFlyoutBehaviorChanged(behavior);
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	public partial class ShellTests
+	{
+		[Fact(DisplayName = "Shell with Flyout Disabled Doesn't Render Flyout")]
+		public async Task ShellWithFlyoutDisabledDoesntRenderFlyout()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new ContentPage());
+			});
+
+			shell.FlyoutBehavior = FlyoutBehavior.Disabled;
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, (handler) =>
+			{
+				IShellContext shellContext = handler;
+				var dl = shellContext.CurrentDrawerLayout;
+				Assert.Equal(1, dl.ChildCount);
+				shell.FlyoutBehavior = FlyoutBehavior.Flyout;
+				Assert.Equal(2, dl.ChildCount);
+				return Task.CompletedTask;
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -12,7 +12,7 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
 
-#if ANDROID
+#if ANDROID || IOS
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
 #endif
 
@@ -27,12 +27,10 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
-#if WINDOWS || ANDROID
 					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
 					handlers.AddHandler<Layout, LayoutHandler>();
 					handlers.AddHandler<Image, ImageHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
-#endif
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Toolbar, ToolbarHandler>();
 #if WINDOWS


### PR DESCRIPTION
### Description of Change

- Don't load any bottom tabs if the structure of shell isn't going to have any visible bottom tabs (24 ms)
- Don't attach or load the flyout if the flyout isn't going to be reachable. So if the user has disabled it on load or if the design has no flyout
- I added some code that attempts to load the flyouts recycler view after the main view is visible. I attempted to only load the flyout when the user first clicks on the flyout but wasn't able to fix some odd flickering behavior.  The flyout itself really needs to be replaced with a [NavigationView](https://developer.android.com/reference/com/google/android/material/navigation/NavigationView). Currently it's using a RecyclerView to display a very small set of things. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
