### PR TITLE
Default Editor.VerticalTextAlignment to Start

### DIFF
--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='VerticalTextAlignmentProperty']/Docs" />
-		public static readonly BindableProperty VerticalTextAlignmentProperty = TextAlignmentElement.VerticalTextAlignmentProperty;
+		public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create(nameof(VerticalTextAlignment), typeof(TextAlignment), typeof(Editor), TextAlignment.Start);
 
 		readonly Lazy<PlatformConfigurationRegistry<Editor>> _platformConfigurationRegistry;
 


### PR DESCRIPTION
### Description of Change

Previously, iOS and Android were out of sync with the VerticalTextAlignment value since the native controls effectively default to Start. Windows honored the default value making its behavior inconsistent with iOS and Android.

This PR updates the default to Start. The iOS and Android native controls are now in sync with the VerticalTextAlignment value. The Windows behavior is now consistent with iOS and Android.

### Issues Fixed

Fixes #4089