### PR TITLE
[Blazor] Initial support for configuring the underlying Web view settings

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -99,6 +99,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
+			var args = new BlazorWebViewInitializingEventArgs();
+			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(args);
+			args?.OnWebViewInitialized(PlatformView);
+
 			if (RootComponents != null)
 			{
 				foreach (var rootComponent in RootComponents)

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -99,9 +99,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
-			var args = new BlazorWebViewInitializingEventArgs();
-			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(args);
-			args.OnWebViewInitialized?.Invoke(PlatformView);
+			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
+			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
+			{
+				WebView = PlatformView,
+			});
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			var args = new BlazorWebViewInitializingEventArgs();
 			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(args);
-			args?.OnWebViewInitialized(PlatformView);
+			args.OnWebViewInitialized?.Invoke(PlatformView);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -33,10 +33,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <inheritdoc />
 		public RootComponentsCollection RootComponents { get; }
 
-		/// <inheritdoc/>
+		/// <inheritdoc />
 		public event EventHandler<UrlLoadingEventArgs>? UrlLoading;
 
-		/// <inheritdoc/>
+		/// <inheritdoc />
+		public event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
+
+		/// <inheritdoc />
 		public virtual IFileProvider CreateFileProvider(string contentRootDir)
 		{
 			// Call into the platform-specific code to get that platform's asset file provider
@@ -47,5 +50,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			UrlLoading?.Invoke(this, args);
 		}
+
+		internal void NotifyBlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args) =>
+			BlazorWebViewInitializing?.Invoke(this, args);
 	}
 }

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -40,6 +40,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		public event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
 
 		/// <inheritdoc />
+		public event EventHandler<BlazorWebViewInitializedEventArgs>? BlazorWebViewInitialized;
+
+		/// <inheritdoc />
 		public virtual IFileProvider CreateFileProvider(string contentRootDir)
 		{
 			// Call into the platform-specific code to get that platform's asset file provider
@@ -53,5 +56,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 		internal void NotifyBlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args) =>
 			BlazorWebViewInitializing?.Invoke(this, args);
+
+		internal void NotifyBlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args) =>
+			BlazorWebViewInitialized?.Invoke(this, args);
 	}
 }

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -82,6 +82,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		internal Action<UrlLoadingEventArgs>? UrlLoading;
 
 		private RootComponentsCollection? _rootComponents;
+
 		private RootComponentsCollection? RootComponents
 		{
 			get => _rootComponents;

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -32,6 +32,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		event EventHandler<UrlLoadingEventArgs>? UrlLoading;
 
 		/// <summary>
+		/// Allows customizing how links are opened.
+		/// By default, opens internal links in the webview and external links in an external app.
+		/// </summary>
+		event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
+
+		/// <summary>
 		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. The default implementation
 		/// serves files from a platform-specific location. Override this method to return a custom <see cref="IFileProvider"/> to serve assets such
 		/// as <c>wwwroot/index.html</c>. Call the base method and combine its return value with a <see cref="CompositeFileProvider"/>

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -32,12 +32,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		event EventHandler<UrlLoadingEventArgs>? UrlLoading;
 
 		/// <summary>
-		/// Allows customizing the web view configuration before it is created.
+		/// Raised before the web view is initialized. On some platforms this enables customizing the web view configuration.
 		/// </summary>
 		event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
 
 		/// <summary>
-		/// Allows customizing the web view configuration after it has been created but before any component has been rendered.
+		/// Raised after the web view is initialized but before any component has been rendered. The event arguments provide the instance of the platform-specific web view control.
 		/// </summary>
 		event EventHandler<BlazorWebViewInitializedEventArgs>? BlazorWebViewInitialized;
 

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -32,9 +32,14 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		event EventHandler<UrlLoadingEventArgs>? UrlLoading;
 
 		/// <summary>
-		/// Allows customizing the web view initialization process.
+		/// Allows customizing the web view configuration before it is created.
 		/// </summary>
 		event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
+
+		/// <summary>
+		/// Allows customizing the web view configuration after it has been created but before any component has been rendered.
+		/// </summary>
+		event EventHandler<BlazorWebViewInitializedEventArgs>? BlazorWebViewInitialized;
 
 		/// <summary>
 		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. The default implementation

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -32,8 +32,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		event EventHandler<UrlLoadingEventArgs>? UrlLoading;
 
 		/// <summary>
-		/// Allows customizing how links are opened.
-		/// By default, opens internal links in the webview and external links in an external app.
+		/// Allows customizing the web view initialization process.
 		/// </summary>
 		event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
 

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -51,6 +51,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			var config = new WKWebViewConfiguration();
 
+			var args = new BlazorWebViewInitializingEventArgs()
+			{
+				Configuration = config
+			};
+
+			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(args);
+
 			config.Preferences.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("developerExtrasEnabled"));
 
 			config.UserContentController.AddScriptMessageHandler(new WebViewScriptMessageHandler(MessageReceived), "webwindowinterop");
