### PR TITLE
[Blazor] Fixes Win UI deployed apps this time for good

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -47,6 +47,14 @@
       <!-- Remove the items in AppDesignerFolder ("Properties", by default) so they don't get copied to the output directory -->
       <Content Remove="$(AppDesignerFolder)\**" Condition="'$(AppDesignerFolder)' != ''" />
     </ItemGroup>
+
+  </Target>
+
+  <Target Name="_RemoveStaticWebAssetsDevelopmentManifest" BeforeTargets="GetCopyToOutputDirectoryItems">
+    <!-- Remove the development manifest from the output since its not used and it will otherwise get incorrectly loaded in production. -->
+    <ItemGroup>
+      <ContentWithTargetPath Remove="$(StaticWebAssetDevelopmentManifestPath)" />
+    </ItemGroup>
   </Target>
 
   <!-- Targets temporarily remove Content items in various folders so that they don't conflict with iOS/MacCatalyst SDK tasks -->


### PR DESCRIPTION
### Description of Change

The static web assets manifest was incorrectly being copied to the AppxPackage of the app.

I wanted to make sure that I had fixed the issue and went back over my steps to make sure that the issue reproed without my change on the SingleProject project. 

I discovered after being able to deploy from main (without my changes) that the app did work without my changes, so I investigated a bunch more.

I created a new app from the template and included it in the repo (not in this change) and then managed to publish that app and it reproduced the behavior after "my fix".

I tried to debug with VS to no avail (the managed debugger is not able to attach to the deployed app) so I switched to WinDBG and with that, I was able to load the managed debugger, put a breakpoint on all exceptions, trigger the issue, get a hold to the exception and inspect the call stack, which led me to the root cause as well as the current fix.

Upon inspecting the app package it was clear that the static web assets development manifest was being incorrectly copied into the package, so once it was removed, everything went back to working. This also explains why it worked on the same machine and not in a different machine, since static web assets is meant for development and hardcodes full paths.

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/6995051/159036936-d5385e0d-f076-4c22-b0e2-213f5efc0096.png">

### Issues Fixed

Fixes #5024