### PR TITLE
Ensure GroupValueChangedMessage is received

### DIFF
--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Maui.Controls
 				{
 					MessagingCenter.Subscribe<RadioButton, RadioButtonGroupSelectionChanged>(this,
 						RadioButtonGroup.GroupSelectionChangedMessage, HandleRadioButtonGroupSelectionChanged);
-					MessagingCenter.Subscribe<Maui.ILayout, RadioButtonGroupValueChanged>(this,
+					MessagingCenter.Subscribe<Element, RadioButtonGroupValueChanged>(this,
 						RadioButtonGroup.GroupValueChangedMessage, HandleRadioButtonGroupValueChanged);
 				}
 
@@ -450,7 +450,7 @@ namespace Microsoft.Maui.Controls
 				if (!string.IsNullOrEmpty(oldGroupName))
 				{
 					MessagingCenter.Unsubscribe<RadioButton, RadioButtonGroupSelectionChanged>(this, RadioButtonGroup.GroupSelectionChangedMessage);
-					MessagingCenter.Unsubscribe<Maui.ILayout, RadioButtonGroupValueChanged>(this, RadioButtonGroup.GroupValueChangedMessage);
+					MessagingCenter.Unsubscribe<Element, RadioButtonGroupValueChanged>(this, RadioButtonGroup.GroupValueChangedMessage);
 				}
 			}
 		}
@@ -470,9 +470,9 @@ namespace Microsoft.Maui.Controls
 			IsChecked = false;
 		}
 
-		void HandleRadioButtonGroupValueChanged(Maui.ILayout layout, RadioButtonGroupValueChanged args)
+		void HandleRadioButtonGroupValueChanged(Element layout, RadioButtonGroupValueChanged args)
 		{
-			if (IsChecked || string.IsNullOrEmpty(GroupName) || GroupName != args.GroupName || Value != args.Value || !MatchesScope(args))
+			if (IsChecked || string.IsNullOrEmpty(GroupName) || GroupName != args.GroupName || !Value.Equals(args.Value) || !MatchesScope(args))
 			{
 				return;
 			}

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleRadioButtonGroupValueChanged(Element layout, RadioButtonGroupValueChanged args)
 		{
-			if (IsChecked || string.IsNullOrEmpty(GroupName) || GroupName != args.GroupName || !Value.Equals(args.Value) || !MatchesScope(args))
+			if (IsChecked || string.IsNullOrEmpty(GroupName) || GroupName != args.GroupName || !object.Equals(Value, args.Value) || !MatchesScope(args))
 			{
 				return;
 			}

--- a/src/Controls/src/Core/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButtonGroupController.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.Controls
 				_layout.SetValue(RadioButtonGroup.SelectedValueProperty, radioButton.Value);
 			}
 
-			if (radioButton.Value.Equals(this.SelectedValue))
+			if (object.Equals(radioButton.Value, this.SelectedValue))
 			{
 				radioButton.IsChecked = true;
 			}

--- a/src/Controls/src/Core/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButtonGroupController.cs
@@ -100,6 +100,11 @@ namespace Microsoft.Maui.Controls
 			{
 				_layout.SetValue(RadioButtonGroup.SelectedValueProperty, radioButton.Value);
 			}
+
+			if (radioButton.Value.Equals(this.SelectedValue))
+			{
+				radioButton.IsChecked = true;
+			}
 		}
 
 		void UpdateGroupName(Element element, string name, string oldName = null)

--- a/src/Controls/src/Core/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButtonGroupController.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls
 
 			if (radioButtonValue != null)
 			{
-				MessagingCenter.Send(_layout, RadioButtonGroup.GroupValueChangedMessage,
+				MessagingCenter.Send<Element, RadioButtonGroupValueChanged>(_layout, RadioButtonGroup.GroupValueChangedMessage,
 					new RadioButtonGroupValueChanged(_groupName, RadioButtonGroup.GetVisualRoot(_layout), radioButtonValue));
 			}
 		}


### PR DESCRIPTION
### Description of Change

There are three fixes in this change.

1. The message registration type is changed from `ILayout` to `Element`. This is because `_layout` in `RadioButtonGroupController` is actually an instance of `Element`.

2. The checking for `Value != args.Value` is changed to `!Value.Equals(args.Value)`. This is because `Value` and `args.Value` can come from different sources and object reference equality often doesn't work.

3. In case the `SelectedValue` of the radio group is changed before the radio buttons are added to the group, the radio button missed the event to set its default value and won't set its `IsChecked` state. Therefore we need to make sure when a radio button is added to the group, it sets its `IsChecked` state to the correct value.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #5645

@softlion 