### PR TITLE
Normalize RTL behavior for layouts

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -171,8 +171,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValueCore(IsFocusedPropertyKey, value);
 		}
 
-		Maui.FlowDirection IView.FlowDirection
-			=> ((IFlowDirectionController)this).EffectiveFlowDirection.ToFlowDirection();
+		FlowDirection IView.FlowDirection => FlowDirection;
 
 		Primitives.LayoutAlignment IView.HorizontalLayoutAlignment => default;
 		Primitives.LayoutAlignment IView.VerticalLayoutAlignment => default;

--- a/src/Core/src/Core/Extensions/IViewExtensions.cs
+++ b/src/Core/src/Core/Extensions/IViewExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.Maui
+{
+	public static class IViewExtensions
+	{
+		public static FlowDirection GetEffectiveFlowDirection(this IView view) 
+		{
+			if (view.FlowDirection != FlowDirection.MatchParent)
+			{
+				return view.FlowDirection;
+			}
+
+			// If the FlowDirection is MatchParent, then ask the Parent, if available
+			if (view.Parent is IView parentView)
+			{
+				return parentView.GetEffectiveFlowDirection();
+			}
+
+			// If there's no parent, try asking the App; failing that, fall back to LTR
+			return view.Handler?.MauiContext?.GetFlowDirection() ?? FlowDirection.LeftToRight;
+		}
+	}
+}

