### PR TITLE
Android reduce singleline usage

### DIFF
--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Maui.Platform
 				maxLines = int.MaxValue;
 
 			bool singleLine = false;
-			bool shouldSetSingleLine = !OperatingSystem.IsAndroidVersionAtLeast(22); // TODO ezhart verify this on 22-25
+			bool shouldSetSingleLine = !OperatingSystem.IsAndroidVersionAtLeast(23); 
 
 			switch (lineBreakMode)
 			{


### PR DESCRIPTION
### Description of Change

Setting the deprecated `singleLine` property is unnecessary for most LineBreakMode situations, and it breaks some of our ButtonHandler tests.

These changes reduce `singleLine` usage only to the necessary API levels and situations.
