### PR TITLE
Use Factory methods in DependencyInjection

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,6 +3,7 @@
   <Import Condition="'$(SampleProject)' == 'true' or '$(CI)' != 'true' " Project="eng\Versions.dev.targets" />
   <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true'" Project="eng\Git.Build.targets" />
   <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true' " Project="eng\Versions.targets" />
+  <Import Condition="'$(SampleProject)' != 'true' and '$(IsTestProject)' != 'true'" Project="eng\BannedApis.targets" />
   <Import Project="eng\AndroidX.targets" />
   <Import Project="eng\Microsoft.Extensions.targets" />
 

--- a/eng/BannedApis.targets
+++ b/eng/BannedApis.targets
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Configure analyzer to forbid certain API calls -->
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
+  </ItemGroup>
+</Project>

--- a/eng/BannedSymbols.txt
+++ b/eng/BannedSymbols.txt
@@ -1,0 +1,1 @@
+M:Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton`2(Microsoft.Extensions.DependencyInjection.IServiceCollection);Use a Factory method to create the service instead

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,6 +33,7 @@
     <MicrosoftJSInteropPackageVersion>6.0.2</MicrosoftJSInteropPackageVersion>
     <MicrosoftWindowsDesktopAppRuntimewinx64Version>6.0.2</MicrosoftWindowsDesktopAppRuntimewinx64Version>
     <!-- Other packages -->
+    <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftMauiGraphicsVersion>6.0.200-preview.14.1092</MicrosoftMauiGraphicsVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
     <_MicrosoftWebWebView2Version>1.0.1020.30</_MicrosoftWebWebView2Version>

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -30,7 +30,9 @@ namespace Microsoft.Maui.Controls.Hosting
 		public static MauiAppBuilder UseMauiApp<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(this MauiAppBuilder builder)
 			where TApp : class, IApplication
 		{
+#pragma warning disable RS0030 // Do not used banned APIs - don't want to use a factory method here
 			builder.Services.TryAddSingleton<IApplication, TApp>();
+#pragma warning restore RS0030
 			builder.SetupDefaults();
 			return builder;
 		}

--- a/src/Core/src/Hosting/HandlerMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/HandlerMauiAppBuilderExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Hosting
 
 		public static IServiceCollection ConfigureMauiHandlers(this IServiceCollection services, Action<IMauiHandlersCollection>? configureDelegate)
 		{
-			services.TryAddSingleton<IMauiHandlersFactory, MauiHandlersFactory>();
+			services.TryAddSingleton<IMauiHandlersFactory>(sp => new MauiHandlersFactory(sp.GetServices<HandlerRegistration>()));
 			if (configureDelegate != null)
 			{
 				services.AddSingleton<HandlerRegistration>(new HandlerRegistration(configureDelegate));

--- a/src/Core/src/Hosting/ImageSources/ImageSourcesMauiAppBuilderExtensions.cs
+++ b/src/Core/src/Hosting/ImageSources/ImageSourcesMauiAppBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Hosting
 			}
 
 			builder.Services.TryAddSingleton<IImageSourceServiceProvider>(svcs => new ImageSourceServiceProvider(svcs.GetRequiredService<IImageSourceServiceCollection>(), svcs));
-			builder.Services.TryAddSingleton<IImageSourceServiceCollection, ImageSourceServiceBuilder>();
+			builder.Services.TryAddSingleton<IImageSourceServiceCollection>(svcs => new ImageSourceServiceBuilder(svcs.GetServices<ImageSourceRegistration>()));
 
 			return builder;
 		}

--- a/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.cs
+++ b/src/Core/src/Hosting/LifecycleEvents/AppHostBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.LifecycleEvents
 	{
 		public static MauiAppBuilder ConfigureLifecycleEvents(this MauiAppBuilder builder, Action<ILifecycleBuilder>? configureDelegate)
 		{
-			builder.Services.TryAddSingleton<ILifecycleEventService, LifecycleEventService>();
+			builder.Services.TryAddSingleton<ILifecycleEventService>(sp => new LifecycleEventService(sp.GetServices<LifecycleEventRegistration>()));
 			if (configureDelegate != null)
 			{
 				builder.Services.AddSingleton<LifecycleEventRegistration>(new LifecycleEventRegistration(configureDelegate));


### PR DESCRIPTION
Using factory methods and directly invoking the constructors instead of letting DI use reflection to find the constructor.

In local testing this appeared to shave off ~7ms from startup of a dotnet new maui app.

With changes:
Average(ms): 571
Average(ms): 579.9
Average(ms): 572.6

Main:
Average(ms): 584.5
Average(ms): 586.9
Average(ms): 579.6