### PR TITLE
Fix ImageConverter

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/ImageConverter.cs
+++ b/src/Controls/src/Core/Platform/Windows/ImageConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls.Platform
 			IMauiContext context = source.FindMauiContext(true);
 			IImageSourceServiceProvider imageSourceServiceProvider = context.Services.GetRequiredService<IImageSourceServiceProvider>();
 			IImageSourceService imageSourceService = imageSourceServiceProvider.GetImageSourceService(source);
-			return imageSourceService.GetImageSourceAsync(source).Result;
+			return imageSourceService.GetImageSourceAsync(source).ContinueWith(task => task.Result.Value).AsAsyncValue();
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/src/Controls/src/Core/Platform/Windows/ImageConverter.cs
+++ b/src/Controls/src/Core/Platform/Windows/ImageConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls.Platform
@@ -8,9 +9,16 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{
-			return value is ImageSource source
-				? source.ToIconSource(source.FindMauiContext())?.CreateIconElement()
-				: null;
+			ImageSource source = value as ImageSource;
+			if (source == null)
+			{
+				return null;
+			}
+
+			IMauiContext context = source.FindMauiContext(true);
+			IImageSourceServiceProvider imageSourceServiceProvider = context.Services.GetRequiredService<IImageSourceServiceProvider>();
+			IImageSourceService imageSourceService = imageSourceServiceProvider.GetImageSourceService(source);
+			return imageSourceService.GetImageSourceAsync(source).Result;
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/src/Controls/src/Core/Platform/Windows/ImageConverter.cs
+++ b/src/Controls/src/Core/Platform/Windows/ImageConverter.cs
@@ -9,16 +9,11 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{
-			ImageSource source = value as ImageSource;
-			if (source == null)
-			{
+			if (value is not ImageSource source)
 				return null;
-			}
 
-			IMauiContext context = source.FindMauiContext(true);
-			IImageSourceServiceProvider imageSourceServiceProvider = context.Services.GetRequiredService<IImageSourceServiceProvider>();
-			IImageSourceService imageSourceService = imageSourceServiceProvider.GetImageSourceService(source);
-			return imageSourceService.GetImageSourceAsync(source).ContinueWith(task => task.Result.Value).AsAsyncValue();
+			var context = source.FindMauiContext(true);
+			return source.GetPlatformImageAsync(context).ContinueWith(task => task.Result.Value).AsAsyncValue();
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
### Description of Change

We accidentally changed the `ImageConverter` in https://github.com/dotnet/maui/commit/5e8e41a691d0c8b8ca759c182e6ae89ea3d5c3a3 such that it no longer converts a MAUI ImageSource to a Windows ImageSource.

A Windows ImageSource is required because it is bind to the `Source` of a Windows Image [here](https://github.com/dotnet/maui/blob/d497f0a1eafe5269b0d0b956667c7e393bf29696/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Windows.cs#L52).

This change fixed the ImageConverter so it performs the correct conversion, now it works to show all 3 icons.

### Issues Fixed

Fixes #5452