### PR TITLE
When swapping out root page on window remove toolbar

### DIFF
--- a/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	[TestFixture]
+	public class ToolbarTests : BaseTestFixture
+	{
+		[Test]
+		public void ToolbarExistsForNavigationPage()
+		{
+			var window = new Window();
+			IToolbarElement toolbarElement = window;
+			var startingPage = new NavigationPage(new ContentPage());
+			window.Page = startingPage;
+			Assert.IsNotNull(toolbarElement.Toolbar);
+		}
+
+		[Test]
+		public void ToolbarEmptyForContentPage()
+		{
+			Window window = new Window();
+			IToolbarElement toolbarElement = window;
+			var startingPage = new ContentPage();
+			window.Page = startingPage;
+			Assert.IsNull(toolbarElement.Toolbar);
+		}
+
+		[Test]
+		public void ToolbarClearsWhenNavigationPageRemoved()
+		{
+			var window = new Window();
+			IToolbarElement toolbarElement = window;
+			var startingPage = new NavigationPage(new ContentPage());
+			window.Page = startingPage;
+			window.Page = new ContentPage();
+			Assert.IsNull(toolbarElement.Toolbar);
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Android.Views;
 using Google.Android.Material.AppBar;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
@@ -21,8 +22,15 @@ namespace Microsoft.Maui.DeviceTests
 		MaterialToolbar GetPlatformToolbar(IMauiContext mauiContext)
 		{
 			var navManager = mauiContext.GetNavigationRootManager();
-			return navManager.ToolbarElement.Toolbar.Handler.PlatformView as
+			ViewGroup appbarLayout =
+				navManager?.RootView?.FindViewById<ViewGroup>(Resource.Id.navigationlayout_appbar);
+
+			var toolBar = appbarLayout?.GetFirstChildOfType<MaterialToolbar>();
+
+			toolBar = toolBar ?? navManager.ToolbarElement?.Toolbar?.Handler?.PlatformView as
 				MaterialToolbar;
+
+			return toolBar;
 		}
 
 		public bool IsBackButtonVisible(IElementHandler handler) =>
@@ -30,7 +38,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public bool IsBackButtonVisible(IMauiContext mauiContext)
 		{
-			return GetPlatformToolbar(mauiContext).NavigationIcon != null;
+			return GetPlatformToolbar(mauiContext)?.NavigationIcon != null;
 		}
 
 		public bool IsNavigationBarVisible(IElementHandler handler) =>
@@ -38,8 +46,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		public bool IsNavigationBarVisible(IMauiContext mauiContext)
 		{
-			return GetPlatformToolbar(mauiContext)
-					.LayoutParameters.Height > 0;
+			return GetPlatformToolbar(mauiContext)?
+					.LayoutParameters?.Height > 0;
 		}
 
 		public bool ToolbarItemsMatch(

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Windows.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Maui.DeviceTests
 		public bool IsNavigationBarVisible(IMauiContext mauiContext)
 		{
 			var navView = GetMauiNavigationView(mauiContext);
-			var header = navView.Header as WFrameworkElement;
-			return header.Visibility == UI.Xaml.Visibility.Visible;
+			var header = navView?.Header as WFrameworkElement;
+			return header?.Visibility == UI.Xaml.Visibility.Visible;
 		}
 
 		public bool ToolbarItemsMatch(

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-
 		[Fact(DisplayName = "Back Button Visibility Changes with push/pop")]
 		public async Task BackButtonVisibilityChangesWithPushPop()
 		{
@@ -75,6 +74,22 @@ namespace Microsoft.Maui.DeviceTests
 				NavigationPage.SetHasNavigationBar(navPage.CurrentPage, true);
 				Assert.True(IsNavigationBarVisible(handler));
 				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "NavigationBar Removes When MainPage Set To ContentPage")]
+		public async Task NavigationBarRemovesWhenMainPageSetToContentPage()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage());
+			var window = new Window(navPage);
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async (handler) =>
+			{
+				var contentPage = new ContentPage();
+				window.Page = contentPage;
+				await OnLoadedAsync(contentPage);
+				Assert.False(IsNavigationBarVisible(handler));
 			});
 		}
 

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Android.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Android.cs
@@ -40,6 +40,13 @@ namespace Microsoft.Maui.Handlers
 			return view;
 		}
 
