### PR TITLE
BlazorWebView public API tracking

### DIFF
--- a/eng/Microsoft.Extensions.targets
+++ b/eng/Microsoft.Extensions.targets
@@ -105,5 +105,9 @@
         Update="Microsoft.Web.WebView2"
         Version="$(_MicrosoftWebWebView2Version)"
     />
+    <PackageReference
+        Update="Microsoft.CodeAnalysis.PublicApiAnalyzers"
+        Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)"
+    />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,6 +34,7 @@
     <MicrosoftJSInteropPackageVersion>6.0.3</MicrosoftJSInteropPackageVersion>
     <MicrosoftWindowsDesktopAppRuntimewinx64Version>6.0.3</MicrosoftWindowsDesktopAppRuntimewinx64Version>
     <!-- Other packages -->
+    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftMauiGraphicsVersion>6.0.300-rc.2.1258</MicrosoftMauiGraphicsVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>

--- a/src/BlazorWebView/src/Directory.Build.props
+++ b/src/BlazorWebView/src/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/src/BlazorWebView/src/Directory.Build.props
+++ b/src/BlazorWebView/src/Directory.Build.props
@@ -6,4 +6,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);RS0041</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
@@ -6,8 +6,8 @@ using Android.Webkit;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-using AWebView = Android.Webkit.WebView;
 using AUri = Android.Net.Uri;
+using AWebView = Android.Webkit.WebView;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
-    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
   <Import Project="$(MauiRootDirectory)src\Workload\Shared\LibraryPacks.targets" />

