### PR TITLE
Correctly notify changes in the Page BackgroundColor property

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls
 	public partial class Page : IView, ITitledElement, IToolbarElement
 	{
 		Toolbar _toolbar;
+
 		IToolbar IToolbarElement.Toolbar
 		{
 			get => _toolbar;
@@ -24,6 +25,16 @@ namespace Microsoft.Maui.Controls
 
 				Handler?.UpdateValue(nameof(IToolbarElement.Toolbar));
 			}
+		}
+
+		public static IPropertyMapper<IContentView, PageHandler> ControlsPageMapper = new PropertyMapper<IContentView, PageHandler>(PageHandler.Mapper)
+		{
+			[nameof(BackgroundColor)] = (handler, __) => handler.UpdateValue(nameof(IContentView.Background)),
+		};
+
+		internal new static void RemapForControls()
+		{
+			PageHandler.Mapper = ControlsPageMapper;
 		}
 
 		internal void SendNavigatedTo(NavigatedToEventArgs args)

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -206,6 +206,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			Label.RemapForControls();
 			Button.RemapForControls();
 			RadioButton.RemapForControls();
+			Page.RemapForControls();
 			FlyoutPage.RemapForControls();
 			Toolbar.RemapForControls();
 			Window.RemapForControls();

--- a/src/Core/src/Handlers/Page/PageHandler.Android.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Android.cs
@@ -1,12 +1,7 @@
-﻿using Android.Views;
-using Microsoft.Maui.Graphics;
-
-namespace Microsoft.Maui.Handlers
+﻿namespace Microsoft.Maui.Handlers
 {
 	public partial class PageHandler : ContentViewHandler
 	{
-		//Graphics.Color? DefaultBackgroundColor;
-
 		public static void MapTitle(IPageHandler handler, IContentView page)
 		{
 		}

--- a/src/Core/src/Handlers/Page/PageHandler.Standard.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Standard.cs
@@ -1,11 +1,7 @@
-﻿using System;
-
-namespace Microsoft.Maui.Handlers
+﻿namespace Microsoft.Maui.Handlers
 {
 	public partial class PageHandler : ContentViewHandler
 	{
-		public static void MapTitle(IPageHandler handler, IContentView page)
-		{
-		}
+		public static void MapTitle(IPageHandler handler, IContentView page) { }
 	}
 }

--- a/src/Core/src/Handlers/Page/PageHandler.Windows.cs
+++ b/src/Core/src/Handlers/Page/PageHandler.Windows.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Microsoft.Maui.Handlers
+﻿namespace Microsoft.Maui.Handlers
 {
 	public partial class PageHandler : ContentViewHandler
 	{


### PR DESCRIPTION
### Description of Change

Correctly notify changes in the Page **BackgroundColor** property.

![fix-5681 ](https://user-images.githubusercontent.com/6755973/161074983-d175e811-e214-4db1-8d03-aa375fa01be8.gif)

### Issues Fixed

Fixes #5681 
Fixes #4335
