### PR TITLE
[Controls] remove allow-listed Converters

### DIFF
--- a/src/Controls/src/Build.Tasks/NodeILExtensions.cs
+++ b/src/Controls/src/Build.Tasks/NodeILExtensions.cs
@@ -174,6 +174,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				{
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "ThicknessTypeConverter")), typeof(ThicknessTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "CornerRadiusTypeConverter")), typeof(CornerRadiusTypeConverter) },
+					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "EasingTypeConverter")), typeof(EasingTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "ColorTypeConverter")), typeof(ColorTypeConverter) }
 				};
 			}

--- a/src/Controls/src/Core/BindableProperty.cs
+++ b/src/Controls/src/Core/BindableProperty.cs
@@ -41,8 +41,6 @@ namespace Microsoft.Maui.Controls
 		static readonly Dictionary<Type, TypeConverter> KnownTypeConverters = new Dictionary<Type, TypeConverter>
 		{
 			{ typeof(Uri), new UriTypeConverter() },
-			{ typeof(Color), new ColorTypeConverter() },
-			{ typeof(Easing), new EasingTypeConverter() },
 		};
 
 		static readonly Dictionary<Type, IValueConverter> KnownIValueConverters = new Dictionary<Type, IValueConverter>

--- a/src/Controls/tests/Core.UnitTests/EasingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/EasingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using NUnit.Framework;
+using Microsoft.Maui.Converters;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {

--- a/src/Core/src/Animations/Easing.cs
+++ b/src/Core/src/Animations/Easing.cs
@@ -1,8 +1,11 @@
 using System;
+using System.ComponentModel;
+using Microsoft.Maui.Converters;
 
 namespace Microsoft.Maui
 {
 	/// <include file="../../docs/Microsoft.Maui/Easing.xml" path="Type[@FullName='Microsoft.Maui.Easing']/Docs" />
+	[TypeConverter(typeof(EasingTypeConverter))]
 	public class Easing
 	{
 		/// <include file="../../docs/Microsoft.Maui/Easing.xml" path="//Member[@MemberName='Default']/Docs" />

--- a/src/Core/src/Converters/EasingTypeConverter.cs
+++ b/src/Core/src/Converters/EasingTypeConverter.cs
@@ -5,21 +5,18 @@ using System.Linq;
 using System.Reflection;
 using static Microsoft.Maui.Easing;
 
-namespace Microsoft.Maui.Controls
+#nullable disable
+
+namespace Microsoft.Maui.Converters
 {
-	/// <include file="../../docs/Microsoft.Maui.Controls/EasingTypeConverter.xml" path="Type[@FullName='Microsoft.Maui.Controls.EasingTypeConverter']/Docs" />
-	[Xaml.ProvideCompiled("Microsoft.Maui.Controls.XamlC.EasingTypeConverter")]
 	public class EasingTypeConverter : TypeConverter
 	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/EasingTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs" />
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 			=> sourceType == typeof(string);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/EasingTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs" />
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 			=> destinationType == typeof(string);
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/EasingTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs" />
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
 			var strValue = value?.ToString();
@@ -67,7 +64,6 @@ namespace Microsoft.Maui.Controls
 			throw new InvalidOperationException($"Cannot convert \"{strValue}\" into {typeof(Easing)}");
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/EasingTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs" />
 		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{
 			if (value is not Easing easing)
@@ -98,15 +94,12 @@ namespace Microsoft.Maui.Controls
 			throw new NotSupportedException();
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/EasingTypeConverter.xml" path="//Member[@MemberName='GetStandardValuesSupported']/Docs" />
 		public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
 			=> true;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/EasingTypeConverter.xml" path="//Member[@MemberName='GetStandardValuesExclusive']/Docs" />
 		public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
 			=> false;
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/EasingTypeConverter.xml" path="//Member[@MemberName='GetStandardValues']/Docs" />
 		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
 			=> new(new[] {
 				"Linear",


### PR DESCRIPTION
### Description of Change

- Move EasingTypeConverter to Core, attribute the type, and register the
compiled converter
- Remove Easing and Color converters from the allow-list

see https://github.com/dotnet/maui/issues/5660
