### PR TITLE
Add additional VisualDiagnostic Image APIs

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<views:BasePage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Pages.RenderViewPage"
+             xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
+             BackgroundColor="{DynamicResource PageBackgroundColor}">
+    <Grid RowDefinitions="Auto, *, Auto">
+        <VerticalStackLayout>
+            <Button x:Name="RenderButton" Text="Render This Button As Image" Clicked="RenderButton_Clicked" />
+        </VerticalStackLayout>
+        <Image x:Name="TestImage" Grid.Row="1"/>
+        <VerticalStackLayout Grid.Row="2">
+            <Label x:Name="StopwatchTime" HorizontalOptions="Center"/>
+        </VerticalStackLayout>
+    </Grid>
+</views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml
@@ -5,12 +5,20 @@
              xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
              BackgroundColor="{DynamicResource PageBackgroundColor}">
     <Grid RowDefinitions="Auto, *, Auto">
-        <VerticalStackLayout>
+        <VerticalStackLayout Spacing="5">
             <Button x:Name="RenderButton" Text="Render This Button As Image" Clicked="RenderButton_Clicked" />
+            <Button Text="Render Window As Image" Clicked="RenderWindow_Clicked" />
+            <HorizontalStackLayout Spacing="5" RadioButtonGroup.GroupName="Image Type" HorizontalOptions="Center"
+                      RadioButtonGroup.SelectedValue="{Binding Selection}">
+                <RadioButton Content="JPEG" Value="JPEG"/>
+                <RadioButton Content="PNG" Value="PNG"/>
+                <RadioButton Content="BMP" Value="BMP"/>
+            </HorizontalStackLayout>
         </VerticalStackLayout>
         <Image x:Name="TestImage" Grid.Row="1"/>
-        <VerticalStackLayout Grid.Row="2">
+        <VerticalStackLayout Spacing="5" Grid.Row="2">
             <Label x:Name="StopwatchTime" HorizontalOptions="Center"/>
+            <Label x:Name="RenderStats" HorizontalOptions="Center"/>
         </VerticalStackLayout>
     </Grid>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml
@@ -19,6 +19,7 @@
         <VerticalStackLayout Spacing="5" Grid.Row="2">
             <Label x:Name="StopwatchTime" HorizontalOptions="Center"/>
             <Label x:Name="RenderStats" HorizontalOptions="Center"/>
+            <Button Text="Save Rendered View" Clicked="RenderViewSaved_Clicked" />
         </VerticalStackLayout>
     </Grid>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
@@ -1,0 +1,50 @@
+#nullable enable
+
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Platform;
+
+namespace Maui.Controls.Sample.Pages
+{
+	public partial class RenderViewPage
+	{
+		Stopwatch stopwatch = new Stopwatch();
+
+		public RenderViewPage()
+		{
+			InitializeComponent();
+		}
+
+		private async void RenderButton_Clicked(object sender, System.EventArgs e)
+		{
+			Reset();
+			byte[]? renderImage = null;
+			stopwatch.Start();
+			try
+			{
+				renderImage = await this.RenderButton.RenderAsBMP();
+				
+			}
+			catch (System.Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine(ex.Message);
+			}
+			stopwatch.Stop();
+
+			if (renderImage is not null)
+			{
+				var imageStream = new MemoryStream(renderImage);
+				this.TestImage.Source = ImageSource.FromStream(() => imageStream);
+			}
+			this.StopwatchTime.Text = stopwatch.Elapsed.ToString();
+		}
+
+		private void Reset()
+		{
+			stopwatch.Reset();
+			StopwatchTime.Text = string.Empty;
+			this.TestImage.Source = null;
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
@@ -2,6 +2,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
@@ -78,7 +79,7 @@ namespace Maui.Controls.Sample.Pages
 				}
 			}
 			this.StopwatchTime.Text = stopwatch.Elapsed.ToString();
-			this.RenderStats.Text = $"Width: {renderImage?.Width}; Height: {renderImage?.Height}; Type: {renderImage?.RenderType}";
+			this.RenderStats.Text = $"Width: {renderImage?.Width}; Height: {renderImage?.Height}; Type: {renderImage?.RenderType}; Size: {SizeInBytes(renderImage?.Render)}";
 		}
 
 		private void Reset()
@@ -87,6 +88,22 @@ namespace Maui.Controls.Sample.Pages
 			StopwatchTime.Text = string.Empty;
 			RenderStats.Text = string.Empty;
 			this.TestImage.Source = null;
+		}
+
+		private string SizeInBytes(byte[]? array)
+		{
+			if (array is null)
+				return string.Empty;
+			string[] sizes = { "B", "KB", "MB", "GB", "TB" };
+			double len = System.Convert.ToDouble(array.Length);
+			int order = 0;
+			while (len >= 1024D && order < sizes.Length - 1)
+			{
+				order++;
+				len /= 1024;
+			}
+
+			return string.Format(CultureInfo.CurrentCulture, "{0:0.##} {1}", len, sizes[order]);
 		}
 	}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