+		private protected override void OnDisconnectHandler(object platformView)
+		{
+			base.OnDisconnectHandler(platformView);
+			if (platformView is MaterialToolbar mt)
+				mt.RemoveFromParent();
+		}
+
 		public static void MapTitle(IToolbarHandler arg1, IToolbar arg2)
 		{
 			arg1.PlatformView.UpdateTitle(arg2);
@@ -80,8 +87,8 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			var appbarConfigBuilder =
-					   new AppBarConfiguration
-						   .Builder(_stackNavigationManager.NavGraph);
+					new AppBarConfiguration
+						.Builder(_stackNavigationManager.NavGraph);
 
 			if (_drawerLayout != null)
 				appbarConfigBuilder = appbarConfigBuilder.SetOpenableLayout(_drawerLayout);

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Windows.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Windows.cs
@@ -13,5 +13,16 @@ namespace Microsoft.Maui.Handlers
 		{
 			arg1.PlatformView.UpdateTitle(arg2);
 		}
+
+		private protected override void OnDisconnectHandler(object platformView)
+		{
+			base.OnDisconnectHandler(platformView);
+			if (platformView is MauiToolbar mauiToolbar)
+			{
+				var navRootManager = MauiContext?.GetNavigationRootManager();
+				if (navRootManager?.ToolBar == mauiToolbar)
+					navRootManager.SetToolbar(null);
+			}
+		}
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -144,32 +144,7 @@ namespace Microsoft.Maui.Handlers
 			if (handler.VirtualView is not IToolbarElement te || te.Toolbar == null)
 				return;
 
-			var rootManager = handler.MauiContext?.GetNavigationRootManager();
-			rootManager?.SetToolbarElement(te);
-
-			var platformView = handler.PlatformView as View;
-			if (platformView == null)
-				return;
-
-			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			var appbarLayout = platformView.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar);
-
-			if (appbarLayout == null)
-				appbarLayout = rootManager?.RootView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar);
-
-			var nativeToolBar = te.Toolbar?.ToPlatform(handler.MauiContext);
-
-			if (appbarLayout == null || nativeToolBar == null)
-			{
-				return;
-			}
-
-			if (nativeToolBar.Parent == appbarLayout)
-			{
-				return;
-			}
-
-			appbarLayout.AddView(nativeToolBar, 0);
+			MapToolbar(handler, te);
 		}
 
 		internal static void MapToolbar(IElementHandler handler, IToolbarElement te)
@@ -183,8 +158,10 @@ namespace Microsoft.Maui.Handlers
 			var platformView = handler.PlatformView as View;
 
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			var appbarLayout = platformView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar) ??
-				rootManager?.RootView?.FindViewById<ViewGroup>(Microsoft.Maui.Resource.Id.navigationlayout_appbar);
+			
+			var appbarLayout = 
+				platformView?.FindViewById<ViewGroup>(Resource.Id.navigationlayout_appbar) ??
+				rootManager?.RootView?.FindViewById<ViewGroup>(Resource.Id.navigationlayout_appbar);
 
 			var nativeToolBar = te.Toolbar?.ToPlatform(handler.MauiContext);
 

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -31,18 +31,18 @@ namespace Microsoft.Maui.Handlers
 			handler.ToPlatform().UpdateShadow(view);
 		}
 