@@ -60,11 +67,15 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			// iOS WKWebView doesn't allow handling 'http'/'https' schemes, so we use the fake 'app' scheme
 			config.SetUrlSchemeHandler(new SchemeHandler(this), urlScheme: "app");
 
-			return new WKWebView(RectangleF.Empty, config)
+			var webview = new WKWebView(RectangleF.Empty, config)
 			{
 				BackgroundColor = UIColor.Clear,
 				AutosizesSubviews = true
 			};
+
+			args?.OnWebViewInitialized(webview);
+
+			return webview;
 		}
 
 		private void MessageReceived(Uri uri, string message)

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -51,12 +51,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			var config = new WKWebViewConfiguration();
 
-			var args = new BlazorWebViewInitializingEventArgs()
+			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs()
 			{
 				Configuration = config
-			};
-
-			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(args);
+			});
 
 			config.Preferences.SetValueForKey(NSObject.FromObject(DeveloperTools.Enabled), new NSString("developerExtrasEnabled"));
 
@@ -73,7 +71,10 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-			args.OnWebViewInitialized?.Invoke(webview);
+			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
+			{
+				WebView = webview
+			});
 
 			return webview;
 		}

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-			args?.OnWebViewInitialized(webview);
+			args.OnWebViewInitialized?.Invoke(webview);
 
 			return webview;
 		}

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+#if WEBVIEW2_WINFORMS
+using Microsoft.Web.WebView2.Core;
+using WebView2Control = Microsoft.Web.WebView2.WinForms.WebView2;
+#elif WEBVIEW2_WPF
+using Microsoft.Web.WebView2.Core;
+using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
+#elif WINDOWS && WEBVIEW2_MAUI
+using Microsoft.Web.WebView2.Core;
+using WebView2Control = Microsoft.UI.Xaml.Controls.WebView2;
+#elif ANDROID
+using AWebView = Android.Webkit.WebView;
+#elif IOS || MACCATALYST
+using WebKit;
+#endif
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+	/// <summary>
+	/// Allows configuring the underlying web view after it has been initialized.
+	/// </summary>
+	public partial class BlazorWebViewInitializedEventArgs : EventArgs
+	{
+#nullable disable
+#if WINDOWS
+		/// <summary>
+		/// Gets or sets a function that will be invoked once the web view has been initialized with
+		/// the default values to allow further configuring additional options.
+		/// </summary>
+		public WebView2Control WebView { get; internal set; }
+#elif ANDROID
+		/// <summary>
+		/// Gets or sets a function that will be invoked once the web view has been initialized with
+		/// the default values to allow further configuring additional options.
+		/// </summary>
+		public AWebView WebView { get; internal set; }
+#elif MACCATALYST || IOS
+		/// <summary>
+		/// Gets or sets a function that will be invoked once the web view has been initialized with
+		/// the default values to allow further configuring additional options.
+		/// </summary>
+		public WKWebView WebView { get; internal set; }
+#endif
+	}
+}

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializedEventArgs.cs
@@ -20,24 +20,22 @@ namespace Microsoft.AspNetCore.Components.WebView
 	/// <summary>
 	/// Allows configuring the underlying web view after it has been initialized.
 	/// </summary>
