### PR TITLE
Avoid reconstructing handler when it is already available

### DIFF
--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			bool PageIsInThisContext(IView page)
 			{
-				var platformView = page.ToPlatform(MauiContext);
+				var platformView = page.ToPlatform();
 
 				if (platformView.Context == null)
 				{

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Platform
 
 		public static PlatformView ToPlatform(this IElement view, IMauiContext context)
 		{
-			var handler = view.Handler ?? view.ToHandler(context);
+			var handler = view.ToHandler(context);
 
 			if (handler.PlatformView is not PlatformView result)
 			{

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Maui.Platform
 
 		public static PlatformView ToPlatform(this IElement view, IMauiContext context)
 		{
-			var handler = view.ToHandler(context);
+			var handler = view.Handler ?? view.ToHandler(context);
 
 			if (handler.PlatformView is not PlatformView result)
 			{


### PR DESCRIPTION
### Description of Change

The root cause of this bugs is this seemly harmless call to `AlertRequestHelper.PageIsInThisContext` accidentally disposed the `GestureManager` through this stack.

```
...
Microsoft.Maui.Controls.Platform.GestureManager.Dispose
Microsoft.Maui.Controls.View.OnHandlerChangingCore
Microsoft.Maui.Controls.Element.SetHandler
Microsoft.Maui.Controls.Element.set_Handler
Microsoft.Maui.Controls.VisualElement.Microsoft.Maui.IElement.set_Handler
Microsoft.Maui.Platform.ElementExtensions.ToHandler
Microsoft.Maui.Platform.ElementExtensions.ToPlatform
Microsoft.Maui.Handlers.ContentViewHandler.UpdateContent
Microsoft.Maui.Handlers.ContentViewHandler.MapContent
Microsoft.Maui.PropertyMapper<Microsoft.Maui.IContentView,Microsoft.Maui.Handlers.IContentViewHandler>.
Microsoft.Maui.PropertyMapper.UpdatePropertyCore
Microsoft.Maui.PropertyMapper.UpdateProperties
Microsoft.Maui.Handlers.ElementHandler.SetVirtualView
Microsoft.Maui.Handlers.ViewHandler.SetVirtualView
Microsoft.Maui.Handlers.ViewHandler<Microsoft.Maui.IContentView,Microsoft.Maui.Platform.ContentViewGroup>.SetVirtualView
Microsoft.Maui.Handlers.ContentViewHandler.SetVirtualView
Microsoft.Maui.Handlers.ViewHandler<Microsoft.Maui.IContentView,Microsoft.Maui.Platform.ContentViewGroup>.SetVirtualView
Microsoft.Maui.Controls.Element.SetHandler
Microsoft.Maui.Controls.Element.set_Handler
Microsoft.Maui.Controls.VisualElement.Microsoft.Maui.IElement.set_Handler
Microsoft.Maui.Platform.ElementExtensions.ToHandler
Microsoft.Maui.Platform.ElementExtensions.ToPlatform
Microsoft.Maui.Controls.Platform.AlertManager.AlertRequestHelper.PageIsInThisContext
...
```

When the GestureManager is disposed of, the associated `OnTouchListener` is unregistered. Later on, it will register the `OnTouchListener` for a label again. But that label is not the same instance as the one that is currently showing, that is why touching the label for the second time won't lead to the event listener.

My observation is that all this heavy lifting just to check if the page is in the current activity is a lot of waste. We could have just reused the existing Handler instance, that is what inspired the fix.

### Issues Fixed

Fixes #5425