--- a/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Windows.cs
@@ -125,14 +125,6 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		public static void MapFlowDirection(ILayoutHandler handler, ILayout layout)
-		{
-			if (handler.PlatformView is LayoutPanel layoutPanel)
-			{
-				layoutPanel.FlowDirection = Microsoft.UI.Xaml.FlowDirection.LeftToRight;
-			}
-		}
-
 		static void MapInputTransparent(ILayoutHandler handler, ILayout layout)
 		{
 			if (handler.PlatformView is LayoutPanel layoutPanel && layout != null)

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -17,9 +17,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			[nameof(ILayout.Background)] = MapBackground,
 			[nameof(ILayout.ClipsToBounds)] = MapClipsToBounds,
-#if WINDOWS
-			[nameof(ILayout.FlowDirection)] = MapFlowDirection,
-#endif
 #if ANDROID || WINDOWS
 			[nameof(IView.InputTransparent)] = MapInputTransparent,
 #endif
@@ -102,6 +99,22 @@ namespace Microsoft.Maui.Handlers
 			{
 				handler.UpdateZIndex(view);
 			}
+		}
+
+		/// <summary>
+		/// Converts a FlowDirection to the appropriate FlowDirection for cross-platform layout 
+		/// </summary>
+		/// <param name="flowDirection"></param>
+		/// <returns>The FlowDirection to assume for cross-platform layout</returns>
+		internal static FlowDirection GetLayoutFlowDirection(FlowDirection flowDirection) 
+		{
+#if WINDOWS
+			// The native LayoutPanel in Windows will automagically flip our layout coordinates if it's in RTL mode.
+			// So for cross-platform layout purposes, we just always treat things as being LTR and let the Panel sort out the rest.
+			return FlowDirection.LeftToRight;
+#else
+			return flowDirection;
+#endif
 		}
 	}
 }

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -5,9 +5,6 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Layouts
 {
-	// TODO ezhart Looks like UWP flips columns in RTL mode
-	// So we need to do that. Need some GLM tests for that.
-
 	public class GridLayoutManager : LayoutManager
 	{
 		GridStructure? _gridStructure;
@@ -33,6 +30,11 @@ namespace Microsoft.Maui.Layouts
 		{
 			var structure = _gridStructure ?? new GridStructure(Grid, bounds.Width, bounds.Height);
 
+			var rtl = FlowDirection.RightToLeft ==
+					LayoutHandler.GetLayoutFlowDirection(Grid.GetEffectiveFlowDirection());
+
+			var reverseColumns = rtl && Grid.ColumnDefinitions.Count > 1;
+
 			foreach (var view in Grid)
 			{
 				if (view.Visibility == Visibility.Collapsed)
@@ -41,6 +43,12 @@ namespace Microsoft.Maui.Layouts
 				}
 
 				var cell = structure.GetCellBoundsFor(view, bounds.Left, bounds.Top);
+
+				if (reverseColumns)
+				{
+					var adjustedXPosition = bounds.Right - cell.Left - cell.Width;
+					cell.Left = adjustedXPosition;
+				}
 
 				view.Arrange(cell);
 			}

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -5,6 +5,9 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Layouts
 {
+	// TODO ezhart Looks like UWP flips columns in RTL mode
+	// So we need to do that. Need some GLM tests for that.
+
 	public class GridLayoutManager : LayoutManager
 	{
 		GridStructure? _gridStructure;

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -30,10 +30,7 @@ namespace Microsoft.Maui.Layouts
 		{
 			var structure = _gridStructure ?? new GridStructure(Grid, bounds.Width, bounds.Height);
 
-			var rtl = FlowDirection.RightToLeft ==
-					LayoutHandler.GetLayoutFlowDirection(Grid.GetEffectiveFlowDirection());
-
-			var reverseColumns = rtl && Grid.ColumnDefinitions.Count > 1;
+			var reverseColumns = Grid.ColumnDefinitions.Count > 1 && !Grid.ShouldArrangeLeftToRight();
 
 			foreach (var view in Grid)
 			{

--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -45,69 +45,60 @@ namespace Microsoft.Maui.Layouts
 		{
 			var padding = Stack.Padding;
 			double top = padding.Top + bounds.Top;
-			double left = padding.Left + bounds.Left;
+			
 			var height = bounds.Height - padding.VerticalThickness;
 			double stackWidth;
 
-			if (Stack.FlowDirection == FlowDirection.LeftToRight)
+			bool leftToRight = Stack.ShouldArrangeLeftToRight();
+
+			// Figure out where we're starting from (the left edge of the padded area, or the right edge)
+			double xPosition = leftToRight ? padding.Left + bounds.Left : bounds.Right - padding.Right;
+
+			// If we're arranging from the right, spacing will be added to the left
+			double spacingDelta = leftToRight ? Stack.Spacing : -Stack.Spacing;
+
+			for (int n = 0; n < Stack.Count; n++)
 			{
-				stackWidth = ArrangeLeftToRight(height, left, top, Stack.Spacing, Stack);
+				var child = Stack[n];
+
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
+				xPosition += leftToRight 
+					? ArrangeChildFromLeftEdge(child, height, top, xPosition) 
+					: ArrangeChildFromRightEdge(child, height, top, xPosition);
+
+				if (n < Stack.Count - 1)
+				{
+					// If we have more than one child and we're not on the last one, add spacing
+					xPosition += spacingDelta;
+				}
 			}
-			else
-			{
-				// We _could_ simply reverse the list of child views when arranging from right to left, 
-				// but this way we avoid extra list and enumerator allocations
-				stackWidth = ArrangeRightToLeft(height, left, top, Stack.Spacing, Stack);
-			}
+
+			// If we started from the left, the total width is the current x position;
+			// If we started from the right, it's the difference between the right edge and the current x position
+			stackWidth = leftToRight ? xPosition : bounds.Right - xPosition;
 
 			var actual = new Size(stackWidth, height);
 
 			return actual.AdjustForFill(bounds, Stack);
 		}
 
-		static double ArrangeLeftToRight(double height, double left, double top, double spacing, IList<IView> children)
-		{
-			double xPosition = left;
-
-			for (int n = 0; n < children.Count; n++)
-			{
-				var child = children[n];
-
-				if (child.Visibility == Visibility.Collapsed)
-				{
-					continue;
-				}
-
-				xPosition += ArrangeChild(child, height, top, spacing, xPosition);
-			}
-
-			return xPosition;
-		}
-
-		static double ArrangeRightToLeft(double height, double left, double top, double spacing, IList<IView> children)
-		{
-			double xPostition = left;
-
-			for (int n = children.Count - 1; n >= 0; n--)
-			{
-				var child = children[n];
-
-				if (child.Visibility == Visibility.Collapsed)
-				{
-					continue;
-				}
-
-				xPostition += ArrangeChild(child, height, top, spacing, xPostition);
-			}
-
-			return xPostition;
-		}
-
-		static double ArrangeChild(IView child, double height, double top, double spacing, double x)
+		static double ArrangeChildFromLeftEdge(IView child, double height, double top, double x)
 		{
 			var destination = new Rect(x, top, child.DesiredSize.Width, height);
 			child.Arrange(destination);
-			return destination.Width + spacing;
+			return destination.Width;
+		}
+
+		static double ArrangeChildFromRightEdge(IView child, double height, double top, double x)
+		{
+			var width = child.DesiredSize.Width;
+			var destination = new Rect(x - width, top, width, height);
+			child.Arrange(destination);
+			return -destination.Width;
 		}
 	}
 }

--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Layouts
 			var desiredWidth = view.DesiredSize.Width;
 			var startX = bounds.X;
 
-			if (view.FlowDirection == FlowDirection.LeftToRight)
+			if (view.ShouldArrangeLeftToRight())
 			{
 				return AlignHorizontal(startX, margin.Left, margin.Right, bounds.Width, desiredWidth, alignment);
 			}
@@ -196,5 +196,18 @@ namespace Microsoft.Maui.Layouts
 
 			return size;
 		}
+
+		public static bool ShouldArrangeLeftToRight(this IView view) 
+		{
+			var viewFlowDirection = view.GetEffectiveFlowDirection();
+
+			// The various platforms handle layout and flow direction in different ways; some platforms
+			// helpfully flip the coordinates of arrange calls when in RTL mode, others don't
+			// So this gives us a place to ask the platform (via LayoutHandler) whether we need to do 
+			// the layout work to flip RTL stuff in our cross-platform layouts or not.
+			var layoutFlowDirection = LayoutHandler.GetLayoutFlowDirection(viewFlowDirection);
+
+			return layoutFlowDirection == FlowDirection.LeftToRight;
+		} 
 	}
 }

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -215,20 +215,13 @@ namespace Microsoft.Maui.Platform
 
 		static ALayoutDirection GetLayoutDirection(IView view)
 		{
-			if (view.FlowDirection == view.Handler?.MauiContext?.GetFlowDirection() ||
-				view.FlowDirection == FlowDirection.MatchParent)
+			return view.FlowDirection switch
 			{
-				return ALayoutDirection.Inherit;
-			}
-			else if (view.FlowDirection == FlowDirection.RightToLeft)
-			{
-				return ALayoutDirection.Rtl;
-			}
-			else if (view.FlowDirection == FlowDirection.LeftToRight)
-			{
-				return ALayoutDirection.Ltr;
-			}
-			return ALayoutDirection.Inherit;
+				FlowDirection.MatchParent => ALayoutDirection.Inherit,
+				FlowDirection.LeftToRight => ALayoutDirection.Ltr,
+				FlowDirection.RightToLeft => ALayoutDirection.Rtl,
+				_ => ALayoutDirection.Inherit,
+			};
 		}
 
 		public static bool GetClipToOutline(this AView view)

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -115,32 +115,21 @@ namespace Microsoft.Maui.Platform
 			platformView?.UpdatePlatformViewBackground(view);
 		}
 
