### PR TITLE
[ci] Don't need to sign on full release

### DIFF
--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -319,4 +319,3 @@ stages:
     - template: common/localization-handoff.yml                     # Process outgoing strings [Localization Handoff]
     - template: common/localization-handback.yml                    # Process incoming translations and Create PR to main [Localization Handback]
     - template: common/merge-translations-update.yml                # Validating incoming translations strings and merge PR [Localization Handback]
-    - template: common/sign.yml                                     # Sign only using the private server


### PR DESCRIPTION
### Description of Change

MAUI pipeline on DevDiv doesn't need to sign since MAUI-Release already does it. And we now don't ship from MAUI pipeline


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
