### PR TITLE
Don't calculate routes on shell startup and don't setup bottom menu

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
@@ -90,6 +90,11 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 				AddSearchHandler("text here");
 		}
 
+		void OnToggleTabBar(object sender, EventArgs e)
+		{
+			Shell.SetTabBarIsVisible(this, !Shell.GetTabBarIsVisible(this));
+		}
+
 		protected void AddSearchHandler(string placeholder)
 		{
 			var searchHandler = new CustomSearchHandler();

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
@@ -4,7 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.ShellGalleries.ShellChromeGallery"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"    
-    Title="Chrome Gallery">
+    Title="Chrome Gallery"
+    Shell.TabBarIsVisible="False"
+    >
     <views:BasePage.Content>
         <StackLayout
             Margin="12">
@@ -32,10 +34,14 @@
                 Text="Pop Page"
                 Style="{StaticResource Headline}"/>
             <Button Text="Pop Page" Clicked="OnPopPage" />
-             <Label
+            <Label
                 Text="Toogle SearchHandler"
                 Style="{StaticResource Headline}"/>
             <Button Text="Toogle SearchHandler" Clicked="OnToggleSearchHandler" />
+            <Label
+                Text="Toogle TabBar"
+                Style="{StaticResource Headline}"/>
+            <Button Text="Toogle TabBar" Clicked="OnToggleTabBar" />
         </StackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -450,12 +450,14 @@ namespace Microsoft.Maui.Controls
 		ShellNavigationState IShellController.GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, bool includeStack)
 			=> ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, includeStack ? shellSection.Stack.ToList() : null, includeStack ? shellSection.Navigation.ModalStack.ToList() : null);
 
-		async void IShellController.OnFlyoutItemSelected(Element element)
+		void IShellController.OnFlyoutItemSelected(Element element)
 		{
-			await (this as IShellController).OnFlyoutItemSelectedAsync(element);
+			(this as IShellController)
+				.OnFlyoutItemSelectedAsync(element)
+				.FireAndForget();
 		}
 
-		async Task IShellController.OnFlyoutItemSelectedAsync(Element element)
+		Task IShellController.OnFlyoutItemSelectedAsync(Element element)
 		{
 			ShellItem shellItem = null;
 			ShellSection shellSection = null;
@@ -484,12 +486,10 @@ namespace Microsoft.Maui.Controls
 			}
 
 			if (shellItem == null || !shellItem.IsEnabled)
-				return;
+				return Task.CompletedTask;
 
 			shellSection = shellSection ?? shellItem.CurrentItem;
 			shellContent = shellContent ?? shellSection?.CurrentItem;
-
-			var state = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, null, null);
 
 			if (FlyoutIsPresented && GetEffectiveFlyoutBehavior() != FlyoutBehavior.Locked)
 				SetValueFromRenderer(FlyoutIsPresentedProperty, false);
@@ -499,7 +499,49 @@ namespace Microsoft.Maui.Controls
 			else if (shellContent == null)
 				shellSection.PropertyChanged += OnShellItemPropertyChanged;
 			else
-				await GoToAsync(state).ConfigureAwait(false);
+			{
+				var state = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, null, null);
+
+				if (this.CurrentItem == null)
+				{
+					var requestBuilder = new RouteRequestBuilder(new List<string>()
+					{
+						shellItem.Route,
+						shellSection.Route,
+						shellContent.Route
+					});
+
+					var node = new ShellUriHandler.NodeLocation();
+					node.SetNode(shellContent);
+					requestBuilder.AddMatch(node);
+
+					var navRequest =
+						new ShellNavigationRequest(
+							new RequestDefinition(requestBuilder, this),
+							 ShellNavigationRequest.WhatToDoWithTheStack.ReplaceIt,
+							 String.Empty,
+							 String.Empty);
+
+					var navParameters = new ShellNavigationParameters()
+					{
+						TargetState = state,
+						Animated = false,
+						EnableRelativeShellRoutes = false,
+						DeferredArgs = null,
+						Parameters = null
+					};
+
+					return _navigationManager
+						.GoToAsync(navParameters, navRequest);
+
+				}
+				else
+				{
+					return GoToAsync(state);
+				}
+			}
+
+			return Task.CompletedTask;
 		}
 
 		void OnShellItemPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -264,6 +264,14 @@ namespace Microsoft.Maui.Controls
 		internal override void ApplyQueryAttributes(ShellRouteParameters query)
 		{
 			base.ApplyQueryAttributes(query);
+
+			// If the query parameters are empty and this attribute wasn't previouslly set
+			// That means there's no work to be done here.
+			// An empty query set is only valid if we've previouslly propagated
+			// something to this bindable property
+			if (query.Count == 0 && !this.IsSet(QueryAttributesProperty))
+				return;
+
 			SetValue(QueryAttributesProperty, query);
 
 			if (ContentCache is BindableObject bindable)

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -265,9 +265,9 @@ namespace Microsoft.Maui.Controls
 		{
 			base.ApplyQueryAttributes(query);
 
-			// If the query parameters are empty and this attribute wasn't previouslly set
+			// If the query parameters are empty and this attribute wasn't previously set
 			// That means there's no work to be done here.
-			// An empty query set is only valid if we've previouslly propagated
+			// An empty query is only valid if we've previously propagated
 			// something to this bindable property
 			if (query.Count == 0 && !this.IsSet(QueryAttributesProperty))
 				return;

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Maui.Controls
 				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameters, _shell.FindMauiContext()?.Services, animate, isRelativePopping);
 			}
 
