### PR TITLE
Fix the layout computation for the SwipeItems

### DIFF
--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SDebug = System.Diagnostics.Debug;
 using System.Linq;
 using Android.Content;
 using Android.Views;
@@ -56,7 +57,7 @@ namespace Microsoft.Maui.Platform
 			AddView(Control, LayoutParams.MatchParent);
 		}
 
-		// temporary workaround to make it work		
+		// temporary workaround to make it work
 		internal void SetElement(ISwipeView swipeView)
 		{
 			Element = swipeView;
@@ -549,9 +550,15 @@ namespace Microsoft.Maui.Platform
 			}
 
 			AddView(_actionView);
-			_contentView?.BringToFront();
-
-			_actionView.Layout(0, 0, _contentView?.Width ?? 0, _contentView?.Height ?? 0);
+			if (_contentView != null)
+			{
+				_contentView.BringToFront();
+				int contextX = (int)_contentView.GetX();
+				int contentY = (int)_contentView.GetY();
+				int contentWidth = _contentView.Width;
+				int contentHeight = _contentView.Height;
+				_actionView.Layout(contextX, contentY, contextX + contentWidth, contentY + contentHeight);
+			}
 			LayoutSwipeItems(swipeItems);
 			swipeItems.Clear();
 		}
@@ -576,27 +583,39 @@ namespace Microsoft.Maui.Platform
 					var item = items[i];
 					var swipeItemSize = GetSwipeItemSize(item);
 
+					int contentWidth = _contentView.Width;
+					int contentHeight = _contentView.Height;
 					var swipeItemHeight = (int)_context.ToPixels(swipeItemSize.Height);
 					var swipeItemWidth = (int)_context.ToPixels(swipeItemSize.Width);
 
-					int contentX = (int)_contentView.GetX();
-					int contentY = (int)_contentView.GetY();
-
+					int l, t, r, b;
 					switch (_swipeDirection)
 					{
 						case SwipeDirection.Left:
-							child.Layout(contentX + _contentView.Width - (swipeItemWidth + previousWidth), contentY, _contentView.Width - previousWidth + contentX, swipeItemHeight + contentY);
+							// Filling from right to left, align to the top
+							l = contentWidth - previousWidth - swipeItemWidth;
+							t = 0;
+							r = contentWidth - previousWidth;
+							b = swipeItemHeight;
 							break;
 						case SwipeDirection.Right:
-							child.Layout(contentX + previousWidth, contentY, ((i + 1) * swipeItemWidth) + contentX, swipeItemHeight + contentY);
-							break;
 						case SwipeDirection.Down:
-							child.Layout(contentX + previousWidth, contentY, ((i + 1) * swipeItemWidth) + contentX, swipeItemHeight + contentY);
+							// Filling from left to right, align to the top
+							l = previousWidth;
+							t = 0;
+							r = previousWidth + swipeItemWidth;
+							b = swipeItemHeight;
 							break;
-						case SwipeDirection.Up:
-							child.Layout(contentX + previousWidth, contentY + _contentView.Height - swipeItemHeight, ((i + 1) * swipeItemWidth) + contentX, _contentView.Height + contentY);
+						default:
+							SDebug.Assert(_swipeDirection == SwipeDirection.Up);
+							// Filling from left to right, align to the bottom
+							l = previousWidth;
+							t = contentHeight - swipeItemHeight;
+							r = previousWidth + swipeItemWidth;
+							b = contentHeight;
 							break;
 					}
+					child.Layout(l, t, r, b);
 
 					i++;
 					previousWidth += swipeItemWidth;


### PR DESCRIPTION
### Description of Change

This change fixed the wrong layout computation for `MauiSwipeView`.

The key to understand this change is that the `Layout` call expects `l,t,r,b` as parameters, representing the left, top, right and bottom for the control relative to its parent.

The `_actionView` has the same parent as the `_contentView`, therefore it should have the same `l,t,r,b` as the `_contentView`. 

The `items` are nested within the `_actionView`, so there is no need to account for `contentX` and `contentY`.

The multiplication is replaced by the accumulated `previousWidth`. This will work better as the `swipeItem` could have different widths.

### Issues Fixed

Fixes #4291

Note that this doesn't eliminate the white margin as the video clip in the bug highlights. That width is expected because the swipe view is nested within a StackLayout with a margin of 20.