### PR TITLE
Fix Blazor Hybrid page reloading for iOS

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 
 			var requestUri = request?.Url?.ToString();
-			var allowFallbackOnHostPage = IsAppOriginPageUri(requestUri);
+			var allowFallbackOnHostPage = AppOriginUri.IsBaseOfPage(requestUri);
 			requestUri = QueryStringHelper.RemovePossibleQueryString(requestUri);
 
 			if (requestUri != null &&
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			base.OnPageFinished(view, url);
 
 			// TODO: How do we know this runs only once?
-			if (view != null && IsAppOriginPageUri(url))
+			if (view != null && AppOriginUri.IsBaseOfPage(url))
 			{
 				// Startup scripts must run in OnPageFinished. If scripts are run earlier they will have no lasting
 				// effect because once the page content loads all the document state gets reset.
@@ -164,23 +164,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					// Done; no more action required
 				}));
 			}));
-		}
-
-		private static bool IsAppOriginPageUri(string? requestUriString)
-		{
-			if (string.IsNullOrEmpty(requestUriString))
-			{
-				return false;
-			}
-
-			var requestUri = new Uri(requestUriString);
-			if (!AppOriginUri.IsBaseOf(requestUri))
-			{
-				return false;
-			}
-
-			// If the path does not end in a file extension, it's most likely referring to a page.
-			return !Path.HasExtension(requestUriString);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/BlazorWebView/src/Maui/Extensions/UriExtensions.cs
+++ b/src/BlazorWebView/src/Maui/Extensions/UriExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.IO;
+
+namespace Microsoft.AspNetCore.Components.WebView.Maui
+{
+	internal static class UriExtensions
+	{
+		internal static bool IsBaseOfPage(this Uri baseUri, string? uriString)
+		{
+			if (Path.HasExtension(uriString))
+			{
+				// If the path ends in a file extension, it's not referring to a page.
+				return false;
+			}
+
+			var uri = new Uri(uriString!);
+			return baseUri.IsBaseOf(uri);
+		}
+	}
+}

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		private IOSWebViewManager? _webviewManager;
 
 		internal const string AppOrigin = "app://" + BlazorWebView.AppHostAddress + "/";
+		private static readonly Uri AppOriginUri = new(AppOrigin);
 		private const string BlazorInitScript = @"
 			window.__receiveMessageCallbacks = [];
 			window.__dispatchMessageCallback = function(message) {
@@ -190,7 +191,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			private byte[] GetResponseBytes(string url, out string contentType, out int statusCode)
 			{
-				var allowFallbackOnHostPage = url.EndsWith("/");
+				var allowFallbackOnHostPage = AppOriginUri.IsBaseOfPage(url);
 				url = QueryStringHelper.RemovePossibleQueryString(url);
 				if (_webViewHandler._webviewManager!.TryGetResponseContentInternal(url, allowFallbackOnHostPage, out statusCode, out var statusMessage, out var content, out var headers))
 				{


### PR DESCRIPTION
### Description of Change

This PR resolves an issue where non-root pages cannot be reloaded in Blazor MAUI on iOS/Mac Catalyst.

### Issues Fixed

Fixes #5247