--- a/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
+++ b/src/BlazorWebView/src/Maui/Microsoft.AspNetCore.Components.WebView.Maui.csproj
@@ -31,6 +31,11 @@
     <ProjectReference Include="..\..\..\Core\src\Core.csproj" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
   <Import Project="$(MauiRootDirectory)src\Workload\Shared\LibraryPacks.targets" />
 
 </Project>

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,31 +1,22 @@
-﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager
+﻿Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager
 Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.AndroidWebKitWebViewManager(Android.Webkit.WebView! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.BlazorAndroidWebView(Android.Content.Context! context) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -37,6 +28,14 @@ Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.SendMessage(string! message) -> void
@@ -44,7 +43,7 @@ override Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.OnKey
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView! platformView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,54 @@
+﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager
+Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.AndroidWebKitWebViewManager(Android.Webkit.WebView! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.BlazorAndroidWebView(Android.Content.Context! context) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.SendMessage(string! message) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.OnKeyDown(Android.Views.Keycode keyCode, Android.Views.KeyEvent? e) -> bool
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView! platformView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebChromeClient() -> Android.Webkit.WebChromeClient!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebViewClient() -> Android.Webkit.WebViewClient!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,9 +1,15 @@
-﻿Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager
+﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager
 Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.AndroidWebKitWebViewManager(Android.Webkit.WebView! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.BlazorAndroidWebView(Android.Content.Context! context) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
@@ -12,6 +18,8 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
@@ -37,6 +45,7 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask
 override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.SendMessage(string! message) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.OnKeyDown(Android.Views.Keycode keyCode, Android.Views.KeyEvent? e) -> bool
@@ -51,3 +60,4 @@ static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandle
 virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebChromeClient() -> Android.Webkit.WebChromeClient!
 virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebViewClient() -> Android.Webkit.WebViewClient!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Android.Webkit.WebView

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,44 +1,44 @@
-﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Android.Webkit.WebView
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.AndroidWebKitWebViewManager(Android.Webkit.WebView webview, System.IServiceProvider services, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.AndroidWebKitWebViewManager(Android.Webkit.WebView! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.BlazorAndroidWebView(Android.Content.Context context) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.BlazorAndroidWebView(Android.Content.Context! context) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -47,17 +47,18 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 ->
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask
-override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.NavigateCore(System.Uri absoluteUri) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.SendMessage(string message) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.OnKeyDown(Android.Views.Keycode keyCode, Android.Views.KeyEvent e) -> bool
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView platformView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebChromeClient() -> Android.Webkit.WebChromeClient
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebViewClient() -> Android.Webkit.WebViewClient
+override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.SendMessage(string! message) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.OnKeyDown(Android.Views.Keycode keyCode, Android.Views.KeyEvent? e) -> bool
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView! platformView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebChromeClient() -> Android.Webkit.WebChromeClient!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebViewClient() -> Android.Webkit.WebViewClient!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Android.Webkit.WebView

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,43 +1,44 @@
 ﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Android.Webkit.WebView
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.AndroidWebKitWebViewManager(Android.Webkit.WebView! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.AndroidWebKitWebViewManager(Android.Webkit.WebView webview, System.IServiceProvider services, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.BlazorAndroidWebView(Android.Content.Context! context) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.BlazorAndroidWebView(Android.Content.Context context) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -46,18 +47,17 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 ->
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask
-override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.SendMessage(string! message) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.OnKeyDown(Android.Views.Keycode keyCode, Android.Views.KeyEvent? e) -> bool
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView!
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView! platformView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebChromeClient() -> Android.Webkit.WebChromeClient!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebViewClient() -> Android.Webkit.WebViewClient!
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Android.Webkit.WebView
+override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.NavigateCore(System.Uri absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.AndroidWebKitWebViewManager.SendMessage(string message) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.OnKeyDown(Android.Views.Keycode keyCode, Android.Views.KeyEvent e) -> bool
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView platformView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebChromeClient() -> Android.Webkit.WebChromeClient
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.GetWebViewClient() -> Android.Webkit.WebViewClient

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,27 +1,18 @@
-﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+﻿Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
 Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
@@ -35,13 +26,21 @@ Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,49 @@
+﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
+Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,44 +1,42 @@
-﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler blazorMauiWebViewHandler, WebKit.WKWebView webview, System.IServiceProvider provider, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -46,14 +44,17 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri absoluteUri) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string message) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,41 +1,44 @@
 ﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler blazorMauiWebViewHandler, WebKit.WKWebView webview, System.IServiceProvider provider, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -43,17 +46,14 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string message) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
-﻿Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
@@ -8,6 +14,8 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
@@ -46,3 +54,6 @@ static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionEx
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
 virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,27 +1,18 @@
-﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+﻿Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
 Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
@@ -35,13 +26,21 @@ Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,0 +1,49 @@
+﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
+Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,44 +1,42 @@
-﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler blazorMauiWebViewHandler, WebKit.WKWebView webview, System.IServiceProvider provider, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -46,14 +44,17 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri absoluteUri) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string message) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,41 +1,44 @@
 ﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler blazorMauiWebViewHandler, WebKit.WKWebView webview, System.IServiceProvider provider, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -43,17 +46,14 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri absoluteUri) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string message) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
-﻿Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
@@ -8,6 +14,8 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
@@ -46,3 +54,6 @@ static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionEx
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
 virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> WebKit.WKWebView
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.get -> WebKit.WKWebViewConfiguration
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.Configuration.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,0 +1,50 @@
+﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager
+Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath, string! contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! webViewHandler) -> void
+Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
+Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
+override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,27 +1,18 @@
-﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+﻿Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -35,6 +26,14 @@ Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponen
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager
 Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath, string! contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! webViewHandler) -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
@@ -42,7 +41,7 @@ override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.Disco
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,48 +1,42 @@
-﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.UI.Xaml.Controls.WebView2
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2 webview, System.IServiceProvider services, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath, string contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler webViewHandler) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath, string! contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! webViewHandler) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -51,14 +45,21 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 ->
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2 platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs eventArgs) -> System.Threading.Tasks.Task
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.UI.Xaml.Controls.WebView2
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
-﻿Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
@@ -8,6 +14,8 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
@@ -36,8 +44,7 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 ->
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object!
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
@@ -47,3 +54,11 @@ static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionEx
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
 virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.UI.Xaml.Controls.WebView2
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> CoreWebView2EnvironmentOptions
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,41 +1,48 @@
 ﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.UI.Xaml.Controls.WebView2
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath, string! contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! webViewHandler) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2 webview, System.IServiceProvider services, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath, string contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler webViewHandler) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -44,21 +51,14 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 ->
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object!
-override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2 platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs eventArgs) -> System.Threading.Tasks.Task
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.UI.Xaml.Controls.WebView2
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> CoreWebView2EnvironmentOptions
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
-~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -5,7 +5,7 @@ Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> CoreWebView2EnvironmentOptions
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
@@ -39,6 +39,8 @@ Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager
+Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2 webview, System.IServiceProvider services, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath, string contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler webViewHandler) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -49,7 +51,10 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 ->
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2 platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs eventArgs) -> System.Threading.Tasks.Task
+override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
@@ -57,4 +62,3 @@ static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionEx
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
 virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -1,48 +1,42 @@
-﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.UI.Xaml.Controls.WebView2
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2 webview, System.IServiceProvider services, Microsoft.AspNetCore.Components.Dispatcher dispatcher, Microsoft.Extensions.FileProviders.IFileProvider fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents, string hostPageRelativePath, string contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler webViewHandler) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath, string! contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! webViewHandler) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -51,14 +45,21 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 ->
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2 platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs eventArgs) -> System.Threading.Tasks.Task
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.UI.Xaml.Controls.WebView2
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -1,0 +1,60 @@
+﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.UI.Xaml.Controls.WebView2
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> CoreWebView2EnvironmentOptions
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
+Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,27 +1,18 @@
-﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+﻿Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -33,10 +24,18 @@ Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object!
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,45 @@
+﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri! uri) -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object!
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyExternalNavigationStarting(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
-﻿Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
+﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
@@ -8,6 +14,8 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,39 +1,40 @@
-﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -41,12 +42,12 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object!
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -4,36 +4,36 @@ Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string?
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.get -> string
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
-Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore jsComponents) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -41,12 +41,12 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object!
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView!, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler!>!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
-virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView webView) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static readonly Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper -> Microsoft.Maui.PropertyMapper<Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler>
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+virtual Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -7,8 +7,8 @@ using Microsoft.AspNetCore.Components.WebView.WebView2;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Web.WebView2.Core;
 using Windows.ApplicationModel;
-using Windows.Storage.Streams;
 using Windows.Storage;
+using Windows.Storage.Streams;
 using WebView2Control = Microsoft.UI.Xaml.Controls.WebView2;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -33,8 +33,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="jsComponents">The <see cref="JSComponentConfigurationStore"/>.</param>
 		/// <param name="hostPageRelativePath">Path to the host page within the <paramref name="fileProvider"/>.</param>
 		/// <param name="contentRootDir">Path to the directory containing application content files.</param>
-        /// <param name="webViewHandler">The <see cref="BlazorWebViewHandler" />.</param>
-        public WinUIWebViewManager(
+		/// <param name="webViewHandler">The <see cref="BlazorWebViewHandler" />.</param>
+		public WinUIWebViewManager(
 			WebView2Control webview,
 			IServiceProvider services,
 			Dispatcher dispatcher,

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		private readonly string _hostPageRelativePath;
 		private readonly string _contentRootDir;
 
+#pragma warning disable RS0022
 		/// <summary>
 		/// Initializes a new instance of <see cref="WinUIWebViewManager"/>
 		/// </summary>
@@ -49,6 +50,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			_hostPageRelativePath = hostPageRelativePath;
 			_contentRootDir = contentRootDir;
 		}
+#pragma warning restore RS0022
 
 		/// <inheritdoc />
 		protected override async Task HandleWebResourceRequest(CoreWebView2WebResourceRequestedEventArgs eventArgs)

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			var args = new BlazorWebViewInitializingEventArgs();
 #if WEBVIEW2_MAUI
 			((BlazorWebView)_blazorWebViewHandler.VirtualView).NotifyBlazorWebViewInitializing(args);
-            _coreWebView2Environment = await CoreWebView2Environment.CreateWithOptionsAsync(
+			_coreWebView2Environment = await CoreWebView2Environment.CreateWithOptionsAsync(
 				browserExecutableFolder: args.BrowserExecutableFolder,
 				userDataFolder: args.UserDataFolder,
 				options: args.EnvironmentOptions)

--- a/src/BlazorWebView/src/WindowsForms/Microsoft.AspNetCore.Components.WebView.WindowsForms.csproj
+++ b/src/BlazorWebView/src/WindowsForms/Microsoft.AspNetCore.Components.WebView.WindowsForms.csproj
@@ -27,4 +27,9 @@
     <None Include="build\**\*" Pack="True" PackagePath="build\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorWebView/src/WindowsForms/Microsoft.AspNetCore.Components.WebView.WindowsForms.csproj
+++ b/src/BlazorWebView/src/WindowsForms/Microsoft.AspNetCore.Components.WebView.WindowsForms.csproj
@@ -27,9 +27,4 @@
     <None Include="build\**\*" Pack="True" PackagePath="build\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
-    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
-  </ItemGroup>
-
 </Project>

--- a/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
@@ -1,21 +1,20 @@
-﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri uri) -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+﻿Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs>
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.get -> System.IServiceProvider
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.set -> void
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebViewManager.get -> Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent

--- a/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
@@ -1,0 +1,38 @@
+﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri uri) -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.ExternalNavigationStarting -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs>
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.set -> void
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.get -> System.IServiceProvider
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.set -> void
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebViewManager.get -> Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.RootComponent(string selector, System.Type componentType, System.Collections.Generic.IDictionary<string, object> parameters) -> void
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection.RootComponentsCollection() -> void
+Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.CreateControlsInstance() -> System.Windows.Forms.Control.ControlCollection
+override Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Dispose(bool disposing) -> void
+override Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.OnCreateControl() -> void
+static Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions.Add<TComponent>(this Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection components, string selector, System.Collections.Generic.IDictionary<string, object> parameters = null) -> void
+static Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions.Remove(this Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection components, string selector) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWindowsFormsBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+virtual Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider

