### PR TITLE
Fix Label.VerticalTextAlignment on Windows

### DIFF
--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -9,7 +9,30 @@ namespace Microsoft.Maui.Handlers
 
 		public override bool NeedsContainer =>
 			VirtualView?.Background != null ||
+			(VirtualView != null && VirtualView.VerticalTextAlignment != TextAlignment.Start) ||
 			base.NeedsContainer;
+
+		protected override void SetupContainer()
+		{
+			base.SetupContainer();
+
+			// VerticalAlignment only works when the child's Height is Auto
+			PlatformView.Height = double.NaN;
+
+			MapHeight(this, VirtualView);
+		}
+
+		protected override void RemoveContainer()
+		{
+			base.RemoveContainer();
+
+			MapHeight(this, VirtualView);
+		}
+
+		public static void MapHeight(ILabelHandler handler, ILabel view) =>
+			// VerticalAlignment only works when the container's Height is set and the child's Height is Auto. The child's Height
+			// is set to Auto when the container is introduced
+			handler.ToPlatform().UpdateHeight(view);
 
 		public static void MapBackground(ILabelHandler handler, ILabel label)
 		{
@@ -44,8 +67,12 @@ namespace Microsoft.Maui.Handlers
 		public static void MapHorizontalTextAlignment(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateHorizontalTextAlignment(label);
 
-		public static void MapVerticalTextAlignment(ILabelHandler handler, ILabel label) =>
+		public static void MapVerticalTextAlignment(ILabelHandler handler, ILabel label)
+		{
+			handler.UpdateValue(nameof(IViewHandler.ContainerView));
+
 			handler.PlatformView?.UpdateVerticalTextAlignment(label);
+		}
 
 		public static void MapLineBreakMode(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateLineBreakMode(label);

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -15,8 +15,12 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<ILabel, ILabelHandler> Mapper = new PropertyMapper<ILabel, ILabelHandler>(ViewHandler.ViewMapper)
 		{
-#if WINDOWS || __IOS__
+#if __IOS__
 			[nameof(ILabel.Background)] = MapBackground,
+			[nameof(ILabel.Opacity)] = MapOpacity,
+#elif WINDOWS
+			[nameof(ILabel.Background)] = MapBackground,
+			[nameof(ILabel.Height)] = MapHeight,
 			[nameof(ILabel.Opacity)] = MapOpacity,
 #endif
 			[nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,


### PR DESCRIPTION
### Description of Change

On WinUI, TextBlock.VerticalAlignment won't take effect unless the control is inside a container and TextBlock.Height is Auto. These conditions are now ensured whenever Label.VerticalTextAlignment is specified.

Before | After
--- | ---
![VerticalTextAlignment broken](https://user-images.githubusercontent.com/1226749/160502262-af2140d8-26f8-487a-85f9-106639990cce.png) | ![VerticalTextAlignment fixed](https://user-images.githubusercontent.com/1226749/160503240-1e445748-63c6-48d1-9dd2-31b9b5122daf.png)

### Issues Fixed

Fixes #3119
