### PR TITLE
[Windows] Fix ScrollView crash with incorrect values to Measure

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Maui.Handlers
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
+			widthConstraint = Math.Max(widthConstraint, 0);
+			heightConstraint = Math.Max(heightConstraint, 0);
+
 			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
 
 			if (GetInsetPanel(PlatformView) == null)


### PR DESCRIPTION
### Description of Change

Fix ScrollView crash with incorrect values to Measure.

![fix-5184](https://user-images.githubusercontent.com/6755973/158172605-5a3fab05-ada5-44a8-a3b7-f11b750ff071.gif)

### Issues Fixed

Fixes #5184
