### PR TITLE
[Windows] Fixes related with Clipping

### DIFF
--- a/src/Core/src/Graphics/ShapeDrawable.cs
+++ b/src/Core/src/Graphics/ShapeDrawable.cs
@@ -31,9 +31,8 @@
 
 			if (path == null)
 				return;
-					
+
 			DrawStrokePath(canvas, rect, path);
-			ClipPath(canvas, path);
 			DrawFillPath(canvas, rect, path);
 		}
 
@@ -108,6 +107,8 @@
 				return;
 
 			canvas.SaveState();
+
+			ClipPath(canvas, path);
 
 			// Set Fill
 			var fillPaint = ShapeView.Fill;

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Windows.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Maui.Handlers
 			oldParent?.Children.Remove(ContainerView);
 
 			((WrapperView)ContainerView).Child = null;
+			((WrapperView)ContainerView).Dispose();
 			ContainerView = null;
 
 			if (oldIndex is int idx && idx >= 0)

--- a/src/Core/src/Platform/Windows/WrapperView.cs
+++ b/src/Core/src/Platform/Windows/WrapperView.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Maui.Platform
 
 		public void Dispose()
 		{
+			DisposeClip();
 			DisposeShadow();
 			DisposeBorder();
 		}
@@ -94,6 +95,12 @@ namespace Microsoft.Maui.Platform
 			visual.Clip = geometricClip;
 		}
 
+		void DisposeClip()
+		{
+			var visual = ElementCompositionPreview.GetElementVisual(Child);
+			visual.Clip = null;
+		}
+		
 		void DisposeBorder()
 		{
 			_borderPath = null;


### PR DESCRIPTION
### Description of Change

Fixes related with Clipping on Windows. Fixed exception `"After calling CanvasDrawingSession.CreateLayer, you must close the resulting CanvasActiveLayer before ending the CanvasDrawingSession"` and allow dynamically removing a Clipping.

![clipping-windows](https://user-images.githubusercontent.com/6755973/157846384-a1882dad-332f-40eb-80a8-1723fd9d0faf.gif)

To test the changes launch the .NET MAUI Gallery, navigate to the Shapes page and use the Clipping samples.

### Issues Fixed

Fixes #4250
