### PR TITLE
[android] Ensure toolbar is removed from parent before adding to appbar

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -164,9 +164,14 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			if (nativeToolBar.Parent == appbarLayout)
+			if (nativeToolBar.Parent is ViewGroup parent)
 			{
-				return;
+				if (parent == appbarLayout && parent.GetChildAt(0) == nativeToolBar)
+				{
+					return;
+				}
+
+				parent.RemoveView(nativeToolBar);
 			}
 
 			appbarLayout.AddView(nativeToolBar, 0);
@@ -188,15 +193,19 @@ namespace Microsoft.Maui.Handlers
 
 			var nativeToolBar = te.Toolbar?.ToPlatform(handler.MauiContext);
 
-			if (appbarLayout == null)
+			if (appbarLayout == null || nativeToolBar == null)
 			{
 				return;
 			}
 
-			if (appbarLayout.ChildCount > 0 &&
-				appbarLayout.GetChildAt(0) == nativeToolBar)
+			if (nativeToolBar.Parent is ViewGroup parent)
 			{
-				return;
+				if (parent == appbarLayout && parent.GetChildAt(0) == nativeToolBar)
+				{
+					return;
+				}
+
+				parent.RemoveView(nativeToolBar);
 			}
 
 			appbarLayout.AddView(nativeToolBar, 0);


### PR DESCRIPTION
### Description of Change

Ensure the android toolbar isn't a part of another view hierarchy before adding it. This mainly (only?) comes up when resetting `Application.MainPage` from something that originally had an Appbar (e.g. NavigationPage).

NOTE: There is a separate (probably partially related) issue that if you set a non-Appbar page as the new MainPage (e.g. change from a NavigationPage as root to a ContentPage as root), the Appbar will still appear. I believe this is due to the code here which triggers a MapToolbar on the Window https://github.com/dotnet/maui/blob/d9ec2b60efe3be835760695da35e38ad5c065c34/src/Core/src/Platform/Android/Navigation/NavigationRootManager.cs#L84 I haven't found a way to workaround that, but I think its better than the current state which is just crashing.

NOTE NOTE: I'm not sure why there are 2 different `MapToolbar` implementations, or why they slightly differed. One was checking if the toolbar was index-0, aka the backmost child, while the other just checked if the toolbar is at _any_ z-index. I only know that we need to ensure the toolbar gets removed from its parent before adding it to the parent, and it makes sense to me that it should be set to index-0.

### Issues Fixed

Possibly fixes #4311 and #5168
