### PR TITLE
[Bug] [AppAction] [Android] Prevent AppAction double handling on Android

### DIFF
--- a/src/Essentials/src/AppActions/AppActions.android.cs
+++ b/src/Essentials/src/AppActions/AppActions.android.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.ApplicationModel
 	class AppActionsImplementation : IAppActions, IPlatformAppActions
 	{
 		public const string IntentAction = "ACTION_XE_APP_ACTION";
+		const string extraAppActionHandled = "EXTRA_XE_APP_ACTION_HANDLED";
 
 		public bool IsSupported => OperatingSystem.IsAndroidVersionAtLeast(25);
 
@@ -53,8 +54,11 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public void OnNewIntent(Intent intent)
 		{
-			if (intent?.Action == IntentAction)
+			if (intent?.Action == IntentAction && !intent.GetBooleanExtra(extraAppActionHandled, false))
 			{
+				// prevent launch intent getting handled on activity resume
+                intent.PutExtra(extraAppActionHandled, true);
+
 				var appAction = intent.ToAppAction();
 
 				if (!string.IsNullOrEmpty(appAction?.Id))


### PR DESCRIPTION
### Description of Change

Port for fix of: https://github.com/xamarin/Essentials/pull/1923

> This prevents the double handling of AppAction Intents on Android by setting an extra in the Intent to ensure that the event is only handled once.
>
> No new test cases or samples. This requires manual testing.

### Issues Fixed

Linked Xamarin.Essentials bug: https://github.com/xamarin/Essentials/issues/1922
