### PR TITLE
[Windows] Fix crash using SearchBar

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
@@ -11,68 +11,69 @@
     <views:BasePage.Content>
         <ScrollView>
             <VerticalStackLayout
-            Margin="12">
+                Margin="12">
                 <Label
-                Text="Default"
-                Style="{StaticResource Headline}"/>
+                    Text="Default"
+                    Style="{StaticResource Headline}"/>
                 <SearchBar/>
                 <Label
-                Text="Disabled"
-                Style="{StaticResource Headline}"/>
+                    Text="Disabled"
+                    Style="{StaticResource Headline}"/>
                 <SearchBar
-                IsEnabled="False"/>
+                    IsEnabled="False"/>
                 <Label
-                Text="TextColor"
-                Style="{StaticResource Headline}"/>
+                    Text="TextColor"
+                    Style="{StaticResource Headline}"/>
                 <SearchBar
-                TextColor="Green"/>
+                    TextColor="Green"/>
                 <Label
-                Text="With Placeholder"
-                Style="{StaticResource Headline}" />
+                    Text="With Placeholder"
+                    Style="{StaticResource Headline}" />
                 <SearchBar 
-                Placeholder="Placeholder"/>
+                    Placeholder="Placeholder"/>
                 <Label
-                Text="Using PlaceholderColor"
-                Style="{StaticResource Headline}" />
+                    Text="Using PlaceholderColor"
+                    Style="{StaticResource Headline}" />
                 <SearchBar 
-                PlaceholderColor="Pink"
-                Placeholder="Placeholder"/>
+                    PlaceholderColor="Pink"
+                    Placeholder="Placeholder"/>
                 <Label
-                Text="Fonts"
-                Style="{StaticResource Headline}"/>
+                    Text="Fonts"
+                    Style="{StaticResource Headline}"/>
                 <SearchBar
-                FontSize="24"
-                FontAttributes="Italic"/>
+                    FontSize="24"
+                    FontAttributes="Italic"/>
                 <Label
-                Text="SearchCommand"
-                Style="{StaticResource Headline}"/>
+                    Text="SearchCommand"
+                    Style="{StaticResource Headline}"/>
                 <SearchBar
-                SearchCommand="{Binding SearchCommand}"
-                SearchCommandParameter="SearchCommandParameter"/>
+                    SearchCommand="{Binding SearchCommand}"
+                    SearchCommandParameter="SearchCommandParameter"/>
                 <Label
-                Text="HorizontalTextAlignment"
-                Style="{StaticResource Headline}" />
+                    Text="HorizontalTextAlignment"
+                    Style="{StaticResource Headline}" />
                 <SearchBar 
-                HorizontalTextAlignment="End"
-                Text="end of the line"
+                    HorizontalTextAlignment="End"
+                    Placeholder="end of the line"
+                    Text="end of the line"
                 />
                 <Label
-                Text="VerticalTextAlignment"
-                Style="{StaticResource Headline}" />
+                    Text="VerticalTextAlignment"
+                    Style="{StaticResource Headline}" />
                 <SearchBar 
-                VerticalTextAlignment="Start"
-                Text="at the bottom"
-                HeightRequest="100"/>
+                    VerticalTextAlignment="Start"
+                    Text="at the bottom"
+                    HeightRequest="100"/>
                 <Label
-                Text="IsTextPredictionEnabled=True"
-                Style="{StaticResource Headline}"/>
+                    Text="IsTextPredictionEnabled=True"
+                    Style="{StaticResource Headline}"/>
                 <SearchBar
-                IsTextPredictionEnabled="True"/>
+                    IsTextPredictionEnabled="True"/>
                 <Label
-                Text="IsTextPredictionEnabled=False"
-                Style="{StaticResource Headline}"/>
+                    Text="IsTextPredictionEnabled=False"
+                    Style="{StaticResource Headline}"/>
                 <SearchBar
-                IsTextPredictionEnabled="False"/>
+                    IsTextPredictionEnabled="False"/>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Windows.cs
@@ -159,6 +159,7 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView != null)
 			{
 				PlatformView?.UpdateTextColor(VirtualView, _defaultTextColorBrush, _defaultTextColorFocusBrush, _queryTextBox);
+				PlatformView?.UpdatePlaceholderColor(VirtualView, _defaultPlaceholderColorBrush, _defaultPlaceholderColorFocusBrush, _queryTextBox);
 				PlatformView?.UpdateHorizontalTextAlignment(VirtualView, _queryTextBox);
 				PlatformView?.UpdateMaxLength(VirtualView, _queryTextBox);
 			}