-		public static void MapTranslationX(IViewHandler handler, IView view) 
-		{ 
+		public static void MapTranslationX(IViewHandler handler, IView view)
+		{
 			handler.ToPlatform().UpdateTransformation(view);
 		}
 
-		public static void MapTranslationY(IViewHandler handler, IView view) 
-		{ 
+		public static void MapTranslationY(IViewHandler handler, IView view)
+		{
 			handler.ToPlatform().UpdateTransformation(view);
 		}
 
-		public static void MapScale(IViewHandler handler, IView view) 
-		{ 
+		public static void MapScale(IViewHandler handler, IView view)
+		{
 			handler.ToPlatform().UpdateTransformation(view);
 		}
 
@@ -56,28 +56,28 @@ namespace Microsoft.Maui.Handlers
 			handler.ToPlatform().UpdateTransformation(view);
 		}
 
-		public static void MapRotation(IViewHandler handler, IView view) 
-		{ 
-			handler.ToPlatform().UpdateTransformation(view); 
-		}
-
-		public static void MapRotationX(IViewHandler handler, IView view) 
-		{ 
+		public static void MapRotation(IViewHandler handler, IView view)
+		{
 			handler.ToPlatform().UpdateTransformation(view);
 		}
 
-		public static void MapRotationY(IViewHandler handler, IView view) 
-		{ 
-			handler.ToPlatform().UpdateTransformation(view); 
+		public static void MapRotationX(IViewHandler handler, IView view)
+		{
+			handler.ToPlatform().UpdateTransformation(view);
 		}
 
-		public static void MapAnchorX(IViewHandler handler, IView view) 
-		{ 
-			handler.ToPlatform().UpdateTransformation(view); 
+		public static void MapRotationY(IViewHandler handler, IView view)
+		{
+			handler.ToPlatform().UpdateTransformation(view);
 		}
 
-		public static void MapAnchorY(IViewHandler handler, IView view) 
-		{ 
+		public static void MapAnchorX(IViewHandler handler, IView view)
+		{
+			handler.ToPlatform().UpdateTransformation(view);
+		}
+
+		public static void MapAnchorY(IViewHandler handler, IView view)
+		{
 			handler.ToPlatform().UpdateTransformation(view);
 		}
 

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Platform
 	{
 		IMauiContext _mauiContext;
 		WindowRootView _rootView;
-		MauiToolbar? _windowHeader;
+		MauiToolbar? _toolbar;
 		IMenuBar? _menuBar;
 
 		public NavigationRootManager(IMauiContext mauiContext)
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Platform
 
 		internal bool UseCustomAppTitleBar { get; set; } = true;
 		internal FrameworkElement? AppTitleBar => _rootView.AppTitleBar;
+		internal MauiToolbar? ToolBar => _toolbar;
 
 		void OnApplyTemplateFinished(object? sender, EventArgs e)
 		{
@@ -37,13 +38,16 @@ namespace Microsoft.Maui.Platform
 
 			if (_rootView.NavigationViewControl != null)
 			{
-				_rootView.NavigationViewControl.HeaderControl = _windowHeader;
+				_rootView.NavigationViewControl.HeaderControl = _toolbar;
 			}
 		}
 
 		void OnBackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args)
 		{
-			_mauiContext.GetPlatformWindow().GetWindow()?.BackButtonClicked();
+			_mauiContext
+				.GetPlatformWindow()
+				.GetWindow()?
+				.BackButtonClicked();
 		}
 
 		public FrameworkElement RootView => _rootView;
@@ -69,7 +73,7 @@ namespace Microsoft.Maui.Platform
 				{
 					rootNavigationView = new RootNavigationView();
 				}
-				
+
 				rootNavigationView.Content = platformView;
 				_rootView.Content = rootNavigationView;
 			}
@@ -119,23 +123,23 @@ namespace Microsoft.Maui.Platform
 		{
 			_menuBar = menuBar;
 
-			if (_windowHeader == null)
+			if (_toolbar == null)
 				return;
 
 			if (menuBar != null)
-				_windowHeader.SetMenuBar((MenuBar)menuBar.ToPlatform(_mauiContext));
+				_toolbar.SetMenuBar((MenuBar)menuBar.ToPlatform(_mauiContext));
 			else
-				_windowHeader.SetMenuBar(null);
+				_toolbar.SetMenuBar(null);
 		}
 
-		internal void SetToolbar(FrameworkElement toolBar)
+		internal void SetToolbar(FrameworkElement? toolBar)
 		{
-			_windowHeader = toolBar as MauiToolbar;
+			_toolbar = toolBar as MauiToolbar;
 			SetMenuBar(_menuBar);
 
 			if (_rootView.NavigationViewControl != null)
 			{
-				_rootView.NavigationViewControl.HeaderControl = _windowHeader;
+				_rootView.NavigationViewControl.HeaderControl = _toolbar;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

When swapping out the MainPage the Toolbar on the window wasn't correctly unsetting and being removed from the layout

Alternative proposal for
https://github.com/dotnet/maui/pull/5255

### Issues Fixed

Fixes #4311
Fixes #5168
