### PR TITLE
Optimize TypeConversionExtensions.ConvertTo

### DIFF
--- a/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
+++ b/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
@@ -26,6 +26,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -42,24 +43,24 @@ namespace Microsoft.Maui.Controls.Xaml
 			{ typeof(Font), typeof(FontTypeConverter) }
 		};
 
-		private static Dictionary<Type, Func<TypeConverter>> KnownConverterFactories = new()
+		static Dictionary<Type, Func<TypeConverter>> KnownConverterFactories = new()
 		{
 			{ typeof(Font), () => new FontTypeConverter() }
 		};
+
+		static readonly ConcurrentDictionary<Type, TypeConverter> s_converterCache = new();
 
 		internal static object ConvertTo(this object value, Type toType, Func<ParameterInfo> pinfoRetriever,
 			IServiceProvider serviceProvider, out Exception exception)
 		{
 			Func<TypeConverter> getConverter = () =>
 			{
-				ParameterInfo pInfo;
-				if (pinfoRetriever == null || (pInfo = pinfoRetriever()) == null)
+				if (pinfoRetriever == null || pinfoRetriever() is not ParameterInfo pInfo)
 					return null;
 
-				var converterTypeName = pInfo.CustomAttributes.GetTypeConverterTypeName();
-				if (converterTypeName == null)
+				var convertertype = pInfo.CustomAttributes.GetTypeConverterType();
+				if (convertertype == null)
 					return null;
-				var convertertype = Type.GetType(converterTypeName);
 				return (TypeConverter)Activator.CreateInstance(convertertype);
 			};
 
@@ -71,23 +72,32 @@ namespace Microsoft.Maui.Controls.Xaml
 		{
 			Func<TypeConverter> getConverter = () =>
 			{
-				MemberInfo memberInfo;
+				if (minfoRetriever != null && minfoRetriever() is MemberInfo memberInfo)
+				{
+					if (memberInfo.CustomAttributes.GetTypeConverterType() is Type converterType)
+					{
+						return (TypeConverter)Activator.CreateInstance(converterType);
+					}
+				}
 
-				var converterTypeName = toType.GetTypeInfo().CustomAttributes.GetTypeConverterTypeName();
-				if (minfoRetriever != null && (memberInfo = minfoRetriever()) != null)
-					converterTypeName = memberInfo.CustomAttributes.GetTypeConverterTypeName() ?? converterTypeName;
-				if (converterTypeName == null && KnownConverterFactories.TryGetValue(toType, out var converterFactory))
+				if (KnownConverterFactories.TryGetValue(toType, out var converterFactory))
 					return converterFactory();
-				if (converterTypeName == null)
-					return null;
-				var convertertype = Type.GetType(converterTypeName);
-				return (TypeConverter)Activator.CreateInstance(convertertype);
+
+				if (!s_converterCache.TryGetValue(toType, out TypeConverter converter))
+				{
+					if (toType.CustomAttributes.GetTypeConverterType() is Type converterType)
+					{
+						converter = (TypeConverter)Activator.CreateInstance(converterType);
+					}
+					s_converterCache[toType] = converter;
+				}
+				return converter;
 			};
 
 			return ConvertTo(value, toType, getConverter, serviceProvider, out exception);
 		}
 
-		static string GetTypeConverterTypeName(this IEnumerable<CustomAttributeData> attributes)
+		static Type GetTypeConverterType(this IEnumerable<CustomAttributeData> attributes)
 		{
 			foreach (var converterAttribute in attributes)
 			{
@@ -95,18 +105,18 @@ namespace Microsoft.Maui.Controls.Xaml
 					continue;
 				var ctor = converterAttribute.ConstructorArguments[0];
 				if (ctor.ArgumentType == typeof(string))
-					return (string)ctor.Value;
+					return Type.GetType((string)ctor.Value);
 				if (ctor.ArgumentType == typeof(Type))
-					return ((Type)ctor.Value).AssemblyQualifiedName;
+					return (Type)ctor.Value;
 			}
 			return null;
 		}
 
 		//Don't change the name or the signature of this, it's used by XamlC
 		public static object ConvertTo(
-			this object value, 
+			this object value,
 			Type toType,
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type convertertype, 
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type convertertype,
 			IServiceProvider serviceProvider)
 		{
 			Exception exception = null;

--- a/src/Core/tests/Benchmarks/Benchmarks/TypeConversionBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/TypeConversionBenchmarker.cs
@@ -1,0 +1,30 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Controls.Xaml.Internals;
+
+namespace Microsoft.Maui.Handlers.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class TypeConversionBenchmarker
+	{
+		XamlServiceProvider _xamlServiceProvider;
+		Setter _setter;
+
+		[GlobalSetup]
+		public void GlobalSetup()
+		{
+			_xamlServiceProvider = new XamlServiceProvider();
+		
+			_setter = new Setter();
+			_setter.Property = Shell.BackgroundColorProperty;
+		}
+
+		[Benchmark]
+		public object ProvideValue()
+		{
+			_setter.Value = "Black";
+			return ((IValueProvider)_setter).ProvideValue(_xamlServiceProvider);
+		}
+	}
+}

--- a/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
+++ b/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Controls\src\Xaml\Controls.Xaml.csproj" />
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
     <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- Change GetTypeConverterTypeName to return the Type directly, so we aren't calling Type.AssemblyQualifiedName, and then Type.GetType.
- Cache TypeConverters from the "toType". This saves allocating toType.CustomAttributes, and allocating a new TypeConverter every time this is called with the same type, e.g. Color.

## Benchmark Results

The easiest public API I could find to exercise this path was Setter.ProvideValue. But this shows up in a startup profile for AppThemeBindingExtension.ProvideValue:

![image](https://user-images.githubusercontent.com/8291187/160728686-666cb6b5-b9f1-4ee1-b4ad-82b9f5fa3d41.png)

### Before

|       Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| ProvideValue | 10.71 us | 0.189 us | 0.232 us | 0.5035 |     - |     - |   3.11 KB |

### After

|       Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| ProvideValue | 309.4 ns | 4.65 ns | 4.13 ns | 0.0353 |     - |     - |     224 B |