### PR TITLE
Make Border render itself on Windows.

### DIFF
--- a/src/Controls/src/Core/Border.cs
+++ b/src/Controls/src/Core/Border.cs
@@ -143,14 +143,14 @@ namespace Microsoft.Maui.Controls
 
 		public Size CrossPlatformArrange(Graphics.Rect bounds)
 		{
-			bounds = bounds.Inset(StrokeThickness / 2);
+			bounds = bounds.Inset(StrokeThickness);
 			this.ArrangeContent(bounds);
 			return bounds.Size;
 		}
 
 		public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
-			var inset = Padding + (StrokeThickness / 2);
+			var inset = Padding + StrokeThickness;
 			return this.MeasureContent(inset, widthConstraint, heightConstraint);
 		}
 

--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Maui.Platform
 
 			var actual = CrossPlatformArrange(new Graphics.Rect(0, 0, width, height));
 
+			_borderPath?.Arrange(new global::Windows.Foundation.Rect(0, 0, finalSize.Width, finalSize.Height));
+
 			return new global::Windows.Foundation.Size(actual.Width, actual.Height);
 		}
 


### PR DESCRIPTION
### Description of Change

The crossplatform arrange used by ContentPanel only arranges the content of the Border. As a result the border element itself (the border line and the background) do not render. 
In this change we arrange _borderPath explicitly.

Also the calculations in `Border.CrossPatformMeasure` work with half the thickness of the border. 
Since the border is added to the padding on all sides, this pushes half of the border outside of the render size.

### Issues Fixed

Fixes: #5061, #4248, #3113, #3791