--- a/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
@@ -1,4 +1,15 @@
-﻿Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
@@ -9,6 +20,8 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> 
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection

--- a/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
+++ b/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
@@ -27,4 +27,9 @@
     <None Include="build\**\*" Pack="True" PackagePath="build\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
+++ b/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
@@ -27,9 +27,4 @@
     <None Include="build\**\*" Pack="True" PackagePath="build\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
-    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
-  </ItemGroup>
-
 </Project>

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -1,23 +1,22 @@
-﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri uri) -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
-Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+﻿Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
+Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebView() -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.DisposeAsync() -> System.Threading.Tasks.ValueTask
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ExternalNavigationStarting.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs>
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ExternalNavigationStarting.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.Services.get -> System.IServiceProvider
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.Services.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.ComponentType.get -> System.Type
@@ -35,9 +34,9 @@ override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnApplyTempla
 override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnInitialized(System.EventArgs e) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWpfBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ExternalNavigationStartingProperty -> System.Windows.DependencyProperty
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPageProperty -> System.Windows.DependencyProperty
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponentsProperty -> System.Windows.DependencyProperty
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ServicesProperty -> System.Windows.DependencyProperty
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoadingProperty -> System.Windows.DependencyProperty
 virtual Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
 virtual Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -1,0 +1,43 @@
+﻿Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationEventArgs(System.Uri uri) -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.get -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.ExternalLinkNavigationPolicy.set -> void
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs.Uri.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.CancelNavigation = 2 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.InsecureOpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy.OpenInExternalBrowser = 0 -> Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationPolicy
+Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ExternalNavigationStarting.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.ExternalLinkNavigationEventArgs>
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ExternalNavigationStarting.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.Services.get -> System.IServiceProvider
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.Services.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.ComponentType.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Parameters.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.RootComponent() -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Selector.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection.RootComponentsCollection() -> void
+Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnApplyTemplate() -> void
+override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnInitialized(System.EventArgs e) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWpfBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ExternalNavigationStartingProperty -> System.Windows.DependencyProperty
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPageProperty -> System.Windows.DependencyProperty
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponentsProperty -> System.Windows.DependencyProperty
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ServicesProperty -> System.Windows.DependencyProperty
+virtual Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+virtual Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -1,4 +1,15 @@
-﻿Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
+﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
@@ -9,6 +20,10 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> 
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebView() -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitialized.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitialized.set -> void
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializing.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializing.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.get -> string
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.set -> void
@@ -34,6 +49,8 @@ override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnApplyTempla
 override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnInitialized(System.EventArgs e) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWpfBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializedProperty -> System.Windows.DependencyProperty
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializingProperty -> System.Windows.DependencyProperty
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPageProperty -> System.Windows.DependencyProperty
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponentsProperty -> System.Windows.DependencyProperty
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ServicesProperty -> System.Windows.DependencyProperty


### PR DESCRIPTION
As a step towards https://github.com/dotnet/maui/issues/2539 and for longer-term API tracking, this PR adds the `Microsoft.CodeAnalysis.PublicApiAnalyzers` analyzer that we also use in the ASP.NET Core repo. It's only enabled for the BlazorWebView src projects (though other parts of MAUI could enable it easily if they wanted).

We don't strictly have to do this. However I don't see much drawback now the APIs should be mostly stable, and will help us to avoid any unwanted breaking change surprises in future releases.