-		(_shell as IShellController).UpdateCurrentState(source);
+			(_shell as IShellController).UpdateCurrentState(source);
 			_accumulateNavigatedEvents = false;
 
 			// this can be null in the event that no navigation actually took place!

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -33,9 +33,14 @@ namespace Microsoft.Maui.Controls
 			});
 		}
 
-		public async Task GoToAsync(ShellNavigationParameters shellNavigationParameters)
+		public Task GoToAsync(ShellNavigationParameters shellNavigationParameters) =>
+			GoToAsync(shellNavigationParameters, null);
+
+		internal async Task GoToAsync(
+			ShellNavigationParameters shellNavigationParameters,
+			ShellNavigationRequest navigationRequest)
 		{
-			if (shellNavigationParameters.PagePushing != null)
+			if (shellNavigationParameters.PagePushing != null && navigationRequest == null)
 				Routing.RegisterImplicitPageRoute(shellNavigationParameters.PagePushing);
 
 			var state = shellNavigationParameters.TargetState ?? new ShellNavigationState(Routing.GetRoute(shellNavigationParameters.PagePushing), false);
@@ -43,7 +48,7 @@ namespace Microsoft.Maui.Controls
 			bool enableRelativeShellRoutes = shellNavigationParameters.EnableRelativeShellRoutes;
 			ShellNavigatingEventArgs deferredArgs = shellNavigationParameters.DeferredArgs;
 
-			var navigationRequest = ShellUriHandler.GetNavigationRequest(_shell, state.FullLocation, enableRelativeShellRoutes, shellNavigationParameters: shellNavigationParameters);
+			navigationRequest ??= ShellUriHandler.GetNavigationRequest(_shell, state.FullLocation, enableRelativeShellRoutes, shellNavigationParameters: shellNavigationParameters);
 			bool isRelativePopping = ShellUriHandler.IsTargetRelativePop(shellNavigationParameters);
 			var parameters = shellNavigationParameters.Parameters ?? new ShellRouteParameters();
 
@@ -169,7 +174,7 @@ namespace Microsoft.Maui.Controls
 				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameters, _shell.FindMauiContext()?.Services, animate, isRelativePopping);
 			}
 
-			(_shell as IShellController).UpdateCurrentState(source);
+		(_shell as IShellController).UpdateCurrentState(source);
 			_accumulateNavigatedEvents = false;
 
 			// this can be null in the event that no navigation actually took place!
@@ -493,7 +498,6 @@ namespace Microsoft.Maui.Controls
 				routeStack.Insert(0, "/");
 
 			return new ShellNavigationState(String.Join("/", routeStack), true);
-
 		}
 
 		public static List<Page> BuildFlattenedNavigationStack(Shell shell)

--- a/src/Controls/src/Core/Shell/ShellNavigationState.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationState.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 
 namespace Microsoft.Maui.Controls
 {
-
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ShellNavigationState.xml" path="Type[@FullName='Microsoft.Maui.Controls.ShellNavigationState']/Docs" />
 	[DebuggerDisplay("Location = {Location}")]
 	public class ShellNavigationState

--- a/src/Controls/src/Core/Shell/ShellUriHandler.cs
+++ b/src/Controls/src/Core/Shell/ShellUriHandler.cs
@@ -181,7 +181,6 @@ namespace Microsoft.Maui.Controls
 
 			Uri request = ConvertToStandardFormat(shell, uri);
 
-
 			var possibleRouteMatches = GenerateRoutePaths(shell, request, uri, enableRelativeShellRoutes);
 
 			if (possibleRouteMatches.Count == 0)
@@ -214,7 +213,7 @@ namespace Microsoft.Maui.Controls
 			RequestDefinition definition =
 				new RequestDefinition(theWinningRoute, shell);
 
-			ShellNavigationRequest navigationRequest = new ShellNavigationRequest(definition, whatDoIDo, request.Query, request.Fragment);
+			var navigationRequest = new ShellNavigationRequest(definition, whatDoIDo, request.Query, request.Fragment);
 
 			return navigationRequest;
 		}

--- a/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void InitialShellDoesntTriggerShellContentBindableProperty()
+		public void InitialNavigationDoesntSetQueryAttributesProperty()
 		{
 			var content = CreateShellContent();
 			_ = new TestShell(content);

--- a/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
@@ -378,5 +378,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var testPage = shell.CurrentPage as ShellTestPage;
 			Assert.AreEqual(urlTest, testPage.SomeQueryParameter);
 		}
+
+		[Test]
+		public void InitialShellDoesntTriggerShellContentBindableProperty()
+		{
+			var content = CreateShellContent();
+			_ = new TestShell(content);
+			Assert.IsFalse(content.IsSet(ShellContent.QueryAttributesProperty));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

- When initially starting up shell we know what ShellElements we want to be active so we don't need to parse any `Uri`'s to figure anything out. This code will just skip past that on initial load.
- If no query strings have been supplied for navigation then just skip the code that processes query strings. This removes a reflection path.
- If the page doesn't have a visible BottomNavigationView then don't setup the menu items or any of the appearance elements

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
