### PR TITLE
[controls] remove Linq usage and collection copying

### DIFF
--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="Type[@FullName='Microsoft.Maui.Controls.Element']/Docs" />
 	public abstract partial class Element : BindableObject, IElement, INameScope, IElementController, IVisualTreeElement
 	{
-		internal static readonly ReadOnlyCollection<Element> EmptyChildren = new ReadOnlyCollection<Element>(new Element[0]);
+		internal static readonly ReadOnlyCollection<Element> EmptyChildren = new ReadOnlyCollection<Element>(Array.Empty<Element>());
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='AutomationIdProperty']/Docs" />
 		public static readonly BindableProperty AutomationIdProperty = BindableProperty.Create(nameof(AutomationId), typeof(string), typeof(Element), null);

--- a/src/Controls/src/Core/ObservableWrapper.cs
+++ b/src/Controls/src/Core/ObservableWrapper.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Linq;
 
 namespace Microsoft.Maui.Controls
 {
@@ -40,10 +39,13 @@ namespace Microsoft.Maui.Controls
 			if (IsReadOnly)
 				throw new NotSupportedException("The collection is read-only.");
 
-			foreach (TRestrict item in _list.OfType<TRestrict>().ToArray())
+			for (int i = _list.Count - 1; i >= 0; i--)
 			{
-				_list.Remove(item);
-				item.Owned = false;
+				if (_list[i] is TRestrict item)
+				{
+					item.Owned = false;
+					_list.RemoveAt(i);
+				}
 			}
 		}
 
@@ -65,7 +67,6 @@ namespace Microsoft.Maui.Controls
 
 		public int Count
 		{
-			//get { return _list.Where(i => i.Owned).OfType<TRestrict>().Count(); }
 			get
 			{
 				int result = 0;
@@ -106,7 +107,13 @@ namespace Microsoft.Maui.Controls
 
 		public IEnumerator<TRestrict> GetEnumerator()
 		{
-			return _list.Where(i => i.Owned).OfType<TRestrict>().GetEnumerator();
+			foreach (TRestrict item in _list)
+			{
+				if (item.Owned)
+				{
+					yield return item;
+				}
+			}
 		}
 
 		public int IndexOf(TRestrict value)
@@ -291,10 +298,7 @@ namespace Microsoft.Maui.Controls
 			Remove((TRestrict)value);
 		}
 
-		public void CopyTo(Array array, int index)
-		{
-			CopyTo(array.Cast<TRestrict>().ToArray(), index);
-		}
+		public void CopyTo(Array array, int index) => _list.CopyTo((TTrack[])array, index);
 
 		public bool IsFixedSize => ((IList)_list).IsFixedSize;
 

--- a/src/Controls/src/Core/ObservableWrapper.cs
+++ b/src/Controls/src/Core/ObservableWrapper.cs
@@ -54,16 +54,18 @@ namespace Microsoft.Maui.Controls
 			return item.Owned && _list.Contains(item);
 		}
 
