### PR TITLE
Ensure that DispatchTimer is re-started if Start() is called again. (on Windows)

### DIFF
--- a/src/Core/src/Dispatching/Dispatcher.Windows.cs
+++ b/src/Core/src/Dispatching/Dispatcher.Windows.cs
@@ -35,20 +35,18 @@ namespace Microsoft.Maui.Dispatching
 
 		IDispatcherTimer CreateTimerImplementation()
 		{
-			return new DispatcherTimer(_dispatcherQueue);
+			return new DispatcherTimer(_dispatcherQueue.CreateTimer());
 		}
 	}
 
 	partial class DispatcherTimer : IDispatcherTimer
 	{
-		readonly DispatcherQueue _dispatcherQueue;
-		DispatcherQueueTimer _timer;
-		bool _started;
+		readonly DispatcherQueueTimer _timer;
 
-		public DispatcherTimer(DispatcherQueue queue)
+		public DispatcherTimer(DispatcherQueueTimer timer)
 		{
-			_dispatcherQueue = queue;
-			_timer = _dispatcherQueue.CreateTimer();
+			_timer = timer;
+			_timer.Tick += OnTimerTick;
 		}
 
 		public TimeSpan Interval
@@ -72,22 +70,6 @@ namespace Microsoft.Maui.Dispatching
 			if (IsRunning)
 				return;
 
-			if (_started)
-			{
-				// if we Start a timer that has already finished, it will immediately fire.
-				// to ensure that Start restarts the timer, we need to replace it.
-				var newTimer = _dispatcherQueue.CreateTimer();
-				newTimer.Interval = Interval;
-				newTimer.IsRepeating = IsRepeating;
-				_timer = newTimer;
-			}
-			else
-			{
-				_started = true;
-			}
-
-			_timer.Tick += OnTimerTick;
-
 			_timer.Start();
 		}
 
@@ -95,8 +77,6 @@ namespace Microsoft.Maui.Dispatching
 		{
 			if (!IsRunning)
 				return;
-
-			_timer.Tick -= OnTimerTick;
 
 			_timer.Stop();
 		}


### PR DESCRIPTION
### Description of Change

When we call `Start()` on a timer that has run before, we expect a restart behavior. 
However, if we reuse the underlying `DispatcherQueueTimer` instance, it will fire right away. 
There appears to be no way to reset the underlying timer, so we need to replace it if we want to start again.

### Issues Fixed

Fixes #5335
