### PR TITLE
Fixed bug in NavigationPage ToolbarItems were not visible

### DIFF
--- a/src/Controls/src/Core/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPageToolbar.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls
 			if (stack.Count > 1)
 				previousPage = stack[stack.Count - 1];
 
-			_toolbarTracker.Target = navigationPage.CurrentPage;
+			_toolbarTracker.Target = navigationPage;
 			_toolbarTracker.AdditionalTargets = navigationPage.GetParentPages();
 			ToolbarItems = _toolbarTracker.ToolbarItems;
 			IsVisible = NavigationPage.GetHasNavigationBar(currentPage) && _hasAppeared;

--- a/src/Controls/tests/Core.UnitTests/ToolbarTrackerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTrackerTests.cs
@@ -202,5 +202,35 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.False(tracker.ToolbarItems.Any());
 		}
+		
+		[Test]
+		public async Task NavigationToolBar()
+        {
+            var toolbarItem1 = new ToolbarItem("Foo", "Foo.png", () => { });
+            var toolbarItem2 = new ToolbarItem("Foo", "Foo.png", () => { });
+			
+            var page = new NavigationPage
+            {
+                ToolbarItems = {
+                    toolbarItem1
+                }
+            };
+
+            var window = new Window()
+            {
+                Page = page
+            };
+
+            var firstPage = new ContentPage
+            {
+                ToolbarItems = { toolbarItem2 }
+            };
+
+            await page.Navigation.PushAsync(firstPage);
+
+            var toolbar = window.Toolbar;
+            Assert.True(toolbar.ToolbarItems.Contains(toolbarItem1));
+            Assert.True(toolbar.ToolbarItems.Contains(toolbarItem2));
+        }
 	}
 }


### PR DESCRIPTION
Fixed in NavigationPage to show ToolbarItems when platform is Android/Windows.

Fixes #5031 
