### PR TITLE
Fix rename for some lifecycle events

### DIFF
--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -217,7 +217,8 @@ namespace Maui.Controls.Sample
 #elif WINDOWS
 					// Log everything in this one
 					events.AddWindows(windows => windows
-						//.OnNativeMessage((a, b) => LogEvent(nameof(WindowsLifecycle.OnNativeMessage)))
+						.OnPlatformMessage((a, b) => 
+							LogEvent(nameof(WindowsLifecycle.OnPlatformMessage)))
 						.OnActivated((a, b) => LogEvent(nameof(WindowsLifecycle.OnActivated)))
 						.OnClosed((a, b) => LogEvent(nameof(WindowsLifecycle.OnClosed)))
 						.OnLaunched((a, b) => LogEvent(nameof(WindowsLifecycle.OnLaunched)))

--- a/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/EssentialsMauiAppBuilderExtensions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Essentials
 					}));
 #elif WINDOWS
 				life.AddWindows(windows => windows
-					.OnNativeMessage((window, args) =>
+					.OnPlatformMessage((window, args) =>
 					{
 						Platform.NewWindowProc(args.Hwnd, args.MessageId, args.WParam, args.LParam);
 					})

--- a/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
+++ b/src/Core/src/LifecycleEvents/Windows/WindowsLifecycleBuilderExtensions.cs
@@ -9,8 +9,8 @@
 		public static IWindowsLifecycleBuilder OnVisibilityChanged(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnVisibilityChanged del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnWindowCreated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnWindowCreated del) => lifecycle.OnEvent(del);
 		public static IWindowsLifecycleBuilder OnResumed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnResumed del) => lifecycle.OnEvent(del);
-		public static IWindowsLifecycleBuilder OnNativeMessage(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnPlatformMessage del) => lifecycle.OnEvent(del);
-		public static IWindowsLifecycleBuilder OnNativeWindowSubclassed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnPlatformWindowSubclassed del) => lifecycle.OnNativeWindowSubclassed(del);
+		public static IWindowsLifecycleBuilder OnPlatformMessage(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnPlatformMessage del) => lifecycle.OnEvent(del);
+		public static IWindowsLifecycleBuilder OnPlatformWindowSubclassed(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnPlatformWindowSubclassed del) => lifecycle.OnPlatformWindowSubclassed(del);
 
 		internal static IWindowsLifecycleBuilder OnMauiContextCreated(this IWindowsLifecycleBuilder lifecycle, WindowsLifecycle.OnMauiContextCreated del) => lifecycle.OnEvent(del);
 	}


### PR DESCRIPTION
Some names were missed which resulted in things not being invoked for lifecycle events.