### PR TITLE
Wire up to display after FlyoutPage has Loaded

### DIFF
--- a/src/Controls/src/Core/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage.cs
@@ -297,6 +297,9 @@ namespace Microsoft.Maui.Controls
 		public FlyoutPage()
 		{
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<FlyoutPage>>(() => new PlatformConfigurationRegistry<FlyoutPage>(this));
+
+			this.Loaded += OnLoaded;
+			this.Unloaded += OnUnloaded;
 		}
 
 		readonly Lazy<PlatformConfigurationRegistry<FlyoutPage>> _platformConfigurationRegistry;
@@ -305,6 +308,22 @@ namespace Microsoft.Maui.Controls
 		public new IPlatformElementConfiguration<T, FlyoutPage> On<T>() where T : IConfigPlatform
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
+		}
+
+		void OnUnloaded(object sender, EventArgs e)
+		{
+			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
+		}
+
+		void OnLoaded(object sender, EventArgs e)
+		{
+			DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
+			Handler?.UpdateValue(nameof(FlyoutBehavior));
+		}
+
+		void OnMainDisplayInfoChanged(object sender, DisplayInfoChangedEventArgs e)
+		{
+			Handler?.UpdateValue(nameof(FlyoutBehavior));
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/FlyoutPage/FlyoutPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/FlyoutPage/FlyoutPage.Impl.cs
@@ -41,28 +41,5 @@ namespace Microsoft.Maui.Controls
 #else
 		double IFlyoutView.FlyoutWidth => -1;
 #endif
-
-
-		private protected override void OnHandlerChangingCore(HandlerChangingEventArgs args)
-		{
-			base.OnHandlerChangingCore(args);
-
-			if (DeviceInfo.Idiom == DeviceIdiom.Phone)
-				return;
-
-			if (args.NewHandler == null)
-			{
-				DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
-			}
-			else if (args.OldHandler == null)
-			{
-				DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
-			}
-		}
-
-		void OnMainDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)
-		{
-			Handler?.UpdateValue(nameof(FlyoutBehavior));
-		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Wire up to display changes after the FlyoutPage has been loaded by the platform.