### PR TITLE
Fix 'Properties' folder visibility in the .NET MAUI Blazor template

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -43,6 +43,9 @@
 
       <Content Remove="@(_ContentToUpdate)" />
       <Content Include="@(_ContentToUpdate)" ExcludeFromContentCheck="true" PublishFolderType="None" />
+
+      <!-- Remove the items in AppDesignerFolder ("Properties", by default) so they don't get copied to the output directory -->
+      <Content Remove="$(AppDesignerFolder)\**" />
     </ItemGroup>
   </Target>
 

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -45,7 +45,7 @@
       <Content Include="@(_ContentToUpdate)" ExcludeFromContentCheck="true" PublishFolderType="None" />
 
       <!-- Remove the items in AppDesignerFolder ("Properties", by default) so they don't get copied to the output directory -->
-      <Content Remove="$(AppDesignerFolder)\**" />
+      <Content Remove="$(AppDesignerFolder)\**" Condition="'$(AppDesignerFolder)' != ''" />
     </ItemGroup>
   </Target>
 

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -64,8 +64,4 @@
 		<RuntimeIdentifier>win10-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<Content Update="$(AppDesignerFolder)\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
-	</ItemGroup>
-
 </Project>

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -65,7 +65,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Content Remove="Properties\launchSettings.json" />
+		<Content Update="$(AppDesignerFolder)\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of Change

The .NET MAUI Blazor App template was explicitly excluding `Properties\launchSettings.json` from the `.csproj` to prevent it from being copied to output directories, but this also prevented the 'Properties' folder from displaying in the VS Solution Explorer. This led to an inconsistent IDE experience, since the 'Properties' folder was visible when using the .NET MAUI App template, but not when using the .NET MAUI Blazor App template.

This change updates the .NET MAUI Blazor App template to exclude the 'Properties' folder from the build output directory without making it invisible in the IDE.

This is only necessary at all because of a difference in SDK behavior between [`Microsoft.NET.Sdk`](https://github.com/dotnet/sdk/blob/85886857f1037a1596603837ffc28022a09ed928/src/WebSdk/Worker/Targets/Microsoft.NET.Sdk.Worker.props#L32) and [`Microsoft.NET.Sdk.Razor`](https://github.com/dotnet/sdk/blob/85886857f1037a1596603837ffc28022a09ed928/src/RazorSdk/Sdk/Sdk.Razor.StaticAssets.ProjectSystem.props#L40).

### Issues Fixed

Fixes #4641
