### PR TITLE
Enforce Width/Height for ContentView on Android

### DIFF
--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -59,6 +59,10 @@ namespace Microsoft.Maui.Platform
 			var platformWidth = Context.ToPixels(width);
 			var platformHeight = Context.ToPixels(height);
 
+			// Minimum values win over everything
+			platformWidth = Math.Max(MinimumWidth, platformWidth);
+			platformHeight = Math.Max(MinimumHeight, platformHeight);
+
 			SetMeasuredDimension((int)platformWidth, (int)platformHeight);
 		}
 

--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -46,12 +46,20 @@ namespace Microsoft.Maui.Platform
 			var deviceIndependentWidth = widthMeasureSpec.ToDouble(Context);
 			var deviceIndependentHeight = heightMeasureSpec.ToDouble(Context);
 
-			var size = CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
 
-			var nativeWidth = Context.ToPixels(size.Width);
-			var nativeHeight = Context.ToPixels(size.Height);
+			var measure = CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
 
-			SetMeasuredDimension((int)nativeWidth, (int)nativeHeight);
+			// If the measure spec was exact, we should return the explicit size value, even if the content
+			// measure came out to a different size
+			var width = widthMode == MeasureSpecMode.Exactly ? deviceIndependentWidth : measure.Width;
+			var height = heightMode == MeasureSpecMode.Exactly ? deviceIndependentHeight : measure.Height;
+
+			var platformWidth = Context.ToPixels(width);
+			var platformHeight = Context.ToPixels(height);
+
+			SetMeasuredDimension((int)platformWidth, (int)platformHeight);
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -105,12 +105,24 @@ namespace Microsoft.Maui.Platform
 			var deviceIndependentWidth = widthMeasureSpec.ToDouble(Context);
 			var deviceIndependentHeight = heightMeasureSpec.ToDouble(Context);
 
-			var size = CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
+			var widthMode = MeasureSpec.GetMode(widthMeasureSpec);
+			var heightMode = MeasureSpec.GetMode(heightMeasureSpec);
 
-			var nativeWidth = Context.ToPixels(size.Width);
-			var nativeHeight = Context.ToPixels(size.Height);
+			var measure = CrossPlatformMeasure(deviceIndependentWidth, deviceIndependentHeight);
 
-			SetMeasuredDimension((int)nativeWidth, (int)nativeHeight);
+			// If the measure spec was exact, we should return the explicit size value, even if the content
+			// measure came out to a different size
+			var width = widthMode == MeasureSpecMode.Exactly ? deviceIndependentWidth : measure.Width;
+			var height = heightMode == MeasureSpecMode.Exactly ? deviceIndependentHeight : measure.Height;
+
+			var platformWidth = Context.ToPixels(width);
+			var platformHeight = Context.ToPixels(height);
+
+			// Minimum values win over everything
+			platformWidth = Math.Max(MinimumWidth, platformWidth);
+			platformHeight = Math.Max(MinimumHeight, platformHeight);
+
+			SetMeasuredDimension((int)platformWidth, (int)platformHeight);
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 
 			var measure = await InvokeOnMainThreadAsync(() => cv.Measure(double.PositiveInfinity, double.PositiveInfinity));
 			
-			Assert.Equal(cv.Width, measure.Width);
-			Assert.Equal(cv.Height, measure.Height);
+			Assert.Equal(cv.Width, measure.Width, 0);
+			Assert.Equal(cv.Height, measure.Height, 0);
 		}
 
 		[Fact]
@@ -47,8 +47,8 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 
 			var measure = await InvokeOnMainThreadAsync(() => cv.Measure(double.PositiveInfinity, double.PositiveInfinity));
 
