### PR TITLE
Make TitleView work in NavigationPage and Shell on Windows

### DIFF
--- a/src/Controls/docs/Microsoft.Maui.Controls/NavigationPage.xml
+++ b/src/Controls/docs/Microsoft.Maui.Controls/NavigationPage.xml
@@ -1487,7 +1487,14 @@
       </ReturnValue>
       <Docs>
         <summary>Backing store for the attached property that gets and sets title views.</summary>
-        <remarks>To be added.</remarks>
+        <remarks>On Windows, the TitleView will appear in the content area of the MauiToolbar control. By default, the content area's width is auto-sized to the content, with the remaining area made available for toolbar commands. This is to support the default Windows-specific dynamic overflow ability of the commands. If a user wants the TitleView to occupy all of the space not used by toolbar commands, dynamic overflow needs to be turned off, which can be accomplished by calling the Page's SetToolbarDynamicOverflowEnabled PlatformSpecific to false:
+		
+		<example>
+			<code>this.On&lt;WindowsOS&gt;().SetToolbarDynamicOverflowEnabled(false);</code>
+		</example>
+		
+		</remarks>
+		
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.INavigationPageController.RemoveAsyncInner">

--- a/src/Controls/src/Core/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPageToolbar.cs
@@ -158,6 +158,21 @@ namespace Microsoft.Maui.Controls
 		Color GetBarTextColor() => _currentNavigationPage?.BarTextColor;
 		Color GetIconColor() => (_currentPage != null) ? NavigationPage.GetIconColor(_currentPage) : null;
 		string GetTitle() => _currentPage?.Title;
-		VisualElement GetTitleView() => (_currentNavigationPage != null) ? NavigationPage.GetTitleView(_currentNavigationPage) : null;
+		VisualElement GetTitleView()
+		{
+			if (_currentNavigationPage == null)
+			{
+				return null;
+			}
+
+			Page target = _currentNavigationPage;
+
+			if (_currentNavigationPage.CurrentPage is Page currentPage)
+			{
+				target = currentPage;
+			}
+
+			return NavigationPage.GetTitleView(target);
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml
@@ -31,7 +31,8 @@
                 <TextBlock VerticalAlignment="Center" x:Name="title" TextWrapping="NoWrap" Margin="10,0,0,0"/>
             </Border>
 
-            <ContentControl x:Name="titleView" Grid.Column="3" HorizontalAlignment="Stretch" />
+            <ContentControl x:Name="titleView" Grid.Column="3" HorizontalAlignment="Stretch" 
+                            HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" />
 
         </Grid>
     </CommandBar.Content>


### PR DESCRIPTION
### Description of Change

TitleView for NavigationPage on Windows:

```
<NavigationPage.TitleView>
    <Button Text="Title View Button" />
</NavigationPage.TitleView>
```

![image](https://user-images.githubusercontent.com/538025/158310161-cb700657-791c-4656-ad04-bc433064d88b.png)

### Issues Fixed

Totally fixes #1628
Fixes the Android and WinUI parts of #3877.

