### PR TITLE
When Fill and Width/Height conflict, center View in Fill area

### DIFF
--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -69,6 +69,14 @@ namespace Microsoft.Maui.Layouts
 		static double AlignHorizontal(IView view, Rect bounds, Thickness margin)
 		{
 			var alignment = view.HorizontalLayoutAlignment;
+
+			if (alignment == LayoutAlignment.Fill && IsExplicitSet(view.Width))
+			{
+				// If the view has an explicit width set and the layout alignment is Fill,
+				// we just treat the view as centered within the space it "fills"
+				alignment = LayoutAlignment.Center;
+			}
+
 			var desiredWidth = view.DesiredSize.Width;
 			var startX = bounds.X;
 
@@ -114,9 +122,18 @@ namespace Microsoft.Maui.Layouts
 
 		static double AlignVertical(IView view, Rect bounds, Thickness margin)
 		{
+			var alignment = view.VerticalLayoutAlignment;
+
+			if (alignment == LayoutAlignment.Fill && IsExplicitSet(view.Height))
+			{
+				// If the view has an explicit height set and the layout alignment is Fill,
+				// we just treat the view as centered within the space it "fills"
+				alignment = LayoutAlignment.Center;
+			}
+
 			double frameY = bounds.Y + margin.Top;
 
-			switch (view.VerticalLayoutAlignment)
+			switch (alignment)
 			{
 				case LayoutAlignment.Center:
 					frameY += (bounds.Height - view.DesiredSize.Height) / 2;

--- a/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/LayoutExtensionTests.cs
@@ -236,5 +236,97 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(expectedX, frame.Left);
 			Assert.Equal(expectedWidth, frame.Width);
 		}
+
+		[Fact]
+		public void WidthOverridesFill() 
+		{
+			var widthConstraint = 300;
+			var heightConstraint = 300;
+
+			var viewWidth = 100;
+			var desiredSize = new Size(viewWidth, 50);
+
+			var element = Substitute.For<IView>();
+			element.DesiredSize.Returns(desiredSize);
+			element.HorizontalLayoutAlignment.Returns(LayoutAlignment.Fill);
+			element.Width.Returns(viewWidth);
+			element.Height.Returns(Dimension.Unset);
+
+			var frame = element.ComputeFrame(new Rect(0, 0, widthConstraint, heightConstraint));
+
+			// Since a width was specified, it wins over the Fill and the width should end up being 100
+			Assert.Equal(100, frame.Width);
+		}
+
+		[Fact]
+		public void WidthOverridesFillFromCenter() 
+		{
+			var widthConstraint = 300;
+			var heightConstraint = 300;
+
+			var viewWidth = 100;
+			var desiredSize = new Size(viewWidth, 50);
+
+			var element = Substitute.For<IView>();
+			element.DesiredSize.Returns(desiredSize);
+			element.HorizontalLayoutAlignment.Returns(LayoutAlignment.Fill);
+			element.Width.Returns(viewWidth);
+			element.Height.Returns(Dimension.Unset);
+
+			var frame = element.ComputeFrame(new Rect(0, 0, widthConstraint, heightConstraint));
+
+			// Since a width was specified, it wins over the Fill
+			// We want to do the filling from the center of the space, so the left edge of the frame should be
+			// the center, minus half of the view
+			var expectedX = (widthConstraint / 2) - (viewWidth / 2);
+
+			Assert.Equal(expectedX, frame.Left);
+		}
+
+		[Fact]
+		public void HeightOverridesFill()
+		{
+			var widthConstraint = 300;
+			var heightConstraint = 300;
+
+			var viewHeight = 100;
+			var desiredSize = new Size(50, viewHeight);
+
+			var element = Substitute.For<IView>();
+			element.DesiredSize.Returns(desiredSize);
+			element.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+			element.Height.Returns(100);
+			element.Width.Returns(Dimension.Unset);
+
+			var frame = element.ComputeFrame(new Rect(0, 0, widthConstraint, heightConstraint));
+
+			// Since a height was specified, it wins over the Fill and the height should end up being 100
+			Assert.Equal(100, frame.Height);
+		}
+
+		[Fact]
+		public void HeightOverridesFillFromCenter()
+		{
+			var widthConstraint = 300;
+			var heightConstraint = 300;
+
+			var viewHeight = 100;
+			var desiredSize = new Size(50, viewHeight);
+
+			var element = Substitute.For<IView>();
+			element.DesiredSize.Returns(desiredSize);
+			element.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+			element.Height.Returns(viewHeight);
+			element.Width.Returns(Dimension.Unset);
+
+			var frame = element.ComputeFrame(new Rect(0, 0, widthConstraint, heightConstraint));
+
+			// Since a height was specified, it wins over the Fill
+			// We want to do the filling from the center of the space, so the top edge of the frame should be
+			// the center, minus half of the view
+			var expectedY = (heightConstraint / 2) - (viewHeight / 2);
+
+			Assert.Equal(expectedY, frame.Top);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #5240

```
<VerticalStackLayout Spacing="10">
    <Button Text="No width"></Button>
    <Button Text="Width 100" WidthRequest="100"></Button>
</VerticalStackLayout>
```

![image](https://user-images.githubusercontent.com/538025/157989909-1b9cc5f6-8754-4e59-a93a-d1224f896565.png)