-		public static WFlowDirection ToPlatform(this FlowDirection flowDirection)
-		{
-			if (flowDirection == FlowDirection.RightToLeft)
-				return WFlowDirection.RightToLeft;
-			else if (flowDirection == FlowDirection.LeftToRight)
-				return WFlowDirection.LeftToRight;
-
-			throw new InvalidOperationException($"Invalid FlowDirection: {flowDirection}");
-		}
-
-		public static void UpdateFlowDirection(this FrameworkElement platformView, IView view)
+		public static void UpdateFlowDirection(this FrameworkElement platformView, IView view) 
 		{
 			var flowDirection = view.FlowDirection;
-
-			if (flowDirection == FlowDirection.MatchParent)
+			switch (flowDirection)
 			{
-				flowDirection = view?.Handler?.MauiContext?.GetFlowDirection()
-					?? FlowDirection.LeftToRight;
-
-				if (flowDirection == FlowDirection.MatchParent)
-				{
-					flowDirection = FlowDirection.LeftToRight;
-				}
+				case FlowDirection.MatchParent:
+					platformView.ClearValue(FrameworkElement.FlowDirectionProperty);
+					break;
+				case FlowDirection.LeftToRight:
+					platformView.FlowDirection = WFlowDirection.LeftToRight;
+					break;
+				case FlowDirection.RightToLeft:
+					platformView.FlowDirection = WFlowDirection.RightToLeft;
+					break;
 			}
-
-			platformView.FlowDirection = flowDirection.ToPlatform();
 		}
 
 		public static void UpdateAutomationId(this FrameworkElement platformView, IView view) =>

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -117,15 +117,18 @@ namespace Microsoft.Maui.Platform
 		{
 			UISemanticContentAttribute updateValue = platformView.SemanticContentAttribute;
 
-			if (view.FlowDirection == view.Handler?.MauiContext?.GetFlowDirection() ||
-				view.FlowDirection == FlowDirection.MatchParent)
+			switch (view.FlowDirection)
 			{
-				updateValue = UISemanticContentAttribute.Unspecified;
+				case FlowDirection.MatchParent:
+					updateValue = UISemanticContentAttribute.Unspecified;
+					break;
+				case FlowDirection.LeftToRight:
+					updateValue = UISemanticContentAttribute.ForceLeftToRight;
+					break;
+				case FlowDirection.RightToLeft:
+					updateValue = UISemanticContentAttribute.ForceRightToLeft;
+					break;
 			}
-			else if (view.FlowDirection == FlowDirection.RightToLeft)
-				updateValue = UISemanticContentAttribute.ForceRightToLeft;
-			else if (view.FlowDirection == FlowDirection.LeftToRight)
-				updateValue = UISemanticContentAttribute.ForceLeftToRight;
 
 			if (updateValue != platformView.SemanticContentAttribute)
 				platformView.SemanticContentAttribute = updateValue;

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1717,5 +1717,26 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, new Rect(0, 0, 100, 100));
 			AssertArranged(view1, new Rect(0, 220, 100, 100));
 		}
