### PR TITLE
Wire up WindowOverlay to the Window Density

### DIFF
--- a/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
@@ -51,9 +51,6 @@ namespace Microsoft.Maui
 			if (_nativeActivity.Window != null)
 				_nativeActivity.Window.DecorView.LayoutChange += DecorViewLayoutChange;
 
-			if (_nativeActivity?.Resources?.DisplayMetrics != null)
-				Density = _nativeActivity.Resources.DisplayMetrics.Density;
-
 			_graphicsView = new PlatformGraphicsView(_nativeLayer.Context, this);
 			if (_graphicsView == null)
 				return false;

--- a/src/Core/src/WindowOverlay/WindowOverlay.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui
 		}
 
 		/// <inheritdoc/>
-		public float Density { get; internal set; } = 1;
+		public float Density => Window?.RequestDisplayDensity() ?? 0f;
 
 		/// <inheritdoc/>
 		public event EventHandler<WindowOverlayTappedEventArgs>? Tapped;

--- a/src/Core/src/WindowOverlay/WindowOverlay.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui
 		}
 
 		/// <inheritdoc/>
-		public float Density => Window?.RequestDisplayDensity() ?? 0f;
+		public float Density => Window?.RequestDisplayDensity() ?? 1f;
 
 		/// <inheritdoc/>
 		public event EventHandler<WindowOverlayTappedEventArgs>? Tapped;


### PR DESCRIPTION
The VisualDiagnostics' WindowOverlay was implemented before we introduced a better API for dealing with display density, but we never hooked that new API up to VisualDiagnostics.

The fix is simple here, just defer to the Window's display density to get the correct value from the WindowOverlay.

This fixes #5334

