### PR TITLE
Use effective flow direction when determining text alignment

### DIFF
--- a/src/Core/src/Platform/iOS/TextAlignmentExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextAlignmentExtensions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Platform
 	public static class TextAlignmentExtensions
 	{
 		public static UITextAlignment ToPlatform(this TextAlignment alignment, IView view)
-			=> alignment.ToPlatform(view.FlowDirection == FlowDirection.LeftToRight);
+			=> alignment.ToPlatform(view.GetEffectiveFlowDirection() == FlowDirection.LeftToRight);
 
 		public static UITextAlignment ToPlatform(this TextAlignment alignment, bool isLtr)
 		{


### PR DESCRIPTION
### Description of Change

The HorizontalTextAlignment check on iOS was not using the effective flow direction. These changes force it to use the correct value.

### Issues Fixed

Fixes #5537