+
+
+		[Fact(DisplayName = "Grids with RTL FlowDirection should order columns from the right")]
+		public void RtlShouldReverseColumnOrder()
+		{
+			var grid = CreateGridLayout(columns: "100, 100", colSpacing: 10);
+			var view0 = CreateTestView(new Size(100, 100));
+			var view1 = CreateTestView(new Size(100, 100));
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view0);
+			SetLocation(grid, view1, col: 1);
+
+			grid.FlowDirection.Returns(FlowDirection.RightToLeft);
+
+			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			
+			// Because the Grid is RTL, we expect the view in column 1 to be on the left,
+			// and the view in column 0 to be on the right
+			AssertArranged(view1, 0, 0, 100, 100);
+			AssertArranged(view0, 110, 0, 100, 100);
+		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
@@ -378,5 +378,29 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(arrangedWidth, actual.Width);
 			Assert.Equal(arrangedHeight, actual.Height);
 		}
+
+		[Fact(DisplayName = "RTL layout starts at right edge")]
+		public void RtlShouldStartAtRightEdge()
+		{
+			var stack = BuildStack(viewCount: 2, viewWidth: 100, viewHeight: 100);
+			stack.FlowDirection.Returns(FlowDirection.RightToLeft);
+			stack.HorizontalLayoutAlignment.Returns(LayoutAlignment.Fill);
+			stack.Spacing.Returns(0);
+
+			var manager = new HorizontalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
+
+			// Arranging in a larger space than measured to simulate a Fill situation
+			var rightEdge = measuredSize.Width * 2;
+			manager.ArrangeChildren(new Rect(0, 0, rightEdge, measuredSize.Height));
+
+			// We expect that the starting view (0) should be arranged on the right,
+			// and the next rectangle (1) should be on the left
+			var expectedRectangle0 = new Rect(rightEdge - 100, 0, 100, 100);
+			var expectedRectangle1 = new Rect(rightEdge - 200, 0, 100, 100);
+
+			stack[0].Received().Arrange(Arg.Is(expectedRectangle0));
+			stack[1].Received().Arrange(Arg.Is(expectedRectangle1));
+		}
 	}
 }

--- a/src/Essentials/src/AppInfo/AppInfo.netstandard.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.netstandard.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Essentials.Implementations
 
 		public AppPackagingModel PackagingModel => throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		public LayoutDirection RequestedLayoutDirection => throw ExceptionUtils.NotSupportedOrImplementedException;
+		// Returning the Unknown value for LayoutDirection so that unit tests can work
+		public LayoutDirection RequestedLayoutDirection => LayoutDirection.Unknown;
 	}
 }


### PR DESCRIPTION
### Description of Change

- When Grids have FlowDirection == RightToLeft, reverses the order of the columns on each plaftorm
- When HorizontalStackLayouts have FlowDirection == RightToLeft, correctly orders the children and stacks them from the right on each platform
- Correctly handles nested changing FlowDirections 

### Issues Fixed

Fixes #3779
Fixes #4748

Should address part 1 of #4245