@@ -1,11 +1,13 @@
 #nullable enable
 
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Essentials;
 using Microsoft.Maui.Platform;
 
 namespace Maui.Controls.Sample.Pages
@@ -14,6 +16,8 @@ namespace Maui.Controls.Sample.Pages
 	{
 		Stopwatch stopwatch = new Stopwatch();
 		RenderBindingModel vm;
+		MemoryStream? imageStream;
+		byte[]? byteStream;
 
 		public RenderViewPage()
 		{
@@ -64,13 +68,32 @@ namespace Maui.Controls.Sample.Pages
 			RenderView(renderImage);
 		}
 
+		private async void RenderViewSaved_Clicked(object sender, System.EventArgs e)
+		{
+			if (byteStream is not null)
+			{
+				var extension = vm.RenderType switch
+				{
+					RenderType.JPEG => "jpg",
+					RenderType.PNG => "png",
+					RenderType.BMP => "bmp",
+					_ => "jpg",
+				};
+				string fileName = $"{System.IO.Path.GetTempFileName()}.{extension}";
+				string filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), fileName);
+				File.WriteAllBytes(filePath, byteStream);
+				await Share.RequestAsync(new ShareFileRequest() { Title = fileName, File = new ShareFile(filePath) });
+			}
+		}
+
 		private void RenderView(RenderedView? renderImage)
 		{
 			if (renderImage?.Render is not null)
 			{
 				try
 				{
-					var imageStream = new MemoryStream(renderImage.Render);
+					byteStream = renderImage.Render;
+					imageStream = new MemoryStream(renderImage.Render);
 					this.TestImage.Source = ImageSource.FromStream(() => imageStream);
 				}
 				catch (System.Exception ex)

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Platform;
 
@@ -19,11 +20,11 @@ namespace Maui.Controls.Sample.Pages
 		private async void RenderButton_Clicked(object sender, System.EventArgs e)
 		{
 			Reset();
-			byte[]? renderImage = null;
+			RenderedView? renderImage = null;
 			stopwatch.Start();
 			try
 			{
-				renderImage = await this.RenderButton.RenderAsBMP();
+				renderImage = await this.RenderButton.RenderAsImage(RenderType.JPEG);
 				
 			}
 			catch (System.Exception ex)
@@ -32,9 +33,9 @@ namespace Maui.Controls.Sample.Pages
 			}
 			stopwatch.Stop();
 
-			if (renderImage is not null)
+			if (renderImage?.Render is not null)
 			{
-				var imageStream = new MemoryStream(renderImage);
+				var imageStream = new MemoryStream(renderImage.Render);
 				this.TestImage.Source = ImageSource.FromStream(() => imageStream);
 			}
 			this.StopwatchTime.Text = stopwatch.Elapsed.ToString();

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
@@ -102,7 +102,7 @@ namespace Maui.Controls.Sample.Pages
 				}
 			}
 			this.StopwatchTime.Text = stopwatch.Elapsed.ToString();
-			this.RenderStats.Text = $"Width: {renderImage?.Width}; Height: {renderImage?.Height}; Type: {renderImage?.RenderType}; Size: {SizeInBytes(renderImage?.Render)}";
+			this.RenderStats.Text = $"Type: {renderImage?.RenderType}; Size: {SizeInBytes(renderImage?.Render)}";
 		}
 
 		private void Reset()

--- a/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Others/RenderViewPage.xaml.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Maui;
@@ -11,10 +12,36 @@ namespace Maui.Controls.Sample.Pages
 	public partial class RenderViewPage
 	{
 		Stopwatch stopwatch = new Stopwatch();
+		RenderBindingModel vm;
 
 		public RenderViewPage()
 		{
 			InitializeComponent();
+			this.BindingContext = this.vm = new RenderBindingModel();
+
+		}
+
+		private async void RenderWindow_Clicked(object sender, System.EventArgs e)
+		{
+			Reset();
+			RenderedView? renderImage = null;
+			var window = this.GetParentWindow() as IWindow;
+			stopwatch.Start();
+			try
+			{
+				if (window is not null)
+				{
+					renderImage = await window.RenderAsImage(vm.RenderType);
+				}
+
+			}
+			catch (System.Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine(ex.Message);
+			}
+			stopwatch.Stop();
+
+			RenderView(renderImage);
 		}
 
 		private async void RenderButton_Clicked(object sender, System.EventArgs e)
@@ -24,7 +51,7 @@ namespace Maui.Controls.Sample.Pages
 			stopwatch.Start();
 			try
 			{
-				renderImage = await this.RenderButton.RenderAsImage(RenderType.JPEG);
+				renderImage = await this.RenderButton.RenderAsImage(vm.RenderType);
 				
 			}
 			catch (System.Exception ex)
@@ -33,19 +60,66 @@ namespace Maui.Controls.Sample.Pages
 			}
 			stopwatch.Stop();
 
