### PR TITLE
Use the current window's dispatcher for MainThread

### DIFF
--- a/src/Essentials/src/MainThread/MainThread.uwp.cs
+++ b/src/Essentials/src/MainThread/MainThread.uwp.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Essentials
 
 				return CoreApplication.MainView.CoreWindow.Dispatcher?.HasThreadAccess ?? false;
 #elif WINDOWS
-				return DispatcherQueue.GetForCurrentThread()?.HasThreadAccess ?? false;
+				return Platform.CurrentWindow.DispatcherQueue.HasThreadAccess;
 #endif
 			}
 		}
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Essentials
 				throw new InvalidOperationException("Unable to find main thread.");
 			dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action()).WatchForError();
 #elif WINDOWS
-			var dispatcher = DispatcherQueue.GetForCurrentThread();
+			var dispatcher = Platform.CurrentWindow.DispatcherQueue;
 
 			if (dispatcher == null)
 				throw new InvalidOperationException("Unable to find main thread.");


### PR DESCRIPTION
### Description of Change

Make sure to use the current window to post actions.

> **NOTE:** We should probably not use this `MainThread` API as it is not able to support multiple threads. All user code should use Maui's `Element.Dispatcher` as that is always assigned to the thread that is a UI thread, regardless of which thread is being used.

For essentials, this is harder, but by default all windows are on the same thread so this doesn't matter.

### Issues Fixed

Fixes #5375