--- a/src/Core/src/Platform/Windows/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/Windows/SearchBarExtensions.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Maui.Platform
 		public static void UpdatePlaceholderColor(this AutoSuggestBox platformControl, ISearchBar searchBar, Brush? defaultPlaceholderColorBrush, Brush? defaultPlaceholderColorFocusBrush, MauiSearchTextBox? queryTextBox)
 		{
 			if (queryTextBox == null)
+				queryTextBox = platformControl.GetFirstDescendant<MauiSearchTextBox>();
+
+			if (queryTextBox == null)
 				return;
 
 			Color placeholderColor = searchBar.PlaceholderColor;
@@ -38,6 +41,9 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateTextColor(this AutoSuggestBox platformControl, ISearchBar searchBar, Brush? defaultTextColorBrush, Brush? defaultTextColorFocusBrush, MauiSearchTextBox? queryTextBox)
 		{
 			if (queryTextBox == null)
+				queryTextBox = platformControl.GetFirstDescendant<MauiSearchTextBox>();
+
+			if (queryTextBox == null)
 				return;
 
 			Color textColor = searchBar.TextColor;
@@ -55,6 +61,9 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateHorizontalTextAlignment(this AutoSuggestBox platformControl, ISearchBar searchBar, MauiSearchTextBox? queryTextBox)
 		{
 			if (queryTextBox == null)
+				queryTextBox = platformControl.GetFirstDescendant<MauiSearchTextBox>();
+
+			if (queryTextBox == null)
 				return;
 
 			queryTextBox.TextAlignment = searchBar.HorizontalTextAlignment.ToPlatform();
@@ -71,6 +80,9 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateMaxLength(this AutoSuggestBox platformControl, ISearchBar searchBar, MauiSearchTextBox? queryTextBox)
 		{
 			if (queryTextBox == null)
+				queryTextBox = platformControl.GetFirstDescendant<MauiSearchTextBox>();
+
+			if (queryTextBox == null)
 				return;
 
 			queryTextBox.MaxLength = searchBar.MaxLength;
@@ -81,14 +93,22 @@ namespace Microsoft.Maui.Platform
 				platformControl.Text = currentControlText.Substring(0, searchBar.MaxLength);
 		}
 		
-		public static void UpdateIsReadOnly(this AutoSuggestBox nativeControl, ISearchBar searchBar, MauiSearchTextBox? queryTextBox)
+		public static void UpdateIsReadOnly(this AutoSuggestBox platformControl, ISearchBar searchBar, MauiSearchTextBox? queryTextBox)
 		{
 			if (queryTextBox == null)
+				queryTextBox = platformControl.GetFirstDescendant<MauiSearchTextBox>();
+
+			if (queryTextBox == null)
 				return;
+
+			queryTextBox.IsReadOnly = searchBar.IsReadOnly;
 		}
 		
 		public static void UpdateIsTextPredictionEnabled(this AutoSuggestBox platformControl, ISearchBar searchBar, MauiSearchTextBox? queryTextBox)
 		{
+			if (queryTextBox == null)
+				queryTextBox = platformControl.GetFirstDescendant<MauiSearchTextBox>();
+
 			if (queryTextBox == null)
 				return;
 

--- a/src/Core/src/Platform/Windows/Styles/MauiAutoSuggestBoxStyle.xaml
+++ b/src/Core/src/Platform/Windows/Styles/MauiAutoSuggestBoxStyle.xaml
@@ -1,8 +1,11 @@
 <ResourceDictionary
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Microsoft.Maui.Platform"
 	xmlns:uwp="using:Microsoft.Maui.Platform">
 
+    <converters:TextAlignmentToHorizontalAlignmentConverter x:Key="AlignmentConverter" />
+    
     <Style x:Key="MauiAutoSuggestBoxStyle" TargetType="AutoSuggestBox">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="IsTabStop" Value="False" />


### PR DESCRIPTION
### Description of Change

Fix crash using SearchBar.

![image](https://user-images.githubusercontent.com/6755973/158783056-3aba8a50-2196-4f2b-a4c0-ba101f7c8162.png)

The error was due to not finding AlignmentConverter in MauiAutoSuggestBoxStyle. Added the Converter and the error is fixed. To test open the Gallery and navigate to the SearchBar samples. Without crashes the issue is fixed. Notice the SearchBar text aligned to the right, the placeholder should also appear right aligned.

### Issues Fixed

Fixes #5359 