-	public partial class BlazorWebViewInitializedEventArgs : EventArgs
+	public class BlazorWebViewInitializedEventArgs : EventArgs
 	{
 #nullable disable
 #if WINDOWS
 		/// <summary>
-		/// Gets or sets a function that will be invoked once the web view has been initialized with
-		/// the default values to allow further configuring additional options.
+		/// Gets the <see cref="WebView2Control"/> instance that was initialized.
 		/// </summary>
 		public WebView2Control WebView { get; internal set; }
 #elif ANDROID
 		/// <summary>
-		/// Gets or sets a function that will be invoked once the web view has been initialized with
-		/// the default values to allow further configuring additional options.
+		/// Gets the <see cref="AWebView"/> instance that was initialized.
 		/// </summary>
 		public AWebView WebView { get; internal set; }
 #elif MACCATALYST || IOS
 		/// <summary>
-		/// Gets or sets a function that will be invoked once the web view has been initialized with
+		/// Gets the <see cref="WKWebView"/> instance that was initialized.
 		/// the default values to allow further configuring additional options.
 		/// </summary>
 		public WKWebView WebView { get; internal set; }

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
@@ -9,6 +9,10 @@ using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
 #elif WINDOWS && WEBVIEW2_MAUI
 using Microsoft.Web.WebView2.Core;
 using WebView2Control = Microsoft.UI.Xaml.Controls.WebView2;
+#elif ANDROID
+using AWebView = Android.Webkit.WebView;
+#elif IOS || MACCATALYST
+using WebKit;
 #endif
 
 namespace Microsoft.AspNetCore.Components.WebView
@@ -18,8 +22,8 @@ namespace Microsoft.AspNetCore.Components.WebView
 	/// </summary>
 	public partial class BlazorWebViewInitializingEventArgs : EventArgs
 	{
-#if WINDOWS
 #nullable disable
+#if WINDOWS
 		/// <summary>
 		/// Gets or sets the browser executable folder path for the <see cref="WebView2Control"/>.
 		/// </summary>
@@ -34,12 +38,31 @@ namespace Microsoft.AspNetCore.Components.WebView
 		/// Gets or sets the environment options for the <see cref="WebView2Control"/>.
 		/// </summary>
 		public CoreWebView2EnvironmentOptions EnvironmentOptions { get; set; }
+#endif
 
+#if WINDOWS
 		/// <summary>
-		/// Gets or sets a function that will be invoked once the WebView has been initialized with
+		/// Gets or sets a function that will be invoked once the web view has been initialized with
 		/// the default values to allow further configuring additional options.
 		/// </summary>
-		public Func<WebView2Control, Task> OnWebViewInitialized { get; set; }
+		public Action<WebView2Control> OnWebViewInitialized { get; set; }
+#elif ANDROID
+		/// <summary>
+		/// Gets or sets a function that will be invoked once the web view has been initialized with
+		/// the default values to allow further configuring additional options.
+		/// </summary>
+		public Action<AWebView> OnWebViewInitialized { get; set; }
+#elif MACCATALYST || IOS
+		/// <summary>
+		/// Gets or sets a function that will be invoked once the web view has been initialized with
+		/// the default values to allow further configuring additional options.
+		/// </summary>
+		public Action<WKWebView> OnWebViewInitialized { get; set; }
+
+		/// <summary>
+		/// Gets or sets the configuration web view configuration.
+		/// </summary>
+		public WKWebViewConfiguration Configuration { get; set; }
 #endif
 	}
 }

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 #if WEBVIEW2_WINFORMS
 using Microsoft.Web.WebView2.Core;
 using WebView2Control = Microsoft.Web.WebView2.WinForms.WebView2;
@@ -38,27 +37,8 @@ namespace Microsoft.AspNetCore.Components.WebView
 		/// Gets or sets the environment options for the <see cref="WebView2Control"/>.
 		/// </summary>
 		public CoreWebView2EnvironmentOptions EnvironmentOptions { get; set; }
-#endif
 
