### PR TITLE
Fix cake

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -83,7 +83,7 @@ sudo pwsh -File ./maui-install.ps1 -b 'release/6.0.2xx-preview14' -v '6.0.200-pr
 
 ### iOS / MacCatalyst
 
-iOS and MacCatalyst will require Xcode 13.1 Stable. You can get this [here](https://developer.apple.com/download/more/?name=Xcode).
+iOS and MacCatalyst will require Xcode 13.3 Stable. You can get this [here](https://developer.apple.com/download/more/?name=Xcode).
 
 ### Android
 

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -352,11 +352,6 @@ Task("VS-NET6")
     .IsDependentOn("dotnet-buildtasks")
     .Does(() =>
     {
-        // VS has trouble building all the references correctly so this makes sure everything is built
-        // and we're ready to go right when VS launches
-        
-        RunMSBuildWithDotNet("./src/Compatibility/Android.FormsViewGroup/src/Compatibility.Android.FormsViewGroup.csproj");
-        RunMSBuildWithDotNet("./src/Compatibility/Core/src/Compatibility.csproj");
         StartVisualStudioForDotNet6();
     });
 

--- a/src/Controls/DualScreen/src/Controls.DualScreen.csproj
+++ b/src/Controls/DualScreen/src/Controls.DualScreen.csproj
@@ -45,8 +45,6 @@
     <Compile Include="**\*.android.*.cs" />
     <AndroidResource Include="Resources\xml\*.xml" />
     <PackageReference Include="Xamarin.DuoSdk" Version="0.0.3.4" />
-    <ProjectReference Include="..\..\..\Compatibility\Android.FormsViewGroup\src\Compatibility.Android.FormsViewGroup.csproj">
-    </ProjectReference>
     <ProjectReference Include="..\..\..\Compatibility\Core\src\Android\Compatibility.Android.csproj">
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change

After commit 680f1fbbdd9fa8e5e4e3f1614d798213d36eace9, the command

`dotnet cake --target=VS-NET6 --workloads=global` 

fails because `Compatibility.Android.FormsViewGroup.csproj` is deleted.

I also noticed that the documentation is a bit out of date, the product failed to build with XCode 13.1. Now it requires 13.3.

### Issues Fixed

The broken build.