### PR TITLE
Remove unused cssFallbackTypeName on Element

### DIFF
--- a/src/Controls/src/Core/Element_StyleSheets.cs
+++ b/src/Controls/src/Core/Element_StyleSheets.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Maui.Controls
 
 		string IStyleSelectable.Id => StyleId;
 
-		internal string _cssFallbackTypeName;
-
 		string[] _styleSelectableNameAndBaseNames;
 		string[] IStyleSelectable.NameAndBases
 		{
@@ -24,8 +22,6 @@ namespace Microsoft.Maui.Controls
 				if (_styleSelectableNameAndBaseNames == null)
 				{
 					var list = new List<string>();
-					if (_cssFallbackTypeName != null)
-						list.Add(_cssFallbackTypeName);
 					var t = GetType();
 					while (t != typeof(BindableObject))
 					{


### PR DESCRIPTION
This field was added for tests that are no longer in this repo. Removing since this creates an unnecessary reference on every Element instance.

This field appears to be added with https://github.com/dotnet/maui/commit/f3c54050333578f134bf3b6050b2a97a2133f718, which added 2 unit tests that set it. However, those tests are no longer in this repo.