-#if WINDOWS
-		/// <summary>
-		/// Gets or sets a function that will be invoked once the web view has been initialized with
-		/// the default values to allow further configuring additional options.
-		/// </summary>
-		public Action<WebView2Control> OnWebViewInitialized { get; set; }
-#elif ANDROID
-		/// <summary>
-		/// Gets or sets a function that will be invoked once the web view has been initialized with
-		/// the default values to allow further configuring additional options.
-		/// </summary>
-		public Action<AWebView> OnWebViewInitialized { get; set; }
 #elif MACCATALYST || IOS
-		/// <summary>
-		/// Gets or sets a function that will be invoked once the web view has been initialized with
-		/// the default values to allow further configuring additional options.
-		/// </summary>
-		public Action<WKWebView> OnWebViewInitialized { get; set; }
-
 		/// <summary>
 		/// Gets or sets the configuration web view configuration.
 		/// </summary>

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+#if WEBVIEW2_WINFORMS
+using Microsoft.Web.WebView2.Core;
+using WebView2Control = Microsoft.Web.WebView2.WinForms.WebView2;
+#elif WEBVIEW2_WPF
+using Microsoft.Web.WebView2.Core;
+using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
+#elif WINDOWS && WEBVIEW2_MAUI
+using Microsoft.Web.WebView2.Core;
+using WebView2Control = Microsoft.UI.Xaml.Controls.WebView2;
+#endif
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+	/// <summary>
+	/// Allows configuring the underlying web view when the application is initializing.
+	/// </summary>
+	public partial class BlazorWebViewInitializingEventArgs : EventArgs
+	{
+#if WINDOWS
+#nullable disable
+		/// <summary>
+		/// Gets or sets the browser executable folder path for the <see cref="WebView2Control"/>.
+		/// </summary>
+		public string BrowserExecutableFolder { get; set; }
+
+		/// <summary>
+		/// Gets or sets the user data folder path for the <see cref="WebView2Control"/>.
+		/// </summary>
+		public string UserDataFolder { get; set; }
+
+		/// <summary>
+		/// Gets or sets the environment options for the <see cref="WebView2Control"/>.
+		/// </summary>
+		public CoreWebView2EnvironmentOptions EnvironmentOptions { get; set; }
+
+		/// <summary>
+		/// Gets or sets a function that will be invoked once the WebView has been initialized with
+		/// the default values to allow further configuring additional options.
+		/// </summary>
+		public Func<WebView2Control, Task> OnWebViewInitialized { get; set; }
+#endif
+	}
+}

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewInitializingEventArgs.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Components.WebView
 	/// <summary>
 	/// Allows configuring the underlying web view when the application is initializing.
 	/// </summary>
-	public partial class BlazorWebViewInitializingEventArgs : EventArgs
+	public class BlazorWebViewInitializingEventArgs : EventArgs
 	{
 #nullable disable
 #if WINDOWS
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Components.WebView
 
 #elif MACCATALYST || IOS
 		/// <summary>
-		/// Gets or sets the configuration web view configuration.
+		/// Gets or sets the web view <see cref="WKWebViewConfiguration"/>.
 		/// </summary>
 		public WKWebViewConfiguration Configuration { get; set; }
 #endif

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 			ApplyDefaultWebViewSettings(developerTools);
 
-			args?.OnWebViewInitialized(_webview);
+			args.OnWebViewInitialized?.Invoke(_webview);
 
 			_webview.CoreWebView2.AddWebResourceRequestedFilter($"{AppOrigin}*", CoreWebView2WebResourceContext.All);
 

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -205,10 +205,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 			ApplyDefaultWebViewSettings(developerTools);
 
-			if (args.OnWebViewInitialized != null)
-			{
-				await args.OnWebViewInitialized(_webview).ConfigureAwait(true);
-			}
+			args?.OnWebViewInitialized(_webview);
 
 			_webview.CoreWebView2.AddWebResourceRequestedFilter($"{AppOrigin}*", CoreWebView2WebResourceContext.All);
 

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -120,6 +120,13 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		[Description("Allows customizing how links are opened. By default, opens internal links in the webview and external links in an external app.")]
 		public EventHandler<UrlLoadingEventArgs> UrlLoading;
 
+		/// <summary>
+		/// Allows customizing the web view initialization process.
+		/// </summary>
+		[Category("Action")]
+		[Description("Allows customizing the web view initialization process.")]
+		public EventHandler<BlazorWebViewInitializingEventArgs> BlazorWebViewInitializing;
+
 		private void OnHostPagePropertyChanged() => StartWebViewCoreIfPossible();
 
 		private void OnServicesPropertyChanged() => StartWebViewCoreIfPossible();
@@ -170,7 +177,8 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				fileProvider,
 				RootComponents.JSComponents,
 				hostPageRelativePath,
-				(args) => UrlLoading?.Invoke(this, args));
+				(args) => UrlLoading?.Invoke(this, args),
+				(args) => BlazorWebViewInitializing?.Invoke(this, args));
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -121,11 +121,18 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		public EventHandler<UrlLoadingEventArgs> UrlLoading;
 
 		/// <summary>
