### PR TITLE
Eliminate the default color extraction logic to fix TimePicker Foreground color

### DIFF
--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs
@@ -6,8 +6,6 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class TimePickerHandler : ViewHandler<ITimePicker, TimePicker>
 	{
-		WBrush? _defaultForeground;
-
 		protected override TimePicker CreatePlatformView() => new TimePicker();
 
 		protected override void ConnectHandler(TimePicker platformView)
@@ -18,11 +16,6 @@ namespace Microsoft.Maui.Handlers
 		protected override void DisconnectHandler(TimePicker platformView)
 		{
 			platformView.TimeChanged -= OnControlTimeChanged;
-		}
-
-		void SetupDefaults(TimePicker platformView)
-		{
-			_defaultForeground = platformView.Foreground;
 		}
 
 		public static void MapFormat(ITimePickerHandler handler, ITimePicker timePicker)
@@ -50,7 +43,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapTextColor(ITimePickerHandler handler, ITimePicker timePicker)
 		{
 			if (handler is TimePickerHandler platformHandler)
-				handler.PlatformView?.UpdateTextColor(timePicker, platformHandler._defaultForeground);
+				handler.PlatformView?.UpdateTextColor(timePicker);
 		}
 
 		void OnControlTimeChanged(object? sender, TimePickerValueChangedEventArgs e)

--- a/src/Core/src/Platform/Windows/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/TimePickerExtensions.cs
@@ -28,11 +28,12 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateFont(this TimePicker nativeTimePicker, ITimePicker timePicker, IFontManager fontManager) =>
 			nativeTimePicker.UpdateFont(timePicker.Font, fontManager);
-	
-		public static void UpdateTextColor(this TimePicker nativeTimePicker, ITimePicker timePicker,WBrush? defaultForeground)
+
+		public static void UpdateTextColor(this TimePicker nativeTimePicker, ITimePicker timePicker)
 		{
 			Color textColor = timePicker.TextColor;
-			nativeTimePicker.Foreground = textColor == null ? (defaultForeground ?? textColor?.ToPlatform()) : textColor.ToPlatform();
+			if (textColor != null)
+				nativeTimePicker.Foreground = textColor.ToPlatform();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Root cause:

The TimePicker's color is initialized to default color [here](https://github.com/dotnet/maui/blob/2a927f63e984551c5e1d0ce0b02646adca3f4b46/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs#L53). The `_defaultForeground` should have been initialized [here](https://github.com/dotnet/maui/blob/2a927f63e984551c5e1d0ce0b02646adca3f4b46/src/Core/src/Handlers/TimePicker/TimePickerHandler.Windows.cs#L25), but `SetupDefault` wasn't called at all.

Solution:

Call `SetupDefault` so that it is initialized. It is called during `ConnectHandler` like most other controls.

### Issues Fixed

Fixes #4165
