### PR TITLE
[MacCatalyst] Only respond to selectors that we exported in this class

### DIFF
--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
@@ -29,7 +29,10 @@ namespace Microsoft.Maui
 
 		public override bool CanPerform(Selector action, NSObject? withSender)
 		{
-			return true;
+			if (action.Name.StartsWith("MenuItem", StringComparison.Ordinal))
+				return true;
+
+			return false;
 		}
 
 		/* The Selector for every single MenuElement has to be unique. If you try to reuse the same selector

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui
 			if (action.Name.StartsWith("MenuItem", StringComparison.Ordinal))
 				return true;
 
-			return base.CanPerform();
+			return base.CanPerform(action, withSender);
 		}
 
 		/* The Selector for every single MenuElement has to be unique. If you try to reuse the same selector

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.Menu.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui
 			if (action.Name.StartsWith("MenuItem", StringComparison.Ordinal))
 				return true;
 
-			return false;
+			return base.CanPerform();
 		}
 
 		/* The Selector for every single MenuElement has to be unique. If you try to reuse the same selector


### PR DESCRIPTION
Fixes #5026

