### PR TITLE
Fix drawing issues related with clipping views or drawing shadows

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShadowPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShadowPage.xaml
@@ -35,10 +35,10 @@
                 FontSize="Large"
                 Text="Label with a Shadow">
                 <Label.Shadow>
-                    <Shadow Brush="{Binding Source={x:Reference ShadowColor}, Path=Text, Converter={StaticResource cnvStringToBrush} }"
-                            Radius="{Binding Source={x:Reference ShadowRadiusSlider}, Path=Value }"
-                            Opacity="{Binding Source={x:Reference ShadowOpacitySlider}, Path=Value }"
-                            />
+                    <Shadow 
+                        Brush="{Binding Source={x:Reference ShadowColor}, Path=Text, Converter={StaticResource cnvStringToBrush} }"
+                        Radius="{Binding Source={x:Reference ShadowRadiusSlider}, Path=Value }"
+                        Opacity="{Binding Source={x:Reference ShadowOpacitySlider}, Path=Value }"/>
                 </Label.Shadow>
             </Label>
             <Label
@@ -57,11 +57,10 @@
                 Stroke="{Binding Source={x:Reference FillColor}, Path=Text, Converter={StaticResource cnvStringToBrush} }"
                 >
                 <Rectangle.Shadow>
-                    <Shadow 
-                            Brush="{Binding Source={x:Reference ShadowColor}, Path=Text, Converter={StaticResource cnvStringToBrush} }"
-                            Radius="{Binding Source={x:Reference ShadowRadiusSlider}, Path=Value }"
-                            Opacity="{Binding Source={x:Reference ShadowOpacitySlider}, Path=Value }"
-                            />
+                    <Shadow    
+                        Brush="{Binding Source={x:Reference ShadowColor}, Path=Text, Converter={StaticResource cnvStringToBrush} }"
+                        Radius="{Binding Source={x:Reference ShadowRadiusSlider}, Path=Value }"
+                        Opacity="{Binding Source={x:Reference ShadowOpacitySlider}, Path=Value }"/>
                 </Rectangle.Shadow>
             </Rectangle>
             <Label
@@ -82,10 +81,10 @@
                         RadiusY="50"/>
                 </Image.Clip>
                 <Image.Shadow>
-                    <Shadow Brush="{Binding Source={x:Reference ShadowColor}, Path=Text, Converter={StaticResource cnvStringToBrush} }"
-                            Radius="{Binding Source={x:Reference ShadowRadiusSlider}, Path=Value }"
-                            Opacity="{Binding Source={x:Reference ShadowOpacitySlider}, Path=Value }"
-                            />
+                    <Shadow 
+                        Brush="{Binding Source={x:Reference ShadowColor}, Path=Text, Converter={StaticResource cnvStringToBrush} }"
+                        Radius="{Binding Source={x:Reference ShadowRadiusSlider}, Path=Value }"
+                        Opacity="{Binding Source={x:Reference ShadowOpacitySlider}, Path=Value }"/>
                 </Image.Shadow>
             </Image>
             <Label

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShadowPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShadowPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 

--- a/src/Controls/src/Core/Shapes/EllipseGeometry.cs
+++ b/src/Controls/src/Core/Shapes/EllipseGeometry.cs
@@ -55,10 +55,18 @@ namespace Microsoft.Maui.Controls.Shapes
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='AppendPath']/Docs" />
 		public override void AppendPath(PathF path)
 		{
-			var radiusX = (float)RadiusX;
-			var radiusY = (float)RadiusY;
+			double density = 1.0d;
+#if ANDROID
+			density = Essentials.DeviceDisplay.MainDisplayInfo.Density;
+#endif
 
-			path.AppendEllipse((float)Center.X - radiusX, (float)Center.Y - radiusY, radiusX * 2f, radiusY * 2f);
+			var centerX = (float)(density * RadiusX);
+			var centerY = (float)(density * RadiusY);
+
+			var radiusX = (float)(density * RadiusX);
+			var radiusY = (float)(density * RadiusY);
+				
+			path.AppendEllipse(centerX - radiusX, centerY - radiusY, radiusX * 2f, radiusY * 2f);
 		}
 	}
 }

