### PR TITLE
In case of width Infinity pass desired size of view

### DIFF
--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Maui.Layouts
 			widthConstraint -= margin.HorizontalThickness;
 			heightConstraint -= margin.VerticalThickness;
 
+			if (Double.IsPositiveInfinity(widthConstraint))
+            {
+				widthConstraint = view.DesiredSize.Width;
+			}
+
 			// Ask the handler to do the actual measuring
 			var measureWithMargins = view.Handler.GetDesiredSize(widthConstraint, heightConstraint);
 


### PR DESCRIPTION
When SearchBar is inside HorizontalStackLayout in ViewHandlerExtensions.iOS.cs GetDesiredSizeFromHandler throws exception on SizeThatFits call. 


Fixes #5346 
