### PR TITLE
Change platform type for ShellItemHandler

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -10,7 +10,7 @@ using WApp = Microsoft.UI.Xaml.Application;
 
 namespace Microsoft.Maui.Controls.Handlers
 {
-	public partial class ShellItemHandler : ElementHandler<ShellItem, MauiNavigationView>, IAppearanceObserver
+	public partial class ShellItemHandler : ElementHandler<ShellItem, FrameworkElement>, IAppearanceObserver
 	{
 		public static PropertyMapper<ShellItem, ShellItemHandler> Mapper =
 				new PropertyMapper<ShellItem, ShellItemHandler>(ElementMapper)
@@ -28,13 +28,16 @@ namespace Microsoft.Maui.Controls.Handlers
 		ObservableCollection<NavigationViewItemViewModel> _mainLevelTabs;
 		ShellItem? _shellItem;
 		SearchHandler? _currentSearchHandler;
+		MauiNavigationView? _mauiNavigationView;
+		MauiNavigationView ShellItemNavigationView => _mauiNavigationView!;
+
 
 		public ShellItemHandler() : base(Mapper, CommandMapper)
 		{
 			_mainLevelTabs = new ObservableCollection<NavigationViewItemViewModel>();
 		}
 
-		protected override MauiNavigationView CreatePlatformElement()
+		protected override FrameworkElement CreatePlatformElement()
 		{
 			var platformView = new MauiNavigationView()
 			{
@@ -46,6 +49,7 @@ namespace Microsoft.Maui.Controls.Handlers
 				MenuItemsSource = _mainLevelTabs
 			};
 
+			_mauiNavigationView = platformView;
 			platformView.SetApplicationResource("NavigationViewContentMargin", null);
 			platformView.SetApplicationResource("NavigationViewMinimalHeaderMargin", null);
 			platformView.SetApplicationResource("NavigationViewHeaderMargin", null);
@@ -54,16 +58,16 @@ namespace Microsoft.Maui.Controls.Handlers
 			return platformView;
 		}
 
-		protected override void ConnectHandler(MauiNavigationView platformView)
+		protected override void ConnectHandler(FrameworkElement platformView)
 		{
 			base.ConnectHandler(platformView);
-			platformView.SelectionChanged += OnNavigationTabChanged;
+			ShellItemNavigationView.SelectionChanged += OnNavigationTabChanged;
 		}
 
-		protected override void DisconnectHandler(MauiNavigationView platformView)
+		protected override void DisconnectHandler(FrameworkElement platformView)
 		{
 			base.DisconnectHandler(platformView);
-			platformView.SelectionChanged -= OnNavigationTabChanged;
+			ShellItemNavigationView.SelectionChanged -= OnNavigationTabChanged;
 		}
 
 		public override void SetVirtualView(Maui.IElement view)
@@ -167,30 +171,30 @@ namespace Microsoft.Maui.Controls.Handlers
 				}
 			});
 
-			if (PlatformView.SelectedItem != selectedItem)
-				PlatformView.SelectedItem = selectedItem;
+			if (ShellItemNavigationView.SelectedItem != selectedItem)
+				ShellItemNavigationView.SelectedItem = selectedItem;
 
 			if (!hasTabs)
 			{
-				PlatformView.PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
+				ShellItemNavigationView.PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
 			}
 			else
 			{
-				PlatformView.PaneDisplayMode = NavigationViewPaneDisplayMode.Top;
+				ShellItemNavigationView.PaneDisplayMode = NavigationViewPaneDisplayMode.Top;
 			}
 		}
 
 		void UpdateSearchHandler()
 		{
-			if(PlatformView.AutoSuggestBox == null)
-				PlatformView.AutoSuggestBox = new Microsoft.UI.Xaml.Controls.AutoSuggestBox() { Width = 300 };
+			if(ShellItemNavigationView.AutoSuggestBox == null)
+				ShellItemNavigationView.AutoSuggestBox = new Microsoft.UI.Xaml.Controls.AutoSuggestBox() { Width = 300 };
 
 			if (VirtualView.Parent is not Shell shell)
 				return;
 
 			_currentSearchHandler = shell.GetEffectiveValue<SearchHandler?>(Shell.SearchHandlerProperty, null);
 
-			var AutoSuggestBox = PlatformView.AutoSuggestBox;
+			var AutoSuggestBox = ShellItemNavigationView.AutoSuggestBox;
 			AutoSuggestBox.TextChanged += OnSearchBoxTextChanged;
 			AutoSuggestBox.QuerySubmitted += OnSearchBoxQuerySubmitted;
 			AutoSuggestBox.SuggestionChosen += OnSearchBoxSuggestionChosen;
@@ -250,9 +254,9 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (_currentSearchHandler != null)
 			{
 				if (_currentSearchHandler.QueryIcon is FileImageSource fis)
-					PlatformView.AutoSuggestBox.QueryIcon = new BitmapIcon() { UriSource = new Uri("ms-appx:///" + fis.File) };
+					ShellItemNavigationView.AutoSuggestBox.QueryIcon = new BitmapIcon() { UriSource = new Uri("ms-appx:///" + fis.File) };
 				else
-					PlatformView.AutoSuggestBox.QueryIcon = new SymbolIcon(Symbol.Find);
+					ShellItemNavigationView.AutoSuggestBox.QueryIcon = new SymbolIcon(Symbol.Find);
 			}
 		}
 