+			RenderView(renderImage);
+		}
+
+		private void RenderView(RenderedView? renderImage)
+		{
 			if (renderImage?.Render is not null)
 			{
-				var imageStream = new MemoryStream(renderImage.Render);
-				this.TestImage.Source = ImageSource.FromStream(() => imageStream);
+				try
+				{
+					var imageStream = new MemoryStream(renderImage.Render);
+					this.TestImage.Source = ImageSource.FromStream(() => imageStream);
+				}
+				catch (System.Exception ex)
+				{
+					System.Diagnostics.Debug.WriteLine(ex.Message);
+				}
 			}
 			this.StopwatchTime.Text = stopwatch.Elapsed.ToString();
+			this.RenderStats.Text = $"Width: {renderImage?.Width}; Height: {renderImage?.Height}; Type: {renderImage?.RenderType}";
 		}
 
 		private void Reset()
 		{
 			stopwatch.Reset();
 			StopwatchTime.Text = string.Empty;
+			RenderStats.Text = string.Empty;
 			this.TestImage.Source = null;
+		}
+	}
+
+	public class RenderBindingModel : INotifyPropertyChanged
+	{
+		private string? _selection;
+
+		public event PropertyChangedEventHandler? PropertyChanged;
+
+		void OnPropertyChanged(string propertyName)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		public string? Selection
+		{
+			get => _selection;
+			set
+			{
+				_selection = value;
+				OnPropertyChanged(nameof(Selection));
+			}
+		}
+
+		public RenderType RenderType
+		{
+			get
+			{
+				if (_selection is null)
+					return RenderType.JPEG;
+
+				return (RenderType)System.Enum.Parse(typeof(RenderType), _selection);
+			}
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/ViewModels/OthersViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/OthersViewModel.cs
@@ -14,8 +14,9 @@ namespace Maui.Controls.Sample.ViewModels
 			new SectionModel(typeof(LargeTitlesPageiOS), "Large Titles - iOS",
 				"This iOS platform-specific is used to display the page title as a large title on the navigation bar of a NavigationPage, for devices that use iOS 11 or greater."),
 			new SectionModel(typeof(StyleSheetsPage), "StyleSheets",
-				"Demonstrates the usage of CSS in XAML.")
-
+				"Demonstrates the usage of CSS in XAML."),
+			new SectionModel(typeof(RenderViewPage), "Render Views",
+				"Demonstrates rendering views as images.")
 		};
 	}
 }

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -308,6 +308,15 @@ namespace Microsoft.Maui.Platform
 				ViewHelper.RemoveFromParent(view);
 		}
 
+		public static Task<byte[]?> RenderAsBMP(this IView view)
+		{
+			var platformView = view?.ToPlatform();
+			if (platformView == null)
+				return Task.FromResult<byte[]?>(null);
+
+			return Task.FromResult<byte[]?>(platformView.RenderAsBMP());
+		}
+
 		public static Task<byte[]?> RenderAsPNG(this IView view)
 		{
 			var platformView = view?.ToPlatform();

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -335,6 +335,17 @@ namespace Microsoft.Maui.Platform
 			return platformView.RenderAsJPEG();
 		}
 
