### PR TITLE
Essentials Location Permissions Set result after cleanup of iOS LocationManager

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.ios.tvos.watchos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.tvos.watchos.cs
@@ -187,9 +187,9 @@ namespace Microsoft.Maui.ApplicationModel
 						}
 
 						del.AuthorizationStatusChanged -= LocationAuthCallback;
-						tcs.TrySetResult(GetLocationStatus(whenInUse));
 						locationManager?.Dispose();
 						locationManager = null;
+						tcs.TrySetResult(GetLocationStatus(whenInUse));
 					}
 					catch (Exception ex)
 					{


### PR DESCRIPTION
### Description of Change

Port of this change in Xamarin.Essentials: https://github.com/xamarin/Essentials/pull/1815

> On IOS if you like to request LocationAlways you have to request locationWhenInUse first. This means in an average implementation one would have 2 consecutive calls
await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
await Permissions.RequestAsync<Permissions.LocationAlways>();
Both use the static LocationManager instance.
Since RequestAsync<Permissions.LocationWhenInUse>() sets the result of the task completition source before cleaning up its locationManager there is a race condition where RequestAsync<Permission.LocationAlways>() already runs and thus this cleanup disposes the locationManager used by the second call. This will not always be the case but in my test around 50% of the time. Workaround wait 3-10 seconds in between the calls

### Issues Fixed

Original Xamarin.Essentials bug: https://github.com/xamarin/Essentials/issues/1489
