### PR TITLE
Optimize BindableProperty

### DIFF
--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -596,9 +596,9 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (element is BindableObject bindable)
 			{
 				//SetValue doesn't throw on mismatching type, so check before to get a chance to try the property setting or the collection adding
-				var nullable = property.ReturnTypeInfo.IsGenericType &&
-							   property.ReturnTypeInfo.GetGenericTypeDefinition() == typeof(Nullable<>);
-				if ((convertedValue == null && (!property.ReturnTypeInfo.IsValueType || nullable)) ||
+				var nullable = property.ReturnType.IsGenericType &&
+							   property.ReturnType.GetGenericTypeDefinition() == typeof(Nullable<>);
+				if ((convertedValue == null && (!property.ReturnType.IsValueType || nullable)) ||
 					(property.ReturnType.IsInstanceOfType(convertedValue)))
 				{
 					try
@@ -803,13 +803,10 @@ namespace Microsoft.Maui.Controls.Xaml
 		{
 			exception = null;
 
-			if (property?.ReturnTypeInfo?.GenericTypeArguments == null)
+			if (property?.ReturnType?.GenericTypeArguments == null)
 				return false;
 
-			if (property.ReturnType == null)
-				return false;
-
-			if (property.ReturnTypeInfo.GenericTypeArguments.Length != 1 || !property.ReturnTypeInfo.GenericTypeArguments[0].IsInstanceOfType(value))
+			if (property.ReturnType.GenericTypeArguments.Length != 1 || !property.ReturnType.GenericTypeArguments[0].IsInstanceOfType(value))
 				return false;
 
 			// This might be a collection we can add to; see if we can find an Add method


### PR DESCRIPTION
### Description of Change

- TryConvert should no-op when the types already match
- Remove unnecessary ReturnTypeInfo field on BindableProperty

TryConvert shows up in profiles when setting simple properties to the type they already are. For example, setting the Color on a Brush in its ctor:

![image](https://user-images.githubusercontent.com/8291187/160662000-cc7f2eb7-8d39-4f2f-b4e2-c341f68ed938.png)

(aside) I can make a separate PR to remove all the `GetTypeInfo()` calls in the codebase. These are no longer necessary as of netstandard2.0.