+		public static Task<byte[]?> RenderAsImage(this AView view, RenderType type)
+		{
+			return type switch
+			{
+				RenderType.JPEG => view.RenderAsJPEG(),
+				RenderType.PNG => view.RenderAsPNG(),
+				RenderType.BMP => Task.FromResult<byte[]?>(view.RenderAsBMP()),
+				_ => throw new NotImplementedException()
+			};
+		}
+
 		public static Task<byte[]?> RenderAsPNG(this AView view)
 			=> Task.FromResult<byte[]?>(view.RenderAsImage(Android.Graphics.Bitmap.CompressFormat.Png));
 

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Android.App;
+using Android.Views;
+using Microsoft.Maui.Essentials;
 
 namespace Microsoft.Maui.Platform
 {
@@ -9,8 +12,22 @@ namespace Microsoft.Maui.Platform
 	{
 		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
 		{
-			await Task.Delay(5);
-			return null;
+			if (window.Handler?.PlatformView is not Activity activity)
+				return null;
+
+			if (activity?.Window?.DecorView?.RootView is not View rootView)
+				return null;
+
+			var bb = rootView.GetBoundingBox();
+			var image = type switch
+			{
+				RenderType.JPEG => await rootView.RenderAsJPEG(),
+				RenderType.PNG => await rootView.RenderAsPNG(),
+				RenderType.BMP => rootView.RenderAsBMP(),
+				_ => throw new NotImplementedException(),
+			};
+
+			return new RenderedView(bb.Width, bb.Height, image, type);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Platform
+{
+	public static partial class WindowExtensions
+	{
+		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
+		{
+			await Task.Delay(5);
+			return null;
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Maui.Platform
 			if (activity?.Window?.DecorView?.RootView is not View rootView)
 				return null;
 
-			var bb = rootView.GetBoundingBox();
 			var image = type switch
 			{
 				RenderType.JPEG => await rootView.RenderAsJPEG(),
@@ -27,7 +26,7 @@ namespace Microsoft.Maui.Platform
 				_ => throw new NotImplementedException(),
 			};
 
-			return new RenderedView(bb.Width, bb.Height, image, type);
+			return new RenderedView(image, type);
 		}
 	}
 }

--- a/src/Core/src/Platform/Standard/ViewExtensions.cs
+++ b/src/Core/src/Platform/Standard/ViewExtensions.cs
@@ -58,6 +58,9 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateMaximumWidth(this object platformView, IView view) { }
 
+		public static System.Threading.Tasks.Task<byte[]?> RenderAsBMP(this IView view)
+			=> System.Threading.Tasks.Task.FromResult<byte[]?>(null);
+
 		public static System.Threading.Tasks.Task<byte[]?> RenderAsPNG(this IView view)
 			=> System.Threading.Tasks.Task.FromResult<byte[]?>(null);
 

--- a/src/Core/src/Platform/Standard/WindowExtensions.cs
+++ b/src/Core/src/Platform/Standard/WindowExtensions.cs
@@ -7,10 +7,9 @@ namespace Microsoft.Maui.Platform
 {
 	public static partial class WindowExtensions
 	{
-		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
+		public static Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
 		{
-			await Task.Delay(5);
-			return null;
+			return Task.FromResult<RenderedView?>(null);
 		}
 	}
 }

--- a/src/Core/src/Platform/Standard/WindowExtensions.cs
+++ b/src/Core/src/Platform/Standard/WindowExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Platform
+{
+	public static partial class WindowExtensions
+	{
+		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
+		{
+			await Task.Delay(5);
+			return null;
+		}
+	}
+}

--- a/src/Core/src/Platform/ViewExtensions.cs
+++ b/src/Core/src/Platform/ViewExtensions.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Maui
 
 		public static async Task<RenderedView> RenderAsImage(this IView view, RenderType type)
 		{
-			var boundingBox = view.GetBoundingBox();
 			byte[]? image = type switch
 			{
 				RenderType.PNG => await view.RenderAsPNG(),
@@ -48,7 +47,7 @@ namespace Microsoft.Maui
 				_ => throw new NotImplementedException(),
 			};
 
-			return new RenderedView(boundingBox.Width, boundingBox.Height, image, type);
+			return new RenderedView(image, type);
 		}
 
 		internal static T? GetParentOfType<T>(this ParentView? view)

--- a/src/Core/src/Platform/ViewExtensions.cs
+++ b/src/Core/src/Platform/ViewExtensions.cs
@@ -37,6 +37,19 @@ namespace Microsoft.Maui
 		public static IPlatformViewHandler ToHandler(this IView view, IMauiContext context) =>
 			(IPlatformViewHandler)ElementExtensions.ToHandler(view, context);
 
+		public static async Task<RenderedView> RenderAsImage(this IView view, RenderType type)
+		{
+			var boundingBox = view.GetBoundingBox();
+			byte[]? image = type switch
+			{
+				RenderType.PNG => await view.RenderAsPNG(),
+				RenderType.JPEG => await view.RenderAsJPEG(),
+				RenderType.BMP => await view.RenderAsBMP(),
+				_ => throw new NotImplementedException(),
+			};
+
+			return new RenderedView(boundingBox.Width, boundingBox.Height, image, type);
+		}
 
 		internal static T? GetParentOfType<T>(this ParentView? view)
 			where T : class

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -260,6 +260,15 @@ namespace Microsoft.Maui.Platform
 			layoutPanel.UpdateInputTransparent(layout.InputTransparent, layout?.Background?.ToPlatform());
 		}
 
+		public static async Task<byte[]?> RenderAsBMP(this IView view)
+		{
+			var platformView = view?.ToPlatform();
+			if (platformView == null)
+				return null;
+
+			return await platformView.RenderAsBMP();
+		}
+
 		public static async Task<byte[]?> RenderAsPNG(this IView view)
 		{
 			var platformView = view?.ToPlatform();
@@ -277,6 +286,8 @@ namespace Microsoft.Maui.Platform
 
 			return await platformView.RenderAsJPEG();
 		}
+
+		public static Task<byte[]?> RenderAsBMP(this FrameworkElement view) => view != null ? view.RenderAsBMPAsync() : Task.FromResult<byte[]?>(null);
 
 		public static Task<byte[]?> RenderAsPNG(this FrameworkElement view) => view != null ? view.RenderAsPNGAsync() : Task.FromResult<byte[]?>(null);
 

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -287,6 +287,17 @@ namespace Microsoft.Maui.Platform
 			return await platformView.RenderAsJPEG();
 		}
 
+		public static Task<byte[]?> RenderAsImage(this FrameworkElement view, RenderType type)
+		{
+			return type switch
+			{
+				RenderType.JPEG => view.RenderAsJPEG(),
+				RenderType.PNG => view.RenderAsPNG(),
+				RenderType.BMP => view.RenderAsBMP(),
+				_ => throw new NotImplementedException()
+			};
+		}
+
 		public static Task<byte[]?> RenderAsBMP(this FrameworkElement view) => view != null ? view.RenderAsBMPAsync() : Task.FromResult<byte[]?>(null);
 
 		public static Task<byte[]?> RenderAsPNG(this FrameworkElement view) => view != null ? view.RenderAsPNGAsync() : Task.FromResult<byte[]?>(null);

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Maui.Essentials;
 using WinRT.Interop;
 
@@ -46,6 +47,26 @@ namespace Microsoft.Maui.Platform
 				return 1.0f;
 
 			return PlatformMethods.GetDpiForWindow(hwnd) / DeviceDisplay.BaseLogicalDpi;
+		}
+
+		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
+		{
+			if (window.Handler?.PlatformView is not UI.Xaml.Window win)
+				return null;
+
+			if (win.Content is not UI.Xaml.FrameworkElement element)
+				return null;
+
+			var bb = element.GetBoundingBox();
+			var image = type switch
+			{
+				RenderType.JPEG => await element.RenderAsJPEGAsync(),
+				RenderType.PNG => await element.RenderAsPNGAsync(),
+				RenderType.BMP => await element.RenderAsBMPAsync(),
+				_ => throw new NotImplementedException(),
+			};
+
+			return new RenderedView(bb.Width, bb.Height, image, type);
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -49,6 +49,17 @@ namespace Microsoft.Maui.Platform
 			return PlatformMethods.GetDpiForWindow(hwnd) / DeviceDisplay.BaseLogicalDpi;
 		}
 
