### PR TITLE
Fixing image shadows on Windows

### DIFF
--- a/src/Core/src/Platform/Windows/ShadowExtensions.cs
+++ b/src/Core/src/Platform/Windows/ShadowExtensions.cs
@@ -48,6 +48,13 @@ namespace Microsoft.Maui.Platform
 							width,
 							height);
 
+						// sometimes RenderAsync produces a 0x0 bitmap for images
+						// in such case we will fall back to GetAlphaMask.
+						if (bitmap.PixelWidth == 0 && element is Image image)
+						{
+							return image.GetAlphaMask();
+						}
+
 						var pixels = await bitmap.GetPixelsAsync();
 
 						using (var softwareBitmap = SoftwareBitmap.CreateCopyFromBuffer(

--- a/src/Core/src/Platform/Windows/ShadowExtensions.cs
+++ b/src/Core/src/Platform/Windows/ShadowExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Shapes;
 using Windows.Foundation;
 using Windows.Graphics.Imaging;
 
@@ -27,10 +28,16 @@ namespace Microsoft.Maui.Platform
                 //generates a shadow with a size more smaller than the control size. 
 				if (element is TextBlock textElement)
 				{
-					mask = textElement.GetAlphaMask();
+					return textElement.GetAlphaMask();
 				}
-				// We also use this option with images and shapes, even though have the option to
-				// get the AlphaMask directly (in case it is clipped).
+				if (element is Image image)
+				{
+					return image.GetAlphaMask();
+				}
+				if (element is Shape shape)
+				{
+					return shape.GetAlphaMask();
+				}
 				else if (element is FrameworkElement frameworkElement)
 				{
 					var height = (int)frameworkElement.ActualHeight;
@@ -47,13 +54,6 @@ namespace Microsoft.Maui.Platform
 							element,
 							width,
 							height);
-
-						// sometimes RenderAsync produces a 0x0 bitmap for images
-						// in such case we will fall back to GetAlphaMask.
-						if (bitmap.PixelWidth == 0 && element is Image image)
-						{
-							return image.GetAlphaMask();
-						}
 
 						var pixels = await bitmap.GetPixelsAsync();
 


### PR DESCRIPTION
### Description of Change

GetAlphaMaskAsync tries to render an image into a render target bitmap and then fetch pixel data to create alpha mask.
According to the comments in the code we use this approach instead of getting the alpha mask directly from the visual because it could potentially result in a clipped mask.

It was observed that `RenderAsync` sometimes does not work properly in this case and returns 0x0 image. Possibly because the rendering happens on the first measure pass and maybe that is too early.

In this fix we detect the bad render result and fallback to `image.GetAlphaMask()` as returning `null` mask results in something that looks a lot worse.

### Issues Fixed

Fixes #3082
