### PR TITLE
[android] update Xamarin.Google.Guava.ListenableFuture

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
+++ b/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
@@ -97,6 +97,7 @@
   <ItemGroup Condition=" '$(_MauiTargetPlatformIsAndroid)' == 'True' ">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
+    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.Fragment" />

--- a/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
+++ b/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
@@ -97,12 +97,14 @@
   <ItemGroup Condition=" '$(_MauiTargetPlatformIsAndroid)' == 'True' ">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
-    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.Fragment" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.Runtime" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.Common" />
+    <!-- TODO: remove these packages the next time AndroidX is updated -->
+    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" />
+    <PackageReference Include="Xamarin.AndroidX.Concurrent.Futures" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(_MauiTargetPlatformIsWindows)' == 'True' ">
     <DefineConstants>WINDOWS;$(DefineConstants)</DefineConstants>

--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -49,10 +49,6 @@
         Version="0.10.0"
     />
     <PackageReference
-        Update="Xamarin.Google.Android.Material"
-        Version="1.4.0.4"
-    />
-    <PackageReference
         Update="Xamarin.Google.Guava.ListenableFuture"
         Version="1.0.0.6"
     />
@@ -60,6 +56,15 @@
         Update="Xamarin.AndroidX.Migration"
         Version="1.0.8"
         NoWarn="NU1701"
+    />
+    <!-- TODO: remove these packages the next time AndroidX is updated -->
+    <PackageReference
+        Update="Xamarin.Google.Android.Material"
+        Version="1.4.0.4"
+    />
+    <PackageReference
+        Update="Xamarin.AndroidX.Concurrent.Futures"
+        Version="1.1.0.7"
     />
   </ItemGroup>
 </Project>

--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -53,6 +53,10 @@
         Version="1.4.0.4"
     />
     <PackageReference
+        Update="Xamarin.Google.Guava.ListenableFuture"
+        Version="1.0.0.6"
+    />
+    <PackageReference
         Update="Xamarin.AndroidX.Migration"
         Version="1.0.8"
         NoWarn="NU1701"

--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -49,8 +49,8 @@
         Version="0.10.0"
     />
     <PackageReference
-        Update="Xamarin.Google.Guava.ListenableFuture"
-        Version="1.0.0.6"
+        Update="Xamarin.Google.Android.Material"
+        Version="1.4.0.4"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Migration"
@@ -59,8 +59,8 @@
     />
     <!-- TODO: remove these packages the next time AndroidX is updated -->
     <PackageReference
-        Update="Xamarin.Google.Android.Material"
-        Version="1.4.0.4"
+        Update="Xamarin.Google.Guava.ListenableFuture"
+        Version="1.0.0.6"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Concurrent.Futures"

--- a/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
+++ b/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" />
     <PackageReference Include="Xamarin.Google.Crypto.Tink.Android" />
-    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">
     <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" />

--- a/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
+++ b/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
@@ -27,6 +27,9 @@
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" />
     <PackageReference Include="Xamarin.Google.Crypto.Tink.Android" />
+    <!-- TODO: remove these packages the next time AndroidX is updated -->
+    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" />
+    <PackageReference Include="Xamarin.AndroidX.Concurrent.Futures" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">
     <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" />

--- a/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
+++ b/src/Workload/Microsoft.Maui.Dependencies/Microsoft.Maui.Dependencies.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Xamarin.Google.Android.Material" />
     <PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" />
     <PackageReference Include="Xamarin.Google.Crypto.Tink.Android" />
+    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">
     <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/AndroidX/issues/509

Building a MAUI project with a certain set of AndroidX dependencies:

    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.7.0" />
    <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.0.2.3" />
    <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.0.2.3" />
    <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.0.0.5-alpha20" />

Fails with:

    Xamarin.Android.D8.targets(79,5): error : java.lang.RuntimeException: com.android.tools.r8.CompilationFailedException:
    Compilation failed to complete, origin: /Users/imac/.nuget/packages/xamarin.google.guava.listenablefuture/1.0.0.5/buildTransitive/net6.0-android31.0/../../jar/guava-listenablefuture.jar : com/google/common/util/concurrent/ListenableFuture.class

If we look at the contents of:

    C:\Program Files\dotnet\packs\Microsoft.Maui.Controls.Ref.android\6.0.200-preview.14.5099\ref\net6.0-android30.0\Microsoft.Maui.Controls.aar

There is a `libs\FCEFAF10B0757418.jar` inside that contains the
contents of `guava-listenablefuture.jar`!

This was a fix for `Xamarin.Google.Guava.*`:

https://github.com/xamarin/XamarinComponents/pull/1313

MAUI is not using the latest version of this package, so we can
specify `Xamarin.Google.Guava.ListenableFuture` explicitly. Now there
are no `.jar` files in `Microsoft.Maui.aar`.

Another approach is to update to the very latest AndroidX packages --
right now we are blocked on trying to get them all on the
`dotnet-public` feed. So we can take that approach later on.