+		public static UI.Windowing.AppWindow? GetAppWindow(this UI.Xaml.Window platformWindow)
+		{
+			var hwnd = platformWindow.GetWindowHandle();
+
+			if (hwnd == IntPtr.Zero)
+				return null;
+
+			var windowId = UI.Win32Interop.GetWindowIdFromWindow(hwnd);
+			return UI.Windowing.AppWindow.GetFromWindowId(windowId);
+		}
+
 		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
 		{
 			if (window.Handler?.PlatformView is not UI.Xaml.Window win)
@@ -57,7 +68,6 @@ namespace Microsoft.Maui.Platform
 			if (win.Content is not UI.Xaml.FrameworkElement element)
 				return null;
 
-			var bb = element.GetBoundingBox();
 			var image = type switch
 			{
 				RenderType.JPEG => await element.RenderAsJPEGAsync(),
@@ -66,7 +76,7 @@ namespace Microsoft.Maui.Platform
 				_ => throw new NotImplementedException(),
 			};
 
-			return new RenderedView(bb.Width, bb.Height, image, type);
+			return new RenderedView(image, type);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -329,31 +329,49 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static Task<byte[]?> RenderAsPNG(this IView view) => view != null ? view.RenderAsImage(true) : Task.FromResult<byte[]?>(null);
-
-		public static Task<byte[]?> RenderAsJPEG(this IView view) => view != null ? view.RenderAsImage(false) : Task.FromResult<byte[]?>(null);
-
-		public static Task<byte[]?> RenderAsPNG(this UIView view, bool skipChildren = true) => view != null ? view.RenderAsImage(skipChildren, true) : Task.FromResult<byte[]?>(null);
-
-		public static Task<byte[]?> RenderAsJPEG(this UIView view, bool skipChildren = true) => view != null ? view.RenderAsImage(skipChildren, false) : Task.FromResult<byte[]?>(null);
-
-		static Task<byte[]?> RenderAsImage(this UIView platformView, bool skipChildren, bool asPng)
+		public static Task<byte[]?> RenderAsBMP(this IView view)
 		{
-			byte[]? result;
-			if (asPng)
-				result = platformView?.Window?.RenderAsPng(platformView.Layer, UIScreen.MainScreen.Scale, skipChildren);
-			else
-				result = platformView?.Window?.RenderAsJpeg(platformView.Layer, UIScreen.MainScreen.Scale, skipChildren);
-			return Task.FromResult<byte[]?>(result);
+			(UIView? platformView, bool skipChildren) = view.GetPlatformRenderBase();
+			if (platformView is null)
+				return Task.FromResult<byte[]?>(null);
+
+			return platformView.RenderAsBMP(skipChildren);
 		}
 
-		static Task<byte[]?> RenderAsImage(this IView view, bool asPng)
+		public static Task<byte[]?> RenderAsPNG(this IView view)
+		{
+			(UIView? platformView, bool skipChildren) = view.GetPlatformRenderBase();
+			if (platformView is null)
+				return Task.FromResult<byte[]?>(null);
+
+			return platformView.RenderAsPNG(skipChildren);
+		}
+
+		public static Task<byte[]?> RenderAsJPEG(this IView view)
+		{
+			(UIView? platformView, bool skipChildren) = view.GetPlatformRenderBase();
+			if (platformView is null)
+				return Task.FromResult<byte[]?>(null);
+
+			return platformView.RenderAsJPEG(skipChildren);
+		}
+
+		public static Task<byte[]?> RenderAsBMP(this UIView view, bool skipChildren = true)
+			=> Task.FromResult(view?.Window?.RenderAsBmp(view.Layer, UIScreen.MainScreen.Scale, skipChildren));
+
+		public static Task<byte[]?> RenderAsPNG(this UIView view, bool skipChildren = true)
+			=> Task.FromResult(view?.Window?.RenderAsPng(view.Layer, UIScreen.MainScreen.Scale, skipChildren));
+
+		public static Task<byte[]?> RenderAsJPEG(this UIView view, bool skipChildren = true)
+			=> Task.FromResult(view?.Window?.RenderAsJpeg(view.Layer, UIScreen.MainScreen.Scale, skipChildren));
+
+		static (UIView? View, bool SkipChildren) GetPlatformRenderBase(this IView view)
 		{
 			var platformView = view?.ToPlatform();
 			if (platformView == null)
-				return Task.FromResult<byte[]?>(null);
+				return (null, false);
 			var skipChildren = !(view is IView && !(view is ILayout));
-			return platformView.RenderAsImage(skipChildren, asPng);
+			return (platformView, skipChildren);
 		}
 
 		internal static Rect GetPlatformViewBounds(this IView view)

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -367,13 +367,13 @@ namespace Microsoft.Maui.Platform
 			};
 		}
 
