### PR TITLE
[Windows] Fix issue updating dynamically Entry TextColor

### DIFF
--- a/src/Core/src/Platform/Windows/TextBoxExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBoxExtensions.cs
@@ -49,12 +49,15 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateTextColor(this TextBox textBox, ITextStyle textStyle)
 		{
 			var brush = textStyle.TextColor?.ToPlatform();
+
 			if (brush is null)
 			{
 				textBox.Resources.Remove("TextControlForeground");
 				textBox.Resources.Remove("TextControlForegroundPointerOver");
 				textBox.Resources.Remove("TextControlForegroundFocused");
 				textBox.Resources.Remove("TextControlForegroundDisabled");
+
+				textBox.ClearValue(TextBox.ForegroundProperty);
 			}
 			else
 			{
@@ -62,6 +65,8 @@ namespace Microsoft.Maui.Platform
 				textBox.Resources["TextControlForegroundPointerOver"] = brush;
 				textBox.Resources["TextControlForegroundFocused"] = brush;
 				textBox.Resources["TextControlForegroundDisabled"] = brush;
+
+				textBox.Foreground = brush;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Fix issue updating dynamically Entry TextColor on Windows.

![fix-5281](https://user-images.githubusercontent.com/6755973/158211119-99b1047b-4304-4f11-8b33-28b7c8d12525.gif)

_NOTE: Before the changes, the text color always was black (the original text color value)._

### Issues Fixed

Fixes #5281 

To test the issue, use the following Behavior: https://docs.microsoft.com/en-us/dotnet/maui/fundamentals/behaviors#attached-behaviors with an Entry.
