### PR TITLE
Lazy-load Configuration

### DIFF
--- a/src/Core/src/Hosting/MauiAppBuilder.cs
+++ b/src/Core/src/Hosting/MauiAppBuilder.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Maui.Essentials;
 using Microsoft.Maui.LifecycleEvents;
-using Microsoft.Maui.Platform;
 using Microsoft.Maui.Dispatching;
 
 namespace Microsoft.Maui.Hosting
@@ -18,12 +17,17 @@ namespace Microsoft.Maui.Hosting
 	{
 		private readonly MauiApplicationServiceCollection _services = new();
 		private Func<IServiceProvider>? _createServiceProvider;
+		private readonly Lazy<ConfigurationManager> _configuration;
 		private ILoggingBuilder? _logging;
 
 		internal MauiAppBuilder(bool useDefaults)
 		{
-			Configuration = new();
-			Services.AddSingleton<IConfiguration>(Configuration);
+			// Lazy-load the ConfigurationManager, so it isn't created if it is never used.
+			// Don't capture the 'this' variable in AddSingleton, so MauiAppBuilder can be GC'd.
+			var configuration = new Lazy<ConfigurationManager>(() => new ConfigurationManager());
+			Services.AddSingleton<IConfiguration>(sp => configuration.Value);
+
+			_configuration = configuration;
 
 			if (useDefaults)
 			{
@@ -82,7 +86,7 @@ namespace Microsoft.Maui.Hosting
 		/// <summary>
 		/// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
 		/// </summary>
-		public ConfigurationManager Configuration { get; }
+		public ConfigurationManager Configuration => _configuration.Value;
 
 		/// <summary>
 		/// A collection of logging providers for the application to compose. This is useful for adding new logging providers.


### PR DESCRIPTION
The Configuration isn't used by default, and isn't used by many apps. However creating a new ConfigurationManager object isn't free.

Only create a ConfigurationManager once someone asks for it.

![image](https://user-images.githubusercontent.com/8291187/158675520-30dcffe4-f379-4064-8fbc-f2e278da916b.png)
