### PR TITLE
Fix DispatcherTimer IsRuning=false during Tick

### DIFF
--- a/src/Core/src/Dispatching/Dispatcher.Android.cs
+++ b/src/Core/src/Dispatching/Dispatcher.Android.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Dispatching
 
 		public TimeSpan Interval { get; set; }
 
-		public bool IsRepeating { get; set; }
+		public bool IsRepeating { get; set; } = true;
 
 		public bool IsRunning { get; private set; }
 

--- a/src/Core/src/Dispatching/Dispatcher.Windows.cs
+++ b/src/Core/src/Dispatching/Dispatcher.Windows.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Dispatching
 			set => _timer.IsRepeating = value;
 		}
 
-		public bool IsRunning => _timer.IsRunning;
+		public bool IsRunning { get; private set; }
 
 		public event EventHandler? Tick;
 
@@ -68,6 +68,8 @@ namespace Microsoft.Maui.Dispatching
 		{
 			if (IsRunning)
 				return;
+
+			IsRunning = true;
 
 			_timer.Tick += OnTimerTick;
 
@@ -79,13 +81,20 @@ namespace Microsoft.Maui.Dispatching
 			if (!IsRunning)
 				return;
 
+			IsRunning = false;
+
 			_timer.Tick -= OnTimerTick;
 
 			_timer.Stop();
 		}
 
-		void OnTimerTick(DispatcherQueueTimer sender, object args) =>
+		void OnTimerTick(DispatcherQueueTimer sender, object args)
+		{
 			Tick?.Invoke(this, EventArgs.Empty);
+
+			if (!IsRepeating)
+				Stop();
+		}
 	}
 
 	public partial class DispatcherProvider

--- a/src/Core/src/Dispatching/Dispatcher.iOS.cs
+++ b/src/Core/src/Dispatching/Dispatcher.iOS.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Dispatching
 
 		public TimeSpan Interval { get; set; }
 
-		public bool IsRepeating { get; set; }
+		public bool IsRepeating { get; set; } = true;
 
 		public bool IsRunning { get; private set; }
 


### PR DESCRIPTION
### Description of Change

Windows DispatcherTimer works differently in that it "stops" during a tick. So we need to independently manage the IsRunning state so we can support stopping during a tick.

### Issues Fixed

Fixes #5335
