### PR TITLE
[Anndroid] Fix crash using Shadows with CollectionView items 

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -4,18 +4,17 @@ using Android.Views;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Fragment.App;
 using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Handlers;
 using AView = Android.Views.View;
-using Object = Java.Lang.Object;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
 	public class ItemContentView : ViewGroup
 	{
-		protected IPlatformViewHandler Content;
-		internal IView View => Content?.VirtualView;
 		Size? _size;
 		Action<Size> _reportMeasure;
+
+		protected IPlatformViewHandler Content;
+		internal IView View => Content?.VirtualView;
 
 		public ItemContentView(Context context) : base(context)
 		{
@@ -26,7 +25,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		internal void RealizeContent(View view, ItemsView itemsView)
 		{
 			Content = CreateHandler(view, itemsView);
-			AddView(Content.PlatformView);
+			var platformView = Content.ContainerView ?? Content.PlatformView;
+			AddView(platformView);
 
 			//TODO: RUI IS THIS THE BEST WAY TO CAST? 
 			(View as VisualElement).MeasureInvalidated += ElementMeasureInvalidated;
@@ -39,9 +39,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				(View as VisualElement).MeasureInvalidated -= ElementMeasureInvalidated;
 			}
 
-			if (Content?.PlatformView != null)
+			var platformView = Content?.ContainerView ?? Content?.PlatformView;
+
+			if (platformView != null)
 			{
-				RemoveView(Content.PlatformView);
+				RemoveView(platformView);
 			}
 
 			Content = null;
@@ -134,8 +136,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		void UpdateContentLayout()
 		{
-			VisualElement mauiControlsView = (View as VisualElement);
-			AView aview = Content.PlatformView;
+			VisualElement mauiControlsView = View as VisualElement;
+			AView aview = Content.ContainerView ?? Content.PlatformView;
 
 			if (mauiControlsView == null || aview == null)
 				return;
@@ -145,7 +147,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var width = Math.Max(0, (int)Context.ToPixels(mauiControlsView.Width));
 			var height = Math.Max(0, (int)Context.ToPixels(mauiControlsView.Height));
 
-			Content.PlatformView.Layout(x, y, width, height);
+			aview.Layout(x, y, width, height);
 
 			if ((aview is LayoutViewGroup || aview is ContentViewGroup || aview is CoordinatorLayout || aview is FragmentContainerView) && width == 0 && height == 0)
 			{


### PR DESCRIPTION
### Description of Change

Fix crash using Shadows with CollectionView items in Android. 
![image](https://user-images.githubusercontent.com/6755973/158996644-f8a453c9-bd4b-4994-905c-5f332b11f2e3.png)

When using shadows on Android, the WrapperView was used, so the PlatformView already had a parent. This PR adds changes to ItemContentView to use the correct native view (ContainerView or PlatformView). 

### Issues Fixed

Fixes #5402 