--- a/src/Controls/src/Core/Shapes/LineGeometry.cs
+++ b/src/Controls/src/Core/Shapes/LineGeometry.cs
@@ -43,8 +43,19 @@ namespace Microsoft.Maui.Controls.Shapes
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='AppendPath']/Docs" />
 		public override void AppendPath(PathF path)
 		{
-			path.Move((float)StartPoint.X, (float)StartPoint.Y);
-			path.LineTo((float)EndPoint.X, (float)EndPoint.Y);
+			double density = 1.0d;
+#if ANDROID
+			density = Essentials.DeviceDisplay.MainDisplayInfo.Density;
+#endif
+
+			float startPointX = (float)(density * StartPoint.X);
+			float startPointY = (float)(density * StartPoint.Y);
+
+			float endPointX = (float)(density * EndPoint.X);
+			float endPointY = (float)(density * EndPoint.Y);
+
+			path.Move(startPointX, startPointY);
+			path.LineTo(endPointX, endPointY);
 		}
 	}
 }

--- a/src/Controls/src/Core/Shapes/PathGeometry.cs
+++ b/src/Controls/src/Core/Shapes/PathGeometry.cs
@@ -51,26 +51,34 @@ namespace Microsoft.Maui.Controls.Shapes
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='AppendPath']/Docs" />
 		public override void AppendPath(PathF path)
 		{
+			double density = 1.0d;
+#if ANDROID
+			density = Essentials.DeviceDisplay.MainDisplayInfo.Density;
+#endif
+
 			foreach (var figure in Figures)
 			{
-				path.MoveTo(figure.StartPoint);
+				float startPointX = (float)(density * figure.StartPoint.X);
+				float startPointY = (float)(density * figure.StartPoint.Y);
+
+				path.MoveTo(startPointX, startPointY);
 
 				foreach (var segment in figure.Segments)
 				{
 					if (segment is ArcSegment arcSegment)
-						AddArc(path, arcSegment);
+						AddArc(path, arcSegment, density);
 					else if (segment is BezierSegment bezierSegment)
-						AddBezier(path, bezierSegment);
+						AddBezier(path, bezierSegment, density);
 					else if (segment is LineSegment lineSegment)
-						AddLine(path, lineSegment);
+						AddLine(path, lineSegment, density);
 					else if (segment is PolyBezierSegment polyBezierSegment)
-						AddPolyBezier(path, polyBezierSegment);
+						AddPolyBezier(path, polyBezierSegment, density);
 					else if (segment is PolyLineSegment polyLineSegment)
-						AddPolyLine(path, polyLineSegment);
+						AddPolyLine(path, polyLineSegment, density);
 					else if (segment is PolyQuadraticBezierSegment polyQuadraticBezierSegment)
-						AddPolyQuad(path, polyQuadraticBezierSegment);
+						AddPolyQuad(path, polyQuadraticBezierSegment, density);
 					else if (segment is QuadraticBezierSegment quadraticBezierSegment)
-						AddQuad(path, quadraticBezierSegment);
+						AddQuad(path, quadraticBezierSegment, density);
 				}
 
 				if (figure.IsClosed)
@@ -78,59 +86,64 @@ namespace Microsoft.Maui.Controls.Shapes
 			}
 		}
 
-		void AddArc(PathF path, ArcSegment arcSegment)
+		void AddArc(PathF path, ArcSegment arcSegment, double density)
 		{
 			path.AddArc(
-				(float)arcSegment.Point.X,
-				(float)arcSegment.Point.Y,
-				(float)arcSegment.Point.X + (float)arcSegment.Size.Width,
-				(float)arcSegment.Point.Y + (float)arcSegment.Size.Height,
-				(float)arcSegment.RotationAngle,
-				(float)arcSegment.RotationAngle,
+				(float)(density * arcSegment.Point.X),
+				(float)(density * arcSegment.Point.Y),
+				(float)(density * arcSegment.Point.X + density * arcSegment.Size.Width),
+				(float)(density * arcSegment.Point.Y + density * arcSegment.Size.Height),
+				(float)(density * arcSegment.RotationAngle),
+				(float)(density * arcSegment.RotationAngle),
 				arcSegment.SweepDirection == SweepDirection.Clockwise);
 		}
 
