### PR TITLE
[Android] Clip Border content based on StrokeShape property

### DIFF
--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -1,15 +1,20 @@
 ﻿using System;
 using Android.Content;
+using Android.Graphics;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
-using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics.Platform;
+using Rect = Microsoft.Maui.Graphics.Rect;
 
 namespace Microsoft.Maui.Platform
 {
 	// TODO ezhart At this point, this is almost exactly a clone of LayoutViewGroup; we may be able to drop this class entirely
 	public class ContentViewGroup : ViewGroup
 	{
+		IBorderStroke? _clip;
+
 		public ContentViewGroup(Context context) : base(context)
 		{
 		}
@@ -28,6 +33,14 @@ namespace Microsoft.Maui.Platform
 
 		public ContentViewGroup(Context context, IAttributeSet attrs, int defStyleAttr, int defStyleRes) : base(context, attrs, defStyleAttr, defStyleRes)
 		{
+		}
+
+		protected override void DispatchDraw(Canvas? canvas)
+		{
+			if (Stroke != null)
+				ClipChild(canvas);
+
+			base.DispatchDraw(canvas);
 		}
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
@@ -84,7 +97,38 @@ namespace Microsoft.Maui.Platform
 			CrossPlatformArrange(destination);
 		}
 
+		internal IBorderStroke? Clip
+		{
+			get => _clip;
+			set
+			{
+				_clip = value;
+				PostInvalidate();
+			}
+		}
+
 		internal Func<double, double, Graphics.Size>? CrossPlatformMeasure { get; set; }
 		internal Func<Graphics.Rect, Graphics.Size>? CrossPlatformArrange { get; set; }
+
+		void ClipChild(Canvas? canvas)
+		{
+			if (Clip == null || canvas == null)
+				return;
+
+			double density = DeviceDisplay.MainDisplayInfo.Density;
+			var strokeThickness = (float)(Clip.StrokeThickness * density);
+
+			float x = (float)strokeThickness / 2;
+			float y = (float)strokeThickness / 2;
+			float w = (float)(canvas.Width - strokeThickness);
+			float h = (float)(canvas.Height - strokeThickness);
+
+			var bounds = new Graphics.RectF(x, y, w, h);
+			var path = Clip.Shape?.PathForBounds(bounds);
+			var currentPath = path?.AsAndroidPath();
+
+			if (currentPath != null)
+				canvas.ClipPath(currentPath);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Platform
 
 		protected override void DispatchDraw(Canvas? canvas)
 		{
-			if (Stroke != null)
+			if (Clip != null)
 				ClipChild(canvas);
 
 			base.DispatchDraw(canvas);

--- a/src/Core/src/Platform/Android/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Android/StrokeExtensions.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Maui.Platform
 			mauiDrawable.SetBorderShape(border.Shape);
 
 			if (platformView is ContentViewGroup contentViewGroup)
-				contentViewGroup.Stroke = border;
+				contentViewGroup.Clip = border;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Android/StrokeExtensions.cs
@@ -149,6 +149,9 @@ namespace Microsoft.Maui.Platform
 				mauiDrawable.SetBackground(new SolidPaint(Colors.Transparent));
 
 			mauiDrawable.SetBorderShape(border.Shape);
+
+			if (platformView is ContentViewGroup contentViewGroup)
+				contentViewGroup.Stroke = border;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Clip Border content based on StrokeShape property on Android.

Before
![image](https://user-images.githubusercontent.com/6755973/161539616-e0973063-aaea-49be-ad28-9b8374781d82.png)

After
![image](https://user-images.githubusercontent.com/6755973/161539429-688635f1-5c92-433d-8301-d854953547f2.png)

### Issues Fixed

Is related with the issue 2694. However, this only include the changes to fix the issue on Android. I am going to create different PRs by different platforms.
