### PR TITLE
[android] fix EmbeddedResource fonts

### DIFF
--- a/src/Core/src/Fonts/FontManager.Android.cs
+++ b/src/Core/src/Fonts/FontManager.Android.cs
@@ -66,6 +66,10 @@ namespace Microsoft.Maui
 			if (asset != null)
 				return asset;
 
+			// The font might be a file, such as a temporary file extracted from EmbeddedResource
+			if (File.Exists(fontName))
+				return Typeface.CreateFromFile(fontName);
+
 			var fontFile = FontFile.FromString(fontName);
 			if (!string.IsNullOrWhiteSpace(fontFile.Extension))
 			{
@@ -127,8 +131,6 @@ namespace Microsoft.Maui
 			{
 				if (GetFromAssets(fontFamily) is Typeface typeface)
 					result = typeface;
-				else if (FontNameToFontFile(fontFamily) is string f && File.Exists(f))
-					result = Typeface.CreateFromFile(f);
 				else
 					result = Typeface.Create(fontFamily, style);
 			}

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -19,6 +19,7 @@
     <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
     <MauiImage Include="Resources\Images\*" />
     <MauiFont Include="Resources\Fonts\*" />
+    <EmbeddedResource Include="Resources\Fonts\dokdo_regular.ttf" />
     <MauiImage Update="Resources\Images\*.gif" Resize="false" />
   </ItemGroup>
 

--- a/src/Core/tests/DeviceTests/Services/FontManagerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/FontManagerTests.Android.cs
@@ -28,4 +28,17 @@ public partial class FontManagerTests : TestBase
 		var expected = Typeface.Create(Typeface.CreateFromAsset(Application.Context.Assets, assetName), (int)fontWeight, italic: false);
 		Assert.True(expected.Equals(actual));
 	}
+
+	[Fact]
+	public void CanLoadEmbeddedFont()
+	{
+		var fontName = "FooBarFont";
+		var fontWeight = FontWeight.Regular;
+		var registrar = new FontRegistrar(new EmbeddedFontLoader ());
+		registrar.Register("dokdo_regular.ttf", fontName, GetType().Assembly);
+		var manager = new FontManager(registrar);
+		var actual = manager.GetTypeface(Font.OfSize(fontName, 12, fontWeight));
+		var defaultFont = Typeface.Create(Typeface.Create(fontName, TypefaceStyle.Normal), (int)fontWeight, italic: false);
+		Assert.False(defaultFont.Equals(actual));
+	}
 }


### PR DESCRIPTION
### Description of Change

In f80db209, I fixed the performance of font loading, as it used to
load every font and extract them to a temporary folder. This would
only be needed for `EmbeddedResource`, as there are only Android APIs
for loading a `Typeface` from a file path or `AndroidAsset`.

Writing a test, I could reproduce the problem with:

    [Fact]
    public void CanLoadEmbeddedFont()
    {
        var fontName = "FooBarFont";
        var fontWeight = FontWeight.Regular;
        var registrar = new FontRegistrar(new EmbeddedFontLoader ());
        registrar.Register("dokdo_regular.ttf", fontName, GetType().Assembly);
        var manager = new FontManager(registrar);
        var actual = manager.GetTypeface(Font.OfSize(fontName, 12, fontWeight));
        var defaultFont = Typeface.Create(Typeface.Create(fontName, TypefaceStyle.Normal), (int)fontWeight, italic: false);
        Assert.False(defaultFont.Equals(actual));
    }

Indeed, the `FooBarFont` in this example was just being loaded as:

    Typeface.Create("FooBarFont", TypefaceStyle.Normal)

We mistakenly thought this case would handle file paths:

    if (GetFromAssets(fontFamily) is Typeface typeface)
        result = typeface;
    else if (FontNameToFontFile(fontFamily) is string f && File.Exists(f))
        result = Typeface.CreateFromFile(f);

However, the `File.Exists()` check needs to actually happen in the
`GetFromAssets()` method, as it is the only place that has the full
file path. After this fix, the test passes.

I still would highly *not* recommend the use of `EmbeddedResource`
fonts, if you care about startup performance. However, it should
actually work if you do, whoops!

### Issues Fixed

Fixes: https://github.com/dotnet/maui/issues/5456