-		/// Allows customizing the web view initialization process.
+		/// Allows customizing the web view before it is created.
 		/// </summary>
 		[Category("Action")]
-		[Description("Allows customizing the web view initialization process.")]
+		[Description("Allows customizing the web view before it is created.")]
 		public EventHandler<BlazorWebViewInitializingEventArgs> BlazorWebViewInitializing;
+
+		/// <summary>
+		/// Allows customizing the web view after it is created.
+		/// </summary>
+		[Category("Action")]
+		[Description("Allows customizing the web view after it is created.")]
+		public EventHandler<BlazorWebViewInitializedEventArgs> BlazorWebViewInitialized;
 
 		private void OnHostPagePropertyChanged() => StartWebViewCoreIfPossible();
 
@@ -178,7 +185,8 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				RootComponents.JSComponents,
 				hostPageRelativePath,
 				(args) => UrlLoading?.Invoke(this, args),
-				(args) => BlazorWebViewInitializing?.Invoke(this, args));
+				(args) => BlazorWebViewInitializing?.Invoke(this, args),
+				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -57,6 +57,15 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			name: nameof(UrlLoading),
 			propertyType: typeof(EventHandler<UrlLoadingEventArgs>),
 			ownerType: typeof(BlazorWebView));
+
+		/// <summary>
+		/// The backing store for the <see cref="UrlLoading"/> property.
+		/// </summary>
+		public static readonly DependencyProperty BlazorWebViewInitializingProperty = DependencyProperty.Register(
+			name: nameof(BlazorWebViewInitializing),
+			propertyType: typeof(EventHandler<BlazorWebViewInitializingEventArgs>),
+			ownerType: typeof(BlazorWebView));
+
 		#endregion
 
 		private const string WebViewTemplateChildName = "WebView";
@@ -115,6 +124,16 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		{
 			get => (EventHandler<UrlLoadingEventArgs>)GetValue(UrlLoadingProperty);
 			set => SetValue(UrlLoadingProperty, value);
+		}
+
+		/// <summary>
+		/// Allows customizing how links are opened.
+		/// By default, opens internal links in the webview and external links in an external app.
+		/// </summary>
+		public EventHandler<BlazorWebViewInitializingEventArgs> BlazorWebViewInitializing
+		{
+			get => (EventHandler<BlazorWebViewInitializingEventArgs>)GetValue(BlazorWebViewInitializingProperty);
+			set => SetValue(BlazorWebViewInitializingProperty, value);
 		}
 
 		/// <summary>
@@ -197,7 +216,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				fileProvider,
 				RootComponents.JSComponents,
 				hostPageRelativePath,
-				(args) => UrlLoading?.Invoke(this, args));
+				(args) => UrlLoading?.Invoke(this, args),
+				(args) => BlazorWebViewInitializing?.Invoke(this, args));
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			ownerType: typeof(BlazorWebView));
 
 		/// <summary>
