### PR TITLE
Move missing styles over to controls from compat

### DIFF
--- a/src/Compatibility/Core/src/Windows/Resources.xaml
+++ b/src/Compatibility/Core/src/Windows/Resources.xaml
@@ -21,19 +21,11 @@
 
     <x:Boolean x:Key="MicrosoftMauiControlsCompatibilityIncluded">true</x:Boolean>
 
-    <uwp:CaseConverter x:Key="LowerConverter" ConvertToUpper="False" />
-	<uwp:CaseConverter x:Key="UpperConverter" ConvertToUpper="True" />
-	<uwp:HeightConverter x:Key="HeightConverter" />
-	<uwp:CollapseWhenEmptyConverter x:Key="CollapseWhenEmpty" />
 	<uwp:BoolToVisibilityConverter x:Key="BoolVisibilityConverter" />
     <uwp:BrushConverter x:Key="BrushConverter" />
 	<uwp:BoolToVisibilityConverter x:Key="InvertedBoolVisibilityConverter" FalseIsVisible="True" />
 	<uwp:PageToRenderedElementConverter x:Key="PageToRenderer" />
-    <maui:ImageConverter x:Key="ImageConverter" />
-	<uwp:ColorConverter x:Key="ColorConverter" />
-	<uwp:HorizontalTextAlignmentConverter x:Key="HorizontalTextAlignmentConverter" />
 	<uwp:TextAlignmentToHorizontalAlignmentConverter x:Key="AlignmentConverter" />
-	<uwp:KeyboardConverter x:Key="KeyboardConverter" />
     <uwp:MasterBackgroundConverter x:Key="MasterBackgroundConverter" />
     <uwp:ImageSourceIconElementConverter x:Key="ImageSourceIconElementConverter" />
     <!-- We probably want to keep this in sync with AppBarThemeCompactHeight in FlyoutPageControlStyle.xaml (in uwp:FormsCommandBar.Resources) -->
@@ -152,7 +144,7 @@
         </Setter>
     </Style>
 
-    <DataTemplate x:Key="TextCell">
+    <DataTemplate x:Key="CompatibilityTextCell">
 		<StackPanel AutomationProperties.AutomationId="{Binding AutomationId}">
 			<TextBlock
 				Text="{Binding Text}"
@@ -168,8 +160,8 @@
 				x:Name="detail"/>
 		</StackPanel>
 	</DataTemplate>
-	
-	<DataTemplate x:Key="ListViewHeaderTextCell">
+
+    <DataTemplate x:Key="CompatibilityListViewHeaderTextCell">
 		<StackPanel>
 			<TextBlock
 				Text="{Binding Text}"
@@ -186,7 +178,7 @@
 		</StackPanel>
 	</DataTemplate>
 
-	<DataTemplate x:Key="ImageCell">
+    <DataTemplate x:Key="CompatibilityImageCell">
 		<Grid AutomationProperties.AutomationId="{Binding AutomationId}">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="Auto" />
@@ -217,8 +209,8 @@
 				x:Name="detail" />
 		</Grid>
 	</DataTemplate>
-	
-	<DataTemplate x:Key="SwitchCell">
+
+    <DataTemplate x:Key="CompatibilitySwitchCell">
 		<Grid HorizontalAlignment="Stretch" x:Name="ParentGrid"  AutomationProperties.AutomationId="{Binding AutomationId}">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="*" />
@@ -231,7 +223,7 @@
 		</Grid>
 	</DataTemplate>
 
-	<DataTemplate x:Key="EntryCell">
+	<DataTemplate x:Key="CompatibilityEntryCell">
         <uwp:EntryCellTextBox  AutomationProperties.AutomationId="{Binding AutomationId}" IsEnabled="{Binding IsEnabled}" Header="{Binding}" Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextAlignment="{Binding HorizontalTextAlignment,Converter={StaticResource HorizontalTextAlignmentConverter}}" PlaceholderText="{Binding Placeholder}"  InputScope="{Binding Keyboard,Converter={StaticResource KeyboardConverter}}" HorizontalAlignment="Stretch">
 			<uwp:EntryCellTextBox.HeaderTemplate>
 				<DataTemplate>
@@ -259,7 +251,7 @@
 		</Setter>
 	</Style>
 
-	<Style TargetType="ToggleSwitch">
+    <Style TargetType="ToggleSwitch" x:Key="CompatibilityToggleSwitch">
 		<Setter Property="MinWidth" Value="0"/>
 	</Style>
 </ResourceDictionary>

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			var color = switchCell.OnColor.IsDefault()
 				? _defaultOnColor
 				: new WSolidColorBrush(switchCell.OnColor.ToWindowsColor());
