### PR TITLE
Set Parent for child elements added to Border

### DIFF
--- a/src/Controls/src/Core/Border.cs
+++ b/src/Controls/src/Core/Border.cs
@@ -159,9 +159,19 @@ namespace Microsoft.Maui.Controls
 			if (bindable is Border border)
 			{
 				if (oldValue is Element oldElement)
-					border.InternalChildren.Remove(oldElement);
+				{
+					int index = border.InternalChildren.IndexOf(oldElement);
+					if (border.InternalChildren.Remove(oldElement))
+					{
+						border.OnChildRemoved(oldElement, index);
+					}
+				}
+
 				if (newValue is Element newElement)
+				{
 					border.InternalChildren.Add(newElement);
+					border.OnChildAdded(newElement);
+				}
 			}
 
 			((IBorderView)bindable).InvalidateMeasure();


### PR DESCRIPTION
### Description of Change

Call `OnChild[Added|Removed]` events in `Border.ContentChanged`

### Issues Fixed

Fixes #4614
