### PR TITLE
Surface exception for not supported phone number on iOS PhoneDialer

### DIFF
--- a/src/Essentials/src/PhoneDialer/PhoneDialer.ios.cs
+++ b/src/Essentials/src/PhoneDialer/PhoneDialer.ios.cs
@@ -6,16 +6,14 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 {
 	partial class PhoneDialerImplementation : IPhoneDialer
 	{
-		const string noNetworkProviderCode = "65535";
-
 		public bool IsSupported => UIApplication.SharedApplication.CanOpenUrl(CreateNsUrl(new string('0', 10)));
 
-		public async void Open(string number)
+		public void Open(string number)
 		{
 			ValidateOpen(number);
 
 			var nsUrl = CreateNsUrl(number);
-			await Launcher.Default.OpenAsync(nsUrl);
+			Launcher.Default.OpenAsync(nsUrl);
 		}
 
 		static NSUrl CreateNsUrl(string number) => new NSUrl(new Uri($"tel:{number}").AbsoluteUri);


### PR DESCRIPTION
### Description of Change

Port from Xamarin.Essentials change: https://github.com/xamarin/Essentials/pull/1986

Before this change if you would enter a phone number like `*123#` iOS would thrown an exception which couldn't be caught because of the `async void`.

This also removes a unused variable.

### Issues Fixed

N/A