-		void AddLine(PathF path, LineSegment lineSegment)
+		void AddLine(PathF path, LineSegment lineSegment, double density)
 		{
-			path.LineTo((float)lineSegment.Point.X, (float)lineSegment.Point.Y);
+			path.LineTo(
+				(float)(density * lineSegment.Point.X), 
+				(float)(density * lineSegment.Point.Y));
 		}
 
-		void AddPolyLine(PathF path, PolyLineSegment polyLineSegment)
+		void AddPolyLine(PathF path, PolyLineSegment polyLineSegment, double density)
 		{
 			foreach (var p in polyLineSegment.Points)
-				path.LineTo((float)p.X, (float)p.Y);
+				path.LineTo(
+					(float)(density * p.X), 
+					(float)(density * p.Y));
 		}
 
-		void AddBezier(PathF path, BezierSegment bezierSegment)
+		void AddBezier(PathF path, BezierSegment bezierSegment, double density)
 		{
-			path.CurveTo(
-				(float)bezierSegment.Point1.X, (float)bezierSegment.Point1.Y,
-				(float)bezierSegment.Point2.X, (float)bezierSegment.Point2.Y,
-				(float)bezierSegment.Point3.X, (float)bezierSegment.Point3.Y);
+			path.CurveTo(	
+				(float)(density * bezierSegment.Point1.X), (float)(density * bezierSegment.Point1.Y),
+				(float)(density * bezierSegment.Point2.X), (float)(density * bezierSegment.Point2.Y),
+				(float)(density * bezierSegment.Point3.X), (float)(density * bezierSegment.Point3.Y));
 		}
 
-		void AddPolyBezier(PathF path, PolyBezierSegment polyBezierSegment)
+		void AddPolyBezier(PathF path, PolyBezierSegment polyBezierSegment, double density)
 		{
 			for (int bez = 0; bez < polyBezierSegment.Points.Count; bez += 3)
 			{
 				if (bez + 2 > polyBezierSegment.Points.Count - 1)
 					break;
 
-				var pt1 = new PointF((float)polyBezierSegment.Points[bez].X, (float)polyBezierSegment.Points[bez].Y);
-				var pt2 = new PointF((float)polyBezierSegment.Points[bez + 1].X, (float)polyBezierSegment.Points[bez + 1].Y);
-				var pt3 = new PointF((float)polyBezierSegment.Points[bez + 2].X, (float)polyBezierSegment.Points[bez + 2].Y);
+				var pt1 = new PointF((float)(density * polyBezierSegment.Points[bez].X), (float)(density * polyBezierSegment.Points[bez].Y));
+				var pt2 = new PointF((float)(density * polyBezierSegment.Points[bez + 1].X), (float)(density * polyBezierSegment.Points[bez + 1].Y));
+				var pt3 = new PointF((float)(density * polyBezierSegment.Points[bez + 2].X), (float)(density * polyBezierSegment.Points[bez + 2].Y));
 
 				path.CurveTo(pt1, pt2, pt3);
 			}
 		}
 
-		void AddQuad(PathF path, QuadraticBezierSegment quadraticBezierSegment)
+		void AddQuad(PathF path, QuadraticBezierSegment quadraticBezierSegment, double density)
 		{
-			path.QuadTo((float)quadraticBezierSegment.Point1.X, (float)quadraticBezierSegment.Point1.Y,
-							(float)quadraticBezierSegment.Point2.X, (float)quadraticBezierSegment.Point2.Y);
+			path.QuadTo(
+				(float)(density * quadraticBezierSegment.Point1.X), (float)(density * quadraticBezierSegment.Point1.Y),
+				(float)(density * quadraticBezierSegment.Point2.X), (float)(density * quadraticBezierSegment.Point2.Y));
 		}
 
-		void AddPolyQuad(PathF path, PolyQuadraticBezierSegment polyQuadraticBezierSegment)
+		void AddPolyQuad(PathF path, PolyQuadraticBezierSegment polyQuadraticBezierSegment, double density)
 		{
 			var points = polyQuadraticBezierSegment.Points;
 
@@ -141,8 +154,8 @@ namespace Microsoft.Maui.Controls.Shapes
 					if (i + 1 > polyQuadraticBezierSegment.Points.Count - 1)
 						break;
 
-					var pt1 = new PointF((float)points[i].X, (float)points[i].Y);
-					var pt2 = new PointF((float)points[i + 1].X, (float)points[i + 1].Y);
+					var pt1 = new PointF((float)(density * points[i].X), (float)(density * points[i].Y));
+					var pt2 = new PointF((float)(density * points[i + 1].X), (float)(density * points[i + 1].Y));
 
 					path.QuadTo(pt1, pt2);
 				}

