### PR TITLE
Get font manager from element with handler

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml
@@ -129,7 +129,7 @@
                     MaxLines="2"
                     LineBreakMode ="TailTruncation"
                     Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." />
-                <Label
+                <Label x:Name="labelFormattedString"
                     >
                     <Label.FormattedText>
                         <FormattedString>
@@ -156,6 +156,7 @@
                     </Label.FormattedText>
 
                 </Label>
+                <Button Text="Change Formatted String" Clicked="ChangeFormattedString_Clicked" />
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml.cs
@@ -18,5 +18,19 @@ namespace Maui.Controls.Sample.Pages
 			if (span != null)
 				span.TextColor = Color.FromRgb((byte)rnd.Next(0, 254), (byte)rnd.Next(0, 254), (byte)rnd.Next(0, 254));
 		}
+
+		void ChangeFormattedString_Clicked(object sender, System.EventArgs e)
+		{
+			labelFormattedString.FormattedText = new FormattedString
+			{
+				Spans =
+			{
+				new Span
+				{
+					Text = "Testing"
+				}
+			}
+			};
+		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
@@ -13,15 +13,15 @@ namespace Microsoft.Maui.Controls.Platform
 	public static class FormattedStringExtensions
 	{
 		public static void UpdateInlines(this TextBlock textBlock, Label label)
-			=> UpdateInlines(textBlock, label.FormattedText, label.LineHeight, label.HorizontalTextAlignment, label.ToFont(), label.TextColor, label.TextTransform);
+			=> UpdateInlines(textBlock, label.RequireFontManager(false), label.FormattedText, label.LineHeight, label.HorizontalTextAlignment, label.ToFont(), label.TextColor, label.TextTransform);
 
-		public static void UpdateInlines(this TextBlock textBlock, FormattedString formattedString, double defaultLineHeight = 0d, TextAlignment defaultHorizontalAlignment = TextAlignment.Start, Font? defaultFont = null, Color? defaultColor = null, TextTransform defaultTextTransform = TextTransform.Default)
+		public static void UpdateInlines(this TextBlock textBlock, IFontManager fontManager, FormattedString formattedString, double defaultLineHeight = 0d, TextAlignment defaultHorizontalAlignment = TextAlignment.Start, Font? defaultFont = null, Color? defaultColor = null, TextTransform defaultTextTransform = TextTransform.Default)
 		{
 			textBlock.Inlines.Clear();
 			// Have to implement a measure here, otherwise inline.ContentStart and ContentEnd will be null, when used in RecalculatePositions
 			textBlock.Measure(new global::Windows.Foundation.Size(double.MaxValue, double.MaxValue));
 
-			var runAndColorTuples = formattedString.ToRunAndColorsTuples(defaultLineHeight, defaultHorizontalAlignment, defaultFont, defaultColor, defaultTextTransform);
+			var runAndColorTuples = formattedString.ToRunAndColorsTuples(fontManager, defaultLineHeight, defaultHorizontalAlignment, defaultFont, defaultColor, defaultTextTransform);
 
 			var heights = new List<double>();
 			int currentTextIndex = 0;
@@ -50,14 +50,12 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
-		public static IEnumerable<Tuple<Run, Color, Color>> ToRunAndColorsTuples(this FormattedString formattedString, double defaultLineHeight = 0d, TextAlignment defaultHorizontalAlignment = TextAlignment.Start, Font? defaultFont = null, Color? defaultColor = null, TextTransform defaultTextTransform = TextTransform.Default, IFontManager? fontManager = null)
+		public static IEnumerable<Tuple<Run, Color, Color>> ToRunAndColorsTuples(this FormattedString formattedString, IFontManager fontManager, double defaultLineHeight = 0d, TextAlignment defaultHorizontalAlignment = TextAlignment.Start, Font? defaultFont = null, Color? defaultColor = null, TextTransform defaultTextTransform = TextTransform.Default)
 		{
 			var runs = new List<Tuple<Run, Color, Color>>();
 
 			if (formattedString != null && formattedString.Spans != null)
 			{
-				fontManager = fontManager ?? formattedString.RequireFontManager();
-
 				for (var i = 0; i < formattedString.Spans.Count; i++)
 				{
 					var span = formattedString.Spans[i];


### PR DESCRIPTION
Since FormattedString is technically an Element, we were using the extension method on that which ultimately used the instance to get a maui context.  This is fine for XAML where the context is somewhere up the tree, but if you create a new FormattedString, it won't have any parent and therefore handlers up the tree to find a maui context.

This instead ensures the font manager gets passed into the extension methods that were trying to find it on the FormattedString.

Fixes #5576


### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
