### PR TITLE
Make `ScreenshotImplementation` on Windows public

### DIFF
--- a/src/Essentials/src/Screenshot/Screenshot.uwp.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.uwp.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Essentials
 
 namespace Microsoft.Maui.Essentials.Implementations
 {
-	internal partial class ScreenshotImplementation : IScreenshot
+	public partial class ScreenshotImplementation : IScreenshot
 	{
 		public bool IsCaptureSupported =>
 			true;


### PR DESCRIPTION
### Description of Change

Seems the `ScreenshotImplementation` class for Windows was forgotten to made public, this PR fixes that

### Issues Fixed

Fixes #5379
