### PR TITLE
Only show .NET MAUI templates in VS 17.2+ & maui workload installed

### DIFF
--- a/src/Templates/README.md
+++ b/src/Templates/README.md
@@ -6,7 +6,7 @@
 Add the local artifacts to the NuGet.config:
 
 ```xml
-<add key="asdf" value="./artifacts" />
+<add key="LocalMauiTemplates" value="./artifacts" />
 ```
 
 ```dotnetcli

--- a/src/Templates/src/templates/maui-blazor/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/ide.host.json
@@ -4,7 +4,15 @@
     "unsupportedHosts": [
         {
             "id": "vs",
-            "version": "(,17.1)"
+            "version": "(,17.2)"
         }
-    ]
+    ],
+    "requiredComponents": [ 
+        { 
+              "id": "Microsoft.VisualStudio.ComponentGroup.Maui.Blazor", 
+              "hostId": "vs", 
+              "componentType": "SetupComponent" 
+        }
+    
+   ]
 }

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/ide.host.json
@@ -7,7 +7,15 @@
     "unsupportedHosts": [
         {
             "id": "vs",
-            "version": "(,17.1)"
+            "version": "(,17.2)"
         }
-    ]
+    ],
+    "requiredComponents": [ 
+        { 
+              "id": "Microsoft.VisualStudio.ComponentGroup.Maui.All", 
+              "hostId": "vs", 
+              "componentType": "SetupComponent" 
+        }
+    
+   ]
 }

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/ide.host.json
@@ -7,7 +7,15 @@
     "unsupportedHosts": [
         {
             "id": "vs",
-            "version": "(,17.1)"
+            "version": "(,17.2)"
         }
-    ]
+    ],
+    "requiredComponents": [ 
+        { 
+              "id": "Microsoft.VisualStudio.ComponentGroup.Maui.All", 
+              "hostId": "vs", 
+              "componentType": "SetupComponent" 
+        }
+    
+   ]
 }

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/ide.host.json
@@ -7,7 +7,15 @@
     "unsupportedHosts": [
         {
             "id": "vs",
-            "version": "(,17.1)"
+            "version": "(,17.2)"
         }
-    ]
+    ],
+    "requiredComponents": [ 
+        { 
+              "id": "Microsoft.VisualStudio.ComponentGroup.Maui.All", 
+              "hostId": "vs", 
+              "componentType": "SetupComponent" 
+        }
+    
+   ]
 }

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/ide.host.json
@@ -7,7 +7,15 @@
     "unsupportedHosts": [
         {
             "id": "vs",
-            "version": "(,17.1)"
+            "version": "(,17.2)"
         }
-    ]
+    ],
+    "requiredComponents": [ 
+        { 
+              "id": "Microsoft.VisualStudio.ComponentGroup.Maui.All", 
+              "hostId": "vs", 
+              "componentType": "SetupComponent" 
+        }
+    
+   ]
 }

--- a/src/Templates/src/templates/maui-lib/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/ide.host.json
@@ -4,7 +4,15 @@
     "unsupportedHosts": [
         {
             "id": "vs",
-            "version": "(,17.1)"
+            "version": "(,17.2)"
         }
-    ]
+    ],
+    "requiredComponents": [ 
+        { 
+              "id": "Microsoft.VisualStudio.ComponentGroup.Maui.All", 
+              "hostId": "vs", 
+              "componentType": "SetupComponent" 
+        }
+    
+   ]
 }

--- a/src/Templates/src/templates/maui-mobile/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/ide.host.json
@@ -4,7 +4,15 @@
     "unsupportedHosts": [
         {
             "id": "vs",
-            "version": "(,17.1)"
+            "version": "(,17.2)"
         }
-    ]
+    ],
+    "requiredComponents": [ 
+        { 
+              "id": "Microsoft.VisualStudio.ComponentGroup.Maui.All", 
+              "hostId": "vs", 
+              "componentType": "SetupComponent" 
+        }
+    
+   ]
 }


### PR DESCRIPTION
### Description of Change

This change makes the .NET MAUI templates only show up in Visual Studio 17.2 and up and only when the .NET MAUI workload is installed

### Issues Fixed

fixes [AB#1475914](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1475914)