-		public static Task<byte[]?> RenderAsBMP(this UIWindow window, bool skipChildren = true)
+		public static Task<byte[]?> RenderAsBMP(this UIWindow window, bool skipChildren = false)
 			=> Task.FromResult(window?.RenderAsBmp(window.Layer, UIScreen.MainScreen.Scale, skipChildren));
 
-		public static Task<byte[]?> RenderAsPNG(this UIWindow window, bool skipChildren = true)
+		public static Task<byte[]?> RenderAsPNG(this UIWindow window, bool skipChildren = false)
 			=> Task.FromResult(window?.RenderAsPng(window.Layer, UIScreen.MainScreen.Scale, skipChildren));
 
-		public static Task<byte[]?> RenderAsJPEG(this UIWindow window, bool skipChildren = true)
+		public static Task<byte[]?> RenderAsJPEG(this UIWindow window, bool skipChildren = false)
 			=> Task.FromResult(window?.RenderAsJpeg(window.Layer, UIScreen.MainScreen.Scale, skipChildren));
 
 		public static Task<byte[]?> RenderAsBMP(this UIView view, bool skipChildren = true)

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -356,6 +356,17 @@ namespace Microsoft.Maui.Platform
 			return platformView.RenderAsJPEG(skipChildren);
 		}
 
+		public static Task<byte[]?> RenderAsImage(this UIView view, RenderType type, bool skipChildren = true)
+		{
+			return type switch
+			{
+				RenderType.JPEG => view.RenderAsJPEG(skipChildren),
+				RenderType.PNG => view.RenderAsPNG(skipChildren),
+				RenderType.BMP => view.RenderAsBMP(skipChildren),
+				_ => throw new NotImplementedException()
+			};
+		}
+
 		public static Task<byte[]?> RenderAsBMP(this UIView view, bool skipChildren = true)
 			=> Task.FromResult(view?.Window?.RenderAsBmp(view.Layer, UIScreen.MainScreen.Scale, skipChildren));
 

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -367,6 +367,15 @@ namespace Microsoft.Maui.Platform
 			};
 		}
 
