### PR TITLE
Optimize Element.OnPropertyChanged

### DIFF
--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -105,12 +105,17 @@ namespace Microsoft.Maui.Controls
 				foreach (var child in LogicalChildrenInternal)
 					yield return child;
 
-				foreach (var child in ChildrenNotDrawnByThisElement)
-					yield return child;
+				var childrenNotDrawnByThisElement = ChildrenNotDrawnByThisElement;
+				if (childrenNotDrawnByThisElement is not null)
+				{
+					foreach (var child in childrenNotDrawnByThisElement)
+						yield return child;
+				}
 			}
 		}
 
-		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => EmptyChildren;
+		// return null by default so we don't need to foreach over an empty collection in OnPropertyChanged
+		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => null;
 
 		IReadOnlyList<Element> IElementController.LogicalChildren => LogicalChildrenInternal;
 
@@ -377,10 +382,14 @@ namespace Microsoft.Maui.Controls
 
 			Handler?.UpdateValue(propertyName);
 
-			foreach (var logicalChildren in ChildrenNotDrawnByThisElement)
+			var childrenNotDrawnByThisElement = ChildrenNotDrawnByThisElement;
+			if (childrenNotDrawnByThisElement is not null)
 			{
-				if (logicalChildren is IPropertyPropagationController controller)
-					PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { logicalChildren });
+				foreach (var logicalChildren in childrenNotDrawnByThisElement)
+				{
+					if (logicalChildren is IPropertyPropagationController controller)
+						PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { logicalChildren });
+				}
 			}
 
 			if (_effects?.Count > 0)

--- a/src/Core/tests/Benchmarks/Benchmarks/ElementBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/ElementBenchmarker.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Handlers.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class ElementBenchmarker
+	{
+		/// <summary>
+		/// Benchmarks setting an Element's property many times.
+		/// </summary>
+		[Benchmark]
+		public bool SetProperty()
+		{
+			SolidColorBrush brush = new SolidColorBrush(Colors.Red);
+			for (int i = 0; i < 10_000; i++)
+			{
+				brush.Color = Colors.Black;
+				brush.Color = Colors.Green;
+			}
+			return brush.Color == Colors.Green;
+		}
+	}
+}


### PR DESCRIPTION
- Don't foreach over the empty collection ChildrenNotDrawnByThisElement. The bulk of Element subclasses don't provide a value. Instead just return null.

This is a pretty minor, low-level optimization. But it shows to save 10% off setting simple properties.

## Benchmark Results

### Before

|      Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|----------:|----------:|------:|------:|------:|----------:|
| SetProperty | 1.736 ms | 0.0068 ms | 0.0057 ms |     - |     - |     - |     665 B |

### After

|      Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|----------:|----------:|------:|------:|------:|----------:|
| SetProperty | 1.546 ms | 0.0151 ms | 0.0133 ms |     - |     - |     - |     665 B |