### PR TITLE
Change handlers to use least derived types

### DIFF
--- a/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.Android.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PolygonHandler
 	{
-		protected override void ConnectHandler(MauiShapeView nativeView)
+		protected override void ConnectHandler(PlatformGraphicsView nativeView)
 		{
 			if (VirtualView is Polygon polygon)
 				polygon.Points.CollectionChanged += OnPointsCollectionChanged;
@@ -13,7 +14,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			base.ConnectHandler(nativeView);
 		}
 
-		protected override void DisconnectHandler(MauiShapeView nativeView)
+		protected override void DisconnectHandler(PlatformGraphicsView nativeView)
 		{
 			if (VirtualView is Polygon polygon)
 				polygon.Points.CollectionChanged -= OnPointsCollectionChanged;

--- a/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polygon/PolygonHandler.iOS.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PolygonHandler
 	{
-		protected override void ConnectHandler(MauiShapeView nativeView)
+		protected override void ConnectHandler(PlatformGraphicsView nativeView)
 		{
 			if (VirtualView is Polygon polygon)
 				polygon.Points.CollectionChanged += OnPointsCollectionChanged;
@@ -13,7 +14,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			base.ConnectHandler(nativeView);
 		}
 
-		protected override void DisconnectHandler(MauiShapeView nativeView)
+		protected override void DisconnectHandler(PlatformGraphicsView nativeView)
 		{
 			if (VirtualView is Polygon polygon)
 				polygon.Points.CollectionChanged -= OnPointsCollectionChanged;

--- a/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.Android.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PolylineHandler 
 	{
-		protected override void ConnectHandler(MauiShapeView nativeView)
+		protected override void ConnectHandler(PlatformGraphicsView nativeView)
 		{
 			if (VirtualView is Polyline polyline)
 				polyline.Points.CollectionChanged += OnPointsCollectionChanged;
@@ -13,7 +14,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			base.ConnectHandler(nativeView);
 		}
 
-		protected override void DisconnectHandler(MauiShapeView nativeView)
+		protected override void DisconnectHandler(PlatformGraphicsView nativeView)
 		{
 			if (VirtualView is Polyline polyline)
 				polyline.Points.CollectionChanged -= OnPointsCollectionChanged;

--- a/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Shapes/Polyline/PolylineHandler.iOS.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Controls.Handlers
 {
 	public partial class PolylineHandler
 	{
-		protected override void ConnectHandler(MauiShapeView nativeView)
+		protected override void ConnectHandler(PlatformGraphicsView nativeView)
 		{
 			if (VirtualView is Polyline polyline)
 				polyline.Points.CollectionChanged += OnPointsCollectionChanged;
@@ -13,7 +14,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			base.ConnectHandler(nativeView);
 		}
 
-		protected override void DisconnectHandler(MauiShapeView nativeView)
+		protected override void DisconnectHandler(PlatformGraphicsView nativeView)
 		{
 			if (VirtualView is Polyline polyline)
 				polyline.Points.CollectionChanged -= OnPointsCollectionChanged;

--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.cs
@@ -1,5 +1,5 @@
 ﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiActivityIndicator;
+using PlatformView = UIKit.UIActivityIndicatorView;
 #elif MONOANDROID
 using PlatformView = Android.Widget.ProgressBar;
 #elif WINDOWS

--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.iOS.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.iOS.cs
@@ -4,9 +4,9 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ActivityIndicatorHandler : ViewHandler<IActivityIndicator, MauiActivityIndicator>
+	public partial class ActivityIndicatorHandler : ViewHandler<IActivityIndicator, UIActivityIndicatorView>
 	{
-		protected override MauiActivityIndicator CreatePlatformView() => new MauiActivityIndicator(CGRect.Empty, VirtualView)
+		protected override UIActivityIndicatorView CreatePlatformView() => new MauiActivityIndicator(CGRect.Empty, VirtualView)
 		{
 			ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray
 		};

--- a/src/Core/src/Handlers/ActivityIndicator/IActivityIndicatorHandler.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/IActivityIndicatorHandler.cs
@@ -1,5 +1,5 @@
 ﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiActivityIndicator;
+using PlatformView = UIKit.UIActivityIndicatorView;
 #elif MONOANDROID
 using PlatformView = Android.Widget.ProgressBar;
 #elif WINDOWS

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 using Android.App;
-using Android.Content.Res;
-using Android.Graphics.Drawables;
 using Microsoft.Maui.Essentials;
+using Android.Views;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class DatePickerHandler : ViewHandler<IDatePicker, MauiDatePicker>
+	public partial class DatePickerHandler : ViewHandler<IDatePicker, View>
 	{
+		MauiDatePicker? GetMauiDatePicker() => PlatformView as MauiDatePicker;
+		static MauiDatePicker? GetMauiDatePicker(IDatePickerHandler handler) => handler.PlatformView as MauiDatePicker;
+
 		DatePickerDialog? _dialog;
 
-		protected override MauiDatePicker CreatePlatformView()
+		protected override View CreatePlatformView()
 		{
 			var mauiDatePicker = new MauiDatePicker(Context)
 			{
@@ -28,14 +30,14 @@ namespace Microsoft.Maui.Handlers
 
 		internal DatePickerDialog? DatePickerDialog { get { return _dialog; } }
 
-		protected override void ConnectHandler(MauiDatePicker platformView)
+		protected override void ConnectHandler(View platformView)
 		{
 			base.ConnectHandler(platformView);
 
 			DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
 		}
 
-		protected override void DisconnectHandler(MauiDatePicker platformView)
+		protected override void DisconnectHandler(View platformView)
 		{
 			if (_dialog != null)
 			{
@@ -71,42 +73,42 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapFormat(IDatePickerHandler handler, IDatePicker datePicker)
 		{
-			handler.PlatformView?.UpdateFormat(datePicker);
+			GetMauiDatePicker(handler)?.UpdateFormat(datePicker);
 		}
 
 		public static void MapDate(IDatePickerHandler handler, IDatePicker datePicker)
 		{
-			handler.PlatformView?.UpdateDate(datePicker);
+			GetMauiDatePicker(handler)?.UpdateDate(datePicker);
 		}
 
 		public static void MapMinimumDate(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			if (handler is DatePickerHandler platformHandler)
-				handler.PlatformView?.UpdateMinimumDate(datePicker, platformHandler._dialog);
+				GetMauiDatePicker(handler)?.UpdateMinimumDate(datePicker, platformHandler._dialog);
 		}
 
 		public static void MapMaximumDate(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			if (handler is DatePickerHandler platformHandler)
-				handler.PlatformView?.UpdateMaximumDate(datePicker, platformHandler._dialog);
+				GetMauiDatePicker(handler)?.UpdateMaximumDate(datePicker, platformHandler._dialog);
 		}
 
 		public static void MapCharacterSpacing(IDatePickerHandler handler, IDatePicker datePicker)
 		{
-			handler.PlatformView?.UpdateCharacterSpacing(datePicker);
+			GetMauiDatePicker(handler)?.UpdateCharacterSpacing(datePicker);
 		}
 
 		public static void MapFont(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
-			handler.PlatformView?.UpdateFont(datePicker, fontManager);
+			GetMauiDatePicker(handler)?.UpdateFont(datePicker, fontManager);
 		}
 
 		public static void MapTextColor(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			if (handler is DatePickerHandler platformHandler)
-				handler.PlatformView?.UpdateTextColor(datePicker);
+				GetMauiDatePicker(handler)?.UpdateTextColor(datePicker);
 		}
 
 		void ShowPickerDialog()

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
@@ -1,7 +1,7 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.CalendarDatePicker;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.iOS.cs
@@ -5,11 +5,14 @@ using RectangleF = CoreGraphics.CGRect;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class DatePickerHandler : ViewHandler<IDatePicker, MauiDatePicker>
+	public partial class DatePickerHandler : ViewHandler<IDatePicker, UIView>
 	{
+		MauiDatePicker? GetMauiDatePicker() => PlatformView as MauiDatePicker;
+		static MauiDatePicker? GetMauiDatePicker(IDatePickerHandler handler) => handler.PlatformView as MauiDatePicker;
+
 		UIDatePicker? _picker;
 
-		protected override MauiDatePicker CreatePlatformView()
+		protected override UIView CreatePlatformView()
 		{
 			MauiDatePicker platformDatePicker = new MauiDatePicker();
 
@@ -47,7 +50,7 @@ namespace Microsoft.Maui.Handlers
 
 		internal UIDatePicker? DatePickerDialog { get { return _picker; } }
 
-		protected override void ConnectHandler(MauiDatePicker platformView)
+		protected override void ConnectHandler(UIView platformView)
 		{
 			if (_picker is UIDatePicker picker)
 			{
@@ -65,7 +68,7 @@ namespace Microsoft.Maui.Handlers
 			base.ConnectHandler(platformView);
 		}
 
-		protected override void DisconnectHandler(MauiDatePicker platformView)
+		protected override void DisconnectHandler(UIView platformView)
 		{
 			if (_picker != null)
 			{
@@ -80,48 +83,48 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFormat(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			var picker = (handler as DatePickerHandler)?._picker;
-			handler.PlatformView?.UpdateFormat(datePicker, picker);
+			GetMauiDatePicker(handler)?.UpdateFormat(datePicker, picker);
 		}
 
 		public static void MapDate(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			var picker = (handler as DatePickerHandler)?._picker;
-			handler.PlatformView?.UpdateDate(datePicker, picker);
+			GetMauiDatePicker(handler)?.UpdateDate(datePicker, picker);
 		}
 
 		public static void MapMinimumDate(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			if (handler is DatePickerHandler platformHandler)
-				handler.PlatformView?.UpdateMinimumDate(datePicker, platformHandler._picker);
+				GetMauiDatePicker(handler)?.UpdateMinimumDate(datePicker, platformHandler._picker);
 		}
 
 		public static void MapMaximumDate(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			if (handler is DatePickerHandler platformHandler)
-				handler.PlatformView?.UpdateMaximumDate(datePicker, platformHandler._picker);
+				GetMauiDatePicker(handler)?.UpdateMaximumDate(datePicker, platformHandler._picker);
 		}
 
 		public static void MapCharacterSpacing(IDatePickerHandler handler, IDatePicker datePicker)
 		{
-			handler.PlatformView?.UpdateCharacterSpacing(datePicker);
+			GetMauiDatePicker(handler)?.UpdateCharacterSpacing(datePicker);
 		}
 
 		public static void MapFont(IDatePickerHandler handler, IDatePicker datePicker)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
-			handler.PlatformView?.UpdateFont(datePicker, fontManager);
+			GetMauiDatePicker(handler)?.UpdateFont(datePicker, fontManager);
 		}
 
 		public static void MapTextColor(IDatePickerHandler handler, IDatePicker datePicker)
 		{
-			handler.PlatformView?.UpdateTextColor(datePicker);
+			GetMauiDatePicker(handler)?.UpdateTextColor(datePicker);
 		}
-    
+
 		public static void MapFlowDirection(DatePickerHandler handler, IDatePicker datePicker)
 		{
 			handler.PlatformView?.UpdateFlowDirection(datePicker);
-			handler.PlatformView?.UpdateTextAlignment(datePicker);
+			GetMauiDatePicker(handler)?.UpdateTextAlignment(datePicker);
 		}
 
 		void OnValueChanged(object? sender, EventArgs? e)

--- a/src/Core/src/Handlers/DatePicker/IDatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/IDatePickerHandler.cs
@@ -1,7 +1,7 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.CalendarDatePicker;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 #if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiTextView;
+using PlatformView = UIKit.UITextView;
 #elif MONOANDROID
 using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 #elif WINDOWS

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -7,26 +7,30 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class EditorHandler : ViewHandler<IEditor, MauiTextView>
+	public partial class EditorHandler : ViewHandler<IEditor, UITextView>
 	{
 		static readonly int BaseHeight = 30;
 
-		protected override MauiTextView CreatePlatformView() => new MauiTextView();
+		protected override UITextView CreatePlatformView() => new MauiTextView();
 
-		protected override void ConnectHandler(MauiTextView platformView)
+		protected override void ConnectHandler(UITextView platformView)
 		{
 			platformView.ShouldChangeText += OnShouldChangeText;
 			platformView.Started += OnStarted;
 			platformView.Ended += OnEnded;
-			platformView.TextSetOrChanged += OnTextPropertySet;
+
+			if (platformView is MauiTextView textField)
+				textField.TextSetOrChanged += OnTextPropertySet;
 		}
 
-		protected override void DisconnectHandler(MauiTextView platformView)
+		protected override void DisconnectHandler(UITextView platformView)
 		{
 			platformView.ShouldChangeText -= OnShouldChangeText;
 			platformView.Started -= OnStarted;
 			platformView.Ended -= OnEnded;
-			platformView.TextSetOrChanged -= OnTextPropertySet;
+
+			if (platformView is MauiTextView textField)
+				textField.TextSetOrChanged -= OnTextPropertySet;
 		}
 
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint) =>
@@ -44,10 +48,10 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateTextColor(editor);
 
 		public static void MapPlaceholder(IEditorHandler handler, IEditor editor) =>
-			handler.PlatformView?.UpdatePlaceholder(editor);
+			(handler.PlatformView as MauiTextView)?.UpdatePlaceholder(editor);
 
 		public static void MapPlaceholderColor(IEditorHandler handler, IEditor editor) =>
-			handler.PlatformView?.UpdatePlaceholderColor(editor);
+			(handler.PlatformView as MauiTextView)?.UpdatePlaceholderColor(editor);
 
 		public static void MapCharacterSpacing(IEditorHandler handler, IEditor editor) =>
 			handler.PlatformView?.UpdateCharacterSpacing(editor);

--- a/src/Core/src/Handlers/Editor/IEditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/IEditorHandler.cs
@@ -1,5 +1,5 @@
 ﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiTextView;
+using PlatformView = UIKit.UITextView;
 #elif MONOANDROID
 using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 #elif WINDOWS

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 #if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiTextField;
+using PlatformView = UIKit.UITextField;
 #elif MONOANDROID
 using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 #elif WINDOWS

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -6,33 +6,39 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class EntryHandler : ViewHandler<IEntry, MauiTextField>
+	public partial class EntryHandler : ViewHandler<IEntry, UITextField>
 	{
-		protected override MauiTextField CreatePlatformView() =>
+		protected override UITextField CreatePlatformView() =>
 			new MauiTextField
 			{
 				BorderStyle = UITextBorderStyle.RoundedRect,
 				ClipsToBounds = true
 			};
 
-		protected override void ConnectHandler(MauiTextField platformView)
+		protected override void ConnectHandler(UITextField platformView)
 		{
 			platformView.ShouldReturn = OnShouldReturn;
 			platformView.EditingDidBegin += OnEditingBegan;
 			platformView.EditingChanged += OnEditingChanged;
 			platformView.EditingDidBegin += OnEditingBegan;
 			platformView.EditingDidEnd += OnEditingEnded;
-			platformView.TextPropertySet += OnTextPropertySet;
+			
+			if (platformView is MauiTextField textField)
+				textField.TextPropertySet += OnTextPropertySet;
+
 			platformView.ShouldChangeCharacters += OnShouldChangeCharacters;
 		}
 
-		protected override void DisconnectHandler(MauiTextField platformView)
+		protected override void DisconnectHandler(UITextField platformView)
 		{
 			platformView.EditingDidBegin -= OnEditingBegan;
 			platformView.EditingChanged -= OnEditingChanged;
 			platformView.EditingDidBegin -= OnEditingBegan;
 			platformView.EditingDidEnd -= OnEditingEnded;
-			platformView.TextPropertySet -= OnTextPropertySet;
+
+			if (platformView is MauiTextField textField)
+				textField.TextPropertySet -= OnTextPropertySet;
+
 			platformView.ShouldChangeCharacters -= OnShouldChangeCharacters;
 		}
 

--- a/src/Core/src/Handlers/Entry/IEntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/IEntryHandler.cs
@@ -1,5 +1,5 @@
 ﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiTextField;
+using PlatformView = UIKit.UITextField;
 #elif MONOANDROID
 using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 #elif WINDOWS

--- a/src/Core/src/Handlers/ImageButton/IImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/IImageButtonHandler.cs
@@ -1,7 +1,7 @@
 ﻿#if __IOS__ || MACCATALYST
 using PlatformView = UIKit.UIButton;
 #elif MONOANDROID
-using PlatformView = Google.Android.Material.ImageView.ShapeableImageView;
+using PlatformView = AndroidX.AppCompat.Widget.AppCompatImageView;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using Android.Graphics.Drawables;
 using Android.Views;
+using AndroidX.AppCompat.Widget;
 using Google.Android.Material.ImageView;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ImageButtonHandler : ViewHandler<IImageButton, ShapeableImageView>
+	public partial class ImageButtonHandler : ViewHandler<IImageButton, AppCompatImageView>
 	{
-		protected override ShapeableImageView CreatePlatformView()
+		protected override AppCompatImageView CreatePlatformView()
 		{
 			var platformView = new ShapeableImageView(Context);
 
@@ -23,7 +24,7 @@ namespace Microsoft.Maui.Handlers
 			PlatformView.SetImageDrawable(obj);
 		}
 
-		protected override void DisconnectHandler(ShapeableImageView platformView)
+		protected override void DisconnectHandler(AppCompatImageView platformView)
 		{
 			platformView.FocusChange -= OnFocusChange;
 			platformView.Click -= OnClick;
@@ -34,7 +35,7 @@ namespace Microsoft.Maui.Handlers
 			SourceLoader.Reset();
 		}
 
-		protected override void ConnectHandler(ShapeableImageView platformView)
+		protected override void ConnectHandler(AppCompatImageView platformView)
 		{
 			platformView.FocusChange += OnFocusChange;
 			platformView.Click += OnClick;

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -1,11 +1,11 @@
-﻿#if __IOS__ || MACCATALYST
+﻿#if IOS || MACCATALYST
 using PlatformImage = UIKit.UIImage;
 using PlatformImageView = UIKit.UIImageView;
 using PlatformView = UIKit.UIButton;
 #elif MONOANDROID
 using PlatformImage = Android.Graphics.Drawables.Drawable;
 using PlatformImageView = Android.Widget.ImageView;
-using PlatformView = Google.Android.Material.ImageView.ShapeableImageView;
+using PlatformView = AndroidX.AppCompat.Widget.AppCompatImageView;
 #elif WINDOWS
 using System;
 using PlatformImage = Microsoft.UI.Xaml.Media.ImageSource;

--- a/src/Core/src/Handlers/IndicatorView/IIndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IIndicatorViewHandler.cs
@@ -1,9 +1,9 @@
 ﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
+using PlatformView = UIKit.UIPageControl;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.Android.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.Android.cs
@@ -2,9 +2,12 @@
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, MauiPageControl>
+	public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, AView>
 	{
-		protected override MauiPageControl CreatePlatformView()
+		MauiPageControl? GetMauiPageControl() => PlatformView as MauiPageControl;
+		static MauiPageControl? GetMauiPageControl(IIndicatorViewHandler handler) => handler.PlatformView as MauiPageControl;
+
+		protected override AView CreatePlatformView()
 		{
 			return new MauiPageControl(Context);
 		}
@@ -12,51 +15,53 @@ namespace Microsoft.Maui.Handlers
 		private protected override void OnConnectHandler(AView platformView)
 		{
 			base.OnConnectHandler(platformView);
-			PlatformView.SetIndicatorView(VirtualView);
+			GetMauiPageControl()?.SetIndicatorView(VirtualView);
 		}
 
 		private protected override void OnDisconnectHandler(AView platformView)
 		{
 			base.OnDisconnectHandler(platformView);
-			PlatformView.SetIndicatorView(null);
+			GetMauiPageControl()?.SetIndicatorView(null);
 		}
 
 		public static void MapCount(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView.UpdateIndicatorCount();
+			GetMauiPageControl(handler)?.UpdateIndicatorCount();
 		}
 
 		public static void MapPosition(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView.UpdatePosition();
+			GetMauiPageControl(handler)?.UpdatePosition();
 		}
 
 		public static void MapHideSingle(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView.UpdateIndicatorCount();
+			GetMauiPageControl(handler)?.UpdateIndicatorCount();
 		}
 
 		public static void MapMaximumVisible(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView.UpdateIndicatorCount();
+			GetMauiPageControl(handler)?.UpdateIndicatorCount();
 		}
 
 		public static void MapIndicatorSize(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView.ResetIndicators();
+			GetMauiPageControl(handler)?.ResetIndicators();
 		}
 
 		public static void MapIndicatorColor(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView.ResetIndicators();
+			GetMauiPageControl(handler)?.ResetIndicators();
 		}
+
 		public static void MapSelectedIndicatorColor(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView.ResetIndicators();
+			GetMauiPageControl(handler)?.ResetIndicators();
 		}
+
 		public static void MapIndicatorShape(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView.ResetIndicators();
+			GetMauiPageControl(handler)?.ResetIndicators();
 		}
 	}
 }

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.Windows.cs
@@ -1,29 +1,31 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, MauiPageControl>
+	public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, FrameworkElement>
 	{
-		protected override MauiPageControl CreatePlatformView() => new MauiPageControl();
+		MauiPageControl? GetMauiPageControl() => PlatformView as MauiPageControl;
+		static MauiPageControl? GetMauiPageControl(IIndicatorViewHandler handler) => handler.PlatformView as MauiPageControl;
 
-		protected override void ConnectHandler(MauiPageControl platformView)
+		protected override FrameworkElement CreatePlatformView() => new MauiPageControl();
+
+		protected override void ConnectHandler(FrameworkElement platformView)
 		{
 			base.ConnectHandler(platformView);
-			PlatformView?.SetIndicatorView(VirtualView);
+			GetMauiPageControl()?.SetIndicatorView(VirtualView);
 			UpdateIndicator();
 		}
 
-		public static void MapCount(IIndicatorViewHandler handler, IIndicatorView indicator) => handler.PlatformView?.CreateIndicators();
-		public static void MapPosition(IIndicatorViewHandler handler, IIndicatorView indicator) => handler.PlatformView?.UpdateIndicatorsColor();
-		public static void MapHideSingle(IIndicatorViewHandler handler, IIndicatorView indicator) => handler.PlatformView?.CreateIndicators();
-		public static void MapMaximumVisible(IIndicatorViewHandler handler, IIndicatorView indicator) => handler.PlatformView?.CreateIndicators();
-		public static void MapIndicatorSize(IIndicatorViewHandler handler, IIndicatorView indicator) => handler.PlatformView?.CreateIndicators();
-		public static void MapIndicatorColor(IIndicatorViewHandler handler, IIndicatorView indicator) => handler.PlatformView?.UpdateIndicatorsColor();
-		public static void MapSelectedIndicatorColor(IIndicatorViewHandler handler, IIndicatorView indicator) => handler.PlatformView?.UpdateIndicatorsColor();
-		public static void MapIndicatorShape(IIndicatorViewHandler handler, IIndicatorView indicator) => handler.PlatformView?.CreateIndicators();
+		public static void MapCount(IIndicatorViewHandler handler, IIndicatorView indicator) => GetMauiPageControl(handler)?.CreateIndicators();
+		public static void MapPosition(IIndicatorViewHandler handler, IIndicatorView indicator) => GetMauiPageControl(handler)?.UpdateIndicatorsColor();
+		public static void MapHideSingle(IIndicatorViewHandler handler, IIndicatorView indicator) => GetMauiPageControl(handler)?.CreateIndicators();
+		public static void MapMaximumVisible(IIndicatorViewHandler handler, IIndicatorView indicator) => GetMauiPageControl(handler)?.CreateIndicators();
+		public static void MapIndicatorSize(IIndicatorViewHandler handler, IIndicatorView indicator) => GetMauiPageControl(handler)?.CreateIndicators();
+		public static void MapIndicatorColor(IIndicatorViewHandler handler, IIndicatorView indicator) => GetMauiPageControl(handler)?.UpdateIndicatorsColor();
+		public static void MapSelectedIndicatorColor(IIndicatorViewHandler handler, IIndicatorView indicator) => GetMauiPageControl(handler)?.UpdateIndicatorsColor();
+		public static void MapIndicatorShape(IIndicatorViewHandler handler, IIndicatorView indicator) => GetMauiPageControl(handler)?.CreateIndicators();
 
 		void UpdateIndicator()
 		{
@@ -35,14 +37,15 @@ namespace Microsoft.Maui.Handlers
 				{
 					ClearIndicators();
 					handler = indicatorsLayoutOverride.ToPlatform(MauiContext);
-					if (handler != null)
-						PlatformView.ItemsSource = new ObservableCollection<FrameworkElement>() { handler };
+					var pager = GetMauiPageControl();
+					if (handler != null && pager != null)
+						pager.ItemsSource = new ObservableCollection<FrameworkElement>() { handler };
 				}
 			}
 
 			void ClearIndicators()
 			{
-				PlatformView.Items.Clear();
+				GetMauiPageControl()?.Items.Clear();
 			}
 		}
 	}

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
@@ -1,10 +1,9 @@
-﻿#nullable enable
-#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
+﻿#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UIPageControl;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.iOS.cs
@@ -3,31 +3,31 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, MauiPageControl>
+	public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, UIPageControl>
 	{
-		protected override MauiPageControl CreatePlatformView() => new MauiPageControl();
+		protected override UIPageControl CreatePlatformView() => new MauiPageControl();
 
-		protected override void ConnectHandler(MauiPageControl platformView)
+		protected override void ConnectHandler(UIPageControl platformView)
 		{
 			base.ConnectHandler(platformView);
-			PlatformView?.SetIndicatorView(VirtualView);
+			(PlatformView as MauiPageControl)?.SetIndicatorView(VirtualView);
 			UpdateIndicator();
 		}
 
-		protected override void DisconnectHandler(MauiPageControl platformView)
+		protected override void DisconnectHandler(UIPageControl platformView)
 		{
 			base.DisconnectHandler(platformView);
-			PlatformView?.SetIndicatorView(null);
+			(PlatformView as MauiPageControl)?.SetIndicatorView(null);
 		}
 
 		public static void MapCount(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView?.UpdateIndicatorCount();
+			(handler.PlatformView as MauiPageControl)?.UpdateIndicatorCount();
 		}
 
 		public static void MapPosition(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView?.UpdatePosition();
+			(handler.PlatformView as MauiPageControl)?.UpdatePosition();
 		}
 
 		public static void MapHideSingle(IIndicatorViewHandler handler, IIndicatorView indicator)
@@ -37,12 +37,12 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapMaximumVisible(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView?.UpdateIndicatorCount();
+			(handler.PlatformView as MauiPageControl)?.UpdateIndicatorCount();
 		}
 
 		public static void MapIndicatorSize(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView?.UpdateIndicatorSize(indicator);
+			(handler.PlatformView as MauiPageControl)?.UpdateIndicatorSize(indicator);
 		}
 
 		public static void MapIndicatorColor(IIndicatorViewHandler handler, IIndicatorView indicator)
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapIndicatorShape(IIndicatorViewHandler handler, IIndicatorView indicator)
 		{
-			handler.PlatformView?.UpdateIndicatorShape(indicator);
+			(handler.PlatformView as MauiPageControl)?.UpdateIndicatorShape(indicator);
 		}
 
 		void UpdateIndicator()

--- a/src/Core/src/Handlers/Label/ILabelHandler.cs
+++ b/src/Core/src/Handlers/Label/ILabelHandler.cs
@@ -1,5 +1,5 @@
 ﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiLabel;
+using PlatformView = UIKit.UILabel;
 #elif MONOANDROID
 using PlatformView = AndroidX.AppCompat.Widget.AppCompatTextView;
 #elif WINDOWS

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -1,6 +1,6 @@
 #nullable enable
 #if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiLabel;
+using PlatformView = UIKit.UILabel;
 #elif MONOANDROID
 using PlatformView = AndroidX.AppCompat.Widget.AppCompatTextView;
 #elif WINDOWS

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -1,8 +1,10 @@
+using UIKit;
+
 namespace Microsoft.Maui.Handlers
 {
-	public partial class LabelHandler : ViewHandler<ILabel, MauiLabel>
+	public partial class LabelHandler : ViewHandler<ILabel, UILabel>
 	{
-		protected override MauiLabel CreatePlatformView() => new MauiLabel();
+		protected override UILabel CreatePlatformView() => new MauiLabel();
 
 		public override bool NeedsContainer =>
 			VirtualView?.Background != null ||
@@ -53,7 +55,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapPadding(ILabelHandler handler, ILabel label)
 		{
-			handler.PlatformView?.UpdatePadding(label);
+			(handler.PlatformView as MauiLabel)?.UpdatePadding(label);
 		}
 
 		public static void MapTextDecorations(ILabelHandler handler, ILabel label)

--- a/src/Core/src/Handlers/Picker/IPickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/IPickerHandler.cs
@@ -1,9 +1,9 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiPicker;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiPicker;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.MauiComboBox;
+using PlatformView = Microsoft.UI.Xaml.Controls.ComboBox;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -6,17 +6,21 @@ using Android.Graphics.Drawables;
 using Android.Text;
 using Android.Text.Style;
 using AResource = Android.Resource;
+using Android.Views;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class PickerHandler : ViewHandler<IPicker, MauiPicker>
+	public partial class PickerHandler : ViewHandler<IPicker, Android.Views.View>
 	{
+		MauiPicker? GetMauiPicker() => PlatformView as MauiPicker;
+		static MauiPicker? GetMauiPicker(IPickerHandler handler) => handler.PlatformView as MauiPicker;
+
 		AlertDialog? _dialog;
 
-		protected override MauiPicker CreatePlatformView() =>
+		protected override View CreatePlatformView() =>
 			new MauiPicker(Context);
 
-		protected override void ConnectHandler(MauiPicker platformView)
+		protected override void ConnectHandler(Android.Views.View platformView)
 		{
 			platformView.FocusChange += OnFocusChange;
 			platformView.Click += OnClick;
@@ -27,7 +31,7 @@ namespace Microsoft.Maui.Handlers
 			base.ConnectHandler(platformView);
 		}
 
-		protected override void DisconnectHandler(MauiPicker platformView)
+		protected override void DisconnectHandler(Android.Views.View platformView)
 		{
 			platformView.FocusChange -= OnFocusChange;
 			platformView.Click -= OnClick;
@@ -48,44 +52,44 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapTitle(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateTitle(picker);
+			GetMauiPicker(handler)?.UpdateTitle(picker);
 		}
 
 		public static void MapTitleColor(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateTitleColor(picker);
+			GetMauiPicker(handler)?.UpdateTitleColor(picker);
 		}
 
 		public static void MapSelectedIndex(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateSelectedIndex(picker);
+			GetMauiPicker(handler)?.UpdateSelectedIndex(picker);
 		}
 
 		public static void MapCharacterSpacing(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateCharacterSpacing(picker);
+			GetMauiPicker(handler)?.UpdateCharacterSpacing(picker);
 		}
 
 		public static void MapFont(IPickerHandler handler, IPicker picker)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
-			handler.PlatformView?.UpdateFont(picker, fontManager);
+			GetMauiPicker(handler)?.UpdateFont(picker, fontManager);
 		}
 
 		public static void MapHorizontalTextAlignment(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateHorizontalAlignment(picker.HorizontalTextAlignment);
+			GetMauiPicker(handler)?.UpdateHorizontalAlignment(picker.HorizontalTextAlignment);
 		}
 
 		public static void MapTextColor(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView.UpdateTextColor(picker);
+			GetMauiPicker(handler)?.UpdateTextColor(picker);
 		}
 
 		public static void MapVerticalTextAlignment(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateVerticalAlignment(picker.VerticalTextAlignment);
+			GetMauiPicker(handler)?.UpdateVerticalAlignment(picker.VerticalTextAlignment);
 		}
 
 		void OnFocusChange(object? sender, global::Android.Views.View.FocusChangeEventArgs e)
@@ -130,7 +134,7 @@ namespace Microsoft.Maui.Handlers
 					{
 						var selectedIndex = e.Which;
 						VirtualView.SelectedIndex = selectedIndex;
-						base.PlatformView?.UpdatePicker(VirtualView);
+						GetMauiPicker()?.UpdatePicker(VirtualView);
 					});
 
 					builder.SetNegativeButton(AResource.String.Cancel, (o, args) => { });
@@ -163,7 +167,7 @@ namespace Microsoft.Maui.Handlers
 			if (handler.VirtualView == null || handler.PlatformView == null)
 				return;
 
-			handler.PlatformView.UpdatePicker(handler.VirtualView);
+			GetMauiPicker(handler)?.UpdatePicker(handler.VirtualView);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -3,12 +3,16 @@ using System;
 using System.Collections.Specialized;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.SelectionChangedEventArgs;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
+	public partial class PickerHandler : ViewHandler<IPicker, ComboBox>
 	{
-		protected override MauiComboBox CreatePlatformView()
+		MauiComboBox? GetMauiPicker() => PlatformView as MauiComboBox;
+		static MauiComboBox? GetMauiPicker(IPickerHandler handler) => handler.PlatformView as MauiComboBox;
+
+		protected override ComboBox CreatePlatformView()
 		{
 			var platformPicker = new MauiComboBox();
 
@@ -18,7 +22,7 @@ namespace Microsoft.Maui.Handlers
 			return platformPicker;
 		}
 
-		protected override void ConnectHandler(MauiComboBox platformView)
+		protected override void ConnectHandler(ComboBox platformView)
 		{
 			platformView.SelectionChanged += OnControlSelectionChanged;
 
@@ -26,7 +30,7 @@ namespace Microsoft.Maui.Handlers
 				notifyCollection.CollectionChanged += OnRowsCollectionChanged;
 		}
 
-		protected override void DisconnectHandler(MauiComboBox platformView)
+		protected override void DisconnectHandler(ComboBox platformView)
 		{
 			platformView.SelectionChanged -= OnControlSelectionChanged;
 
@@ -45,17 +49,17 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapTitle(IPickerHandler handler, IPicker picker) 
 		{
-			handler.PlatformView?.UpdateTitle(picker);
+			GetMauiPicker(handler)?.UpdateTitle(picker);
 		}
 
 		public static void MapTitleColor(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateTitle(picker);
+			GetMauiPicker(handler)?.UpdateTitle(picker);
 		}
 
 		public static void MapSelectedIndex(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateSelectedIndex(picker);
+			GetMauiPicker(handler)?.UpdateSelectedIndex(picker);
 		}
 
 		public static void MapCharacterSpacing(IPickerHandler handler, IPicker picker) 
@@ -80,7 +84,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapHorizontalTextAlignment(IPickerHandler handler, IPicker picker)
 		{
-			handler.PlatformView?.UpdateHorizontalTextAlignment(picker);
+			GetMauiPicker(handler)?.UpdateHorizontalTextAlignment(picker);
 		}
 		
 		public static void MapVerticalTextAlignment(IPickerHandler handler, IPicker picker)

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -1,9 +1,9 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiPicker;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiPicker;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.MauiComboBox;
+using PlatformView = Microsoft.UI.Xaml.Controls.ComboBox;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/RadioButton/IRadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/IRadioButtonHandler.cs
@@ -3,7 +3,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentView;
 #elif MONOANDROID
 using PlatformView = Android.Views.View;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.MauiRadioButton;
+using PlatformView = Microsoft.UI.Xaml.Controls.RadioButton;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.Windows.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class RadioButtonHandler : ViewHandler<IRadioButton, MauiRadioButton>
+	public partial class RadioButtonHandler : ViewHandler<IRadioButton, RadioButton>
 	{
 		protected override MauiRadioButton CreatePlatformView() => new MauiRadioButton();
 
-		protected override void ConnectHandler(MauiRadioButton platformView)
+		protected override void ConnectHandler(RadioButton platformView)
 		{
 			platformView.Checked += OnCheckedOrUnchecked;
 			platformView.Unchecked += OnCheckedOrUnchecked;
@@ -14,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 			base.ConnectHandler(platformView);
 		}
 
-		protected override void DisconnectHandler(MauiRadioButton platformView)
+		protected override void DisconnectHandler(RadioButton platformView)
 		{
 			platformView.Checked -= OnCheckedOrUnchecked;
 			platformView.Unchecked -= OnCheckedOrUnchecked;

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
@@ -3,7 +3,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentView;
 #elif MONOANDROID
 using PlatformView = Android.Views.View;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.MauiRadioButton;
+using PlatformView = Microsoft.UI.Xaml.Controls.RadioButton;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/RefreshView/IRefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/IRefreshViewHandler.cs
@@ -1,7 +1,7 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiRefreshView;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiSwipeRefreshLayout;
+using PlatformView = AndroidX.SwipeRefreshLayout.Widget.SwipeRefreshLayout;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.RefreshContainer;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Android.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Android.cs
@@ -1,15 +1,16 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using AndroidX.SwipeRefreshLayout.Widget;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class RefreshViewHandler : ViewHandler<IRefreshView, MauiSwipeRefreshLayout>
+	public partial class RefreshViewHandler : ViewHandler<IRefreshView, SwipeRefreshLayout>
 	{
-		protected override MauiSwipeRefreshLayout CreatePlatformView()
+		protected override SwipeRefreshLayout CreatePlatformView()
 		{
 			return new MauiSwipeRefreshLayout(Context);
 		}
 
-		protected override void ConnectHandler(MauiSwipeRefreshLayout platformView)
+		protected override void ConnectHandler(SwipeRefreshLayout platformView)
 		{
 			base.ConnectHandler(platformView);
 			platformView.Refresh += OnSwipeRefresh;
@@ -20,16 +21,17 @@ namespace Microsoft.Maui.Handlers
 			VirtualView.IsRefreshing = true;
 		}
 
-		protected override void DisconnectHandler(MauiSwipeRefreshLayout platformView)
+		protected override void DisconnectHandler(SwipeRefreshLayout platformView)
 		{
 			// If we're being disconnected from the xplat element, then we should no longer be managing its chidren
 			platformView.Refresh -= OnSwipeRefresh;
-			platformView.UpdateContent(null, null);
+			(platformView as MauiSwipeRefreshLayout)?.UpdateContent(null, null);
 			base.DisconnectHandler(platformView);
 		}
 
 		static void UpdateContent(IRefreshViewHandler handler) =>
-			handler.PlatformView.UpdateContent(handler.VirtualView.Content, handler.MauiContext);
+			(handler.PlatformView as MauiSwipeRefreshLayout)?
+			.UpdateContent(handler.VirtualView.Content, handler.MauiContext);
 
 		static void UpdateRefreshColor(IRefreshViewHandler handler)
 		{

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
@@ -1,7 +1,7 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiRefreshView;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiSwipeRefreshLayout;
+using PlatformView = AndroidX.SwipeRefreshLayout.Widget.SwipeRefreshLayout;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.RefreshContainer;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.iOS.cs
@@ -7,29 +7,34 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class RefreshViewHandler : ViewHandler<IRefreshView, MauiRefreshView>
+	public partial class RefreshViewHandler : ViewHandler<IRefreshView, UIView>
 	{
-		protected override MauiRefreshView CreatePlatformView()
+		MauiRefreshView? GetMauiRefreshView() => PlatformView as MauiRefreshView;
+		static MauiRefreshView? GetMauiRefreshView(IRefreshViewHandler handler) => handler.PlatformView as MauiRefreshView;
+
+		protected override UIView CreatePlatformView()
 		{
 			return new MauiRefreshView();
 		}
 
-		protected override void ConnectHandler(MauiRefreshView platformView)
+		protected override void ConnectHandler(UIView platformView)
 		{
-			platformView.RefreshControl.ValueChanged += OnRefresh;
-      
+			if (platformView is MauiRefreshView refreshView)
+				refreshView.RefreshControl.ValueChanged += OnRefresh;
+
 			base.ConnectHandler(platformView);
 		}
 
-		protected override void DisconnectHandler(MauiRefreshView platformView)
+		protected override void DisconnectHandler(UIView platformView)
 		{
-			platformView.RefreshControl.ValueChanged -= OnRefresh;
-      
+			if (platformView is MauiRefreshView refreshView)
+				refreshView.RefreshControl.ValueChanged -= OnRefresh;
+
 			base.DisconnectHandler(platformView);
 		}
 
 		public static void MapBackground(IRefreshViewHandler handler, IRefreshView view)
-			=> handler.PlatformView.RefreshControl.UpdateBackground(view);
+			=> GetMauiRefreshView(handler)?.RefreshControl?.UpdateBackground(view);
 
 		public static void MapIsRefreshing(IRefreshViewHandler handler, IRefreshView refreshView)
 			=> UpdateIsRefreshing(handler);
@@ -41,7 +46,7 @@ namespace Microsoft.Maui.Handlers
 			=> UpdateRefreshColor(handler);
 
 		public static void MapIsEnabled(IRefreshViewHandler handler, IRefreshView refreshView)
-			=> handler.PlatformView?.UpdateIsEnabled(refreshView.IsEnabled);
+			=> GetMauiRefreshView(handler)?.UpdateIsEnabled(refreshView.IsEnabled);
 
 		void OnRefresh(object? sender, EventArgs e)
 		{
@@ -50,18 +55,19 @@ namespace Microsoft.Maui.Handlers
 
 		static void UpdateIsRefreshing(IRefreshViewHandler handler)
 		{
-			handler.PlatformView.IsRefreshing = handler.VirtualView.IsRefreshing;
+			if (handler.PlatformView is MauiRefreshView refreshView)
+				refreshView.IsRefreshing = handler.VirtualView.IsRefreshing;
 		}
 
 		static void UpdateContent(IRefreshViewHandler handler) =>
-			handler.PlatformView.UpdateContent(handler.VirtualView.Content, handler.MauiContext);
+			GetMauiRefreshView(handler)?.UpdateContent(handler.VirtualView.Content, handler.MauiContext);
 
 		static void UpdateRefreshColor(IRefreshViewHandler handler)
 		{
 			var color = handler.VirtualView?.RefreshColor?.ToColor()?.ToPlatform();
 
-			if (color != null)
-				handler.PlatformView.RefreshControl.TintColor = color;
+			if (color != null && handler.PlatformView is MauiRefreshView refreshView)
+				refreshView.TintColor = color;
 		}
 	}
 }

--- a/src/Core/src/Handlers/ScrollView/IScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/IScrollViewHandler.cs
@@ -1,7 +1,7 @@
 ﻿#if __IOS__ || MACCATALYST
 using PlatformView = UIKit.UIScrollView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiScrollView;
+using PlatformView = AndroidX.Core.Widget.NestedScrollView;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.ScrollViewer;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using Android.Views;
+using AndroidX.Core.Widget;
 using Microsoft.Maui.Graphics;
 using static Microsoft.Maui.Layouts.LayoutExtensions;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ScrollViewHandler : ViewHandler<IScrollView, MauiScrollView>
+	public partial class ScrollViewHandler : ViewHandler<IScrollView, NestedScrollView>
 	{
+		MauiScrollView? GetMauiScrollView() => PlatformView as MauiScrollView;
+		static MauiScrollView? GetMauiScrollView(IScrollViewHandler handler) => handler.PlatformView as MauiScrollView;
+
 		const string InsetPanelTag = "MAUIContentInsetPanel";
 
 		protected override MauiScrollView CreatePlatformView()
@@ -20,13 +24,13 @@ namespace Microsoft.Maui.Handlers
 			return scrollView;
 		}
 
-		protected override void ConnectHandler(MauiScrollView platformView)
+		protected override void ConnectHandler(NestedScrollView platformView)
 		{
 			base.ConnectHandler(platformView);
 			platformView.ScrollChange += ScrollChange;
 		}
 
-		protected override void DisconnectHandler(MauiScrollView platformView)
+		protected override void DisconnectHandler(NestedScrollView platformView)
 		{
 			base.DisconnectHandler(platformView);
 			platformView.ScrollChange -= ScrollChange;
@@ -68,23 +72,23 @@ namespace Microsoft.Maui.Handlers
 			}
 			else
 			{
-				handler.PlatformView.UpdateContent(scrollView.PresentedContent, handler.MauiContext);
+				GetMauiScrollView(handler)?.UpdateContent(scrollView.PresentedContent, handler.MauiContext);
 			}
 		}
 
 		public static void MapHorizontalScrollBarVisibility(IScrollViewHandler handler, IScrollView scrollView)
 		{
-			handler.PlatformView.SetHorizontalScrollBarVisibility(scrollView.HorizontalScrollBarVisibility);
+			GetMauiScrollView(handler)?.SetHorizontalScrollBarVisibility(scrollView.HorizontalScrollBarVisibility);
 		}
 
 		public static void MapVerticalScrollBarVisibility(IScrollViewHandler handler, IScrollView scrollView)
 		{
-			handler.PlatformView.SetVerticalScrollBarVisibility(scrollView.HorizontalScrollBarVisibility);
+			GetMauiScrollView(handler)?.SetVerticalScrollBarVisibility(scrollView.HorizontalScrollBarVisibility);
 		}
 
 		public static void MapOrientation(IScrollViewHandler handler, IScrollView scrollView)
 		{
-			handler.PlatformView.SetOrientation(scrollView.Orientation);
+			GetMauiScrollView(handler)?.SetOrientation(scrollView.Orientation);
 		}
 
 		public static void MapRequestScrollTo(IScrollViewHandler handler, IScrollView scrollView, object? args)
@@ -104,7 +108,7 @@ namespace Microsoft.Maui.Handlers
 			var horizontalOffsetDevice = (int)context.ToPixels(request.HoriztonalOffset);
 			var verticalOffsetDevice = (int)context.ToPixels(request.VerticalOffset);
 
-			handler.PlatformView.ScrollTo(horizontalOffsetDevice, verticalOffsetDevice,
+			GetMauiScrollView(handler)?.ScrollTo(horizontalOffsetDevice, verticalOffsetDevice,
 				request.Instant, () => handler.VirtualView.ScrollFinished());
 		}
 
@@ -189,7 +193,7 @@ namespace Microsoft.Maui.Handlers
 
 			handler.PlatformView.RemoveAllViews();
 			paddingShim.AddView(nativeContent);
-			handler.PlatformView.SetContent(paddingShim);
+			GetMauiScrollView(handler)?.SetContent(paddingShim);
 		}
 
 		static Func<double, double, Size> IncludeScrollViewInsets(Func<double, double, Size> internalMeasure, IScrollView scrollView)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
@@ -3,7 +3,7 @@ using System;
 #if __IOS__ || MACCATALYST
 using PlatformView = UIKit.UIScrollView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiScrollView;
+using PlatformView = AndroidX.Core.Widget.NestedScrollView;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.ScrollViewer;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/SearchBar/ISearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/ISearchBarHandler.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 #if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiSearchBar;
+using PlatformView = UIKit.UISearchBar;
 using QueryEditor = UIKit.UITextField;
 #elif MONOANDROID
 using PlatformView = AndroidX.AppCompat.Widget.SearchView;

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 #if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiSearchBar;
+using PlatformView = UIKit.UISearchBar;
 #elif MONOANDROID
 using PlatformView = AndroidX.AppCompat.Widget.SearchView;
 #elif WINDOWS

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -4,13 +4,13 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class SearchBarHandler : ViewHandler<ISearchBar, MauiSearchBar>
+	public partial class SearchBarHandler : ViewHandler<ISearchBar, UISearchBar>
 	{
 		UITextField? _editor;
 
 		public UITextField? QueryEditor => _editor;
 
-		protected override MauiSearchBar CreatePlatformView()
+		protected override UISearchBar CreatePlatformView()
 		{
 			var searchBar = new MauiSearchBar() { ShowsCancelButton = true, BarStyle = UIBarStyle.Default };
 
@@ -22,11 +22,13 @@ namespace Microsoft.Maui.Handlers
 			return searchBar;
 		}
 
-		protected override void ConnectHandler(MauiSearchBar platformView)
+		protected override void ConnectHandler(UISearchBar platformView)
 		{
 			platformView.CancelButtonClicked += OnCancelClicked;
 			platformView.SearchButtonClicked += OnSearchButtonClicked;
-			platformView.TextSetOrChanged += OnTextPropertySet;
+			if (platformView is MauiSearchBar searchBar)
+				searchBar.TextSetOrChanged += OnTextPropertySet;
+
 			platformView.ShouldChangeTextInRange += ShouldChangeText;
 
 			platformView.OnEditingStarted += OnEditingStarted;
@@ -35,11 +37,14 @@ namespace Microsoft.Maui.Handlers
 			base.ConnectHandler(platformView);
 		}
 
-		protected override void DisconnectHandler(MauiSearchBar platformView)
+		protected override void DisconnectHandler(UISearchBar platformView)
 		{
 			platformView.CancelButtonClicked -= OnCancelClicked;
 			platformView.SearchButtonClicked -= OnSearchButtonClicked;
-			platformView.TextSetOrChanged -= OnTextPropertySet;
+
+			if (platformView is MauiSearchBar searchBar)
+				searchBar.TextSetOrChanged -= OnTextPropertySet;
+
 			platformView.ShouldChangeTextInRange -= ShouldChangeText;
 
 			platformView.OnEditingStarted -= OnEditingStarted;

--- a/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
@@ -1,7 +1,7 @@
 ﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
+using PlatformView = Microsoft.Maui.Graphics.Platform.PlatformGraphicsView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
+using PlatformView = Microsoft.Maui.Graphics.Platform.PlatformGraphicsView;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Android.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ShapeViewHandler : ViewHandler<IShapeView, MauiShapeView>
+	public partial class ShapeViewHandler : ViewHandler<IShapeView, PlatformGraphicsView>
 	{
 		protected override MauiShapeView CreatePlatformView() =>
 			new MauiShapeView(Context);

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
@@ -1,7 +1,7 @@
 ﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
+using PlatformView = Microsoft.Maui.Graphics.Platform.PlatformGraphicsView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
+using PlatformView = Microsoft.Maui.Graphics.Platform.PlatformGraphicsView;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.iOS.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ShapeViewHandler : ViewHandler<IShapeView, MauiShapeView>
+	public partial class ShapeViewHandler : ViewHandler<IShapeView, PlatformGraphicsView>
 	{
-		protected override MauiShapeView CreatePlatformView()
+		protected override PlatformGraphicsView CreatePlatformView()
 		{
 			return new MauiShapeView();
 		}

--- a/src/Core/src/Handlers/Stepper/IStepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/IStepperHandler.cs
@@ -1,9 +1,9 @@
-﻿#if __IOS__ || MACCATALYST
+﻿#if IOS || MACCATALYST
 using PlatformView = UIKit.UIStepper;
 #elif MONOANDROID
-using PlatformView = Android.Widget.LinearLayout;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.MauiStepper;
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/Stepper/StepperHandler.Android.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.Android.cs
@@ -6,7 +6,7 @@ using AOrientation = Android.Widget.Orientation;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class StepperHandler : ViewHandler<IStepper, LinearLayout>, IAndroidStepperHandler
+	public partial class StepperHandler : ViewHandler<IStepper, Android.Views.View>, IAndroidStepperHandler
 	{
 		AButton? _downButton;
 		AButton? _upButton;
@@ -16,11 +16,11 @@ namespace Microsoft.Maui.Handlers
 
 		AButton? IAndroidStepperHandler.DownButton => _downButton;
 
-		protected override LinearLayout CreatePlatformView()
+		protected override Android.Views.View CreatePlatformView()
 		{
-			var stepperLayout = new LinearLayout(Context)
+			var stepperLayout = new MauiStepper(Context)
 			{
-				Orientation = AOrientation.Horizontal,
+				Orientation = (int)AOrientation.Horizontal,
 				Focusable = true,
 				DescendantFocusability = DescendantFocusability.AfterDescendants
 			};
@@ -38,22 +38,22 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapMinimum(IStepperHandler handler, IStepper stepper)
 		{
-			handler.PlatformView?.UpdateMinimum(stepper);
+			(handler.PlatformView as MauiStepper)?.UpdateMinimum(stepper);
 		}
 
 		public static void MapMaximum(IStepperHandler handler, IStepper stepper)
 		{
-			handler.PlatformView?.UpdateMaximum(stepper);
+			(handler.PlatformView as MauiStepper)?.UpdateMaximum(stepper);
 		}
 
 		public static void MapIncrement(IStepperHandler handler, IStepper stepper)
 		{
-			handler.PlatformView?.UpdateIncrement(stepper);
+			(handler.PlatformView as MauiStepper)?.UpdateIncrement(stepper);
 		}
 
 		public static void MapValue(IStepperHandler handler, IStepper stepper)
 		{
-			handler.PlatformView?.UpdateValue(stepper);
+			(handler.PlatformView as MauiStepper)?.UpdateValue(stepper);
 		}
 
 		AButton IAndroidStepperHandler.CreateButton()

--- a/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.Windows.cs
@@ -1,44 +1,49 @@
-﻿#nullable disable
-using System;
+﻿using System;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class StepperHandler : ViewHandler<IStepper, MauiStepper>
+	public partial class StepperHandler : ViewHandler<IStepper, Microsoft.UI.Xaml.FrameworkElement>
 	{
-		protected override MauiStepper CreatePlatformView() => new MauiStepper();
+		MauiStepper? GetMauiStepper() => PlatformView as MauiStepper;
+		static MauiStepper? GetMauiStepper(IStepperHandler handler) => handler.PlatformView as MauiStepper;
 
-		protected override void ConnectHandler(MauiStepper platformView)
+		protected override FrameworkElement CreatePlatformView() => new MauiStepper();
+
+		protected override void ConnectHandler(FrameworkElement platformView)
 		{
-			platformView.ValueChanged += OnValueChanged;
+			if (platformView is MauiStepper mauiStepper)
+				mauiStepper.ValueChanged += OnValueChanged;
 
 			base.ConnectHandler(platformView);
 		}
 
-		protected override void DisconnectHandler(MauiStepper platformView)
+		protected override void DisconnectHandler(FrameworkElement platformView)
 		{
-			platformView.ValueChanged -= OnValueChanged;
+			if (platformView is MauiStepper mauiStepper)
+				mauiStepper.ValueChanged -= OnValueChanged;
 
 			base.DisconnectHandler(platformView);
 		}
 
-		public static void MapMinimum(IStepperHandler handler, IStepper stepper) 
-		{ 
-			handler.PlatformView?.UpdateMinimum(stepper); 
+		public static void MapMinimum(IStepperHandler handler, IStepper stepper)
+		{
+			GetMauiStepper(handler)?.UpdateMinimum(stepper);
 		}
 
-		public static void MapMaximum(IStepperHandler handler, IStepper stepper) 
-		{ 
-			handler.PlatformView?.UpdateMaximum(stepper); 
+		public static void MapMaximum(IStepperHandler handler, IStepper stepper)
+		{
+			GetMauiStepper(handler)?.UpdateMaximum(stepper);
 		}
 
-		public static void MapIncrement(IStepperHandler handler, IStepper stepper) 
-		{ 
-			handler.PlatformView?.UpdateInterval(stepper); 
+		public static void MapIncrement(IStepperHandler handler, IStepper stepper)
+		{
+			GetMauiStepper(handler)?.UpdateInterval(stepper);
 		}
 
-		public static void MapValue(IStepperHandler handler, IStepper stepper) 
-		{ 
-			handler.PlatformView?.UpdateValue(stepper); 
+		public static void MapValue(IStepperHandler handler, IStepper stepper)
+		{
+			GetMauiStepper(handler)?.UpdateValue(stepper);
 		}
 
 		// This is a Windows-specific mapping
@@ -47,12 +52,13 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateBackground(view);
 		}
 
-		void OnValueChanged(object sender, EventArgs e)
+		void OnValueChanged(object? sender, EventArgs e)
 		{
 			if (VirtualView == null || PlatformView == null)
 				return;
 
-			VirtualView.Value = PlatformView.Value;
+			if (PlatformView is MauiStepper mauiStepper)
+				VirtualView.Value = mauiStepper.Value;
 		}
 	}
 }

--- a/src/Core/src/Handlers/Stepper/StepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.cs
@@ -1,9 +1,9 @@
-﻿#if __IOS__ || MACCATALYST
+﻿#if IOS || MACCATALYST
 using PlatformView = UIKit.UIStepper;
 #elif MONOANDROID
-using PlatformView = Android.Widget.LinearLayout;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
-using PlatformView = Microsoft.Maui.Platform.MauiStepper;
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/SwipeView/ISwipeViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeView/ISwipeViewHandler.cs
@@ -1,7 +1,7 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeControl;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/SwipeView/SwipeViewHandler.Android.cs
+++ b/src/Core/src/Handlers/SwipeView/SwipeViewHandler.Android.cs
@@ -4,6 +4,9 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class SwipeViewHandler : ViewHandler<ISwipeView, MauiSwipeView>
 	{
+		MauiSwipeView? GetMauiSwipeView() => PlatformView as MauiSwipeView;
+		static MauiSwipeView? GetMauiSwipeView(ISwipeViewHandler handler) => handler.PlatformView as MauiSwipeView;
+
 		protected override MauiSwipeView CreatePlatformView()
 		{
 			var returnValue = new MauiSwipeView(Context)
@@ -45,26 +48,26 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			handler.PlatformView.UpdateContent();
+			GetMauiSwipeView(handler)?.UpdateContent();
 		}
 
 		public static void MapIsEnabled(ISwipeViewHandler handler, ISwipeView swipeView)
 		{
-			handler.PlatformView.UpdateIsSwipeEnabled(swipeView.IsEnabled);
+			GetMauiSwipeView(handler)?.UpdateIsSwipeEnabled(swipeView.IsEnabled);
 			ViewHandler.MapIsEnabled(handler, swipeView);
 		}
 
 		public static void MapBackground(ISwipeViewHandler handler, ISwipeView swipeView)
 		{
 			if (swipeView.Background == null)
-				handler.PlatformView.Control?.SetWindowBackground();
+				GetMauiSwipeView(handler)?.Control?.SetWindowBackground();
 			else
 				ViewHandler.MapBackground(handler, swipeView);
 		}
 
 		public static void MapSwipeTransitionMode(ISwipeViewHandler handler, ISwipeView swipeView)
 		{
-			handler.PlatformView.UpdateSwipeTransitionMode(swipeView.SwipeTransitionMode);
+			GetMauiSwipeView(handler)?.UpdateSwipeTransitionMode(swipeView.SwipeTransitionMode);
 		}
 
 		public static void MapRequestOpen(ISwipeViewHandler handler, ISwipeView swipeView, object? args)
@@ -74,7 +77,7 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			handler.PlatformView.OnOpenRequested(request);
+			GetMauiSwipeView(handler)?.OnOpenRequested(request);
 		}
 
 		public static void MapRequestClose(ISwipeViewHandler handler, ISwipeView swipeView, object? args)
@@ -84,7 +87,7 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			handler.PlatformView.OnCloseRequested(request);
+			GetMauiSwipeView(handler)?.OnCloseRequested(request);
 		}
 	}
 }

--- a/src/Core/src/Handlers/SwipeView/SwipeViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeView/SwipeViewHandler.cs
@@ -1,7 +1,7 @@
 #if IOS || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
-#elif ANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
+using PlatformView = UIKit.UIView;
+#elif MONOANDROID
+using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeControl;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/SwipeView/SwipeViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/SwipeView/SwipeViewHandler.iOS.cs
@@ -4,9 +4,12 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class SwipeViewHandler : ViewHandler<ISwipeView, MauiSwipeView>
+	public partial class SwipeViewHandler : ViewHandler<ISwipeView, UIView>
 	{
-		protected override MauiSwipeView CreatePlatformView()
+		MauiSwipeView? GetMauiSwipeView() => PlatformView as MauiSwipeView;
+		static MauiSwipeView? GetMauiSwipeView(ISwipeViewHandler handler) => handler.PlatformView as MauiSwipeView;
+
+		protected override UIView CreatePlatformView()
 		{
 			return new MauiSwipeView
 			{
@@ -21,9 +24,12 @@ namespace Microsoft.Maui.Handlers
 			base.SetVirtualView(view);
 			_ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");
 
-			PlatformView.Element = VirtualView;
-			PlatformView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
-			PlatformView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
+			if (PlatformView is MauiSwipeView swipeView)
+			{
+				swipeView.Element = VirtualView;
+				swipeView.CrossPlatformMeasure = VirtualView.CrossPlatformMeasure;
+				swipeView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
+			}
 		}
 
 		public static void MapContent(ISwipeViewHandler handler, ISwipeView view)
@@ -32,18 +38,18 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 			_ = handler.VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} should have been set by base class.");
 
-			handler.PlatformView.UpdateContent(view, handler.MauiContext);
+			GetMauiSwipeView(handler)?.UpdateContent(view, handler.MauiContext);
 		}
 
 		public static void MapIsEnabled(ISwipeViewHandler handler, ISwipeView swipeView)
 		{
-			handler.PlatformView.UpdateIsSwipeEnabled(swipeView);
+			GetMauiSwipeView(handler)?.UpdateIsSwipeEnabled(swipeView);
 			ViewHandler.MapIsEnabled(handler, swipeView);
 		}
 
 		public static void MapSwipeTransitionMode(ISwipeViewHandler handler, ISwipeView swipeView)
 		{
-			handler.PlatformView.UpdateSwipeTransitionMode(swipeView.SwipeTransitionMode);
+			GetMauiSwipeView(handler)?.UpdateSwipeTransitionMode(swipeView.SwipeTransitionMode);
 		}
 
 		public static void MapRequestOpen(ISwipeViewHandler handler, ISwipeView swipeView, object? args)
@@ -53,7 +59,7 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
-			handler.PlatformView.ProgrammaticallyOpenSwipeItem(request.OpenSwipeItem, request.Animated);
+			GetMauiSwipeView(handler)?.ProgrammaticallyOpenSwipeItem(request.OpenSwipeItem, request.Animated);
 		}
 
 		public static void MapRequestClose(ISwipeViewHandler handler, ISwipeView swipeView, object? args)
@@ -62,7 +68,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				return;
 			}
-			handler.PlatformView.ResetSwipe(request.Animated);
+			GetMauiSwipeView(handler)?.ResetSwipe(request.Animated);
 		}
 
 		public static void MapLeftItems(ISwipeViewHandler handler, ISwipeView view)

--- a/src/Core/src/Handlers/TimePicker/ITimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/ITimePickerHandler.cs
@@ -1,7 +1,7 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.TimePicker;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.Android.cs
@@ -3,11 +3,15 @@ using Android.App;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
 using Android.Text.Format;
+using Android.Views;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class TimePickerHandler : ViewHandler<ITimePicker, MauiTimePicker>
+	public partial class TimePickerHandler : ViewHandler<ITimePicker, View>
 	{
+		MauiTimePicker? GetMauiTimePicker() => PlatformView as MauiTimePicker;
+		static MauiTimePicker? GetMauiTimePicker(ITimePickerHandler handler) => handler.PlatformView as MauiTimePicker;
+
 		MauiTimePicker? _timePicker;
 		AlertDialog? _dialog;
 
@@ -22,7 +26,7 @@ namespace Microsoft.Maui.Handlers
 			return _timePicker;
 		}
 
-		protected override void DisconnectHandler(MauiTimePicker platformView)
+		protected override void DisconnectHandler(View platformView)
 		{
 			if (_dialog != null)
 			{
@@ -60,29 +64,29 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapFormat(ITimePickerHandler handler, ITimePicker timePicker)
 		{
-			handler.PlatformView?.UpdateFormat(timePicker);
+			GetMauiTimePicker(handler)?.UpdateFormat(timePicker);
 		}
 
 		public static void MapTime(ITimePickerHandler handler, ITimePicker timePicker)
 		{
-			handler.PlatformView?.UpdateTime(timePicker);
+			GetMauiTimePicker(handler)?.UpdateTime(timePicker);
 		}
 
 		public static void MapCharacterSpacing(ITimePickerHandler handler, ITimePicker timePicker)
 		{
-			handler.PlatformView?.UpdateCharacterSpacing(timePicker);
+			GetMauiTimePicker(handler)?.UpdateCharacterSpacing(timePicker);
 		}
 
 		public static void MapFont(ITimePickerHandler handler, ITimePicker timePicker)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
-			handler.PlatformView?.UpdateFont(timePicker, fontManager);
+			GetMauiTimePicker(handler)?.UpdateFont(timePicker, fontManager);
 		}
 
 		public static void MapTextColor(ITimePickerHandler handler, ITimePicker timePicker)
 		{
-			handler.PlatformView?.UpdateTextColor(timePicker);
+			GetMauiTimePicker(handler)?.UpdateTextColor(timePicker);
 		}
 
 		void ShowPickerDialog()

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
@@ -1,7 +1,7 @@
-﻿#if __IOS__ || MACCATALYST
-using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
+﻿#if IOS || MACCATALYST
+using PlatformView = UIKit.UIView;
 #elif MONOANDROID
-using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
+using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.TimePicker;
 #elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.iOS.cs
@@ -3,9 +3,12 @@ using UIKit;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class TimePickerHandler : ViewHandler<ITimePicker, MauiTimePicker>
+	public partial class TimePickerHandler : ViewHandler<ITimePicker, UIView>
 	{
-		protected override MauiTimePicker CreatePlatformView()
+		MauiTimePicker? GetMauiTimePicker() => PlatformView as MauiTimePicker;
+		static MauiTimePicker? GetMauiTimePicker(ITimePickerHandler handler) => handler.PlatformView as MauiTimePicker;
+
+		protected override UIView CreatePlatformView()
 		{
 			return new MauiTimePicker(() =>
 			{
@@ -14,32 +17,32 @@ namespace Microsoft.Maui.Handlers
 			});
 		}
 
-		protected override void ConnectHandler(MauiTimePicker platformView)
+		protected override void ConnectHandler(UIView platformView)
 		{
 			base.ConnectHandler(platformView);
 
-			if (platformView != null)
+			if (platformView is MauiTimePicker picker)
 			{
-				platformView.EditingDidBegin += OnStarted;
-				platformView.EditingDidEnd += OnEnded;
-				platformView.ValueChanged += OnValueChanged;
-				platformView.DateSelected += OnDateSelected;	
-				platformView.UpdateTime(VirtualView.Time);
+				picker.EditingDidBegin += OnStarted;
+				picker.EditingDidEnd += OnEnded;
+				picker.ValueChanged += OnValueChanged;
+				picker.DateSelected += OnDateSelected;
+				picker.UpdateTime(VirtualView.Time);
 			}
 		}
 
-		protected override void DisconnectHandler(MauiTimePicker platformView)
+		protected override void DisconnectHandler(UIView platformView)
 		{
 			base.DisconnectHandler(platformView);
 
-			if (platformView != null)
+			if (platformView is MauiTimePicker picker)
 			{
 				platformView.RemoveFromSuperview();
 
-				platformView.EditingDidBegin -= OnStarted;
-				platformView.EditingDidEnd -= OnEnded;
-				platformView.ValueChanged -= OnValueChanged;
-				platformView.DateSelected -= OnDateSelected;
+				picker.EditingDidBegin -= OnStarted;
+				picker.EditingDidEnd -= OnEnded;
+				picker.ValueChanged -= OnValueChanged;
+				picker.DateSelected -= OnDateSelected;
 
 				platformView.Dispose();
 			}
@@ -47,35 +50,35 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapFormat(ITimePickerHandler handler, ITimePicker timePicker)
 		{
-			handler.PlatformView?.UpdateFormat(timePicker, handler.PlatformView?.Picker);
+			GetMauiTimePicker(handler)?.UpdateFormat(timePicker, GetMauiTimePicker(handler)?.Picker);
 		}
 
 		public static void MapTime(ITimePickerHandler handler, ITimePicker timePicker)
 		{
-			handler.PlatformView?.UpdateTime(timePicker, handler.PlatformView?.Picker);
+			GetMauiTimePicker(handler)?.UpdateTime(timePicker, GetMauiTimePicker(handler)?.Picker);
 		}
 
 		public static void MapCharacterSpacing(ITimePickerHandler handler, ITimePicker timePicker)
 		{
-			handler.PlatformView?.UpdateCharacterSpacing(timePicker);
+			GetMauiTimePicker(handler)?.UpdateCharacterSpacing(timePicker);
 		}
 
 		public static void MapFont(ITimePickerHandler handler, ITimePicker timePicker)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
-			handler.PlatformView?.UpdateFont(timePicker, fontManager);
+			GetMauiTimePicker(handler)?.UpdateFont(timePicker, fontManager);
 		}
 
 		public static void MapTextColor(ITimePickerHandler handler, ITimePicker timePicker)
 		{
-			handler.PlatformView?.UpdateTextColor(timePicker);
+			GetMauiTimePicker(handler)?.UpdateTextColor(timePicker);
 		}
 
 		public static void MapFlowDirection(TimePickerHandler handler, ITimePicker timePicker)
 		{
 			handler.PlatformView?.UpdateFlowDirection(timePicker);
-			handler.PlatformView?.UpdateTextAlignment(timePicker);
+			GetMauiTimePicker(handler)?.UpdateTextAlignment(timePicker);
 		}
 
 		void OnStarted(object? sender, EventArgs eventArgs)
@@ -105,8 +108,11 @@ namespace Microsoft.Maui.Handlers
 			if (VirtualView == null || PlatformView == null)
 				return;
 
-			var datetime = PlatformView.Date.ToDateTime();
-			VirtualView.Time = new TimeSpan(datetime.Hour, datetime.Minute, 0);
+			if (PlatformView is MauiTimePicker timePicker)
+			{
+				var datetime = timePicker.Date.ToDateTime();
+				VirtualView.Time = new TimeSpan(datetime.Hour, datetime.Minute, 0);
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiStepper.cs
+++ b/src/Core/src/Platform/Android/MauiStepper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.Content;
+using AndroidX.AppCompat.Widget;
+
+namespace Microsoft.Maui.Platform
+{
+	public class MauiStepper : LinearLayoutCompat
+	{
+		public MauiStepper(Context context) : base(context)
+		{
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/ShapeViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ShapeViewExtensions.cs
@@ -1,15 +1,16 @@
 ﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Platform
 {
 	public static class ShapeViewExtensions
 	{
-		public static void UpdateShape(this MauiShapeView platformView, IShapeView shapeView)
+		public static void UpdateShape(this PlatformGraphicsView platformView, IShapeView shapeView)
 		{
 			platformView.Drawable = new ShapeDrawable(shapeView);
 		}
 
-		public static void InvalidateShape(this MauiShapeView platformView, IShapeView shapeView)
+		public static void InvalidateShape(this PlatformGraphicsView platformView, IShapeView shapeView)
 		{
 			platformView.Invalidate();
 		}

--- a/src/Core/src/Platform/Android/StepperExtensions.cs
+++ b/src/Core/src/Platform/Android/StepperExtensions.cs
@@ -5,32 +5,32 @@ namespace Microsoft.Maui.Platform
 {
 	public static class StepperExtensions
 	{
-		public static void UpdateMinimum(this LinearLayout linearLayout, IStepper stepper)
+		public static void UpdateMinimum(this MauiStepper linearLayout, IStepper stepper)
 		{
 			UpdateButtons(linearLayout, stepper);
 		}
 
-		public static void UpdateMaximum(this LinearLayout linearLayout, IStepper stepper)
+		public static void UpdateMaximum(this MauiStepper linearLayout, IStepper stepper)
 		{
 			UpdateButtons(linearLayout, stepper);
 		}
 
-		public static void UpdateIncrement(this LinearLayout linearLayout, IStepper stepper)
+		public static void UpdateIncrement(this MauiStepper linearLayout, IStepper stepper)
 		{
 			UpdateButtons(linearLayout, stepper);
 		}
 
-		public static void UpdateValue(this LinearLayout linearLayout, IStepper stepper)
+		public static void UpdateValue(this MauiStepper linearLayout, IStepper stepper)
 		{
 			UpdateButtons(linearLayout, stepper);
 		}
 
-		public static void UpdateIsEnabled(this LinearLayout linearLayout, IStepper stepper)
+		public static void UpdateIsEnabled(this MauiStepper linearLayout, IStepper stepper)
 		{
 			UpdateButtons(linearLayout, stepper);
 		}
 
-		internal static void UpdateButtons(this LinearLayout linearLayout, IStepper stepper)
+		internal static void UpdateButtons(this MauiStepper linearLayout, IStepper stepper)
 		{
 			AButton? downButton = null;
 			AButton? upButton = null;

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Platform
 
 		public MauiNavigationView()
 		{
+
 		}
 
 		protected override void OnApplyTemplate()

--- a/src/Core/src/Platform/iOS/ActivityIndicatorExtensions.cs
+++ b/src/Core/src/Platform/iOS/ActivityIndicatorExtensions.cs
@@ -1,8 +1,10 @@
-﻿namespace Microsoft.Maui.Platform
+﻿using UIKit;
+
+namespace Microsoft.Maui.Platform
 {
 	public static class ActivityIndicatorExtensions
 	{
-		public static void UpdateIsRunning(this MauiActivityIndicator activityIndicatorView, IActivityIndicator activityIndicator)
+		public static void UpdateIsRunning(this UIActivityIndicatorView activityIndicatorView, IActivityIndicator activityIndicator)
 		{
 			if (activityIndicator.IsRunning)
 				activityIndicatorView.StartAnimating();
@@ -10,7 +12,7 @@
 				activityIndicatorView.StopAnimating();
 		}
 
-		public static void UpdateColor(this MauiActivityIndicator activityIndicatorView, IActivityIndicator activityIndicator)
+		public static void UpdateColor(this UIActivityIndicatorView activityIndicatorView, IActivityIndicator activityIndicator)
 			=> activityIndicatorView.Color = activityIndicator.Color?.ToPlatform();
 	}
 }

--- a/src/Core/src/Platform/iOS/ShapeViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ShapeViewExtensions.cs
@@ -1,15 +1,16 @@
 ﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
 
 namespace Microsoft.Maui.Platform
 {
 	public static class ShapeViewExtensions
 	{
-		public static void UpdateShape(this MauiShapeView platformView, IShapeView shapeView)
+		public static void UpdateShape(this PlatformGraphicsView platformView, IShapeView shapeView)
 		{
 			platformView.Drawable = new ShapeDrawable(shapeView);
 		}
 
-		public static void InvalidateShape(this MauiShapeView platformView, IShapeView shapeView)
+		public static void InvalidateShape(this PlatformGraphicsView platformView, IShapeView shapeView)
 		{
 			platformView.InvalidateDrawable();
 		}


### PR DESCRIPTION
### Description of Change

- If the control has a platform representation I just used that `MauiLabel => UiLabel`
- If the control was something we mostly made up then I just used the base view of the platform `MauiPicker => Android.Views.View`


