### PR TITLE
Add tests for Parent property

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BorderUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BorderUnitTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(visualTreeChildren[0], label);
 		}
 
-
 		[Test]
 		public void ChildrenHaveParentsWhenContentIsSet()
 		{

--- a/src/Controls/tests/Core.UnitTests/BorderUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BorderUnitTests.cs
@@ -30,5 +30,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsNotEmpty(visualTreeChildren);
 			Assert.AreSame(visualTreeChildren[0], label);
 		}
+
+
+		[Test]
+		public void ChildrenHaveParentsWhenContentIsSet()
+		{
+			var border = new Border();
+
+			var label = new Label();
+			border.Content = label;
+
+			Assert.AreSame(border, label.Parent);
+
+			border.Content = null;
+			Assert.Null(label.Parent);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ContentViewUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ContentViewUnitTest.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(added);
 			Assert.AreEqual(child1, contentView.Content);
+			Assert.AreEqual(child1.Parent, contentView);
 
 			added = false;
 			contentView.Content = child1;
@@ -60,6 +61,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			contentView.ChildAdded += (sender, e) => added = true;
 
 			contentView.Content = child2;
+
+			Assert.Null(child1.Parent);
 
 			Assert.True(removed);
 			Assert.True(added);

--- a/src/Controls/tests/Core.UnitTests/FrameUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FrameUnitTests.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(added);
 			Assert.AreEqual(child1, frame.Content);
+			Assert.AreEqual(child1.Parent, frame);
 
 			added = false;
 			frame.Content = child1;
@@ -100,6 +101,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			frame.ChildAdded += (sender, e) => added = true;
 
 			frame.Content = child2;
+			Assert.Null(child1.Parent);
 
 			Assert.True(removed);
 			Assert.True(added);

--- a/src/Controls/tests/Core.UnitTests/GridTests.cs
+++ b/src/Controls/tests/Core.UnitTests/GridTests.cs
@@ -24,6 +24,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
+		public void ChildrenHaveParentsWhenAdded()
+		{
+			var layout = new Grid();
+			var label = new Label();
+			layout.Children.Add(label);
+
+			Assert.AreSame(layout, label.Parent);
+
+			layout.Children.Remove(label);
+			Assert.Null(label.Parent);
+		}
+
+		[Test]
 		public void ThrowsOnNullRemove()
 		{
 			var layout = new Grid();

--- a/src/Controls/tests/Core.UnitTests/PageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageTests.cs
@@ -23,8 +23,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var child = new Label();
 			Page root = new ContentPage { Content = child };
 
+			Assert.AreEqual(root, child.Parent);
+
 			Assert.AreEqual(((IElementController)root).LogicalChildren.Count, 1);
 			Assert.AreSame(((IElementController)root).LogicalChildren.First(), child);
+
+			((ContentPage)root).Content = null;
+			Assert.Null(child.Parent);
 		}
 
 		[Test]
@@ -35,6 +40,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			root.IsPlatformEnabled = child.IsPlatformEnabled = true;
 
 			root.Layout(new Rect(0, 0, 200, 500));
+
 
 			Assert.AreEqual(child.Width, 200);
 			Assert.AreEqual(child.Height, 500);

--- a/src/Controls/tests/Core.UnitTests/ScrollViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ScrollViewUnitTests.cs
@@ -307,6 +307,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(changed);
 			Assert.AreEqual(child, scrollView.Content);
+			Assert.AreEqual(child.Parent, scrollView);
 
 			changed = false;
 
@@ -318,6 +319,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(changed);
 			Assert.Null(scrollView.Content);
+			Assert.Null(child.Parent);
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change

As discussed in https://github.com/dotnet/maui/pull/5216 - additional test coverage for `Parent` in 

- [x] Border 
- [x] Grid 
- [x] ContentView 
- [x] Frame
- [x] ScrollView 
- [x] Page
