### PR TITLE
Clip image to ImageView bounds when using CenterCrop (AspectFill)

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -45,5 +45,24 @@ namespace Microsoft.Maui.Handlers
 		{
 			PlatformView.SetImageDrawable(obj);
 		}
+
+		public override void PlatformArrange(Graphics.Rect frame)
+		{
+			if (PlatformView.GetScaleType() == ImageView.ScaleType.CenterCrop)
+			{
+				// If the image is center cropped (AspectFill), then the size of the image likely exceeds
+				// the view size in some dimension. So we need to clip to the to the view's bounds.
+
+				var (left, top, right, bottom) = PlatformView.Context!.ToPixels(frame);
+				var clipRect = new Android.Graphics.Rect(left, top, right, bottom);
+				PlatformView.ClipBounds = clipRect;
+			}
+			else
+			{
+				PlatformView.ClipBounds = null;
+			}
+
+			base.PlatformArrange(frame);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Given the following XAML:

```
<Grid RowDefinitions="100,100,*" >
    <Image x:Name="TheImage" Source="dotnet_bot.png" Grid.Row="0" Aspect="AspectFill" />
    <Label Text="Howdy" HorizontalTextAlignment="Center" BackgroundColor="LightBlue" Grid.Row="1"/>
</Grid>
```

The image should be confined to the first row of the Grid. On Android, the image is currently displaying outside the grid when the image is taller than it is wide.

This change ensures that when using AspectFill, the image is clipped at the bounds of the view.

### Issues Fixed

Fixes #5165