@@ -266,12 +270,12 @@ namespace Microsoft.Maui.Controls.Handlers
 
 			if(shellItemController.ShowTabs)
 			{
-				handler.PlatformView.PaneDisplayMode 
+				handler.ShellItemNavigationView.PaneDisplayMode 
 					= NavigationViewPaneDisplayMode.Top;
 			}
 			else
 			{
-				handler.PlatformView.PaneDisplayMode
+				handler.ShellItemNavigationView.PaneDisplayMode
 					= NavigationViewPaneDisplayMode.LeftMinimal;
 			}
 		}
@@ -282,8 +286,8 @@ namespace Microsoft.Maui.Controls.Handlers
 			{
 				handler._shellSectionHandler ??= (ShellSectionHandler)item.CurrentItem.ToHandler(handler.MauiContext!);
 
-				if (handler._shellSectionHandler.PlatformView != (FrameworkElement)handler.PlatformView.Content)
-					handler.PlatformView.Content = handler._shellSectionHandler.PlatformView;
+				if (handler._shellSectionHandler.PlatformView != (FrameworkElement)handler.ShellItemNavigationView.Content)
+					handler.ShellItemNavigationView.Content = handler._shellSectionHandler.PlatformView;
 
 				if (handler._shellSectionHandler.VirtualView != item.CurrentItem)
 					handler._shellSectionHandler.SetVirtualView(item.CurrentItem);
@@ -297,13 +301,13 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (appearance is IShellAppearanceElement a)
 			{
 				// This means the template hasn't been applied yet
-				if (PlatformView.TopNavArea == null)
+				if (ShellItemNavigationView.TopNavArea == null)
 				{
-					PlatformView.OnApplyTemplateFinished += OnApplyTemplateFinished;
+					ShellItemNavigationView.OnApplyTemplateFinished += OnApplyTemplateFinished;
 
 					void OnApplyTemplateFinished(object? sender, EventArgs e)
 					{
-						PlatformView.OnApplyTemplateFinished -= OnApplyTemplateFinished;
+						ShellItemNavigationView.OnApplyTemplateFinished -= OnApplyTemplateFinished;
 						ApplyAppearance();
 					}
 				}
@@ -314,8 +318,8 @@ namespace Microsoft.Maui.Controls.Handlers
 
 				void ApplyAppearance()
 				{
-					PlatformView.UpdateTopNavAreaBackground(a.EffectiveTabBarBackgroundColor?.AsPaint());
-					PlatformView.UpdateTopNavigationViewItemTextColor(a.EffectiveTabBarForegroundColor?.AsPaint());
+					ShellItemNavigationView.UpdateTopNavAreaBackground(a.EffectiveTabBarBackgroundColor?.AsPaint());
+					ShellItemNavigationView.UpdateTopNavigationViewItemTextColor(a.EffectiveTabBarForegroundColor?.AsPaint());
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change

Change  `ShellItemHandler` to return `FrameworkElement`

Future scenarios will require us to return different types of elements for the platform element on `ShellItemHandler`