-			Assert.Equal(cv.MinimumWidth, measure.Width);
-			Assert.Equal(cv.MinimumHeight, measure.Height);
+			Assert.Equal(cv.MinimumWidth, measure.Width, 0);
+			Assert.Equal(cv.MinimumHeight, measure.Height, 0);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 	public class ContentViewTests : HandlerTestBase<ContentViewHandler, ContentViewStub>
 	{
 		[Fact]
-		public async Task ContentViewDesiredSizeMatchesExplicitValues()
+		public async Task MeasureMatchesExplicitValues()
 		{
 			var cv = new ContentViewStub();
 
@@ -27,6 +27,28 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 			
 			Assert.Equal(cv.Width, measure.Width);
 			Assert.Equal(cv.Height, measure.Height);
+		}
+
+		[Fact]
+		public async Task RespectsMinimumValues()
+		{
+			var cv = new ContentViewStub();
+
+			var content = new SliderStub
+			{
+				DesiredSize = new Size(50, 50)
+			};
+
+			cv.Content = content;
+			cv.MinimumWidth = 100;
+			cv.MinimumHeight = 150;
+
+			var contentViewHandler = await CreateHandlerAsync(cv);
+
+			var measure = await InvokeOnMainThreadAsync(() => cv.Measure(double.PositiveInfinity, double.PositiveInfinity));
+
+			Assert.Equal(cv.MinimumWidth, measure.Width);
+			Assert.Equal(cv.MinimumHeight, measure.Height);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
+{
+	[Category(TestCategory.ContentView)]
+	public class ContentViewTests : HandlerTestBase<ContentViewHandler, ContentViewStub>
+	{
+		[Fact]
+		public async Task ContentViewDesiredSizeMatchesExplicitValues()
+		{
+			var cv = new ContentViewStub();
+
+			var content = new SliderStub
+			{
+				DesiredSize = new Size(50, 50)
+			};
+
+			cv.Content = content;
+			cv.Width = 100;
+			cv.Height = 150;
+
+			var contentViewHandler = await CreateHandlerAsync(cv);
+
+			var measure = await InvokeOnMainThreadAsync(() => cv.Measure(double.PositiveInfinity, double.PositiveInfinity));
+			
+			Assert.Equal(cv.Width, measure.Width);
+			Assert.Equal(cv.Height, measure.Height);
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -365,8 +365,8 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			var measure = await InvokeOnMainThreadAsync(() => layout.Measure(double.PositiveInfinity, double.PositiveInfinity));
 
-			Assert.Equal(layout.Width, measure.Width);
-			Assert.Equal(layout.Height, measure.Height);
+			Assert.Equal(layout.Width, measure.Width, 0);
+			Assert.Equal(layout.Height, measure.Height, 0);
 		}
 
 		[Fact]
@@ -387,8 +387,8 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 
 			var measure = await InvokeOnMainThreadAsync(() => layout.Measure(double.PositiveInfinity, double.PositiveInfinity));
 
-			Assert.Equal(layout.MinimumWidth, measure.Width);
-			Assert.Equal(layout.MinimumHeight, measure.Height);
+			Assert.Equal(layout.MinimumWidth, measure.Width, 0);
+			Assert.Equal(layout.MinimumHeight, measure.Height, 0);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Layout/LayoutHandlerTests.cs
@@ -346,5 +346,49 @@ namespace Microsoft.Maui.DeviceTests.Handlers.Layout
 			// Verify the views are in the correct order
 			await AssertZIndexOrder(handler);
 		}
+
+		[Fact]
+		public async Task MeasureMatchesExplicitValues()
+		{
+			var layout = new LayoutStub();
+
+			var content = new SliderStub
+			{
+				DesiredSize = new Size(50, 50)
+			};
+
+			layout.Add(content);
+			layout.Width = 100;
+			layout.Height = 150;
+
+			var contentViewHandler = await CreateHandlerAsync(layout);
+
+			var measure = await InvokeOnMainThreadAsync(() => layout.Measure(double.PositiveInfinity, double.PositiveInfinity));
+
+			Assert.Equal(layout.Width, measure.Width);
+			Assert.Equal(layout.Height, measure.Height);
+		}
+
+		[Fact]
+		public async Task RespectsMinimumValues()
+		{
+			var layout = new LayoutStub();
+
+			var content = new SliderStub
+			{
+				DesiredSize = new Size(50, 50)
+			};
+
+			layout.Add(content);
+			layout.MinimumWidth = 100;
+			layout.MinimumHeight = 150;
+
+			var contentViewHandler = await CreateHandlerAsync(layout);
+
+			var measure = await InvokeOnMainThreadAsync(() => layout.Measure(double.PositiveInfinity, double.PositiveInfinity));
+
+			Assert.Equal(layout.MinimumWidth, measure.Width);
+			Assert.Equal(layout.MinimumHeight, measure.Height);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/ContentViewStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ContentViewStub.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			return LayoutManager.Measure(widthConstraint, heightConstraint);
+			return PresentedContent?.Measure(widthConstraint, heightConstraint) ?? Size.Zero;
 		}
 
 		public Size CrossPlatformArrange(Rect bounds)
 		{
-			return LayoutManager.ArrangeChildren(bounds);
+			return PresentedContent?.Arrange(bounds) ?? Size.Zero;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/ContentViewStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ContentViewStub.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+
+#nullable enable
+
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public class ContentViewStub : StubBase, IContentView 
+	{
+		ILayoutManager? _layoutManager;
+
+		public object? Content { get; set; }
+
+		public IView? PresentedContent { get; set; }
+
+		public Thickness Padding { get; set; }
+
+		ILayoutManager LayoutManager => _layoutManager ??= new LayoutManagerStub();
+
+		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			return LayoutManager.Measure(widthConstraint, heightConstraint);
+		}
+
+		public Size CrossPlatformArrange(Rect bounds)
+		{
+			return LayoutManager.ArrangeChildren(bounds);
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Stubs/LayoutManagerStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LayoutManagerStub.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Size Measure(double widthConstraint, double heightConstraint)
 		{
-			return new Size(widthConstraint, heightConstraint);
+			return new Size(widthConstraint - 1, heightConstraint - 1);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -126,6 +126,11 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public Size Measure(double widthConstraint, double heightConstraint)
 		{
+			if (Handler != null)
+			{ 
+				return Handler.GetDesiredSize(widthConstraint, heightConstraint);
+			}
+
 			return new Size(widthConstraint, heightConstraint);
 		}
 

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -10,6 +10,7 @@
 		public const string BoxView = "BoxView";
 		public const string Button = "Button";
 		public const string CheckBox = "CheckBox";
+		public const string ContentView = "ContentView";
 		public const string DatePicker = "DatePicker";
 		public const string Dispatcher = "Dispatcher";
 		public const string Editor = "Editor";


### PR DESCRIPTION
ContentView on Android was sizing itself to its Content even when explicit Width/Height were provided. These changes make the backing control enforce the explicit and minimum Width/Height values.

These changes also make the backing view for Layouts respect explicit and minimum Width/Height values.

Fixes #4164



