### PR TITLE
[android] update to the latest AndroidX packages

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -2,55 +2,55 @@
   <ItemGroup>
     <PackageReference
         Update="Xamarin.AndroidX.AppCompat.AppCompatResources"
-        Version="1.3.1.3"
+        Version="1.4.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Browser"
-        Version="1.3.0.8"
+        Version="1.4.0"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Legacy.Support.V4"
-        Version="1.0.0.10"
+        Version="1.0.0.12"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Lifecycle.LiveData"
-        Version="2.3.1.3"
+        Version="2.4.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.UI"
-        Version="2.3.5.3"
+        Version="2.4.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Fragment"
-        Version="2.3.5.3"
+        Version="2.4.1.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Runtime"
-        Version="2.3.5.3"
+        Version="2.4.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Common"
-        Version="2.3.5.3"
+        Version="2.4.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.MediaRouter"
-        Version="1.2.5.2"
+        Version="1.2.6"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Palette"
-        Version="1.0.0.10"
+        Version="1.0.0.12"
     />
     <PackageReference
         Update="Xamarin.AndroidX.RecyclerView"
-        Version="1.2.1.3"
+        Version="1.2.1.5"
     />
     <PackageReference
         Update="Xamarin.Build.Download"
-        Version="0.10.0"
+        Version="0.11.0"
     />
     <PackageReference
         Update="Xamarin.Google.Android.Material"
-        Version="1.4.0.4"
+        Version="1.5.0.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Migration"

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -11,6 +11,7 @@ using AndroidX.Navigation;
 using AndroidX.Navigation.Fragment;
 using AndroidX.Navigation.UI;
 using Google.Android.Material.AppBar;
+using Kotlin.Collections;
 using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
 using AView = Android.Views.View;
 
@@ -142,7 +143,7 @@ namespace Microsoft.Maui.Platform
 
 			IsAnimated = animated;
 
-			var iterator = NavHost.NavController.BackStack.Iterator();
+			var iterator = NavHost.NavController.BackQueue.Iterator();
 			var fragmentNavDestinations = new List<FragmentNavigator.Destination>();
 
 			while (iterator.HasNext)
@@ -185,7 +186,7 @@ namespace Microsoft.Maui.Platform
 			// We only keep destinations around that are on the backstack
 			// This iterates over the new backstack and removes any destinations
 			// that are no longer apart of the back stack
-			var iterateNewStack = NavHost.NavController.BackStack.Iterator();
+			var iterateNewStack = NavHost.NavController.BackQueue.Iterator();
 			int startId = -1;
 			while (iterateNewStack.HasNext)
 			{
@@ -242,7 +243,7 @@ namespace Microsoft.Maui.Platform
 			var navController = NavHost.NavController;
 
 			// We are subtracting one because the navgraph itself is the first item on the stack
-			int NativeNavigationStackCount = navController.BackStack.Size() - 1;
+			int NativeNavigationStackCount = navController.BackQueue.Size() - 1;
 
 			// set this to one because when the graph is first attached to the controller
 			// it will add the graph and the first destination

--- a/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Navigation/NavigationViewHandlerTests.Android.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.DeviceTests
 	public partial class NavigationViewHandlerTests
 	{
 		int GetNativeNavigationStackCount(NavigationViewHandler navigationViewHandler) =>
-			navigationViewHandler.StackNavigationManager.NavHost.NavController.BackStack.Size() - 1;
+			navigationViewHandler.StackNavigationManager.NavHost.NavController.BackQueue.Size() - 1;
 
 		Task CreateNavigationViewHandlerAsync(IStackNavigationView navigationView, Func<NavigationViewHandler, Task> action)
 		{

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
@@ -4,6 +4,8 @@
     <EnableDefaultXamlItems Condition=" '$(EnableDefaultXamlItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultXamlItems>
     <EnableDefaultCssItems  Condition=" '$(EnableDefaultCssItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultCssItems>
     <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultEmbeddedResourceItems>
+    <!-- TODO: workaround https://github.com/xamarin/xamarin-android/issues/6809#issuecomment-1061115254 -->
+    <NoWarn Condition=" '$(TargetPlatformIdentifier)' == 'Android' ">$(NoWarn);XA4218</NoWarn>
   </PropertyGroup>
   <Import Project="Microsoft.Maui.Controls.targets" />
   <Import Project="WinUI.targets" Condition=" '$(TargetPlatformIdentifier)' == 'windows' " />

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets
@@ -5,7 +5,7 @@
     <EnableDefaultCssItems  Condition=" '$(EnableDefaultCssItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultCssItems>
     <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">$(EnableDefaultMauiItems)</EnableDefaultEmbeddedResourceItems>
     <!-- TODO: workaround https://github.com/xamarin/xamarin-android/issues/6809#issuecomment-1061115254 -->
-    <NoWarn Condition=" '$(TargetPlatformIdentifier)' == 'Android' ">$(NoWarn);XA4218</NoWarn>
+    <MSBuildWarningsAsMessages Condition=" '$(TargetPlatformIdentifier)' == 'Android' ">$(MSBuildWarningsAsMessages);XA4218</MSBuildWarningsAsMessages>
   </PropertyGroup>
   <Import Project="Microsoft.Maui.Controls.targets" />
   <Import Project="WinUI.targets" Condition=" '$(TargetPlatformIdentifier)' == 'windows' " />


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/5305
Fixes: https://github.com/xamarin/AndroidX/issues/509

Update to the latest AndroidX packages, so we also use the latest
Xamarin.Google.Guava.ListenableFuture

This currently has build failures:

```
src\Core\src\Platform\Android\Navigation\StackNavigationManager.cs(145,41): error CS1061: 'NavController' does not contain a definition for 'BackStack' and no accessible extension method 'BackStack' accepting a first argument of type 'NavController' could be found (are you missing a using directive or an assembly reference?)
src\Core\src\Platform\Android\Navigation\StackNavigationManager.cs(188,48): error CS1061: 'NavController' does not contain a definition for 'BackStack' and no accessible extension method 'BackStack' accepting a first argument of type 'NavController' could be found (are you missing a using directive or an assembly reference?)
src\Core\src\Platform\Android\Navigation\StackNavigationManager.cs(245,51): error CS1061: 'NavController' does not contain a definition for 'BackStack' and no accessible extension method 'BackStack' accepting a first argument of type 'NavController' could be found (are you missing a using directive or an assembly reference?)
```

Looking at:

    ~\.nuget\packages\xamarin.androidx.navigation.runtime\2.4.1\lib\net6.0-android31.0\Xamarin.AndroidX.Navigation.Runtime.dll

I can't find:

    [Register("androidx/navigation/NavController", DoNotGenerateAcw = true)]
    public class NavController : Object
    {
        public unsafe virtual IDeque BackStack
        {
            [Register("getBackStack", "()Ljava/util/Deque;", "GetGetBackStackHandler")]
            get;

But it's not documented here either:

https://developer.android.com/reference/androidx/navigation/NavController
