### PR TITLE
Expose a Window property on VisualElement

### DIFF
--- a/src/Controls/src/Core/Cells/Cell.cs
+++ b/src/Controls/src/Core/Cells/Cell.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 {
 	// Don't add IElementConfiguration<Cell> because it kills performance on UWP structures that use Cells
 	/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="Type[@FullName='Microsoft.Maui.Controls.Cell']/Docs" />
-	public abstract class Cell : Element, ICellController, IFlowDirectionController, IPropertyPropagationController, IVisualController
+	public abstract class Cell : Element, ICellController, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController
 	{
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="//Member[@MemberName='DefaultCellHeight']/Docs" />
 		public const int DefaultCellHeight = 40;
@@ -66,6 +66,20 @@ namespace Microsoft.Maui.Controls
 
 		IFlowDirectionController FlowController => this;
 		IPropertyPropagationController PropertyPropagationController => this;
+
+		Window _window;
+		Window IWindowController.Window
+		{
+			get => _window;
+			set
+			{
+				if (value == _window)
+					return;
+
+				_window = value;
+				OnPropertyChanged(VisualElement.WindowProperty.PropertyName);
+			}
+		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Cell.xml" path="//Member[@MemberName='ContextActions']/Docs" />
 		public IList<MenuItem> ContextActions

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Controls.Xaml.Diagnostics;
 
 namespace Microsoft.Maui.Controls
 {
@@ -20,11 +19,6 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='ClassIdProperty']/Docs" />
 		public static readonly BindableProperty ClassIdProperty = BindableProperty.Create(nameof(ClassId), typeof(string), typeof(Element), null);
-
-		internal static readonly BindablePropertyKey WindowPropertyKey = BindableProperty.CreateReadOnly(nameof(Window), typeof(IWindow), typeof(Element), null, propertyChanged: OnWindowChanged);
-
-
-		internal static readonly BindableProperty WindowProperty = WindowPropertyKey.BindableProperty;
 
 		IList<BindableObject> _bindableResources;
 
@@ -41,7 +35,6 @@ namespace Microsoft.Maui.Controls
 		Element _parentOverride;
 
 		string _styleId;
-
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='AutomationId']/Docs" />
 		public string AutomationId
@@ -101,15 +94,6 @@ namespace Microsoft.Maui.Controls
 				_styleId = value;
 				OnPropertyChanged();
 			}
-		}
-
-		internal IWindow Window => (IWindow)GetValue(WindowProperty);
-		internal void SetWindow(IWindow window) => SetValue(WindowPropertyKey, window);
-
-		protected private virtual void OnWindowChanged(IWindow oldValue, IWindow newValue) { }
-		static void OnWindowChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			(bindable as Element)?.OnWindowChanged((IWindow)oldValue, (IWindow)newValue);
 		}
 
 		internal virtual IReadOnlyList<Element> LogicalChildrenInternal => EmptyChildren;

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.VisualElement']/Docs" />
-	public partial class VisualElement : IView, IWindowController
+	public partial class VisualElement : IView
 	{
 		Semantics _semantics;
 		bool _isLoadedFired;

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Layouts;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.VisualElement']/Docs" />
-	public partial class VisualElement : IView
+	public partial class VisualElement : IView, IWindowController
 	{
 		Semantics _semantics;
 		bool _isLoadedFired;
@@ -387,14 +387,15 @@ namespace Microsoft.Maui.Controls
 			_unloaded?.Invoke(this, EventArgs.Empty);
 		}
 
-		private protected override void OnWindowChanged(IWindow oldValue, IWindow newValue)
+		static void OnWindowChanged(BindableObject bindable, object? oldValue, object? newValue)
 		{
-			base.OnWindowChanged(oldValue, newValue);
+			if (bindable is not VisualElement visualElement)
+				return;
 
-			if (_watchingPlatformLoaded && oldValue is Element oldWindow)
-				oldWindow.HandlerChanged -= OnWindowHandlerChanged;
+			if (visualElement._watchingPlatformLoaded && oldValue is Window oldWindow)
+				oldWindow.HandlerChanged -= visualElement.OnWindowHandlerChanged;
 
-			UpdatePlatformUnloadedLoadedWiring(newValue);
+			visualElement.UpdatePlatformUnloadedLoadedWiring(newValue as Window);
 		}
 
 		void OnWindowHandlerChanged(object? sender, EventArgs e)
@@ -406,7 +407,7 @@ namespace Microsoft.Maui.Controls
 		// if the user is watching for them. Otherwise
 		// this will get wired up for every single VE that's on 
 		// the screen
-		void UpdatePlatformUnloadedLoadedWiring(IWindow? window)
+		void UpdatePlatformUnloadedLoadedWiring(Window? window)
 		{
 			// If I'm not attached to a window and I haven't started watching any platform events
 			// then it's not useful to wire anything up. We will just wait until
@@ -416,21 +417,22 @@ namespace Microsoft.Maui.Controls
 
 			if (_unloaded == null && _loaded == null)
 			{
-				if (window is Element elementWindow)
-					elementWindow.HandlerChanged -= OnWindowHandlerChanged;
+				if (window is not null)
+					window.HandlerChanged -= OnWindowHandlerChanged;
 
 #if PLATFORM
 				_loadedUnloadedToken?.Dispose();
 				_loadedUnloadedToken = null;
 #endif
+
 				_watchingPlatformLoaded = false;
 				return;
 			}
 
 			if (!_watchingPlatformLoaded)
 			{
-				if (window is Element elementWindow)
-					elementWindow.HandlerChanged += OnWindowHandlerChanged;
+				if (window is not null)
+					window.HandlerChanged += OnWindowHandlerChanged;
 
 				_watchingPlatformLoaded = true;
 			}

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -12,7 +12,7 @@ using Microsoft.Maui.Controls.Platform;
 namespace Microsoft.Maui.Controls
 {
 	[ContentProperty(nameof(Page))]
-	public partial class Window : NavigableElement, IWindow, IVisualTreeElement, IToolbarElement, IMenuBarElement, IFlowDirectionController
+	public partial class Window : NavigableElement, IWindow, IVisualTreeElement, IToolbarElement, IMenuBarElement, IFlowDirectionController, IWindowController
 	{
 		public static readonly BindableProperty TitleProperty = BindableProperty.Create(
 			nameof(Title), typeof(string), typeof(Window), default(string?));
@@ -198,6 +198,12 @@ namespace Microsoft.Maui.Controls
 
 		bool IFlowDirectionController.ApplyEffectiveFlowDirectionToChildContainer => true;
 
+		Window IWindowController.Window
+		{
+			get => this;
+			set => throw new InvalidOperationException("A window cannot set a window.");
+		}
+
 		IView IWindow.Content =>
 			Page ?? throw new InvalidOperationException("No page was set on the window.");
 
@@ -373,15 +379,11 @@ namespace Microsoft.Maui.Controls
 				window.InternalChildren.Remove(oldPage);
 				oldPage.HandlerChanged -= OnPageHandlerChanged;
 				oldPage.HandlerChanging -= OnPageHandlerChanging;
-
-				((IWindowController)oldPage).Window = null;
 			}
 
 			var newPage = newValue as Page;
 			if (newPage != null)
 			{
-				((IWindowController)newPage).Window = window;
-
 				window.InternalChildren.Add(newPage);
 				newPage.NavigationProxy.Inner = window.NavigationProxy;
 				window._menuBarTracker.Target = newPage;

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Maui.Controls
 
 		public Window()
 		{
-			SetWindow(this);
 			_visualChildren = new List<IVisualTreeElement>();
 			AlertManager = new AlertManager(this);
 			ModalNavigationManager = new ModalNavigationManager(this);
@@ -374,11 +373,15 @@ namespace Microsoft.Maui.Controls
 				window.InternalChildren.Remove(oldPage);
 				oldPage.HandlerChanged -= OnPageHandlerChanged;
 				oldPage.HandlerChanging -= OnPageHandlerChanging;
+
+				((IWindowController)oldPage).Window = null;
 			}
 
 			var newPage = newValue as Page;
 			if (newPage != null)
 			{
+				((IWindowController)newPage).Window = window;
+
 				window.InternalChildren.Add(newPage);
 				newPage.NavigationProxy.Inner = window.NavigationProxy;
 				window._menuBarTracker.Target = newPage;

--- a/src/Controls/src/Core/IWindowController.cs
+++ b/src/Controls/src/Core/IWindowController.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Maui.Controls
+{
+	interface IWindowController
+	{
+		Window Window { get; set; }
+	}
+}

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Maui.Controls.Internals
 {
@@ -16,6 +13,9 @@ namespace Microsoft.Maui.Controls.Internals
 			if (propertyName == null || propertyName == VisualElement.VisualProperty.PropertyName)
 				SetVisualFromParent(element);
 
+			if (propertyName == null || propertyName == VisualElement.WindowProperty.PropertyName)
+				SetWindowFromParent(element);
+
 			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
 
@@ -24,9 +24,6 @@ namespace Microsoft.Maui.Controls.Internals
 
 			if (propertyName == null || propertyName == Shell.TabBarIsVisibleProperty.PropertyName)
 				BaseShellItem.PropagateFromParent(Shell.TabBarIsVisibleProperty, element);
-
-			if (propertyName == null || propertyName == Element.WindowProperty.PropertyName)
-				SetWindowFromParent(element);
 
 			foreach (var child in children)
 			{
@@ -43,6 +40,9 @@ namespace Microsoft.Maui.Controls.Internals
 
 			if (propertyName == null || propertyName == VisualElement.VisualProperty.PropertyName)
 				PropagateVisual(target, source);
+
+			if (propertyName == null || propertyName == VisualElement.WindowProperty.PropertyName)
+				PropagateWindow(target, source);
 
 			if (target is IPropertyPropagationController view)
 				view.PropagatePropertyChanged(propertyName);
@@ -99,7 +99,15 @@ namespace Microsoft.Maui.Controls.Internals
 
 		internal static void PropagateWindow(Element target, Element source)
 		{
-			target.SetWindow(source?.Window);
+			var controller = target as IWindowController;
+			if (controller == null)
+				return;
+
+			var sourceController = source as IWindowController;
+			if (sourceController == null)
+				return;
+
+			controller.Window = sourceController.Window;
 		}
 
 		internal static void SetWindowFromParent(Element child)

--- a/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
+++ b/src/Controls/src/Core/Internals/PropertyPropagationExtensions.cs
@@ -104,10 +104,8 @@ namespace Microsoft.Maui.Controls.Internals
 				return;
 
 			var sourceController = source as IWindowController;
-			if (sourceController == null)
-				return;
 
-			controller.Window = sourceController.Window;
+			controller.Window = sourceController?.Window;
 		}
 
 		internal static void SetWindowFromParent(Element child)

--- a/src/Controls/src/Core/Shell/BaseShellItem.cs
+++ b/src/Controls/src/Core/Shell/BaseShellItem.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/BaseShellItem.xml" path="Type[@FullName='Microsoft.Maui.Controls.BaseShellItem']/Docs" />
 	[DebuggerDisplay("Title = {Title}, Route = {Route}")]
-	public class BaseShellItem : NavigableElement, IPropertyPropagationController, IVisualController, IFlowDirectionController
+	public class BaseShellItem : NavigableElement, IPropertyPropagationController, IVisualController, IFlowDirectionController, IWindowController
 	{
 		public event EventHandler Appearing;
 		public event EventHandler Disappearing;
@@ -264,6 +264,19 @@ namespace Microsoft.Maui.Controls
 
 		bool IFlowDirectionController.ApplyEffectiveFlowDirectionToChildContainer => true;
 		double IFlowDirectionController.Width => (Parent as VisualElement)?.Width ?? 0;
+
+		static readonly BindablePropertyKey WindowPropertyKey = BindableProperty.CreateReadOnly(
+			nameof(Window), typeof(Window), typeof(BaseShellItem), null);
+
+		public static readonly BindableProperty WindowProperty = WindowPropertyKey.BindableProperty;
+
+		public Window Window => (Window)GetValue(WindowProperty);
+
+		Window IWindowController.Window
+		{
+			get => (Window)GetValue(WindowProperty);
+			set => SetValue(WindowPropertyKey, value);
+		}
 
 		internal virtual void ApplyQueryAttributes(ShellRouteParameters query)
 		{

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -361,6 +361,21 @@ namespace Microsoft.Maui.Controls
 
 		EffectiveFlowDirection IVisualElementController.EffectiveFlowDirection => FlowController.EffectiveFlowDirection;
 
+
+		static readonly BindablePropertyKey WindowPropertyKey = BindableProperty.CreateReadOnly(
+			nameof(Window), typeof(Window), typeof(VisualElement), null, propertyChanged: OnWindowChanged);
+
+		public static readonly BindableProperty WindowProperty = WindowPropertyKey.BindableProperty;
+
+		public Window Window => (Window)GetValue(WindowProperty);
+
+		Window IWindowController.Window
+		{
+			get => (Window)GetValue(WindowProperty);
+			set => SetValue(WindowPropertyKey, value);
+		}
+
+
 		readonly Dictionary<Size, SizeRequest> _measureCache = new Dictionary<Size, SizeRequest>();
 
 

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -12,7 +12,7 @@ using Rect = Microsoft.Maui.Graphics.Rect;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="Type[@FullName='Microsoft.Maui.Controls.VisualElement']/Docs" />
-	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController
+	public partial class VisualElement : NavigableElement, IAnimatable, IVisualElementController, IResourcesProvider, IStyleElement, IFlowDirectionController, IPropertyPropagationController, IVisualController, IWindowController
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='NavigationProperty']/Docs" />
 		public new static readonly BindableProperty NavigationProperty = NavigableElement.NavigationProperty;

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -89,6 +89,123 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(wind1.VisualDiagnosticsOverlay.WindowElements.Count == 0);
 		}
 
+		[Test]
+		public void ListViewWindowIsInheritedByViewCells()
+		{
+			var lv = new ListView { ItemTemplate = new DataTemplate(() => new ViewCell { View = new View() }) };
+			var window = new Window(new ContentPage { Content = lv });
+
+			lv.ItemsSource = Enumerable.Range(0, 10);
+
+			ViewCell cell = lv.TemplatedItems[0] as ViewCell;
+			Assert.AreEqual(window, cell.View.Window);
+		}
+
+		[Test]
+		public void ListViewWindowIsInheritedByLabelInViewCells()
+		{
+			var lv = new ListView { ItemTemplate = new DataTemplate(() => new ViewCell { View = new Label() }) };
+			var window = new Window(new ContentPage { Content = lv });
+
+			lv.ItemsSource = Enumerable.Range(0, 10);
+
+			ViewCell cell = lv.TemplatedItems[0] as ViewCell;
+			Assert.AreEqual(window, cell.View.Window);
+		}
+
+		[Test]
+		public void NestedControlsAllHaveTheSameWindow()
+		{
+			var btn = new Button();
+			var grid = new Grid { btn };
+			var cp = new ContentPage { Content = grid };
+			var window = new Window(cp);
+
+			Assert.AreEqual(window, btn.Window);
+			Assert.AreEqual(window, grid.Window);
+			Assert.AreEqual(window, cp.Window);
+		}
+
+		[Test]
+		public void NestedControlsAllHaveTheSameWindowWhenAddedLater()
+		{
+			var btn = new Button();
+			var grid = new Grid { btn };
+			var cp = new ContentPage { Content = grid };
+			var window = new Window();
+
+			Assert.Null(btn.Window);
+			Assert.Null(grid.Window);
+			Assert.Null(cp.Window);
+
+			window.Page = cp;
+
+			Assert.AreEqual(window, btn.Window);
+			Assert.AreEqual(window, grid.Window);
+			Assert.AreEqual(window, cp.Window);
+		}
+
+
+		[Test]
+		public void SwappingPagesUpdatesTheWindow()
+		{
+			var btn = new Button();
+			var grid = new Grid { btn };
+			var cp = new ContentPage { Content = grid };
+			
+			var window = new Window(cp);
+			var window2 = new Window(cp);
+
+			Assert.AreEqual(window2, btn.Window);
+			Assert.AreEqual(window2, grid.Window);
+			Assert.AreEqual(window2, cp.Window);
+		}
+
+		[Test]
+		public void DetachingThePageUnsetsTheWindow()
+		{
+			var btn = new Button();
+			var grid = new Grid { btn };
+			var cp = new ContentPage { Content = grid };
+			var window = new Window(cp);
+
+			window.Page = null;
+
+			Assert.Null(btn.Window);
+			Assert.Null(grid.Window);
+			Assert.Null(cp.Window);
+		}
+
+		[Test]
+		public void DetachingInTheMiddleUnsetsTheWindow()
+		{
+			var btn = new Button();
+			var grid = new Grid { btn };
+			var cp = new ContentPage { Content = grid };
+			var window = new Window(cp);
+
+			cp.Content = null;
+
+			Assert.Null(btn.Window);
+			Assert.Null(grid.Window);
+			Assert.AreEqual(window, cp.Window);
+		}
+
+		[Test]
+		public void RemovingControlsFromLayoutsUnsetsTheWindow()
+		{
+			var btn = new Button();
+			var grid = new Grid { btn };
+			var cp = new ContentPage { Content = grid };
+			var window = new Window(cp);
+
+			grid.Remove(btn);
+
+			Assert.Null(btn.Window);
+			Assert.AreEqual(window, grid.Window);
+			Assert.AreEqual(window, cp.Window);
+		}
+
 		void ValidateSetup(Application app, Page page = null)
 		{
 			var window = (Window)app.Windows[0];

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
@@ -105,12 +106,38 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void ListViewWindowIsInheritedByLabelInViewCells()
 		{
 			var lv = new ListView { ItemTemplate = new DataTemplate(() => new ViewCell { View = new Label() }) };
-			var window = new Window(new ContentPage { Content = lv });
+			var cp = new ContentPage { Content = lv };
+			var window = new Window(cp);
+
+			Assert.AreEqual(window, lv.Window);
+			Assert.AreEqual(window, cp.Window);
 
 			lv.ItemsSource = Enumerable.Range(0, 10);
 
-			ViewCell cell = lv.TemplatedItems[0] as ViewCell;
+			var cell = lv.TemplatedItems[0] as ViewCell;
+
 			Assert.AreEqual(window, cell.View.Window);
+		}
+
+		[Test]
+		public void ListViewWindowIsInheritedByLayoutsInViewCells()
+		{
+			var lv = new ListView { ItemTemplate = new DataTemplate(() => new ViewCell { View = new Grid { new Label() } }) };
+			var cp = new ContentPage { Content = lv };
+			var window = new Window(cp);
+
+			Assert.AreEqual(window, lv.Window);
+			Assert.AreEqual(window, cp.Window);
+
+			lv.ItemsSource = Enumerable.Range(0, 10);
+
+			var cell = lv.TemplatedItems[0] as ViewCell;
+			var grid = cell.View as Grid;
+			var label = grid.Children[0] as Label;
+
+			Assert.AreEqual(window, ((IWindowController)cell).Window);
+			Assert.AreEqual(window, cell.View.Window);
+			Assert.AreEqual(window, label.Window);
 		}
 
 		[Test]
@@ -127,7 +154,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void NestedControlsAllHaveTheSameWindowWhenAddedLater()
+		public void PageHasTheSameWindowWhenAddedLater()
 		{
 			var btn = new Button();
 			var grid = new Grid { btn };
@@ -145,6 +172,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(window, cp.Window);
 		}
 
+		[Test]
+		public void NestedControlsAllHaveTheSameWindowWhenAddedLater()
+		{
+			var btn = new Button();
+			var grid = new Grid();
+			var cp = new ContentPage { Content = grid };
+			var window = new Window(cp);
+
+			Assert.Null(btn.Window);
+			Assert.AreEqual(window, grid.Window);
+			Assert.AreEqual(window, cp.Window);
+
+			grid.Children.Add(btn);
+
+			Assert.AreEqual(window, btn.Window);
+			Assert.AreEqual(window, grid.Window);
+			Assert.AreEqual(window, cp.Window);
+		}
 
 		[Test]
 		public void SwappingPagesUpdatesTheWindow()
@@ -152,7 +197,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var btn = new Button();
 			var grid = new Grid { btn };
 			var cp = new ContentPage { Content = grid };
-			
+
 			var window = new Window(cp);
 			var window2 = new Window(cp);
 


### PR DESCRIPTION
### Description of Change

This follows on from the work for #5027.

I made some changes to make it fit a bit better. The biggest is that I moved it to `VisualElement` because `Window` and `Application` are `Element`. This means that there would now be a `Application.Element` property which is strange. And also even non-UI things like menu popups.

