### PR TITLE
Remove BuildTools as it is part of VS

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -236,7 +236,6 @@ Task("dotnet-pack-library-packs")
         Download("Microsoft.Maui.Graphics", "MicrosoftMauiGraphicsVersion", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json");
         Download("Microsoft.Maui.Graphics.Win2D.WinUI.Desktop", "MicrosoftMauiGraphicsVersion", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json", "https://api.nuget.org/v3/index.json");
         Download("Microsoft.WindowsAppSDK", "MicrosoftWindowsAppSDKPackageVersion", "https://api.nuget.org/v3/index.json");
-        Download("Microsoft.Windows.SDK.BuildTools", "MicrosoftWindowsSDKBuildToolsPackageVersion", "https://api.nuget.org/v3/index.json");
     });
 
 Task("dotnet-pack")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -235,7 +235,6 @@ Task("dotnet-pack-library-packs")
 
         Download("Microsoft.Maui.Graphics", "MicrosoftMauiGraphicsVersion", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json");
         Download("Microsoft.Maui.Graphics.Win2D.WinUI.Desktop", "MicrosoftMauiGraphicsVersion", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json", "https://api.nuget.org/v3/index.json");
-        Download("Microsoft.WindowsAppSDK", "MicrosoftWindowsAppSDKPackageVersion", "https://api.nuget.org/v3/index.json");
     });
 
 Task("dotnet-pack")

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -70,18 +70,6 @@
         NewValue="$(MicrosoftMauiGraphicsVersion)"
     />
     <ReplaceText
-        Input="$(IntermediateOutputPath)WorkloadManifest.json"
-        Output="$(IntermediateOutputPath)WorkloadManifest.json"
-        OldValue="@WASDK_VERSION@"
-        NewValue="$(MicrosoftWindowsAppSDKPackageVersion)"
-    />
-    <ReplaceText
-        Input="$(IntermediateOutputPath)WorkloadManifest.json"
-        Output="$(IntermediateOutputPath)WorkloadManifest.json"
-        OldValue="@WASDK_BUILD_TOOLS_VERSION@"
-        NewValue="$(MicrosoftWindowsSDKBuildToolsPackageVersion)"
-    />
-    <ReplaceText
         Input="%(_JsonVariableMatrix.OutputPath)"
         Output="%(_JsonVariableMatrix.OutputPath)"
         OldValue="%(_JsonVariableMatrix.OldValue)"

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -103,8 +103,7 @@
           "Microsoft.Maui.Controls.Runtime.win",
           "Microsoft.Maui.Essentials.Ref.win",
           "Microsoft.Maui.Essentials.Runtime.win",
-          "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop",
-          "Microsoft.WindowsAppSDK"
+          "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop"
       ]
     }
   },
@@ -248,10 +247,6 @@
     "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop": {
       "kind": "library",
       "version": "@MAUI_GRAPHICS_VERSION@"
-    },
-    "Microsoft.WindowsAppSDK": {
-      "kind": "library",
-      "version": "@WASDK_VERSION@"
     },
     "Microsoft.Maui.Sdk": {
       "kind": "sdk",

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -104,8 +104,7 @@
           "Microsoft.Maui.Essentials.Ref.win",
           "Microsoft.Maui.Essentials.Runtime.win",
           "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop",
-          "Microsoft.WindowsAppSDK",
-          "Microsoft.Windows.SDK.BuildTools"
+          "Microsoft.WindowsAppSDK"
       ]
     }
   },
@@ -253,10 +252,6 @@
     "Microsoft.WindowsAppSDK": {
       "kind": "library",
       "version": "@WASDK_VERSION@"
-    },
-    "Microsoft.Windows.SDK.BuildTools": {
-      "kind": "library",
-      "version": "@WASDK_BUILD_TOOLS_VERSION@"
     },
     "Microsoft.Maui.Sdk": {
       "kind": "sdk",


### PR DESCRIPTION
### Description of Change

Remove the BuildTools from the manifest because this is not a runtime package and also it already exists in VS.

Since it is not a runtime package, we can't really include it in the way we need:

> VALIDATEMANIFEST : warning : PackageDependenciesAreSatisfiedWarnings failed : Dependencies for chip='', language='' : The dependent package of 'maui.windows,version=#NUM#.#NUM#.#NUM#.#NUM#' cannot be found: Microsoft.Windows.SDK.BuildTools.#NUM#.#NUM#.#NUM#.#NUM#,version=#NUM#.#NUM#.#NUM#.#NUM#. : [manifest=VisualStudio/#NUM#.#NUM#.#NUM#+#NUM#.#NUM#.main]

Also removing the WASDK from the inserting because of missing symbols.