### PR TITLE
Fixing ALL doc warnings in MAUI

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls.Internals/TextTransformUtilites.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.Internals/TextTransformUtilites.xml
@@ -52,10 +52,10 @@
       </Docs>
     </Member>
     <Member MemberName="SetPlainText">
-      <MemberSignature Language="C#" Value="public static void SetPlainText (Microsoft.Maui.Controls.InputView inputView, string nativeText);" />
-      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetPlainText(class Microsoft.Maui.Controls.InputView inputView, string nativeText) cil managed" />
+      <MemberSignature Language="C#" Value="public static void SetPlainText (Microsoft.Maui.Controls.InputView inputView, string platformText);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetPlainText(class Microsoft.Maui.Controls.InputView inputView, string platformText) cil managed" />
       <MemberSignature Language="DocId" Value="M:Microsoft.Maui.Controls.Internals.TextTransformUtilites.SetPlainText(Microsoft.Maui.Controls.InputView,System.String)" />
-      <MemberSignature Language="F#" Value="static member SetPlainText : Microsoft.Maui.Controls.InputView * string -&gt; unit" Usage="Microsoft.Maui.Controls.Internals.TextTransformUtilites.SetPlainText (inputView, nativeText)" />
+      <MemberSignature Language="F#" Value="static member SetPlainText : Microsoft.Maui.Controls.InputView * string -&gt; unit" Usage="Microsoft.Maui.Controls.Internals.TextTransformUtilites.SetPlainText (inputView, platformText)" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyName>Microsoft.Maui.Controls.Core</AssemblyName>
@@ -71,11 +71,11 @@
       </ReturnValue>
       <Parameters>
         <Parameter Name="inputView" Type="Microsoft.Maui.Controls.InputView" />
-        <Parameter Name="nativeText" Type="System.String" />
+        <Parameter Name="platformText" Type="System.String" />
       </Parameters>
       <Docs>
         <param name="inputView">To be added.</param>
-        <param name="nativeText">To be added.</param>
+        <param name="platformText">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml
@@ -79,7 +79,7 @@
       </Parameters>
       <Docs>
         <param name="config">The platform configuration for the element whose bar height to get.</param>
-        <summary>Gets the navigation bar height for the specified <paramref name="element" />.</summary>
+        <summary>Gets the navigation bar height for the specified element.</summary>
         <returns>The new bar height.</returns>
         <remarks>To be added.</remarks>
       </Docs>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml
@@ -311,7 +311,7 @@
       </Parameters>
       <Docs>
         <param name="element">To be added.</param>
-        <summary>Gets whether smooth scrolling is enabled for <param name="element" />.</summary>
+        <summary>Gets whether smooth scrolling is enabled for <paramref name="element" />.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
@@ -742,8 +742,8 @@
       <Docs>
         <param name="element">The <see cref="T:Microsoft.Maui.Controls.BindableObject" /> to adjust.</param>
         <param name="value">
-          <see langword="true" /> if <param name="element" /> should enable smooth scrolling.</param>
-        <summary>Enables or disables smooth scrolling on <param name="element" />.</summary>
+          <see langword="true" /> if <paramref name="element" /> should enable smooth scrolling.</param>
+        <summary>Enables or disables smooth scrolling on <paramref name="element" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml
@@ -170,7 +170,7 @@
         <Parameter Name="value" Type="System.Nullable&lt;System.Single&gt;" />
       </Parameters>
       <Docs>
-        <param name="element">The visual element on the Android platform whose elevation to set.</param>
+        <param name="config">The visual element on the Android platform whose elevation to set.</param>
         <param name="value">The new elevation value.</param>
         <summary>Sets the elevation for the visual element.</summary>
         <remarks>To be added.</remarks>
@@ -220,7 +220,7 @@
         <Parameter Name="value" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="config">The platform configuration for the visual element on the Android platform whose legacy color mode status to set.</param>
+        <param name="element">The platform configuration for the visual element on the Android platform whose legacy color mode status to set.</param>
         <param name="value">
           <see langword="true" /> to enable legacy color mode. Otherwise, <see langword="false" />.</param>
         <summary>Sets a Boolean value that controls whether the legacy color mode is enabled.</summary>

--- a/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml
@@ -59,7 +59,7 @@
       </Parameters>
       <Docs>
         <param name="element">The <see cref="T:Microsoft.Maui.Controls.BindableObject" /> whose modal presentation style is being retrieved.</param>
-        <summary>Gets the <see cref="T:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle" /> for <param name="element" />.</summary>
+        <summary>Gets the <see cref="T:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle" /> for <paramref name="element" />.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
@@ -512,7 +512,7 @@
           <c>this</c>
         </param>
         <param name="value">The desired <see cref="T:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle" />.</param>
-        <summary>Sets the modal presentation style to <param name="value" />.</summary>
+        <summary>Sets the modal presentation style to <paramref name="value" />.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ResolutionGroupNameAttribute.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ResolutionGroupNameAttribute.xml
@@ -20,7 +20,7 @@
   <Docs>
     <summary>Attribute that identifies a group name, typically a company name or reversed company URL, that provides a scope for effect names.</summary>
     <remarks>
-      <para>Developers must supply a name to <see cref="T:Microsoft.Maui.Controls.ExportEffectAttribute" /> that is unique over the scope of  the <param name="name" /> that they supply to <see cref="T:Microsoft.Maui.Controls.ResolutionGroupNameAttribute" />. The <see cref="M:Microsoft.Maui.Controls.Effect.Resolve(System.String)" /> method takes a string that is the concatenation of <paramref name="name" /> (the resolution group name), <c>'.'</c>, and the unique name that was supplied to <see cref="T:Microsoft.Maui.Controls.ExportEffectAttribute" />, and returns the specified effect.</para>
+      <para>Developers must supply a name to <see cref="T:Microsoft.Maui.Controls.ExportEffectAttribute" /> that is unique over the scope of the name that they supply to <see cref="T:Microsoft.Maui.Controls.ResolutionGroupNameAttribute" />. The <see cref="M:Microsoft.Maui.Controls.Effect.Resolve(System.String)" /> method takes a string that is the concatenation of the name (the resolution group name), <c>'.'</c>, and the unique name that was supplied to <see cref="T:Microsoft.Maui.Controls.ExportEffectAttribute" />, and returns the specified effect.</para>
       <example>
         <para>For example, with the declarations:</para>
         <code lang="c#"><![CDATA[
@@ -52,7 +52,7 @@ button.Effects.Add (Effect.Resolve ("com.YourCompany.ShadowEffect"));]]></code>
         <param name="name">A name, such as a company name or reversed company URL, that helps to uniquely identify effects.</param>
         <summary>Creates a new resolution group name attribute.</summary>
         <remarks>
-          <para>Developers must supply a name to <see cref="T:Microsoft.Maui.Controls.ExportEffectAttribute" /> that is unique over the scope of  the <param name="name" /> that they supply to <see cref="T:Microsoft.Maui.Controls.ResolutionGroupNameAttribute" />. The <see cref="M:Microsoft.Maui.Controls.Effect.Resolve(System.String)" /> method takes a string that is the concatenation of <paramref name="name" /> (the resolution group name), <c>'.'</c>, and the unique name that was supplied to <see cref="T:Microsoft.Maui.Controls.ExportEffectAttribute" />, and returns the specified effect.</para>
+          <para>Developers must supply a name to <see cref="T:Microsoft.Maui.Controls.ExportEffectAttribute" /> that is unique over the scope of  the <paramref name="name" /> that they supply to <see cref="T:Microsoft.Maui.Controls.ResolutionGroupNameAttribute" />. The <see cref="M:Microsoft.Maui.Controls.Effect.Resolve(System.String)" /> method takes a string that is the concatenation of <paramref name="name" /> (the resolution group name), <c>'.'</c>, and the unique name that was supplied to <see cref="T:Microsoft.Maui.Controls.ExportEffectAttribute" />, and returns the specified effect.</para>
           <example>
             <para>For example, with the declarations:</para>
             <code lang="c#"><![CDATA[

--- a/src/Controls/docs/Microsoft.Maui.Controls/SelectedPositionChangedEventArgs.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SelectedPositionChangedEventArgs.xml
@@ -33,7 +33,7 @@
       </Parameters>
       <Docs>
         <param name="selectedPosition">The newly selected position.</param>
-        <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.SelectedPositionChangedEventArgs" /> with the specified new <paramref name="selectecPosition" />.</summary>
+        <summary>Creates a new <see cref="T:Microsoft.Maui.Controls.SelectedPositionChangedEventArgs" /> with the specified new <paramref name="selectedPosition" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/src/Controls/docs/Microsoft.Maui.Controls/SettersExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/SettersExtensions.xml
@@ -75,7 +75,7 @@
         <Parameter Name="binding" Type="Microsoft.Maui.Controls.Binding" />
       </Parameters>
       <Docs>
-        <param name="setters">The list of setters to which to add a setter that binds <paramref name="property" /> to <paramref name="value" />.</param>
+        <param name="setters">The list of setters to which to add a setter that binds <paramref name="property" /> using <paramref name="binding" />.</param>
         <param name="property">The property to set.</param>
         <param name="binding">The binding to add.</param>
         <summary>Add a Setter with a Binding to the IList&lt;Setter&gt;</summary>

--- a/src/Controls/docs/Microsoft.Maui.Controls/Shell.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/Shell.xml
@@ -1217,7 +1217,7 @@
       <Docs>
         <param name="state">To be added.</param>
         <param name="animate">To be added.</param>
-        <summary>Asynchronously navigates to <param name="state" />, optionally animating.</summary>
+        <summary>Asynchronously navigates to <paramref name="state" />, optionally animating.</summary>
         <returns>To be added.</returns>
         <remarks>
           <para>Note that <see cref="T:Microsoft.Maui.Controls.ShellNavigationState" /> has implicit conversions from <see langword="string" /> and <see cref="T:System.Uri" />, so developers may write code such as the following, with no explicit instantiation of the <see cref="T:Microsoft.Maui.Controls.ShellNavigationState" />:</para>
@@ -1560,7 +1560,7 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="obj">To be added.</param>
         <param name="behavior">To be added.</param>
-        <summary>Sets the back button behavior of <param name="obj" /> to <param name="behavior" />.</summary>
+        <summary>Sets the back button behavior of <paramref name="obj" /> to <paramref name="behavior" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1656,7 +1656,7 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="obj">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>Sets the flyout behavior of <param name="obj" /> to <param name="value" />.</summary>
+        <summary>Sets the flyout behavior of <paramref name="obj" /> to <paramref name="value" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1776,7 +1776,7 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="obj">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>Sets the navigation bar visibility of <param name="obj" />.</summary>
+        <summary>Sets the navigation bar visibility of <paramref name="obj" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1824,7 +1824,7 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="obj">To be added.</param>
         <param name="handler">To be added.</param>
-        <summary>Sets the <see cref="T:Microsoft.Maui.Controls.SearchHandler" /> for <param name="obj" />.</summary>
+        <summary>Sets the <see cref="T:Microsoft.Maui.Controls.SearchHandler" /> for <paramref name="obj" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1920,7 +1920,7 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="obj">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>Sets the tab bar visibility of <param name="obj" />.</summary>
+        <summary>Sets the tab bar visibility of <paramref name="obj" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -2016,7 +2016,7 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
       <Docs>
         <param name="obj">To be added.</param>
         <param name="value">To be added.</param>
-        <summary>Sets the title <see cref="T:Microsoft.Maui.Controls.View" /> of <param name="obj" />.</summary>
+        <summary>Sets the title <see cref="T:Microsoft.Maui.Controls.View" /> of <paramref name="obj" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/src/Controls/docs/Microsoft.Maui.Controls/ViewExtensions.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/ViewExtensions.xml
@@ -263,7 +263,7 @@
         <param name="rotation">The final rotation value.</param>
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
-        <summary>Returns a task that skews the Y axis by <paramref name="opacity" />, taking time <paramref name="length" /> and using <paramref name="easing" />.</summary>
+        <summary>Returns a task that skews the X axis by <paramref name="rotation" />, taking time <paramref name="length" /> and using <paramref name="easing" />.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
@@ -299,7 +299,7 @@
         <param name="rotation">The final rotation value.</param>
         <param name="length">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
         <param name="easing">The easing function to use for the animation.</param>
-        <summary>Returns a task that skews the X axis by <paramref name="opacity" />, taking time <paramref name="length" /> and using <paramref name="easing" />.</summary>
+        <summary>Returns a task that skews the Y axis by <paramref name="rotation" />, taking time <paramref name="length" /> and using <paramref name="easing" />.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>

--- a/src/Controls/src/Core/Animation.cs
+++ b/src/Controls/src/Core/Animation.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	{
 		bool _finishedTriggered;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Animation()
 		{
 			Easing = Easing.Linear;

--- a/src/Controls/src/Core/Animation.cs
+++ b/src/Controls/src/Core/Animation.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			return this;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='WithConcurrent']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='WithConcurrent' and position()=0]/Docs" />
 		public Animation WithConcurrent(Animation animation, double beginAt = 0.0f, double finishAt = 1.0f)
 		{
 			animation.StartDelay = beginAt;
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Controls
 			return this;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='WithConcurrent']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='WithConcurrent' and position()=1]/Docs" />
 		public Animation WithConcurrent(Action<double> callback, double start = 0.0f, double end = 1.0f, Easing easing = null, double beginAt = 0.0f, double finishAt = 1.0f)
 		{
 			var child = new Animation(callback, start, end, easing);

--- a/src/Controls/src/Core/Animation.cs
+++ b/src/Controls/src/Core/Animation.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 	{
 		bool _finishedTriggered;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Animation()
 		{
 			Easing = Easing.Linear;
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			return this;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='WithConcurrent' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='WithConcurrent'][1]/Docs" />
 		public Animation WithConcurrent(Animation animation, double beginAt = 0.0f, double finishAt = 1.0f)
 		{
 			animation.StartDelay = beginAt;
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Controls
 			return this;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='WithConcurrent' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='WithConcurrent'][2]/Docs" />
 		public Animation WithConcurrent(Action<double> callback, double start = 0.0f, double end = 1.0f, Easing easing = null, double beginAt = 0.0f, double finishAt = 1.0f)
 		{
 			var child = new Animation(callback, start, end, easing);

--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls
 			return true;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][2]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Animation animation, uint rate = 16, uint length = 250, Easing easing = null, Action<double, bool> finished = null,
 								   Func<bool> repeat = null)
 		{
@@ -123,21 +123,21 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][3]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Action<double> callback, double start, double end, uint rate = 16, uint length = 250, Easing easing = null,
 								   Action<double, bool> finished = null, Func<bool> repeat = null)
 		{
 			self.Animate(name, Interpolate(start, end), callback, rate, length, easing, finished, repeat);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][1]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Action<double> callback, uint rate = 16, uint length = 250, Easing easing = null, Action<double, bool> finished = null,
 								   Func<bool> repeat = null)
 		{
 			self.Animate(name, x => x, callback, rate, length, easing, finished, repeat);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate&lt;T&gt;'][1]/Docs" />
 		public static void Animate<T>(this IAnimatable self, string name, Func<double, T> transform, Action<T> callback,
 			uint rate = 16, uint length = 250, Easing easing = null,
 			Action<T, bool> finished = null, Func<bool> repeat = null, IAnimationManager animationManager = null)

--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls
 			return true;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][1]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Animation animation, uint rate = 16, uint length = 250, Easing easing = null, Action<double, bool> finished = null,
 								   Func<bool> repeat = null)
 		{
@@ -123,21 +123,21 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][2]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Action<double> callback, double start, double end, uint rate = 16, uint length = 250, Easing easing = null,
 								   Action<double, bool> finished = null, Func<bool> repeat = null)
 		{
 			self.Animate(name, Interpolate(start, end), callback, rate, length, easing, finished, repeat);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][3]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Action<double> callback, uint rate = 16, uint length = 250, Easing easing = null, Action<double, bool> finished = null,
 								   Func<bool> repeat = null)
 		{
 			self.Animate(name, x => x, callback, rate, length, easing, finished, repeat);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate'][4]/Docs" />
 		public static void Animate<T>(this IAnimatable self, string name, Func<double, T> transform, Action<T> callback,
 			uint rate = 16, uint length = 250, Easing easing = null,
 			Action<T, bool> finished = null, Func<bool> repeat = null, IAnimationManager animationManager = null)

--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Controls
 			return true;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate' and position()=0]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Animation animation, uint rate = 16, uint length = 250, Easing easing = null, Action<double, bool> finished = null,
 								   Func<bool> repeat = null)
 		{
@@ -123,21 +123,21 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate' and position()=1]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Action<double> callback, double start, double end, uint rate = 16, uint length = 250, Easing easing = null,
 								   Action<double, bool> finished = null, Func<bool> repeat = null)
 		{
 			self.Animate(name, Interpolate(start, end), callback, rate, length, easing, finished, repeat);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate' and position()=2]/Docs" />
 		public static void Animate(this IAnimatable self, string name, Action<double> callback, uint rate = 16, uint length = 250, Easing easing = null, Action<double, bool> finished = null,
 								   Func<bool> repeat = null)
 		{
 			self.Animate(name, x => x, callback, rate, length, easing, finished, repeat);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate' and position()=3]/Docs" />
 		public static void Animate<T>(this IAnimatable self, string name, Func<double, T> transform, Action<T> callback,
 			uint rate = 16, uint length = 250, Easing easing = null,
 			Action<T, bool> finished = null, Func<bool> repeat = null, IAnimationManager animationManager = null)

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Maui.Controls
 		public event PropertyChangingEventHandler PropertyChanging;
 		public event EventHandler BindingContextChanged;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='ClearValue'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='ClearValue' and position()=0]/Docs" />
 		public void ClearValue(BindableProperty property) => ClearValue(property, fromStyle: false, checkAccess: true);
 
 		internal void ClearValue(BindableProperty property, bool fromStyle) => ClearValue(property, fromStyle: fromStyle, checkAccess: true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='ClearValue'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='ClearValue' and position()=1]/Docs" />
 		public void ClearValue(BindablePropertyKey propertyKey)
 		{
 			if (propertyKey == null)
@@ -358,10 +358,10 @@ namespace Microsoft.Maui.Controls
 			OnSetDynamicResource(property, key);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetValue'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetValue' and position()=0]/Docs" />
 		public void SetValue(BindableProperty property, object value) => SetValue(property, value, false, true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetValue'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetValue' and position()=1]/Docs" />
 		public void SetValue(BindablePropertyKey propertyKey, object value)
 		{
 			if (propertyKey == null)
@@ -595,10 +595,10 @@ namespace Microsoft.Maui.Controls
 			context.Binding = null;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='CoerceValue'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='CoerceValue' and position()=0]/Docs" />
 		public void CoerceValue(BindableProperty property) => CoerceValue(property, checkAccess: true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='CoerceValue'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='CoerceValue' and position()=1]/Docs" />
 		public void CoerceValue(BindablePropertyKey propertyKey)
 		{
 			if (propertyKey == null)

--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Maui.Controls
 		public event PropertyChangingEventHandler PropertyChanging;
 		public event EventHandler BindingContextChanged;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='ClearValue' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='ClearValue'][1]/Docs" />
 		public void ClearValue(BindableProperty property) => ClearValue(property, fromStyle: false, checkAccess: true);
 
 		internal void ClearValue(BindableProperty property, bool fromStyle) => ClearValue(property, fromStyle: fromStyle, checkAccess: true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='ClearValue' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='ClearValue'][2]/Docs" />
 		public void ClearValue(BindablePropertyKey propertyKey)
 		{
 			if (propertyKey == null)
@@ -358,10 +358,10 @@ namespace Microsoft.Maui.Controls
 			OnSetDynamicResource(property, key);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetValue' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetValue'][1]/Docs" />
 		public void SetValue(BindableProperty property, object value) => SetValue(property, value, false, true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetValue' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='SetValue'][2]/Docs" />
 		public void SetValue(BindablePropertyKey propertyKey, object value)
 		{
 			if (propertyKey == null)
@@ -595,10 +595,10 @@ namespace Microsoft.Maui.Controls
 			context.Binding = null;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='CoerceValue' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='CoerceValue'][1]/Docs" />
 		public void CoerceValue(BindableProperty property) => CoerceValue(property, checkAccess: true);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='CoerceValue' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='CoerceValue'][2]/Docs" />
 		public void CoerceValue(BindablePropertyKey propertyKey)
 		{
 			if (propertyKey == null)

--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 		object _source;
 		string _updateSourceEventName;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Binding.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Binding.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Binding()
 		{
 		}

--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 		object _source;
 		string _updateSourceEventName;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Binding.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Binding.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Binding()
 		{
 		}

--- a/src/Controls/src/Core/BindingBase.cs
+++ b/src/Controls/src/Core/BindingBase.cs
@@ -105,7 +105,9 @@ namespace Microsoft.Maui.Controls
 			SynchronizedCollections.Remove(collection);
 		}
 
+#pragma warning disable CS1734 // XML comment on 'BindingBase.EnableCollectionSynchronization(IEnumerable, object, CollectionSynchronizationCallback)' has a paramref tag for 'writeAccess', but there is no parameter by that name
 		/// <include file="../../docs/Microsoft.Maui.Controls/BindingBase.xml" path="//Member[@MemberName='EnableCollectionSynchronization']/Docs" />
+#pragma warning restore CS1734
 		public static void EnableCollectionSynchronization(IEnumerable collection, object context, CollectionSynchronizationCallback callback)
 		{
 			if (collection == null)

--- a/src/Controls/src/Core/Command.cs
+++ b/src/Controls/src/Core/Command.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls
 			_execute = execute;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Command(Action execute) : this(o => execute())
 		{
 			if (execute == null)

--- a/src/Controls/src/Core/Command.cs
+++ b/src/Controls/src/Core/Command.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls
 		readonly Action<object> _execute;
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Command(Action<object> execute)
 		{
 			if (execute == null)
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			_canExecute = canExecute;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public Command(Action execute, Func<bool> canExecute) : this(o => execute(), o => canExecute())
 		{
 			if (execute == null)

--- a/src/Controls/src/Core/Command.cs
+++ b/src/Controls/src/Core/Command.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="Type[@FullName='Microsoft.Maui.Controls.Command' and position()=0]/Docs" />
 	public sealed class Command<T> : Command
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Command(Action<T> execute)
 			: base(o =>
 			{
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Command(Action<T> execute, Func<T, bool> canExecute)
 			: base(o =>
 			{
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls
 		readonly Action<object> _execute;
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public Command(Action<object> execute)
 		{
 			if (execute == null)
@@ -76,14 +76,14 @@ namespace Microsoft.Maui.Controls
 			_execute = execute;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Command(Action execute) : this(o => execute())
 		{
 			if (execute == null)
 				throw new ArgumentNullException(nameof(execute));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public Command(Action<object> execute, Func<object, bool> canExecute) : this(execute)
 		{
 			if (canExecute == null)
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			_canExecute = canExecute;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][5]/Docs" />
 		public Command(Action execute, Func<bool> canExecute) : this(o => execute(), o => canExecute())
 		{
 			if (execute == null)

--- a/src/Controls/src/Core/Command.cs
+++ b/src/Controls/src/Core/Command.cs
@@ -4,10 +4,10 @@ using System.Windows.Input;
 
 namespace Microsoft.Maui.Controls
 {
-	/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="Type[@FullName='Microsoft.Maui.Controls.Command']/Docs" />
+	/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="Type[@FullName='Microsoft.Maui.Controls.Command' and position()=0]/Docs" />
 	public sealed class Command<T> : Command
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Command(Action<T> execute)
 			: base(o =>
 			{
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Command(Action<T> execute, Func<T, bool> canExecute)
 			: base(o =>
 			{
@@ -60,14 +60,14 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="Type[@FullName='Microsoft.Maui.Controls.Command']/Docs" />
+	/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="Type[@FullName='Microsoft.Maui.Controls.Command' and position()=1]/Docs" />
 	public class Command : ICommand
 	{
 		readonly Func<object, bool> _canExecute;
 		readonly Action<object> _execute;
 		readonly WeakEventManager _weakEventManager = new WeakEventManager();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public Command(Action<object> execute)
 		{
 			if (execute == null)
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Controls
 				throw new ArgumentNullException(nameof(execute));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public Command(Action<object> execute, Func<object, bool> canExecute) : this(execute)
 		{
 			if (canExecute == null)
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			_canExecute = canExecute;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor' and position()=4]/Docs" />
 		public Command(Action execute, Func<bool> canExecute) : this(o => execute(), o => canExecute())
 		{
 			if (execute == null)

--- a/src/Controls/src/Core/ControlTemplate.cs
+++ b/src/Controls/src/Core/ControlTemplate.cs
@@ -6,12 +6,12 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="Type[@FullName='Microsoft.Maui.Controls.ControlTemplate']/Docs" />
 	public class ControlTemplate : ElementTemplate
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ControlTemplate()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ControlTemplate(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
 			: base(type)

--- a/src/Controls/src/Core/ControlTemplate.cs
+++ b/src/Controls/src/Core/ControlTemplate.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ControlTemplate(Func<object> createTemplate) : base(createTemplate)
 		{
 		}

--- a/src/Controls/src/Core/ControlTemplate.cs
+++ b/src/Controls/src/Core/ControlTemplate.cs
@@ -6,12 +6,12 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="Type[@FullName='Microsoft.Maui.Controls.ControlTemplate']/Docs" />
 	public class ControlTemplate : ElementTemplate
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ControlTemplate()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ControlTemplate.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public ControlTemplate(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
 			: base(type)

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -7,7 +7,6 @@
     <IsPackable>false</IsPackable>
     <_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' And '$(MSBuildRuntimeType)' == 'Full'">True</_MauiDesignDllBuild>
     <GitInfoReportImportance>high</GitInfoReportImportance>
-	<WarningsNotAsErrors>CS1571;CS1572;CS1734</WarningsNotAsErrors>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\.nuspec\Microsoft.Maui.Controls.MultiTargeting.targets" />

--- a/src/Controls/src/Core/DataTemplate.cs
+++ b/src/Controls/src/Core/DataTemplate.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui.Controls
 
 		int _id;
 		string _idString;
-		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public DataTemplate()
 		{
 			_id = Interlocked.Increment(ref idCounter);
 			_idString = GetType().FullName + _id;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public DataTemplate(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type) 
 			: base(type)

--- a/src/Controls/src/Core/DataTemplate.cs
+++ b/src/Controls/src/Core/DataTemplate.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui.Controls
 
 		int _id;
 		string _idString;
-		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public DataTemplate()
 		{
 			_id = Interlocked.Increment(ref idCounter);
 			_idString = GetType().FullName + _id;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public DataTemplate(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type) 
 			: base(type)

--- a/src/Controls/src/Core/DataTemplate.cs
+++ b/src/Controls/src/Core/DataTemplate.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 			_idString = type.FullName;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DataTemplate.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public DataTemplate(Func<object> loadTemplate) : base(loadTemplate)
 		{
 			_id = Interlocked.Increment(ref idCounter);

--- a/src/Controls/src/Core/DependencyResolver.cs
+++ b/src/Controls/src/Core/DependencyResolver.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Maui.Controls.Internals
 		static Type _defaultVisualType = typeof(VisualMarker.DefaultVisual);
 		static Func<Type, object[], object> Resolver { get; set; }
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="//Member[@MemberName='ResolveUsing']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="//Member[@MemberName='ResolveUsing' and position()=0]/Docs" />
 		public static void ResolveUsing(Func<Type, object[], object> resolver)
 		{
 			Resolver = resolver;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="//Member[@MemberName='ResolveUsing']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="//Member[@MemberName='ResolveUsing' and position()=1]/Docs" />
 		public static void ResolveUsing(Func<Type, object> resolver)
 		{
 			Resolver = (type, objects) => resolver.Invoke(type);

--- a/src/Controls/src/Core/DependencyResolver.cs
+++ b/src/Controls/src/Core/DependencyResolver.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Maui.Controls.Internals
 		static Type _defaultVisualType = typeof(VisualMarker.DefaultVisual);
 		static Func<Type, object[], object> Resolver { get; set; }
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="//Member[@MemberName='ResolveUsing' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="//Member[@MemberName='ResolveUsing'][1]/Docs" />
 		public static void ResolveUsing(Func<Type, object[], object> resolver)
 		{
 			Resolver = resolver;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="//Member[@MemberName='ResolveUsing' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/DependencyResolver.xml" path="//Member[@MemberName='ResolveUsing'][2]/Docs" />
 		public static void ResolveUsing(Func<Type, object> resolver)
 		{
 			Resolver = (type, objects) => resolver.Invoke(type);

--- a/src/Controls/src/Core/DependencyService.cs
+++ b/src/Controls/src/Core/DependencyService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls
 			return (T)Activator.CreateInstance(dependencyImplementation.ImplementorType);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register' and position()=0]/Docs" />
 		public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>() where T : class
 		{
 			Type type = typeof(T);
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Controls
 				DependencyTypes.Add(type);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register' and position()=1]/Docs" />
 		public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TImpl>() where T : class where TImpl : class, T
 		{
 			Type targetType = typeof(T);
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register' and position()=2]/Docs" />
 		public static void Register(Assembly[] assemblies)
 		{
 			lock (s_initializeLock)

--- a/src/Controls/src/Core/DependencyService.cs
+++ b/src/Controls/src/Core/DependencyService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls
 			return (T)Activator.CreateInstance(dependencyImplementation.ImplementorType);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register'][1]/Docs" />
 		public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>() where T : class
 		{
 			Type type = typeof(T);
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Controls
 				DependencyTypes.Add(type);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register'][2]/Docs" />
 		public static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TImpl>() where T : class where TImpl : class, T
 		{
 			Type targetType = typeof(T);
@@ -126,7 +126,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register'][3]/Docs" />
 		public static void Register(Assembly[] assemblies)
 		{
 			lock (s_initializeLock)

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.Controls
 		public static void BeginInvokeOnMainThread(Action action) =>
 			Application.Current.FindDispatcher().Dispatch(action);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=0]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<T> func) =>
 			Application.Current.FindDispatcher().DispatchAsync(func);
@@ -101,12 +101,12 @@ namespace Microsoft.Maui.Controls
 		public static Task InvokeOnMainThreadAsync(Action action) =>
 			Application.Current.FindDispatcher().DispatchAsync(action);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=1]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask) =>
 			Application.Current.FindDispatcher().DispatchAsync(funcTask);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=2]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask) =>
 			Application.Current.FindDispatcher().DispatchAsync(funcTask);

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Maui.Controls
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<T> func) =>
 			Application.Current.FindDispatcher().DispatchAsync(func);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=0]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task InvokeOnMainThreadAsync(Action action) =>
 			Application.Current.FindDispatcher().DispatchAsync(action);
@@ -116,13 +116,13 @@ namespace Microsoft.Maui.Controls
 		public static Task<SynchronizationContext> GetMainThreadSynchronizationContextAsync() =>
 			Application.Current.FindDispatcher().GetSynchronizationContextAsync();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize' and position()=1]/Docs" />
 		public static double GetNamedSize(NamedSize size, Element targetElement)
 		{
 			return GetNamedSize(size, targetElement.GetType());
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize' and position()=0]/Docs" />
 		public static double GetNamedSize(NamedSize size, Type targetElementType)
 		{
 			return GetNamedSize(size, targetElementType, false);
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls
 			dispatcher.StartTimer(interval, callback);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize' and position()=2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes) =>
 			DependencyService.Get<IFontNamedSizeService>()?.GetNamedSize(size, targetElementType, useOldSizes) ??

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.Controls
 		public static void BeginInvokeOnMainThread(Action action) =>
 			Application.Current.FindDispatcher().Dispatch(action);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync&lt;T&gt;'][2]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<T> func) =>
 			Application.Current.FindDispatcher().DispatchAsync(func);
@@ -101,12 +101,12 @@ namespace Microsoft.Maui.Controls
 		public static Task InvokeOnMainThreadAsync(Action action) =>
 			Application.Current.FindDispatcher().DispatchAsync(action);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync&lt;T&gt;'][1]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask) =>
 			Application.Current.FindDispatcher().DispatchAsync(funcTask);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][2]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask) =>
 			Application.Current.FindDispatcher().DispatchAsync(funcTask);

--- a/src/Controls/src/Core/Device.cs
+++ b/src/Controls/src/Core/Device.cs
@@ -91,22 +91,22 @@ namespace Microsoft.Maui.Controls
 		public static void BeginInvokeOnMainThread(Action action) =>
 			Application.Current.FindDispatcher().Dispatch(action);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][1]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<T> func) =>
 			Application.Current.FindDispatcher().DispatchAsync(func);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][1]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task InvokeOnMainThreadAsync(Action action) =>
 			Application.Current.FindDispatcher().DispatchAsync(action);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][2]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask) =>
 			Application.Current.FindDispatcher().DispatchAsync(funcTask);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][3]/Docs" />
 		[Obsolete("Use BindableObject.Dispatcher.DispatchAsync() instead.")]
 		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask) =>
 			Application.Current.FindDispatcher().DispatchAsync(funcTask);
@@ -116,13 +116,13 @@ namespace Microsoft.Maui.Controls
 		public static Task<SynchronizationContext> GetMainThreadSynchronizationContextAsync() =>
 			Application.Current.FindDispatcher().GetSynchronizationContextAsync();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][2]/Docs" />
 		public static double GetNamedSize(NamedSize size, Element targetElement)
 		{
 			return GetNamedSize(size, targetElement.GetType());
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][1]/Docs" />
 		public static double GetNamedSize(NamedSize size, Type targetElementType)
 		{
 			return GetNamedSize(size, targetElementType, false);
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls
 			dispatcher.StartTimer(interval, callback);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Device.xml" path="//Member[@MemberName='GetNamedSize'][3]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes) =>
 			DependencyService.Get<IFontNamedSizeService>()?.GetNamedSize(size, targetElementType, useOldSizes) ??

--- a/src/Controls/src/Core/DoubleCollection.cs
+++ b/src/Controls/src/Core/DoubleCollection.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Maui.Controls
 	[System.ComponentModel.TypeConverter(typeof(DoubleCollectionConverter))]
 	public sealed class DoubleCollection : ObservableCollection<double>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public DoubleCollection()
 		{ }
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public DoubleCollection(double[] values)
 			: base(values)
 		{

--- a/src/Controls/src/Core/DoubleCollection.cs
+++ b/src/Controls/src/Core/DoubleCollection.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Maui.Controls
 	[System.ComponentModel.TypeConverter(typeof(DoubleCollectionConverter))]
 	public sealed class DoubleCollection : ObservableCollection<double>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public DoubleCollection()
 		{ }
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public DoubleCollection(double[] values)
 			: base(values)
 		{

--- a/src/Controls/src/Core/Effect.cs
+++ b/src/Controls/src/Core/Effect.cs
@@ -20,7 +20,9 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/Effect.xml" path="//Member[@MemberName='IsAttached']/Docs" />
 		public bool IsAttached { get; private set; }
 
+#pragma warning disable CS1734 // XML comment on 'Effect.ResolveId' has a paramref tag for 'name', but there is no parameter by that name
 		/// <include file="../../docs/Microsoft.Maui.Controls/Effect.xml" path="//Member[@MemberName='ResolveId']/Docs" />
+#pragma warning restore CS1734
 		public string ResolveId { get; internal set; }
 
 		#region Statics

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -265,14 +265,14 @@ namespace Microsoft.Maui.Controls
 		}
 
 		void IElementController.SetValueFromRenderer(BindableProperty property, object value) => SetValueFromRenderer(property, value);
-		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='SetValueFromRenderer' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='SetValueFromRenderer'][1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetValueFromRenderer(BindableProperty property, object value)
 		{
 			SetValueCore(property, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='SetValueFromRenderer' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='SetValueFromRenderer'][2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetValueFromRenderer(BindablePropertyKey property, object value)
 		{

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -265,14 +265,14 @@ namespace Microsoft.Maui.Controls
 		}
 
 		void IElementController.SetValueFromRenderer(BindableProperty property, object value) => SetValueFromRenderer(property, value);
-		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='SetValueFromRenderer'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='SetValueFromRenderer' and position()=0]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetValueFromRenderer(BindableProperty property, object value)
 		{
 			SetValueCore(property, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='SetValueFromRenderer'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='SetValueFromRenderer' and position()=1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetValueFromRenderer(BindablePropertyKey property, object value)
 		{

--- a/src/Controls/src/Core/ExportEffectAttribute.cs
+++ b/src/Controls/src/Core/ExportEffectAttribute.cs
@@ -2,7 +2,9 @@ using System;
 
 namespace Microsoft.Maui.Controls
 {
+#pragma warning disable CS1734 // XML comment on 'ExportEffectAttribute' has a paramref tag for 'effectType', but there is no parameter by that name
 	/// <include file="../../docs/Microsoft.Maui.Controls/ExportEffectAttribute.xml" path="Type[@FullName='Microsoft.Maui.Controls.ExportEffectAttribute']/Docs" />
+#pragma warning restore CS1734
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
 	public sealed class ExportEffectAttribute : Attribute
 	{

--- a/src/Controls/src/Core/GradientStop.cs
+++ b/src/Controls/src/Core/GradientStop.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(OffsetProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public GradientStop() { }
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public GradientStop(Color color, float offset)
 		{
 			Color = color;

--- a/src/Controls/src/Core/GradientStop.cs
+++ b/src/Controls/src/Core/GradientStop.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(OffsetProperty, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public GradientStop() { }
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public GradientStop(Color color, float offset)
 		{
 			Color = color;

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Controls
 			return FromResource(resource, resolvingType.GetTypeInfo().Assembly);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource'][1]/Docs" />
 		public static ImageSource FromResource(string resource, Assembly sourceAssembly = null)
 		{
 #if !NETSTANDARD1_0

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Controls
 			return new FileImageSource { File = file };
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource' and position()=1]/Docs" />
 		public static ImageSource FromResource(string resource, Type resolvingType)
 		{
 			return FromResource(resource, resolvingType.GetTypeInfo().Assembly);

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -95,13 +95,13 @@ namespace Microsoft.Maui.Controls
 			return FromStream(() => sourceAssembly.GetManifestResourceStream(resource));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromStream']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromStream' and position()=0]/Docs" />
 		public static ImageSource FromStream(Func<Stream> stream)
 		{
 			return new StreamImageSource { Stream = token => Task.Run(stream, token) };
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromStream']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromStream' and position()=1]/Docs" />
 		public static ImageSource FromStream(Func<CancellationToken, Task<Stream>> stream)
 		{
 			return new StreamImageSource { Stream = stream };

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.Controls
 			return FromResource(resource, resolvingType.GetTypeInfo().Assembly);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource' and position()=1]/Docs" />
 		public static ImageSource FromResource(string resource, Assembly sourceAssembly = null)
 		{
 #if !NETSTANDARD1_0

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -66,13 +66,13 @@ namespace Microsoft.Maui.Controls
 			return new FileImageSource { File = file };
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource'][2]/Docs" />
 		public static ImageSource FromResource(string resource, Type resolvingType)
 		{
 			return FromResource(resource, resolvingType.GetTypeInfo().Assembly);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource'][2]/Docs" />
 		public static ImageSource FromResource(string resource, Assembly sourceAssembly = null)
 		{
 #if !NETSTANDARD1_0
@@ -95,13 +95,13 @@ namespace Microsoft.Maui.Controls
 			return FromStream(() => sourceAssembly.GetManifestResourceStream(resource));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromStream' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromStream'][1]/Docs" />
 		public static ImageSource FromStream(Func<Stream> stream)
 		{
 			return new StreamImageSource { Stream = token => Task.Run(stream, token) };
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromStream' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromStream'][2]/Docs" />
 		public static ImageSource FromStream(Func<CancellationToken, Task<Stream>> stream)
 		{
 			return new StreamImageSource { Stream = stream };

--- a/src/Controls/src/Core/Interactivity/Behavior.cs
+++ b/src/Controls/src/Core/Interactivity/Behavior.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls
 {
-	/// <include file="../../../docs/Microsoft.Maui.Controls/Behavior.xml" path="Type[@FullName='Microsoft.Maui.Controls.Behavior']/Docs" />
+	/// <include file="../../../docs/Microsoft.Maui.Controls/Behavior.xml" path="Type[@FullName='Microsoft.Maui.Controls.Behavior' and position()=0]/Docs" />
 	public abstract class Behavior : BindableObject, IAttachedObject
 	{
 		protected Behavior() : this(typeof(BindableObject))
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	/// <include file="../../../docs/Microsoft.Maui.Controls/Behavior.xml" path="Type[@FullName='Microsoft.Maui.Controls.Behavior']/Docs" />
+	/// <include file="../../../docs/Microsoft.Maui.Controls/Behavior.xml" path="Type[@FullName='Microsoft.Maui.Controls.Behavior' and position()=1]/Docs" />
 	public abstract class Behavior<T> : Behavior where T : BindableObject
 	{
 		protected Behavior() : base(typeof(T))

--- a/src/Controls/src/Core/Interactivity/TriggerAction.cs
+++ b/src/Controls/src/Core/Interactivity/TriggerAction.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Microsoft.Maui.Controls
 {
-	/// <include file="../../../docs/Microsoft.Maui.Controls/TriggerAction.xml" path="Type[@FullName='Microsoft.Maui.Controls.TriggerAction']/Docs" />
+	/// <include file="../../../docs/Microsoft.Maui.Controls/TriggerAction.xml" path="Type[@FullName='Microsoft.Maui.Controls.TriggerAction' and position()=0]/Docs" />
 	public abstract class TriggerAction
 	{
 		internal TriggerAction(Type associatedType)
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	/// <include file="../../../docs/Microsoft.Maui.Controls/TriggerAction.xml" path="Type[@FullName='Microsoft.Maui.Controls.TriggerAction']/Docs" />
+	/// <include file="../../../docs/Microsoft.Maui.Controls/TriggerAction.xml" path="Type[@FullName='Microsoft.Maui.Controls.TriggerAction' and position()=1]/Docs" />
 	public abstract class TriggerAction<T> : TriggerAction where T : BindableObject
 	{
 		protected TriggerAction() : base(typeof(T))

--- a/src/Controls/src/Core/Internals/ImageParser.cs
+++ b/src/Controls/src/Core/Internals/ImageParser.cs
@@ -9,19 +9,19 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.GIFDecoderFormatException']/Docs" />
 	public class GIFDecoderFormatException : Exception
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public GIFDecoderFormatException()
 		{
 			;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public GIFDecoderFormatException(string message) : base(message)
 		{
 			;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public GIFDecoderFormatException(string message, Exception innerException) : base(message, innerException)
 		{
 			;

--- a/src/Controls/src/Core/Internals/ImageParser.cs
+++ b/src/Controls/src/Core/Internals/ImageParser.cs
@@ -9,19 +9,19 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.GIFDecoderFormatException']/Docs" />
 	public class GIFDecoderFormatException : Exception
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public GIFDecoderFormatException()
 		{
 			;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public GIFDecoderFormatException(string message) : base(message)
 		{
 			;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFDecoderFormatException.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public GIFDecoderFormatException(string message, Exception innerException) : base(message, innerException)
 		{
 			;

--- a/src/Controls/src/Core/Internals/NavigationRequestedEventArgs.cs
+++ b/src/Controls/src/Core/Internals/NavigationRequestedEventArgs.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NavigationRequestedEventArgs : NavigationEventArgs
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public NavigationRequestedEventArgs(Page page, bool animated) : base(page)
 		{
 			Animated = animated;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public NavigationRequestedEventArgs(Page page, Page before, bool animated) : this(page, animated)
 		{
 			BeforePage = before;

--- a/src/Controls/src/Core/Internals/NavigationRequestedEventArgs.cs
+++ b/src/Controls/src/Core/Internals/NavigationRequestedEventArgs.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NavigationRequestedEventArgs : NavigationEventArgs
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public NavigationRequestedEventArgs(Page page, bool animated) : base(page)
 		{
 			Animated = animated;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NavigationRequestedEventArgs.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public NavigationRequestedEventArgs(Page page, Page before, bool animated) : this(page, animated)
 		{
 			BeforePage = before;

--- a/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsEx.cs
+++ b/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsEx.cs
@@ -8,67 +8,67 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NotifyCollectionChangedEventArgsEx : NotifyCollectionChangedEventArgs
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action) : base(action)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList changedItems) : base(action, changedItems)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList newItems, IList oldItems) : base(action, newItems, oldItems)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=7]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][8]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList newItems, IList oldItems, int startingIndex) : base(action, newItems, oldItems, startingIndex)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=4]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][5]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList changedItems, int startingIndex) : base(action, changedItems, startingIndex)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=8]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][9]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList changedItems, int index, int oldIndex) : base(action, changedItems, index, oldIndex)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object changedItem) : base(action, changedItem)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=5]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][6]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object changedItem, int index) : base(action, changedItem, index)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=9]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][10]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object changedItem, int index, int oldIndex) : base(action, changedItem, index, oldIndex)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=6]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][7]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object newItem, object oldItem) : base(action, newItem, oldItem)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=10]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][11]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object newItem, object oldItem, int index) : base(action, newItem, oldItem, index)
 		{
 			Count = count;

--- a/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsEx.cs
+++ b/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsEx.cs
@@ -8,67 +8,67 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class NotifyCollectionChangedEventArgsEx : NotifyCollectionChangedEventArgs
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action) : base(action)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList changedItems) : base(action, changedItems)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList newItems, IList oldItems) : base(action, newItems, oldItems)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][7]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=7]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList newItems, IList oldItems, int startingIndex) : base(action, newItems, oldItems, startingIndex)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=4]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList changedItems, int startingIndex) : base(action, changedItems, startingIndex)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][8]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=8]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, IList changedItems, int index, int oldIndex) : base(action, changedItems, index, oldIndex)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object changedItem) : base(action, changedItem)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][5]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=5]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object changedItem, int index) : base(action, changedItem, index)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][9]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=9]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object changedItem, int index, int oldIndex) : base(action, changedItem, index, oldIndex)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][6]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=6]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object newItem, object oldItem) : base(action, newItem, oldItem)
 		{
 			Count = count;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor'][10]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsEx.xml" path="//Member[@MemberName='.ctor' and position()=10]/Docs" />
 		public NotifyCollectionChangedEventArgsEx(int count, NotifyCollectionChangedAction action, object newItem, object oldItem, int index) : base(action, newItem, oldItem, index)
 		{
 			Count = count;

--- a/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
+++ b/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class NotifyCollectionChangedEventArgsExtensions
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply'][1]/Docs" />
 		public static void Apply<TFrom>(this NotifyCollectionChangedEventArgs self, IList<TFrom> from, IList<object> to)
 		{
 			self.Apply((o, i, b) => to.Insert(i, o), (o, i) => to.RemoveAt(i), () =>
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Internals
 			});
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply'][2]/Docs" />
 		public static NotifyCollectionChangedAction Apply(this NotifyCollectionChangedEventArgs self, Action<object, int, bool> insert, Action<object, int> removeAt, Action reset)
 		{
 			if (self == null)

--- a/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
+++ b/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class NotifyCollectionChangedEventArgsExtensions
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply' and position()=0]/Docs" />
 		public static void Apply<TFrom>(this NotifyCollectionChangedEventArgs self, IList<TFrom> from, IList<object> to)
 		{
 			self.Apply((o, i, b) => to.Insert(i, o), (o, i) => to.RemoveAt(i), () =>
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Internals
 			});
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply' and position()=1]/Docs" />
 		public static NotifyCollectionChangedAction Apply(this NotifyCollectionChangedEventArgs self, Action<object, int, bool> insert, Action<object, int> removeAt, Action reset)
 		{
 			if (self == null)

--- a/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
+++ b/src/Controls/src/Core/Internals/NotifyCollectionChangedEventArgsExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class NotifyCollectionChangedEventArgsExtensions
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply&lt;TFrom&gt;'][1]/Docs" />
 		public static void Apply<TFrom>(this NotifyCollectionChangedEventArgs self, IList<TFrom> from, IList<object> to)
 		{
 			self.Apply((o, i, b) => to.Insert(i, o), (o, i) => to.RemoveAt(i), () =>
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Internals
 			});
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/NotifyCollectionChangedEventArgsExtensions.xml" path="//Member[@MemberName='Apply'][1]/Docs" />
 		public static NotifyCollectionChangedAction Apply(this NotifyCollectionChangedEventArgs self, Action<object, int, bool> insert, Action<object, int> removeAt, Action reset)
 		{
 			if (self == null)

--- a/src/Controls/src/Core/Internals/PreserveAttribute.cs
+++ b/src/Controls/src/Core/Internals/PreserveAttribute.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui.Controls.Internals
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='Conditional']/Docs" />
 		public bool Conditional;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public PreserveAttribute(bool allMembers, bool conditional)
 		{
 			AllMembers = allMembers;
 			Conditional = conditional;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public PreserveAttribute()
 		{
 		}

--- a/src/Controls/src/Core/Internals/PreserveAttribute.cs
+++ b/src/Controls/src/Core/Internals/PreserveAttribute.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui.Controls.Internals
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='Conditional']/Docs" />
 		public bool Conditional;
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public PreserveAttribute(bool allMembers, bool conditional)
 		{
 			AllMembers = allMembers;
 			Conditional = conditional;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Internals/PreserveAttribute.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public PreserveAttribute()
 		{
 		}

--- a/src/Controls/src/Core/InvalidNavigationException.cs
+++ b/src/Controls/src/Core/InvalidNavigationException.cs
@@ -9,18 +9,18 @@ namespace Microsoft.Maui.Controls
 #endif
 	public class InvalidNavigationException : Exception
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public InvalidNavigationException()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public InvalidNavigationException(string message)
 			: base(message)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public InvalidNavigationException(string message, Exception innerException)
 			: base(message, innerException)
 		{

--- a/src/Controls/src/Core/InvalidNavigationException.cs
+++ b/src/Controls/src/Core/InvalidNavigationException.cs
@@ -9,18 +9,18 @@ namespace Microsoft.Maui.Controls
 #endif
 	public class InvalidNavigationException : Exception
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public InvalidNavigationException()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public InvalidNavigationException(string message)
 			: base(message)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/InvalidNavigationException.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public InvalidNavigationException(string message, Exception innerException)
 			: base(message, innerException)
 		{

--- a/src/Controls/src/Core/ItemTappedEventArgs.cs
+++ b/src/Controls/src/Core/ItemTappedEventArgs.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ItemTappedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.ItemTappedEventArgs']/Docs" />
 	public class ItemTappedEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ItemTappedEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ItemTappedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ItemTappedEventArgs(object group, object item, int itemIndex)
 		{
 			Group = group;

--- a/src/Controls/src/Core/ItemTappedEventArgs.cs
+++ b/src/Controls/src/Core/ItemTappedEventArgs.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ItemTappedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.ItemTappedEventArgs']/Docs" />
 	public class ItemTappedEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ItemTappedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ItemTappedEventArgs.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ItemTappedEventArgs(object group, object item, int itemIndex)
 		{
 			Group = group;

--- a/src/Controls/src/Core/ItemVisibilityEventArgs.cs
+++ b/src/Controls/src/Core/ItemVisibilityEventArgs.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ItemVisibilityEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.ItemVisibilityEventArgs']/Docs" />
 	public sealed class ItemVisibilityEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ItemVisibilityEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ItemVisibilityEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ItemVisibilityEventArgs(object item, int itemIndex)
 		{
 			Item = item;

--- a/src/Controls/src/Core/ItemVisibilityEventArgs.cs
+++ b/src/Controls/src/Core/ItemVisibilityEventArgs.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ItemVisibilityEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.ItemVisibilityEventArgs']/Docs" />
 	public sealed class ItemVisibilityEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ItemVisibilityEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ItemVisibilityEventArgs.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ItemVisibilityEventArgs(object item, int itemIndex)
 		{
 			Item = item;

--- a/src/Controls/src/Core/Items/GridItemsLayout.cs
+++ b/src/Controls/src/Core/Items/GridItemsLayout.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SpanProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public GridItemsLayout([Parameter("Orientation")] ItemsLayoutOrientation orientation) : base(orientation)
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public GridItemsLayout(int span, [Parameter("Orientation")] ItemsLayoutOrientation orientation) :
 			base(orientation)
 		{

--- a/src/Controls/src/Core/Items/GridItemsLayout.cs
+++ b/src/Controls/src/Core/Items/GridItemsLayout.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(SpanProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public GridItemsLayout([Parameter("Orientation")] ItemsLayoutOrientation orientation) : base(orientation)
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/GridItemsLayout.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public GridItemsLayout(int span, [Parameter("Orientation")] ItemsLayoutOrientation orientation) :
 			base(orientation)
 		{

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -185,14 +185,14 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ItemsUpdatingScrollModeProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ScrollTo']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ScrollTo' and position()=0]/Docs" />
 		public void ScrollTo(int index, int groupIndex = -1,
 			ScrollToPosition position = ScrollToPosition.MakeVisible, bool animate = true)
 		{
 			OnScrollToRequested(new ScrollToRequestEventArgs(index, groupIndex, position, animate));
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ScrollTo']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ScrollTo' and position()=1]/Docs" />
 		public void ScrollTo(object item, object group = null,
 			ScrollToPosition position = ScrollToPosition.MakeVisible, bool animate = true)
 		{

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -185,14 +185,14 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(ItemsUpdatingScrollModeProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ScrollTo' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ScrollTo'][1]/Docs" />
 		public void ScrollTo(int index, int groupIndex = -1,
 			ScrollToPosition position = ScrollToPosition.MakeVisible, bool animate = true)
 		{
 			OnScrollToRequested(new ScrollToRequestEventArgs(index, groupIndex, position, animate));
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ScrollTo' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='ScrollTo'][2]/Docs" />
 		public void ScrollTo(object item, object group = null,
 			ScrollToPosition position = ScrollToPosition.MakeVisible, bool animate = true)
 		{

--- a/src/Controls/src/Core/Items/ScrollToRequestEventArgs.cs
+++ b/src/Controls/src/Core/Items/ScrollToRequestEventArgs.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='Group']/Docs" />
 		public object Group { get; }
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ScrollToRequestEventArgs(int index, int groupIndex,
 			ScrollToPosition scrollToPosition, bool isAnimated)
 		{
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls
 			IsAnimated = isAnimated;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ScrollToRequestEventArgs(object item, object group,
 			ScrollToPosition scrollToPosition, bool isAnimated)
 		{

--- a/src/Controls/src/Core/Items/ScrollToRequestEventArgs.cs
+++ b/src/Controls/src/Core/Items/ScrollToRequestEventArgs.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='Group']/Docs" />
 		public object Group { get; }
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ScrollToRequestEventArgs(int index, int groupIndex,
 			ScrollToPosition scrollToPosition, bool isAnimated)
 		{
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls
 			IsAnimated = isAnimated;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ScrollToRequestEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ScrollToRequestEventArgs(object item, object group,
 			ScrollToPosition scrollToPosition, bool isAnimated)
 		{

--- a/src/Controls/src/Core/Layout/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/Layout/AbsoluteLayout.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
@@ -36,26 +36,26 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags' and position()=0]/Docs" />
 		public static AbsoluteLayoutFlags GetLayoutFlags(BindableObject bindable)
 		{
 			return (AbsoluteLayoutFlags)bindable.GetValue(LayoutFlagsProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds' and position()=0]/Docs" />
 		[System.ComponentModel.TypeConverter(typeof(BoundsTypeConverter))]
 		public static Rect GetLayoutBounds(BindableObject bindable)
 		{
 			return (Rect)bindable.GetValue(LayoutBoundsProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags' and position()=0]/Docs" />
 		public static void SetLayoutFlags(BindableObject bindable, AbsoluteLayoutFlags value)
 		{
 			bindable.SetValue(LayoutFlagsProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds' and position()=0]/Docs" />
 		public static void SetLayoutBounds(BindableObject bindable, Rect value)
 		{
 			bindable.SetValue(LayoutBoundsProperty, value);
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls
 
 		#endregion
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags' and position()=1]/Docs" />
 		public AbsoluteLayoutFlags GetLayoutFlags(IView view)
 		{
 			return view switch
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds' and position()=1]/Docs" />
 		public Rect GetLayoutBounds(IView view)
 		{
 			return view switch
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags' and position()=1]/Docs" />
 		public void SetLayoutFlags(IView view, AbsoluteLayoutFlags flags)
 		{
 			switch (view)
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds' and position()=1]/Docs" />
 		public void SetLayoutBounds(IView view, Rect bounds)
 		{
 			switch (view)

--- a/src/Controls/src/Core/Layout/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/Layout/AbsoluteLayout.cs
@@ -36,26 +36,26 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags'][1]/Docs" />
 		public static AbsoluteLayoutFlags GetLayoutFlags(BindableObject bindable)
 		{
 			return (AbsoluteLayoutFlags)bindable.GetValue(LayoutFlagsProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds'][1]/Docs" />
 		[System.ComponentModel.TypeConverter(typeof(BoundsTypeConverter))]
 		public static Rect GetLayoutBounds(BindableObject bindable)
 		{
 			return (Rect)bindable.GetValue(LayoutBoundsProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags'][1]/Docs" />
 		public static void SetLayoutFlags(BindableObject bindable, AbsoluteLayoutFlags value)
 		{
 			bindable.SetValue(LayoutFlagsProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds'][1]/Docs" />
 		public static void SetLayoutBounds(BindableObject bindable, Rect value)
 		{
 			bindable.SetValue(LayoutBoundsProperty, value);
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls
 
 		#endregion
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags'][2]/Docs" />
 		public AbsoluteLayoutFlags GetLayoutFlags(IView view)
 		{
 			return view switch
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds'][2]/Docs" />
 		public Rect GetLayoutBounds(IView view)
 		{
 			return view switch
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags'][2]/Docs" />
 		public void SetLayoutFlags(IView view, AbsoluteLayoutFlags flags)
 		{
 			switch (view)
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds'][2]/Docs" />
 		public void SetLayoutBounds(IView view, Rect bounds)
 		{
 			switch (view)

--- a/src/Controls/src/Core/Layout/AbsoluteLayout.cs
+++ b/src/Controls/src/Core/Layout/AbsoluteLayout.cs
@@ -50,15 +50,15 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags'][1]/Docs" />
-		public static void SetLayoutFlags(BindableObject bindable, AbsoluteLayoutFlags value)
+		public static void SetLayoutFlags(BindableObject bindable, AbsoluteLayoutFlags flags)
 		{
-			bindable.SetValue(LayoutFlagsProperty, value);
+			bindable.SetValue(LayoutFlagsProperty, flags);
 		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds'][1]/Docs" />
-		public static void SetLayoutBounds(BindableObject bindable, Rect value)
+		public static void SetLayoutBounds(BindableObject bindable, Rect bounds)
 		{
-			bindable.SetValue(LayoutBoundsProperty, value);
+			bindable.SetValue(LayoutBoundsProperty, bounds);
 		}
 
 		#endregion
@@ -83,7 +83,6 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutFlags'][2]/Docs" />
 		public void SetLayoutFlags(IView view, AbsoluteLayoutFlags flags)
 		{
 			switch (view)
@@ -97,7 +96,6 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='SetLayoutBounds'][2]/Docs" />
 		public void SetLayoutBounds(IView view, Rect bounds)
 		{
 			switch (view)

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -110,43 +110,43 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(WrapProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder'][1]/Docs" />
 		public static int GetOrder(BindableObject bindable)
 			=> (int)bindable.GetValue(OrderProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder'][1]/Docs" />
 		public static void SetOrder(BindableObject bindable, int value)
 			=> bindable.SetValue(OrderProperty, value);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow'][1]/Docs" />
 		public static float GetGrow(BindableObject bindable)
 			=> (float)bindable.GetValue(GrowProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow'][1]/Docs" />
 		public static void SetGrow(BindableObject bindable, float value)
 			=> bindable.SetValue(GrowProperty, value);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink'][1]/Docs" />
 		public static float GetShrink(BindableObject bindable)
 			=> (float)bindable.GetValue(ShrinkProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink'][1]/Docs" />
 		public static void SetShrink(BindableObject bindable, float value)
 			=> bindable.SetValue(ShrinkProperty, value);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf'][1]/Docs" />
 		public static FlexAlignSelf GetAlignSelf(BindableObject bindable)
 			=> (FlexAlignSelf)bindable.GetValue(AlignSelfProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf'][1]/Docs" />
 		public static void SetAlignSelf(BindableObject bindable, FlexAlignSelf value)
 			=> bindable.SetValue(AlignSelfProperty, value);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis'][1]/Docs" />
 		public static FlexBasis GetBasis(BindableObject bindable)
 			=> (FlexBasis)bindable.GetValue(BasisProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis'][1]/Docs" />
 		public static void SetBasis(BindableObject bindable, FlexBasis value)
 			=> bindable.SetValue(BasisProperty, value);
 
@@ -263,7 +263,7 @@ namespace Microsoft.Maui.Controls
 			public Flex.Item FlexItem { get; set; }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder'][2]/Docs" />
 		public int GetOrder(IView view)
 		{
 			return view switch
@@ -273,7 +273,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder'][2]/Docs" />
 		public void SetOrder(IView view, int order)
 		{
 			switch (view)
@@ -287,7 +287,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow'][2]/Docs" />
 		public float GetGrow(IView view)
 		{
 			return view switch
@@ -297,7 +297,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow'][2]/Docs" />
 		public void SetGrow(IView view, float grow)
 		{
 			switch (view)
@@ -311,7 +311,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink'][2]/Docs" />
 		public float GetShrink(IView view)
 		{
 			return view switch
@@ -321,7 +321,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink'][2]/Docs" />
 		public void SetShrink(IView view, float shrink)
 		{
 			switch (view)
@@ -335,7 +335,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf'][2]/Docs" />
 		public FlexAlignSelf GetAlignSelf(IView view)
 		{
 			return view switch
@@ -345,7 +345,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf'][2]/Docs" />
 		public void SetAlignSelf(IView view, FlexAlignSelf alignSelf)
 		{
 			switch (view)
@@ -359,7 +359,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis'][2]/Docs" />
 		public FlexBasis GetBasis(IView view)
 		{
 			return view switch
@@ -369,7 +369,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis'][2]/Docs" />
 		public void SetBasis(IView view, FlexBasis basis)
 		{
 			switch (view)

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Maui.Controls.Internals;
@@ -110,43 +110,43 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(WrapProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder' and position()=0]/Docs" />
 		public static int GetOrder(BindableObject bindable)
 			=> (int)bindable.GetValue(OrderProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder' and position()=0]/Docs" />
 		public static void SetOrder(BindableObject bindable, int value)
 			=> bindable.SetValue(OrderProperty, value);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow' and position()=0]/Docs" />
 		public static float GetGrow(BindableObject bindable)
 			=> (float)bindable.GetValue(GrowProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow' and position()=0]/Docs" />
 		public static void SetGrow(BindableObject bindable, float value)
 			=> bindable.SetValue(GrowProperty, value);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink' and position()=0]/Docs" />
 		public static float GetShrink(BindableObject bindable)
 			=> (float)bindable.GetValue(ShrinkProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink' and position()=0]/Docs" />
 		public static void SetShrink(BindableObject bindable, float value)
 			=> bindable.SetValue(ShrinkProperty, value);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf' and position()=0]/Docs" />
 		public static FlexAlignSelf GetAlignSelf(BindableObject bindable)
 			=> (FlexAlignSelf)bindable.GetValue(AlignSelfProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf' and position()=0]/Docs" />
 		public static void SetAlignSelf(BindableObject bindable, FlexAlignSelf value)
 			=> bindable.SetValue(AlignSelfProperty, value);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis' and position()=0]/Docs" />
 		public static FlexBasis GetBasis(BindableObject bindable)
 			=> (FlexBasis)bindable.GetValue(BasisProperty);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis' and position()=0]/Docs" />
 		public static void SetBasis(BindableObject bindable, FlexBasis value)
 			=> bindable.SetValue(BasisProperty, value);
 
@@ -263,7 +263,7 @@ namespace Microsoft.Maui.Controls
 			public Flex.Item FlexItem { get; set; }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder' and position()=1]/Docs" />
 		public int GetOrder(IView view)
 		{
 			return view switch
@@ -273,7 +273,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder' and position()=1]/Docs" />
 		public void SetOrder(IView view, int order)
 		{
 			switch (view)
@@ -287,7 +287,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow' and position()=1]/Docs" />
 		public float GetGrow(IView view)
 		{
 			return view switch
@@ -297,7 +297,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow' and position()=1]/Docs" />
 		public void SetGrow(IView view, float grow)
 		{
 			switch (view)
@@ -311,7 +311,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink' and position()=1]/Docs" />
 		public float GetShrink(IView view)
 		{
 			return view switch
@@ -321,7 +321,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink' and position()=1]/Docs" />
 		public void SetShrink(IView view, float shrink)
 		{
 			switch (view)
@@ -335,7 +335,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf' and position()=1]/Docs" />
 		public FlexAlignSelf GetAlignSelf(IView view)
 		{
 			return view switch
@@ -345,7 +345,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf' and position()=1]/Docs" />
 		public void SetAlignSelf(IView view, FlexAlignSelf alignSelf)
 		{
 			switch (view)
@@ -359,7 +359,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis' and position()=1]/Docs" />
 		public FlexBasis GetBasis(IView view)
 		{
 			return view switch
@@ -369,7 +369,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis' and position()=1]/Docs" />
 		public void SetBasis(IView view, FlexBasis basis)
 		{
 			switch (view)

--- a/src/Controls/src/Core/Layout/Grid.cs
+++ b/src/Controls/src/Core/Layout/Grid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Maui.Layouts;
 
@@ -60,49 +60,49 @@ namespace Microsoft.Maui.Controls
 			typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1,
 			propertyChanged: Invalidate);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn' and position()=0]/Docs" />
 		public static int GetColumn(BindableObject bindable)
 		{
 			return (int)bindable.GetValue(ColumnProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan' and position()=0]/Docs" />
 		public static int GetColumnSpan(BindableObject bindable)
 		{
 			return (int)bindable.GetValue(ColumnSpanProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow' and position()=0]/Docs" />
 		public static int GetRow(BindableObject bindable)
 		{
 			return (int)bindable.GetValue(RowProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan' and position()=0]/Docs" />
 		public static int GetRowSpan(BindableObject bindable)
 		{
 			return (int)bindable.GetValue(RowSpanProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn' and position()=0]/Docs" />
 		public static void SetColumn(BindableObject bindable, int value)
 		{
 			bindable.SetValue(ColumnProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan' and position()=0]/Docs" />
 		public static void SetColumnSpan(BindableObject bindable, int value)
 		{
 			bindable.SetValue(ColumnSpanProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow' and position()=0]/Docs" />
 		public static void SetRow(BindableObject bindable, int value)
 		{
 			bindable.SetValue(RowProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan' and position()=0]/Docs" />
 		public static void SetRowSpan(BindableObject bindable, int value)
 		{
 			bindable.SetValue(RowSpanProperty, value);
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(ColumnSpacingProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn' and position()=1]/Docs" />
 		public int GetColumn(IView view)
 		{
 			return view switch
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan' and position()=1]/Docs" />
 		public int GetColumnSpan(IView view)
 		{
 			return view switch
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow' and position()=1]/Docs" />
 		public int GetRow(IView view)
 		{
 			return view switch
@@ -175,7 +175,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan' and position()=1]/Docs" />
 		public int GetRowSpan(IView view)
 		{
 			return view switch
@@ -197,7 +197,7 @@ namespace Microsoft.Maui.Controls
 			ColumnDefinitions.Add(gridColumnDefinition);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow' and position()=1]/Docs" />
 		public void SetRow(IView view, int row)
 		{
 			switch (view)
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan' and position()=1]/Docs" />
 		public void SetRowSpan(IView view, int span)
 		{
 			switch (view)
@@ -227,7 +227,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn' and position()=1]/Docs" />
 		public void SetColumn(IView view, int col)
 		{
 			switch (view)
@@ -242,7 +242,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan' and position()=1]/Docs" />
 		public void SetColumnSpan(IView view, int span)
 		{
 			switch (view)

--- a/src/Controls/src/Core/Layout/Grid.cs
+++ b/src/Controls/src/Core/Layout/Grid.cs
@@ -60,49 +60,49 @@ namespace Microsoft.Maui.Controls
 			typeof(int), typeof(Grid), 1, validateValue: (bindable, value) => (int)value >= 1,
 			propertyChanged: Invalidate);
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn'][1]/Docs" />
 		public static int GetColumn(BindableObject bindable)
 		{
 			return (int)bindable.GetValue(ColumnProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan'][1]/Docs" />
 		public static int GetColumnSpan(BindableObject bindable)
 		{
 			return (int)bindable.GetValue(ColumnSpanProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow'][1]/Docs" />
 		public static int GetRow(BindableObject bindable)
 		{
 			return (int)bindable.GetValue(RowProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan'][1]/Docs" />
 		public static int GetRowSpan(BindableObject bindable)
 		{
 			return (int)bindable.GetValue(RowSpanProperty);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn'][1]/Docs" />
 		public static void SetColumn(BindableObject bindable, int value)
 		{
 			bindable.SetValue(ColumnProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan'][1]/Docs" />
 		public static void SetColumnSpan(BindableObject bindable, int value)
 		{
 			bindable.SetValue(ColumnSpanProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow'][1]/Docs" />
 		public static void SetRow(BindableObject bindable, int value)
 		{
 			bindable.SetValue(RowProperty, value);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan'][1]/Docs" />
 		public static void SetRowSpan(BindableObject bindable, int value)
 		{
 			bindable.SetValue(RowSpanProperty, value);
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(ColumnSpacingProperty, value); }
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn'][2]/Docs" />
 		public int GetColumn(IView view)
 		{
 			return view switch
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan'][2]/Docs" />
 		public int GetColumnSpan(IView view)
 		{
 			return view switch
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow'][2]/Docs" />
 		public int GetRow(IView view)
 		{
 			return view switch
@@ -175,7 +175,7 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan'][2]/Docs" />
 		public int GetRowSpan(IView view)
 		{
 			return view switch
@@ -197,7 +197,7 @@ namespace Microsoft.Maui.Controls
 			ColumnDefinitions.Add(gridColumnDefinition);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow'][2]/Docs" />
 		public void SetRow(IView view, int row)
 		{
 			switch (view)
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan'][2]/Docs" />
 		public void SetRowSpan(IView view, int span)
 		{
 			switch (view)
@@ -227,7 +227,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn'][2]/Docs" />
 		public void SetColumn(IView view, int col)
 		{
 			switch (view)
@@ -242,7 +242,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan'][2]/Docs" />
 		public void SetColumnSpan(IView view, int span)
 		{
 			switch (view)

--- a/src/Controls/src/Core/LinearGradientBrush.cs
+++ b/src/Controls/src/Core/LinearGradientBrush.cs
@@ -5,19 +5,19 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="Type[@FullName='Microsoft.Maui.Controls.LinearGradientBrush']/Docs" />
 	public class LinearGradientBrush : GradientBrush
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public LinearGradientBrush()
 		{
 
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public LinearGradientBrush(GradientStopCollection gradientStops)
 		{
 			GradientStops = gradientStops;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public LinearGradientBrush(GradientStopCollection gradientStops, Point startPoint, Point endPoint)
 		{
 			GradientStops = gradientStops;

--- a/src/Controls/src/Core/LinearGradientBrush.cs
+++ b/src/Controls/src/Core/LinearGradientBrush.cs
@@ -5,19 +5,19 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="Type[@FullName='Microsoft.Maui.Controls.LinearGradientBrush']/Docs" />
 	public class LinearGradientBrush : GradientBrush
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public LinearGradientBrush()
 		{
 
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public LinearGradientBrush(GradientStopCollection gradientStops)
 		{
 			GradientStops = gradientStops;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/LinearGradientBrush.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public LinearGradientBrush(GradientStopCollection gradientStops, Point startPoint, Point endPoint)
 		{
 			GradientStops = gradientStops;

--- a/src/Controls/src/Core/ListView.cs
+++ b/src/Controls/src/Core/ListView.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler Refreshing;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='ScrollTo'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='ScrollTo' and position()=0]/Docs" />
 		public void ScrollTo(object item, ScrollToPosition position, bool animated)
 		{
 			if (!Enum.IsDefined(typeof(ScrollToPosition), position))
@@ -392,7 +392,7 @@ namespace Microsoft.Maui.Controls
 				_pendingScroll = args;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='ScrollTo'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='ScrollTo' and position()=1]/Docs" />
 		public void ScrollTo(object item, object group, ScrollToPosition position, bool animated)
 		{
 			if (!IsGroupingEnabled)
@@ -520,7 +520,7 @@ namespace Microsoft.Maui.Controls
 			ItemTapped?.Invoke(this, new ItemTappedEventArgs(ItemsSource.Cast<object>().ElementAt(groupIndex), cell?.BindingContext, TemplatedItems.GetGlobalIndexOfItem(cell?.BindingContext)));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped' and position()=3]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell, bool isContextMenuRequested)
 		{
@@ -575,7 +575,7 @@ namespace Microsoft.Maui.Controls
 				NotifyRowTapped(0, index, cell);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped' and position()=2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int index, Cell cell, bool isContextmenuRequested)
 		{

--- a/src/Controls/src/Core/ListView.cs
+++ b/src/Controls/src/Core/ListView.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		bool _refreshAllowed = true;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ListView()
 		{
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Controls/src/Core/ListView.cs
+++ b/src/Controls/src/Core/ListView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -494,7 +494,7 @@ namespace Microsoft.Maui.Controls
 			return displayBinding;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped' and position()=0]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell = null)
 		{
@@ -560,7 +560,7 @@ namespace Microsoft.Maui.Controls
 					TemplatedItems.GetGlobalIndexOfItem(cell?.BindingContext)));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped' and position()=1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int index, Cell cell = null)
 		{

--- a/src/Controls/src/Core/ListView.cs
+++ b/src/Controls/src/Core/ListView.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Controls
 		/// </summary>
 		bool _refreshAllowed = true;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ListView()
 		{
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -379,7 +379,7 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler Refreshing;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='ScrollTo' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='ScrollTo'][1]/Docs" />
 		public void ScrollTo(object item, ScrollToPosition position, bool animated)
 		{
 			if (!Enum.IsDefined(typeof(ScrollToPosition), position))
@@ -392,7 +392,7 @@ namespace Microsoft.Maui.Controls
 				_pendingScroll = args;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='ScrollTo' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='ScrollTo'][2]/Docs" />
 		public void ScrollTo(object item, object group, ScrollToPosition position, bool animated)
 		{
 			if (!IsGroupingEnabled)
@@ -494,7 +494,7 @@ namespace Microsoft.Maui.Controls
 			return displayBinding;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell = null)
 		{
@@ -520,7 +520,7 @@ namespace Microsoft.Maui.Controls
 			ItemTapped?.Invoke(this, new ItemTappedEventArgs(ItemsSource.Cast<object>().ElementAt(groupIndex), cell?.BindingContext, TemplatedItems.GetGlobalIndexOfItem(cell?.BindingContext)));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][4]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell, bool isContextMenuRequested)
 		{
@@ -560,7 +560,7 @@ namespace Microsoft.Maui.Controls
 					TemplatedItems.GetGlobalIndexOfItem(cell?.BindingContext)));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int index, Cell cell = null)
 		{
@@ -575,7 +575,7 @@ namespace Microsoft.Maui.Controls
 				NotifyRowTapped(0, index, cell);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][3]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int index, Cell cell, bool isContextmenuRequested)
 		{

--- a/src/Controls/src/Core/ListView.cs
+++ b/src/Controls/src/Core/ListView.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Maui.Controls
 			return displayBinding;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int groupIndex, int inGroupIndex, Cell cell = null)
 		{
@@ -560,7 +560,7 @@ namespace Microsoft.Maui.Controls
 					TemplatedItems.GetGlobalIndexOfItem(cell?.BindingContext)));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ListView.xml" path="//Member[@MemberName='NotifyRowTapped'][1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void NotifyRowTapped(int index, Cell cell = null)
 		{

--- a/src/Controls/src/Core/MessagingCenter.cs
+++ b/src/Controls/src/Core/MessagingCenter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls
 		readonly Dictionary<Sender, List<Subscription>> _subscriptions =
 			new Dictionary<Sender, List<Subscription>>();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send'][1]/Docs" />
 		public static void Send<TSender, TArgs>(TSender sender, string message, TArgs args) where TSender : class
 		{
 			Instance.Send(sender, message, args);
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.Controls
 			InnerSend(message, typeof(TSender), typeof(TArgs), sender, args);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send'][2]/Docs" />
 		public static void Send<TSender>(TSender sender, string message) where TSender : class
 		{
 			Instance.Send(sender, message);
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls
 			InnerSend(message, typeof(TSender), null, sender, null);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe'][1]/Docs" />
 		public static void Subscribe<TSender, TArgs>(object subscriber, string message, Action<TSender, TArgs> callback, TSender source = null) where TSender : class
 		{
 			Instance.Subscribe(subscriber, message, callback, source);
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Controls
 			InnerSubscribe(subscriber, message, typeof(TSender), typeof(TArgs), target, callback.GetMethodInfo(), filter);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe'][2]/Docs" />
 		public static void Subscribe<TSender>(object subscriber, string message, Action<TSender> callback, TSender source = null) where TSender : class
 		{
 			Instance.Subscribe(subscriber, message, callback, source);
@@ -179,7 +179,7 @@ namespace Microsoft.Maui.Controls
 			InnerSubscribe(subscriber, message, typeof(TSender), null, target, callback.GetMethodInfo(), filter);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe'][1]/Docs" />
 		public static void Unsubscribe<TSender, TArgs>(object subscriber, string message) where TSender : class
 		{
 			Instance.Unsubscribe<TSender, TArgs>(subscriber, message);
@@ -190,7 +190,7 @@ namespace Microsoft.Maui.Controls
 			InnerUnsubscribe(message, typeof(TSender), typeof(TArgs), subscriber);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe'][2]/Docs" />
 		public static void Unsubscribe<TSender>(object subscriber, string message) where TSender : class
 		{
 			Instance.Unsubscribe<TSender>(subscriber, message);

--- a/src/Controls/src/Core/MessagingCenter.cs
+++ b/src/Controls/src/Core/MessagingCenter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls
 		readonly Dictionary<Sender, List<Subscription>> _subscriptions =
 			new Dictionary<Sender, List<Subscription>>();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send' and position()=0]/Docs" />
 		public static void Send<TSender, TArgs>(TSender sender, string message, TArgs args) where TSender : class
 		{
 			Instance.Send(sender, message, args);
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.Controls
 			InnerSend(message, typeof(TSender), typeof(TArgs), sender, args);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send' and position()=1]/Docs" />
 		public static void Send<TSender>(TSender sender, string message) where TSender : class
 		{
 			Instance.Send(sender, message);
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls
 			InnerSend(message, typeof(TSender), null, sender, null);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe' and position()=0]/Docs" />
 		public static void Subscribe<TSender, TArgs>(object subscriber, string message, Action<TSender, TArgs> callback, TSender source = null) where TSender : class
 		{
 			Instance.Subscribe(subscriber, message, callback, source);
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Controls
 			InnerSubscribe(subscriber, message, typeof(TSender), typeof(TArgs), target, callback.GetMethodInfo(), filter);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe' and position()=1]/Docs" />
 		public static void Subscribe<TSender>(object subscriber, string message, Action<TSender> callback, TSender source = null) where TSender : class
 		{
 			Instance.Subscribe(subscriber, message, callback, source);
@@ -179,7 +179,7 @@ namespace Microsoft.Maui.Controls
 			InnerSubscribe(subscriber, message, typeof(TSender), null, target, callback.GetMethodInfo(), filter);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe' and position()=0]/Docs" />
 		public static void Unsubscribe<TSender, TArgs>(object subscriber, string message) where TSender : class
 		{
 			Instance.Unsubscribe<TSender, TArgs>(subscriber, message);
@@ -190,7 +190,7 @@ namespace Microsoft.Maui.Controls
 			InnerUnsubscribe(message, typeof(TSender), typeof(TArgs), subscriber);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe' and position()=1]/Docs" />
 		public static void Unsubscribe<TSender>(object subscriber, string message) where TSender : class
 		{
 			Instance.Unsubscribe<TSender>(subscriber, message);

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -60,12 +60,12 @@ namespace Microsoft.Maui.Controls
 #endif
 
 		bool _setForMaui;
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public NavigationPage() : this(UseMauiHandler)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public NavigationPage(Page root) : this(UseMauiHandler, root)
 		{
 		}
@@ -206,13 +206,13 @@ namespace Microsoft.Maui.Controls
 			return (Color)bindable.GetValue(IconColorProperty);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopAsync'][1]/Docs" />
 		public Task<Page> PopAsync()
 		{
 			return PopAsync(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopAsync'][2]/Docs" />
 		public async Task<Page> PopAsync(bool animated)
 		{
 			// If Navigation interactions are being handled by the MAUI APIs
@@ -252,13 +252,13 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler<NavigationEventArgs> PoppedToRoot;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopToRootAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopToRootAsync'][1]/Docs" />
 		public Task PopToRootAsync()
 		{
 			return PopToRootAsync(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopToRootAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopToRootAsync'][2]/Docs" />
 		public async Task PopToRootAsync(bool animated)
 		{
 			// If Navigation interactions are being handled by the MAUI APIs
@@ -286,13 +286,13 @@ namespace Microsoft.Maui.Controls
 			await result;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PushAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PushAsync'][1]/Docs" />
 		public Task PushAsync(Page page)
 		{
 			return PushAsync(page, true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PushAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PushAsync'][2]/Docs" />
 		public async Task PushAsync(Page page, bool animated)
 		{
 			// If Navigation interactions are being handled by the MAUI APIs

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -60,12 +60,12 @@ namespace Microsoft.Maui.Controls
 #endif
 
 		bool _setForMaui;
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public NavigationPage() : this(UseMauiHandler)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public NavigationPage(Page root) : this(UseMauiHandler, root)
 		{
 		}

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -206,13 +206,13 @@ namespace Microsoft.Maui.Controls
 			return (Color)bindable.GetValue(IconColorProperty);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopAsync' and position()=0]/Docs" />
 		public Task<Page> PopAsync()
 		{
 			return PopAsync(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopAsync' and position()=1]/Docs" />
 		public async Task<Page> PopAsync(bool animated)
 		{
 			// If Navigation interactions are being handled by the MAUI APIs
@@ -252,13 +252,13 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler<NavigationEventArgs> PoppedToRoot;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopToRootAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopToRootAsync' and position()=0]/Docs" />
 		public Task PopToRootAsync()
 		{
 			return PopToRootAsync(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopToRootAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PopToRootAsync' and position()=1]/Docs" />
 		public async Task PopToRootAsync(bool animated)
 		{
 			// If Navigation interactions are being handled by the MAUI APIs
@@ -286,13 +286,13 @@ namespace Microsoft.Maui.Controls
 			await result;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PushAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PushAsync' and position()=0]/Docs" />
 		public Task PushAsync(Page page)
 		{
 			return PushAsync(page, true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PushAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/NavigationPage.xml" path="//Member[@MemberName='PushAsync' and position()=1]/Docs" />
 		public async Task PushAsync(Page page, bool animated)
 		{
 			// If Navigation interactions are being handled by the MAUI APIs

--- a/src/Controls/src/Core/NavigationProxy.cs
+++ b/src/Controls/src/Core/NavigationProxy.cs
@@ -80,49 +80,49 @@ namespace Microsoft.Maui.Controls.Internals
 			get { return GetNavigationStack(); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopAsync'][1]/Docs" />
 		public Task<Page> PopAsync()
 		{
 			return OnPopAsync(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopAsync'][2]/Docs" />
 		public Task<Page> PopAsync(bool animated)
 		{
 			return OnPopAsync(animated);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopModalAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopModalAsync'][1]/Docs" />
 		public Task<Page> PopModalAsync()
 		{
 			return OnPopModal(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopModalAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopModalAsync'][2]/Docs" />
 		public Task<Page> PopModalAsync(bool animated)
 		{
 			return OnPopModal(animated);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopToRootAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopToRootAsync'][1]/Docs" />
 		public Task PopToRootAsync()
 		{
 			return OnPopToRootAsync(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopToRootAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopToRootAsync'][2]/Docs" />
 		public Task PopToRootAsync(bool animated)
 		{
 			return OnPopToRootAsync(animated);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushAsync'][1]/Docs" />
 		public Task PushAsync(Page root)
 		{
 			return PushAsync(root, true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushAsync'][2]/Docs" />
 		public Task PushAsync(Page root, bool animated)
 		{
 			if (root.RealParent != null)
@@ -130,13 +130,13 @@ namespace Microsoft.Maui.Controls.Internals
 			return OnPushAsync(root, animated);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushModalAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushModalAsync'][1]/Docs" />
 		public Task PushModalAsync(Page modal)
 		{
 			return PushModalAsync(modal, true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushModalAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushModalAsync'][2]/Docs" />
 		public Task PushModalAsync(Page modal, bool animated)
 		{
 			if (modal.RealParent != null && modal.RealParent is not IWindow)

--- a/src/Controls/src/Core/NavigationProxy.cs
+++ b/src/Controls/src/Core/NavigationProxy.cs
@@ -80,49 +80,49 @@ namespace Microsoft.Maui.Controls.Internals
 			get { return GetNavigationStack(); }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopAsync' and position()=0]/Docs" />
 		public Task<Page> PopAsync()
 		{
 			return OnPopAsync(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopAsync' and position()=1]/Docs" />
 		public Task<Page> PopAsync(bool animated)
 		{
 			return OnPopAsync(animated);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopModalAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopModalAsync' and position()=0]/Docs" />
 		public Task<Page> PopModalAsync()
 		{
 			return OnPopModal(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopModalAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopModalAsync' and position()=1]/Docs" />
 		public Task<Page> PopModalAsync(bool animated)
 		{
 			return OnPopModal(animated);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopToRootAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopToRootAsync' and position()=0]/Docs" />
 		public Task PopToRootAsync()
 		{
 			return OnPopToRootAsync(true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopToRootAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PopToRootAsync' and position()=1]/Docs" />
 		public Task PopToRootAsync(bool animated)
 		{
 			return OnPopToRootAsync(animated);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushAsync' and position()=0]/Docs" />
 		public Task PushAsync(Page root)
 		{
 			return PushAsync(root, true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushAsync' and position()=1]/Docs" />
 		public Task PushAsync(Page root, bool animated)
 		{
 			if (root.RealParent != null)
@@ -130,13 +130,13 @@ namespace Microsoft.Maui.Controls.Internals
 			return OnPushAsync(root, animated);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushModalAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushModalAsync' and position()=0]/Docs" />
 		public Task PushModalAsync(Page modal)
 		{
 			return PushModalAsync(modal, true);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushModalAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/NavigationProxy.xml" path="//Member[@MemberName='PushModalAsync' and position()=1]/Docs" />
 		public Task PushModalAsync(Page modal, bool animated)
 		{
 			if (modal.RealParent != null && modal.RealParent is not IWindow)

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Maui.Controls
 			return args.Result.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayPromptAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayPromptAsync'][2]/Docs" />
 		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -204,13 +204,13 @@ namespace Microsoft.Maui.Controls
 			return args.Result.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert' and position()=0]/Docs" />
 		public Task DisplayAlert(string title, string message, string cancel)
 		{
 			return DisplayAlert(title, message, null, cancel, FlowDirection.MatchParent);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert' and position()=1]/Docs" />
 		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel)
 		{
 			return DisplayAlert(title, message, accept, cancel, FlowDirection.MatchParent);

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -183,13 +183,13 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler Disappearing;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet' and position()=0]/Docs" />
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons)
 		{
 			return DisplayActionSheet(title, cancel, destruction, FlowDirection.MatchParent, buttons);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet' and position()=1]/Docs" />
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, FlowDirection flowDirection, params string[] buttons)
 		{
 			var args = new ActionSheetArguments(title, cancel, destruction, buttons);
@@ -216,13 +216,13 @@ namespace Microsoft.Maui.Controls
 			return DisplayAlert(title, message, accept, cancel, FlowDirection.MatchParent);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert' and position()=0]/Docs" />
 		public Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection)
 		{
 			return DisplayAlert(title, message, null, cancel, flowDirection);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert' and position()=1]/Docs" />
 		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection)
 		{
 			if (string.IsNullOrEmpty(cancel))

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -183,13 +183,13 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler Disappearing;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet'][1]/Docs" />
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons)
 		{
 			return DisplayActionSheet(title, cancel, destruction, FlowDirection.MatchParent, buttons);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet'][2]/Docs" />
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, FlowDirection flowDirection, params string[] buttons)
 		{
 			var args = new ActionSheetArguments(title, cancel, destruction, buttons);
@@ -204,25 +204,25 @@ namespace Microsoft.Maui.Controls
 			return args.Result.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert'][1]/Docs" />
 		public Task DisplayAlert(string title, string message, string cancel)
 		{
 			return DisplayAlert(title, message, null, cancel, FlowDirection.MatchParent);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert'][2]/Docs" />
 		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel)
 		{
 			return DisplayAlert(title, message, accept, cancel, FlowDirection.MatchParent);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert'][1]/Docs" />
 		public Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection)
 		{
 			return DisplayAlert(title, message, null, cancel, flowDirection);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert'][2]/Docs" />
 		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection)
 		{
 			if (string.IsNullOrEmpty(cancel))

--- a/src/Controls/src/Core/PanUpdatedEventArgs.cs
+++ b/src/Controls/src/Core/PanUpdatedEventArgs.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.PanUpdatedEventArgs']/Docs" />
 	public class PanUpdatedEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public PanUpdatedEventArgs(GestureStatus type, int gestureId, double totalx, double totaly) : this(type, gestureId)
 		{
 			TotalX = totalx;
 			TotalY = totaly;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public PanUpdatedEventArgs(GestureStatus type, int gestureId)
 		{
 			StatusType = type;

--- a/src/Controls/src/Core/PanUpdatedEventArgs.cs
+++ b/src/Controls/src/Core/PanUpdatedEventArgs.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.PanUpdatedEventArgs']/Docs" />
 	public class PanUpdatedEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public PanUpdatedEventArgs(GestureStatus type, int gestureId, double totalx, double totaly) : this(type, gestureId)
 		{
 			TotalX = totalx;
 			TotalY = totaly;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/PanUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public PanUpdatedEventArgs(GestureStatus type, int gestureId)
 		{
 			StatusType = type;

--- a/src/Controls/src/Core/Performance.cs
+++ b/src/Controls/src/Core/Performance.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Internals
 			Provider = instance;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Performance.xml" path="//Member[@MemberName='Start' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Performance.xml" path="//Member[@MemberName='Start'][1]/Docs" />
 		public static void Start(out string reference, string tag = null, [CallerFilePath] string path = null, [CallerMemberName] string member = null)
 		{
 			if (Provider == null)
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Internals
 			Provider.Start(reference, tag, path, member);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Performance.xml" path="//Member[@MemberName='Start' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Performance.xml" path="//Member[@MemberName='Start'][2]/Docs" />
 		public static void Start(string reference, string tag = null, [CallerFilePath] string path = null,
 			[CallerMemberName] string member = null)
 		{

--- a/src/Controls/src/Core/Performance.cs
+++ b/src/Controls/src/Core/Performance.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.Internals
 			Provider = instance;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Performance.xml" path="//Member[@MemberName='Start']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Performance.xml" path="//Member[@MemberName='Start' and position()=0]/Docs" />
 		public static void Start(out string reference, string tag = null, [CallerFilePath] string path = null, [CallerMemberName] string member = null)
 		{
 			if (Provider == null)
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Internals
 			Provider.Start(reference, tag, path, member);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Performance.xml" path="//Member[@MemberName='Start']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Performance.xml" path="//Member[@MemberName='Start' and position()=1]/Docs" />
 		public static void Start(string reference, string tag = null, [CallerFilePath] string path = null,
 			[CallerMemberName] string member = null)
 		{

--- a/src/Controls/src/Core/PinchGestureUpdatedEventArgs.cs
+++ b/src/Controls/src/Core/PinchGestureUpdatedEventArgs.cs
@@ -6,14 +6,14 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.PinchGestureUpdatedEventArgs']/Docs" />
 	public class PinchGestureUpdatedEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public PinchGestureUpdatedEventArgs(GestureStatus status, double scale, Point origin) : this(status)
 		{
 			ScaleOrigin = origin;
 			Scale = scale;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public PinchGestureUpdatedEventArgs(GestureStatus status)
 		{
 			Status = status;

--- a/src/Controls/src/Core/PinchGestureUpdatedEventArgs.cs
+++ b/src/Controls/src/Core/PinchGestureUpdatedEventArgs.cs
@@ -6,14 +6,14 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.PinchGestureUpdatedEventArgs']/Docs" />
 	public class PinchGestureUpdatedEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public PinchGestureUpdatedEventArgs(GestureStatus status, double scale, Point origin) : this(status)
 		{
 			ScaleOrigin = origin;
 			Scale = scale;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/PinchGestureUpdatedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public PinchGestureUpdatedEventArgs(GestureStatus status)
 		{
 			Status = status;

--- a/src/Controls/src/Core/PlatformBindingHelpers.cs
+++ b/src/Controls/src/Core/PlatformBindingHelpers.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.PlatformBindingHelpers']/Docs" />	
 	internal static class PlatformBindingHelpers
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding' and position()=0]/Docs" />
 		public static void SetBinding<TPlatformView>(TPlatformView target, string targetProperty, BindingBase bindingBase, string updateSourceEventName = null) where TPlatformView : class
 		{
 			var binding = bindingBase as Binding;
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Internals
 			SetBinding(target, targetProperty, bindingBase, eventWrapper);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding' and position()=1]/Docs" />
 		public static void SetBinding<TPlatformView>(TPlatformView target, string targetProperty, BindingBase bindingBase, INotifyPropertyChanged propertyChanged) where TPlatformView : class
 		{
 			if (target == null)
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Controls.Internals
 			bindable.SetValueCore(property, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding' and position()=2]/Docs" />
 		public static void SetBinding<TPlatformView>(TPlatformView target, BindableProperty targetProperty, BindingBase binding) where TPlatformView : class
 		{
 			if (target == null)

--- a/src/Controls/src/Core/PlatformBindingHelpers.cs
+++ b/src/Controls/src/Core/PlatformBindingHelpers.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.Internals
 	/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.PlatformBindingHelpers']/Docs" />	
 	internal static class PlatformBindingHelpers
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding'][1]/Docs" />
 		public static void SetBinding<TPlatformView>(TPlatformView target, string targetProperty, BindingBase bindingBase, string updateSourceEventName = null) where TPlatformView : class
 		{
 			var binding = bindingBase as Binding;
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.Internals
 			SetBinding(target, targetProperty, bindingBase, eventWrapper);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding'][2]/Docs" />
 		public static void SetBinding<TPlatformView>(TPlatformView target, string targetProperty, BindingBase bindingBase, INotifyPropertyChanged propertyChanged) where TPlatformView : class
 		{
 			if (target == null)
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.Controls.Internals
 			bindable.SetValueCore(property, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PlatformBindingHelpers.xml" path="//Member[@MemberName='SetBinding'][3]/Docs" />
 		public static void SetBinding<TPlatformView>(TPlatformView target, BindableProperty targetProperty, BindingBase binding) where TPlatformView : class
 		{
 			if (target == null)

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			element.SetValue(SendDisappearingEventOnPauseProperty, value);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause']/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause' and position()=1]/Docs" />
 		public static bool GetSendDisappearingEventOnPause(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetSendDisappearingEventOnPause(config.Element);
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			element.SetValue(SendAppearingEventOnResumeProperty, value);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume']/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume' and position()=1]/Docs" />
 		public static bool GetSendAppearingEventOnResume(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetSendAppearingEventOnResume(config.Element);
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			element.SetValue(ShouldPreserveKeyboardOnResumeProperty, value);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume']/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume' and position()=1]/Docs" />
 		public static bool GetShouldPreserveKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetShouldPreserveKeyboardOnResume(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='SendDisappearingEventOnPauseProperty']/Docs" />
 		public static readonly BindableProperty SendDisappearingEventOnPauseProperty = BindableProperty.Create(nameof(SendDisappearingEventOnPause), typeof(bool), typeof(Application), true);
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause' and position()=0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause'][1]/Docs" />
 		public static bool GetSendDisappearingEventOnPause(BindableObject element)
 		{
 			return (bool)element.GetValue(SendDisappearingEventOnPauseProperty);
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			element.SetValue(SendDisappearingEventOnPauseProperty, value);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause' and position()=1]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause'][2]/Docs" />
 		public static bool GetSendDisappearingEventOnPause(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetSendDisappearingEventOnPause(config.Element);
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='SendAppearingEventOnResumeProperty']/Docs" />
 		public static readonly BindableProperty SendAppearingEventOnResumeProperty = BindableProperty.Create(nameof(SendAppearingEventOnResume), typeof(bool), typeof(Application), true);
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume' and position()=0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume'][1]/Docs" />
 		public static bool GetSendAppearingEventOnResume(BindableObject element)
 		{
 			return (bool)element.GetValue(SendAppearingEventOnResumeProperty);
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			element.SetValue(SendAppearingEventOnResumeProperty, value);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume' and position()=1]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume'][2]/Docs" />
 		public static bool GetSendAppearingEventOnResume(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetSendAppearingEventOnResume(config.Element);
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='ShouldPreserveKeyboardOnResumeProperty']/Docs" />
 		public static readonly BindableProperty ShouldPreserveKeyboardOnResumeProperty = BindableProperty.Create(nameof(ShouldPreserveKeyboardOnResume), typeof(bool), typeof(Application), false);
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume' and position()=0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume'][1]/Docs" />
 		public static bool GetShouldPreserveKeyboardOnResume(BindableObject element)
 		{
 			return (bool)element.GetValue(ShouldPreserveKeyboardOnResumeProperty);
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			element.SetValue(ShouldPreserveKeyboardOnResumeProperty, value);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume' and position()=1]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume'][2]/Docs" />
 		public static bool GetShouldPreserveKeyboardOnResume(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetShouldPreserveKeyboardOnResume(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/Application.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='SendDisappearingEventOnPauseProperty']/Docs" />
 		public static readonly BindableProperty SendDisappearingEventOnPauseProperty = BindableProperty.Create(nameof(SendDisappearingEventOnPause), typeof(bool), typeof(Application), true);
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause'][0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendDisappearingEventOnPause' and position()=0]/Docs" />
 		public static bool GetSendDisappearingEventOnPause(BindableObject element)
 		{
 			return (bool)element.GetValue(SendDisappearingEventOnPauseProperty);
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='SendAppearingEventOnResumeProperty']/Docs" />
 		public static readonly BindableProperty SendAppearingEventOnResumeProperty = BindableProperty.Create(nameof(SendAppearingEventOnResume), typeof(bool), typeof(Application), true);
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume'][0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetSendAppearingEventOnResume' and position()=0]/Docs" />
 		public static bool GetSendAppearingEventOnResume(BindableObject element)
 		{
 			return (bool)element.GetValue(SendAppearingEventOnResumeProperty);
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='ShouldPreserveKeyboardOnResumeProperty']/Docs" />
 		public static readonly BindableProperty ShouldPreserveKeyboardOnResumeProperty = BindableProperty.Create(nameof(ShouldPreserveKeyboardOnResume), typeof(bool), typeof(Application), false);
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume'][0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/Application.xml" path="//Member[@MemberName='GetShouldPreserveKeyboardOnResume' and position()=0]/Docs" />
 		public static bool GetShouldPreserveKeyboardOnResume(BindableObject element)
 		{
 			return (bool)element.GetValue(ShouldPreserveKeyboardOnResumeProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='BarHeightProperty']/Docs" />
 		public static readonly BindableProperty BarHeightProperty = BindableProperty.Create("BarHeight", typeof(int), typeof(NavigationPage), default(int));
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight'][0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight' and position()=0]/Docs" />
 		public static int GetBarHeight(BindableObject element)
 		{
 			return (int)element.GetValue(BarHeightProperty);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='SetBarHeight'][0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='SetBarHeight' and position()=0]/Docs" />
 		public static void SetBarHeight(BindableObject element, int value)
 		{
 			element.SetValue(BarHeightProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
@@ -8,25 +8,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='BarHeightProperty']/Docs" />
 		public static readonly BindableProperty BarHeightProperty = BindableProperty.Create("BarHeight", typeof(int), typeof(NavigationPage), default(int));
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight' and position()=0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight'][1]/Docs" />
 		public static int GetBarHeight(BindableObject element)
 		{
 			return (int)element.GetValue(BarHeightProperty);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='SetBarHeight' and position()=0]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='SetBarHeight'][1]/Docs" />
 		public static void SetBarHeight(BindableObject element, int value)
 		{
 			element.SetValue(BarHeightProperty, value);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight' and position()=1]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight'][2]/Docs" />
 		public static int GetBarHeight(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetBarHeight(config.Element);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='SetBarHeight' and position()=1]/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='SetBarHeight'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetBarHeight(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
 		{
 			SetBarHeight(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/AppCompat/NavigationPage.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompa
 			element.SetValue(BarHeightProperty, value);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight']/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='GetBarHeight' and position()=1]/Docs" />
 		public static int GetBarHeight(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetBarHeight(config.Element);
 		}
 
-		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='SetBarHeight']/Docs" />
+		/// <include file="../../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.AppCompat/NavigationPage.xml" path="//Member[@MemberName='SetBarHeight' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetBarHeight(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
 		{
 			SetBarHeight(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Application.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.Create("WindowSoftInputModeAdjust", typeof(WindowSoftInputModeAdjust),
 			typeof(Application), WindowSoftInputModeAdjust.Pan);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='GetWindowSoftInputModeAdjust'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='GetWindowSoftInputModeAdjust' and position()=0]/Docs" />
 		public static WindowSoftInputModeAdjust GetWindowSoftInputModeAdjust(BindableObject element)
 		{
 			return (WindowSoftInputModeAdjust)element.GetValue(WindowSoftInputModeAdjustProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Application.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			element.SetValue(WindowSoftInputModeAdjustProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='GetWindowSoftInputModeAdjust']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='GetWindowSoftInputModeAdjust' and position()=1]/Docs" />
 		public static WindowSoftInputModeAdjust GetWindowSoftInputModeAdjust(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetWindowSoftInputModeAdjust(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Application.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.Create("WindowSoftInputModeAdjust", typeof(WindowSoftInputModeAdjust),
 			typeof(Application), WindowSoftInputModeAdjust.Pan);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='GetWindowSoftInputModeAdjust' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='GetWindowSoftInputModeAdjust'][1]/Docs" />
 		public static WindowSoftInputModeAdjust GetWindowSoftInputModeAdjust(BindableObject element)
 		{
 			return (WindowSoftInputModeAdjust)element.GetValue(WindowSoftInputModeAdjustProperty);
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			element.SetValue(WindowSoftInputModeAdjustProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='GetWindowSoftInputModeAdjust' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Application.xml" path="//Member[@MemberName='GetWindowSoftInputModeAdjust'][2]/Docs" />
 		public static WindowSoftInputModeAdjust GetWindowSoftInputModeAdjust(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetWindowSoftInputModeAdjust(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Button.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Button.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(UseDefaultPaddingProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultPadding'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultPadding' and position()=0]/Docs" />
 		public static void SetUseDefaultPadding(BindableObject element, bool value)
 		{
 			element.SetValue(UseDefaultPaddingProperty, value);
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(UseDefaultShadowProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultShadow'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultShadow' and position()=0]/Docs" />
 		public static void SetUseDefaultShadow(BindableObject element, bool value)
 		{
 			element.SetValue(UseDefaultShadowProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Button.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Button.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetUseDefaultPadding(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultPadding']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultPadding' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetUseDefaultPadding(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetUseDefaultPadding(config.Element, value);
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetUseDefaultShadow(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultShadow']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultShadow' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetUseDefaultShadow(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetUseDefaultShadow(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Button.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Button.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(UseDefaultPaddingProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultPadding' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultPadding'][1]/Docs" />
 		public static void SetUseDefaultPadding(BindableObject element, bool value)
 		{
 			element.SetValue(UseDefaultPaddingProperty, value);
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetUseDefaultPadding(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultPadding' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultPadding'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetUseDefaultPadding(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetUseDefaultPadding(config.Element, value);
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(UseDefaultShadowProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultShadow' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultShadow'][1]/Docs" />
 		public static void SetUseDefaultShadow(BindableObject element, bool value)
 		{
 			element.SetValue(UseDefaultShadowProperty, value);
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetUseDefaultShadow(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultShadow' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Button.xml" path="//Member[@MemberName='SetUseDefaultShadow'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetUseDefaultShadow(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetUseDefaultShadow(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Entry.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (ImeFlags)element.GetValue(ImeOptionsProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='SetImeOptions' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='SetImeOptions'][1]/Docs" />
 		public static void SetImeOptions(BindableObject element, ImeFlags value)
 		{
 			element.SetValue(ImeOptionsProperty, value);
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetImeOptions(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='SetImeOptions' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='SetImeOptions'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetImeOptions(this IPlatformElementConfiguration<Microsoft.Maui.Controls.PlatformConfiguration.Android, FormsElement> config, ImeFlags value)
 		{
 			SetImeOptions(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Entry.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (ImeFlags)element.GetValue(ImeOptionsProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='SetImeOptions'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='SetImeOptions' and position()=0]/Docs" />
 		public static void SetImeOptions(BindableObject element, ImeFlags value)
 		{
 			element.SetValue(ImeOptionsProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/Entry.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetImeOptions(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='SetImeOptions']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/Entry.xml" path="//Member[@MemberName='SetImeOptions' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetImeOptions(this IPlatformElementConfiguration<Microsoft.Maui.Controls.PlatformConfiguration.Android, FormsElement> config, ImeFlags value)
 		{
 			SetImeOptions(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
@@ -10,25 +10,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='IsShadowEnabledProperty']/Docs" />
 		public static readonly BindableProperty IsShadowEnabledProperty = BindableProperty.Create("IsShadowEnabled", typeof(bool), typeof(Maui.Controls.ImageButton), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled'][1]/Docs" />
 		public static bool GetIsShadowEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsShadowEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetIsShadowEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetIsShadowEnabled'][1]/Docs" />
 		public static void SetIsShadowEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsShadowEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled'][2]/Docs" />
 		public static bool GetIsShadowEnabled(this IPlatformElementConfiguration<Android, FormsImageButton> config)
 		{
 			return GetIsShadowEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetIsShadowEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetIsShadowEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsImageButton> SetIsShadowEnabled(this IPlatformElementConfiguration<Android, FormsImageButton> config, bool value)
 		{
 			SetIsShadowEnabled(config.Element, value);
@@ -38,25 +38,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowColorProperty']/Docs" />
 		public static readonly BindableProperty ShadowColorProperty = BindableProperty.Create("ShadowColor", typeof(Color), typeof(ImageButton), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor'][1]/Docs" />
 		public static Color GetShadowColor(BindableObject element)
 		{
 			return (Color)element.GetValue(ShadowColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowColor'][1]/Docs" />
 		public static void SetShadowColor(BindableObject element, Color value)
 		{
 			element.SetValue(ShadowColorProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor'][2]/Docs" />
 		public static Color GetShadowColor(this IPlatformElementConfiguration<Android, FormsImageButton> config)
 		{
 			return GetShadowColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowColor'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsImageButton> SetShadowColor(this IPlatformElementConfiguration<Android, FormsImageButton> config, Color value)
 		{
 			SetShadowColor(config.Element, value);
@@ -66,25 +66,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowRadiusProperty']/Docs" />
 		public static readonly BindableProperty ShadowRadiusProperty = BindableProperty.Create("ShadowRadius", typeof(double), typeof(ImageButton), 10.0);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius'][1]/Docs" />
 		public static double GetShadowRadius(BindableObject element)
 		{
 			return (double)element.GetValue(ShadowRadiusProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowRadius' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowRadius'][1]/Docs" />
 		public static void SetShadowRadius(BindableObject element, double value)
 		{
 			element.SetValue(ShadowRadiusProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius'][2]/Docs" />
 		public static double GetShadowRadius(this IPlatformElementConfiguration<Android, FormsImageButton> config)
 		{
 			return GetShadowRadius(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowRadius' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowRadius'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsImageButton> SetShadowRadius(this IPlatformElementConfiguration<Android, FormsImageButton> config, double value)
 		{
 			SetShadowRadius(config.Element, value);
@@ -94,25 +94,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowOffsetProperty']/Docs" />
 		public static readonly BindableProperty ShadowOffsetProperty = BindableProperty.Create("ShadowOffset", typeof(Size), typeof(VisualElement), Size.Zero);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset'][1]/Docs" />
 		public static Size GetShadowOffset(BindableObject element)
 		{
 			return (Size)element.GetValue(ShadowOffsetProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowOffset' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowOffset'][1]/Docs" />
 		public static void SetShadowOffset(BindableObject element, Size value)
 		{
 			element.SetValue(ShadowOffsetProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset'][2]/Docs" />
 		public static Size GetShadowOffset(this IPlatformElementConfiguration<Android, FormsImageButton> config)
 		{
 			return GetShadowOffset(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowOffset' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowOffset'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsImageButton> SetShadowOffset(this IPlatformElementConfiguration<Android, FormsImageButton> config, Size value)
 		{
 			SetShadowOffset(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
+namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 {
 	using Microsoft.Maui.Graphics;
 	using FormsImageButton = Maui.Controls.ImageButton;
@@ -22,13 +22,13 @@
 			element.SetValue(IsShadowEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled' and position()=1]/Docs" />
 		public static bool GetIsShadowEnabled(this IPlatformElementConfiguration<Android, FormsImageButton> config)
 		{
 			return GetIsShadowEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetIsShadowEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetIsShadowEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsImageButton> SetIsShadowEnabled(this IPlatformElementConfiguration<Android, FormsImageButton> config, bool value)
 		{
 			SetIsShadowEnabled(config.Element, value);
@@ -50,13 +50,13 @@
 			element.SetValue(ShadowColorProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor' and position()=1]/Docs" />
 		public static Color GetShadowColor(this IPlatformElementConfiguration<Android, FormsImageButton> config)
 		{
 			return GetShadowColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowColor' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsImageButton> SetShadowColor(this IPlatformElementConfiguration<Android, FormsImageButton> config, Color value)
 		{
 			SetShadowColor(config.Element, value);
@@ -78,13 +78,13 @@
 			element.SetValue(ShadowRadiusProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius' and position()=1]/Docs" />
 		public static double GetShadowRadius(this IPlatformElementConfiguration<Android, FormsImageButton> config)
 		{
 			return GetShadowRadius(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowRadius']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowRadius' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsImageButton> SetShadowRadius(this IPlatformElementConfiguration<Android, FormsImageButton> config, double value)
 		{
 			SetShadowRadius(config.Element, value);
@@ -106,13 +106,13 @@
 			element.SetValue(ShadowOffsetProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset' and position()=1]/Docs" />
 		public static Size GetShadowOffset(this IPlatformElementConfiguration<Android, FormsImageButton> config)
 		{
 			return GetShadowOffset(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowOffset']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowOffset' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsImageButton> SetShadowOffset(this IPlatformElementConfiguration<Android, FormsImageButton> config, Size value)
 		{
 			SetShadowOffset(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ImageButton.cs
@@ -10,13 +10,13 @@
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='IsShadowEnabledProperty']/Docs" />
 		public static readonly BindableProperty IsShadowEnabledProperty = BindableProperty.Create("IsShadowEnabled", typeof(bool), typeof(Maui.Controls.ImageButton), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetIsShadowEnabled' and position()=0]/Docs" />
 		public static bool GetIsShadowEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsShadowEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetIsShadowEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetIsShadowEnabled' and position()=0]/Docs" />
 		public static void SetIsShadowEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsShadowEnabledProperty, value);
@@ -38,13 +38,13 @@
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowColorProperty']/Docs" />
 		public static readonly BindableProperty ShadowColorProperty = BindableProperty.Create("ShadowColor", typeof(Color), typeof(ImageButton), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowColor' and position()=0]/Docs" />
 		public static Color GetShadowColor(BindableObject element)
 		{
 			return (Color)element.GetValue(ShadowColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowColor' and position()=0]/Docs" />
 		public static void SetShadowColor(BindableObject element, Color value)
 		{
 			element.SetValue(ShadowColorProperty, value);
@@ -66,13 +66,13 @@
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowRadiusProperty']/Docs" />
 		public static readonly BindableProperty ShadowRadiusProperty = BindableProperty.Create("ShadowRadius", typeof(double), typeof(ImageButton), 10.0);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowRadius' and position()=0]/Docs" />
 		public static double GetShadowRadius(BindableObject element)
 		{
 			return (double)element.GetValue(ShadowRadiusProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowRadius'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowRadius' and position()=0]/Docs" />
 		public static void SetShadowRadius(BindableObject element, double value)
 		{
 			element.SetValue(ShadowRadiusProperty, value);
@@ -94,13 +94,13 @@
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='ShadowOffsetProperty']/Docs" />
 		public static readonly BindableProperty ShadowOffsetProperty = BindableProperty.Create("ShadowOffset", typeof(Size), typeof(VisualElement), Size.Zero);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='GetShadowOffset' and position()=0]/Docs" />
 		public static Size GetShadowOffset(BindableObject element)
 		{
 			return (Size)element.GetValue(ShadowOffsetProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowOffset'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ImageButton.xml" path="//Member[@MemberName='SetShadowOffset' and position()=0]/Docs" />
 		public static void SetShadowOffset(BindableObject element, Size value)
 		{
 			element.SetValue(ShadowOffsetProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(IsFastScrollEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled' and position()=0]/Docs" />
 		public static void SetIsFastScrollEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsFastScrollEnabledProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetIsFastScrollEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsFastScrollEnabled(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetIsFastScrollEnabled(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ListView.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(IsFastScrollEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled'][1]/Docs" />
 		public static void SetIsFastScrollEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsFastScrollEnabledProperty, value);
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetIsFastScrollEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ListView.xml" path="//Member[@MemberName='SetIsFastScrollEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsFastScrollEnabled(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetIsFastScrollEnabled(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/SwipeView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/SwipeView.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			element.SetValue(SwipeTransitionModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode' and position()=1]/Docs" />
 		public static SwipeTransitionMode GetSwipeTransitionMode(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetSwipeTransitionMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetSwipeTransitionMode(this IPlatformElementConfiguration<Android, FormsElement> config, SwipeTransitionMode value)
 		{
 			SetSwipeTransitionMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/SwipeView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/SwipeView.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SwipeTransitionModeProperty']/Docs" />
 		public static readonly BindableProperty SwipeTransitionModeProperty = BindableProperty.Create("SwipeTransitionMode", typeof(SwipeTransitionMode), typeof(SwipeView), SwipeTransitionMode.Reveal);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode' and position()=0]/Docs" />
 		public static SwipeTransitionMode GetSwipeTransitionMode(BindableObject element)
 		{
 			return (SwipeTransitionMode)element.GetValue(SwipeTransitionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode' and position()=0]/Docs" />
 		public static void SetSwipeTransitionMode(BindableObject element, SwipeTransitionMode value)
 		{
 			element.SetValue(SwipeTransitionModeProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/SwipeView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/SwipeView.cs
@@ -8,25 +8,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SwipeTransitionModeProperty']/Docs" />
 		public static readonly BindableProperty SwipeTransitionModeProperty = BindableProperty.Create("SwipeTransitionMode", typeof(SwipeTransitionMode), typeof(SwipeView), SwipeTransitionMode.Reveal);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode'][1]/Docs" />
 		public static SwipeTransitionMode GetSwipeTransitionMode(BindableObject element)
 		{
 			return (SwipeTransitionMode)element.GetValue(SwipeTransitionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode'][1]/Docs" />
 		public static void SetSwipeTransitionMode(BindableObject element, SwipeTransitionMode value)
 		{
 			element.SetValue(SwipeTransitionModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode'][2]/Docs" />
 		public static SwipeTransitionMode GetSwipeTransitionMode(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetSwipeTransitionMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetSwipeTransitionMode(this IPlatformElementConfiguration<Android, FormsElement> config, SwipeTransitionMode value)
 		{
 			SetSwipeTransitionMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetIsSwipePagingEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSwipePagingEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSwipePagingEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsSwipePagingEnabled(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetIsSwipePagingEnabled(config.Element, value);
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetIsSmoothScrollEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSmoothScrollEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSmoothScrollEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsSmoothScrollEnabled(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetIsSmoothScrollEnabled(config.Element, value);
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetOffscreenPageLimit(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetOffscreenPageLimit']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetOffscreenPageLimit' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetOffscreenPageLimit(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
 		{
 			SetOffscreenPageLimit(config.Element, value);
@@ -146,13 +146,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			element.SetValue(ToolbarPlacementProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetToolbarPlacement']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetToolbarPlacement' and position()=1]/Docs" />
 		public static ToolbarPlacement GetToolbarPlacement(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetToolbarPlacement(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetToolbarPlacement']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetToolbarPlacement' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetToolbarPlacement(this IPlatformElementConfiguration<Android, FormsElement> config, ToolbarPlacement value)
 		{
 			SetToolbarPlacement(config.Element, value);
@@ -170,7 +170,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return int.MaxValue;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetMaxItemCount']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetMaxItemCount' and position()=1]/Docs" />
 		public static int GetMaxItemCount(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetMaxItemCount(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(IsSwipePagingEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSwipePagingEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSwipePagingEnabled'][1]/Docs" />
 		public static void SetIsSwipePagingEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsSwipePagingEnabledProperty, value);
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetIsSwipePagingEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSwipePagingEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSwipePagingEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsSwipePagingEnabled(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetIsSwipePagingEnabled(config.Element, value);
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(IsSmoothScrollEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSmoothScrollEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSmoothScrollEnabled'][1]/Docs" />
 		public static void SetIsSmoothScrollEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsSmoothScrollEnabledProperty, value);
@@ -73,7 +73,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetIsSmoothScrollEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSmoothScrollEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSmoothScrollEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsSmoothScrollEnabled(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetIsSmoothScrollEnabled(config.Element, value);
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (int)element.GetValue(OffscreenPageLimitProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetOffscreenPageLimit' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetOffscreenPageLimit'][1]/Docs" />
 		public static void SetOffscreenPageLimit(BindableObject element, int value)
 		{
 			element.SetValue(OffscreenPageLimitProperty, value);
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetOffscreenPageLimit(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetOffscreenPageLimit' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetOffscreenPageLimit'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetOffscreenPageLimit(this IPlatformElementConfiguration<Android, FormsElement> config, int value)
 		{
 			SetOffscreenPageLimit(config.Element, value);
@@ -129,13 +129,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.Create("ToolbarPlacement", typeof(ToolbarPlacement),
 			typeof(TabbedPage), ToolbarPlacement.Top);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetToolbarPlacement' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetToolbarPlacement'][1]/Docs" />
 		public static ToolbarPlacement GetToolbarPlacement(BindableObject element)
 		{
 			return (ToolbarPlacement)element.GetValue(ToolbarPlacementProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetToolbarPlacement' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetToolbarPlacement'][1]/Docs" />
 		public static void SetToolbarPlacement(BindableObject element, ToolbarPlacement value)
 		{
 			if (element.IsSet(ToolbarPlacementProperty) && GetToolbarPlacement(element) != value)
@@ -146,20 +146,20 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			element.SetValue(ToolbarPlacementProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetToolbarPlacement' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetToolbarPlacement'][2]/Docs" />
 		public static ToolbarPlacement GetToolbarPlacement(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetToolbarPlacement(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetToolbarPlacement' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetToolbarPlacement'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetToolbarPlacement(this IPlatformElementConfiguration<Android, FormsElement> config, ToolbarPlacement value)
 		{
 			SetToolbarPlacement(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetMaxItemCount' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetMaxItemCount'][1]/Docs" />
 		public static int GetMaxItemCount(BindableObject element)
 		{
 			if (GetToolbarPlacement(element) == ToolbarPlacement.Bottom)
@@ -170,7 +170,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return int.MaxValue;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetMaxItemCount' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetMaxItemCount'][2]/Docs" />
 		public static int GetMaxItemCount(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetMaxItemCount(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/TabbedPage.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(IsSwipePagingEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSwipePagingEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSwipePagingEnabled' and position()=0]/Docs" />
 		public static void SetIsSwipePagingEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsSwipePagingEnabledProperty, value);
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(IsSmoothScrollEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSmoothScrollEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetIsSmoothScrollEnabled' and position()=0]/Docs" />
 		public static void SetIsSmoothScrollEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsSmoothScrollEnabledProperty, value);
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (int)element.GetValue(OffscreenPageLimitProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetOffscreenPageLimit'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetOffscreenPageLimit' and position()=0]/Docs" />
 		public static void SetOffscreenPageLimit(BindableObject element, int value)
 		{
 			element.SetValue(OffscreenPageLimitProperty, value);
@@ -129,13 +129,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.Create("ToolbarPlacement", typeof(ToolbarPlacement),
 			typeof(TabbedPage), ToolbarPlacement.Top);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetToolbarPlacement'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetToolbarPlacement' and position()=0]/Docs" />
 		public static ToolbarPlacement GetToolbarPlacement(BindableObject element)
 		{
 			return (ToolbarPlacement)element.GetValue(ToolbarPlacementProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetToolbarPlacement'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='SetToolbarPlacement' and position()=0]/Docs" />
 		public static void SetToolbarPlacement(BindableObject element, ToolbarPlacement value)
 		{
 			if (element.IsSet(ToolbarPlacementProperty) && GetToolbarPlacement(element) != value)
@@ -159,7 +159,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetMaxItemCount'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/TabbedPage.xml" path="//Member[@MemberName='GetMaxItemCount' and position()=0]/Docs" />
 		public static int GetMaxItemCount(BindableObject element)
 		{
 			if (GetToolbarPlacement(element) == ToolbarPlacement.Bottom)

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			cell.IsContextActionsLegacyModeEnabled = (bool)newValue;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled' and position()=0]/Docs" />
 		public static bool GetIsContextActionsLegacyModeEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsContextActionsLegacyModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled' and position()=0]/Docs" />
 		public static void SetIsContextActionsLegacyModeEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsContextActionsLegacyModeEnabledProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
@@ -15,25 +15,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			cell.IsContextActionsLegacyModeEnabled = (bool)newValue;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled'][1]/Docs" />
 		public static bool GetIsContextActionsLegacyModeEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsContextActionsLegacyModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled'][1]/Docs" />
 		public static void SetIsContextActionsLegacyModeEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsContextActionsLegacyModeEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled'][2]/Docs" />
 		public static bool GetIsContextActionsLegacyModeEnabled(this IPlatformElementConfiguration<Android, FormsCell> config)
 		{
 			return GetIsContextActionsLegacyModeEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsCell> SetIsContextActionsLegacyModeEnabled(this IPlatformElementConfiguration<Android, FormsCell> config, bool value)
 		{
 			SetIsContextActionsLegacyModeEnabled(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/ViewCell.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			element.SetValue(IsContextActionsLegacyModeEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='GetIsContextActionsLegacyModeEnabled' and position()=1]/Docs" />
 		public static bool GetIsContextActionsLegacyModeEnabled(this IPlatformElementConfiguration<Android, FormsCell> config)
 		{
 			return GetIsContextActionsLegacyModeEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/ViewCell.xml" path="//Member[@MemberName='SetIsContextActionsLegacyModeEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsCell> SetIsContextActionsLegacyModeEnabled(this IPlatformElementConfiguration<Android, FormsCell> config, bool value)
 		{
 			SetIsContextActionsLegacyModeEnabled(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
@@ -12,25 +12,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.Create("Elevation", typeof(float?),
 				typeof(FormsElement));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation'][1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation'][2]/Docs" />
 		public static float? GetElevation(FormsElement element)
 		{
 			return (float?)element.GetValue(ElevationProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation'][1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation'][2]/Docs" />
 		public static void SetElevation(FormsElement element, float? value)
 		{
 			element.SetValue(ElevationProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation'][2]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation'][1]/Docs" />
 		public static float? GetElevation(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetElevation(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation'][2]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation'][1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetElevation(this IPlatformElementConfiguration<Android, FormsElement> config, float? value)
 		{
 			SetElevation(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
@@ -12,25 +12,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.Create("Elevation", typeof(float?),
 				typeof(FormsElement));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation' and position()=0]/Docs" />
 		public static float? GetElevation(FormsElement element)
 		{
 			return (float?)element.GetValue(ElevationProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation' and position()=0]/Docs" />
 		public static void SetElevation(FormsElement element, float? value)
 		{
 			element.SetValue(ElevationProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation' and position()=1]/Docs" />
 		public static float? GetElevation(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetElevation(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetElevation(this IPlatformElementConfiguration<Android, FormsElement> config, float? value)
 		{
 			SetElevation(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
@@ -46,13 +46,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=0]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=0]/Docs" />
 		public static void SetIsLegacyColorModeEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
@@ -12,25 +12,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.Create("Elevation", typeof(float?),
 				typeof(FormsElement));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation'][1]/Docs" />
 		public static float? GetElevation(FormsElement element)
 		{
 			return (float?)element.GetValue(ElevationProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation'][1]/Docs" />
 		public static void SetElevation(FormsElement element, float? value)
 		{
 			element.SetValue(ElevationProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetElevation'][2]/Docs" />
 		public static float? GetElevation(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return GetElevation(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetElevation'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetElevation(this IPlatformElementConfiguration<Android, FormsElement> config, float? value)
 		{
 			SetElevation(config.Element, value);
@@ -46,25 +46,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][1]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][1]/Docs" />
 		public static void SetIsLegacyColorModeEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][2]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsLegacyColorModeEnabled(
 			this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/VisualElement.cs
@@ -58,13 +58,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=1]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(this IPlatformElementConfiguration<Android, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetIsLegacyColorModeEnabled(
 			this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(EnableZoomControlsProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls' and position()=0]/Docs" />
 		public static void SetEnableZoomControls(FormsElement element, bool value)
 		{
 			element.SetValue(EnableZoomControlsProperty, value);
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetEnableZoomControls(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetEnableZoomControls(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetEnableZoomControls(config.Element, value);
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(DisplayZoomControlsProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls' and position()=0]/Docs" />
 		public static void SetDisplayZoomControls(FormsElement element, bool value)
 		{
 			element.SetValue(DisplayZoomControlsProperty, value);
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetDisplayZoomControls(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetDisplayZoomControls(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetDisplayZoomControls(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(EnableZoomControlsProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls'][1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls'][2]/Docs" />
 		public static void SetEnableZoomControls(FormsElement element, bool value)
 		{
 			element.SetValue(EnableZoomControlsProperty, value);
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetEnableZoomControls(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls'][2]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls'][1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetEnableZoomControls(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetEnableZoomControls(config.Element, value);
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(DisplayZoomControlsProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls'][1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls'][2]/Docs" />
 		public static void SetDisplayZoomControls(FormsElement element, bool value)
 		{
 			element.SetValue(DisplayZoomControlsProperty, value);
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetDisplayZoomControls(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls'][2]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls'][1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetDisplayZoomControls(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetDisplayZoomControls(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (MixedContentHandling)element.GetValue(MixedContentModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetMixedContentMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetMixedContentMode'][1]/Docs" />
 		public static void SetMixedContentMode(BindableObject element, MixedContentHandling value)
 		{
 			element.SetValue(MixedContentModeProperty, value);
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetMixedContentMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetMixedContentMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetMixedContentMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetMixedContentMode(this IPlatformElementConfiguration<Android, FormsElement> config, MixedContentHandling value)
 		{
 			SetMixedContentMode(config.Element, value);
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(EnableZoomControlsProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls'][1]/Docs" />
 		public static void SetEnableZoomControls(FormsElement element, bool value)
 		{
 			element.SetValue(EnableZoomControlsProperty, value);
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetEnableZoomControls(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetEnableZoomControls'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetEnableZoomControls(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetEnableZoomControls(config.Element, value);
@@ -87,7 +87,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (bool)element.GetValue(DisplayZoomControlsProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls'][1]/Docs" />
 		public static void SetDisplayZoomControls(FormsElement element, bool value)
 		{
 			element.SetValue(DisplayZoomControlsProperty, value);
@@ -105,7 +105,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetDisplayZoomControls(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetDisplayZoomControls'][2]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetDisplayZoomControls(this IPlatformElementConfiguration<Android, FormsElement> config, bool value)
 		{
 			SetDisplayZoomControls(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return (MixedContentHandling)element.GetValue(MixedContentModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetMixedContentMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetMixedContentMode' and position()=0]/Docs" />
 		public static void SetMixedContentMode(BindableObject element, MixedContentHandling value)
 		{
 			element.SetValue(MixedContentModeProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/AndroidSpecific/WebView.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 			return GetMixedContentMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetMixedContentMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific/WebView.xml" path="//Member[@MemberName='SetMixedContentMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Android, FormsElement> SetMixedContentMode(this IPlatformElementConfiguration<Android, FormsElement> config, MixedContentHandling value)
 		{
 			SetMixedContentMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
@@ -22,14 +22,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			element.SetValue(HasCornerRadiusProperty, tabPosition);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='GetHasCornerRadius']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='GetHasCornerRadius' and position()=1]/Docs" />
 		public static bool GetHasCornerRadius(
 			this IPlatformElementConfiguration<GTK, FormsElement> config)
 		{
 			return GetHasCornerRadius(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='SetHasCornerRadius']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='SetHasCornerRadius' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<GTK, FormsElement> SetHasCornerRadius(
 			this IPlatformElementConfiguration<GTK, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			BindableProperty.Create("HasCornerRadius", typeof(bool),
 				typeof(BoxView), default(bool));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='GetHasCornerRadius'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='GetHasCornerRadius' and position()=0]/Docs" />
 		public static bool GetHasCornerRadius(BindableObject element)
 		{
 			return (bool)element.GetValue(HasCornerRadiusProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='SetHasCornerRadius'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='SetHasCornerRadius' and position()=0]/Docs" />
 		public static void SetHasCornerRadius(BindableObject element, bool tabPosition)
 		{
 			element.SetValue(HasCornerRadiusProperty, tabPosition);

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/BoxView.cs
@@ -10,26 +10,26 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			BindableProperty.Create("HasCornerRadius", typeof(bool),
 				typeof(BoxView), default(bool));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='GetHasCornerRadius' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='GetHasCornerRadius'][1]/Docs" />
 		public static bool GetHasCornerRadius(BindableObject element)
 		{
 			return (bool)element.GetValue(HasCornerRadiusProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='SetHasCornerRadius' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='SetHasCornerRadius'][1]/Docs" />
 		public static void SetHasCornerRadius(BindableObject element, bool tabPosition)
 		{
 			element.SetValue(HasCornerRadiusProperty, tabPosition);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='GetHasCornerRadius' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='GetHasCornerRadius'][2]/Docs" />
 		public static bool GetHasCornerRadius(
 			this IPlatformElementConfiguration<GTK, FormsElement> config)
 		{
 			return GetHasCornerRadius(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='SetHasCornerRadius' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/BoxView.xml" path="//Member[@MemberName='SetHasCornerRadius'][2]/Docs" />
 		public static IPlatformElementConfiguration<GTK, FormsElement> SetHasCornerRadius(
 			this IPlatformElementConfiguration<GTK, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
@@ -22,14 +22,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			element.SetValue(BackButtonIconProperty, backButtonIcon);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonIcon']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonIcon' and position()=1]/Docs" />
 		public static string GetBackButtonIcon(
 			this IPlatformElementConfiguration<GTK, FormsElement> config)
 		{
 			return GetBackButtonIcon(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='SetBackButtonIcon']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='SetBackButtonIcon' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<GTK, FormsElement> SetBackButtonIcon(
 			this IPlatformElementConfiguration<GTK, FormsElement> config, string value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			BindableProperty.Create("BackButtonIcon", typeof(string),
 				typeof(NavigationPage), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonIcon'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonIcon' and position()=0]/Docs" />
 		public static string GetBackButtonIcon(BindableObject element)
 		{
 			return (string)element.GetValue(BackButtonIconProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='SetBackButtonIcon'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='SetBackButtonIcon' and position()=0]/Docs" />
 		public static void SetBackButtonIcon(BindableObject element, string backButtonIcon)
 		{
 			element.SetValue(BackButtonIconProperty, backButtonIcon);

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/NavigationPage.cs
@@ -10,26 +10,26 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			BindableProperty.Create("BackButtonIcon", typeof(string),
 				typeof(NavigationPage), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonIcon' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonIcon'][1]/Docs" />
 		public static string GetBackButtonIcon(BindableObject element)
 		{
 			return (string)element.GetValue(BackButtonIconProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='SetBackButtonIcon' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='SetBackButtonIcon'][1]/Docs" />
 		public static void SetBackButtonIcon(BindableObject element, string backButtonIcon)
 		{
 			element.SetValue(BackButtonIconProperty, backButtonIcon);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonIcon' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='GetBackButtonIcon'][2]/Docs" />
 		public static string GetBackButtonIcon(
 			this IPlatformElementConfiguration<GTK, FormsElement> config)
 		{
 			return GetBackButtonIcon(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='SetBackButtonIcon' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/NavigationPage.xml" path="//Member[@MemberName='SetBackButtonIcon'][2]/Docs" />
 		public static IPlatformElementConfiguration<GTK, FormsElement> SetBackButtonIcon(
 			this IPlatformElementConfiguration<GTK, FormsElement> config, string value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/TabbedPage.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			BindableProperty.Create("TabPosition", typeof(TabPosition),
 				typeof(TabbedPage), TabPosition.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabPosition'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabPosition' and position()=0]/Docs" />
 		public static TabPosition GetTabPosition(BindableObject element)
 		{
 			return (TabPosition)element.GetValue(TabPositionProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTabPosition'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTabPosition' and position()=0]/Docs" />
 		public static void SetTabPosition(BindableObject element, TabPosition tabPosition)
 		{
 			element.SetValue(TabPositionProperty, tabPosition);

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/TabbedPage.cs
@@ -10,26 +10,26 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			BindableProperty.Create("TabPosition", typeof(TabPosition),
 				typeof(TabbedPage), TabPosition.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabPosition' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabPosition'][1]/Docs" />
 		public static TabPosition GetTabPosition(BindableObject element)
 		{
 			return (TabPosition)element.GetValue(TabPositionProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTabPosition' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTabPosition'][1]/Docs" />
 		public static void SetTabPosition(BindableObject element, TabPosition tabPosition)
 		{
 			element.SetValue(TabPositionProperty, tabPosition);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabPosition' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabPosition'][2]/Docs" />
 		public static TabPosition GetTabPosition(
 			this IPlatformElementConfiguration<GTK, FormsElement> config)
 		{
 			return GetTabPosition(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTabPosition' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTabPosition'][2]/Docs" />
 		public static IPlatformElementConfiguration<GTK, FormsElement> SetTabPosition(
 			this IPlatformElementConfiguration<GTK, FormsElement> config, TabPosition value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/GTKSpecific/TabbedPage.cs
@@ -22,14 +22,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific
 			element.SetValue(TabPositionProperty, tabPosition);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabPosition']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabPosition' and position()=1]/Docs" />
 		public static TabPosition GetTabPosition(
 			this IPlatformElementConfiguration<GTK, FormsElement> config)
 		{
 			return GetTabPosition(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTabPosition']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.GTKSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTabPosition' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<GTK, FormsElement> SetTabPosition(
 			this IPlatformElementConfiguration<GTK, FormsElement> config, TabPosition value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='UseBezelInteractionProperty']/Docs" />
 		public static readonly BindableProperty UseBezelInteractionProperty = BindableProperty.Create("UseBezelInteraction", typeof(bool), typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction' and position()=0]/Docs" />
 		public static bool GetUseBezelInteraction(BindableObject element)
 		{
 			return (bool)element.GetValue(UseBezelInteractionProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetUseBezelInteraction'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetUseBezelInteraction' and position()=0]/Docs" />
 		public static void SetUseBezelInteraction(BindableObject element, bool value)
 		{
 			element.SetValue(UseBezelInteractionProperty, value);
@@ -38,13 +38,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='OverlayContentProperty']/Docs" />
 		public static readonly BindableProperty OverlayContentProperty = BindableProperty.CreateAttached("OverlayContent", typeof(View), typeof(FormsElement), default(View));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent' and position()=0]/Docs" />
 		public static View GetOverlayContent(BindableObject application)
 		{
 			return (View)application.GetValue(OverlayContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetOverlayContent'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetOverlayContent' and position()=0]/Docs" />
 		public static void SetOverlayContent(BindableObject application, View value)
 		{
 			application.SetValue(OverlayContentProperty, value);
@@ -66,13 +66,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='ActiveBezelInteractionElementPropertyKey']/Docs" />
 		public static readonly BindablePropertyKey ActiveBezelInteractionElementPropertyKey = BindableProperty.CreateAttachedReadOnly("ActiveBezelInteractionElement", typeof(Element), typeof(FormsElement), default(Element));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetActiveBezelInteractionElement'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetActiveBezelInteractionElement' and position()=0]/Docs" />
 		public static Element GetActiveBezelInteractionElement(BindableObject application)
 		{
 			return (Element)application.GetValue(ActiveBezelInteractionElementPropertyKey.BindableProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetActiveBezelInteractionElement'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetActiveBezelInteractionElement' and position()=0]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetActiveBezelInteractionElement(BindableObject application, Element value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
@@ -10,25 +10,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='UseBezelInteractionProperty']/Docs" />
 		public static readonly BindableProperty UseBezelInteractionProperty = BindableProperty.Create("UseBezelInteraction", typeof(bool), typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction'][1]/Docs" />
 		public static bool GetUseBezelInteraction(BindableObject element)
 		{
 			return (bool)element.GetValue(UseBezelInteractionProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetUseBezelInteraction' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetUseBezelInteraction'][1]/Docs" />
 		public static void SetUseBezelInteraction(BindableObject element, bool value)
 		{
 			element.SetValue(UseBezelInteractionProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction'][2]/Docs" />
 		public static bool GetUseBezelInteraction(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetUseBezelInteraction(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetUseBezelInteraction' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetUseBezelInteraction'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetUseBezelInteraction(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool value)
 		{
 			SetUseBezelInteraction(config.Element, value);
@@ -38,25 +38,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='OverlayContentProperty']/Docs" />
 		public static readonly BindableProperty OverlayContentProperty = BindableProperty.CreateAttached("OverlayContent", typeof(View), typeof(FormsElement), default(View));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent'][1]/Docs" />
 		public static View GetOverlayContent(BindableObject application)
 		{
 			return (View)application.GetValue(OverlayContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetOverlayContent' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetOverlayContent'][1]/Docs" />
 		public static void SetOverlayContent(BindableObject application, View value)
 		{
 			application.SetValue(OverlayContentProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent'][2]/Docs" />
 		public static View GetOverlayContent(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetOverlayContent(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetOverlayContent' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetOverlayContent'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetOverlayContent(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetOverlayContent(config.Element, value);
@@ -66,26 +66,26 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='ActiveBezelInteractionElementPropertyKey']/Docs" />
 		public static readonly BindablePropertyKey ActiveBezelInteractionElementPropertyKey = BindableProperty.CreateAttachedReadOnly("ActiveBezelInteractionElement", typeof(Element), typeof(FormsElement), default(Element));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetActiveBezelInteractionElement' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetActiveBezelInteractionElement'][1]/Docs" />
 		public static Element GetActiveBezelInteractionElement(BindableObject application)
 		{
 			return (Element)application.GetValue(ActiveBezelInteractionElementPropertyKey.BindableProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetActiveBezelInteractionElement' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetActiveBezelInteractionElement'][1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetActiveBezelInteractionElement(BindableObject application, Element value)
 		{
 			application.SetValue(ActiveBezelInteractionElementPropertyKey, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetActiveBezelInteractionElement' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetActiveBezelInteractionElement'][2]/Docs" />
 		public static Element GetActiveBezelInteractionElement(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetActiveBezelInteractionElement(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetActiveBezelInteractionElement' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetActiveBezelInteractionElement'][2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetActiveBezelInteractionElement(this IPlatformElementConfiguration<Tizen, FormsElement> config, Element value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Application.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(UseBezelInteractionProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetUseBezelInteraction' and position()=1]/Docs" />
 		public static bool GetUseBezelInteraction(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetUseBezelInteraction(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetUseBezelInteraction']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetUseBezelInteraction' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetUseBezelInteraction(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool value)
 		{
 			SetUseBezelInteraction(config.Element, value);
@@ -50,13 +50,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			application.SetValue(OverlayContentProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetOverlayContent' and position()=1]/Docs" />
 		public static View GetOverlayContent(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetOverlayContent(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetOverlayContent']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetOverlayContent' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetOverlayContent(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetOverlayContent(config.Element, value);
@@ -79,13 +79,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			application.SetValue(ActiveBezelInteractionElementPropertyKey, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetActiveBezelInteractionElement']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='GetActiveBezelInteractionElement' and position()=1]/Docs" />
 		public static Element GetActiveBezelInteractionElement(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetActiveBezelInteractionElement(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetActiveBezelInteractionElement']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Application.xml" path="//Member[@MemberName='SetActiveBezelInteractionElement' and position()=1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetActiveBezelInteractionElement(this IPlatformElementConfiguration<Tizen, FormsElement> config, Element value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Entry.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(FontWeightProperty, weight);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight' and position()=1]/Docs" />
 		public static string GetFontWeight(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetFontWeight(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='SetFontWeight']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='SetFontWeight' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFontWeight(this IPlatformElementConfiguration<Tizen, FormsElement> config, string weight)
 		{
 			SetFontWeight(config.Element, weight);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Entry.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='FontWeightProperty']/Docs" />
 		public static readonly BindableProperty FontWeightProperty = BindableProperty.Create("FontWeight", typeof(string), typeof(FormsElement), FontWeight.None);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight' and position()=0]/Docs" />
 		public static string GetFontWeight(BindableObject element)
 		{
 			return (string)element.GetValue(FontWeightProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='SetFontWeight'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='SetFontWeight' and position()=0]/Docs" />
 		public static void SetFontWeight(BindableObject element, string weight)
 		{
 			element.SetValue(FontWeightProperty, weight);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Entry.cs
@@ -8,25 +8,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='FontWeightProperty']/Docs" />
 		public static readonly BindableProperty FontWeightProperty = BindableProperty.Create("FontWeight", typeof(string), typeof(FormsElement), FontWeight.None);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight'][1]/Docs" />
 		public static string GetFontWeight(BindableObject element)
 		{
 			return (string)element.GetValue(FontWeightProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='SetFontWeight' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='SetFontWeight'][1]/Docs" />
 		public static void SetFontWeight(BindableObject element, string weight)
 		{
 			element.SetValue(FontWeightProperty, weight);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='GetFontWeight'][2]/Docs" />
 		public static string GetFontWeight(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetFontWeight(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='SetFontWeight' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Entry.xml" path="//Member[@MemberName='SetFontWeight'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFontWeight(this IPlatformElementConfiguration<Tizen, FormsElement> config, string weight)
 		{
 			SetFontWeight(config.Element, weight);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
+namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 {
 	using Microsoft.Maui.Graphics;
 	using FormsElement = Maui.Controls.Image;
@@ -24,13 +24,13 @@
 			element.SetValue(BlendColorProperty, color);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor' and position()=1]/Docs" />
 		public static Color GetBlendColor(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetBlendColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetBlendColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetBlendColor' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetBlendColor(this IPlatformElementConfiguration<Tizen, FormsElement> config, Color color)
 		{
 			SetBlendColor(config.Element, color);
@@ -49,13 +49,13 @@
 			element.SetValue(FileProperty, file);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetFile']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetFile' and position()=1]/Docs" />
 		public static string GetFile(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetFile(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetFile']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetFile' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFile(this IPlatformElementConfiguration<Tizen, FormsElement> config, string file)
 		{
 			SetFile(config.Element, file);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
@@ -12,50 +12,50 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='FileProperty']/Docs" />
 		public static readonly BindableProperty FileProperty = BindableProperty.Create("File", typeof(string), typeof(FormsElement), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor'][1]/Docs" />
 		public static Color GetBlendColor(BindableObject element)
 		{
 			return (Color)element.GetValue(BlendColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetBlendColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetBlendColor'][1]/Docs" />
 		public static void SetBlendColor(BindableObject element, Color color)
 		{
 			element.SetValue(BlendColorProperty, color);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor'][2]/Docs" />
 		public static Color GetBlendColor(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetBlendColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetBlendColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetBlendColor'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetBlendColor(this IPlatformElementConfiguration<Tizen, FormsElement> config, Color color)
 		{
 			SetBlendColor(config.Element, color);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetFile' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetFile'][1]/Docs" />
 		public static string GetFile(BindableObject element)
 		{
 			return (string)element.GetValue(FileProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetFile' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetFile'][1]/Docs" />
 		public static void SetFile(BindableObject element, string file)
 		{
 			element.SetValue(FileProperty, file);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetFile' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetFile'][2]/Docs" />
 		public static string GetFile(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetFile(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetFile' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetFile'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFile(this IPlatformElementConfiguration<Tizen, FormsElement> config, string file)
 		{
 			SetFile(config.Element, file);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Image.cs
@@ -12,13 +12,13 @@
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='FileProperty']/Docs" />
 		public static readonly BindableProperty FileProperty = BindableProperty.Create("File", typeof(string), typeof(FormsElement), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetBlendColor' and position()=0]/Docs" />
 		public static Color GetBlendColor(BindableObject element)
 		{
 			return (Color)element.GetValue(BlendColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetBlendColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetBlendColor' and position()=0]/Docs" />
 		public static void SetBlendColor(BindableObject element, Color color)
 		{
 			element.SetValue(BlendColorProperty, color);
@@ -37,13 +37,13 @@
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetFile'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='GetFile' and position()=0]/Docs" />
 		public static string GetFile(BindableObject element)
 		{
 			return (string)element.GetValue(FileProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetFile'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Image.xml" path="//Member[@MemberName='SetFile' and position()=0]/Docs" />
 		public static void SetFile(BindableObject element, string file)
 		{
 			element.SetValue(FileProperty, file);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Label.cs
@@ -8,25 +8,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='FontWeightProperty']/Docs" />
 		public static readonly BindableProperty FontWeightProperty = BindableProperty.Create("FontWeight", typeof(string), typeof(FormsElement), FontWeight.None);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight'][1]/Docs" />
 		public static string GetFontWeight(BindableObject element)
 		{
 			return (string)element.GetValue(FontWeightProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='SetFontWeight' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='SetFontWeight'][1]/Docs" />
 		public static void SetFontWeight(BindableObject element, string weight)
 		{
 			element.SetValue(FontWeightProperty, weight);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight'][2]/Docs" />
 		public static string GetFontWeight(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetFontWeight(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='SetFontWeight' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='SetFontWeight'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFontWeight(this IPlatformElementConfiguration<Tizen, FormsElement> config, string weight)
 		{
 			SetFontWeight(config.Element, weight);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Label.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(FontWeightProperty, weight);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight' and position()=1]/Docs" />
 		public static string GetFontWeight(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetFontWeight(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='SetFontWeight']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='SetFontWeight' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFontWeight(this IPlatformElementConfiguration<Tizen, FormsElement> config, string weight)
 		{
 			SetFontWeight(config.Element, weight);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Label.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='FontWeightProperty']/Docs" />
 		public static readonly BindableProperty FontWeightProperty = BindableProperty.Create("FontWeight", typeof(string), typeof(FormsElement), FontWeight.None);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='GetFontWeight' and position()=0]/Docs" />
 		public static string GetFontWeight(BindableObject element)
 		{
 			return (string)element.GetValue(FontWeightProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='SetFontWeight'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Label.xml" path="//Member[@MemberName='SetFontWeight' and position()=0]/Docs" />
 		public static void SetFontWeight(BindableObject element, string weight)
 		{
 			element.SetValue(FontWeightProperty, weight);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return (bool)element.GetValue(HasBreadCrumbsBarProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHasBreadCrumbsBar' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHasBreadCrumbsBar'][1]/Docs" />
 		public static void SetHasBreadCrumbsBar(BindableObject element, bool value)
 		{
 			element.SetValue(HasBreadCrumbsBarProperty, value);
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return GetHasBreadCrumbsBar(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHasBreadCrumbsBar' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHasBreadCrumbsBar'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetHasBreadCrumbsBar(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool value)
 		{
 			SetHasBreadCrumbsBar(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return GetHasBreadCrumbsBar(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHasBreadCrumbsBar']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHasBreadCrumbsBar' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetHasBreadCrumbsBar(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool value)
 		{
 			SetHasBreadCrumbsBar(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/NavigationPage.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return (bool)element.GetValue(HasBreadCrumbsBarProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHasBreadCrumbsBar'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHasBreadCrumbsBar' and position()=0]/Docs" />
 		public static void SetHasBreadCrumbsBar(BindableObject element, bool value)
 		{
 			element.SetValue(HasBreadCrumbsBarProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
@@ -10,25 +10,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		public static readonly BindableProperty BreadCrumbProperty
 			= BindableProperty.CreateAttached("BreadCrumb", typeof(string), typeof(FormsElement), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='GetBreadCrumb' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='GetBreadCrumb'][1]/Docs" />
 		public static string GetBreadCrumb(BindableObject page)
 		{
 			return (string)page.GetValue(BreadCrumbProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='SetBreadCrumb' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='SetBreadCrumb'][1]/Docs" />
 		public static void SetBreadCrumb(BindableObject page, string value)
 		{
 			page.SetValue(BreadCrumbProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='GetBreadCrumb' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='GetBreadCrumb'][2]/Docs" />
 		public static string GetBreadCrumb(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetBreadCrumb(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='SetBreadCrumb' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='SetBreadCrumb'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetBreadCrumb(this IPlatformElementConfiguration<Tizen, FormsElement> config, string value)
 		{
 			SetBreadCrumb(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			page.SetValue(BreadCrumbProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='GetBreadCrumb']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='GetBreadCrumb' and position()=1]/Docs" />
 		public static string GetBreadCrumb(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetBreadCrumb(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='SetBreadCrumb']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='SetBreadCrumb' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetBreadCrumb(this IPlatformElementConfiguration<Tizen, FormsElement> config, string value)
 		{
 			SetBreadCrumb(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Page.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		public static readonly BindableProperty BreadCrumbProperty
 			= BindableProperty.CreateAttached("BreadCrumb", typeof(string), typeof(FormsElement), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='GetBreadCrumb'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='GetBreadCrumb' and position()=0]/Docs" />
 		public static string GetBreadCrumb(BindableObject page)
 		{
 			return (string)page.GetValue(BreadCrumbProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='SetBreadCrumb'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Page.xml" path="//Member[@MemberName='SetBreadCrumb' and position()=0]/Docs" />
 		public static void SetBreadCrumb(BindableObject page, string value)
 		{
 			page.SetValue(BreadCrumbProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			}
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='GetPulsingStatus']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='GetPulsingStatus' and position()=1]/Docs" />
 		public static bool GetPulsingStatus(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetPulsingStatus(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='SetPulsingStatus']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='SetPulsingStatus' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetPulsingStatus(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool isPulsing)
 		{
 			SetPulsingStatus(config.Element, isPulsing);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			BindableProperty.Create("ProgressBarPulsingStatus", typeof(bool),
 			typeof(FormsElement), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='GetPulsingStatus'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='GetPulsingStatus' and position()=0]/Docs" />
 		public static bool GetPulsingStatus(BindableObject element)
 		{
 			return (bool)element.GetValue(ProgressBarPulsingStatusProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='SetPulsingStatus'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='SetPulsingStatus' and position()=0]/Docs" />
 		public static void SetPulsingStatus(BindableObject element, bool isPulsing)
 		{
 			string style = VisualElement.GetStyle(element);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/ProgressBar.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			BindableProperty.Create("ProgressBarPulsingStatus", typeof(bool),
 			typeof(FormsElement), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='GetPulsingStatus' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='GetPulsingStatus'][1]/Docs" />
 		public static bool GetPulsingStatus(BindableObject element)
 		{
 			return (bool)element.GetValue(ProgressBarPulsingStatusProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='SetPulsingStatus' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='SetPulsingStatus'][1]/Docs" />
 		public static void SetPulsingStatus(BindableObject element, bool isPulsing)
 		{
 			string style = VisualElement.GetStyle(element);
@@ -27,13 +27,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			}
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='GetPulsingStatus' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='GetPulsingStatus'][2]/Docs" />
 		public static bool GetPulsingStatus(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetPulsingStatus(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='SetPulsingStatus' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/ProgressBar.xml" path="//Member[@MemberName='SetPulsingStatus'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetPulsingStatus(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool isPulsing)
 		{
 			SetPulsingStatus(config.Element, isPulsing);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
@@ -10,25 +10,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='ColorProperty']/Docs" />
 		public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(FormsElement), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor'][1]/Docs" />
 		public static Color GetColor(BindableObject element)
 		{
 			return (Color)element.GetValue(ColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor'][1]/Docs" />
 		public static void SetColor(BindableObject element, Color color)
 		{
 			element.SetValue(ColorProperty, color);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor'][2]/Docs" />
 		public static Color GetColor(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetColor(this IPlatformElementConfiguration<Tizen, FormsElement> config, Color color)
 		{
 			SetColor(config.Element, color);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 {
 	using Microsoft.Maui.Graphics;
@@ -22,13 +22,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(ColorProperty, color);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor' and position()=1]/Docs" />
 		public static Color GetColor(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetColor(this IPlatformElementConfiguration<Tizen, FormsElement> config, Color color)
 		{
 			SetColor(config.Element, color);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/Switch.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='ColorProperty']/Docs" />
 		public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(FormsElement), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='GetColor' and position()=0]/Docs" />
 		public static Color GetColor(BindableObject element)
 		{
 			return (Color)element.GetValue(ColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/Switch.xml" path="//Member[@MemberName='SetColor' and position()=0]/Docs" />
 		public static void SetColor(BindableObject element, Color color)
 		{
 			element.SetValue(ColorProperty, color);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
@@ -37,78 +37,78 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='ToolTipProperty']/Docs" />
 		public static readonly BindableProperty ToolTipProperty = BindableProperty.Create("ToolTip", typeof(string), typeof(VisualElement), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle'][1]/Docs" />
 		public static string GetStyle(BindableObject element)
 		{
 			return (string)element.GetValue(StyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetStyle'][1]/Docs" />
 		public static void SetStyle(BindableObject element, string value)
 		{
 			element.SetValue(StyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle'][2]/Docs" />
 		public static string GetStyle(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetStyle(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetStyle'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetStyle(this IPlatformElementConfiguration<Tizen, FormsElement> config, string value)
 		{
 			SetStyle(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowed' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowed'][1]/Docs" />
 		public static bool? IsFocusAllowed(BindableObject element)
 		{
 			return (bool?)element.GetValue(IsFocusAllowedProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetFocusAllowed' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetFocusAllowed'][1]/Docs" />
 		public static void SetFocusAllowed(BindableObject element, bool value)
 		{
 			element.SetValue(IsFocusAllowedProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowed' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowed'][2]/Docs" />
 		public static bool? IsFocusAllowed(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return IsFocusAllowed(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetFocusAllowed' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetFocusAllowed'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFocusAllowed(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool value)
 		{
 			SetFocusAllowed(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDirection' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDirection'][1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static string GetNextFocusDirection(BindableObject element)
 		{
 			return (string)element.GetValue(NextFocusDirectionProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDirection' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDirection'][1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetNextFocusDirection(BindableObject element, string value)
 		{
 			element.SetValue(NextFocusDirectionProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDirection' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDirection'][2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static string GetNextFocusDirection(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusDirection(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDirection' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDirection'][2]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusDirection(this IPlatformElementConfiguration<Tizen, FormsElement> config, string value)
 		{
@@ -158,150 +158,150 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusUpView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusUpView'][1]/Docs" />
 		public static View GetNextFocusUpView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusUpViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusUpView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusUpView'][1]/Docs" />
 		public static void SetNextFocusUpView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusUpViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusUpView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusUpView'][2]/Docs" />
 		public static View GetNextFocusUpView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusUpView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusUpView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusUpView'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusUpView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusUpView(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDownView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDownView'][1]/Docs" />
 		public static View GetNextFocusDownView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusDownViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDownView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDownView'][1]/Docs" />
 		public static void SetNextFocusDownView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusDownViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDownView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDownView'][2]/Docs" />
 		public static View GetNextFocusDownView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusDownView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDownView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDownView'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusDownView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusDownView(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusLeftView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusLeftView'][1]/Docs" />
 		public static View GetNextFocusLeftView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusLeftViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusLeftView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusLeftView'][1]/Docs" />
 		public static void SetNextFocusLeftView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusLeftViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusLeftView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusLeftView'][2]/Docs" />
 		public static View GetNextFocusLeftView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusLeftView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusLeftView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusLeftView'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusLeftView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusLeftView(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusRightView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusRightView'][1]/Docs" />
 		public static View GetNextFocusRightView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusRightViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusRightView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusRightView'][1]/Docs" />
 		public static void SetNextFocusRightView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusRightViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusRightView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusRightView'][2]/Docs" />
 		public static View GetNextFocusRightView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusRightView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusRightView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusRightView'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusRightView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusRightView(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusBackView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusBackView'][1]/Docs" />
 		public static View GetNextFocusBackView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusBackViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusBackView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusBackView'][1]/Docs" />
 		public static void SetNextFocusBackView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusBackViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusBackView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusBackView'][2]/Docs" />
 		public static View GetNextFocusBackView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusBackView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusBackView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusBackView'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusBackView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusBackView(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusForwardView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusForwardView'][1]/Docs" />
 		public static View GetNextFocusForwardView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusForwardViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusForwardView' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusForwardView'][1]/Docs" />
 		public static void SetNextFocusForwardView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusForwardViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusForwardView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusForwardView'][2]/Docs" />
 		public static View GetNextFocusForwardView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusForwardView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusForwardView' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusForwardView'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusForwardView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusForwardView(config.Element, value);
@@ -313,25 +313,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			bindable.SetValue(NextFocusDirectionProperty, FocusDirection.None);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetToolTip' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetToolTip'][1]/Docs" />
 		public static string GetToolTip(BindableObject element)
 		{
 			return (string)element.GetValue(ToolTipProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetToolTip' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetToolTip'][1]/Docs" />
 		public static void SetToolTip(BindableObject element, string value)
 		{
 			element.SetValue(ToolTipProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetToolTip' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetToolTip'][2]/Docs" />
 		public static string GetToolTip(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetToolTip(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetToolTip' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetToolTip'][2]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetToolTip(this IPlatformElementConfiguration<Tizen, FormsElement> config, string value)
 		{
 			SetToolTip(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
@@ -37,13 +37,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='ToolTipProperty']/Docs" />
 		public static readonly BindableProperty ToolTipProperty = BindableProperty.Create("ToolTip", typeof(string), typeof(VisualElement), default(string));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle' and position()=0]/Docs" />
 		public static string GetStyle(BindableObject element)
 		{
 			return (string)element.GetValue(StyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetStyle' and position()=0]/Docs" />
 		public static void SetStyle(BindableObject element, string value)
 		{
 			element.SetValue(StyleProperty, value);
@@ -62,13 +62,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowed'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowed' and position()=0]/Docs" />
 		public static bool? IsFocusAllowed(BindableObject element)
 		{
 			return (bool?)element.GetValue(IsFocusAllowedProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetFocusAllowed'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetFocusAllowed' and position()=0]/Docs" />
 		public static void SetFocusAllowed(BindableObject element, bool value)
 		{
 			element.SetValue(IsFocusAllowedProperty, value);
@@ -87,14 +87,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDirection'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDirection' and position()=0]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static string GetNextFocusDirection(BindableObject element)
 		{
 			return (string)element.GetValue(NextFocusDirectionProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDirection'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDirection' and position()=0]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void SetNextFocusDirection(BindableObject element, string value)
 		{
@@ -158,13 +158,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusUpView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusUpView' and position()=0]/Docs" />
 		public static View GetNextFocusUpView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusUpViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusUpView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusUpView' and position()=0]/Docs" />
 		public static void SetNextFocusUpView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusUpViewProperty, value);
@@ -183,13 +183,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDownView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDownView' and position()=0]/Docs" />
 		public static View GetNextFocusDownView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusDownViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDownView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDownView' and position()=0]/Docs" />
 		public static void SetNextFocusDownView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusDownViewProperty, value);
@@ -208,13 +208,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusLeftView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusLeftView' and position()=0]/Docs" />
 		public static View GetNextFocusLeftView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusLeftViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusLeftView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusLeftView' and position()=0]/Docs" />
 		public static void SetNextFocusLeftView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusLeftViewProperty, value);
@@ -233,13 +233,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusRightView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusRightView' and position()=0]/Docs" />
 		public static View GetNextFocusRightView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusRightViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusRightView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusRightView' and position()=0]/Docs" />
 		public static void SetNextFocusRightView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusRightViewProperty, value);
@@ -258,13 +258,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusBackView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusBackView' and position()=0]/Docs" />
 		public static View GetNextFocusBackView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusBackViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusBackView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusBackView' and position()=0]/Docs" />
 		public static void SetNextFocusBackView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusBackViewProperty, value);
@@ -283,13 +283,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusForwardView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusForwardView' and position()=0]/Docs" />
 		public static View GetNextFocusForwardView(BindableObject element)
 		{
 			return (View)element.GetValue(NextFocusForwardViewProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusForwardView'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusForwardView' and position()=0]/Docs" />
 		public static void SetNextFocusForwardView(BindableObject element, View value)
 		{
 			element.SetValue(NextFocusForwardViewProperty, value);
@@ -313,13 +313,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			bindable.SetValue(NextFocusDirectionProperty, FocusDirection.None);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetToolTip'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetToolTip' and position()=0]/Docs" />
 		public static string GetToolTip(BindableObject element)
 		{
 			return (string)element.GetValue(ToolTipProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetToolTip'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetToolTip' and position()=0]/Docs" />
 		public static void SetToolTip(BindableObject element, string value)
 		{
 			element.SetValue(ToolTipProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/TizenSpecific/VisualElement.cs
@@ -49,13 +49,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(StyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetStyle' and position()=1]/Docs" />
 		public static string GetStyle(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetStyle(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetStyle' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetStyle(this IPlatformElementConfiguration<Tizen, FormsElement> config, string value)
 		{
 			SetStyle(config.Element, value);
@@ -74,13 +74,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(IsFocusAllowedProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowed']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='IsFocusAllowed' and position()=1]/Docs" />
 		public static bool? IsFocusAllowed(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return IsFocusAllowed(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetFocusAllowed']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetFocusAllowed' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFocusAllowed(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool value)
 		{
 			SetFocusAllowed(config.Element, value);
@@ -101,14 +101,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(NextFocusDirectionProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDirection']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDirection' and position()=1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static string GetNextFocusDirection(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusDirection(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDirection']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDirection' and position()=1]/Docs" />
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusDirection(this IPlatformElementConfiguration<Tizen, FormsElement> config, string value)
 		{
@@ -170,13 +170,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(NextFocusUpViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusUpView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusUpView' and position()=1]/Docs" />
 		public static View GetNextFocusUpView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusUpView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusUpView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusUpView' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusUpView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusUpView(config.Element, value);
@@ -195,13 +195,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(NextFocusDownViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDownView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusDownView' and position()=1]/Docs" />
 		public static View GetNextFocusDownView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusDownView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDownView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusDownView' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusDownView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusDownView(config.Element, value);
@@ -220,13 +220,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(NextFocusLeftViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusLeftView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusLeftView' and position()=1]/Docs" />
 		public static View GetNextFocusLeftView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusLeftView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusLeftView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusLeftView' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusLeftView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusLeftView(config.Element, value);
@@ -245,13 +245,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(NextFocusRightViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusRightView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusRightView' and position()=1]/Docs" />
 		public static View GetNextFocusRightView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusRightView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusRightView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusRightView' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusRightView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusRightView(config.Element, value);
@@ -270,13 +270,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(NextFocusBackViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusBackView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusBackView' and position()=1]/Docs" />
 		public static View GetNextFocusBackView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusBackView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusBackView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusBackView' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusBackView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusBackView(config.Element, value);
@@ -295,13 +295,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(NextFocusForwardViewProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusForwardView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetNextFocusForwardView' and position()=1]/Docs" />
 		public static View GetNextFocusForwardView(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetNextFocusForwardView(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusForwardView']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetNextFocusForwardView' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetNextFocusForwardView(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetNextFocusForwardView(config.Element, value);
@@ -325,13 +325,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific
 			element.SetValue(ToolTipProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetToolTip']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='GetToolTip' and position()=1]/Docs" />
 		public static string GetToolTip(this IPlatformElementConfiguration<Tizen, FormsElement> config)
 		{
 			return GetToolTip(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetToolTip']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.TizenSpecific/VisualElement.xml" path="//Member[@MemberName='SetToolTip' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetToolTip(this IPlatformElementConfiguration<Tizen, FormsElement> config, string value)
 		{
 			SetToolTip(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(ImageDirectoryProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='GetImageDirectory']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='GetImageDirectory' and position()=1]/Docs" />
 		public static string GetImageDirectory(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (string)config.Element.GetValue(ImageDirectoryProperty);
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (string)element.GetValue(ImageDirectoryProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='SetImageDirectory']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='SetImageDirectory' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetImageDirectory(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, string value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.Create("ImageDirectory", typeof(string), typeof(FormsElement), string.Empty,
 				propertyChanged: OnImageDirectoryChanged);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='SetImageDirectory'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='SetImageDirectory' and position()=0]/Docs" />
 		public static void SetImageDirectory(BindableObject element, string value)
 		{
 			element.SetValue(ImageDirectoryProperty, value);
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (string)config.Element.GetValue(ImageDirectoryProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='GetImageDirectory'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='GetImageDirectory' and position()=0]/Docs" />
 		public static string GetImageDirectory(BindableObject element)
 		{
 			return (string)element.GetValue(ImageDirectoryProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Application.cs
@@ -11,25 +11,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.Create("ImageDirectory", typeof(string), typeof(FormsElement), string.Empty,
 				propertyChanged: OnImageDirectoryChanged);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='SetImageDirectory' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='SetImageDirectory'][1]/Docs" />
 		public static void SetImageDirectory(BindableObject element, string value)
 		{
 			element.SetValue(ImageDirectoryProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='GetImageDirectory' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='GetImageDirectory'][2]/Docs" />
 		public static string GetImageDirectory(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (string)config.Element.GetValue(ImageDirectoryProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='GetImageDirectory' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='GetImageDirectory'][1]/Docs" />
 		public static string GetImageDirectory(BindableObject element)
 		{
 			return (string)element.GetValue(ImageDirectoryProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='SetImageDirectory' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Application.xml" path="//Member[@MemberName='SetImageDirectory'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetImageDirectory(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, string value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("CollapseStyle", typeof(CollapseStyle),
 				typeof(FlyoutPage), CollapseStyle.Full);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle' and position()=0]/Docs" />
 		public static CollapseStyle GetCollapseStyle(BindableObject element)
 		{
 			return (CollapseStyle)element.GetValue(CollapseStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetCollapseStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetCollapseStyle' and position()=0]/Docs" />
 		public static void SetCollapseStyle(BindableObject element, CollapseStyle collapseStyle)
 		{
 			element.SetValue(CollapseStyleProperty, collapseStyle);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -69,13 +69,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(CollapsedPaneWidthProperty, collapsedPaneWidth);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidth']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidth' and position()=0]/Docs" />
 		public static double CollapsedPaneWidth(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (double)config.Element.GetValue(CollapsedPaneWidthProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidth']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidth' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> CollapsedPaneWidth(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, double value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -14,25 +14,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("CollapseStyle", typeof(CollapseStyle),
 				typeof(FlyoutPage), CollapseStyle.Full);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle'][1]/Docs" />
 		public static CollapseStyle GetCollapseStyle(BindableObject element)
 		{
 			return (CollapseStyle)element.GetValue(CollapseStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetCollapseStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetCollapseStyle'][1]/Docs" />
 		public static void SetCollapseStyle(BindableObject element, CollapseStyle collapseStyle)
 		{
 			element.SetValue(CollapseStyleProperty, collapseStyle);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle'][2]/Docs" />
 		public static CollapseStyle GetCollapseStyle(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (CollapseStyle)config.Element.GetValue(CollapseStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetCollapseStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetCollapseStyle'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetCollapseStyle(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, CollapseStyle value)
 		{
@@ -69,13 +69,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(CollapsedPaneWidthProperty, collapsedPaneWidth);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidth' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidth'][1]/Docs" />
 		public static double CollapsedPaneWidth(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (double)config.Element.GetValue(CollapsedPaneWidthProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidth' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='CollapsedPaneWidth'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> CollapsedPaneWidth(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, double value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/FlyoutPage.cs
@@ -26,13 +26,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(CollapseStyleProperty, collapseStyle);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetCollapseStyle' and position()=1]/Docs" />
 		public static CollapseStyle GetCollapseStyle(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (CollapseStyle)config.Element.GetValue(CollapseStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetCollapseStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetCollapseStyle' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetCollapseStyle(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, CollapseStyle value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(DetectReadingOrderFromContentProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent' and position()=1]/Docs" />
 		public static bool GetDetectReadingOrderFromContent(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(DetectReadingOrderFromContentProperty);
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (bool)element.GetValue(DetectReadingOrderFromContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetDetectReadingOrderFromContent(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='DetectReadingOrderFromContentProperty']/Docs" />
 		public static readonly BindableProperty DetectReadingOrderFromContentProperty = BindableProperty.Create("DetectReadingOrderFromContent", typeof(bool), typeof(FormsElement), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent' and position()=0]/Docs" />
 		public static void SetDetectReadingOrderFromContent(BindableObject element, bool value)
 		{
 			element.SetValue(DetectReadingOrderFromContentProperty, value);
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (bool)config.Element.GetValue(DetectReadingOrderFromContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent' and position()=0]/Docs" />
 		public static bool GetDetectReadingOrderFromContent(BindableObject element)
 		{
 			return (bool)element.GetValue(DetectReadingOrderFromContentProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/InputView.cs
@@ -10,25 +10,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='DetectReadingOrderFromContentProperty']/Docs" />
 		public static readonly BindableProperty DetectReadingOrderFromContentProperty = BindableProperty.Create("DetectReadingOrderFromContent", typeof(bool), typeof(FormsElement), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][1]/Docs" />
 		public static void SetDetectReadingOrderFromContent(BindableObject element, bool value)
 		{
 			element.SetValue(DetectReadingOrderFromContentProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent'][2]/Docs" />
 		public static bool GetDetectReadingOrderFromContent(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(DetectReadingOrderFromContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent'][1]/Docs" />
 		public static bool GetDetectReadingOrderFromContent(BindableObject element)
 		{
 			return (bool)element.GetValue(DetectReadingOrderFromContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/InputView.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetDetectReadingOrderFromContent(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
@@ -10,25 +10,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='DetectReadingOrderFromContentProperty']/Docs" />
 		public static readonly BindableProperty DetectReadingOrderFromContentProperty = BindableProperty.Create("DetectReadingOrderFromContent", typeof(bool), typeof(FormsElement), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][1]/Docs" />
 		public static void SetDetectReadingOrderFromContent(BindableObject element, bool value)
 		{
 			element.SetValue(DetectReadingOrderFromContentProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent'][2]/Docs" />
 		public static bool GetDetectReadingOrderFromContent(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(DetectReadingOrderFromContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent'][1]/Docs" />
 		public static bool GetDetectReadingOrderFromContent(BindableObject element)
 		{
 			return (bool)element.GetValue(DetectReadingOrderFromContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetDetectReadingOrderFromContent(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(DetectReadingOrderFromContentProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent' and position()=1]/Docs" />
 		public static bool GetDetectReadingOrderFromContent(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(DetectReadingOrderFromContentProperty);
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (bool)element.GetValue(DetectReadingOrderFromContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetDetectReadingOrderFromContent(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Label.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='DetectReadingOrderFromContentProperty']/Docs" />
 		public static readonly BindableProperty DetectReadingOrderFromContentProperty = BindableProperty.Create("DetectReadingOrderFromContent", typeof(bool), typeof(FormsElement), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='SetDetectReadingOrderFromContent' and position()=0]/Docs" />
 		public static void SetDetectReadingOrderFromContent(BindableObject element, bool value)
 		{
 			element.SetValue(DetectReadingOrderFromContentProperty, value);
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (bool)config.Element.GetValue(DetectReadingOrderFromContentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Label.xml" path="//Member[@MemberName='GetDetectReadingOrderFromContent' and position()=0]/Docs" />
 		public static bool GetDetectReadingOrderFromContent(BindableObject element)
 		{
 			return (bool)element.GetValue(DetectReadingOrderFromContentProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("WindowsSelectionMode", typeof(ListViewSelectionMode),
 				typeof(ListView), ListViewSelectionMode.Accessible);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode' and position()=0]/Docs" />
 		public static ListViewSelectionMode GetSelectionMode(BindableObject element)
 		{
 			return (ListViewSelectionMode)element.GetValue(SelectionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode' and position()=0]/Docs" />
 		public static void SetSelectionMode(BindableObject element, ListViewSelectionMode value)
 		{
 			element.SetValue(SelectionModeProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
@@ -26,13 +26,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(SelectionModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode' and position()=1]/Docs" />
 		public static ListViewSelectionMode GetSelectionMode(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (ListViewSelectionMode)config.Element.GetValue(SelectionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetSelectionMode(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, ListViewSelectionMode value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/ListView.cs
@@ -14,25 +14,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("WindowsSelectionMode", typeof(ListViewSelectionMode),
 				typeof(ListView), ListViewSelectionMode.Accessible);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode'][1]/Docs" />
 		public static ListViewSelectionMode GetSelectionMode(BindableObject element)
 		{
 			return (ListViewSelectionMode)element.GetValue(SelectionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode'][1]/Docs" />
 		public static void SetSelectionMode(BindableObject element, ListViewSelectionMode value)
 		{
 			element.SetValue(SelectionModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='GetSelectionMode'][2]/Docs" />
 		public static ListViewSelectionMode GetSelectionMode(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (ListViewSelectionMode)config.Element.GetValue(SelectionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/ListView.xml" path="//Member[@MemberName='SetSelectionMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetSelectionMode(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, ListViewSelectionMode value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
@@ -18,13 +18,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("ToolbarPlacement", typeof(ToolbarPlacement),
 				typeof(FormsElement), ToolbarPlacement.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarPlacement'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarPlacement' and position()=0]/Docs" />
 		public static ToolbarPlacement GetToolbarPlacement(BindableObject element)
 		{
 			return (ToolbarPlacement)element.GetValue(ToolbarPlacementProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarPlacement'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarPlacement' and position()=0]/Docs" />
 		public static void SetToolbarPlacement(BindableObject element, ToolbarPlacement toolbarPlacement)
 		{
 			element.SetValue(ToolbarPlacementProperty, toolbarPlacement);
@@ -53,13 +53,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("ToolbarDynamicOverflowEnabled", typeof(bool),
 				typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarDynamicOverflowEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarDynamicOverflowEnabled' and position()=0]/Docs" />
 		public static bool GetToolbarDynamicOverflowEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(ToolbarDynamicOverflowEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarDynamicOverflowEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarDynamicOverflowEnabled' and position()=0]/Docs" />
 		public static void SetToolbarDynamicOverflowEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(ToolbarDynamicOverflowEnabledProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
@@ -18,25 +18,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("ToolbarPlacement", typeof(ToolbarPlacement),
 				typeof(FormsElement), ToolbarPlacement.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarPlacement' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarPlacement'][1]/Docs" />
 		public static ToolbarPlacement GetToolbarPlacement(BindableObject element)
 		{
 			return (ToolbarPlacement)element.GetValue(ToolbarPlacementProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarPlacement' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarPlacement'][1]/Docs" />
 		public static void SetToolbarPlacement(BindableObject element, ToolbarPlacement toolbarPlacement)
 		{
 			element.SetValue(ToolbarPlacementProperty, toolbarPlacement);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarPlacement' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarPlacement'][2]/Docs" />
 		public static ToolbarPlacement GetToolbarPlacement(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (ToolbarPlacement)config.Element.GetValue(ToolbarPlacementProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarPlacement' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarPlacement'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetToolbarPlacement(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, ToolbarPlacement value)
 		{
@@ -53,25 +53,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("ToolbarDynamicOverflowEnabled", typeof(bool),
 				typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarDynamicOverflowEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarDynamicOverflowEnabled'][1]/Docs" />
 		public static bool GetToolbarDynamicOverflowEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(ToolbarDynamicOverflowEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarDynamicOverflowEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarDynamicOverflowEnabled'][1]/Docs" />
 		public static void SetToolbarDynamicOverflowEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(ToolbarDynamicOverflowEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarDynamicOverflowEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarDynamicOverflowEnabled'][2]/Docs" />
 		public static bool GetToolbarDynamicOverflowEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(ToolbarDynamicOverflowEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarDynamicOverflowEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarDynamicOverflowEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetToolbarDynamicOverflowEnabled(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/Page.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(ToolbarPlacementProperty, toolbarPlacement);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarPlacement']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarPlacement' and position()=1]/Docs" />
 		public static ToolbarPlacement GetToolbarPlacement(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (ToolbarPlacement)config.Element.GetValue(ToolbarPlacementProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarPlacement']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarPlacement' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetToolbarPlacement(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, ToolbarPlacement value)
 		{
@@ -65,13 +65,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(ToolbarDynamicOverflowEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarDynamicOverflowEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='GetToolbarDynamicOverflowEnabled' and position()=1]/Docs" />
 		public static bool GetToolbarDynamicOverflowEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(ToolbarDynamicOverflowEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarDynamicOverflowEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/Page.xml" path="//Member[@MemberName='SetToolbarDynamicOverflowEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetToolbarDynamicOverflowEnabled(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/RefreshView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/RefreshView.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='RefreshPullDirectionProperty']/Docs" />
 		public static readonly BindableProperty RefreshPullDirectionProperty = BindableProperty.Create("RefreshPullDirection", typeof(RefreshPullDirection), typeof(FormsElement), RefreshPullDirection.TopToBottom);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection' and position()=0]/Docs" />
 		public static void SetRefreshPullDirection(BindableObject element, RefreshPullDirection value)
 		{
 			element.SetValue(RefreshPullDirectionProperty, value);
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return GetRefreshPullDirection(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='GetRefreshPullDirection'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='GetRefreshPullDirection' and position()=0]/Docs" />
 		public static RefreshPullDirection GetRefreshPullDirection(BindableObject element)
 		{
 			return (RefreshPullDirection)element.GetValue(RefreshPullDirectionProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/RefreshView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/RefreshView.cs
@@ -20,25 +20,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='RefreshPullDirectionProperty']/Docs" />
 		public static readonly BindableProperty RefreshPullDirectionProperty = BindableProperty.Create("RefreshPullDirection", typeof(RefreshPullDirection), typeof(FormsElement), RefreshPullDirection.TopToBottom);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection'][1]/Docs" />
 		public static void SetRefreshPullDirection(BindableObject element, RefreshPullDirection value)
 		{
 			element.SetValue(RefreshPullDirectionProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='GetRefreshPullDirection' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='GetRefreshPullDirection'][2]/Docs" />
 		public static RefreshPullDirection GetRefreshPullDirection(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetRefreshPullDirection(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='GetRefreshPullDirection' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='GetRefreshPullDirection'][1]/Docs" />
 		public static RefreshPullDirection GetRefreshPullDirection(BindableObject element)
 		{
 			return (RefreshPullDirection)element.GetValue(RefreshPullDirectionProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetRefreshPullDirection(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, RefreshPullDirection value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/RefreshView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/RefreshView.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(RefreshPullDirectionProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='GetRefreshPullDirection']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='GetRefreshPullDirection' and position()=1]/Docs" />
 		public static RefreshPullDirection GetRefreshPullDirection(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetRefreshPullDirection(config.Element);
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (RefreshPullDirection)element.GetValue(RefreshPullDirectionProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='SetRefreshPullDirection' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetRefreshPullDirection(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, RefreshPullDirection value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (bool)element.GetValue(IsSpellCheckEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='GetIsSpellCheckEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='GetIsSpellCheckEnabled' and position()=1]/Docs" />
 		public static bool GetIsSpellCheckEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetIsSpellCheckEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='SetIsSpellCheckEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='SetIsSpellCheckEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetIsSpellCheckEnabled(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
@@ -13,25 +13,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		public static readonly BindableProperty IsSpellCheckEnabledProperty =
 			BindableProperty.Create("IsSpellCheckEnabled ", typeof(bool), typeof(SearchBar), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='SetIsSpellCheckEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='SetIsSpellCheckEnabled'][1]/Docs" />
 		public static void SetIsSpellCheckEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsSpellCheckEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='GetIsSpellCheckEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='GetIsSpellCheckEnabled'][1]/Docs" />
 		public static bool GetIsSpellCheckEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsSpellCheckEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='GetIsSpellCheckEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='GetIsSpellCheckEnabled'][2]/Docs" />
 		public static bool GetIsSpellCheckEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetIsSpellCheckEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='SetIsSpellCheckEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='SetIsSpellCheckEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetIsSpellCheckEnabled(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/SearchBar.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		public static readonly BindableProperty IsSpellCheckEnabledProperty =
 			BindableProperty.Create("IsSpellCheckEnabled ", typeof(bool), typeof(SearchBar), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='SetIsSpellCheckEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='SetIsSpellCheckEnabled' and position()=0]/Docs" />
 		public static void SetIsSpellCheckEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsSpellCheckEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='GetIsSpellCheckEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/SearchBar.xml" path="//Member[@MemberName='GetIsSpellCheckEnabled' and position()=0]/Docs" />
 		public static bool GetIsSpellCheckEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsSpellCheckEnabledProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
@@ -18,25 +18,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		public static readonly BindableProperty HeaderIconsSizeProperty =
 			BindableProperty.Create(nameof(HeaderIconsSizeProperty), typeof(Size), typeof(TabbedPage), new Size(16, 16));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsEnabled'][1]/Docs" />
 		public static void SetHeaderIconsEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(HeaderIconsEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsEnabled'][1]/Docs" />
 		public static bool GetHeaderIconsEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(HeaderIconsEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsEnabled'][2]/Docs" />
 		public static bool GetHeaderIconsEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetHeaderIconsEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetHeaderIconsEnabled(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{
@@ -62,25 +62,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			SetHeaderIconsEnabled(config.Element, false);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsSize' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsSize'][1]/Docs" />
 		public static void SetHeaderIconsSize(BindableObject element, Size value)
 		{
 			element.SetValue(HeaderIconsSizeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsSize' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsSize'][1]/Docs" />
 		public static Size GetHeaderIconsSize(BindableObject element)
 		{
 			return (Size)element.GetValue(HeaderIconsSizeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsSize' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsSize'][2]/Docs" />
 		public static Size GetHeaderIconsSize(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetHeaderIconsSize(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsSize' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsSize'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetHeaderIconsSize(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, Size value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
@@ -18,13 +18,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		public static readonly BindableProperty HeaderIconsSizeProperty =
 			BindableProperty.Create(nameof(HeaderIconsSizeProperty), typeof(Size), typeof(TabbedPage), new Size(16, 16));
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsEnabled' and position()=0]/Docs" />
 		public static void SetHeaderIconsEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(HeaderIconsEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsEnabled' and position()=0]/Docs" />
 		public static bool GetHeaderIconsEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(HeaderIconsEnabledProperty);
@@ -62,13 +62,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			SetHeaderIconsEnabled(config.Element, false);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsSize'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsSize' and position()=0]/Docs" />
 		public static void SetHeaderIconsSize(BindableObject element, Size value)
 		{
 			element.SetValue(HeaderIconsSizeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsSize'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsSize' and position()=0]/Docs" />
 		public static Size GetHeaderIconsSize(BindableObject element)
 		{
 			return (Size)element.GetValue(HeaderIconsSizeProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/TabbedPage.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (bool)element.GetValue(HeaderIconsEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsEnabled' and position()=1]/Docs" />
 		public static bool GetHeaderIconsEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetHeaderIconsEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetHeaderIconsEnabled(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{
@@ -74,13 +74,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (Size)element.GetValue(HeaderIconsSizeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsSize']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='GetHeaderIconsSize' and position()=1]/Docs" />
 		public static Size GetHeaderIconsSize(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetHeaderIconsSize(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsSize']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/TabbedPage.xml" path="//Member[@MemberName='SetHeaderIconsSize' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetHeaderIconsSize(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, Size value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
@@ -33,13 +33,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(AccessKeyProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKey']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKey' and position()=1]/Docs" />
 		public static string GetAccessKey(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (string)config.Element.GetValue(AccessKeyProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKey']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKey' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetAccessKey(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, string value)
 		{
@@ -57,13 +57,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		{
 			element.SetValue(AccessKeyPlacementProperty, value);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyPlacement']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyPlacement' and position()=1]/Docs" />
 		public static AccessKeyPlacement GetAccessKeyPlacement(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (AccessKeyPlacement)config.Element.GetValue(AccessKeyPlacementProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyPlacement']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyPlacement' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetAccessKeyPlacement(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, AccessKeyPlacement value)
 		{
@@ -80,12 +80,12 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		{
 			element.SetValue(AccessKeyHorizontalOffsetProperty, value);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyHorizontalOffset']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyHorizontalOffset' and position()=1]/Docs" />
 		public static double GetAccessKeyHorizontalOffset(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (double)config.Element.GetValue(AccessKeyHorizontalOffsetProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyHorizontalOffset']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyHorizontalOffset' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetAccessKeyHorizontalOffset(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, double value)
 		{
@@ -102,12 +102,12 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		{
 			element.SetValue(AccessKeyVerticalOffsetProperty, value);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyVerticalOffset']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyVerticalOffset' and position()=1]/Docs" />
 		public static double GetAccessKeyVerticalOffset(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (double)config.Element.GetValue(AccessKeyVerticalOffsetProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyVerticalOffset']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyVerticalOffset' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetAccessKeyVerticalOffset(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, double value)
 		{
@@ -133,13 +133,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=1]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetIsLegacyColorModeEnabled(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
@@ -21,25 +21,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		public static readonly BindableProperty AccessKeyVerticalOffsetProperty =
 					BindableProperty.Create("AccessKeyVerticalOffset", typeof(double), typeof(FormsElement), 0.0);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKey' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKey'][1]/Docs" />
 		public static string GetAccessKey(BindableObject element)
 		{
 			return (string)element.GetValue(AccessKeyProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKey' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKey'][1]/Docs" />
 		public static void SetAccessKey(BindableObject element, string value)
 		{
 			element.SetValue(AccessKeyProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKey' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKey'][2]/Docs" />
 		public static string GetAccessKey(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (string)config.Element.GetValue(AccessKeyProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKey' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKey'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetAccessKey(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, string value)
 		{
@@ -47,67 +47,67 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyPlacement' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyPlacement'][1]/Docs" />
 		public static AccessKeyPlacement GetAccessKeyPlacement(BindableObject element)
 		{
 			return (AccessKeyPlacement)element.GetValue(AccessKeyPlacementProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyPlacement' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyPlacement'][1]/Docs" />
 		public static void SetAccessKeyPlacement(BindableObject element, AccessKeyPlacement value)
 		{
 			element.SetValue(AccessKeyPlacementProperty, value);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyPlacement' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyPlacement'][2]/Docs" />
 		public static AccessKeyPlacement GetAccessKeyPlacement(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (AccessKeyPlacement)config.Element.GetValue(AccessKeyPlacementProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyPlacement' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyPlacement'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetAccessKeyPlacement(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, AccessKeyPlacement value)
 		{
 			config.Element.SetValue(AccessKeyPlacementProperty, value);
 			return config;
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyHorizontalOffset' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyHorizontalOffset'][1]/Docs" />
 		public static double GetAccessKeyHorizontalOffset(BindableObject element)
 		{
 			return (double)element.GetValue(AccessKeyHorizontalOffsetProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyHorizontalOffset' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyHorizontalOffset'][1]/Docs" />
 		public static void SetAccessKeyHorizontalOffset(BindableObject element, double value)
 		{
 			element.SetValue(AccessKeyHorizontalOffsetProperty, value);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyHorizontalOffset' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyHorizontalOffset'][2]/Docs" />
 		public static double GetAccessKeyHorizontalOffset(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (double)config.Element.GetValue(AccessKeyHorizontalOffsetProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyHorizontalOffset' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyHorizontalOffset'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetAccessKeyHorizontalOffset(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, double value)
 		{
 			config.Element.SetValue(AccessKeyHorizontalOffsetProperty, value);
 			return config;
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyVerticalOffset' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyVerticalOffset'][1]/Docs" />
 		public static double GetAccessKeyVerticalOffset(BindableObject element)
 		{
 			return (double)element.GetValue(AccessKeyVerticalOffsetProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyVerticalOffset' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyVerticalOffset'][1]/Docs" />
 		public static void SetAccessKeyVerticalOffset(BindableObject element, double value)
 		{
 			element.SetValue(AccessKeyVerticalOffsetProperty, value);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyVerticalOffset' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyVerticalOffset'][2]/Docs" />
 		public static double GetAccessKeyVerticalOffset(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (double)config.Element.GetValue(AccessKeyVerticalOffsetProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyVerticalOffset' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyVerticalOffset'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetAccessKeyVerticalOffset(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, double value)
 		{
@@ -121,25 +121,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][1]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][1]/Docs" />
 		public static void SetIsLegacyColorModeEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][2]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetIsLegacyColorModeEnabled(
 			this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/VisualElement.cs
@@ -21,13 +21,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		public static readonly BindableProperty AccessKeyVerticalOffsetProperty =
 					BindableProperty.Create("AccessKeyVerticalOffset", typeof(double), typeof(FormsElement), 0.0);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKey'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKey' and position()=0]/Docs" />
 		public static string GetAccessKey(BindableObject element)
 		{
 			return (string)element.GetValue(AccessKeyProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKey'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKey' and position()=0]/Docs" />
 		public static void SetAccessKey(BindableObject element, string value)
 		{
 			element.SetValue(AccessKeyProperty, value);
@@ -47,12 +47,12 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyPlacement'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyPlacement' and position()=0]/Docs" />
 		public static AccessKeyPlacement GetAccessKeyPlacement(BindableObject element)
 		{
 			return (AccessKeyPlacement)element.GetValue(AccessKeyPlacementProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyPlacement'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyPlacement' and position()=0]/Docs" />
 		public static void SetAccessKeyPlacement(BindableObject element, AccessKeyPlacement value)
 		{
 			element.SetValue(AccessKeyPlacementProperty, value);
@@ -70,12 +70,12 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			config.Element.SetValue(AccessKeyPlacementProperty, value);
 			return config;
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyHorizontalOffset'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyHorizontalOffset' and position()=0]/Docs" />
 		public static double GetAccessKeyHorizontalOffset(BindableObject element)
 		{
 			return (double)element.GetValue(AccessKeyHorizontalOffsetProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyHorizontalOffset'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyHorizontalOffset' and position()=0]/Docs" />
 		public static void SetAccessKeyHorizontalOffset(BindableObject element, double value)
 		{
 			element.SetValue(AccessKeyHorizontalOffsetProperty, value);
@@ -92,12 +92,12 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			config.Element.SetValue(AccessKeyHorizontalOffsetProperty, value);
 			return config;
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyVerticalOffset'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetAccessKeyVerticalOffset' and position()=0]/Docs" />
 		public static double GetAccessKeyVerticalOffset(BindableObject element)
 		{
 			return (double)element.GetValue(AccessKeyVerticalOffsetProperty);
 		}
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyVerticalOffset'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetAccessKeyVerticalOffset' and position()=0]/Docs" />
 		public static void SetAccessKeyVerticalOffset(BindableObject element, double value)
 		{
 			element.SetValue(AccessKeyVerticalOffsetProperty, value);
@@ -121,13 +121,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=0]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=0]/Docs" />
 		public static void SetIsLegacyColorModeEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (bool)element.GetValue(IsJavaScriptAlertEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetIsJavaScriptAlertEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetIsJavaScriptAlertEnabled' and position()=0]/Docs" />
 		public static void SetIsJavaScriptAlertEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsJavaScriptAlertEnabledProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return (bool)element.GetValue(IsJavaScriptAlertEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetIsJavaScriptAlertEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetIsJavaScriptAlertEnabled'][1]/Docs" />
 		public static void SetIsJavaScriptAlertEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsJavaScriptAlertEnabledProperty, value);
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return GetIsJavaScriptAlertEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetIsJavaScriptAlertEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetIsJavaScriptAlertEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetIsJavaScriptAlertEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{
 			SetIsJavaScriptAlertEnabled(config.Element, value);
@@ -39,25 +39,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='ExecutionModeProperty']/Docs" />
 		public static readonly BindableProperty ExecutionModeProperty = BindableProperty.Create("ExecutionMode", typeof(WebViewExecutionMode), typeof(WebView), WebViewExecutionMode.SameThread);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode'][1]/Docs" />
 		public static WebViewExecutionMode GetExecutionMode(BindableObject element)
 		{
 			return (WebViewExecutionMode)element.GetValue(ExecutionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode'][1]/Docs" />
 		public static void SetExecutionMode(BindableObject element, WebViewExecutionMode value)
 		{
 			element.SetValue(ExecutionModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode'][2]/Docs" />
 		public static WebViewExecutionMode GetExecutionMode(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetExecutionMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetExecutionMode(this IPlatformElementConfiguration<Windows, FormsElement> config, WebViewExecutionMode value)
 		{
 			SetExecutionMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 			return GetIsJavaScriptAlertEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetIsJavaScriptAlertEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetIsJavaScriptAlertEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetIsJavaScriptAlertEnabled(this IPlatformElementConfiguration<Windows, FormsElement> config, bool value)
 		{
 			SetIsJavaScriptAlertEnabled(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/WindowsSpecific/WebView.cs
@@ -39,25 +39,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='ExecutionModeProperty']/Docs" />
 		public static readonly BindableProperty ExecutionModeProperty = BindableProperty.Create("ExecutionMode", typeof(WebViewExecutionMode), typeof(WebView), WebViewExecutionMode.SameThread);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode' and position()=0]/Docs" />
 		public static WebViewExecutionMode GetExecutionMode(BindableObject element)
 		{
 			return (WebViewExecutionMode)element.GetValue(ExecutionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode' and position()=0]/Docs" />
 		public static void SetExecutionMode(BindableObject element, WebViewExecutionMode value)
 		{
 			element.SetValue(ExecutionModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode' and position()=1]/Docs" />
 		public static WebViewExecutionMode GetExecutionMode(this IPlatformElementConfiguration<Windows, FormsElement> config)
 		{
 			return GetExecutionMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<Windows, FormsElement> SetExecutionMode(this IPlatformElementConfiguration<Windows, FormsElement> config, WebViewExecutionMode value)
 		{
 			SetExecutionMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='PanGestureRecognizerShouldRecognizeSimultaneouslyProperty']/Docs" />
 		public static readonly BindableProperty PanGestureRecognizerShouldRecognizeSimultaneouslyProperty = BindableProperty.Create("PanGestureRecognizerShouldRecognizeSimultaneously", typeof(bool), typeof(Application), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously' and position()=0]/Docs" />
 		public static bool GetPanGestureRecognizerShouldRecognizeSimultaneously(BindableObject element)
 		{
 			return (bool)element.GetValue(PanGestureRecognizerShouldRecognizeSimultaneouslyProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetPanGestureRecognizerShouldRecognizeSimultaneously'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetPanGestureRecognizerShouldRecognizeSimultaneously' and position()=0]/Docs" />
 		public static void SetPanGestureRecognizerShouldRecognizeSimultaneously(BindableObject element, bool value)
 		{
 			element.SetValue(PanGestureRecognizerShouldRecognizeSimultaneouslyProperty, value);
@@ -39,13 +39,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='HandleControlUpdatesOnMainThreadProperty']/Docs" />
 		public static readonly BindableProperty HandleControlUpdatesOnMainThreadProperty = BindableProperty.Create("HandleControlUpdatesOnMainThread", typeof(bool), typeof(Application), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread' and position()=0]/Docs" />
 		public static bool GetHandleControlUpdatesOnMainThread(BindableObject element)
 		{
 			return (bool)element.GetValue(HandleControlUpdatesOnMainThreadProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetHandleControlUpdatesOnMainThread'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetHandleControlUpdatesOnMainThread' and position()=0]/Docs" />
 		public static void SetHandleControlUpdatesOnMainThread(BindableObject element, bool value)
 		{
 			element.SetValue(HandleControlUpdatesOnMainThreadProperty, value);
@@ -69,13 +69,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='EnableAccessibilityScalingForNamedFontSizesProperty']/Docs" />
 		public static readonly BindableProperty EnableAccessibilityScalingForNamedFontSizesProperty = BindableProperty.Create("EnableAccessibilityScalingForNamedFontSizes", typeof(bool), typeof(Application), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes' and position()=0]/Docs" />
 		public static bool GetEnableAccessibilityScalingForNamedFontSizes(BindableObject element)
 		{
 			return (bool)element.GetValue(EnableAccessibilityScalingForNamedFontSizesProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetEnableAccessibilityScalingForNamedFontSizes'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetEnableAccessibilityScalingForNamedFontSizes' and position()=0]/Docs" />
 		public static void SetEnableAccessibilityScalingForNamedFontSizes(BindableObject element, bool value)
 		{
 			element.SetValue(EnableAccessibilityScalingForNamedFontSizesProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
@@ -21,13 +21,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(PanGestureRecognizerShouldRecognizeSimultaneouslyProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously' and position()=1]/Docs" />
 		public static bool GetPanGestureRecognizerShouldRecognizeSimultaneously(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetPanGestureRecognizerShouldRecognizeSimultaneously(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetPanGestureRecognizerShouldRecognizeSimultaneously']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetPanGestureRecognizerShouldRecognizeSimultaneously' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPanGestureRecognizerShouldRecognizeSimultaneously(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetPanGestureRecognizerShouldRecognizeSimultaneously(config.Element, value);
@@ -51,13 +51,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(HandleControlUpdatesOnMainThreadProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread' and position()=1]/Docs" />
 		public static bool GetHandleControlUpdatesOnMainThread(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetHandleControlUpdatesOnMainThread(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetHandleControlUpdatesOnMainThread']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetHandleControlUpdatesOnMainThread' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetHandleControlUpdatesOnMainThread(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetHandleControlUpdatesOnMainThread(config.Element, value);
@@ -81,13 +81,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(EnableAccessibilityScalingForNamedFontSizesProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes' and position()=1]/Docs" />
 		public static bool GetEnableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetEnableAccessibilityScalingForNamedFontSizes(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetEnableAccessibilityScalingForNamedFontSizes']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetEnableAccessibilityScalingForNamedFontSizes' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetEnableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetEnableAccessibilityScalingForNamedFontSizes(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Application.cs
@@ -9,25 +9,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='PanGestureRecognizerShouldRecognizeSimultaneouslyProperty']/Docs" />
 		public static readonly BindableProperty PanGestureRecognizerShouldRecognizeSimultaneouslyProperty = BindableProperty.Create("PanGestureRecognizerShouldRecognizeSimultaneously", typeof(bool), typeof(Application), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously'][1]/Docs" />
 		public static bool GetPanGestureRecognizerShouldRecognizeSimultaneously(BindableObject element)
 		{
 			return (bool)element.GetValue(PanGestureRecognizerShouldRecognizeSimultaneouslyProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetPanGestureRecognizerShouldRecognizeSimultaneously' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetPanGestureRecognizerShouldRecognizeSimultaneously'][1]/Docs" />
 		public static void SetPanGestureRecognizerShouldRecognizeSimultaneously(BindableObject element, bool value)
 		{
 			element.SetValue(PanGestureRecognizerShouldRecognizeSimultaneouslyProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetPanGestureRecognizerShouldRecognizeSimultaneously'][2]/Docs" />
 		public static bool GetPanGestureRecognizerShouldRecognizeSimultaneously(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetPanGestureRecognizerShouldRecognizeSimultaneously(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetPanGestureRecognizerShouldRecognizeSimultaneously' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetPanGestureRecognizerShouldRecognizeSimultaneously'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPanGestureRecognizerShouldRecognizeSimultaneously(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetPanGestureRecognizerShouldRecognizeSimultaneously(config.Element, value);
@@ -39,25 +39,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='HandleControlUpdatesOnMainThreadProperty']/Docs" />
 		public static readonly BindableProperty HandleControlUpdatesOnMainThreadProperty = BindableProperty.Create("HandleControlUpdatesOnMainThread", typeof(bool), typeof(Application), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread'][1]/Docs" />
 		public static bool GetHandleControlUpdatesOnMainThread(BindableObject element)
 		{
 			return (bool)element.GetValue(HandleControlUpdatesOnMainThreadProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetHandleControlUpdatesOnMainThread' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetHandleControlUpdatesOnMainThread'][1]/Docs" />
 		public static void SetHandleControlUpdatesOnMainThread(BindableObject element, bool value)
 		{
 			element.SetValue(HandleControlUpdatesOnMainThreadProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetHandleControlUpdatesOnMainThread'][2]/Docs" />
 		public static bool GetHandleControlUpdatesOnMainThread(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetHandleControlUpdatesOnMainThread(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetHandleControlUpdatesOnMainThread' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetHandleControlUpdatesOnMainThread'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetHandleControlUpdatesOnMainThread(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetHandleControlUpdatesOnMainThread(config.Element, value);
@@ -69,25 +69,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='EnableAccessibilityScalingForNamedFontSizesProperty']/Docs" />
 		public static readonly BindableProperty EnableAccessibilityScalingForNamedFontSizesProperty = BindableProperty.Create("EnableAccessibilityScalingForNamedFontSizes", typeof(bool), typeof(Application), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes'][1]/Docs" />
 		public static bool GetEnableAccessibilityScalingForNamedFontSizes(BindableObject element)
 		{
 			return (bool)element.GetValue(EnableAccessibilityScalingForNamedFontSizesProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetEnableAccessibilityScalingForNamedFontSizes' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetEnableAccessibilityScalingForNamedFontSizes'][1]/Docs" />
 		public static void SetEnableAccessibilityScalingForNamedFontSizes(BindableObject element, bool value)
 		{
 			element.SetValue(EnableAccessibilityScalingForNamedFontSizesProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='GetEnableAccessibilityScalingForNamedFontSizes'][2]/Docs" />
 		public static bool GetEnableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetEnableAccessibilityScalingForNamedFontSizes(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetEnableAccessibilityScalingForNamedFontSizes' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Application.xml" path="//Member[@MemberName='SetEnableAccessibilityScalingForNamedFontSizes'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetEnableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetEnableAccessibilityScalingForNamedFontSizes(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
+namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 {
 	using Microsoft.Maui.Graphics;
 	using FormsElement = Maui.Controls.Cell;
@@ -21,7 +21,7 @@
 		public static Color DefaultBackgroundColor(this IPlatformElementConfiguration<iOS, FormsElement> config)
 			=> GetDefaultBackgroundColor(config.Element);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetDefaultBackgroundColor(this IPlatformElementConfiguration<iOS, FormsElement> config, Color value)
 		{
 			SetDefaultBackgroundColor(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
@@ -13,7 +13,7 @@
 		public static Color GetDefaultBackgroundColor(BindableObject element)
 			=> (Color)element.GetValue(DefaultBackgroundColorProperty);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor' and position()=0]/Docs" />
 		public static void SetDefaultBackgroundColor(BindableObject element, Color value)
 			=> element.SetValue(DefaultBackgroundColorProperty, value);
 

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Cell.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		public static Color GetDefaultBackgroundColor(BindableObject element)
 			=> (Color)element.GetValue(DefaultBackgroundColorProperty);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor'][1]/Docs" />
 		public static void SetDefaultBackgroundColor(BindableObject element, Color value)
 			=> element.SetValue(DefaultBackgroundColorProperty, value);
 
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		public static Color DefaultBackgroundColor(this IPlatformElementConfiguration<iOS, FormsElement> config)
 			=> GetDefaultBackgroundColor(config.Element);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Cell.xml" path="//Member[@MemberName='SetDefaultBackgroundColor'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetDefaultBackgroundColor(this IPlatformElementConfiguration<iOS, FormsElement> config, Color value)
 		{
 			SetDefaultBackgroundColor(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetUpdateMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='SetUpdateMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config, UpdateMode value)
 		{
 			SetUpdateMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (UpdateMode)element.GetValue(UpdateModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='SetUpdateMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=0]/Docs" />
 		public static void SetUpdateMode(BindableObject element, UpdateMode value)
 		{
 			element.SetValue(UpdateModeProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (UpdateMode)element.GetValue(UpdateModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='SetUpdateMode'][1]/Docs" />
 		public static void SetUpdateMode(BindableObject element, UpdateMode value)
 		{
 			element.SetValue(UpdateModeProperty, value);
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetUpdateMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/DatePicker.xml" path="//Member[@MemberName='SetUpdateMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config, UpdateMode value)
 		{
 			SetUpdateMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(AdjustsFontSizeToFitWidthProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetAdjustsFontSizeToFitWidth'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetAdjustsFontSizeToFitWidth' and position()=0]/Docs" />
 		public static void SetAdjustsFontSizeToFitWidth(BindableObject element, bool value)
 		{
 			element.SetValue(AdjustsFontSizeToFitWidthProperty, value);
@@ -57,13 +57,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetCursorColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetCursorColor' and position()=0]/Docs" />
 		public static Color GetCursorColor(BindableObject element)
 		{
 			return (Color)element.GetValue(CursorColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetCursorColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetCursorColor' and position()=0]/Docs" />
 		public static void SetCursorColor(BindableObject element, Color value)
 		{
 			element.SetValue(CursorColorProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetAdjustsFontSizeToFitWidth(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetAdjustsFontSizeToFitWidth']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetAdjustsFontSizeToFitWidth' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetAdjustsFontSizeToFitWidth(
 			this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
@@ -69,13 +69,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(CursorColorProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetCursorColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetCursorColor' and position()=1]/Docs" />
 		public static Color GetCursorColor(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetCursorColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetCursorColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetCursorColor' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetCursorColor(this IPlatformElementConfiguration<iOS, FormsElement> config, Color value)
 		{
 			SetCursorColor(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Entry.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(AdjustsFontSizeToFitWidthProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetAdjustsFontSizeToFitWidth' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetAdjustsFontSizeToFitWidth'][1]/Docs" />
 		public static void SetAdjustsFontSizeToFitWidth(BindableObject element, bool value)
 		{
 			element.SetValue(AdjustsFontSizeToFitWidthProperty, value);
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetAdjustsFontSizeToFitWidth(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetAdjustsFontSizeToFitWidth' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetAdjustsFontSizeToFitWidth'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetAdjustsFontSizeToFitWidth(
 			this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
@@ -57,25 +57,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetCursorColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetCursorColor'][1]/Docs" />
 		public static Color GetCursorColor(BindableObject element)
 		{
 			return (Color)element.GetValue(CursorColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetCursorColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetCursorColor'][1]/Docs" />
 		public static void SetCursorColor(BindableObject element, Color value)
 		{
 			element.SetValue(CursorColorProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetCursorColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='GetCursorColor'][2]/Docs" />
 		public static Color GetCursorColor(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetCursorColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetCursorColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Entry.xml" path="//Member[@MemberName='SetCursorColor'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetCursorColor(this IPlatformElementConfiguration<iOS, FormsElement> config, Color value)
 		{
 			SetCursorColor(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
@@ -10,26 +10,26 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='ApplyShadowProperty']/Docs" />
 		public static readonly BindableProperty ApplyShadowProperty = BindableProperty.Create("ApplyShadow", typeof(bool), typeof(FlyoutPage), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow'][1]/Docs" />
 		public static bool GetApplyShadow(BindableObject element)
 		{
 			return (bool)element.GetValue(ApplyShadowProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetApplyShadow' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetApplyShadow'][1]/Docs" />
 		public static void SetApplyShadow(BindableObject element, bool value)
 		{
 			element.SetValue(ApplyShadowProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetApplyShadow' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetApplyShadow'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetApplyShadow(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetApplyShadow(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow'][2]/Docs" />
 		public static bool GetApplyShadow(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetApplyShadow(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='ApplyShadowProperty']/Docs" />
 		public static readonly BindableProperty ApplyShadowProperty = BindableProperty.Create("ApplyShadow", typeof(bool), typeof(FlyoutPage), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow' and position()=0]/Docs" />
 		public static bool GetApplyShadow(BindableObject element)
 		{
 			return (bool)element.GetValue(ApplyShadowProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetApplyShadow'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetApplyShadow' and position()=0]/Docs" />
 		public static void SetApplyShadow(BindableObject element, bool value)
 		{
 			element.SetValue(ApplyShadowProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/FlyoutPage.cs
@@ -22,14 +22,14 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(ApplyShadowProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetApplyShadow']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='SetApplyShadow' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetApplyShadow(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetApplyShadow(config.Element, value);
 			return config;
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/FlyoutPage.xml" path="//Member[@MemberName='GetApplyShadow' and position()=1]/Docs" />
 		public static bool GetApplyShadow(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetApplyShadow(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(SeparatorStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle' and position()=1]/Docs" />
 		public static SeparatorStyle GetSeparatorStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetSeparatorStyle(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetSeparatorStyle(this IPlatformElementConfiguration<iOS, FormsElement> config, SeparatorStyle value)
 		{
 			SetSeparatorStyle(config.Element, value);
@@ -48,13 +48,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(GroupHeaderStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle' and position()=1]/Docs" />
 		public static GroupHeaderStyle GetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetGroupHeaderStyle(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config, GroupHeaderStyle value)
 		{
 			SetGroupHeaderStyle(config.Element, value);
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(RowAnimationsEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetRowAnimationsEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetRowAnimationsEnabled(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SeparatorStyleProperty']/Docs" />
 		public static readonly BindableProperty SeparatorStyleProperty = BindableProperty.Create(nameof(SeparatorStyle), typeof(SeparatorStyle), typeof(FormsElement), SeparatorStyle.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle' and position()=0]/Docs" />
 		public static SeparatorStyle GetSeparatorStyle(BindableObject element)
 		{
 			return (SeparatorStyle)element.GetValue(SeparatorStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle' and position()=0]/Docs" />
 		public static void SetSeparatorStyle(BindableObject element, SeparatorStyle value)
 		{
 			element.SetValue(SeparatorStyleProperty, value);
@@ -36,13 +36,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GroupHeaderStyleProperty']/Docs" />
 		public static readonly BindableProperty GroupHeaderStyleProperty = BindableProperty.Create(nameof(GroupHeaderStyle), typeof(GroupHeaderStyle), typeof(FormsElement), GroupHeaderStyle.Plain);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle' and position()=0]/Docs" />
 		public static GroupHeaderStyle GetGroupHeaderStyle(BindableObject element)
 		{
 			return (GroupHeaderStyle)element.GetValue(GroupHeaderStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle' and position()=0]/Docs" />
 		public static void SetGroupHeaderStyle(BindableObject element, GroupHeaderStyle value)
 		{
 			element.SetValue(GroupHeaderStyleProperty, value);
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(RowAnimationsEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled' and position()=0]/Docs" />
 		public static void SetRowAnimationsEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(RowAnimationsEnabledProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ListView.cs
@@ -8,25 +8,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SeparatorStyleProperty']/Docs" />
 		public static readonly BindableProperty SeparatorStyleProperty = BindableProperty.Create(nameof(SeparatorStyle), typeof(SeparatorStyle), typeof(FormsElement), SeparatorStyle.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle'][1]/Docs" />
 		public static SeparatorStyle GetSeparatorStyle(BindableObject element)
 		{
 			return (SeparatorStyle)element.GetValue(SeparatorStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle'][1]/Docs" />
 		public static void SetSeparatorStyle(BindableObject element, SeparatorStyle value)
 		{
 			element.SetValue(SeparatorStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetSeparatorStyle'][2]/Docs" />
 		public static SeparatorStyle GetSeparatorStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetSeparatorStyle(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetSeparatorStyle'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetSeparatorStyle(this IPlatformElementConfiguration<iOS, FormsElement> config, SeparatorStyle value)
 		{
 			SetSeparatorStyle(config.Element, value);
@@ -36,25 +36,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GroupHeaderStyleProperty']/Docs" />
 		public static readonly BindableProperty GroupHeaderStyleProperty = BindableProperty.Create(nameof(GroupHeaderStyle), typeof(GroupHeaderStyle), typeof(FormsElement), GroupHeaderStyle.Plain);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle'][1]/Docs" />
 		public static GroupHeaderStyle GetGroupHeaderStyle(BindableObject element)
 		{
 			return (GroupHeaderStyle)element.GetValue(GroupHeaderStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle'][1]/Docs" />
 		public static void SetGroupHeaderStyle(BindableObject element, GroupHeaderStyle value)
 		{
 			element.SetValue(GroupHeaderStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='GetGroupHeaderStyle'][2]/Docs" />
 		public static GroupHeaderStyle GetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetGroupHeaderStyle(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetGroupHeaderStyle'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetGroupHeaderStyle(this IPlatformElementConfiguration<iOS, FormsElement> config, GroupHeaderStyle value)
 		{
 			SetGroupHeaderStyle(config.Element, value);
@@ -70,13 +70,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(RowAnimationsEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled'][1]/Docs" />
 		public static void SetRowAnimationsEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(RowAnimationsEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ListView.xml" path="//Member[@MemberName='SetRowAnimationsEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetRowAnimationsEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetRowAnimationsEnabled(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(IsNavigationBarTranslucentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent'][1]/Docs" />
 		public static void SetIsNavigationBarTranslucent(BindableObject element, bool value)
 		{
 			element.SetValue(IsNavigationBarTranslucentProperty, value);
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetIsNavigationBarTranslucent(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsNavigationBarTranslucent(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetIsNavigationBarTranslucent(config.Element, value);
@@ -59,25 +59,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.Create("StatusBarColorTextMode", typeof(StatusBarTextColorMode),
 			typeof(NavigationPage), StatusBarTextColorMode.MatchNavigationBarTextLuminosity);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetStatusBarTextColorMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetStatusBarTextColorMode'][1]/Docs" />
 		public static StatusBarTextColorMode GetStatusBarTextColorMode(BindableObject element)
 		{
 			return (StatusBarTextColorMode)element.GetValue(StatusBarTextColorModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetStatusBarTextColorMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetStatusBarTextColorMode'][1]/Docs" />
 		public static void SetStatusBarTextColorMode(BindableObject element, StatusBarTextColorMode value)
 		{
 			element.SetValue(StatusBarTextColorModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetStatusBarTextColorMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetStatusBarTextColorMode'][2]/Docs" />
 		public static StatusBarTextColorMode GetStatusBarTextColorMode(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetStatusBarTextColorMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetStatusBarTextColorMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetStatusBarTextColorMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetStatusBarTextColorMode(this IPlatformElementConfiguration<iOS, FormsElement> config, StatusBarTextColorMode value)
 		{
 			SetStatusBarTextColorMode(config.Element, value);
@@ -95,13 +95,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(PrefersLargeTitlesProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetPrefersLargeTitles' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetPrefersLargeTitles'][1]/Docs" />
 		public static void SetPrefersLargeTitles(BindableObject element, bool value)
 		{
 			element.SetValue(PrefersLargeTitlesProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetPrefersLargeTitles' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetPrefersLargeTitles'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersLargeTitles(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetPrefersLargeTitles(config.Element, value);
@@ -125,13 +125,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(HideNavigationBarSeparatorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHideNavigationBarSeparator' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHideNavigationBarSeparator'][1]/Docs" />
 		public static void SetHideNavigationBarSeparator(BindableObject element, bool value)
 		{
 			element.SetValue(HideNavigationBarSeparatorProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHideNavigationBarSeparator' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHideNavigationBarSeparator'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetHideNavigationBarSeparator(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetHideNavigationBarSeparator(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(IsNavigationBarTranslucentProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent' and position()=0]/Docs" />
 		public static void SetIsNavigationBarTranslucent(BindableObject element, bool value)
 		{
 			element.SetValue(IsNavigationBarTranslucentProperty, value);
@@ -59,13 +59,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.Create("StatusBarColorTextMode", typeof(StatusBarTextColorMode),
 			typeof(NavigationPage), StatusBarTextColorMode.MatchNavigationBarTextLuminosity);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetStatusBarTextColorMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetStatusBarTextColorMode' and position()=0]/Docs" />
 		public static StatusBarTextColorMode GetStatusBarTextColorMode(BindableObject element)
 		{
 			return (StatusBarTextColorMode)element.GetValue(StatusBarTextColorModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetStatusBarTextColorMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetStatusBarTextColorMode' and position()=0]/Docs" />
 		public static void SetStatusBarTextColorMode(BindableObject element, StatusBarTextColorMode value)
 		{
 			element.SetValue(StatusBarTextColorModeProperty, value);
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(PrefersLargeTitlesProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetPrefersLargeTitles'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetPrefersLargeTitles' and position()=0]/Docs" />
 		public static void SetPrefersLargeTitles(BindableObject element, bool value)
 		{
 			element.SetValue(PrefersLargeTitlesProperty, value);
@@ -125,7 +125,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(HideNavigationBarSeparatorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHideNavigationBarSeparator'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHideNavigationBarSeparator' and position()=0]/Docs" />
 		public static void SetHideNavigationBarSeparator(BindableObject element, bool value)
 		{
 			element.SetValue(HideNavigationBarSeparatorProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/NavigationPage.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetIsNavigationBarTranslucent(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetIsNavigationBarTranslucent' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsNavigationBarTranslucent(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetIsNavigationBarTranslucent(config.Element, value);
@@ -71,13 +71,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(StatusBarTextColorModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetStatusBarTextColorMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetStatusBarTextColorMode' and position()=1]/Docs" />
 		public static StatusBarTextColorMode GetStatusBarTextColorMode(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetStatusBarTextColorMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetStatusBarTextColorMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetStatusBarTextColorMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetStatusBarTextColorMode(this IPlatformElementConfiguration<iOS, FormsElement> config, StatusBarTextColorMode value)
 		{
 			SetStatusBarTextColorMode(config.Element, value);
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(PrefersLargeTitlesProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetPrefersLargeTitles']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetPrefersLargeTitles' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersLargeTitles(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetPrefersLargeTitles(config.Element, value);
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(HideNavigationBarSeparatorProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHideNavigationBarSeparator']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetHideNavigationBarSeparator' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetHideNavigationBarSeparator(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetHideNavigationBarSeparator(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (StatusBarHiddenMode)element.GetValue(PrefersStatusBarHiddenProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersStatusBarHidden' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersStatusBarHidden'][1]/Docs" />
 		public static void SetPrefersStatusBarHidden(BindableObject element, StatusBarHiddenMode value)
 		{
 			element.SetValue(PrefersStatusBarHiddenProperty, value);
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetPrefersStatusBarHidden(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersStatusBarHidden' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersStatusBarHidden'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersStatusBarHidden(this IPlatformElementConfiguration<iOS, FormsElement> config, StatusBarHiddenMode value)
 		{
 			SetPrefersStatusBarHidden(config.Element, value);
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (UIStatusBarAnimation)element.GetValue(PreferredStatusBarUpdateAnimationProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPreferredStatusBarUpdateAnimation' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPreferredStatusBarUpdateAnimation'][1]/Docs" />
 		public static void SetPreferredStatusBarUpdateAnimation(BindableObject element, UIStatusBarAnimation value)
 		{
 			if (value == UIStatusBarAnimation.Fade)
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetPreferredStatusBarUpdateAnimation(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPreferredStatusBarUpdateAnimation' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPreferredStatusBarUpdateAnimation'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPreferredStatusBarUpdateAnimation(this IPlatformElementConfiguration<iOS, FormsElement> config, UIStatusBarAnimation value)
 		{
 			SetPreferredStatusBarUpdateAnimation(config.Element, value);
@@ -79,13 +79,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(UseSafeAreaProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetUseSafeArea' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetUseSafeArea'][1]/Docs" />
 		public static void SetUseSafeArea(BindableObject element, bool value)
 		{
 			element.SetValue(UseSafeAreaProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetUseSafeArea' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetUseSafeArea'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUseSafeArea(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetUseSafeArea(config.Element, value);
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (LargeTitleDisplayMode)element.GetValue(LargeTitleDisplayProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetLargeTitleDisplay' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetLargeTitleDisplay'][1]/Docs" />
 		public static void SetLargeTitleDisplay(BindableObject element, LargeTitleDisplayMode value)
 		{
 			element.SetValue(LargeTitleDisplayProperty, value);
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetLargeTitleDisplay(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetLargeTitleDisplay' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetLargeTitleDisplay'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetLargeTitleDisplay(this IPlatformElementConfiguration<iOS, FormsElement> config, LargeTitleDisplayMode value)
 		{
 			SetLargeTitleDisplay(config.Element, value);
@@ -194,7 +194,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(PrefersHomeIndicatorAutoHiddenProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersHomeIndicatorAutoHidden' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersHomeIndicatorAutoHidden'][1]/Docs" />
 		public static void SetPrefersHomeIndicatorAutoHidden(BindableObject element, bool value)
 		{
 			element.SetValue(PrefersHomeIndicatorAutoHiddenProperty, value);
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetPrefersHomeIndicatorAutoHidden(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersHomeIndicatorAutoHidden' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersHomeIndicatorAutoHidden'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersHomeIndicatorAutoHidden(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetPrefersHomeIndicatorAutoHidden(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (StatusBarHiddenMode)element.GetValue(PrefersStatusBarHiddenProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersStatusBarHidden'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersStatusBarHidden' and position()=0]/Docs" />
 		public static void SetPrefersStatusBarHidden(BindableObject element, StatusBarHiddenMode value)
 		{
 			element.SetValue(PrefersStatusBarHiddenProperty, value);
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (UIStatusBarAnimation)element.GetValue(PreferredStatusBarUpdateAnimationProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPreferredStatusBarUpdateAnimation'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPreferredStatusBarUpdateAnimation' and position()=0]/Docs" />
 		public static void SetPreferredStatusBarUpdateAnimation(BindableObject element, UIStatusBarAnimation value)
 		{
 			if (value == UIStatusBarAnimation.Fade)
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(UseSafeAreaProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetUseSafeArea'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetUseSafeArea' and position()=0]/Docs" />
 		public static void SetUseSafeArea(BindableObject element, bool value)
 		{
 			element.SetValue(UseSafeAreaProperty, value);
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (LargeTitleDisplayMode)element.GetValue(LargeTitleDisplayProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetLargeTitleDisplay'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetLargeTitleDisplay' and position()=0]/Docs" />
 		public static void SetLargeTitleDisplay(BindableObject element, LargeTitleDisplayMode value)
 		{
 			element.SetValue(LargeTitleDisplayProperty, value);
@@ -194,7 +194,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(PrefersHomeIndicatorAutoHiddenProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersHomeIndicatorAutoHidden'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersHomeIndicatorAutoHidden' and position()=0]/Docs" />
 		public static void SetPrefersHomeIndicatorAutoHidden(BindableObject element, bool value)
 		{
 			element.SetValue(PrefersHomeIndicatorAutoHiddenProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Page.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetPrefersStatusBarHidden(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersStatusBarHidden']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersStatusBarHidden' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersStatusBarHidden(this IPlatformElementConfiguration<iOS, FormsElement> config, StatusBarHiddenMode value)
 		{
 			SetPrefersStatusBarHidden(config.Element, value);
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetPreferredStatusBarUpdateAnimation(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPreferredStatusBarUpdateAnimation']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPreferredStatusBarUpdateAnimation' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPreferredStatusBarUpdateAnimation(this IPlatformElementConfiguration<iOS, FormsElement> config, UIStatusBarAnimation value)
 		{
 			SetPreferredStatusBarUpdateAnimation(config.Element, value);
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(UseSafeAreaProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetUseSafeArea']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetUseSafeArea' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUseSafeArea(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetUseSafeArea(config.Element, value);
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetLargeTitleDisplay(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetLargeTitleDisplay']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetLargeTitleDisplay' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetLargeTitleDisplay(this IPlatformElementConfiguration<iOS, FormsElement> config, LargeTitleDisplayMode value)
 		{
 			SetLargeTitleDisplay(config.Element, value);
@@ -206,7 +206,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetPrefersHomeIndicatorAutoHidden(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersHomeIndicatorAutoHidden']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Page.xml" path="//Member[@MemberName='SetPrefersHomeIndicatorAutoHidden' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetPrefersHomeIndicatorAutoHidden(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetPrefersHomeIndicatorAutoHidden(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Picker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Picker.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (UpdateMode)element.GetValue(UpdateModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='SetUpdateMode'][1]/Docs" />
 		public static void SetUpdateMode(BindableObject element, UpdateMode value)
 		{
 			element.SetValue(UpdateModeProperty, value);
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetUpdateMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='SetUpdateMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config, UpdateMode value)
 		{
 			SetUpdateMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Picker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Picker.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (UpdateMode)element.GetValue(UpdateModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='SetUpdateMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=0]/Docs" />
 		public static void SetUpdateMode(BindableObject element, UpdateMode value)
 		{
 			element.SetValue(UpdateModeProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Picker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Picker.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetUpdateMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='SetUpdateMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Picker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config, UpdateMode value)
 		{
 			SetUpdateMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ScrollView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ScrollView.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetShouldDelayContentTouches(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='SetShouldDelayContentTouches']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='SetShouldDelayContentTouches' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShouldDelayContentTouches(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetShouldDelayContentTouches(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ScrollView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ScrollView.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(ShouldDelayContentTouchesProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='SetShouldDelayContentTouches' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='SetShouldDelayContentTouches'][1]/Docs" />
 		public static void SetShouldDelayContentTouches(BindableObject element, bool value)
 		{
 			element.SetValue(ShouldDelayContentTouchesProperty, value);
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetShouldDelayContentTouches(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='SetShouldDelayContentTouches' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='SetShouldDelayContentTouches'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShouldDelayContentTouches(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetShouldDelayContentTouches(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ScrollView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/ScrollView.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(ShouldDelayContentTouchesProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='SetShouldDelayContentTouches'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/ScrollView.xml" path="//Member[@MemberName='SetShouldDelayContentTouches' and position()=0]/Docs" />
 		public static void SetShouldDelayContentTouches(BindableObject element, bool value)
 		{
 			element.SetValue(ShouldDelayContentTouchesProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(SearchBarStyleProperty, style);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle' and position()=1]/Docs" />
 		public static UISearchBarStyle GetSearchBarStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetSearchBarStyle(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SetSearchBarStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SetSearchBarStyle' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetSearchBarStyle(
 			this IPlatformElementConfiguration<iOS, FormsElement> config, UISearchBarStyle style)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
@@ -13,25 +13,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SearchBarStyleProperty']/Docs" />
 		public static readonly BindableProperty SearchBarStyleProperty = BindableProperty.Create("SearchBarStyle", typeof(UISearchBarStyle), typeof(SearchBar), UISearchBarStyle.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle'][1]/Docs" />
 		public static UISearchBarStyle GetSearchBarStyle(BindableObject element)
 		{
 			return (UISearchBarStyle)element.GetValue(SearchBarStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SetSearchBarStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SetSearchBarStyle'][1]/Docs" />
 		public static void SetSearchBarStyle(BindableObject element, UISearchBarStyle style)
 		{
 			element.SetValue(SearchBarStyleProperty, style);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle'][2]/Docs" />
 		public static UISearchBarStyle GetSearchBarStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetSearchBarStyle(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SetSearchBarStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SetSearchBarStyle'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetSearchBarStyle(
 			this IPlatformElementConfiguration<iOS, FormsElement> config, UISearchBarStyle style)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SearchBarStyleProperty']/Docs" />
 		public static readonly BindableProperty SearchBarStyleProperty = BindableProperty.Create("SearchBarStyle", typeof(UISearchBarStyle), typeof(SearchBar), UISearchBarStyle.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='GetSearchBarStyle' and position()=0]/Docs" />
 		public static UISearchBarStyle GetSearchBarStyle(BindableObject element)
 		{
 			return (UISearchBarStyle)element.GetValue(SearchBarStyleProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SetSearchBarStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SearchBar.xml" path="//Member[@MemberName='SetSearchBarStyle' and position()=0]/Docs" />
 		public static void SetSearchBarStyle(BindableObject element, UISearchBarStyle style)
 		{
 			element.SetValue(SearchBarStyleProperty, style);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
@@ -8,25 +8,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='UpdateOnTapProperty']/Docs" />
 		public static readonly BindableProperty UpdateOnTapProperty = BindableProperty.Create("UpdateOnTap", typeof(bool), typeof(Slider), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap'][1]/Docs" />
 		public static bool GetUpdateOnTap(BindableObject element)
 		{
 			return (bool)element.GetValue(UpdateOnTapProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='SetUpdateOnTap' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='SetUpdateOnTap'][1]/Docs" />
 		public static void SetUpdateOnTap(BindableObject element, bool value)
 		{
 			element.SetValue(UpdateOnTapProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap'][2]/Docs" />
 		public static bool GetUpdateOnTap(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetUpdateOnTap(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='SetUpdateOnTap' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='SetUpdateOnTap'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateOnTap(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetUpdateOnTap(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(UpdateOnTapProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap' and position()=1]/Docs" />
 		public static bool GetUpdateOnTap(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetUpdateOnTap(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='SetUpdateOnTap']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='SetUpdateOnTap' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateOnTap(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetUpdateOnTap(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/Slider.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='UpdateOnTapProperty']/Docs" />
 		public static readonly BindableProperty UpdateOnTapProperty = BindableProperty.Create("UpdateOnTap", typeof(bool), typeof(Slider), false);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='GetUpdateOnTap' and position()=0]/Docs" />
 		public static bool GetUpdateOnTap(BindableObject element)
 		{
 			return (bool)element.GetValue(UpdateOnTapProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='SetUpdateOnTap'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/Slider.xml" path="//Member[@MemberName='SetUpdateOnTap' and position()=0]/Docs" />
 		public static void SetUpdateOnTap(BindableObject element, bool value)
 		{
 			element.SetValue(UpdateOnTapProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SwipeView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SwipeView.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(SwipeTransitionModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode' and position()=1]/Docs" />
 		public static SwipeTransitionMode GetSwipeTransitionMode(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetSwipeTransitionMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetSwipeTransitionMode(this IPlatformElementConfiguration<iOS, FormsElement> config, SwipeTransitionMode value)
 		{
 			SetSwipeTransitionMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SwipeView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SwipeView.cs
@@ -8,25 +8,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SwipeTransitionModeProperty']/Docs" />
 		public static readonly BindableProperty SwipeTransitionModeProperty = BindableProperty.Create("SwipeTransitionMode", typeof(SwipeTransitionMode), typeof(SwipeView), SwipeTransitionMode.Reveal);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode'][1]/Docs" />
 		public static SwipeTransitionMode GetSwipeTransitionMode(BindableObject element)
 		{
 			return (SwipeTransitionMode)element.GetValue(SwipeTransitionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode'][1]/Docs" />
 		public static void SetSwipeTransitionMode(BindableObject element, SwipeTransitionMode value)
 		{
 			element.SetValue(SwipeTransitionModeProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode'][2]/Docs" />
 		public static SwipeTransitionMode GetSwipeTransitionMode(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetSwipeTransitionMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetSwipeTransitionMode(this IPlatformElementConfiguration<iOS, FormsElement> config, SwipeTransitionMode value)
 		{
 			SetSwipeTransitionMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SwipeView.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/SwipeView.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SwipeTransitionModeProperty']/Docs" />
 		public static readonly BindableProperty SwipeTransitionModeProperty = BindableProperty.Create("SwipeTransitionMode", typeof(SwipeTransitionMode), typeof(SwipeView), SwipeTransitionMode.Reveal);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='GetSwipeTransitionMode' and position()=0]/Docs" />
 		public static SwipeTransitionMode GetSwipeTransitionMode(BindableObject element)
 		{
 			return (SwipeTransitionMode)element.GetValue(SwipeTransitionModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/SwipeView.xml" path="//Member[@MemberName='SetSwipeTransitionMode' and position()=0]/Docs" />
 		public static void SetSwipeTransitionMode(BindableObject element, SwipeTransitionMode value)
 		{
 			element.SetValue(SwipeTransitionModeProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.Create("TranslucencyMode",
 				typeof(TranslucencyMode), typeof(TabbedPage), TranslucencyMode.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTranslucencyMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTranslucencyMode' and position()=0]/Docs" />
 		public static TranslucencyMode GetTranslucencyMode(BindableObject element)
 			=> (TranslucencyMode)element.GetValue(TranslucencyModeProperty);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTranslucencyMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTranslucencyMode' and position()=0]/Docs" />
 		public static void SetTranslucencyMode(BindableObject element, TranslucencyMode value)
 			=> element.SetValue(TranslucencyModeProperty, value);
 

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
@@ -10,20 +10,20 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.Create("TranslucencyMode",
 				typeof(TranslucencyMode), typeof(TabbedPage), TranslucencyMode.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTranslucencyMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTranslucencyMode'][1]/Docs" />
 		public static TranslucencyMode GetTranslucencyMode(BindableObject element)
 			=> (TranslucencyMode)element.GetValue(TranslucencyModeProperty);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTranslucencyMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTranslucencyMode'][1]/Docs" />
 		public static void SetTranslucencyMode(BindableObject element, TranslucencyMode value)
 			=> element.SetValue(TranslucencyModeProperty, value);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTranslucencyMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTranslucencyMode'][2]/Docs" />
 		public static TranslucencyMode GetTranslucencyMode(
 			this IPlatformElementConfiguration<iOS, FormsElement> config)
 			=> GetTranslucencyMode(config.Element);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTranslucencyMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTranslucencyMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetTranslucencyMode(
 			this IPlatformElementConfiguration<iOS, FormsElement> config, TranslucencyMode value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		public static void SetTranslucencyMode(BindableObject element, TranslucencyMode value)
 			=> element.SetValue(TranslucencyModeProperty, value);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTranslucencyMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTranslucencyMode' and position()=1]/Docs" />
 		public static TranslucencyMode GetTranslucencyMode(
 			this IPlatformElementConfiguration<iOS, FormsElement> config)
 			=> GetTranslucencyMode(config.Element);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTranslucencyMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TabbedPage.xml" path="//Member[@MemberName='SetTranslucencyMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetTranslucencyMode(
 			this IPlatformElementConfiguration<iOS, FormsElement> config, TranslucencyMode value)
 		{

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (UpdateMode)element.GetValue(UpdateModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='SetUpdateMode'][1]/Docs" />
 		public static void SetUpdateMode(BindableObject element, UpdateMode value)
 		{
 			element.SetValue(UpdateModeProperty, value);
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetUpdateMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='SetUpdateMode'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config, UpdateMode value)
 		{
 			SetUpdateMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetUpdateMode(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='SetUpdateMode']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config, UpdateMode value)
 		{
 			SetUpdateMode(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (UpdateMode)element.GetValue(UpdateModeProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='SetUpdateMode'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/TimePicker.xml" path="//Member[@MemberName='SetUpdateMode' and position()=0]/Docs" />
 		public static void SetUpdateMode(BindableObject element, UpdateMode value)
 		{
 			element.SetValue(UpdateModeProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='BlurEffectProperty']/Docs" />
 		public static readonly BindableProperty BlurEffectProperty = BindableProperty.Create("BlurEffect", typeof(BlurEffectStyle), typeof(VisualElement), BlurEffectStyle.None);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect'][1]/Docs" />
 		public static BlurEffectStyle GetBlurEffect(BindableObject element)
 		{
 			return (BlurEffectStyle)element.GetValue(BlurEffectProperty);
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(BlurEffectProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect'][2]/Docs" />
 		public static BlurEffectStyle GetBlurEffect(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetBlurEffect(config.Element);
@@ -69,25 +69,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			}
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsShadowEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsShadowEnabled'][1]/Docs" />
 		public static bool GetIsShadowEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsShadowEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsShadowEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsShadowEnabled'][1]/Docs" />
 		public static void SetIsShadowEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsShadowEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsShadowEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsShadowEnabled'][2]/Docs" />
 		public static bool GetIsShadowEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetIsShadowEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsShadowEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsShadowEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsShadowEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetIsShadowEnabled(config.Element, value);
@@ -99,25 +99,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.Create("ShadowColor", typeof(Color),
 			typeof(VisualElement), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowColor'][1]/Docs" />
 		public static Color GetShadowColor(BindableObject element)
 		{
 			return (Color)element.GetValue(ShadowColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowColor' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowColor'][1]/Docs" />
 		public static void SetShadowColor(BindableObject element, Color value)
 		{
 			element.SetValue(ShadowColorProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowColor'][2]/Docs" />
 		public static Color GetShadowColor(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetShadowColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowColor' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowColor'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShadowColor(this IPlatformElementConfiguration<iOS, FormsElement> config, Color value)
 		{
 			SetShadowColor(config.Element, value);
@@ -129,25 +129,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.Create("ShadowRadius", typeof(double),
 			typeof(VisualElement), 10.0);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowRadius' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowRadius'][1]/Docs" />
 		public static double GetShadowRadius(BindableObject element)
 		{
 			return (double)element.GetValue(ShadowRadiusProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowRadius' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowRadius'][1]/Docs" />
 		public static void SetShadowRadius(BindableObject element, double value)
 		{
 			element.SetValue(ShadowRadiusProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowRadius' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowRadius'][2]/Docs" />
 		public static double GetShadowRadius(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetShadowRadius(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowRadius' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowRadius'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShadowRadius(this IPlatformElementConfiguration<iOS, FormsElement> config, double value)
 		{
 			SetShadowRadius(config.Element, value);
@@ -159,25 +159,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		BindableProperty.Create("ShadowOffset", typeof(Size),
 		typeof(VisualElement), Size.Zero);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOffset' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOffset'][1]/Docs" />
 		public static Size GetShadowOffset(BindableObject element)
 		{
 			return (Size)element.GetValue(ShadowOffsetProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOffset' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOffset'][1]/Docs" />
 		public static void SetShadowOffset(BindableObject element, Size value)
 		{
 			element.SetValue(ShadowOffsetProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOffset' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOffset'][2]/Docs" />
 		public static Size GetShadowOffset(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetShadowOffset(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOffset' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOffset'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShadowOffset(this IPlatformElementConfiguration<iOS, FormsElement> config, Size value)
 		{
 			SetShadowOffset(config.Element, value);
@@ -189,25 +189,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		BindableProperty.Create("ShadowOpacity", typeof(double),
 		typeof(VisualElement), 0.5);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOpacity' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOpacity'][1]/Docs" />
 		public static double GetShadowOpacity(BindableObject element)
 		{
 			return (double)element.GetValue(ShadowOpacityProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOpacity' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOpacity'][1]/Docs" />
 		public static void SetShadowOpacity(BindableObject element, double value)
 		{
 			element.SetValue(ShadowOpacityProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOpacity' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOpacity'][2]/Docs" />
 		public static double GetShadowOpacity(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetShadowOpacity(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOpacity' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOpacity'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShadowOpacity(this IPlatformElementConfiguration<iOS, FormsElement> config, double value)
 		{
 			SetShadowOpacity(config.Element, value);
@@ -223,25 +223,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][1]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][1]/Docs" />
 		public static void SetIsLegacyColorModeEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][2]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsLegacyColorModeEnabled(
 			this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
@@ -260,7 +260,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(CanBecomeFirstResponderProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetCanBecomeFirstResponder' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetCanBecomeFirstResponder'][1]/Docs" />
 		public static void SetCanBecomeFirstResponder(BindableObject element, bool value)
 		{
 			element.SetValue(CanBecomeFirstResponderProperty, value);
@@ -272,7 +272,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetCanBecomeFirstResponder(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetCanBecomeFirstResponder' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetCanBecomeFirstResponder'][2]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetCanBecomeFirstResponder(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetCanBecomeFirstResponder(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='BlurEffectProperty']/Docs" />
 		public static readonly BindableProperty BlurEffectProperty = BindableProperty.Create("BlurEffect", typeof(BlurEffectStyle), typeof(VisualElement), BlurEffectStyle.None);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect' and position()=0]/Docs" />
 		public static BlurEffectStyle GetBlurEffect(BindableObject element)
 		{
 			return (BlurEffectStyle)element.GetValue(BlurEffectProperty);
@@ -69,13 +69,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			}
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsShadowEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsShadowEnabled' and position()=0]/Docs" />
 		public static bool GetIsShadowEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsShadowEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsShadowEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsShadowEnabled' and position()=0]/Docs" />
 		public static void SetIsShadowEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsShadowEnabledProperty, value);
@@ -99,13 +99,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.Create("ShadowColor", typeof(Color),
 			typeof(VisualElement), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowColor' and position()=0]/Docs" />
 		public static Color GetShadowColor(BindableObject element)
 		{
 			return (Color)element.GetValue(ShadowColorProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowColor'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowColor' and position()=0]/Docs" />
 		public static void SetShadowColor(BindableObject element, Color value)
 		{
 			element.SetValue(ShadowColorProperty, value);
@@ -129,13 +129,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.Create("ShadowRadius", typeof(double),
 			typeof(VisualElement), 10.0);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowRadius'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowRadius' and position()=0]/Docs" />
 		public static double GetShadowRadius(BindableObject element)
 		{
 			return (double)element.GetValue(ShadowRadiusProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowRadius'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowRadius' and position()=0]/Docs" />
 		public static void SetShadowRadius(BindableObject element, double value)
 		{
 			element.SetValue(ShadowRadiusProperty, value);
@@ -159,13 +159,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		BindableProperty.Create("ShadowOffset", typeof(Size),
 		typeof(VisualElement), Size.Zero);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOffset'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOffset' and position()=0]/Docs" />
 		public static Size GetShadowOffset(BindableObject element)
 		{
 			return (Size)element.GetValue(ShadowOffsetProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOffset'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOffset' and position()=0]/Docs" />
 		public static void SetShadowOffset(BindableObject element, Size value)
 		{
 			element.SetValue(ShadowOffsetProperty, value);
@@ -189,13 +189,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 		BindableProperty.Create("ShadowOpacity", typeof(double),
 		typeof(VisualElement), 0.5);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOpacity'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOpacity' and position()=0]/Docs" />
 		public static double GetShadowOpacity(BindableObject element)
 		{
 			return (double)element.GetValue(ShadowOpacityProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOpacity'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOpacity' and position()=0]/Docs" />
 		public static void SetShadowOpacity(BindableObject element, double value)
 		{
 			element.SetValue(ShadowOpacityProperty, value);
@@ -223,13 +223,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			BindableProperty.CreateAttached("IsLegacyColorModeEnabled", typeof(bool),
 				typeof(FormsElement), true);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=0]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(BindableObject element)
 		{
 			return (bool)element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=0]/Docs" />
 		public static void SetIsLegacyColorModeEnabled(BindableObject element, bool value)
 		{
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);
@@ -260,7 +260,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return (bool)element.GetValue(CanBecomeFirstResponderProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetCanBecomeFirstResponder'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetCanBecomeFirstResponder' and position()=0]/Docs" />
 		public static void SetCanBecomeFirstResponder(BindableObject element, bool value)
 		{
 			element.SetValue(CanBecomeFirstResponderProperty, value);

--- a/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/iOSSpecific/VisualElement.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 {
 	using System;
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(BlurEffectProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetBlurEffect' and position()=1]/Docs" />
 		public static BlurEffectStyle GetBlurEffect(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetBlurEffect(config.Element);
@@ -81,13 +81,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(IsShadowEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsShadowEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsShadowEnabled' and position()=1]/Docs" />
 		public static bool GetIsShadowEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetIsShadowEnabled(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsShadowEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsShadowEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsShadowEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetIsShadowEnabled(config.Element, value);
@@ -111,13 +111,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(ShadowColorProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowColor' and position()=1]/Docs" />
 		public static Color GetShadowColor(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetShadowColor(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowColor']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowColor' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShadowColor(this IPlatformElementConfiguration<iOS, FormsElement> config, Color value)
 		{
 			SetShadowColor(config.Element, value);
@@ -141,13 +141,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(ShadowRadiusProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowRadius']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowRadius' and position()=1]/Docs" />
 		public static double GetShadowRadius(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetShadowRadius(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowRadius']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowRadius' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShadowRadius(this IPlatformElementConfiguration<iOS, FormsElement> config, double value)
 		{
 			SetShadowRadius(config.Element, value);
@@ -171,13 +171,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(ShadowOffsetProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOffset']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOffset' and position()=1]/Docs" />
 		public static Size GetShadowOffset(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetShadowOffset(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOffset']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOffset' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShadowOffset(this IPlatformElementConfiguration<iOS, FormsElement> config, Size value)
 		{
 			SetShadowOffset(config.Element, value);
@@ -201,13 +201,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(ShadowOpacityProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOpacity']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetShadowOpacity' and position()=1]/Docs" />
 		public static double GetShadowOpacity(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return GetShadowOpacity(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOpacity']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetShadowOpacity' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetShadowOpacity(this IPlatformElementConfiguration<iOS, FormsElement> config, double value)
 		{
 			SetShadowOpacity(config.Element, value);
@@ -235,13 +235,13 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			element.SetValue(IsLegacyColorModeEnabledProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='GetIsLegacyColorModeEnabled' and position()=1]/Docs" />
 		public static bool GetIsLegacyColorModeEnabled(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
 			return (bool)config.Element.GetValue(IsLegacyColorModeEnabledProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetIsLegacyColorModeEnabled' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetIsLegacyColorModeEnabled(
 			this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
@@ -272,7 +272,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific
 			return GetCanBecomeFirstResponder(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetCanBecomeFirstResponder']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific/VisualElement.xml" path="//Member[@MemberName='SetCanBecomeFirstResponder' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<iOS, FormsElement> SetCanBecomeFirstResponder(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
 			SetCanBecomeFirstResponder(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		public static readonly BindableProperty NavigationTransitionPopStyleProperty = BindableProperty.Create("NavigationTransitionPopStyle", typeof(NavigationTransitionStyle), typeof(NavigationPage), NavigationTransitionStyle.SlideBackward);
 
 		#region PushStyle
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPushStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPushStyle' and position()=0]/Docs" />
 		public static NavigationTransitionStyle GetNavigationTransitionPushStyle(BindableObject element)
 		{
 			return (NavigationTransitionStyle)element.GetValue(NavigationTransitionPushStyleProperty);
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		#endregion
 
 		#region PopStyle
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPopStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPopStyle' and position()=0]/Docs" />
 		public static NavigationTransitionStyle GetNavigationTransitionPopStyle(BindableObject element)
 		{
 			return (NavigationTransitionStyle)element.GetValue(NavigationTransitionPopStyleProperty);
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		}
 		#endregion
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetNavigationTransitionStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetNavigationTransitionStyle' and position()=0]/Docs" />
 		public static void SetNavigationTransitionStyle(BindableObject element, NavigationTransitionStyle pushStyle, NavigationTransitionStyle popStyle)
 		{
 			SetNavigationTransitionPushStyle(element, pushStyle);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		public static readonly BindableProperty NavigationTransitionPopStyleProperty = BindableProperty.Create("NavigationTransitionPopStyle", typeof(NavigationTransitionStyle), typeof(NavigationPage), NavigationTransitionStyle.SlideBackward);
 
 		#region PushStyle
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPushStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPushStyle'][1]/Docs" />
 		public static NavigationTransitionStyle GetNavigationTransitionPushStyle(BindableObject element)
 		{
 			return (NavigationTransitionStyle)element.GetValue(NavigationTransitionPushStyleProperty);
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			element.SetValue(NavigationTransitionPushStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPushStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPushStyle'][2]/Docs" />
 		public static NavigationTransitionStyle GetNavigationTransitionPushStyle(this IPlatformElementConfiguration<macOS, FormsElement> config)
 		{
 			return GetNavigationTransitionPushStyle(config.Element);
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		#endregion
 
 		#region PopStyle
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPopStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPopStyle'][1]/Docs" />
 		public static NavigationTransitionStyle GetNavigationTransitionPopStyle(BindableObject element)
 		{
 			return (NavigationTransitionStyle)element.GetValue(NavigationTransitionPopStyleProperty);
@@ -43,21 +43,21 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			element.SetValue(NavigationTransitionPopStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPopStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPopStyle'][2]/Docs" />
 		public static NavigationTransitionStyle GetNavigationTransitionPopStyle(this IPlatformElementConfiguration<macOS, FormsElement> config)
 		{
 			return GetNavigationTransitionPopStyle(config.Element);
 		}
 		#endregion
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetNavigationTransitionStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetNavigationTransitionStyle'][1]/Docs" />
 		public static void SetNavigationTransitionStyle(BindableObject element, NavigationTransitionStyle pushStyle, NavigationTransitionStyle popStyle)
 		{
 			SetNavigationTransitionPushStyle(element, pushStyle);
 			SetNavigationTransitionPopStyle(element, popStyle);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetNavigationTransitionStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetNavigationTransitionStyle'][2]/Docs" />
 		public static IPlatformElementConfiguration<macOS, FormsElement> SetNavigationTransitionStyle(this IPlatformElementConfiguration<macOS, FormsElement> config, NavigationTransitionStyle pushStyle, NavigationTransitionStyle popStyle)
 		{
 			SetNavigationTransitionStyle(config.Element, pushStyle, popStyle);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/NavigationPage.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			element.SetValue(NavigationTransitionPushStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPushStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPushStyle' and position()=1]/Docs" />
 		public static NavigationTransitionStyle GetNavigationTransitionPushStyle(this IPlatformElementConfiguration<macOS, FormsElement> config)
 		{
 			return GetNavigationTransitionPushStyle(config.Element);
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			element.SetValue(NavigationTransitionPopStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPopStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='GetNavigationTransitionPopStyle' and position()=1]/Docs" />
 		public static NavigationTransitionStyle GetNavigationTransitionPopStyle(this IPlatformElementConfiguration<macOS, FormsElement> config)
 		{
 			return GetNavigationTransitionPopStyle(config.Element);
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			SetNavigationTransitionPopStyle(element, popStyle);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetNavigationTransitionStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/NavigationPage.xml" path="//Member[@MemberName='SetNavigationTransitionStyle' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<macOS, FormsElement> SetNavigationTransitionStyle(this IPlatformElementConfiguration<macOS, FormsElement> config, NavigationTransitionStyle pushStyle, NavigationTransitionStyle popStyle)
 		{
 			SetNavigationTransitionStyle(config.Element, pushStyle, popStyle);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			return (VisualElement[])element.GetValue(TabOrderProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='SetTabOrder']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='SetTabOrder' and position()=0]/Docs" />
 		public static void SetTabOrder(BindableObject element, params VisualElement[] value)
 		{
 			element.SetValue(TabOrderProperty, value);
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			return GetTabOrder(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='SetTabOrder']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='SetTabOrder' and position()=1]/Docs" />
 		public static IPlatformElementConfiguration<macOS, FormsElement> SetTabOrder(this IPlatformElementConfiguration<macOS, FormsElement> config, params VisualElement[] value)
 		{
 			SetTabOrder(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
@@ -9,25 +9,25 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='TabOrderProperty']/Docs" />
 		public static readonly BindableProperty TabOrderProperty = BindableProperty.Create("TabOrder", typeof(VisualElement[]), typeof(Page), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder'][1]/Docs" />
 		public static VisualElement[] GetTabOrder(BindableObject element)
 		{
 			return (VisualElement[])element.GetValue(TabOrderProperty);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='SetTabOrder' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='SetTabOrder'][1]/Docs" />
 		public static void SetTabOrder(BindableObject element, params VisualElement[] value)
 		{
 			element.SetValue(TabOrderProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder'][2]/Docs" />
 		public static VisualElement[] GetTabOrder(this IPlatformElementConfiguration<macOS, FormsElement> config)
 		{
 			return GetTabOrder(config.Element);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='SetTabOrder' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='SetTabOrder'][2]/Docs" />
 		public static IPlatformElementConfiguration<macOS, FormsElement> SetTabOrder(this IPlatformElementConfiguration<macOS, FormsElement> config, params VisualElement[] value)
 		{
 			SetTabOrder(config.Element, value);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			element.SetValue(TabOrderProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder' and position()=1]/Docs" />
 		public static VisualElement[] GetTabOrder(this IPlatformElementConfiguration<macOS, FormsElement> config)
 		{
 			return GetTabOrder(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/Page.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='TabOrderProperty']/Docs" />
 		public static readonly BindableProperty TabOrderProperty = BindableProperty.Create("TabOrder", typeof(VisualElement[]), typeof(Page), null);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/Page.xml" path="//Member[@MemberName='GetTabOrder' and position()=0]/Docs" />
 		public static VisualElement[] GetTabOrder(BindableObject element)
 		{
 			return (VisualElement[])element.GetValue(TabOrderProperty);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/TabbedPage.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			element.SetValue(TabsStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle']/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle' and position()=1]/Docs" />
 		public static TabsStyle GetTabsStyle(this IPlatformElementConfiguration<macOS, FormsElement> config)
 		{
 			return GetTabsStyle(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/TabbedPage.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='TabsStyleProperty']/Docs" />
 		public static readonly BindableProperty TabsStyleProperty = BindableProperty.Create("TabsStyle", typeof(TabsStyle), typeof(TabbedPage), TabsStyle.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle' and position()=0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle'][1]/Docs" />
 		public static TabsStyle GetTabsStyle(BindableObject element)
 		{
 			return (TabsStyle)element.GetValue(TabsStyleProperty);
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 			element.SetValue(TabsStyleProperty, value);
 		}
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle' and position()=1]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle'][2]/Docs" />
 		public static TabsStyle GetTabsStyle(this IPlatformElementConfiguration<macOS, FormsElement> config)
 		{
 			return GetTabsStyle(config.Element);

--- a/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/TabbedPage.cs
+++ b/src/Controls/src/Core/PlatformConfiguration/macOSSpecific/TabbedPage.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific
 		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='TabsStyleProperty']/Docs" />
 		public static readonly BindableProperty TabsStyleProperty = BindableProperty.Create("TabsStyle", typeof(TabsStyle), typeof(TabbedPage), TabsStyle.Default);
 
-		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle'][0]/Docs" />
+		/// <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.macOSSpecific/TabbedPage.xml" path="//Member[@MemberName='GetTabsStyle' and position()=0]/Docs" />
 		public static TabsStyle GetTabsStyle(BindableObject element)
 		{
 			return (TabsStyle)element.GetValue(TabsStyleProperty);

--- a/src/Controls/src/Core/PromptArguments.cs
+++ b/src/Controls/src/Core/PromptArguments.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PromptArguments
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PromptArguments.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/PromptArguments.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			Title = title;

--- a/src/Controls/src/Core/RadialGradientBrush.cs
+++ b/src/Controls/src/Core/RadialGradientBrush.cs
@@ -5,26 +5,26 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="Type[@FullName='Microsoft.Maui.Controls.RadialGradientBrush']/Docs" />
 	public class RadialGradientBrush : GradientBrush
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public RadialGradientBrush()
 		{
 
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public RadialGradientBrush(GradientStopCollection gradientStops)
 		{
 			GradientStops = gradientStops;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public RadialGradientBrush(GradientStopCollection gradientStops, double radius)
 		{
 			GradientStops = gradientStops;
 			Radius = radius;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public RadialGradientBrush(GradientStopCollection gradientStops, Point center, double radius)
 		{
 			GradientStops = gradientStops;

--- a/src/Controls/src/Core/RadialGradientBrush.cs
+++ b/src/Controls/src/Core/RadialGradientBrush.cs
@@ -5,26 +5,26 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="Type[@FullName='Microsoft.Maui.Controls.RadialGradientBrush']/Docs" />
 	public class RadialGradientBrush : GradientBrush
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public RadialGradientBrush()
 		{
 
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public RadialGradientBrush(GradientStopCollection gradientStops)
 		{
 			GradientStops = gradientStops;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public RadialGradientBrush(GradientStopCollection gradientStops, double radius)
 		{
 			GradientStops = gradientStops;
 			Radius = radius;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RadialGradientBrush.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public RadialGradientBrush(GradientStopCollection gradientStops, Point center, double radius)
 		{
 			GradientStops = gradientStops;

--- a/src/Controls/src/Core/Region.cs
+++ b/src/Controls/src/Core/Region.cs
@@ -51,13 +51,13 @@ namespace Microsoft.Maui.Controls
 			return new Region(positions);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Contains'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Contains' and position()=0]/Docs" />
 		public bool Contains(Point pt)
 		{
 			return Contains(pt.X, pt.Y);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Contains'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Contains' and position()=1]/Docs" />
 		public bool Contains(double x, double y)
 		{
 			if (Regions == null)
@@ -79,13 +79,13 @@ namespace Microsoft.Maui.Controls
 			return Inflate(_inflation.Value.Left * -1, _inflation.Value.Top * -1, _inflation.Value.Right * -1, _inflation.Value.Bottom * -1);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Inflate'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Inflate' and position()=0]/Docs" />
 		public Region Inflate(double size)
 		{
 			return Inflate(size, size, size, size);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Inflate'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Inflate' and position()=1]/Docs" />
 		public Region Inflate(double left, double top, double right, double bottom)
 		{
 			if (Regions == null)

--- a/src/Controls/src/Core/Region.cs
+++ b/src/Controls/src/Core/Region.cs
@@ -51,13 +51,13 @@ namespace Microsoft.Maui.Controls
 			return new Region(positions);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Contains' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Contains'][1]/Docs" />
 		public bool Contains(Point pt)
 		{
 			return Contains(pt.X, pt.Y);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Contains' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Contains'][2]/Docs" />
 		public bool Contains(double x, double y)
 		{
 			if (Regions == null)
@@ -79,13 +79,13 @@ namespace Microsoft.Maui.Controls
 			return Inflate(_inflation.Value.Left * -1, _inflation.Value.Top * -1, _inflation.Value.Right * -1, _inflation.Value.Bottom * -1);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Inflate' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Inflate'][1]/Docs" />
 		public Region Inflate(double size)
 		{
 			return Inflate(size, size, size, size);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Inflate' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="//Member[@MemberName='Inflate'][2]/Docs" />
 		public Region Inflate(double left, double top, double right, double bottom)
 		{
 			if (Regions == null)

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 
 namespace Microsoft.Maui.Controls.Internals
 {
-	/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.Registrar']/Docs" />
+	/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.Registrar' and position()=0]/Docs" />
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class Registrar<TRegistrable> where TRegistrable : class
 	{
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 		static Type[] _defaultVisualRenderers = new[] { _defaultVisualType };
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register' and position()=0]/Docs" />
 		public void Register(Type tview, Type trender, Type[] supportedVisuals, short priority)
 		{
 			supportedVisuals = supportedVisuals ?? _defaultVisualRenderers;
@@ -73,10 +73,10 @@ namespace Microsoft.Maui.Controls.Internals
 			//	});
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register' and position()=1]/Docs" />
 		public void Register(Type tview, Type trender, Type[] supportedVisual) => Register(tview, trender, supportedVisual, 0);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register' and position()=2]/Docs" />
 		public void Register(Type tview, Type trender) => Register(tview, trender, _defaultVisualRenderers);
 
 		internal TRegistrable GetHandler(Type type) => GetHandler(type, _defaultVisualType);
@@ -109,19 +109,19 @@ namespace Microsoft.Maui.Controls.Internals
 			return returnValue;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler' and position()=0]/Docs" />
 		public TOut GetHandler<TOut>(Type type) where TOut : class, TRegistrable
 		{
 			return GetHandler(type) as TOut;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler' and position()=1]/Docs" />
 		public TOut GetHandler<TOut>(Type type, params object[] args) where TOut : class, TRegistrable
 		{
 			return GetHandler(type, null, null, args) as TOut;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject' and position()=0]/Docs" />
 		public TOut GetHandlerForObject<TOut>(object obj) where TOut : class, TRegistrable
 		{
 			if (obj == null)
@@ -133,7 +133,7 @@ namespace Microsoft.Maui.Controls.Internals
 			return GetHandler(type, (obj as IVisualController)?.EffectiveVisual?.GetType()) as TOut;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject' and position()=1]/Docs" />
 		public TOut GetHandlerForObject<TOut>(object obj, params object[] args) where TOut : class, TRegistrable
 		{
 			if (obj == null)
@@ -145,10 +145,10 @@ namespace Microsoft.Maui.Controls.Internals
 			return GetHandler(type, obj, (obj as IVisualController)?.EffectiveVisual, args) as TOut;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType' and position()=0]/Docs" />
 		public Type GetHandlerType(Type viewType) => GetHandlerType(viewType, _defaultVisualType);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType' and position()=1]/Docs" />
 		public Type GetHandlerType(Type viewType, Type visualType)
 		{
 			visualType = visualType ?? _defaultVisualType;
@@ -270,7 +270,7 @@ namespace Microsoft.Maui.Controls.Internals
 		}
 	}
 
-	/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.Registrar']/Docs" />
+	/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.Registrar' and position()=1]/Docs" />
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class Registrar
 	{
@@ -383,14 +383,14 @@ namespace Microsoft.Maui.Controls.Internals
 			Effects[resolutionName + "." + id] = effectType;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll' and position()=0]/Docs" />
 		[Obsolete]
 		public static void RegisterAll(Type[] attrTypes, IFontRegistrar fontRegistrar = null)
 		{
 			RegisterAll(attrTypes, default(InitializationFlags), fontRegistrar);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll' and position()=1]/Docs" />
 		[Obsolete]
 		public static void RegisterAll(Type[] attrTypes, InitializationFlags flags, IFontRegistrar fontRegistrar = null)
 		{

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 		static Type[] _defaultVisualRenderers = new[] { _defaultVisualType };
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register'][1]/Docs" />
 		public void Register(Type tview, Type trender, Type[] supportedVisuals, short priority)
 		{
 			supportedVisuals = supportedVisuals ?? _defaultVisualRenderers;
@@ -73,10 +73,10 @@ namespace Microsoft.Maui.Controls.Internals
 			//	});
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register'][2]/Docs" />
 		public void Register(Type tview, Type trender, Type[] supportedVisual) => Register(tview, trender, supportedVisual, 0);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register'][3]/Docs" />
 		public void Register(Type tview, Type trender) => Register(tview, trender, _defaultVisualRenderers);
 
 		internal TRegistrable GetHandler(Type type) => GetHandler(type, _defaultVisualType);
@@ -109,19 +109,19 @@ namespace Microsoft.Maui.Controls.Internals
 			return returnValue;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler'][1]/Docs" />
 		public TOut GetHandler<TOut>(Type type) where TOut : class, TRegistrable
 		{
 			return GetHandler(type) as TOut;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler'][2]/Docs" />
 		public TOut GetHandler<TOut>(Type type, params object[] args) where TOut : class, TRegistrable
 		{
 			return GetHandler(type, null, null, args) as TOut;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject'][1]/Docs" />
 		public TOut GetHandlerForObject<TOut>(object obj) where TOut : class, TRegistrable
 		{
 			if (obj == null)
@@ -133,7 +133,7 @@ namespace Microsoft.Maui.Controls.Internals
 			return GetHandler(type, (obj as IVisualController)?.EffectiveVisual?.GetType()) as TOut;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject'][2]/Docs" />
 		public TOut GetHandlerForObject<TOut>(object obj, params object[] args) where TOut : class, TRegistrable
 		{
 			if (obj == null)
@@ -145,10 +145,10 @@ namespace Microsoft.Maui.Controls.Internals
 			return GetHandler(type, obj, (obj as IVisualController)?.EffectiveVisual, args) as TOut;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType'][1]/Docs" />
 		public Type GetHandlerType(Type viewType) => GetHandlerType(viewType, _defaultVisualType);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType'][2]/Docs" />
 		public Type GetHandlerType(Type viewType, Type visualType)
 		{
 			visualType = visualType ?? _defaultVisualType;
@@ -383,14 +383,14 @@ namespace Microsoft.Maui.Controls.Internals
 			Effects[resolutionName + "." + id] = effectType;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll'][1]/Docs" />
 		[Obsolete]
 		public static void RegisterAll(Type[] attrTypes, IFontRegistrar fontRegistrar = null)
 		{
 			RegisterAll(attrTypes, default(InitializationFlags), fontRegistrar);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll'][2]/Docs" />
 		[Obsolete]
 		public static void RegisterAll(Type[] attrTypes, InitializationFlags flags, IFontRegistrar fontRegistrar = null)
 		{

--- a/src/Controls/src/Core/RenderWithAttribute.cs
+++ b/src/Controls/src/Core/RenderWithAttribute.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Maui.Controls
 	public sealed class RenderWithAttribute : Attribute
 	{
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RenderWithAttribute.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RenderWithAttribute.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public RenderWithAttribute(Type type) : this(type, new[] { typeof(VisualMarker.DefaultVisual) })
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RenderWithAttribute.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RenderWithAttribute.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public RenderWithAttribute(Type type, Type[] supportedVisuals)
 		{
 			Type = type;

--- a/src/Controls/src/Core/RenderWithAttribute.cs
+++ b/src/Controls/src/Core/RenderWithAttribute.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Maui.Controls
 	public sealed class RenderWithAttribute : Attribute
 	{
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RenderWithAttribute.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RenderWithAttribute.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public RenderWithAttribute(Type type) : this(type, new[] { typeof(VisualMarker.DefaultVisual) })
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/RenderWithAttribute.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RenderWithAttribute.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public RenderWithAttribute(Type type, Type[] supportedVisuals)
 		{
 			Type = type;

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Controls
 			return ((ICollection<KeyValuePair<string, object>>)_innerDictionary).Remove(item);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add'][4]/Docs" />
 		public void Add(string key, object value)
 		{
 			if (ContainsKey(key))
@@ -285,7 +285,7 @@ namespace Microsoft.Maui.Controls
 			remove { ValuesChanged -= value; }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add'][2]/Docs" />
 		public void Add(Style style)
 		{
 			if (string.IsNullOrEmpty(style.Class))
@@ -301,13 +301,13 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add'][1]/Docs" />
 		public void Add(ResourceDictionary mergedResourceDictionary)
 		{
 			MergedDictionaries.Add(mergedResourceDictionary);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add'][3]/Docs" />
 		public void Add(StyleSheets.StyleSheet styleSheet)
 		{
 			StyleSheets = StyleSheets ?? new List<StyleSheets.StyleSheet>(2);

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Maui.Controls
 			return ((ICollection<KeyValuePair<string, object>>)_innerDictionary).Remove(item);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add' and position()=3]/Docs" />
 		public void Add(string key, object value)
 		{
 			if (ContainsKey(key))
@@ -285,7 +285,7 @@ namespace Microsoft.Maui.Controls
 			remove { ValuesChanged -= value; }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add' and position()=1]/Docs" />
 		public void Add(Style style)
 		{
 			if (string.IsNullOrEmpty(style.Class))
@@ -301,7 +301,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add' and position()=0]/Docs" />
 		public void Add(ResourceDictionary mergedResourceDictionary)
 		{
 			MergedDictionaries.Add(mergedResourceDictionary);

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Maui.Controls
 			MergedDictionaries.Add(mergedResourceDictionary);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='Add' and position()=2]/Docs" />
 		public void Add(StyleSheets.StyleSheet styleSheet)
 		{
 			StyleSheets = StyleSheets ?? new List<StyleSheets.StyleSheet>(2);

--- a/src/Controls/src/Core/RouteFactory.cs
+++ b/src/Controls/src/Core/RouteFactory.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="Type[@FullName='Microsoft.Maui.Controls.RouteFactory']/Docs" />
 	public abstract class RouteFactory
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate' and position()=0]/Docs" />
 		public abstract Element GetOrCreate();
-		/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate' and position()=1]/Docs" />
 		public abstract Element GetOrCreate(IServiceProvider services);
 	}
 }

--- a/src/Controls/src/Core/RouteFactory.cs
+++ b/src/Controls/src/Core/RouteFactory.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="Type[@FullName='Microsoft.Maui.Controls.RouteFactory']/Docs" />
 	public abstract class RouteFactory
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate'][1]/Docs" />
 		public abstract Element GetOrCreate();
-		/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate'][2]/Docs" />
 		public abstract Element GetOrCreate(IServiceProvider services);
 	}
 }

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Maui.Controls
 			return $"{source}/";
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute'][1]/Docs" />
 		public static string FormatRoute(List<string> segments)
 		{
 			var route = FormatRoute(String.Join(PathSeparator, segments));

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -186,13 +186,13 @@ namespace Microsoft.Maui.Controls
 			return route;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute' and position()=1]/Docs" />
 		public static string FormatRoute(string route)
 		{
 			return route;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute' and position()=1]/Docs" />
 		public static void RegisterRoute(string route, RouteFactory factory)
 		{
 			if (!String.IsNullOrWhiteSpace(route))
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute' and position()=0]/Docs" />
 		public static void RegisterRoute(
 			string route,
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Maui.Controls
 			return $"{source}/";
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute' and position()=1]/Docs" />
 		public static string FormatRoute(List<string> segments)
 		{
 			var route = FormatRoute(String.Join(PathSeparator, segments));

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -179,20 +179,20 @@ namespace Microsoft.Maui.Controls
 			return $"{source}/";
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute'][2]/Docs" />
 		public static string FormatRoute(List<string> segments)
 		{
 			var route = FormatRoute(String.Join(PathSeparator, segments));
 			return route;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='FormatRoute'][2]/Docs" />
 		public static string FormatRoute(string route)
 		{
 			return route;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute'][2]/Docs" />
 		public static void RegisterRoute(string route, RouteFactory factory)
 		{
 			if (!String.IsNullOrWhiteSpace(route))
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='RegisterRoute'][1]/Docs" />
 		public static void RegisterRoute(
 			string route,
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)

--- a/src/Controls/src/Core/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Maui.Controls
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollToAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollToAsync' and position()=0]/Docs" />
 		public Task ScrollToAsync(double x, double y, bool animated)
 		{
 			if (Orientation == ScrollOrientation.Neither)
@@ -213,7 +213,7 @@ namespace Microsoft.Maui.Controls
 			return _scrollCompletionSource.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollToAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollToAsync' and position()=1]/Docs" />
 		public Task ScrollToAsync(Element element, ScrollToPosition position, bool animated)
 		{
 			if (Orientation == ScrollOrientation.Neither)

--- a/src/Controls/src/Core/ScrollView.cs
+++ b/src/Controls/src/Core/ScrollView.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Maui.Controls
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollToAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollToAsync'][1]/Docs" />
 		public Task ScrollToAsync(double x, double y, bool animated)
 		{
 			if (Orientation == ScrollOrientation.Neither)
@@ -213,7 +213,7 @@ namespace Microsoft.Maui.Controls
 			return _scrollCompletionSource.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollToAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ScrollView.xml" path="//Member[@MemberName='ScrollToAsync'][2]/Docs" />
 		public Task ScrollToAsync(Element element, ScrollToPosition position, bool animated)
 		{
 			if (Orientation == ScrollOrientation.Neither)

--- a/src/Controls/src/Core/SelectedItemChangedEventArgs.cs
+++ b/src/Controls/src/Core/SelectedItemChangedEventArgs.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/SelectedItemChangedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.SelectedItemChangedEventArgs']/Docs" />
 	public class SelectedItemChangedEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/SelectedItemChangedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/SelectedItemChangedEventArgs.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public SelectedItemChangedEventArgs(object selectedItem, int selectedItemIndex)
 		{
 			SelectedItem = selectedItem;

--- a/src/Controls/src/Core/SelectedItemChangedEventArgs.cs
+++ b/src/Controls/src/Core/SelectedItemChangedEventArgs.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/SelectedItemChangedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.SelectedItemChangedEventArgs']/Docs" />
 	public class SelectedItemChangedEventArgs : EventArgs
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/SelectedItemChangedEventArgs.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/SelectedItemChangedEventArgs.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public SelectedItemChangedEventArgs(object selectedItem, int selectedItemIndex)
 		{
 			SelectedItem = selectedItem;

--- a/src/Controls/src/Core/Shapes/ArcSegment.cs
+++ b/src/Controls/src/Core/Shapes/ArcSegment.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.ArcSegment']/Docs" />
 	public class ArcSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ArcSegment()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ArcSegment(Point point, Size size, double rotationAngle, SweepDirection sweepDirection, bool isLargeArc)
 		{
 			Point = point;

--- a/src/Controls/src/Core/Shapes/ArcSegment.cs
+++ b/src/Controls/src/Core/Shapes/ArcSegment.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.ArcSegment']/Docs" />
 	public class ArcSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ArcSegment()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ArcSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ArcSegment(Point point, Size size, double rotationAngle, SweepDirection sweepDirection, bool isLargeArc)
 		{
 			Point = point;

--- a/src/Controls/src/Core/Shapes/BezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/BezierSegment.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.BezierSegment']/Docs" />
 	public class BezierSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public BezierSegment()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public BezierSegment(Point point1, Point point2, Point point3)
 		{
 			Point1 = point1;

--- a/src/Controls/src/Core/Shapes/BezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/BezierSegment.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.BezierSegment']/Docs" />
 	public class BezierSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public BezierSegment()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/BezierSegment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public BezierSegment(Point point1, Point point2, Point point3)
 		{
 			Point1 = point1;

--- a/src/Controls/src/Core/Shapes/EllipseGeometry.cs
+++ b/src/Controls/src/Core/Shapes/EllipseGeometry.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.EllipseGeometry']/Docs" />
 	public class EllipseGeometry : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public EllipseGeometry()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public EllipseGeometry(Point center, double radiusX, double radiusY)
 		{
 			Center = center;

--- a/src/Controls/src/Core/Shapes/EllipseGeometry.cs
+++ b/src/Controls/src/Core/Shapes/EllipseGeometry.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.EllipseGeometry']/Docs" />
 	public class EllipseGeometry : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public EllipseGeometry()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public EllipseGeometry(Point center, double radiusX, double radiusY)
 		{
 			Center = center;

--- a/src/Controls/src/Core/Shapes/GeometryHelper.cs
+++ b/src/Controls/src/Core/Shapes/GeometryHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	{
 		static readonly List<Point> Points = new List<Point>();
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml" path="//Member[@MemberName='FlattenGeometry'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml" path="//Member[@MemberName='FlattenGeometry' and position()=0]/Docs" />
 		public static PathGeometry FlattenGeometry(Geometry geoSrc, double tolerance)
 		{
 			// Return empty PathGeometry if Geometry is null
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			return pathGeoDst;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml" path="//Member[@MemberName='FlattenGeometry'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml" path="//Member[@MemberName='FlattenGeometry' and position()=1]/Docs" />
 		public static void FlattenGeometry(PathGeometry pathGeoDst, Geometry geoSrc, double tolerance, Matrix matxPrevious)
 		{
 			Matrix matx = matxPrevious;

--- a/src/Controls/src/Core/Shapes/GeometryHelper.cs
+++ b/src/Controls/src/Core/Shapes/GeometryHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	{
 		static readonly List<Point> Points = new List<Point>();
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml" path="//Member[@MemberName='FlattenGeometry' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml" path="//Member[@MemberName='FlattenGeometry'][1]/Docs" />
 		public static PathGeometry FlattenGeometry(Geometry geoSrc, double tolerance)
 		{
 			// Return empty PathGeometry if Geometry is null
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			return pathGeoDst;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml" path="//Member[@MemberName='FlattenGeometry' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryHelper.xml" path="//Member[@MemberName='FlattenGeometry'][2]/Docs" />
 		public static void FlattenGeometry(PathGeometry pathGeoDst, Geometry geoSrc, double tolerance, Matrix matxPrevious)
 		{
 			Matrix matx = matxPrevious;

--- a/src/Controls/src/Core/Shapes/Line.cs
+++ b/src/Controls/src/Core/Shapes/Line.cs
@@ -3,12 +3,12 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Line']/Docs" />
 	public sealed partial class Line : Shape
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Line() : base()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Line(double x1, double y1, double x2, double y2) : this()
 		{
 			X1 = x1;

--- a/src/Controls/src/Core/Shapes/Line.cs
+++ b/src/Controls/src/Core/Shapes/Line.cs
@@ -3,12 +3,12 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Line']/Docs" />
 	public sealed partial class Line : Shape
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Line() : base()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Line(double x1, double y1, double x2, double y2) : this()
 		{
 			X1 = x1;

--- a/src/Controls/src/Core/Shapes/LineGeometry.cs
+++ b/src/Controls/src/Core/Shapes/LineGeometry.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.LineGeometry']/Docs" />
 	public class LineGeometry : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public LineGeometry()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public LineGeometry(Point startPoint, Point endPoint)
 		{
 			StartPoint = startPoint;

--- a/src/Controls/src/Core/Shapes/LineGeometry.cs
+++ b/src/Controls/src/Core/Shapes/LineGeometry.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.LineGeometry']/Docs" />
 	public class LineGeometry : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public LineGeometry()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public LineGeometry(Point startPoint, Point endPoint)
 		{
 			StartPoint = startPoint;

--- a/src/Controls/src/Core/Shapes/LineSegment.cs
+++ b/src/Controls/src/Core/Shapes/LineSegment.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.LineSegment']/Docs" />
 	public class LineSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public LineSegment()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public LineSegment(Point point)
 		{
 			Point = point;

--- a/src/Controls/src/Core/Shapes/LineSegment.cs
+++ b/src/Controls/src/Core/Shapes/LineSegment.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.LineSegment']/Docs" />
 	public class LineSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public LineSegment()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineSegment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public LineSegment(Point point)
 		{
 			Point = point;

--- a/src/Controls/src/Core/Shapes/Matrix.cs
+++ b/src/Controls/src/Core/Shapes/Matrix.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			this = CreateTranslation(offsetX, offsetY) * this;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform' and position()=0]/Docs" />
 		public Point Transform(Point point)
 		{
 			Point newPoint = point;
@@ -208,7 +208,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			return new Point(x, y);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform' and position()=1]/Docs" />
 		public void Transform(Point[] points)
 		{
 			if (points != null)
@@ -226,7 +226,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform' and position()=2]/Docs" />
 		public Vector2 Transform(Vector2 vector)
 		{
 			Vector2 newVector = vector;
@@ -239,7 +239,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			return new Vector2(x, y);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform'][3]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform' and position()=3]/Docs" />
 		public void Transform(Vector2[] vectors)
 		{
 			if (vectors != null)

--- a/src/Controls/src/Core/Shapes/Matrix.cs
+++ b/src/Controls/src/Core/Shapes/Matrix.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			this = CreateTranslation(offsetX, offsetY) * this;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform'][1]/Docs" />
 		public Point Transform(Point point)
 		{
 			Point newPoint = point;
@@ -208,7 +208,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			return new Point(x, y);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform'][2]/Docs" />
 		public void Transform(Point[] points)
 		{
 			if (points != null)
@@ -226,7 +226,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			}
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform'][3]/Docs" />
 		public Vector2 Transform(Vector2 vector)
 		{
 			Vector2 newVector = vector;
@@ -239,7 +239,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			return new Vector2(x, y);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform' and position()=3]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="//Member[@MemberName='Transform'][4]/Docs" />
 		public void Transform(Vector2[] vectors)
 		{
 			if (vectors != null)

--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -5,12 +5,12 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Path']/Docs" />
 	public sealed partial class Path : Shape
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Path() : base()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Path(Geometry data) : this()
 		{
 			Data = data;

--- a/src/Controls/src/Core/Shapes/Path.cs
+++ b/src/Controls/src/Core/Shapes/Path.cs
@@ -5,12 +5,12 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Path']/Docs" />
 	public sealed partial class Path : Shape
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Path() : base()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Path(Geometry data) : this()
 		{
 			Data = data;

--- a/src/Controls/src/Core/Shapes/PathGeometry.cs
+++ b/src/Controls/src/Core/Shapes/PathGeometry.cs
@@ -6,19 +6,19 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Figures")]
 	public sealed class PathGeometry : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public PathGeometry()
 		{
 			Figures = new PathFigureCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public PathGeometry(PathFigureCollection figures)
 		{
 			Figures = figures;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public PathGeometry(PathFigureCollection figures, FillRule fillRule)
 		{
 			Figures = figures;

--- a/src/Controls/src/Core/Shapes/PathGeometry.cs
+++ b/src/Controls/src/Core/Shapes/PathGeometry.cs
@@ -6,19 +6,19 @@ namespace Microsoft.Maui.Controls.Shapes
 	[ContentProperty("Figures")]
 	public sealed class PathGeometry : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public PathGeometry()
 		{
 			Figures = new PathFigureCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public PathGeometry(PathFigureCollection figures)
 		{
 			Figures = figures;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public PathGeometry(PathFigureCollection figures, FillRule fillRule)
 		{
 			Figures = figures;

--- a/src/Controls/src/Core/Shapes/PolyBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyBezierSegment.cs
@@ -3,13 +3,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.PolyBezierSegment']/Docs" />
 	public sealed class PolyBezierSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public PolyBezierSegment()
 		{
 			Points = new PointCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public PolyBezierSegment(PointCollection points)
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/PolyBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyBezierSegment.cs
@@ -3,13 +3,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.PolyBezierSegment']/Docs" />
 	public sealed class PolyBezierSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public PolyBezierSegment()
 		{
 			Points = new PointCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyBezierSegment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public PolyBezierSegment(PointCollection points)
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/PolyLineSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyLineSegment.cs
@@ -3,13 +3,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.PolyLineSegment']/Docs" />
 	public class PolyLineSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public PolyLineSegment()
 		{
 			Points = new PointCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public PolyLineSegment(PointCollection points)
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/PolyLineSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyLineSegment.cs
@@ -3,13 +3,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.PolyLineSegment']/Docs" />
 	public class PolyLineSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public PolyLineSegment()
 		{
 			Points = new PointCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyLineSegment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public PolyLineSegment(PointCollection points)
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/PolyQuadraticBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyQuadraticBezierSegment.cs
@@ -3,13 +3,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.PolyQuadraticBezierSegment']/Docs" />
 	public class PolyQuadraticBezierSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public PolyQuadraticBezierSegment()
 		{
 			Points = new PointCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public PolyQuadraticBezierSegment(PointCollection points)
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/PolyQuadraticBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/PolyQuadraticBezierSegment.cs
@@ -3,13 +3,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.PolyQuadraticBezierSegment']/Docs" />
 	public class PolyQuadraticBezierSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public PolyQuadraticBezierSegment()
 		{
 			Points = new PointCollection();
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PolyQuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public PolyQuadraticBezierSegment(PointCollection points)
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/Polygon.cs
+++ b/src/Controls/src/Core/Shapes/Polygon.cs
@@ -3,12 +3,12 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Polygon']/Docs" />
 	public sealed partial class Polygon : Shape
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Polygon() : base()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Polygon(PointCollection points) : this()
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/Polygon.cs
+++ b/src/Controls/src/Core/Shapes/Polygon.cs
@@ -3,12 +3,12 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Polygon']/Docs" />
 	public sealed partial class Polygon : Shape
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Polygon() : base()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Polygon(PointCollection points) : this()
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/Polyline.cs
+++ b/src/Controls/src/Core/Shapes/Polyline.cs
@@ -3,12 +3,12 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Polyline']/Docs" />
 	public sealed partial class Polyline : Shape
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Polyline() : base()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Polyline(PointCollection points) : this()
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/Polyline.cs
+++ b/src/Controls/src/Core/Shapes/Polyline.cs
@@ -3,12 +3,12 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Polyline']/Docs" />
 	public sealed partial class Polyline : Shape
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Polyline() : base()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Polyline(PointCollection points) : this()
 		{
 			Points = points;

--- a/src/Controls/src/Core/Shapes/QuadraticBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/QuadraticBezierSegment.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.QuadraticBezierSegment']/Docs" />
 	public class QuadraticBezierSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public QuadraticBezierSegment()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public QuadraticBezierSegment(Point point1, Point point2)
 		{
 			Point1 = point1;

--- a/src/Controls/src/Core/Shapes/QuadraticBezierSegment.cs
+++ b/src/Controls/src/Core/Shapes/QuadraticBezierSegment.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.QuadraticBezierSegment']/Docs" />
 	public class QuadraticBezierSegment : PathSegment
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public QuadraticBezierSegment()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/QuadraticBezierSegment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public QuadraticBezierSegment(Point point1, Point point2)
 		{
 			Point1 = point1;

--- a/src/Controls/src/Core/Shapes/RectangleGeometry.cs
+++ b/src/Controls/src/Core/Shapes/RectangleGeometry.cs
@@ -4,13 +4,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.RectangleGeometry']/Docs" />
 	public class RectangleGeometry : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public RectangleGeometry()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public RectangleGeometry(Rect rect)
 		{
 			Rect = rect;

--- a/src/Controls/src/Core/Shapes/RectangleGeometry.cs
+++ b/src/Controls/src/Core/Shapes/RectangleGeometry.cs
@@ -4,13 +4,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.RectangleGeometry']/Docs" />
 	public class RectangleGeometry : Geometry
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public RectangleGeometry()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public RectangleGeometry(Rect rect)
 		{
 			Rect = rect;

--- a/src/Controls/src/Core/Shapes/RotateTransform.cs
+++ b/src/Controls/src/Core/Shapes/RotateTransform.cs
@@ -5,19 +5,19 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.RotateTransform']/Docs" />
 	public class RotateTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public RotateTransform()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public RotateTransform(double angle)
 		{
 			Angle = angle;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public RotateTransform(double angle, double centerX, double centerY)
 		{
 			Angle = angle;

--- a/src/Controls/src/Core/Shapes/RotateTransform.cs
+++ b/src/Controls/src/Core/Shapes/RotateTransform.cs
@@ -5,19 +5,19 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.RotateTransform']/Docs" />
 	public class RotateTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public RotateTransform()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public RotateTransform(double angle)
 		{
 			Angle = angle;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RotateTransform.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public RotateTransform(double angle, double centerX, double centerY)
 		{
 			Angle = angle;

--- a/src/Controls/src/Core/Shapes/RoundRectangleGeometry.cs
+++ b/src/Controls/src/Core/Shapes/RoundRectangleGeometry.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.RoundRectangleGeometry']/Docs" />
 	public class RoundRectangleGeometry : GeometryGroup
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public RoundRectangleGeometry()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public RoundRectangleGeometry(CornerRadius cornerRadius, Rect rect)
 		{
 			CornerRadius = cornerRadius;

--- a/src/Controls/src/Core/Shapes/RoundRectangleGeometry.cs
+++ b/src/Controls/src/Core/Shapes/RoundRectangleGeometry.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.RoundRectangleGeometry']/Docs" />
 	public class RoundRectangleGeometry : GeometryGroup
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public RoundRectangleGeometry()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RoundRectangleGeometry.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public RoundRectangleGeometry(CornerRadius cornerRadius, Rect rect)
 		{
 			CornerRadius = cornerRadius;

--- a/src/Controls/src/Core/Shapes/ScaleTransform.cs
+++ b/src/Controls/src/Core/Shapes/ScaleTransform.cs
@@ -3,20 +3,20 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.ScaleTransform']/Docs" />
 	public class ScaleTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ScaleTransform()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ScaleTransform(double scaleX, double scaleY)
 		{
 			ScaleX = scaleX;
 			ScaleY = scaleY;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public ScaleTransform(double scaleX, double scaleY, double centerX, double centerY)
 		{
 			ScaleX = scaleX;

--- a/src/Controls/src/Core/Shapes/ScaleTransform.cs
+++ b/src/Controls/src/Core/Shapes/ScaleTransform.cs
@@ -3,20 +3,20 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.ScaleTransform']/Docs" />
 	public class ScaleTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ScaleTransform()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ScaleTransform(double scaleX, double scaleY)
 		{
 			ScaleX = scaleX;
 			ScaleY = scaleY;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/ScaleTransform.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ScaleTransform(double scaleX, double scaleY, double centerX, double centerY)
 		{
 			ScaleX = scaleX;

--- a/src/Controls/src/Core/Shapes/SkewTransform.cs
+++ b/src/Controls/src/Core/Shapes/SkewTransform.cs
@@ -5,20 +5,20 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.SkewTransform']/Docs" />
 	public class SkewTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public SkewTransform()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public SkewTransform(double angleX, double angleY)
 		{
 			AngleX = angleX;
 			AngleY = angleY;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public SkewTransform(double angleX, double angleY, double centerX, double centerY)
 		{
 			AngleX = angleX;

--- a/src/Controls/src/Core/Shapes/SkewTransform.cs
+++ b/src/Controls/src/Core/Shapes/SkewTransform.cs
@@ -5,20 +5,20 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.SkewTransform']/Docs" />
 	public class SkewTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public SkewTransform()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public SkewTransform(double angleX, double angleY)
 		{
 			AngleX = angleX;
 			AngleY = angleY;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/SkewTransform.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public SkewTransform(double angleX, double angleY, double centerX, double centerY)
 		{
 			AngleX = angleX;

--- a/src/Controls/src/Core/Shapes/TranslateTransform.cs
+++ b/src/Controls/src/Core/Shapes/TranslateTransform.cs
@@ -3,13 +3,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.TranslateTransform']/Docs" />
 	public class TranslateTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public TranslateTransform()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public TranslateTransform(double x, double y)
 		{
 			X = x;

--- a/src/Controls/src/Core/Shapes/TranslateTransform.cs
+++ b/src/Controls/src/Core/Shapes/TranslateTransform.cs
@@ -3,13 +3,13 @@ namespace Microsoft.Maui.Controls.Shapes
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.TranslateTransform']/Docs" />
 	public class TranslateTransform : Transform
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public TranslateTransform()
 		{
 
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TranslateTransform.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public TranslateTransform(double x, double y)
 		{
 			X = x;

--- a/src/Controls/src/Core/Shapes/Vector2.cs
+++ b/src/Controls/src/Core/Shapes/Vector2.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public struct Vector2
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public Vector2(double x, double y)
 			: this()
 		{
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Y = y;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Vector2(Point p)
 			: this()
 		{
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Y = p.Y;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Vector2(double angle)
 			: this()
 		{

--- a/src/Controls/src/Core/Shapes/Vector2.cs
+++ b/src/Controls/src/Core/Shapes/Vector2.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.Shapes
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public struct Vector2
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public Vector2(double x, double y)
 			: this()
 		{
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Y = y;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Vector2(Point p)
 			: this()
 		{
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls.Shapes
 			Y = p.Y;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Vector2.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Vector2(double angle)
 			: this()
 		{

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -577,13 +577,13 @@ namespace Microsoft.Maui.Controls
 			return _navigationManager.GoToAsync(state, animate, false);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync' and position()=0]/Docs" />
 		public Task GoToAsync(ShellNavigationState state, IDictionary<string, object> parameters)
 		{
 			return _navigationManager.GoToAsync(state, null, false, parameters: new ShellRouteParameters(parameters));
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync']/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync' and position()=1]/Docs" />
 		public Task GoToAsync(ShellNavigationState state, bool animate, IDictionary<string, object> parameters)
 		{
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(parameters));

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -565,25 +565,25 @@ namespace Microsoft.Maui.Controls
 		public static Shell Current => Application.Current?.MainPage as Shell;
 
 		internal ShellNavigationManager NavigationManager => _navigationManager;
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][1]/Docs" />
 		public Task GoToAsync(ShellNavigationState state)
 		{
 			return _navigationManager.GoToAsync(state, null, false);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][2]/Docs" />
 		public Task GoToAsync(ShellNavigationState state, bool animate)
 		{
 			return _navigationManager.GoToAsync(state, animate, false);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][1]/Docs" />
 		public Task GoToAsync(ShellNavigationState state, IDictionary<string, object> parameters)
 		{
 			return _navigationManager.GoToAsync(state, null, false, parameters: new ShellRouteParameters(parameters));
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][2]/Docs" />
 		public Task GoToAsync(ShellNavigationState state, bool animate, IDictionary<string, object> parameters)
 		{
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(parameters));

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -565,13 +565,13 @@ namespace Microsoft.Maui.Controls
 		public static Shell Current => Application.Current?.MainPage as Shell;
 
 		internal ShellNavigationManager NavigationManager => _navigationManager;
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync' and position()=0]/Docs" />
 		public Task GoToAsync(ShellNavigationState state)
 		{
 			return _navigationManager.GoToAsync(state, null, false);
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync' and position()=1]/Docs" />
 		public Task GoToAsync(ShellNavigationState state, bool animate)
 		{
 			return _navigationManager.GoToAsync(state, animate, false);

--- a/src/Controls/src/Core/Shell/ShellNavigationState.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationState.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Maui.Controls
 			private set;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ShellNavigationState() { }
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ShellNavigationState(string location) : this(location, true)
 		{
 		}
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls
 				Location = FullLocation;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public ShellNavigationState(Uri location)
 		{
 			FullLocation = location;

--- a/src/Controls/src/Core/Shell/ShellNavigationState.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationState.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Maui.Controls
 			private set;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ShellNavigationState() { }
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ShellNavigationState(string location) : this(location, true)
 		{
 		}
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls
 				Location = FullLocation;
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ShellNavigationState(Uri location)
 		{
 			FullLocation = location;

--- a/src/Controls/src/Core/Slider.cs
+++ b/src/Controls/src/Core/Slider.cs
@@ -63,13 +63,13 @@ namespace Microsoft.Maui.Controls
 
 		readonly Lazy<PlatformConfigurationRegistry<Slider>> _platformConfigurationRegistry;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Slider()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Slider>>(() => new PlatformConfigurationRegistry<Slider>(this));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Slider(double min, double max, double val) : this()
 		{
 			if (min >= max)

--- a/src/Controls/src/Core/Slider.cs
+++ b/src/Controls/src/Core/Slider.cs
@@ -63,13 +63,13 @@ namespace Microsoft.Maui.Controls
 
 		readonly Lazy<PlatformConfigurationRegistry<Slider>> _platformConfigurationRegistry;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Slider()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Slider>>(() => new PlatformConfigurationRegistry<Slider>(this));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Slider(double min, double max, double val) : this()
 		{
 			if (min >= max)

--- a/src/Controls/src/Core/SolidColorBrush.cs
+++ b/src/Controls/src/Core/SolidColorBrush.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Maui.Controls
 	[System.ComponentModel.TypeConverter(typeof(BrushTypeConverter))]
 	public class SolidColorBrush : Brush
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public SolidColorBrush()
 		{
 
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public SolidColorBrush(Color color)
 		{
 			Color = color;

--- a/src/Controls/src/Core/SolidColorBrush.cs
+++ b/src/Controls/src/Core/SolidColorBrush.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Maui.Controls
 	[System.ComponentModel.TypeConverter(typeof(BrushTypeConverter))]
 	public class SolidColorBrush : Brush
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public SolidColorBrush()
 		{
 
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/SolidColorBrush.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public SolidColorBrush(Color color)
 		{
 			Color = color;

--- a/src/Controls/src/Core/Stepper.cs
+++ b/src/Controls/src/Core/Stepper.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Maui.Controls
 
 		readonly Lazy<PlatformConfigurationRegistry<Stepper>> _platformConfigurationRegistry;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Stepper() => _platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Stepper>>(() => new PlatformConfigurationRegistry<Stepper>(this));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Stepper(double min, double max, double val, double increment) : this()
 		{
 			if (min >= max)

--- a/src/Controls/src/Core/Stepper.cs
+++ b/src/Controls/src/Core/Stepper.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Maui.Controls
 
 		readonly Lazy<PlatformConfigurationRegistry<Stepper>> _platformConfigurationRegistry;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Stepper() => _platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Stepper>>(() => new PlatformConfigurationRegistry<Stepper>(this));
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Stepper.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Stepper(double min, double max, double val, double increment) : this()
 		{
 			if (min >= max)

--- a/src/Controls/src/Core/SwipeItems.cs
+++ b/src/Controls/src/Core/SwipeItems.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 			_swipeItems.CollectionChanged += OnSwipeItemsChanged;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public SwipeItems() : this(Enumerable.Empty<ISwipeItem>())
 		{
 

--- a/src/Controls/src/Core/SwipeItems.cs
+++ b/src/Controls/src/Core/SwipeItems.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 			_swipeItems.CollectionChanged += OnSwipeItemsChanged;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeItems.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public SwipeItems() : this(Enumerable.Empty<ISwipeItem>())
 		{
 

--- a/src/Controls/src/Core/TableModel.cs
+++ b/src/Controls/src/Core/TableModel.cs
@@ -57,13 +57,13 @@ namespace Microsoft.Maui.Controls.Internals
 
 		public event EventHandler<EventArg<object>> ItemSelected;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowLongPressed'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowLongPressed' and position()=1]/Docs" />
 		public void RowLongPressed(int section, int row)
 		{
 			RowLongPressed(GetItem(section, row));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowLongPressed'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowLongPressed' and position()=0]/Docs" />
 		public void RowLongPressed(object item)
 		{
 			if (ItemLongPressed != null)
@@ -72,13 +72,13 @@ namespace Microsoft.Maui.Controls.Internals
 			OnRowLongPressed(item);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowSelected'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowSelected' and position()=1]/Docs" />
 		public void RowSelected(int section, int row)
 		{
 			RowSelected(GetItem(section, row));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowSelected'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowSelected' and position()=0]/Docs" />
 		public void RowSelected(object item)
 		{
 			if (ItemSelected != null)

--- a/src/Controls/src/Core/TableModel.cs
+++ b/src/Controls/src/Core/TableModel.cs
@@ -57,13 +57,13 @@ namespace Microsoft.Maui.Controls.Internals
 
 		public event EventHandler<EventArg<object>> ItemSelected;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowLongPressed' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowLongPressed'][2]/Docs" />
 		public void RowLongPressed(int section, int row)
 		{
 			RowLongPressed(GetItem(section, row));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowLongPressed' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowLongPressed'][1]/Docs" />
 		public void RowLongPressed(object item)
 		{
 			if (ItemLongPressed != null)
@@ -72,13 +72,13 @@ namespace Microsoft.Maui.Controls.Internals
 			OnRowLongPressed(item);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowSelected' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowSelected'][2]/Docs" />
 		public void RowSelected(int section, int row)
 		{
 			RowSelected(GetItem(section, row));
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowSelected' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/TableModel.xml" path="//Member[@MemberName='RowSelected'][1]/Docs" />
 		public void RowSelected(object item)
 		{
 			if (ItemSelected != null)

--- a/src/Controls/src/Core/TableRoot.cs
+++ b/src/Controls/src/Core/TableRoot.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="Type[@FullName='Microsoft.Maui.Controls.TableRoot']/Docs" />
 	public sealed class TableRoot : TableSectionBase<TableSection>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public TableRoot()
 		{
 			SetupEvents();
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public TableRoot(string title) : base(title)
 		{
 			SetupEvents();

--- a/src/Controls/src/Core/TableRoot.cs
+++ b/src/Controls/src/Core/TableRoot.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="Type[@FullName='Microsoft.Maui.Controls.TableRoot']/Docs" />
 	public sealed class TableRoot : TableSectionBase<TableSection>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public TableRoot()
 		{
 			SetupEvents();
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableRoot.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public TableRoot(string title) : base(title)
 		{
 			SetupEvents();

--- a/src/Controls/src/Core/TableSection.cs
+++ b/src/Controls/src/Core/TableSection.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 			_children.CollectionChanged += OnChildrenChanged;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add'][1]/Docs" />
 		public void Add(T item)
 		{
 			_children.Add(item);
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls
 			remove { _children.CollectionChanged -= value; }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add'][2]/Docs" />
 		public void Add(IEnumerable<T> items)
 		{
 			items.ForEach(_children.Add);
@@ -174,12 +174,12 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="Type[@FullName='Microsoft.Maui.Controls.TableSection']/Docs" />
 	public sealed class TableSection : TableSectionBase<Cell>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public TableSection()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public TableSection(string title) : base(title)
 		{
 		}

--- a/src/Controls/src/Core/TableSection.cs
+++ b/src/Controls/src/Core/TableSection.cs
@@ -174,12 +174,12 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="Type[@FullName='Microsoft.Maui.Controls.TableSection']/Docs" />
 	public sealed class TableSection : TableSectionBase<Cell>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public TableSection()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableSection.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public TableSection(string title) : base(title)
 		{
 		}

--- a/src/Controls/src/Core/TableSection.cs
+++ b/src/Controls/src/Core/TableSection.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls
 			_children.CollectionChanged += OnChildrenChanged;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add' and position()=0]/Docs" />
 		public void Add(T item)
 		{
 			_children.Add(item);
@@ -139,7 +139,7 @@ namespace Microsoft.Maui.Controls
 			remove { _children.CollectionChanged -= value; }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add' and position()=1]/Docs" />
 		public void Add(IEnumerable<T> items)
 		{
 			items.ForEach(_children.Add);

--- a/src/Controls/src/Core/TableView.cs
+++ b/src/Controls/src/Core/TableView.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Maui.Controls
 
 		TableModel _model;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public TableView() : this(null)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public TableView(TableRoot root)
 		{
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Controls/src/Core/TableView.cs
+++ b/src/Controls/src/Core/TableView.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Maui.Controls
 
 		TableModel _model;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public TableView() : this(null)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TableView.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public TableView(TableRoot root)
 		{
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='NumberOfTapsRequiredProperty']/Docs" />
 		public static readonly BindableProperty NumberOfTapsRequiredProperty = BindableProperty.Create("NumberOfTapsRequired", typeof(int), typeof(TapGestureRecognizer), 1);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public TapGestureRecognizer()
 		{
 		}

--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='NumberOfTapsRequiredProperty']/Docs" />
 		public static readonly BindableProperty NumberOfTapsRequiredProperty = BindableProperty.Create("NumberOfTapsRequired", typeof(int), typeof(TapGestureRecognizer), 1);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public TapGestureRecognizer()
 		{
 		}

--- a/src/Controls/src/Core/TemplateBinding.cs
+++ b/src/Controls/src/Core/TemplateBinding.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 		BindingExpression _expression;
 		string _path;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TemplateBinding.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TemplateBinding.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public TemplateBinding()
 		{
 		}

--- a/src/Controls/src/Core/TemplateBinding.cs
+++ b/src/Controls/src/Core/TemplateBinding.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls
 		BindingExpression _expression;
 		string _path;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/TemplateBinding.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/TemplateBinding.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public TemplateBinding()
 		{
 		}

--- a/src/Controls/src/Core/ToolbarItem.cs
+++ b/src/Controls/src/Core/ToolbarItem.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 
 		static readonly BindableProperty PriorityProperty = BindableProperty.Create("Priority", typeof(int), typeof(ToolbarItem), 0);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ToolbarItem.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ToolbarItem.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ToolbarItem()
 		{
 		}

--- a/src/Controls/src/Core/ToolbarItem.cs
+++ b/src/Controls/src/Core/ToolbarItem.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 
 		static readonly BindableProperty PriorityProperty = BindableProperty.Create("Priority", typeof(int), typeof(ToolbarItem), 0);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/ToolbarItem.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/ToolbarItem.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ToolbarItem()
 		{
 		}

--- a/src/Controls/src/Core/UnsolvableConstraintsException.cs
+++ b/src/Controls/src/Core/UnsolvableConstraintsException.cs
@@ -8,18 +8,18 @@ namespace Microsoft.Maui.Controls
 #endif
 	public class UnsolvableConstraintsException : Exception
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public UnsolvableConstraintsException()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public UnsolvableConstraintsException(string message)
 			: base(message)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public UnsolvableConstraintsException(string message, Exception innerException)
 			: base(message, innerException)
 		{

--- a/src/Controls/src/Core/UnsolvableConstraintsException.cs
+++ b/src/Controls/src/Core/UnsolvableConstraintsException.cs
@@ -8,18 +8,18 @@ namespace Microsoft.Maui.Controls
 #endif
 	public class UnsolvableConstraintsException : Exception
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public UnsolvableConstraintsException()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public UnsolvableConstraintsException(string message)
 			: base(message)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/UnsolvableConstraintsException.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public UnsolvableConstraintsException(string message, Exception innerException)
 			: base(message, innerException)
 		{

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -181,12 +181,12 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateGroupList.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateGroupList.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public VisualStateGroupList() : this(false)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateGroupList.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateGroupList.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public VisualStateGroupList(bool isDefault)
 		{
 			IsDefault = isDefault;

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -181,12 +181,12 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateGroupList.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateGroupList.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public VisualStateGroupList() : this(false)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateGroupList.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateGroupList.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public VisualStateGroupList(bool isDefault)
 		{
 			IsDefault = isDefault;

--- a/src/Controls/src/Core/WeakEventManager.cs
+++ b/src/Controls/src/Core/WeakEventManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly Dictionary<string, List<Subscription>> _eventHandlers = new Dictionary<string, List<Subscription>>();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler' and position()=0]/Docs" />
 		public void AddEventHandler<TEventArgs>(EventHandler<TEventArgs> handler, [CallerMemberName] string eventName = "")
 			where TEventArgs : EventArgs
 		{
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls
 			AddEventHandler(eventName, handler.Target, handler.GetMethodInfo());
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler' and position()=1]/Docs" />
 		public void AddEventHandler(Delegate? handler, [CallerMemberName] string eventName = "")
 		{
 			if (IsNullOrEmpty(eventName))
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler' and position()=0]/Docs" />
 		public void RemoveEventHandler<TEventArgs>(EventHandler<TEventArgs> handler, [CallerMemberName] string eventName = "")
 			where TEventArgs : EventArgs
 		{
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			RemoveEventHandler(eventName, handler.Target, handler.GetMethodInfo());
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler' and position()=1]/Docs" />
 		public void RemoveEventHandler(Delegate? handler, [CallerMemberName] string eventName = "")
 		{
 			if (IsNullOrEmpty(eventName))

--- a/src/Controls/src/Core/WeakEventManager.cs
+++ b/src/Controls/src/Core/WeakEventManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls
 	{
 		readonly Dictionary<string, List<Subscription>> _eventHandlers = new Dictionary<string, List<Subscription>>();
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler'][1]/Docs" />
 		public void AddEventHandler<TEventArgs>(EventHandler<TEventArgs> handler, [CallerMemberName] string eventName = "")
 			where TEventArgs : EventArgs
 		{
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls
 			AddEventHandler(eventName, handler.Target, handler.GetMethodInfo());
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler'][2]/Docs" />
 		public void AddEventHandler(Delegate? handler, [CallerMemberName] string eventName = "")
 		{
 			if (IsNullOrEmpty(eventName))
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler'][1]/Docs" />
 		public void RemoveEventHandler<TEventArgs>(EventHandler<TEventArgs> handler, [CallerMemberName] string eventName = "")
 			where TEventArgs : EventArgs
 		{
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Controls
 			RemoveEventHandler(eventName, handler.Target, handler.GetMethodInfo());
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler'][2]/Docs" />
 		public void RemoveEventHandler(Delegate? handler, [CallerMemberName] string eventName = "")
 		{
 			if (IsNullOrEmpty(eventName))

--- a/src/Controls/src/Core/XamlParseException.cs
+++ b/src/Controls/src/Core/XamlParseException.cs
@@ -12,18 +12,18 @@ namespace Microsoft.Maui.Controls.Xaml
 	{
 		readonly string _unformattedMessage;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public XamlParseException()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public XamlParseException(string message)
 		   : base(message)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public XamlParseException(string message, Exception innerException)
 		   : base(message, innerException)
 		{

--- a/src/Controls/src/Core/XamlParseException.cs
+++ b/src/Controls/src/Core/XamlParseException.cs
@@ -12,18 +12,18 @@ namespace Microsoft.Maui.Controls.Xaml
 	{
 		readonly string _unformattedMessage;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public XamlParseException()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public XamlParseException(string message)
 		   : base(message)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public XamlParseException(string message, Exception innerException)
 		   : base(message, innerException)
 		{

--- a/src/Controls/src/Core/XamlParseException.cs
+++ b/src/Controls/src/Core/XamlParseException.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		{
 		}
 
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		protected XamlParseException(global::System.Runtime.Serialization.SerializationInfo info, global::System.Runtime.Serialization.StreamingContext context)
 			: base(info, context)
 		{
@@ -39,7 +40,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XamlParseException.xml" path="//Member[@MemberName='.ctor'][5]/Docs" />
 		public XamlParseException(string message, IXmlLineInfo xmlInfo, Exception innerException = null)
 			: base(FormatMessage(message, xmlInfo), innerException)
 		{

--- a/src/Controls/src/Core/XmlLineInfo.cs
+++ b/src/Controls/src/Core/XmlLineInfo.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Maui.Controls.Xaml
 	{
 		readonly bool _hasLineInfo;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public XmlLineInfo()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public XmlLineInfo(int linenumber, int lineposition)
 		{
 			_hasLineInfo = true;

--- a/src/Controls/src/Core/XmlLineInfo.cs
+++ b/src/Controls/src/Core/XmlLineInfo.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Maui.Controls.Xaml
 	{
 		readonly bool _hasLineInfo;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public XmlLineInfo()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls.Xaml/XmlLineInfo.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public XmlLineInfo(int linenumber, int lineposition)
 		{
 			_hasLineInfo = true;

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.Maui</AssemblyName>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-	<WarningsNotAsErrors>CS1571;CS1572;CS1734</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="..\..\..\.nuspec\Microsoft.Maui.Controls.MultiTargeting.targets" />
   <ItemGroup>

--- a/src/Core/src/Fonts/FontFile.cs
+++ b/src/Core/src/Fonts/FontFile.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='PostScriptName']/Docs" />
 		public string? PostScriptName { get; set; }
 
-		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='FileNameWithExtension'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='FileNameWithExtension' and position()=1]/Docs" />
 		public string FileNameWithExtension(string? extension) => $"{FileName}{extension}";
 
-		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='FileNameWithExtension'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='FileNameWithExtension' and position()=0]/Docs" />
 		public string FileNameWithExtension() => FileNameWithExtension(Extension);
 
 		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='GetPostScriptNameWithSpaces']/Docs" />

--- a/src/Core/src/Fonts/FontFile.cs
+++ b/src/Core/src/Fonts/FontFile.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='PostScriptName']/Docs" />
 		public string? PostScriptName { get; set; }
 
-		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='FileNameWithExtension' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='FileNameWithExtension'][2]/Docs" />
 		public string FileNameWithExtension(string? extension) => $"{FileName}{extension}";
 
-		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='FileNameWithExtension' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='FileNameWithExtension'][1]/Docs" />
 		public string FileNameWithExtension() => FileNameWithExtension(Extension);
 
 		/// <include file="../../docs/Microsoft.Maui/FontFile.xml" path="//Member[@MemberName='GetPostScriptNameWithSpaces']/Docs" />

--- a/src/Core/src/Primitives/CornerRadius.cs
+++ b/src/Core/src/Primitives/CornerRadius.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='BottomRight']/Docs" />
 		public double BottomRight { get; }
 
-		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public CornerRadius(double uniformRadius) : this(uniformRadius, uniformRadius, uniformRadius, uniformRadius)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public CornerRadius(double topLeft, double topRight, double bottomLeft, double bottomRight)
 		{
 			_isParameterized = true;

--- a/src/Core/src/Primitives/CornerRadius.cs
+++ b/src/Core/src/Primitives/CornerRadius.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='BottomRight']/Docs" />
 		public double BottomRight { get; }
 
-		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public CornerRadius(double uniformRadius) : this(uniformRadius, uniformRadius, uniformRadius, uniformRadius)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/CornerRadius.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public CornerRadius(double topLeft, double topRight, double bottomLeft, double bottomRight)
 		{
 			_isParameterized = true;

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -77,11 +77,11 @@ namespace Microsoft.Maui
 			return new Font(Family, Size, fontSlant, weight, AutoScalingEnabled);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='OfSize']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='OfSize'][1]/Docs" />
 		public static Font OfSize(string? name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
 			new(name, size, fontSlant, weight, enableScaling);
 
-		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='SystemFontOfSize']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='SystemFontOfSize'][1]/Docs" />
 		public static Font SystemFontOfSize(double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
 			new(null, size, fontSlant, weight, enableScaling);
 

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui
 			return new Font(Family, Size, Slant, Weight, enabled);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithSize'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithSize' and position()=0]/Docs" />
 		public Font WithSize(double size)
 		{
 			return new Font(Family, size, Slant, Weight, AutoScalingEnabled);

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui
 			return new Font(Family, Size, Slant, Weight, enabled);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithSize' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithSize'][1]/Docs" />
 		public Font WithSize(double size)
 		{
 			return new Font(Family, size, Slant, Weight, AutoScalingEnabled);
@@ -65,13 +65,13 @@ namespace Microsoft.Maui
 			return new Font(Family, Size, fontSlant, Weight, AutoScalingEnabled);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight'][1]/Docs" />
 		public Font WithWeight(FontWeight weight)
 		{
 			return new Font(Family, Size, Slant, weight, AutoScalingEnabled);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight'][2]/Docs" />
 		public Font WithWeight(FontWeight weight, FontSlant fontSlant)
 		{
 			return new Font(Family, Size, fontSlant, weight, AutoScalingEnabled);

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -65,13 +65,13 @@ namespace Microsoft.Maui
 			return new Font(Family, Size, fontSlant, Weight, AutoScalingEnabled);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight' and position()=0]/Docs" />
 		public Font WithWeight(FontWeight weight)
 		{
 			return new Font(Family, Size, Slant, weight, AutoScalingEnabled);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight' and position()=1]/Docs" />
 		public Font WithWeight(FontWeight weight, FontSlant fontSlant)
 		{
 			return new Font(Family, Size, fontSlant, weight, AutoScalingEnabled);

--- a/src/Core/src/Primitives/GridLength.cs
+++ b/src/Core/src/Primitives/GridLength.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Maui
 			get { return GridUnitType == GridUnitType.Star; }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public GridLength(double value) : this(value, GridUnitType.Absolute)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public GridLength(double value, GridUnitType type)
 		{
 			if (value < 0 || double.IsNaN(value))

--- a/src/Core/src/Primitives/GridLength.cs
+++ b/src/Core/src/Primitives/GridLength.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Maui
 			get { return GridUnitType == GridUnitType.Star; }
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public GridLength(double value) : this(value, GridUnitType.Absolute)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/GridLength.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public GridLength(double value, GridUnitType type)
 		{
 			if (value < 0 || double.IsNaN(value))

--- a/src/Core/src/Primitives/SizeRequest.cs
+++ b/src/Core/src/Primitives/SizeRequest.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='Minimum']/Docs" />
 		public Size Minimum { get; set; }
 
-		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public SizeRequest(Size request, Size minimum)
 		{
 			Request = request;
 			Minimum = minimum;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public SizeRequest(Size request)
 		{
 			Request = request;

--- a/src/Core/src/Primitives/SizeRequest.cs
+++ b/src/Core/src/Primitives/SizeRequest.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='Minimum']/Docs" />
 		public Size Minimum { get; set; }
 
-		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public SizeRequest(Size request, Size minimum)
 		{
 			Request = request;
 			Minimum = minimum;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public SizeRequest(Size request)
 		{
 			Request = request;

--- a/src/Core/src/Primitives/Thickness.cs
+++ b/src/Core/src/Primitives/Thickness.cs
@@ -34,17 +34,17 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='IsNaN']/Docs" />
 		public bool IsNaN => double.IsNaN(Left) && double.IsNaN(Top) && double.IsNaN(Right) && double.IsNaN(Bottom);
 
-		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Thickness(double uniformSize) : this(uniformSize, uniformSize, uniformSize, uniformSize)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Thickness(double horizontalSize, double verticalSize) : this(horizontalSize, verticalSize, horizontalSize, verticalSize)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public Thickness(double left, double top, double right, double bottom) : this()
 		{
 			Left = left;

--- a/src/Core/src/Primitives/Thickness.cs
+++ b/src/Core/src/Primitives/Thickness.cs
@@ -34,17 +34,17 @@ namespace Microsoft.Maui
 		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='IsNaN']/Docs" />
 		public bool IsNaN => double.IsNaN(Left) && double.IsNaN(Top) && double.IsNaN(Right) && double.IsNaN(Bottom);
 
-		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Thickness(double uniformSize) : this(uniformSize, uniformSize, uniformSize, uniformSize)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Thickness(double horizontalSize, double verticalSize) : this(horizontalSize, verticalSize, horizontalSize, verticalSize)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public Thickness(double left, double top, double right, double bottom) : this()
 		{
 			Left = left;

--- a/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui
 		public static SourceInfo? GetSourceInfo(object obj) =>
 			sourceInfos.TryGetValue(obj, out var sourceinfo) ? sourceinfo : null;
 
-		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded' and position()=0]/Docs" />
 		public static void OnChildAdded(IVisualTreeElement parent, IVisualTreeElement child)
 		{
 			if (!DebuggerHelper.DebuggerIsAttached)
@@ -39,7 +39,7 @@ namespace Microsoft.Maui
 			OnChildAdded(parent, child, index);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded' and position()=1]/Docs" />
 		public static void OnChildAdded(IVisualTreeElement? parent, IVisualTreeElement child, int newLogicalIndex)
 		{
 			if (!DebuggerHelper.DebuggerIsAttached)

--- a/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui
 		public static SourceInfo? GetSourceInfo(object obj) =>
 			sourceInfos.TryGetValue(obj, out var sourceinfo) ? sourceinfo : null;
 
-		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded'][1]/Docs" />
 		public static void OnChildAdded(IVisualTreeElement parent, IVisualTreeElement child)
 		{
 			if (!DebuggerHelper.DebuggerIsAttached)
@@ -39,7 +39,7 @@ namespace Microsoft.Maui
 			OnChildAdded(parent, child, index);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded'][2]/Docs" />
 		public static void OnChildAdded(IVisualTreeElement? parent, IVisualTreeElement child, int newLogicalIndex)
 		{
 			if (!DebuggerHelper.DebuggerIsAttached)

--- a/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
+++ b/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
@@ -84,24 +84,24 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="Type[@FullName='Microsoft.Maui.Essentials.AccelerometerData']/Docs" />
 	public readonly struct AccelerometerData : IEquatable<AccelerometerData>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public AccelerometerData(double x, double y, double z)
 			: this((float)x, (float)y, (float)z)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public AccelerometerData(float x, float y, float z) =>
 			Acceleration = new Vector3(x, y, z);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Acceleration']/Docs" />
 		public Vector3 Acceleration { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object? obj) =>
 			(obj is AccelerometerData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(AccelerometerData other) =>
 			Acceleration.Equals(other.Acceleration);
 

--- a/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
+++ b/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
@@ -97,11 +97,11 @@ namespace Microsoft.Maui.Essentials
 		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Acceleration']/Docs" />
 		public Vector3 Acceleration { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object? obj) =>
 			(obj is AccelerometerData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(AccelerometerData other) =>
 			Acceleration.Equals(other.Acceleration);
 

--- a/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
+++ b/src/Essentials/src/Accelerometer/Accelerometer.shared.cs
@@ -84,13 +84,13 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="Type[@FullName='Microsoft.Maui.Essentials.AccelerometerData']/Docs" />
 	public readonly struct AccelerometerData : IEquatable<AccelerometerData>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public AccelerometerData(double x, double y, double z)
 			: this((float)x, (float)y, (float)z)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AccelerometerData.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public AccelerometerData(float x, float y, float z) =>
 			Acceleration = new Vector3(x, y, z);
 

--- a/src/Essentials/src/AppActions/AppActions.shared.cs
+++ b/src/Essentials/src/AppActions/AppActions.shared.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Maui.Essentials
 		public static Task<IEnumerable<AppAction>> GetAsync()
 			=> Current.GetAsync();
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='SetAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='SetAsync' and position()=0]/Docs" />
 		public static Task SetAsync(params AppAction[] actions)
 			=> Current.SetAsync(actions);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='SetAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='SetAsync' and position()=1]/Docs" />
 		public static Task SetAsync(IEnumerable<AppAction> actions)
 			=> Current.SetAsync(actions);
 

--- a/src/Essentials/src/AppActions/AppActions.shared.cs
+++ b/src/Essentials/src/AppActions/AppActions.shared.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Maui.Essentials
 		public static Task<IEnumerable<AppAction>> GetAsync()
 			=> Current.GetAsync();
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='SetAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='SetAsync'][1]/Docs" />
 		public static Task SetAsync(params AppAction[] actions)
 			=> Current.SetAsync(actions);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='SetAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='SetAsync'][2]/Docs" />
 		public static Task SetAsync(IEnumerable<AppAction> actions)
 			=> Current.SetAsync(actions);
 

--- a/src/Essentials/src/Barometer/Barometer.shared.cs
+++ b/src/Essentials/src/Barometer/Barometer.shared.cs
@@ -84,11 +84,11 @@ namespace Microsoft.Maui.Essentials
 		public static bool operator !=(BarometerData left, BarometerData right) =>
 			!left.Equals(right);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/BarometerData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/BarometerData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is BarometerData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/BarometerData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/BarometerData.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(BarometerData other) =>
 			PressureInHectopascals.Equals(other.PressureInHectopascals);
 

--- a/src/Essentials/src/Barometer/Barometer.shared.cs
+++ b/src/Essentials/src/Barometer/Barometer.shared.cs
@@ -84,11 +84,11 @@ namespace Microsoft.Maui.Essentials
 		public static bool operator !=(BarometerData left, BarometerData right) =>
 			!left.Equals(right);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/BarometerData.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/BarometerData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is BarometerData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/BarometerData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/BarometerData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(BarometerData other) =>
 			PressureInHectopascals.Equals(other.PressureInHectopascals);
 

--- a/src/Essentials/src/Browser/Browser.shared.cs
+++ b/src/Essentials/src/Browser/Browser.shared.cs
@@ -25,18 +25,18 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Browser']/Docs" />
 	public static partial class Browser
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=0]/Docs" />
 		public static Task OpenAsync(string uri) =>
 			Current.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=2]/Docs" />
 		public static Task OpenAsync(string uri, BrowserLaunchMode launchMode) =>
 			Current.OpenAsync(uri, new BrowserLaunchOptions()
 			{
 				LaunchMode = launchMode
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=3]/Docs" />
 		public static Task OpenAsync(string uri, BrowserLaunchOptions options)
 		{
 			if (string.IsNullOrWhiteSpace(uri))
@@ -47,18 +47,18 @@ namespace Microsoft.Maui.Essentials
 			return Current.OpenAsync(new Uri(uri), options);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=1]/Docs" />
 		public static Task OpenAsync(Uri uri) =>
 			Current.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=4]/Docs" />
 		public static Task OpenAsync(Uri uri, BrowserLaunchMode launchMode) =>
 			Current.OpenAsync(uri, new BrowserLaunchOptions()
 			{
 				LaunchMode = launchMode
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=5]/Docs" />
 		public static Task<bool> OpenAsync(Uri uri, BrowserLaunchOptions options) =>
 			Current.OpenAsync(EscapeUri(uri), options);
 

--- a/src/Essentials/src/Browser/Browser.shared.cs
+++ b/src/Essentials/src/Browser/Browser.shared.cs
@@ -25,18 +25,18 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Browser']/Docs" />
 	public static partial class Browser
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][1]/Docs" />
 		public static Task OpenAsync(string uri) =>
 			Current.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][3]/Docs" />
 		public static Task OpenAsync(string uri, BrowserLaunchMode launchMode) =>
 			Current.OpenAsync(uri, new BrowserLaunchOptions()
 			{
 				LaunchMode = launchMode
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][4]/Docs" />
 		public static Task OpenAsync(string uri, BrowserLaunchOptions options)
 		{
 			if (string.IsNullOrWhiteSpace(uri))
@@ -47,18 +47,18 @@ namespace Microsoft.Maui.Essentials
 			return Current.OpenAsync(new Uri(uri), options);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][2]/Docs" />
 		public static Task OpenAsync(Uri uri) =>
 			Current.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][5]/Docs" />
 		public static Task OpenAsync(Uri uri, BrowserLaunchMode launchMode) =>
 			Current.OpenAsync(uri, new BrowserLaunchOptions()
 			{
 				LaunchMode = launchMode
 			});
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync' and position()=5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Browser.xml" path="//Member[@MemberName='OpenAsync'][6]/Docs" />
 		public static Task<bool> OpenAsync(Uri uri, BrowserLaunchOptions options) =>
 			Current.OpenAsync(EscapeUri(uri), options);
 

--- a/src/Essentials/src/Compass/Compass.shared.cs
+++ b/src/Essentials/src/Compass/Compass.shared.cs
@@ -45,14 +45,14 @@ namespace Microsoft.Maui.Essentials
 		public static bool IsMonitoring
 			=> Current.IsMonitoring;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Start' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Start'][1]/Docs" />
 		public static void Start(SensorSpeed sensorSpeed) => Start(sensorSpeed, true);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Start' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Start'][2]/Docs" />
 		public static void Start(SensorSpeed sensorSpeed, bool applyLowPassFilter)
 			=> Current.Start(sensorSpeed, applyLowPassFilter);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Stop' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Stop'][1]/Docs" />
 		public static void Stop()
 			=> Current.Stop();
 
@@ -109,11 +109,11 @@ namespace Microsoft.Maui.Essentials
 		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='HeadingMagneticNorth']/Docs" />
 		public double HeadingMagneticNorth { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is CompassData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(CompassData other) =>
 			HeadingMagneticNorth.Equals(other.HeadingMagneticNorth);
 
@@ -172,7 +172,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Stop' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Stop'][2]/Docs" />
 		public void Stop()
 		{
 			if (!PlatformIsSupported)

--- a/src/Essentials/src/Compass/Compass.shared.cs
+++ b/src/Essentials/src/Compass/Compass.shared.cs
@@ -45,10 +45,10 @@ namespace Microsoft.Maui.Essentials
 		public static bool IsMonitoring
 			=> Current.IsMonitoring;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Start'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Start' and position()=0]/Docs" />
 		public static void Start(SensorSpeed sensorSpeed) => Start(sensorSpeed, true);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Start'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Start' and position()=1]/Docs" />
 		public static void Start(SensorSpeed sensorSpeed, bool applyLowPassFilter)
 			=> Current.Start(sensorSpeed, applyLowPassFilter);
 
@@ -109,11 +109,11 @@ namespace Microsoft.Maui.Essentials
 		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='HeadingMagneticNorth']/Docs" />
 		public double HeadingMagneticNorth { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is CompassData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/CompassData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(CompassData other) =>
 			HeadingMagneticNorth.Equals(other.HeadingMagneticNorth);
 

--- a/src/Essentials/src/Compass/Compass.shared.cs
+++ b/src/Essentials/src/Compass/Compass.shared.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Essentials
 		public static void Start(SensorSpeed sensorSpeed, bool applyLowPassFilter)
 			=> Current.Start(sensorSpeed, applyLowPassFilter);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Stop']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Stop' and position()=0]/Docs" />
 		public static void Stop()
 			=> Current.Stop();
 
@@ -172,7 +172,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Stop']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Compass.xml" path="//Member[@MemberName='Stop' and position()=1]/Docs" />
 		public void Stop()
 		{
 			if (!PlatformIsSupported)

--- a/src/Essentials/src/Email/Email.shared.cs
+++ b/src/Essentials/src/Email/Email.shared.cs
@@ -22,15 +22,15 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Email']/Docs" />
 	public static partial class Email
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync'][1]/Docs" />
 		public static Task ComposeAsync()
 			=> ComposeAsync(null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync'][3]/Docs" />
 		public static Task ComposeAsync(string subject, string body, params string[] to)
 			=> ComposeAsync(new EmailMessage(subject, body, to));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync'][2]/Docs" />
 		public static Task ComposeAsync(EmailMessage message)
 		{
 			if (!Current.IsComposeSupported)
@@ -83,12 +83,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="Type[@FullName='Microsoft.Maui.Essentials.EmailMessage']/Docs" />
 	public class EmailMessage
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public EmailMessage()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public EmailMessage(string subject, string body, params string[] to)
 		{
 			Subject = subject;
@@ -130,19 +130,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="Type[@FullName='Microsoft.Maui.Essentials.EmailAttachment']/Docs" />
 	public partial class EmailAttachment : FileBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public EmailAttachment(string fullPath)
 			: base(fullPath)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public EmailAttachment(string fullPath, string contentType)
 			: base(fullPath, contentType)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public EmailAttachment(FileBase file)
 			: base(file)
 		{

--- a/src/Essentials/src/Email/Email.shared.cs
+++ b/src/Essentials/src/Email/Email.shared.cs
@@ -83,12 +83,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="Type[@FullName='Microsoft.Maui.Essentials.EmailMessage']/Docs" />
 	public class EmailMessage
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public EmailMessage()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailMessage.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public EmailMessage(string subject, string body, params string[] to)
 		{
 			Subject = subject;
@@ -130,19 +130,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="Type[@FullName='Microsoft.Maui.Essentials.EmailAttachment']/Docs" />
 	public partial class EmailAttachment : FileBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public EmailAttachment(string fullPath)
 			: base(fullPath)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public EmailAttachment(string fullPath, string contentType)
 			: base(fullPath, contentType)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/EmailAttachment.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public EmailAttachment(FileBase file)
 			: base(file)
 		{

--- a/src/Essentials/src/Email/Email.shared.cs
+++ b/src/Essentials/src/Email/Email.shared.cs
@@ -22,15 +22,15 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Email']/Docs" />
 	public static partial class Email
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync' and position()=0]/Docs" />
 		public static Task ComposeAsync()
 			=> ComposeAsync(null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync' and position()=2]/Docs" />
 		public static Task ComposeAsync(string subject, string body, params string[] to)
 			=> ComposeAsync(new EmailMessage(subject, body, to));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Email.xml" path="//Member[@MemberName='ComposeAsync' and position()=1]/Docs" />
 		public static Task ComposeAsync(EmailMessage message)
 		{
 			if (!Current.IsComposeSupported)

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -6,7 +6,6 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <WarningsNotAsErrors>BI1234</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
-	<WarningsNotAsErrors>CS1571;CS1572;CS1734</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="..\..\..\.nuspec\Microsoft.Maui.Controls.MultiTargeting.targets" />
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">

--- a/src/Essentials/src/FileSystem/FileSystem.shared.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.shared.cs
@@ -258,19 +258,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ReadOnlyFile']/Docs" />
 	public class ReadOnlyFile : FileBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ReadOnlyFile(string fullPath)
 			: base(fullPath)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ReadOnlyFile(string fullPath, string contentType)
 			: base(fullPath, contentType)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ReadOnlyFile(FileBase file)
 			: base(file)
 		{
@@ -285,19 +285,19 @@ namespace Microsoft.Maui.Essentials
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public FileResult(string fullPath)
 			: base(fullPath)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public FileResult(string fullPath, string contentType)
 			: base(fullPath, contentType)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public FileResult(FileBase file)
 			: base(file)
 		{

--- a/src/Essentials/src/FileSystem/FileSystem.shared.cs
+++ b/src/Essentials/src/FileSystem/FileSystem.shared.cs
@@ -258,19 +258,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ReadOnlyFile']/Docs" />
 	public class ReadOnlyFile : FileBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ReadOnlyFile(string fullPath)
 			: base(fullPath)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public ReadOnlyFile(string fullPath, string contentType)
 			: base(fullPath, contentType)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ReadOnlyFile.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ReadOnlyFile(FileBase file)
 			: base(file)
 		{
@@ -285,19 +285,19 @@ namespace Microsoft.Maui.Essentials
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public FileResult(string fullPath)
 			: base(fullPath)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public FileResult(string fullPath, string contentType)
 			: base(fullPath, contentType)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/FileResult.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public FileResult(FileBase file)
 			: base(file)
 		{

--- a/src/Essentials/src/Geocoding/Geocoding.shared.cs
+++ b/src/Essentials/src/Geocoding/Geocoding.shared.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Geocoding']/Docs" />
 	public static class Geocoding
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="//Member[@MemberName='GetPlacemarksAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="//Member[@MemberName='GetPlacemarksAsync'][1]/Docs" />
 		public static Task<IEnumerable<Placemark>> GetPlacemarksAsync(Location location)
 		{
 			if (location == null)
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Essentials
 			return GetPlacemarksAsync(location.Latitude, location.Longitude);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="//Member[@MemberName='GetPlacemarksAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="//Member[@MemberName='GetPlacemarksAsync'][2]/Docs" />
 		public static Task<IEnumerable<Placemark>> GetPlacemarksAsync(double latitude, double longitude)
 			=> Current.GetPlacemarksAsync(latitude, longitude);
 

--- a/src/Essentials/src/Geocoding/Geocoding.shared.cs
+++ b/src/Essentials/src/Geocoding/Geocoding.shared.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Geocoding']/Docs" />
 	public static class Geocoding
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="//Member[@MemberName='GetPlacemarksAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="//Member[@MemberName='GetPlacemarksAsync' and position()=0]/Docs" />
 		public static Task<IEnumerable<Placemark>> GetPlacemarksAsync(Location location)
 		{
 			if (location == null)
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Essentials
 			return GetPlacemarksAsync(location.Latitude, location.Longitude);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="//Member[@MemberName='GetPlacemarksAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geocoding.xml" path="//Member[@MemberName='GetPlacemarksAsync' and position()=1]/Docs" />
 		public static Task<IEnumerable<Placemark>> GetPlacemarksAsync(double latitude, double longitude)
 			=> Current.GetPlacemarksAsync(latitude, longitude);
 

--- a/src/Essentials/src/Geolocation/Geolocation.shared.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.shared.cs
@@ -27,15 +27,15 @@ namespace Microsoft.Maui.Essentials
 		public static Task<Location> GetLastKnownLocationAsync() =>
 			Current.GetLastKnownLocationAsync();
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync' and position()=0]/Docs" />
 		public static Task<Location> GetLocationAsync() =>
 			Current.GetLocationAsync(new GeolocationRequest(), default);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync' and position()=1]/Docs" />
 		public static Task<Location> GetLocationAsync(GeolocationRequest request) =>
 			Current.GetLocationAsync(request ?? new GeolocationRequest(), default);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync' and position()=2]/Docs" />
 		public static Task<Location> GetLocationAsync(GeolocationRequest request, CancellationToken cancelToken) =>
 			Current.GetLocationAsync(request ?? new GeolocationRequest(), cancelToken);
 

--- a/src/Essentials/src/Geolocation/Geolocation.shared.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.shared.cs
@@ -27,15 +27,15 @@ namespace Microsoft.Maui.Essentials
 		public static Task<Location> GetLastKnownLocationAsync() =>
 			Current.GetLastKnownLocationAsync();
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync'][1]/Docs" />
 		public static Task<Location> GetLocationAsync() =>
 			Current.GetLocationAsync(new GeolocationRequest(), default);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync'][2]/Docs" />
 		public static Task<Location> GetLocationAsync(GeolocationRequest request) =>
 			Current.GetLocationAsync(request ?? new GeolocationRequest(), default);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Geolocation.xml" path="//Member[@MemberName='GetLocationAsync'][3]/Docs" />
 		public static Task<Location> GetLocationAsync(GeolocationRequest request, CancellationToken cancelToken) =>
 			Current.GetLocationAsync(request ?? new GeolocationRequest(), cancelToken);
 

--- a/src/Essentials/src/Geolocation/GeolocationRequest.shared.cs
+++ b/src/Essentials/src/Geolocation/GeolocationRequest.shared.cs
@@ -43,21 +43,21 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.GeolocationRequest']/Docs" />
 	public partial class GeolocationRequest
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public GeolocationRequest()
 		{
 			Timeout = TimeSpan.Zero;
 			DesiredAccuracy = GeolocationAccuracy.Default;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public GeolocationRequest(GeolocationAccuracy accuracy)
 		{
 			Timeout = TimeSpan.Zero;
 			DesiredAccuracy = accuracy;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public GeolocationRequest(GeolocationAccuracy accuracy, TimeSpan timeout)
 		{
 			Timeout = timeout;

--- a/src/Essentials/src/Geolocation/GeolocationRequest.shared.cs
+++ b/src/Essentials/src/Geolocation/GeolocationRequest.shared.cs
@@ -43,21 +43,21 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.GeolocationRequest']/Docs" />
 	public partial class GeolocationRequest
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public GeolocationRequest()
 		{
 			Timeout = TimeSpan.Zero;
 			DesiredAccuracy = GeolocationAccuracy.Default;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public GeolocationRequest(GeolocationAccuracy accuracy)
 		{
 			Timeout = TimeSpan.Zero;
 			DesiredAccuracy = accuracy;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public GeolocationRequest(GeolocationAccuracy accuracy, TimeSpan timeout)
 		{
 			Timeout = timeout;

--- a/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
+++ b/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials
 		public static void Start(SensorSpeed sensorSpeed)
 			=> Current.Start(sensorSpeed);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Gyroscope.xml" path="//Member[@MemberName='Stop' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Gyroscope.xml" path="//Member[@MemberName='Stop'][1]/Docs" />
 		public static void Stop()
 			=> Current.Stop();
 
@@ -77,24 +77,24 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="Type[@FullName='Microsoft.Maui.Essentials.GyroscopeData']/Docs" />
 	public readonly struct GyroscopeData : IEquatable<GyroscopeData>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public GyroscopeData(double x, double y, double z)
 			: this((float)x, (float)y, (float)z)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public GyroscopeData(float x, float y, float z) =>
 			AngularVelocity = new Vector3(x, y, z);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='AngularVelocity']/Docs" />
 		public Vector3 AngularVelocity { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is GyroscopeData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(GyroscopeData other) =>
 			AngularVelocity.Equals(other.AngularVelocity);
 
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Gyroscope.xml" path="//Member[@MemberName='Stop' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Gyroscope.xml" path="//Member[@MemberName='Stop'][2]/Docs" />
 		public void Stop()
 		{
 			if (!PlatformIsSupported)

--- a/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
+++ b/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials
 		public static void Start(SensorSpeed sensorSpeed)
 			=> Current.Start(sensorSpeed);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Gyroscope.xml" path="//Member[@MemberName='Stop']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Gyroscope.xml" path="//Member[@MemberName='Stop' and position()=0]/Docs" />
 		public static void Stop()
 			=> Current.Stop();
 
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Gyroscope.xml" path="//Member[@MemberName='Stop']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Gyroscope.xml" path="//Member[@MemberName='Stop' and position()=1]/Docs" />
 		public void Stop()
 		{
 			if (!PlatformIsSupported)

--- a/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
+++ b/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
@@ -90,11 +90,11 @@ namespace Microsoft.Maui.Essentials
 		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='AngularVelocity']/Docs" />
 		public Vector3 AngularVelocity { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is GyroscopeData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(GyroscopeData other) =>
 			AngularVelocity.Equals(other.AngularVelocity);
 

--- a/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
+++ b/src/Essentials/src/Gyroscope/Gyroscope.shared.cs
@@ -77,13 +77,13 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="Type[@FullName='Microsoft.Maui.Essentials.GyroscopeData']/Docs" />
 	public readonly struct GyroscopeData : IEquatable<GyroscopeData>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public GyroscopeData(double x, double y, double z)
 			: this((float)x, (float)y, (float)z)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GyroscopeData.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public GyroscopeData(float x, float y, float z) =>
 			AngularVelocity = new Vector3(x, y, z);
 

--- a/src/Essentials/src/Launcher/Launcher.shared.cs
+++ b/src/Essentials/src/Launcher/Launcher.shared.cs
@@ -25,31 +25,31 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Launcher']/Docs" />
 	public static partial class Launcher
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='CanOpenAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='CanOpenAsync'][1]/Docs" />
 		public static Task<bool> CanOpenAsync(string uri)
 			=> Current.CanOpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='CanOpenAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='CanOpenAsync'][2]/Docs" />
 		public static Task<bool> CanOpenAsync(Uri uri)
 			=> Current.CanOpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync'][1]/Docs" />
 		public static Task<bool> OpenAsync(string uri)
 			=> Current.OpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync'][2]/Docs" />
 		public static Task<bool> OpenAsync(Uri uri)
 			=> Current.OpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync'][3]/Docs" />
 		public static Task<bool> OpenAsync(OpenFileRequest request)
 			=> Current.OpenAsync(request);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='TryOpenAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='TryOpenAsync'][1]/Docs" />
 		public static Task<bool> TryOpenAsync(string uri)
 			=> Current.TryOpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='TryOpenAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='TryOpenAsync'][2]/Docs" />
 		public static Task<bool> TryOpenAsync(Uri uri)
 			=> Current.TryOpenAsync(uri);
 
@@ -69,19 +69,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.OpenFileRequest']/Docs" />
 	public class OpenFileRequest
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public OpenFileRequest()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public OpenFileRequest(string title, ReadOnlyFile file)
 		{
 			Title = title;
 			File = file;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public OpenFileRequest(string title, FileBase file)
 		{
 			Title = title;

--- a/src/Essentials/src/Launcher/Launcher.shared.cs
+++ b/src/Essentials/src/Launcher/Launcher.shared.cs
@@ -69,19 +69,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.OpenFileRequest']/Docs" />
 	public class OpenFileRequest
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public OpenFileRequest()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public OpenFileRequest(string title, ReadOnlyFile file)
 		{
 			Title = title;
 			File = file;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OpenFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public OpenFileRequest(string title, FileBase file)
 		{
 			Title = title;

--- a/src/Essentials/src/Launcher/Launcher.shared.cs
+++ b/src/Essentials/src/Launcher/Launcher.shared.cs
@@ -25,31 +25,31 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Launcher']/Docs" />
 	public static partial class Launcher
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='CanOpenAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='CanOpenAsync' and position()=0]/Docs" />
 		public static Task<bool> CanOpenAsync(string uri)
 			=> Current.CanOpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='CanOpenAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='CanOpenAsync' and position()=1]/Docs" />
 		public static Task<bool> CanOpenAsync(Uri uri)
 			=> Current.CanOpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync' and position()=0]/Docs" />
 		public static Task<bool> OpenAsync(string uri)
 			=> Current.OpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync' and position()=1]/Docs" />
 		public static Task<bool> OpenAsync(Uri uri)
 			=> Current.OpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='OpenAsync' and position()=2]/Docs" />
 		public static Task<bool> OpenAsync(OpenFileRequest request)
 			=> Current.OpenAsync(request);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='TryOpenAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='TryOpenAsync' and position()=0]/Docs" />
 		public static Task<bool> TryOpenAsync(string uri)
 			=> Current.TryOpenAsync(uri);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='TryOpenAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Launcher.xml" path="//Member[@MemberName='TryOpenAsync' and position()=1]/Docs" />
 		public static Task<bool> TryOpenAsync(Uri uri)
 			=> Current.TryOpenAsync(uri);
 

--- a/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
+++ b/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
@@ -77,13 +77,13 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="Type[@FullName='Microsoft.Maui.Essentials.MagnetometerData']/Docs" />
 	public readonly struct MagnetometerData : IEquatable<MagnetometerData>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public MagnetometerData(double x, double y, double z)
 			: this((float)x, (float)y, (float)z)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public MagnetometerData(float x, float y, float z) =>
 			MagneticField = new Vector3(x, y, z);
 

--- a/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
+++ b/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials
 		public static void Start(SensorSpeed sensorSpeed)
 			=> Current.Start(sensorSpeed);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Magnetometer.xml" path="//Member[@MemberName='Stop' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Magnetometer.xml" path="//Member[@MemberName='Stop'][1]/Docs" />
 		public static void Stop()
 			=> Current.Stop();
 
@@ -77,24 +77,24 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="Type[@FullName='Microsoft.Maui.Essentials.MagnetometerData']/Docs" />
 	public readonly struct MagnetometerData : IEquatable<MagnetometerData>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public MagnetometerData(double x, double y, double z)
 			: this((float)x, (float)y, (float)z)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public MagnetometerData(float x, float y, float z) =>
 			MagneticField = new Vector3(x, y, z);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='MagneticField']/Docs" />
 		public Vector3 MagneticField { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is MagnetometerData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(MagnetometerData other) =>
 			MagneticField.Equals(other.MagneticField);
 
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Magnetometer.xml" path="//Member[@MemberName='Stop' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Magnetometer.xml" path="//Member[@MemberName='Stop'][2]/Docs" />
 		public void Stop()
 		{
 			if (!PlatformIsSupported)

--- a/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
+++ b/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
@@ -90,11 +90,11 @@ namespace Microsoft.Maui.Essentials
 		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='MagneticField']/Docs" />
 		public Vector3 MagneticField { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is MagnetometerData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MagnetometerData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(MagnetometerData other) =>
 			MagneticField.Equals(other.MagneticField);
 

--- a/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
+++ b/src/Essentials/src/Magnetometer/Magnetometer.shared.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials
 		public static void Start(SensorSpeed sensorSpeed)
 			=> Current.Start(sensorSpeed);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Magnetometer.xml" path="//Member[@MemberName='Stop']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Magnetometer.xml" path="//Member[@MemberName='Stop' and position()=0]/Docs" />
 		public static void Stop()
 			=> Current.Stop();
 
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Magnetometer.xml" path="//Member[@MemberName='Stop']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Magnetometer.xml" path="//Member[@MemberName='Stop' and position()=1]/Docs" />
 		public void Stop()
 		{
 			if (!PlatformIsSupported)

--- a/src/Essentials/src/MainThread/MainThread.shared.cs
+++ b/src/Essentials/src/MainThread/MainThread.shared.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Essentials
 			return tcs.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync&lt;T&gt;'][2]/Docs" />
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<T> func)
 		{
 			if (IsMainThread)
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Essentials
 			return tcs.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync&lt;T&gt;'][1]/Docs" />
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask)
 		{
 			if (IsMainThread)

--- a/src/Essentials/src/MainThread/MainThread.shared.cs
+++ b/src/Essentials/src/MainThread/MainThread.shared.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Essentials
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][1]/Docs" />
 		public static Task InvokeOnMainThreadAsync(Action action)
 		{
 			if (IsMainThread)
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Essentials
 			return tcs.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][1]/Docs" />
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<T> func)
 		{
 			if (IsMainThread)
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Essentials
 			return tcs.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][2]/Docs" />
 		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask)
 		{
 			if (IsMainThread)
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Essentials
 			return tcs.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][3]/Docs" />
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask)
 		{
 			if (IsMainThread)

--- a/src/Essentials/src/MainThread/MainThread.shared.cs
+++ b/src/Essentials/src/MainThread/MainThread.shared.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Essentials
 			return tcs.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=0]/Docs" />
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<T> func)
 		{
 			if (IsMainThread)
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Essentials
 			return tcs.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=1]/Docs" />
 		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask)
 		{
 			if (IsMainThread)
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Essentials
 			return tcs.Task;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=2]/Docs" />
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask)
 		{
 			if (IsMainThread)

--- a/src/Essentials/src/MainThread/MainThread.shared.cs
+++ b/src/Essentials/src/MainThread/MainThread.shared.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Essentials
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/MainThread.xml" path="//Member[@MemberName='InvokeOnMainThreadAsync' and position()=0]/Docs" />
 		public static Task InvokeOnMainThreadAsync(Action action)
 		{
 			if (IsMainThread)

--- a/src/Essentials/src/Map/Map.shared.cs
+++ b/src/Essentials/src/Map/Map.shared.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Map']/Docs" />
 	public static class Map
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][1]/Docs" />
 		public static Task OpenAsync(Location location) =>
 			OpenAsync(location, new MapLaunchOptions());
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][4]/Docs" />
 		public static Task OpenAsync(Location location, MapLaunchOptions options)
 		{
 			if (location == null)
@@ -30,11 +30,11 @@ namespace Microsoft.Maui.Essentials
 			return Current.OpenMapsAsync(location.Latitude, location.Longitude, options);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][3]/Docs" />
 		public static Task OpenAsync(double latitude, double longitude) =>
 			OpenAsync(latitude, longitude, new MapLaunchOptions());
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][6]/Docs" />
 		public static Task OpenAsync(double latitude, double longitude, MapLaunchOptions options)
 		{
 			if (options == null)
@@ -43,11 +43,11 @@ namespace Microsoft.Maui.Essentials
 			return Current.OpenMapsAsync(latitude, longitude, options);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][2]/Docs" />
 		public static Task OpenAsync(Placemark placemark) =>
 			OpenAsync(placemark, new MapLaunchOptions());
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][5]/Docs" />
 		public static Task OpenAsync(Placemark placemark, MapLaunchOptions options)
 		{
 			if (placemark == null)

--- a/src/Essentials/src/Map/Map.shared.cs
+++ b/src/Essentials/src/Map/Map.shared.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Map']/Docs" />
 	public static class Map
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=0]/Docs" />
 		public static Task OpenAsync(Location location) =>
 			OpenAsync(location, new MapLaunchOptions());
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=3]/Docs" />
 		public static Task OpenAsync(Location location, MapLaunchOptions options)
 		{
 			if (location == null)
@@ -30,11 +30,11 @@ namespace Microsoft.Maui.Essentials
 			return Current.OpenMapsAsync(location.Latitude, location.Longitude, options);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=2]/Docs" />
 		public static Task OpenAsync(double latitude, double longitude) =>
 			OpenAsync(latitude, longitude, new MapLaunchOptions());
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=5]/Docs" />
 		public static Task OpenAsync(double latitude, double longitude, MapLaunchOptions options)
 		{
 			if (options == null)
@@ -43,11 +43,11 @@ namespace Microsoft.Maui.Essentials
 			return Current.OpenMapsAsync(latitude, longitude, options);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=1]/Docs" />
 		public static Task OpenAsync(Placemark placemark) =>
 			OpenAsync(placemark, new MapLaunchOptions());
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync'][4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Map.xml" path="//Member[@MemberName='OpenAsync' and position()=4]/Docs" />
 		public static Task OpenAsync(Placemark placemark, MapLaunchOptions options)
 		{
 			if (placemark == null)

--- a/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
+++ b/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
@@ -90,11 +90,11 @@ namespace Microsoft.Maui.Essentials
 		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Orientation']/Docs" />
 		public Quaternion Orientation { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is OrientationSensorData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(OrientationSensorData other) =>
 			Orientation.Equals(other.Orientation);
 

--- a/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
+++ b/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials
 		public static void Start(SensorSpeed sensorSpeed)
 			=> Current.Start(sensorSpeed);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensor.xml" path="//Member[@MemberName='Stop']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensor.xml" path="//Member[@MemberName='Stop' and position()=0]/Docs" />
 		public static void Stop()
 			=> Current.Stop();
 
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensor.xml" path="//Member[@MemberName='Stop']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensor.xml" path="//Member[@MemberName='Stop' and position()=1]/Docs" />
 		public void Stop()
 		{
 			if (!PlatformIsSupported)

--- a/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
+++ b/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
@@ -77,13 +77,13 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="Type[@FullName='Microsoft.Maui.Essentials.OrientationSensorData']/Docs" />
 	public readonly struct OrientationSensorData : IEquatable<OrientationSensorData>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public OrientationSensorData(double x, double y, double z, double w)
 			: this((float)x, (float)y, (float)z, (float)w)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public OrientationSensorData(float x, float y, float z, float w) =>
 			Orientation = new Quaternion(x, y, z, w);
 

--- a/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
+++ b/src/Essentials/src/OrientationSensor/OrientationSensor.shared.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials
 		public static void Start(SensorSpeed sensorSpeed)
 			=> Current.Start(sensorSpeed);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensor.xml" path="//Member[@MemberName='Stop' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensor.xml" path="//Member[@MemberName='Stop'][1]/Docs" />
 		public static void Stop()
 			=> Current.Stop();
 
@@ -77,24 +77,24 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="Type[@FullName='Microsoft.Maui.Essentials.OrientationSensorData']/Docs" />
 	public readonly struct OrientationSensorData : IEquatable<OrientationSensorData>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public OrientationSensorData(double x, double y, double z, double w)
 			: this((float)x, (float)y, (float)z, (float)w)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public OrientationSensorData(float x, float y, float z, float w) =>
 			Orientation = new Quaternion(x, y, z, w);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Orientation']/Docs" />
 		public Quaternion Orientation { get; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is OrientationSensorData data) && Equals(data);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensorData.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(OrientationSensorData other) =>
 			Orientation.Equals(other.Orientation);
 
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensor.xml" path="//Member[@MemberName='Stop' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/OrientationSensor.xml" path="//Member[@MemberName='Stop'][2]/Docs" />
 		public void Stop()
 		{
 			if (!PlatformIsSupported)

--- a/src/Essentials/src/Preferences/Preferences.shared.cs
+++ b/src/Essentials/src/Preferences/Preferences.shared.cs
@@ -22,143 +22,143 @@ namespace Microsoft.Maui.Essentials
 
 		// overloads
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='ContainsKey' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='ContainsKey'][1]/Docs" />
 		public static bool ContainsKey(string key) =>
 			ContainsKey(key, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Remove' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Remove'][1]/Docs" />
 		public static void Remove(string key) =>
 			Remove(key, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Clear' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Clear'][1]/Docs" />
 		public static void Clear() =>
 			Clear(null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=6]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][7]/Docs" />
 		public static string Get(string key, string defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][1]/Docs" />
 		public static bool Get(string key, bool defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][4]/Docs" />
 		public static int Get(string key, int defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][3]/Docs" />
 		public static double Get(string key, double defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][6]/Docs" />
 		public static float Get(string key, float defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][5]/Docs" />
 		public static long Get(string key, long defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=6]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][7]/Docs" />
 		public static void Set(string key, string value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][1]/Docs" />
 		public static void Set(string key, bool value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][4]/Docs" />
 		public static void Set(string key, int value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][3]/Docs" />
 		public static void Set(string key, double value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][6]/Docs" />
 		public static void Set(string key, float value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][5]/Docs" />
 		public static void Set(string key, long value) =>
 			Set(key, value, null);
 
 		// shared -> platform
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='ContainsKey' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='ContainsKey'][2]/Docs" />
 		public static bool ContainsKey(string key, string? sharedName) =>
 			Current.ContainsKey(key, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Remove' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Remove'][2]/Docs" />
 		public static void Remove(string key, string? sharedName) =>
 			Current.Remove(key, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Clear' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Clear'][2]/Docs" />
 		public static void Clear(string? sharedName) =>
 			Current.Clear(sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=13]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][14]/Docs" />
 		public static string Get(string key, string defaultValue, string? sharedName) =>
 			Current.Get<string>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=7]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][8]/Docs" />
 		public static bool Get(string key, bool defaultValue, string? sharedName) =>
 			Current.Get<bool>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=10]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][11]/Docs" />
 		public static int Get(string key, int defaultValue, string? sharedName) =>
 			Current.Get<int>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=9]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][10]/Docs" />
 		public static double Get(string key, double defaultValue, string? sharedName) =>
 			Current.Get<double>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=12]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][13]/Docs" />
 		public static float Get(string key, float defaultValue, string? sharedName) =>
 			Current.Get<float>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=11]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][12]/Docs" />
 		public static long Get(string key, long defaultValue, string? sharedName) =>
 			Current.Get<long>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=13]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][14]/Docs" />
 		public static void Set(string key, string value, string? sharedName) =>
 			Current.Set<string>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=7]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][8]/Docs" />
 		public static void Set(string key, bool value, string? sharedName) =>
 			Current.Set<bool>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=10]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][11]/Docs" />
 		public static void Set(string key, int value, string? sharedName) =>
 			Current.Set<int>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=9]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][10]/Docs" />
 		public static void Set(string key, double value, string? sharedName) =>
 			Current.Set<double>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=12]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][13]/Docs" />
 		public static void Set(string key, float value, string? sharedName) =>
 			Current.Set<float>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=11]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][12]/Docs" />
 		public static void Set(string key, long value, string? sharedName) =>
 			Current.Set<long>(key, value, sharedName);
 
 		// DateTime
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][2]/Docs" />
 		public static DateTime Get(string key, DateTime defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][2]/Docs" />
 		public static void Set(string key, DateTime value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=8]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][9]/Docs" />
 		public static DateTime Get(string key, DateTime defaultValue, string? sharedName) =>
 			DateTime.FromBinary(Current.Get<long>(key, defaultValue.ToBinary(), sharedName));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=8]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][9]/Docs" />
 		public static void Set(string key, DateTime value, string? sharedName) =>
 			Current.Set<long>(key, value.ToBinary(), sharedName);
 

--- a/src/Essentials/src/Preferences/Preferences.shared.cs
+++ b/src/Essentials/src/Preferences/Preferences.shared.cs
@@ -22,143 +22,143 @@ namespace Microsoft.Maui.Essentials
 
 		// overloads
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='ContainsKey'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='ContainsKey' and position()=0]/Docs" />
 		public static bool ContainsKey(string key) =>
 			ContainsKey(key, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Remove'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Remove' and position()=0]/Docs" />
 		public static void Remove(string key) =>
 			Remove(key, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Clear'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Clear' and position()=0]/Docs" />
 		public static void Clear() =>
 			Clear(null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][6]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=6]/Docs" />
 		public static string Get(string key, string defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=0]/Docs" />
 		public static bool Get(string key, bool defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=3]/Docs" />
 		public static int Get(string key, int defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=2]/Docs" />
 		public static double Get(string key, double defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=5]/Docs" />
 		public static float Get(string key, float defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=4]/Docs" />
 		public static long Get(string key, long defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][6]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=6]/Docs" />
 		public static void Set(string key, string value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=0]/Docs" />
 		public static void Set(string key, bool value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=3]/Docs" />
 		public static void Set(string key, int value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=2]/Docs" />
 		public static void Set(string key, double value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][5]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=5]/Docs" />
 		public static void Set(string key, float value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=4]/Docs" />
 		public static void Set(string key, long value) =>
 			Set(key, value, null);
 
 		// shared -> platform
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='ContainsKey'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='ContainsKey' and position()=1]/Docs" />
 		public static bool ContainsKey(string key, string? sharedName) =>
 			Current.ContainsKey(key, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Remove'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Remove' and position()=1]/Docs" />
 		public static void Remove(string key, string? sharedName) =>
 			Current.Remove(key, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Clear'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Clear' and position()=1]/Docs" />
 		public static void Clear(string? sharedName) =>
 			Current.Clear(sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][13]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=13]/Docs" />
 		public static string Get(string key, string defaultValue, string? sharedName) =>
 			Current.Get<string>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][7]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=7]/Docs" />
 		public static bool Get(string key, bool defaultValue, string? sharedName) =>
 			Current.Get<bool>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][10]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=10]/Docs" />
 		public static int Get(string key, int defaultValue, string? sharedName) =>
 			Current.Get<int>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][9]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=9]/Docs" />
 		public static double Get(string key, double defaultValue, string? sharedName) =>
 			Current.Get<double>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][12]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=12]/Docs" />
 		public static float Get(string key, float defaultValue, string? sharedName) =>
 			Current.Get<float>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][11]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=11]/Docs" />
 		public static long Get(string key, long defaultValue, string? sharedName) =>
 			Current.Get<long>(key, defaultValue, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][13]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=13]/Docs" />
 		public static void Set(string key, string value, string? sharedName) =>
 			Current.Set<string>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][7]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=7]/Docs" />
 		public static void Set(string key, bool value, string? sharedName) =>
 			Current.Set<bool>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][10]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=10]/Docs" />
 		public static void Set(string key, int value, string? sharedName) =>
 			Current.Set<int>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][9]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=9]/Docs" />
 		public static void Set(string key, double value, string? sharedName) =>
 			Current.Set<double>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][12]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=12]/Docs" />
 		public static void Set(string key, float value, string? sharedName) =>
 			Current.Set<float>(key, value, sharedName);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][11]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=11]/Docs" />
 		public static void Set(string key, long value, string? sharedName) =>
 			Current.Set<long>(key, value, sharedName);
 
 		// DateTime
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=1]/Docs" />
 		public static DateTime Get(string key, DateTime defaultValue) =>
 			Get(key, defaultValue, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=1]/Docs" />
 		public static void Set(string key, DateTime value) =>
 			Set(key, value, null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][8]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get' and position()=8]/Docs" />
 		public static DateTime Get(string key, DateTime defaultValue, string? sharedName) =>
 			DateTime.FromBinary(Current.Get<long>(key, defaultValue.ToBinary(), sharedName));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][8]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set' and position()=8]/Docs" />
 		public static void Set(string key, DateTime value, string? sharedName) =>
 			Current.Set<long>(key, value.ToBinary(), sharedName);
 

--- a/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="Type[@FullName='Microsoft.Maui.Essentials.SecureStorage']/Docs" />
 	public static partial class SecureStorage
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='GetAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='GetAsync'][1]/Docs" />
 		public static Task<string> GetAsync(string key)
 		{
 			if (string.IsNullOrWhiteSpace(key))
@@ -46,11 +46,11 @@ namespace Microsoft.Maui.Essentials
 			return Current.SetAsync(key, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='Remove' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='Remove'][1]/Docs" />
 		public static bool Remove(string key)
 			=> Current.Remove(key);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='RemoveAll' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='RemoveAll'][1]/Docs" />
 		public static void RemoveAll()
 			=> Current.RemoveAll();
 
@@ -111,7 +111,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 		internal static readonly string Alias = Preferences.GetPrivatePreferencesSharedName("preferences");
 #endif
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='GetAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='GetAsync'][2]/Docs" />
 		public Task<string> GetAsync(string key)
 		{
 			if (string.IsNullOrWhiteSpace(key))
@@ -132,11 +132,11 @@ namespace Microsoft.Maui.Essentials.Implementations
 			return PlatformSetAsync(key, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='Remove' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='Remove'][2]/Docs" />
 		public bool Remove(string key)
 			=> PlatformRemove(key);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='RemoveAll' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='RemoveAll'][2]/Docs" />
 		public void RemoveAll()
 			=> PlatformRemoveAll();
 

--- a/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="Type[@FullName='Microsoft.Maui.Essentials.SecureStorage']/Docs" />
 	public static partial class SecureStorage
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='GetAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='GetAsync' and position()=0]/Docs" />
 		public static Task<string> GetAsync(string key)
 		{
 			if (string.IsNullOrWhiteSpace(key))
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Essentials
 			return Current.GetAsync(key);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='SetAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='SetAsync'][0 and position()=0]/Docs" />
 		public static Task SetAsync(string key, string value)
 		{
 			if (string.IsNullOrWhiteSpace(key))
@@ -46,11 +46,11 @@ namespace Microsoft.Maui.Essentials
 			return Current.SetAsync(key, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='Remove']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='Remove' and position()=0]/Docs" />
 		public static bool Remove(string key)
 			=> Current.Remove(key);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='RemoveAll']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='RemoveAll' and position()=0]/Docs" />
 		public static void RemoveAll()
 			=> Current.RemoveAll();
 
@@ -111,7 +111,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 		internal static readonly string Alias = Preferences.GetPrivatePreferencesSharedName("preferences");
 #endif
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='GetAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='GetAsync' and position()=1]/Docs" />
 		public Task<string> GetAsync(string key)
 		{
 			if (string.IsNullOrWhiteSpace(key))
@@ -120,7 +120,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 			return PlatformGetAsync(key);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='SetAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='SetAsync'][0 and position()=1]/Docs" />
 		public Task SetAsync(string key, string value)
 		{
 			if (string.IsNullOrWhiteSpace(key))
@@ -132,11 +132,11 @@ namespace Microsoft.Maui.Essentials.Implementations
 			return PlatformSetAsync(key, value);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='Remove']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='Remove' and position()=1]/Docs" />
 		public bool Remove(string key)
 			=> PlatformRemove(key);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='RemoveAll']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='RemoveAll' and position()=1]/Docs" />
 		public void RemoveAll()
 			=> PlatformRemoveAll();
 

--- a/src/Essentials/src/Share/Share.shared.cs
+++ b/src/Essentials/src/Share/Share.shared.cs
@@ -157,21 +157,21 @@ namespace Microsoft.Maui.Essentials
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ShareMultipleFilesRequest(IEnumerable<ShareFile> files) =>
 			Files = files.ToList();
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ShareMultipleFilesRequest(IEnumerable<FileBase> files)
 			: this(ConvertList(files))
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public ShareMultipleFilesRequest(string title, IEnumerable<ShareFile> files)
 			: this(files) => Title = title;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public ShareMultipleFilesRequest(string title, IEnumerable<FileBase> files)
 			: this(title, ConvertList(files))
 		{

--- a/src/Essentials/src/Share/Share.shared.cs
+++ b/src/Essentials/src/Share/Share.shared.cs
@@ -93,15 +93,15 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ShareTextRequest']/Docs" />
 	public class ShareTextRequest : ShareRequestBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ShareTextRequest()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ShareTextRequest(string text) => Text = text;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public ShareTextRequest(string text, string title)
 			: this(text) => Title = title;
 
@@ -118,30 +118,30 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ShareFileRequest']/Docs" />
 	public class ShareFileRequest : ShareRequestBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ShareFileRequest()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=4]/Docs" />
 		public ShareFileRequest(string title, ShareFile file)
 		{
 			Title = title;
 			File = file;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public ShareFileRequest(string title, FileBase file)
 		{
 			Title = title;
 			File = new ShareFile(file);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public ShareFileRequest(ShareFile file)
 			=> File = file;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ShareFileRequest(FileBase file)
 			=> File = new ShareFile(file);
 
@@ -152,7 +152,7 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ShareMultipleFilesRequest']/Docs" />
 	public class ShareMultipleFilesRequest : ShareRequestBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ShareMultipleFilesRequest()
 		{
 		}
@@ -194,19 +194,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ShareFile']/Docs" />
 	public class ShareFile : FileBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ShareFile(string fullPath)
 			: base(fullPath)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public ShareFile(string fullPath, string contentType)
 			: base(fullPath, contentType)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ShareFile(FileBase file)
 			: base(file)
 		{

--- a/src/Essentials/src/Share/Share.shared.cs
+++ b/src/Essentials/src/Share/Share.shared.cs
@@ -17,15 +17,15 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Share']/Docs" />
 	public static partial class Share
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][1]/Docs" />
 		public static Task RequestAsync(string text) =>
 			RequestAsync(new ShareTextRequest(text));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][5]/Docs" />
 		public static Task RequestAsync(string text, string title) =>
 			RequestAsync(new ShareTextRequest(text, title));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][4]/Docs" />
 		public static Task RequestAsync(ShareTextRequest request)
 		{
 			if (request == null)
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Essentials
 			return Current.RequestAsync(request);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][2]/Docs" />
 		public static Task RequestAsync(ShareFileRequest request)
 		{
 			if (request == null)
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Essentials
 			return Current.RequestAsync((ShareMultipleFilesRequest)request);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][3]/Docs" />
 		public static Task RequestAsync(ShareMultipleFilesRequest request)
 		{
 			if (request == null)
@@ -93,15 +93,15 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ShareTextRequest']/Docs" />
 	public class ShareTextRequest : ShareRequestBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ShareTextRequest()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ShareTextRequest(string text) => Text = text;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareTextRequest.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ShareTextRequest(string text, string title)
 			: this(text) => Title = title;
 
@@ -118,30 +118,30 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ShareFileRequest']/Docs" />
 	public class ShareFileRequest : ShareRequestBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ShareFileRequest()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][5]/Docs" />
 		public ShareFileRequest(string title, ShareFile file)
 		{
 			Title = title;
 			File = file;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public ShareFileRequest(string title, FileBase file)
 		{
 			Title = title;
 			File = new ShareFile(file);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ShareFileRequest(ShareFile file)
 			=> File = file;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFileRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ShareFileRequest(FileBase file)
 			=> File = new ShareFile(file);
 
@@ -152,26 +152,26 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ShareMultipleFilesRequest']/Docs" />
 	public class ShareMultipleFilesRequest : ShareRequestBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ShareMultipleFilesRequest()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ShareMultipleFilesRequest(IEnumerable<ShareFile> files) =>
 			Files = files.ToList();
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ShareMultipleFilesRequest(IEnumerable<FileBase> files)
 			: this(ConvertList(files))
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ShareMultipleFilesRequest(string title, IEnumerable<ShareFile> files)
 			: this(files) => Title = title;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public ShareMultipleFilesRequest(string title, IEnumerable<FileBase> files)
 			: this(title, ConvertList(files))
 		{
@@ -194,19 +194,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ShareFile']/Docs" />
 	public class ShareFile : FileBase
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ShareFile(string fullPath)
 			: base(fullPath)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ShareFile(string fullPath, string contentType)
 			: base(fullPath, contentType)
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareFile.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ShareFile(FileBase file)
 			: base(file)
 		{

--- a/src/Essentials/src/Share/Share.shared.cs
+++ b/src/Essentials/src/Share/Share.shared.cs
@@ -17,15 +17,15 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Share']/Docs" />
 	public static partial class Share
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=0]/Docs" />
 		public static Task RequestAsync(string text) =>
 			RequestAsync(new ShareTextRequest(text));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=4]/Docs" />
 		public static Task RequestAsync(string text, string title) =>
 			RequestAsync(new ShareTextRequest(text, title));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=3]/Docs" />
 		public static Task RequestAsync(ShareTextRequest request)
 		{
 			if (request == null)
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Essentials
 			return Current.RequestAsync(request);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=1]/Docs" />
 		public static Task RequestAsync(ShareFileRequest request)
 		{
 			if (request == null)
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Essentials
 			return Current.RequestAsync((ShareMultipleFilesRequest)request);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Share.xml" path="//Member[@MemberName='RequestAsync' and position()=2]/Docs" />
 		public static Task RequestAsync(ShareMultipleFilesRequest request)
 		{
 			if (request == null)

--- a/src/Essentials/src/Sms/Sms.shared.cs
+++ b/src/Essentials/src/Sms/Sms.shared.cs
@@ -46,12 +46,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="Type[@FullName='Microsoft.Maui.Essentials.SmsMessage']/Docs" />
 	public class SmsMessage
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public SmsMessage()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public SmsMessage(string body, string recipient)
 		{
 			Body = body;

--- a/src/Essentials/src/Sms/Sms.shared.cs
+++ b/src/Essentials/src/Sms/Sms.shared.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Sms']/Docs" />
 	public static class Sms
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="//Member[@MemberName='ComposeAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="//Member[@MemberName='ComposeAsync'][1]/Docs" />
 		public static Task ComposeAsync()
 			=> Current.ComposeAsync(null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="//Member[@MemberName='ComposeAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="//Member[@MemberName='ComposeAsync'][2]/Docs" />
 		public static Task ComposeAsync(SmsMessage message)
 		{
 			if (!SmsImplementation.IsComposeSupported)
@@ -46,12 +46,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="Type[@FullName='Microsoft.Maui.Essentials.SmsMessage']/Docs" />
 	public class SmsMessage
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public SmsMessage()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public SmsMessage(string body, string recipient)
 		{
 			Body = body;

--- a/src/Essentials/src/Sms/Sms.shared.cs
+++ b/src/Essentials/src/Sms/Sms.shared.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Sms']/Docs" />
 	public static class Sms
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="//Member[@MemberName='ComposeAsync'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="//Member[@MemberName='ComposeAsync' and position()=0]/Docs" />
 		public static Task ComposeAsync()
 			=> Current.ComposeAsync(null);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="//Member[@MemberName='ComposeAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Sms.xml" path="//Member[@MemberName='ComposeAsync' and position()=1]/Docs" />
 		public static Task ComposeAsync(SmsMessage message)
 		{
 			if (!SmsImplementation.IsComposeSupported)

--- a/src/Essentials/src/Sms/Sms.shared.cs
+++ b/src/Essentials/src/Sms/Sms.shared.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Essentials
 				Recipients.Add(recipient);
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/SmsMessage.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public SmsMessage(string body, IEnumerable<string> recipients)
 		{
 			Body = body;

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Maui.Essentials
 		public static Task<IEnumerable<Locale>> GetLocalesAsync() =>
 			Current.GetLocalesAsync();
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/TextToSpeech.xml" path="//Member[@MemberName='SpeakAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/TextToSpeech.xml" path="//Member[@MemberName='SpeakAsync'][1]/Docs" />
 		public static Task SpeakAsync(string text, CancellationToken cancelToken = default) =>
 			SpeakAsync(text, default, cancelToken);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/TextToSpeech.xml" path="//Member[@MemberName='SpeakAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/TextToSpeech.xml" path="//Member[@MemberName='SpeakAsync'][2]/Docs" />
 		public static async Task SpeakAsync(string text, SpeechOptions options, CancellationToken cancelToken = default)
 		{
 			if (string.IsNullOrEmpty(text))

--- a/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
+++ b/src/Essentials/src/TextToSpeech/TextToSpeech.shared.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Maui.Essentials
 		public static Task<IEnumerable<Locale>> GetLocalesAsync() =>
 			Current.GetLocalesAsync();
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/TextToSpeech.xml" path="//Member[@MemberName='SpeakAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/TextToSpeech.xml" path="//Member[@MemberName='SpeakAsync' and position()=0]/Docs" />
 		public static Task SpeakAsync(string text, CancellationToken cancelToken = default) =>
 			SpeakAsync(text, default, cancelToken);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/TextToSpeech.xml" path="//Member[@MemberName='SpeakAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/TextToSpeech.xml" path="//Member[@MemberName='SpeakAsync' and position()=1]/Docs" />
 		public static async Task SpeakAsync(string text, SpeechOptions options, CancellationToken cancelToken = default)
 		{
 			if (string.IsNullOrEmpty(text))

--- a/src/Essentials/src/Types/Contact.shared.cs
+++ b/src/Essentials/src/Types/Contact.shared.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Essentials
 	{
 		string displayName;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Contact.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Contact.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Contact()
 		{
 		}
@@ -84,12 +84,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ContactEmail']/Docs" />
 	public class ContactEmail
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ContactEmail()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ContactEmail(string emailAddress)
 		{
 			EmailAddress = emailAddress;
@@ -105,12 +105,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ContactPhone']/Docs" />
 	public class ContactPhone
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public ContactPhone()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public ContactPhone(string phoneNumber)
 		{
 			PhoneNumber = phoneNumber;

--- a/src/Essentials/src/Types/Contact.shared.cs
+++ b/src/Essentials/src/Types/Contact.shared.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Essentials
 	{
 		string displayName;
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Contact.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Contact.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Contact()
 		{
 		}
@@ -84,12 +84,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ContactEmail']/Docs" />
 	public class ContactEmail
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ContactEmail()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ContactEmail(string emailAddress)
 		{
 			EmailAddress = emailAddress;
@@ -105,12 +105,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="Type[@FullName='Microsoft.Maui.Essentials.ContactPhone']/Docs" />
 	public class ContactPhone
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public ContactPhone()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public ContactPhone(string phoneNumber)
 		{
 			PhoneNumber = phoneNumber;

--- a/src/Essentials/src/Types/DeviceIdiom.shared.cs
+++ b/src/Essentials/src/Types/DeviceIdiom.shared.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Maui.Essentials
 		public static DeviceIdiom Create(string deviceIdiom) =>
 			new DeviceIdiom(deviceIdiom);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(DeviceIdiom other) =>
 			Equals(other.deviceIdiom);
 
 		internal bool Equals(string other) =>
 			string.Equals(deviceIdiom, other, StringComparison.Ordinal);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object obj) =>
 			obj is DeviceIdiom && Equals((DeviceIdiom)obj);
 

--- a/src/Essentials/src/Types/DeviceIdiom.shared.cs
+++ b/src/Essentials/src/Types/DeviceIdiom.shared.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Maui.Essentials
 		public static DeviceIdiom Create(string deviceIdiom) =>
 			new DeviceIdiom(deviceIdiom);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(DeviceIdiom other) =>
 			Equals(other.deviceIdiom);
 
 		internal bool Equals(string other) =>
 			string.Equals(deviceIdiom, other, StringComparison.Ordinal);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DeviceIdiom.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object obj) =>
 			obj is DeviceIdiom && Equals((DeviceIdiom)obj);
 

--- a/src/Essentials/src/Types/DevicePlatform.shared.cs
+++ b/src/Essentials/src/Types/DevicePlatform.shared.cs
@@ -51,14 +51,14 @@ namespace Microsoft.Maui.Essentials
 		public static DevicePlatform Create(string devicePlatform) =>
 			new DevicePlatform(devicePlatform);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(DevicePlatform other) =>
 			Equals(other.devicePlatform);
 
 		internal bool Equals(string other) =>
 			string.Equals(devicePlatform, other, StringComparison.Ordinal);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object obj) =>
 			obj is DevicePlatform && Equals((DevicePlatform)obj);
 

--- a/src/Essentials/src/Types/DevicePlatform.shared.cs
+++ b/src/Essentials/src/Types/DevicePlatform.shared.cs
@@ -51,14 +51,14 @@ namespace Microsoft.Maui.Essentials
 		public static DevicePlatform Create(string devicePlatform) =>
 			new DevicePlatform(devicePlatform);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(DevicePlatform other) =>
 			Equals(other.devicePlatform);
 
 		internal bool Equals(string other) =>
 			string.Equals(devicePlatform, other, StringComparison.Ordinal);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DevicePlatform.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object obj) =>
 			obj is DevicePlatform && Equals((DevicePlatform)obj);
 

--- a/src/Essentials/src/Types/DisplayInfo.shared.cs
+++ b/src/Essentials/src/Types/DisplayInfo.shared.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Essentials
 	[Preserve(AllMembers = true)]
 	public readonly struct DisplayInfo : IEquatable<DisplayInfo>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public DisplayInfo(double width, double height, double density, DisplayOrientation orientation, DisplayRotation rotation)
 		{
 			Width = width;
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Essentials
 			RefreshRate = 0;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public DisplayInfo(double width, double height, double density, DisplayOrientation orientation, DisplayRotation rotation, float rate)
 		{
 			Width = width;

--- a/src/Essentials/src/Types/DisplayInfo.shared.cs
+++ b/src/Essentials/src/Types/DisplayInfo.shared.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Essentials
 	[Preserve(AllMembers = true)]
 	public readonly struct DisplayInfo : IEquatable<DisplayInfo>
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public DisplayInfo(double width, double height, double density, DisplayOrientation orientation, DisplayRotation rotation)
 		{
 			Width = width;
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Essentials
 			RefreshRate = 0;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public DisplayInfo(double width, double height, double density, DisplayOrientation orientation, DisplayRotation rotation, float rate)
 		{
 			Width = width;
@@ -52,11 +52,11 @@ namespace Microsoft.Maui.Essentials
 		public static bool operator !=(DisplayInfo left, DisplayInfo right) =>
 			!left.Equals(right);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is DisplayInfo metrics) && Equals(metrics);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='Equals'][2]/Docs" />
 		public bool Equals(DisplayInfo other) =>
 			Width.Equals(other.Width) &&
 			Height.Equals(other.Height) &&

--- a/src/Essentials/src/Types/DisplayInfo.shared.cs
+++ b/src/Essentials/src/Types/DisplayInfo.shared.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Maui.Essentials
 		public static bool operator !=(DisplayInfo left, DisplayInfo right) =>
 			!left.Equals(right);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='Equals'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='Equals' and position()=0]/Docs" />
 		public override bool Equals(object obj) =>
 			(obj is DisplayInfo metrics) && Equals(metrics);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='Equals'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/DisplayInfo.xml" path="//Member[@MemberName='Equals' and position()=1]/Docs" />
 		public bool Equals(DisplayInfo other) =>
 			Width.Equals(other.Width) &&
 			Height.Equals(other.Height) &&

--- a/src/Essentials/src/Types/Location.shared.cs
+++ b/src/Essentials/src/Types/Location.shared.cs
@@ -108,15 +108,15 @@ namespace Microsoft.Maui.Essentials
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='AltitudeReferenceSystem']/Docs" />
 		public AltitudeReferenceSystem AltitudeReferenceSystem { get; set; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance' and position()=1]/Docs" />
 		public static double CalculateDistance(double latitudeStart, double longitudeStart, Location locationEnd, DistanceUnits units) =>
 			CalculateDistance(latitudeStart, longitudeStart, locationEnd.Latitude, locationEnd.Longitude, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance' and position()=2]/Docs" />
 		public static double CalculateDistance(Location locationStart, double latitudeEnd, double longitudeEnd, DistanceUnits units) =>
 		   CalculateDistance(locationStart.Latitude, locationStart.Longitude, latitudeEnd, longitudeEnd, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance' and position()=0]/Docs" />
 		public static double CalculateDistance(Location locationStart, Location locationEnd, DistanceUnits units) =>
 			CalculateDistance(locationStart.Latitude, locationStart.Longitude, locationEnd.Latitude, locationEnd.Longitude, units);
 

--- a/src/Essentials/src/Types/Location.shared.cs
+++ b/src/Essentials/src/Types/Location.shared.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Maui.Essentials
 		public static double CalculateDistance(Location locationStart, Location locationEnd, DistanceUnits units) =>
 			CalculateDistance(locationStart.Latitude, locationStart.Longitude, locationEnd.Latitude, locationEnd.Longitude, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance' and position()=3]/Docs" />
 		public static double CalculateDistance(
 			double latitudeStart,
 			double longitudeStart,

--- a/src/Essentials/src/Types/Location.shared.cs
+++ b/src/Essentials/src/Types/Location.shared.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Location']/Docs" />
 	public class Location
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Location()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public Location(double latitude, double longitude)
 		{
 			Latitude = latitude;
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials
 			Timestamp = DateTimeOffset.UtcNow;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public Location(double latitude, double longitude, DateTimeOffset timestamp)
 		{
 			Latitude = latitude;
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Essentials
 			Timestamp = timestamp;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][5]/Docs" />
 		public Location(double latitude, double longitude, double altitude)
 		{
 			Latitude = latitude;
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Essentials
 			Timestamp = DateTimeOffset.UtcNow;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Location(Location point)
 		{
 			if (point == null)
@@ -108,19 +108,19 @@ namespace Microsoft.Maui.Essentials
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='AltitudeReferenceSystem']/Docs" />
 		public AltitudeReferenceSystem AltitudeReferenceSystem { get; set; }
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance'][2]/Docs" />
 		public static double CalculateDistance(double latitudeStart, double longitudeStart, Location locationEnd, DistanceUnits units) =>
 			CalculateDistance(latitudeStart, longitudeStart, locationEnd.Latitude, locationEnd.Longitude, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance'][3]/Docs" />
 		public static double CalculateDistance(Location locationStart, double latitudeEnd, double longitudeEnd, DistanceUnits units) =>
 		   CalculateDistance(locationStart.Latitude, locationStart.Longitude, latitudeEnd, longitudeEnd, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance'][1]/Docs" />
 		public static double CalculateDistance(Location locationStart, Location locationEnd, DistanceUnits units) =>
 			CalculateDistance(locationStart.Latitude, locationStart.Longitude, locationEnd.Latitude, locationEnd.Longitude, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance' and position()=3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='CalculateDistance'][4]/Docs" />
 		public static double CalculateDistance(
 			double latitudeStart,
 			double longitudeStart,

--- a/src/Essentials/src/Types/Location.shared.cs
+++ b/src/Essentials/src/Types/Location.shared.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Location']/Docs" />
 	public class Location
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Location()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public Location(double latitude, double longitude)
 		{
 			Latitude = latitude;
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Essentials
 			Timestamp = DateTimeOffset.UtcNow;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=3]/Docs" />
 		public Location(double latitude, double longitude, DateTimeOffset timestamp)
 		{
 			Latitude = latitude;
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Essentials
 			Timestamp = timestamp;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=4]/Docs" />
 		public Location(double latitude, double longitude, double altitude)
 		{
 			Latitude = latitude;
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Essentials
 			Timestamp = DateTimeOffset.UtcNow;
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Location(Location point)
 		{
 			if (point == null)

--- a/src/Essentials/src/Types/LocationExtensions.shared.cs
+++ b/src/Essentials/src/Types/LocationExtensions.shared.cs
@@ -5,19 +5,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="Type[@FullName='Microsoft.Maui.Essentials.LocationExtensions']/Docs" />
 	public static partial class LocationExtensions
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance' and position()=0]/Docs" />
 		public static double CalculateDistance(this Location locationStart, double latitudeEnd, double longitudeEnd, DistanceUnits units) =>
 			Location.CalculateDistance(locationStart, latitudeEnd, longitudeEnd, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance' and position()=1]/Docs" />
 		public static double CalculateDistance(this Location locationStart, Location locationEnd, DistanceUnits units) =>
 			Location.CalculateDistance(locationStart, locationEnd, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync' and position()=0]/Docs" />
 		public static Task OpenMapsAsync(this Location location, MapLaunchOptions options) =>
 			Map.OpenAsync(location, options);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync' and position()=1]/Docs" />
 		public static Task OpenMapsAsync(this Location location) =>
 			Map.OpenAsync(location);
 	}

--- a/src/Essentials/src/Types/LocationExtensions.shared.cs
+++ b/src/Essentials/src/Types/LocationExtensions.shared.cs
@@ -5,19 +5,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="Type[@FullName='Microsoft.Maui.Essentials.LocationExtensions']/Docs" />
 	public static partial class LocationExtensions
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance'][1]/Docs" />
 		public static double CalculateDistance(this Location locationStart, double latitudeEnd, double longitudeEnd, DistanceUnits units) =>
 			Location.CalculateDistance(locationStart, latitudeEnd, longitudeEnd, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance'][2]/Docs" />
 		public static double CalculateDistance(this Location locationStart, Location locationEnd, DistanceUnits units) =>
 			Location.CalculateDistance(locationStart, locationEnd, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][1]/Docs" />
 		public static Task OpenMapsAsync(this Location location, MapLaunchOptions options) =>
 			Map.OpenAsync(location, options);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][2]/Docs" />
 		public static Task OpenMapsAsync(this Location location) =>
 			Map.OpenAsync(location);
 	}

--- a/src/Essentials/src/Types/LocationExtensions.shared.cs
+++ b/src/Essentials/src/Types/LocationExtensions.shared.cs
@@ -5,19 +5,19 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="Type[@FullName='Microsoft.Maui.Essentials.LocationExtensions']/Docs" />
 	public static partial class LocationExtensions
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance'][2]/Docs" />
 		public static double CalculateDistance(this Location locationStart, double latitudeEnd, double longitudeEnd, DistanceUnits units) =>
 			Location.CalculateDistance(locationStart, latitudeEnd, longitudeEnd, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='CalculateDistance'][1]/Docs" />
 		public static double CalculateDistance(this Location locationStart, Location locationEnd, DistanceUnits units) =>
 			Location.CalculateDistance(locationStart, locationEnd, units);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][2]/Docs" />
 		public static Task OpenMapsAsync(this Location location, MapLaunchOptions options) =>
 			Map.OpenAsync(location, options);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/LocationExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][1]/Docs" />
 		public static Task OpenMapsAsync(this Location location) =>
 			Map.OpenAsync(location);
 	}

--- a/src/Essentials/src/Types/Placemark.shared.cs
+++ b/src/Essentials/src/Types/Placemark.shared.cs
@@ -5,12 +5,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Placemark']/Docs" />
 	public class Placemark
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public Placemark()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public Placemark(Placemark placemark)
 		{
 			if (placemark == null)

--- a/src/Essentials/src/Types/Placemark.shared.cs
+++ b/src/Essentials/src/Types/Placemark.shared.cs
@@ -5,12 +5,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Placemark']/Docs" />
 	public class Placemark
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public Placemark()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Placemark.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public Placemark(Placemark placemark)
 		{
 			if (placemark == null)

--- a/src/Essentials/src/Types/PlacemarkExtensions.shared.cs
+++ b/src/Essentials/src/Types/PlacemarkExtensions.shared.cs
@@ -6,11 +6,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="Type[@FullName='Microsoft.Maui.Essentials.PlacemarkExtensions']/Docs" />
 	public static partial class PlacemarkExtensions
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync' and position()=0]/Docs" />
 		public static Task OpenMapsAsync(this Placemark placemark, MapLaunchOptions options) =>
 			Map.OpenAsync(placemark, options);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync' and position()=1]/Docs" />
 		public static Task OpenMapsAsync(this Placemark placemark) =>
 			Map.OpenAsync(placemark);
 

--- a/src/Essentials/src/Types/PlacemarkExtensions.shared.cs
+++ b/src/Essentials/src/Types/PlacemarkExtensions.shared.cs
@@ -6,11 +6,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="Type[@FullName='Microsoft.Maui.Essentials.PlacemarkExtensions']/Docs" />
 	public static partial class PlacemarkExtensions
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][2]/Docs" />
 		public static Task OpenMapsAsync(this Placemark placemark, MapLaunchOptions options) =>
 			Map.OpenAsync(placemark, options);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][1]/Docs" />
 		public static Task OpenMapsAsync(this Placemark placemark) =>
 			Map.OpenAsync(placemark);
 

--- a/src/Essentials/src/Types/PlacemarkExtensions.shared.cs
+++ b/src/Essentials/src/Types/PlacemarkExtensions.shared.cs
@@ -6,11 +6,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="Type[@FullName='Microsoft.Maui.Essentials.PlacemarkExtensions']/Docs" />
 	public static partial class PlacemarkExtensions
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][1]/Docs" />
 		public static Task OpenMapsAsync(this Placemark placemark, MapLaunchOptions options) =>
 			Map.OpenAsync(placemark, options);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/PlacemarkExtensions.xml" path="//Member[@MemberName='OpenMapsAsync'][2]/Docs" />
 		public static Task OpenMapsAsync(this Placemark placemark) =>
 			Map.OpenAsync(placemark);
 

--- a/src/Essentials/src/Types/Shared/Exceptions.shared.cs
+++ b/src/Essentials/src/Types/Shared/Exceptions.shared.cs
@@ -37,18 +37,18 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="Type[@FullName='Microsoft.Maui.Essentials.FeatureNotSupportedException']/Docs" />
 	public class FeatureNotSupportedException : NotSupportedException
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public FeatureNotSupportedException()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public FeatureNotSupportedException(string message)
 			: base(message)
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public FeatureNotSupportedException(string message, Exception innerException)
 			: base(message, innerException)
 		{
@@ -58,18 +58,18 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="Type[@FullName='Microsoft.Maui.Essentials.FeatureNotEnabledException']/Docs" />
 	public class FeatureNotEnabledException : InvalidOperationException
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public FeatureNotEnabledException()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
 		public FeatureNotEnabledException(string message)
 			: base(message)
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public FeatureNotEnabledException(string message, Exception innerException)
 			: base(message, innerException)
 		{

--- a/src/Essentials/src/Types/Shared/Exceptions.shared.cs
+++ b/src/Essentials/src/Types/Shared/Exceptions.shared.cs
@@ -37,18 +37,18 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="Type[@FullName='Microsoft.Maui.Essentials.FeatureNotSupportedException']/Docs" />
 	public class FeatureNotSupportedException : NotSupportedException
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public FeatureNotSupportedException()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public FeatureNotSupportedException(string message)
 			: base(message)
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotSupportedException.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public FeatureNotSupportedException(string message, Exception innerException)
 			: base(message, innerException)
 		{
@@ -58,18 +58,18 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="Type[@FullName='Microsoft.Maui.Essentials.FeatureNotEnabledException']/Docs" />
 	public class FeatureNotEnabledException : InvalidOperationException
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public FeatureNotEnabledException()
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor' and position()=1]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public FeatureNotEnabledException(string message)
 			: base(message)
 		{
 		}
 
-		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../../docs/Microsoft.Maui.Essentials/FeatureNotEnabledException.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public FeatureNotEnabledException(string message, Exception innerException)
 			: base(message, innerException)
 		{

--- a/src/Essentials/src/Vibration/Vibration.shared.cs
+++ b/src/Essentials/src/Vibration/Vibration.shared.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Vibration']/Docs" />
 	public static partial class Vibration
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate' and position()=0]/Docs" />
 		public static void Vibrate()
 			=> Current.Vibrate(TimeSpan.FromMilliseconds(500));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate' and position()=1]/Docs" />
 		public static void Vibrate(double duration)
 			=> Current.Vibrate(TimeSpan.FromMilliseconds(duration));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate' and position()=2]/Docs" />
 		public static void Vibrate(TimeSpan duration)
 		{
 			if (!Current.IsSupported)

--- a/src/Essentials/src/Vibration/Vibration.shared.cs
+++ b/src/Essentials/src/Vibration/Vibration.shared.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Vibration']/Docs" />
 	public static partial class Vibration
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate'][1]/Docs" />
 		public static void Vibrate()
 			=> Current.Vibrate(TimeSpan.FromMilliseconds(500));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate'][2]/Docs" />
 		public static void Vibrate(double duration)
 			=> Current.Vibrate(TimeSpan.FromMilliseconds(duration));
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Vibration.xml" path="//Member[@MemberName='Vibrate'][3]/Docs" />
 		public static void Vibrate(TimeSpan duration)
 		{
 			if (!Current.IsSupported)

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="Type[@FullName='Microsoft.Maui.Essentials.WebAuthenticator']/Docs" />
 	public static partial class WebAuthenticator
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync'][1]/Docs" />
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(Uri url, Uri callbackUrl)
 			=> Current.AuthenticateAsync(url, callbackUrl);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync' and position()=1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync'][2]/Docs" />
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
 			=> Current.AuthenticateAsync(webAuthenticatorOptions);
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.shared.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="Type[@FullName='Microsoft.Maui.Essentials.WebAuthenticator']/Docs" />
 	public static partial class WebAuthenticator
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync' and position()=0]/Docs" />
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(Uri url, Uri callbackUrl)
 			=> Current.AuthenticateAsync(url, callbackUrl);
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync' and position()=1]/Docs" />
 		public static Task<WebAuthenticatorResult> AuthenticateAsync(WebAuthenticatorOptions webAuthenticatorOptions)
 			=> Current.AuthenticateAsync(webAuthenticatorOptions);
 

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorResult.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorResult.shared.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="Type[@FullName='Microsoft.Maui.Essentials.WebAuthenticatorResult']/Docs" />
 	public class WebAuthenticatorResult
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor'][0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
 		public WebAuthenticatorResult()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
 		public WebAuthenticatorResult(Uri uri)
 		{
 			foreach (var kvp in WebUtils.ParseQueryString(uri.ToString()))

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorResult.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorResult.shared.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Maui.Essentials
 	/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="Type[@FullName='Microsoft.Maui.Essentials.WebAuthenticatorResult']/Docs" />
 	public class WebAuthenticatorResult
 	{
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor' and position()=0]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public WebAuthenticatorResult()
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor' and position()=2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public WebAuthenticatorResult(Uri uri)
 		{
 			foreach (var kvp in WebUtils.ParseQueryString(uri.ToString()))

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticatorResult.shared.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticatorResult.shared.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Essentials
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor']/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticatorResult.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
 		public WebAuthenticatorResult(IDictionary<string, string> properties)
 		{
 			foreach (var kvp in properties)


### PR DESCRIPTION
### Description of Change

Fixing every doc warning in the repo!

The fixes involved a few things:
1. Most problems were due to method overloads and the XPath queries were picking out the wrong XML docs from the XML file. XPath is 1-based, so much of it was changing 0 to 1, 1 to 2, etc. Yes, you read that right, **XPath is 1-based!**
2. Some method overloads had no disambiguation so they needed an explicit overload choice from the XML docs
3. Some generic methods were using the wrong name to find the docs. They were referencing "FooBar" instead of "FooBar&lt;T&gt;".
4. A few places had invalid doc comments:
   - Using wrong XML doc tags, such as using `<param name="..." />` (used to _define_ a parameter doc) instead of `<paramref name="..." />` (used to _reference_ a parameter).
   - Some had `<paramref>` tags that pointed to parameters that don't exist. They _may_ have meant to point to a _property_ of some other _type_. Either way, I left the invalid doc comments in the XML as-is and used a `#pragma` to disable the warning on the exact offending lines in the C# source.
   - Some had parameter names that were different from the imported docs
   - Some had simple typos when referencing other members

And finally, I removed the excluded warnings from the various CSPROJ files, so if someone re-introduces a doc warning, it will be treated as an error and fail the build.