+		public static Task<byte[]?> RenderAsBMP(this UIWindow window, bool skipChildren = true)
+			=> Task.FromResult(window?.RenderAsBmp(window.Layer, UIScreen.MainScreen.Scale, skipChildren));
+
+		public static Task<byte[]?> RenderAsPNG(this UIWindow window, bool skipChildren = true)
+			=> Task.FromResult(window?.RenderAsPng(window.Layer, UIScreen.MainScreen.Scale, skipChildren));
+
+		public static Task<byte[]?> RenderAsJPEG(this UIWindow window, bool skipChildren = true)
+			=> Task.FromResult(window?.RenderAsJpeg(window.Layer, UIScreen.MainScreen.Scale, skipChildren));
+
 		public static Task<byte[]?> RenderAsBMP(this UIView view, bool skipChildren = true)
 			=> Task.FromResult(view?.Window?.RenderAsBmp(view.Layer, UIScreen.MainScreen.Scale, skipChildren));
 

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -32,8 +32,19 @@ namespace Microsoft.Maui.Platform
 
 		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
 		{
-			await Task.Delay(5);
-			return null;
+			if (window.Handler?.PlatformView is not UIWindow win)
+				return null;
+
+			var bb = win.GetBoundingBox();
+			var image = type switch
+			{
+				RenderType.JPEG => await win.RenderAsJPEG(),
+				RenderType.PNG => await win.RenderAsPNG(),
+				RenderType.BMP => await win.RenderAsBMP(),
+				_ => throw new NotImplementedException(),
+			};
+
+			return new RenderedView(bb.Width, bb.Height, image, type);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Maui.Platform
 			if (window?.ToPlatform() is not UIWindow win)
 				return null;
 
-			var bb = win.GetBoundingBox();
 			var image = type switch
 			{
 				RenderType.JPEG => await win.RenderAsJPEG(),
@@ -44,7 +43,7 @@ namespace Microsoft.Maui.Platform
 				_ => throw new NotImplementedException(),
 			};
 
-			return new RenderedView(bb.Width, bb.Height, image, type);
+			return new RenderedView(image, type);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Platform
 
 		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
 		{
-			if (window.Handler?.PlatformView is not UIWindow win)
+			if (window?.ToPlatform() is not UIWindow win)
 				return null;
 
 			var bb = win.GetBoundingBox();

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
@@ -28,5 +29,11 @@ namespace Microsoft.Maui.Platform
 
 		public static float GetDisplayDensity(this UIWindow uiWindow) =>
 			(float)(uiWindow.Screen?.Scale ?? new nfloat(1.0f));
+
+		public static async Task<RenderedView?> RenderAsImage(this IWindow window, RenderType type)
+		{
+			await Task.Delay(5);
+			return null;
+		}
 	}
 }

--- a/src/Core/src/VisualDiagnostics/RenderedView.cs
+++ b/src/Core/src/VisualDiagnostics/RenderedView.cs
@@ -6,17 +6,11 @@ namespace Microsoft.Maui
 {
 	public class RenderedView
 	{
-		public RenderedView(double width, double height, byte[]? render, RenderType renderType)
+		public RenderedView(byte[]? render, RenderType renderType)
 		{
-			this.Width = width;
-			this.Height = height;
 			this.Render = render;
 			this.RenderType = renderType;
 		}
-
-		public double Width { get; }
-
-		public double Height { get; }
 
 		public byte[]? Render { get; }
 

--- a/src/Core/src/VisualDiagnostics/RenderedView.cs
+++ b/src/Core/src/VisualDiagnostics/RenderedView.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Maui
+{
+	public class RenderedView
+	{
+		public RenderedView(double width, double height, byte[]? render, RenderType renderType)
+		{
+			this.Width = width;
+			this.Height = height;
+			this.Render = render;
+			this.RenderType = renderType;
+		}
+
+		public double Width { get; }
+
+		public double Height { get; }
+
+		public byte[]? Render { get; }
+
+		public RenderType RenderType { get; }
+	}
+
+	public enum RenderType
+	{
+		JPEG,
+		PNG,
+		BMP,
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -220,8 +220,6 @@ namespace Microsoft.Maui.DeviceTests
 			var result = await (await GetValueAsync(view, handler => GetRenderedView(handler, type)));
 			Assert.NotNull(result);
 			Assert.NotNull(result?.Render);
-			Assert.True(result.Width > 0);
-			Assert.True(result.Height > 0);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -216,8 +216,8 @@ namespace Microsoft.Maui.DeviceTests
 			var result = await (await GetValueAsync(view, handler => GetRenderedView(handler, type)));
 			Assert.NotNull(result);
 			Assert.NotNull(result?.Render);
-			Assert.Equal(result.Width, view.Width);
-			Assert.Equal(result.Height, view.Height);
+			Assert.True(result.Width > 0);
+			Assert.True(result.Height > 0);
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -201,7 +201,11 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.NotEqual(platformViewTransform, new System.Numerics.Matrix4x4());
 		}
 
-		[Theory(DisplayName = "View Renders To Image")]
+		[Theory(DisplayName = "View Renders To Image"
+#if __IOS__
+			, Skip = "iOS is missing `Window` in the test runner, so it can't run these tests from here."
+#endif
+			)]
 		[InlineData(RenderType.JPEG)]
 		[InlineData(RenderType.PNG)]
 		[InlineData(RenderType.BMP)]

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -202,8 +202,8 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Theory(DisplayName = "View Renders To Image"
-#if __IOS__
-			, Skip = "iOS is missing `Window` in the test runner, so it can't run these tests from here."
+#if !__ANDROID__
+			, Skip = "iOS and Windows can't render elements to images from test runner. It's missing the required root windows."
 #endif
 			)]
 		[InlineData(RenderType.JPEG)]

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public abstract partial class HandlerTestBase<THandler, TStub>
 	{
+		protected async Task<RenderedView> GetRenderedView(IViewHandler viewHandler, RenderType type) =>
+			await (viewHandler.VirtualView).RenderAsImage(type);
+
 		[Fact(DisplayName = "Automation Id is set correctly")]
 		[InlineData()]
 		public async Task SetAutomationId()
@@ -196,6 +199,25 @@ namespace Microsoft.Maui.DeviceTests
 
 			var platformViewTransform = await GetValueAsync(view, handler => GetViewTransform(handler));
 			Assert.NotEqual(platformViewTransform, new System.Numerics.Matrix4x4());
+		}
+
+		[Theory(DisplayName = "View Renders To Image")]
+		[InlineData(RenderType.JPEG)]
+		[InlineData(RenderType.PNG)]
+		[InlineData(RenderType.BMP)]
+		public async Task RendersAsImage(RenderType type)
+		{
+			var view = new TStub()
+			{
+				Height = 100,
+				Width = 100,
+			};
+
+			var result = await (await GetValueAsync(view, handler => GetRenderedView(handler, type)));
+			Assert.NotNull(result);
+			Assert.NotNull(result?.Render);
+			Assert.Equal(result.Width, view.Width);
+			Assert.Equal(result.Height, view.Height);
 		}
 	}
 }

