### PR TITLE
Add MAUI and WPF Blazor Hybrid XAML namespaces

### DIFF
--- a/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml
+++ b/src/BlazorWebView/samples/BlazorWpfApp/MainWindow.xaml
@@ -2,9 +2,9 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:blazor="http://schemas.microsoft.com/winfx/2006/xaml/presentation/blazor"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:BlazorWpfApp"
-        xmlns:blazor="clr-namespace:Microsoft.AspNetCore.Components.WebView.Wpf;assembly=Microsoft.AspNetCore.Components.WebView.Wpf"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <DockPanel>

--- a/src/BlazorWebView/src/Maui/Properties/AssemblyInfo.cs
+++ b/src/BlazorWebView/src/Maui/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
+
+[assembly: Preserve]
+
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui", "Microsoft.AspNetCore.Components.WebView.Maui")]

--- a/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
+++ b/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\SharedSource\**\*.cs" Link="SharedSource\%(Filename)%(Extension)"/>
+    <Compile Include="..\SharedSource\**\*.cs" Link="SharedSource\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorWebView/src/Wpf/Properties/AssemblyInfo.cs
+++ b/src/BlazorWebView/src/Wpf/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Windows.Markup;
+
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation/blazor", "Microsoft.AspNetCore.Components.WebView.Wpf")]

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml
@@ -7,8 +7,6 @@
     Title="Blazor">
 
     <!--
-    xmlns:b="clr-namespace:Microsoft.AspNetCore.Components.WebView.Maui;assembly=Microsoft.AspNetCore.Components.WebView.Maui"
-
     <VerticalStackLayout
         Margin="12"
         Spacing="5"
@@ -18,23 +16,23 @@
             FontSize="24"
             TextColor="BlanchedAlmond"
             HorizontalOptions="Center" />
-        <b:BlazorWebView
+        <BlazorWebView
             HostPage="wwwroot/index.html"
             BackgroundColor="Orange"
             HeightRequest="400"
             MinimumHeightRequest="400"
             VerticalOptions="FillAndExpand">
-            <b:BlazorWebView.RootComponents>
-                <b:RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
-            </b:BlazorWebView.RootComponents>
-        </b:BlazorWebView>
+            <BlazorWebView.RootComponents>
+                <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
+            </BlazorWebView.RootComponents>
+        </BlazorWebView>
         <Label
             Text="Thank you for using Blazor and .NET MAUI!"
             FontSize="24"
             TextColor="BlanchedAlmond"
             HorizontalOptions="Center" />
     </VerticalStackLayout>
-
+    
     -->
 
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml
@@ -32,7 +32,7 @@
             TextColor="BlanchedAlmond"
             HorizontalOptions="Center" />
     </VerticalStackLayout>
-    
+
     -->
 
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml
@@ -6,33 +6,35 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="Blazor">
 
-    <!--
-    <VerticalStackLayout
-        Margin="12"
-        Spacing="5"
+    <Grid
+        VerticalOptions="Fill"
         BackgroundColor="Purple">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
         <Label
+            Grid.Row="0"
             Text="The content below is brought to you by Blazor!"
             FontSize="24"
             TextColor="BlanchedAlmond"
             HorizontalOptions="Center" />
         <BlazorWebView
+            x:Name="bwv"
+            Grid.Row="1"
             HostPage="wwwroot/index.html"
-            BackgroundColor="Orange"
-            HeightRequest="400"
-            MinimumHeightRequest="400"
-            VerticalOptions="FillAndExpand">
+            BackgroundColor="Orange">
             <BlazorWebView.RootComponents>
                 <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
             </BlazorWebView.RootComponents>
         </BlazorWebView>
         <Label
+            Grid.Row="2"
             Text="Thank you for using Blazor and .NET MAUI!"
             FontSize="24"
             TextColor="BlanchedAlmond"
             HorizontalOptions="Center" />
-    </VerticalStackLayout>
-
-    -->
+    </Grid>
 
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml.cs
@@ -1,13 +1,8 @@
-using Maui.Controls.Sample.Controls;
 using Maui.Controls.Sample.Pages.Base;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
 
 #if NET6_0_OR_GREATER
 using Maui.Controls.Sample.Pages.Blazor;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.AspNetCore.Components.WebView.Maui;
 #endif
 
 namespace Maui.Controls.Sample.Pages
@@ -19,35 +14,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 
 #if NET6_0_OR_GREATER
-			var grid = new Grid() { VerticalOptions = LayoutOptions.Fill, BackgroundColor = Colors.Purple, };
-			grid.AddRowDefinition(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
-			grid.AddRowDefinition(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
-			grid.AddRowDefinition(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
-
-			var headerLabel = new Label { Text = "The content below is brought to you by Blazor!", FontSize = 24, TextColor = Colors.BlanchedAlmond, HorizontalOptions = LayoutOptions.Center, };
-			grid.Add(headerLabel);
-			Grid.SetRow(headerLabel, 0);
-
-			// You can replace this BlazorWebView with CustomBlazorWebView to see loading custom static assets
-			var bwv = new BlazorWebView
-			{
-				// General properties
-				BackgroundColor = Colors.Orange,
-
-				// BlazorWebView properties
-				HostPage = @"wwwroot/index.html",
-			};
-			bwv.RootComponents.Add(new RootComponent { Selector = "#app", ComponentType = typeof(Main) });
 			bwv.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
-
-			grid.Add(bwv);
-			Grid.SetRow(bwv, 1);
-
-			var footerLabel = new Label { Text = "Thank you for using Blazor and .NET MAUI!", FontSize = 24, TextColor = Colors.BlanchedAlmond, HorizontalOptions = LayoutOptions.Center, };
-			grid.Add(footerLabel);
-			Grid.SetRow(footerLabel, 2);
-
-			Content = grid;
 #endif
 		}
 	}

--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml
@@ -1,15 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:b="clr-namespace:Microsoft.AspNetCore.Components.WebView.Maui;assembly=Microsoft.AspNetCore.Components.WebView.Maui"
              xmlns:local="clr-namespace:MauiApp._1"
              x:Class="MauiApp._1.MainPage"
              BackgroundColor="{DynamicResource PageBackgroundColor}">
 
-    <b:BlazorWebView HostPage="wwwroot/index.html">
-        <b:BlazorWebView.RootComponents>
-            <b:RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
-        </b:BlazorWebView.RootComponents>
-    </b:BlazorWebView>
+    <BlazorWebView HostPage="wwwroot/index.html">
+        <BlazorWebView.RootComponents>
+            <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
+        </BlazorWebView.RootComponents>
+    </BlazorWebView>
 
 </ContentPage>


### PR DESCRIPTION
### Description of Change

Added the following XAML namespaces for Blazor Hybrid:
MAUI: `http://schemas.microsoft.com/dotnet/2021/maui` (same as other MAUI controls)
WPF: `http://schemas.microsoft.com/winfx/2006/xaml/presentation/blazor`

The namespace names are subject to further discussion in this PR.

The templates and sample projects have been updated to reflect this change.

### Issues Fixed

Fixes #4303