--- a/src/Controls/src/Core/Shapes/RectangleGeometry.cs
+++ b/src/Controls/src/Core/Shapes/RectangleGeometry.cs
@@ -30,7 +30,16 @@ namespace Microsoft.Maui.Controls.Shapes
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='AppendPath']/Docs" />
 		public override void AppendPath(Graphics.PathF path)
 		{
-			path.AppendRectangle(Rect);
+			double density = 1.0d;
+#if ANDROID
+			density = Essentials.DeviceDisplay.MainDisplayInfo.Density;
+#endif
+			float x = (float)(density * Rect.X);
+			float y = (float)(density * Rect.Y);
+			float w = (float)(density * Rect.Width);
+			float h = (float)(density * Rect.Height);
+
+			path.AppendRectangle(x, y, w, h);
 		}
 	}
 }

--- a/src/Core/src/Graphics/PaintExtensions.Android.cs
+++ b/src/Core/src/Graphics/PaintExtensions.Android.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.Graphics
 		static bool IsValid(this GradientPaint? gradienPaint) =>
 			gradienPaint?.GradientStops?.Length > 0;
 
-		internal static GradientData GetGradientPaintData(GradientPaint gradientPaint)
+		internal static GradientData GetGradientPaintData(GradientPaint gradientPaint, float alpha = 1.0f)
 		{
 			var orderStops = gradientPaint.GradientStops;
 
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Graphics
 			int count = 0;
 			foreach (var orderStop in orderStops)
 			{
-				data.Colors[count] = orderStop.Color.ToPlatform().ToArgb();
+				data.Colors[count] = orderStop.Color.WithAlpha(alpha).ToPlatform().ToArgb();
 				data.Offsets[count] = orderStop.Offset;
 				count++;
 			}
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.Graphics
 			return data;
 		}
 
-		internal static LinearGradientShaderFactory GetLinearGradientShaderFactory(LinearGradientPaint linearGradientPaint)
+		internal static LinearGradientShaderFactory GetLinearGradientShaderFactory(LinearGradientPaint linearGradientPaint, float alpha = 1.0f)
 		{
 			var p1 = linearGradientPaint.StartPoint;
 			var x1 = (float)p1.X;
@@ -100,20 +100,20 @@ namespace Microsoft.Maui.Graphics
 			var p2 = linearGradientPaint.EndPoint;
 			var x2 = (float)p2.X;
 			var y2 = (float)p2.Y;
-			var data = GetGradientPaintData(linearGradientPaint);
+			var data = GetGradientPaintData(linearGradientPaint, alpha);
 			var linearGradientShaderFactory = new LinearGradientShaderFactory(new LinearGradientData(data.Colors, data.Offsets, x1, y1, x2, y2));
 
 			return linearGradientShaderFactory;
 		}
 