--- a/src/Essentials/src/Screenshot/Screenshot.android.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.android.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Android.Graphics;
 using Android.Views;
+using Java.Nio;
 
 namespace Microsoft.Maui.Essentials
 {
@@ -11,6 +13,18 @@ namespace Microsoft.Maui.Essentials
 		public static byte[] RenderAsJPEG(this View view, int quality = 100) => view?.RenderAsImage(Bitmap.CompressFormat.Jpeg, quality);
 
 		public static byte[] RenderAsPNG(this View view, int quality = 100) => view?.RenderAsImage(Bitmap.CompressFormat.Png, quality);
+
+		public static byte[] RenderAsBMP(this View view)
+		{
+			using (var bitmap = view.Render())
+			{
+				var byteBuffer = ByteBuffer.AllocateDirect(bitmap.ByteCount);
+				bitmap.CopyPixelsToBuffer(byteBuffer);
+				byte[] byt = new byte[bitmap.ByteCount];
+				Marshal.Copy(byteBuffer.GetDirectBufferAddress(), byt, 0, bitmap.ByteCount);
+				return byt;
+			}
+		}
 
 		public static byte[] RenderAsImage(this View view, Bitmap.CompressFormat format, int quality = 100)
 		{

--- a/src/Essentials/src/Screenshot/Screenshot.uwp.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.uwp.cs
@@ -25,15 +25,22 @@ namespace Microsoft.Maui.Essentials
 
 		public static async Task<byte[]> RenderAsJPEGAsync(this FrameworkElement element)
 		{
-			var memoryStream = new InMemoryRandomAccessStream();
+			using var memoryStream = new InMemoryRandomAccessStream();
 			BitmapEncoder enc = await BitmapEncoder.CreateAsync(BitmapEncoder.JpegEncoderId, memoryStream);
 			return await element.RenderAsImageAsync(enc, memoryStream);
 		}
 
 		public static async Task<byte[]> RenderAsPNGAsync(this FrameworkElement element)
 		{
-			var memoryStream = new InMemoryRandomAccessStream();
+			using var memoryStream = new InMemoryRandomAccessStream();
 			BitmapEncoder enc = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, memoryStream);
+			return await element.RenderAsImageAsync(enc, memoryStream);
+		}
+
+		public static async Task<byte[]> RenderAsBMPAsync(this FrameworkElement element)
+		{
+			using var memoryStream = new InMemoryRandomAccessStream();
+			BitmapEncoder enc = await BitmapEncoder.CreateAsync(BitmapEncoder.BmpEncoderId, memoryStream);
 			return await element.RenderAsImageAsync(enc, memoryStream);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/5340

- Adds `RenderAsBMP`
- Adds `RenderedView`, a class that contains a "Rendered" image, it's width, height, and what kind of image it is. (I am _very_ open to new name for this, since I think it's terrible)
- Adds `RenderAsImage` to `IWindow`, which will render a `IWindow` as an image, including all IWindowOverlays and Adorners.

Still need to add new tests, perf, check math on width/height, etc.