### PR TITLE
Update WinUI secret dependencies (WinRT.Runtime and Microsoft.Windows.SDK.NET)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -60,7 +60,7 @@
 
   <!-- Until we get a new enough dotnet -->
   <ItemGroup Condition="'$(_MauiTargetPlatformIsWindows)' == 'True'">
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.18" TargetingPackVersion="10.0.18362.18" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.22" TargetingPackVersion="10.0.18362.22" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description of Change

When you get warnings like this:

> warning MSB3277: Found conflicts between different versions of "WinRT.Runtime" that could not be resolved.

Look for the hidden version:

> There was a conflict between "WinRT.Runtime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=99ea127f02d97709" and "WinRT.Runtime, Version=1.4.0.0, Culture=neutral, PublicKeyToken=99ea127f02d97709".

That tells us that we need to find the `WinRT.Runtime.dll` with version `1.4.0.0`. This is found in the NuGet: https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref/

So how do we know what version to pick? Well, by being a detective. The version has 2 parts: Windows version and then build version: `10.0.17763.22` This appears to be related to Windows `10.0.17763` and has a build of `22`

Not sure which Windows version to pick at the moment, I just pick the one that the Windows App SDK uses. I think that is `10.0.17763`, however, the Microspft.Graphics.Win2D package uses `10.0.18362`, and you can tell that by the fact you get another warning if you go too low:

> warning MSB3277: There was a conflict between "Microsoft.Windows.SDK.NET, Version=10.0.17763.22, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "Microsoft.Windows.SDK.NET, Version=10.0.18362.18, Culture=neutral, PublicKeyToken=31bf3856ad364e35".

So, you must play the detective and find the build that matches the highest Windows version and WinRT.Runtime version.

Currently, the versions are:

| Thing | Windows Version | WinRT Version |
| -: | :-: | :-: | 
| **WASDK** | 10.017763 | 1.4.0.0 |
| **WinRT** | 10.0.18362 | 1.3.0.0 |

So what do you pick? Well, 10.0.18362 and a build that is around 1.4.0.0.

Now, I know what you are thinking: "Why do we need to specify a version? Won't the SDK pick one?"

You are right, the SDK will pick one. But which one will it pick? The VERY latest - often the one that is like the preview that is not yet available to the public or on some fancy feed. I saw this once when we were doing a security build, it failed to compile samples because Maui ended up being built on a version that did not yet exist on the normal feeds.

So, this one small line in the props makes sure the Maui framework is using the lowest possible SDK for the widest support.

How do you find the build version? Well, there might be some special rules, but I just crack open the NuGet:

![image](https://user-images.githubusercontent.com/1096616/159100896-f637f5dd-c2a2-49be-8a4d-14d14e3e94fd.png)