-		public void CopyTo(TRestrict[] array, int destIndex)
+		public void CopyTo(Array array, int destIndex)
 		{
 			if (array.Length - destIndex < Count)
 				throw new ArgumentException("Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
 			foreach (TRestrict item in this)
 			{
-				array[destIndex] = item;
+				array.SetValue(item, destIndex);
 				destIndex++;
 			}
 		}
+
+		public void CopyTo(TRestrict[] array, int index) => CopyTo ((Array)array, index);
 
 		public int Count
 		{
@@ -107,9 +109,9 @@ namespace Microsoft.Maui.Controls
 
 		public IEnumerator<TRestrict> GetEnumerator()
 		{
-			foreach (TRestrict item in _list)
+			foreach (var i in _list)
 			{
-				if (item.Owned)
+				if (i is TRestrict item && item.Owned)
 				{
 					yield return item;
 				}
@@ -297,8 +299,6 @@ namespace Microsoft.Maui.Controls
 		{
 			Remove((TRestrict)value);
 		}
-
-		public void CopyTo(Array array, int index) => _list.CopyTo((TTrack[])array, index);
 
 		public bool IsFixedSize => ((IList)_list).IsFixedSize;
 

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -552,8 +552,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		ReadOnlyCollection<ShellItem> IShellController.GetItems() =>
-			new ReadOnlyCollection<ShellItem>(((ShellItemCollection)Items).VisibleItemsReadOnly.ToList());
+		ReadOnlyCollection<ShellItem> IShellController.GetItems() => ((ShellItemCollection)Items).VisibleItemsReadOnly;
 
 		event NotifyCollectionChangedEventHandler IShellController.ItemsCollectionChanged
 		{

--- a/src/Controls/src/Core/Shell/ShellItem.cs
+++ b/src/Controls/src/Core/Shell/ShellItem.cs
@@ -84,8 +84,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		// we want the list returned from here to remain point in time accurate
-		ReadOnlyCollection<ShellSection> IShellItemController.GetItems() =>
-			new ReadOnlyCollection<ShellSection>(((ShellSectionCollection)Items).VisibleItemsReadOnly.ToList());
+		ReadOnlyCollection<ShellSection> IShellItemController.GetItems() => ((ShellSectionCollection)Items).VisibleItemsReadOnly;
 
 		event NotifyCollectionChangedEventHandler IShellItemController.ItemsCollectionChanged
 		{
@@ -328,6 +327,6 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		IReadOnlyList<Maui.IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => Items.ToList().AsReadOnly();
+		IReadOnlyList<Maui.IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => Items.ToList();
 	}
 }

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -154,8 +154,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		// we want the list returned from here to remain point in time accurate
-		ReadOnlyCollection<ShellContent> IShellSectionController.GetItems()
-			=> new ReadOnlyCollection<ShellContent>(((ShellContentCollection)Items).VisibleItemsReadOnly.ToList());
+		ReadOnlyCollection<ShellContent> IShellSectionController.GetItems() => ((ShellContentCollection)Items).VisibleItemsReadOnly;
 
 		[Obsolete]
 		[EditorBrowsable(EditorBrowsableState.Never)]
@@ -1230,6 +1229,6 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		IReadOnlyList<Maui.IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => AllChildren.ToList().AsReadOnly();
+		IReadOnlyList<Maui.IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => AllChildren.ToList();
 	}
 }

--- a/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
+++ b/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
@@ -30,10 +30,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Maui.Controls.Xaml.Internals;
-using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.Xaml
 {
@@ -91,14 +89,16 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		static string GetTypeConverterTypeName(this IEnumerable<CustomAttributeData> attributes)
 		{
-			var converterAttribute =
-				attributes.FirstOrDefault(cad => cad.AttributeType == typeof(System.ComponentModel.TypeConverterAttribute));
-			if (converterAttribute == null)
-				return null;
-			if (converterAttribute.ConstructorArguments[0].ArgumentType == typeof(string))
-				return (string)converterAttribute.ConstructorArguments[0].Value;
-			if (converterAttribute.ConstructorArguments[0].ArgumentType == typeof(Type))
-				return ((Type)converterAttribute.ConstructorArguments[0].Value).AssemblyQualifiedName;
+			foreach (var converterAttribute in attributes)
+			{
+				if (converterAttribute.AttributeType != typeof(System.ComponentModel.TypeConverterAttribute))
+					continue;
+				var ctor = converterAttribute.ConstructorArguments[0];
+				if (ctor.ArgumentType == typeof(string))
+					return (string)ctor.Value;
+				if (ctor.ArgumentType == typeof(Type))
+					return ((Type)ctor.Value).AssemblyQualifiedName;
+			}
 			return null;
 		}
 
@@ -253,16 +253,6 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		internal static MethodInfo GetImplicitConversionOperator(this Type onType, Type fromType, Type toType)
 		{
-#if NETSTANDARD1_0
-			var mi = onType.GetRuntimeMethod("op_Implicit", new[] { fromType });
-			if (mi == null) return null;
-			if (!mi.IsSpecialName) return null;
-			if (!mi.IsPublic) return null;
-			if (!mi.IsStatic) return null;
-			if (!toType.IsAssignableFrom(mi.ReturnType)) return null;
-
-			return mi;		
-#else
 			var bindingAttr = BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;
 			IEnumerable<MethodInfo> mis = null;
 			try
@@ -276,10 +266,10 @@ namespace Microsoft.Maui.Controls.Xaml
 				{
 					if (mi.Name != "op_Implicit")
 						break;
-					var p = mi.GetParameters()?.FirstOrDefault();
-					if (p == null)
+					var parameters = mi.GetParameters();
+					if (parameters.Length == 0)
 						continue;
-					if (!p.ParameterType.IsAssignableFrom(fromType))
+					if (!parameters[0].ParameterType.IsAssignableFrom(fromType))
 						continue;
 					((List<MethodInfo>)mis).Add(mi);
 				}
@@ -301,8 +291,6 @@ namespace Microsoft.Maui.Controls.Xaml
 				return mi;
 			}
 			return null;
-#endif
-
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ObservableWrapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ObservableWrapperTests.cs
@@ -406,5 +406,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(child1, oldItem);
 			Assert.AreEqual(child2, newItem);
 		}
+
+		[Test]
+		public void Clear()
+		{
+			var oc = new ObservableCollection<View>();
+			var wrapper = new ObservableWrapper<View, Button>(oc);
+
+			oc.Add(new Stepper());
+
+			wrapper.Add(new Button());
+			wrapper.Add(new Button());
+
+			wrapper.Clear();
+			Assert.AreEqual(1, oc.Count);
+			Assert.AreEqual(0, wrapper.Count);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ObservableWrapperTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ObservableWrapperTests.cs
@@ -422,5 +422,46 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(1, oc.Count);
 			Assert.AreEqual(0, wrapper.Count);
 		}
+
+		[Test]
+		public void DifferentTypes()
+		{
+			var oc = new ObservableCollection<Element>();
+			var wrapper = new ObservableWrapper<Element, Button>(oc);
+
+			// Wrong type!
+			oc.Add(new Label());
+
+			var child1 = new Button();
+			var child2 = new Button();
+			wrapper.Add(child1);
+			wrapper.Add(child2);
+
+			// Do things that might cast
+			foreach (var item in wrapper) { }
+			var target = new Button[4];
+			wrapper.CopyTo(target, 2);
+			Assert.AreEqual(target[2], child1);
+			Assert.AreEqual(target[3], child2);
+		}
+
+		[Test]
+		public void CopyToArrayBaseType()
+		{
+			var oc = new ObservableCollection<View>();
+			var wrapper = new ObservableWrapper<View, Button>(oc);
+
+			oc.Add(new Stepper());
+
+			var child1 = new Button();
+			var child2 = new Button();
+			wrapper.Add(child1);
+			wrapper.Add(child2);
+
+			var target = new View[4];
+			wrapper.CopyTo((Array)target, 2);
+			Assert.AreEqual(target[2], child1);
+			Assert.AreEqual(target[3], child2);
+		}
 	}
 }


### PR DESCRIPTION
Reviewing `dotnet trace` output of `dotnet new maui`:

2.64ms System.Linq!System.Linq.Enumerable.Where
    ... ObservableWrapper<TTrack_ref,TRestrict_REF>.GetEnumerator

2.61ms System.Linq!System.Linq.Enumerable.FirstOrDefault
    ... TypeConversionExtensions.GetTypeConverterTypeName

2.81ms System.Linq!System.Linq.Enumerable.ToList
    ... IShellController.GetItems
    ... IVisualTreeElement.GetVisualChildren

I reworked each of these places to just use plain `foreach` loops, and
not copy entire collections where appropriate.

`ObservableWrapper` could just use the underlying collection for many
of the methods, where we shouldn't need our own implementation.