-		internal static RadialGradientShaderFactory GetRadialGradientShaderFactory(RadialGradientPaint radialGradientPaint)
+		internal static RadialGradientShaderFactory GetRadialGradientShaderFactory(RadialGradientPaint radialGradientPaint, float alpha = 1.0f)
 		{
 			var center = radialGradientPaint.Center;
 			float centerX = (float)center.X;
 			float centerY = (float)center.Y;
 			float radius = (float)radialGradientPaint.Radius;
 
-			var data = PaintExtensions.GetGradientPaintData(radialGradientPaint);
+			var data = GetGradientPaintData(radialGradientPaint, alpha);
 			var shader = new RadialGradientData(data.Colors, data.Offsets, centerX, centerY, radius);
 
 			var radialGradientShaderFactory = new RadialGradientShaderFactory(shader);

--- a/src/Core/src/Graphics/ShapeDrawable.cs
+++ b/src/Core/src/Graphics/ShapeDrawable.cs
@@ -37,8 +37,6 @@ namespace Microsoft.Maui.Graphics
 		{
 			var rect = dirtyRect;
 
-			DrawBackground(canvas, rect);
-
 			IShape? shape = ShapeView?.Shape;
 
 			if (shape == null)
@@ -53,22 +51,6 @@ namespace Microsoft.Maui.Graphics
 
 			DrawStrokePath(canvas, rect, path);
 			DrawFillPath(canvas, rect, path);
-		}
-
-		void DrawBackground(ICanvas canvas, RectF dirtyRect)
-		{
-			if (ShapeView == null)
-				return;
-
-			canvas.SaveState();
-
-			// Set Background
-			var backgroundPaint = ShapeView.Background;
-			canvas.SetFillPaint(backgroundPaint, dirtyRect);
-
-			canvas.FillRectangle(dirtyRect);
-
-			canvas.RestoreState();
 		}
 
 		void DrawStrokePath(ICanvas canvas, RectF dirtyRect, PathF path)

--- a/src/Core/src/Platform/Android/WrapperView.cs
+++ b/src/Core/src/Platform/Android/WrapperView.cs
@@ -139,15 +139,16 @@ namespace Microsoft.Maui.Platform
 			if (Border == null)
 			{
 				if (_borderView != null)
-					this.RemoveView(_borderView);
+					RemoveView(_borderView);
 				_borderView = null;
 				return;
 			}
 
 			if (_borderView == null)
 			{
-				this.AddView(_borderView = new AView(Context));
+				AddView(_borderView = new AView(Context));
 			}
+
 			_borderView.UpdateBorderStroke(Border);
 		}
 
@@ -228,12 +229,12 @@ namespace Microsoft.Maui.Platform
 
 					if (Shadow.Paint is LinearGradientPaint linearGradientPaint)
 					{
-						var linearGradientShaderFactory = PaintExtensions.GetLinearGradientShaderFactory(linearGradientPaint);
+						var linearGradientShaderFactory = PaintExtensions.GetLinearGradientShaderFactory(linearGradientPaint, shadowOpacity);
 						_shadowPaint.SetShader(linearGradientShaderFactory.Resize(bitmapWidth, bitmapHeight));
 					}
 					if (Shadow.Paint is RadialGradientPaint radialGradientPaint)
 					{
-						var radialGradientShaderFactory = PaintExtensions.GetRadialGradientShaderFactory(radialGradientPaint);
+						var radialGradientShaderFactory = PaintExtensions.GetRadialGradientShaderFactory(radialGradientPaint, shadowOpacity);
 						_shadowPaint.SetShader(radialGradientShaderFactory.Resize(bitmapWidth, bitmapHeight));
 					}
 					if (Shadow.Paint is SolidPaint solidPaint)


### PR DESCRIPTION
### Description of Change

This PR include several fixes related with clipping views and drawing shadows.

Shadows on views were not being drawn correctly using Maui Graphics (example: shapes):
![shadows-wrong](https://user-images.githubusercontent.com/6755973/159918029-96950a06-a98b-4972-9f74-1f1aa8adf4f9.PNG)

Fixed:
![shadows-fixed](https://user-images.githubusercontent.com/6755973/159918022-989ad9e7-215a-4cf7-bdad-9b6f547d9d96.PNG)

Also the gradient shadow was not taking into account the opacity:
![shadow-opacity](https://user-images.githubusercontent.com/6755973/159918252-e18c72a1-328f-48ec-9fbb-d084ba0163f0.gif)

In Android, the clipping was wrong mostly because not take into account the screen density (wrong size and position).

Before
![ellipse-clip-before](https://user-images.githubusercontent.com/6755973/159918363-b0dac48f-f2fd-42f1-8522-2257839e9656.PNG)

![path-clip-before](https://user-images.githubusercontent.com/6755973/159918449-82bb02da-5289-44e0-b496-d177948c8688.PNG)

After
![ellipse-clip-after](https://user-images.githubusercontent.com/6755973/159918367-63ae32b1-2d50-45c3-99a2-7c9b93a59660.PNG)

![path-clip-after](https://user-images.githubusercontent.com/6755973/159918445-8835ae21-ed4b-4fb3-a8d3-e8f524395f51.PNG)

### Issues Fixed

Fixes #3843
Fixes #4285
