### PR TITLE
[Android] Reset pressed state if touch event is cancelled

### DIFF
--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -193,6 +193,7 @@ namespace Microsoft.Maui.Handlers
 				case MotionEventActions.Down:
 					button?.Pressed();
 					break;
+				case MotionEventActions.Cancel:
 				case MotionEventActions.Up:
 					button?.Released();
 					break;


### PR DESCRIPTION
### Description of Change

 Reset pressed state if touch event is cancelled. For example: tap the Button and then scroll, tap and move outside etc.

### Issues Fixed

Fixes #5457
