### PR TITLE
[Windows] Fix TextColor issues on TimePicler 

### DIFF
--- a/src/Core/src/Platform/Windows/TimePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/TimePickerExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml.Controls;
-using WBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace Microsoft.Maui.Platform
 {
@@ -21,19 +20,38 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void UpdateCharacterSpacing(this TimePicker nativeTimePicker, ITimePicker timePicker)
+		public static void UpdateCharacterSpacing(this TimePicker platformTimePicker, ITimePicker timePicker)
 		{
-			nativeTimePicker.CharacterSpacing = timePicker.CharacterSpacing.ToEm();
+			platformTimePicker.CharacterSpacing = timePicker.CharacterSpacing.ToEm();
 		}
 
-		public static void UpdateFont(this TimePicker nativeTimePicker, ITimePicker timePicker, IFontManager fontManager) =>
-			nativeTimePicker.UpdateFont(timePicker.Font, fontManager);
+		public static void UpdateFont(this TimePicker platformTimePicker, ITimePicker timePicker, IFontManager fontManager) =>
+			platformTimePicker.UpdateFont(timePicker.Font, fontManager);
 
-		public static void UpdateTextColor(this TimePicker nativeTimePicker, ITimePicker timePicker)
+		public static void UpdateTextColor(this TimePicker platformTimePicker, ITimePicker timePicker)
 		{
 			Color textColor = timePicker.TextColor;
-			if (textColor != null)
-				nativeTimePicker.Foreground = textColor.ToPlatform();
+
+			UI.Xaml.Media.Brush? brush = textColor?.ToPlatform();
+
+			if (brush is null)
+			{
+				platformTimePicker.Resources.Remove("TimePickerButtonForeground");
+				platformTimePicker.Resources.Remove("TimePickerButtonForegroundPointerOver");
+				platformTimePicker.Resources.Remove("TimePickerButtonForegroundPressed");
+				platformTimePicker.Resources.Remove("TimePickerButtonForegroundDisabled");
+
+				platformTimePicker.ClearValue(TimePicker.ForegroundProperty);
+			}
+			else
+			{
+				platformTimePicker.Resources["TimePickerButtonForeground"] = brush;
+				platformTimePicker.Resources["TimePickerButtonForegroundPointerOver"] = brush;
+				platformTimePicker.Resources["TimePickerButtonForegroundPressed"] = brush;
+				platformTimePicker.Resources["TimePickerButtonForegroundDisabled"] = brush;
+
+				platformTimePicker.Foreground = brush;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Correctly set the TextColor in all the different TimePicker VisualStates on Windows

![issue-5358](https://user-images.githubusercontent.com/6755973/158790688-deadb41a-0d64-4cd3-a8bb-890ff6286fab.gif)

### Description of Change

### Issues Fixed

Fixes #5358 
