### PR TITLE
Update the Windows path so we null check like UWP

### DIFF
--- a/src/Essentials/src/MainThread/MainThread.uwp.cs
+++ b/src/Essentials/src/MainThread/MainThread.uwp.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Essentials
 
 				return CoreApplication.MainView.CoreWindow.Dispatcher?.HasThreadAccess ?? false;
 #elif WINDOWS
-				return Platform.CurrentWindow.DispatcherQueue.HasThreadAccess;
+				return Platform.CurrentWindow?.DispatcherQueue?.HasThreadAccess ?? true;
 #endif
 			}
 		}


### PR DESCRIPTION
### Description of Change

UWP null checks the window, so main thread call won't crash during initial UI Construction, now we do that for Windows as well.