### PR TITLE
Clean up flow direction tests for Layouts on Windows

### DIFF
--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -28,8 +28,22 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				FlowDirection = flowDirection
 			};
+
+			var expectedFlowDirection = flowDirection;
+
+#if WINDOWS
+			if (view is LayoutStub)
+			{
+				// On Windows, we deliberately _do not_ set the platform FlowDirection
+				// for Layouts, because the cross-platform layout code is already taking
+				// flow direction into account. The result of setting the cross-platform
+				// flow direction will always be Microsoft.UI.Xaml.FlowDirection.LeftToRight
+				expectedFlowDirection = FlowDirection.LeftToRight;
+			}
+#endif
+
 			var id = await GetValueAsync(view, handler => GetFlowDirection(handler));
-			Assert.Equal(view.FlowDirection, id);
+			Assert.Equal(expectedFlowDirection, id);
 		}
 
 		[Theory(DisplayName = "Opacity is set correctly")]

--- a/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
@@ -84,11 +84,5 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public bool ClipsToBounds { get; set; }
 
 		public IView this[int index] { get => _children[index]; set => _children[index] = value; }
-
-		public override FlowDirection FlowDirection
-		{
-			get => FlowDirection.LeftToRight;
-			set { }
-		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public string AutomationId { get; set; }
 
-		public virtual FlowDirection FlowDirection { get; set; } = FlowDirection.LeftToRight;
+		public FlowDirection FlowDirection { get; set; } = FlowDirection.LeftToRight;
 
 		public LayoutAlignment HorizontalLayoutAlignment { get; set; }
 


### PR DESCRIPTION
### Description of Change

Makes the FlowDirection setting test for layout handlers on Windows meaningful (since LayoutStub FlowDirection is no longer coerced to LTR); allows FlowDirection setting test to pass for Layouts on Windows.