-			
+
 			var nativeSwitch = this.GetFirstDescendant<ToggleSwitch>();
 
 			// change fill color in switch rectangle
@@ -215,12 +215,21 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 
 			var visualStates = vState.Storyboard.Children;
-			foreach (ObjectAnimationUsingKeyFrames item in visualStates)
+			foreach (var state in visualStates)
 			{
-				if ((string)item.GetValue(Storyboard.TargetNameProperty) == "SwitchKnobBounds")
+				// in XF we were setting the MinWidth of the ToggleSwitch to zero which looks to 
+				// setup the visual states of ToggleSwitch to all be ObjectAnimationUsingKeyFrames.
+				// This MinWidth was removed which is why this check was added
+				//
+				// If you find yourself here trying to figure out a SwitchCell issue
+				// Try setting the MinWidth on ToggleSwitch to zero	
+				if (state is ObjectAnimationUsingKeyFrames item)
 				{
-					item.KeyFrames[0].Value = color;
-					break;
+					if ((string)item.GetValue(Storyboard.TargetNameProperty) == "SwitchKnobBounds")
+					{
+						item.KeyFrames[0].Value = color;
+						break;
+					}
 				}
 			}
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewStyles.xaml
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewStyles.xaml
@@ -7,11 +7,19 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:primitiveContract7Present="using:Microsoft.UI.Xaml.Controls.Primitives?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:xf="using:Microsoft.Maui.Controls.Platform"
+    xmlns:maui="using:Microsoft.Maui.Controls.Platform"
 	xmlns:platform="using:Microsoft.Maui.Controls.Platform.Compatibility">
 
 
+    <platform:HeightConverter x:Key="HeightConverter" />
     <platform:ListViewGroupStyleSelector x:Key="ListViewGroupSelector" />
+    <platform:CaseConverter x:Key="LowerConverter" ConvertToUpper="False" />
+    <platform:CaseConverter x:Key="UpperConverter" ConvertToUpper="True" />
+    <platform:ColorConverter x:Key="ColorConverter" />
+    <platform:CollapseWhenEmptyConverter x:Key="CollapseWhenEmpty" />
+    <platform:HorizontalTextAlignmentConverter x:Key="HorizontalTextAlignmentConverter" />
+    <maui:ImageConverter x:Key="ImageConverter" />
+    <platform:KeyboardConverter x:Key="KeyboardConverter" />
 
     <DataTemplate x:Key="View">
         <ContentPresenter Content="{Binding Converter={StaticResource ViewToRenderer}}" />

--- a/src/Controls/src/Core/Compatibility/Windows/CaseConverter.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/CaseConverter.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
+namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public class CaseConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{

--- a/src/Controls/src/Core/Compatibility/Windows/CollapseWhenEmptyConverter.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/CollapseWhenEmptyConverter.cs
@@ -1,7 +1,7 @@
 using System;
 using WVisibility = Microsoft.UI.Xaml.Visibility;
 
-namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
+namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public class CollapseWhenEmptyConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{

--- a/src/Controls/src/Core/Compatibility/Windows/ColorConverter.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/ColorConverter.cs
@@ -5,7 +5,7 @@ using Windows.UI;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
 using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 
-namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
+namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public sealed class ColorConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{

--- a/src/Controls/src/Core/Compatibility/Windows/HeightConverter.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/HeightConverter.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
+namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public sealed class HeightConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{

--- a/src/Controls/src/Core/Compatibility/Windows/HorizontalTextAlignmentConverter.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/HorizontalTextAlignmentConverter.cs
@@ -1,13 +1,13 @@
 using System;
 
-namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
+namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public class HorizontalTextAlignmentConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{
 			var textAlign = (TextAlignment)value;
-			return textAlign.ToPlatformTextAlignment();
+			return textAlign.ToPlatform();
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/src/Controls/src/Core/Compatibility/Windows/KeyboardConverter.cs
+++ b/src/Controls/src/Core/Compatibility/Windows/KeyboardConverter.cs
@@ -1,6 +1,8 @@
 using System;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.UI.Xaml.Input;
 
-namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
+namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public class KeyboardConverter : Microsoft.UI.Xaml.Data.IValueConverter
 	{
@@ -10,7 +12,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			if (keyboard == null)
 				return null;
 
-			return keyboard.ToInputScope();
+
+			var result = new InputScope();
+			result.Names.Add(keyboard.ToInputScopeName());
+			return result;
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
### Description of Change

- Some converters needed for TableView/ListView were still living inside compatibility
- Fixed an issue with `SwitchCell` if you don't apply a `MinWidth` of zero
- renamed Cell Styles in compatibility to `Compatibility<Type>` this way if users use `UseCompatibility` it doesn't replace our styles

### Issues Fixed

Fixes #5551