-		/// The backing store for the <see cref="BlazorWebViewInitializing"/> property.
+		/// The backing store for the <see cref="BlazorWebViewInitializing"/> event.
 		/// </summary>
 		public static readonly DependencyProperty BlazorWebViewInitializingProperty = DependencyProperty.Register(
 			name: nameof(BlazorWebViewInitializing),
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			ownerType: typeof(BlazorWebView));
 
 		/// <summary>
-		/// The backing store for the <see cref="BlazorWebViewInitialized"/> property.
+		/// The backing store for the <see cref="BlazorWebViewInitialized"/> event.
 		/// </summary>
 		public static readonly DependencyProperty BlazorWebViewInitializedProperty = DependencyProperty.Register(
 			name: nameof(BlazorWebViewInitialized),

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -66,6 +66,14 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			propertyType: typeof(EventHandler<BlazorWebViewInitializingEventArgs>),
 			ownerType: typeof(BlazorWebView));
 
+		/// <summary>
+		/// The backing store for the <see cref="BlazorWebViewInitialized"/> property.
+		/// </summary>
+		public static readonly DependencyProperty BlazorWebViewInitializedProperty = DependencyProperty.Register(
+			name: nameof(BlazorWebViewInitialized),
+			propertyType: typeof(EventHandler<BlazorWebViewInitializedEventArgs>),
+			ownerType: typeof(BlazorWebView));
+
 		#endregion
 
 		private const string WebViewTemplateChildName = "WebView";
@@ -127,12 +135,21 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		}
 
 		/// <summary>
-		/// Allows customizing the web view initialization process.
+		/// Allows customizing the web view before it is created.
 		/// </summary>
 		public EventHandler<BlazorWebViewInitializingEventArgs> BlazorWebViewInitializing
 		{
 			get => (EventHandler<BlazorWebViewInitializingEventArgs>)GetValue(BlazorWebViewInitializingProperty);
 			set => SetValue(BlazorWebViewInitializingProperty, value);
+		}
+
+		/// <summary>
+		/// Allows customizing the web view after it is created.
+		/// </summary>
+		public EventHandler<BlazorWebViewInitializedEventArgs> BlazorWebViewInitialized
+		{
+			get => (EventHandler<BlazorWebViewInitializedEventArgs>)GetValue(BlazorWebViewInitializedProperty);
+			set => SetValue(BlazorWebViewInitializedProperty, value);
 		}
 
 		/// <summary>
@@ -216,7 +233,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				RootComponents.JSComponents,
 				hostPageRelativePath,
 				(args) => UrlLoading?.Invoke(this, args),
-				(args) => BlazorWebViewInitializing?.Invoke(this, args));
+				(args) => BlazorWebViewInitializing?.Invoke(this, args),
+				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			ownerType: typeof(BlazorWebView));
 
 		/// <summary>
-		/// The backing store for the <see cref="UrlLoading"/> property.
+		/// The backing store for the <see cref="BlazorWebViewInitializing"/> property.
 		/// </summary>
 		public static readonly DependencyProperty BlazorWebViewInitializingProperty = DependencyProperty.Register(
 			name: nameof(BlazorWebViewInitializing),
@@ -127,8 +127,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		}
 
 		/// <summary>
-		/// Allows customizing how links are opened.
-		/// By default, opens internal links in the webview and external links in an external app.
+		/// Allows customizing the web view initialization process.
 		/// </summary>
 		public EventHandler<BlazorWebViewInitializingEventArgs> BlazorWebViewInitializing
 		{

--- a/src/Templates/src/templates/maui-blazor/MauiProgram.cs
+++ b/src/Templates/src/templates/maui-blazor/MauiProgram.cs
@@ -16,9 +16,11 @@ public static class MauiProgram
 			});
 
 		builder.Services.AddMauiBlazorWebView();
+//-:cnd:noEmit
 #if DEBUG
 		builder.Services.AddBlazorWebViewDeveloperTools();
 #endif
+//+:cnd:noEmit
 
 		builder.Services.AddSingleton<WeatherForecastService>();
 


### PR DESCRIPTION
### Description of Change

Adds an event that can be used to configure the underlying platform Web View implementation settings. The initial commit covers Windows, with Mac and Android to be added later on if needed

### Issues Fixed

Fixes #5512
