### PR TITLE
Exclude Templates folder from running device tests CI

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -13,6 +13,7 @@ trigger:
     exclude:
     - .github/*
     - docs/*
+    - src/Templates/*
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
     - LICENSE.TXT
@@ -32,6 +33,7 @@ pr:
     exclude:
     - .github/*
     - docs/*
+    - src/Templates/*
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
     - LICENSE.TXT


### PR DESCRIPTION
### Description of Change

While making an update to the templates I noticed the device tests are kicked off, this doesn't seem very useful.