### PR TITLE
Remove trivial calls to GetTypeInfo

### DIFF
--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/DynamicViewGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/DynamicViewGallery.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 			// BindableProperty used to clean property values
 			var bindableProperties = elementType
 				.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-				.Where(p => p.FieldType.GetTypeInfo().IsAssignableFrom(typeof(BindableProperty).GetTypeInfo()))
+				.Where(p => p.FieldType.IsAssignableFrom(typeof(BindableProperty)))
 				.Select(p => (BindableProperty)p.GetValue(element));
 
 			foreach (var property in publicProperties)
@@ -167,7 +167,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 				{
 					propertyLayout.Children.Add(CreateThicknessPicker(property, element));
 				}
-				else if (property.PropertyType.GetTypeInfo().IsEnum)
+				else if (property.PropertyType.IsEnum)
 				{
 					propertyLayout.Children.Add(CreateEnumPicker(property, element));
 				}

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/ImageGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/ImageGallery.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 			var disabled = new Image { Source = ImageSource.FromFile("cover1.jpg") };
 			var rotate = new Image { Source = ImageSource.FromFile("cover1.jpg") };
 			var transparent = new Image { Source = ImageSource.FromFile("cover1.jpg") };
-			var embedded = new Image { Source = ImageSource.FromResource("Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.crimson.jpg", typeof(ImageGallery).GetTypeInfo().Assembly) };
+			var embedded = new Image { Source = ImageSource.FromResource("Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.crimson.jpg", typeof(ImageGallery).Assembly) };
 			var gif = new Image { Source = "GifOne.gif" };
 			_autoPlayGif = new Image { Source = "GifOne.gif" };
 

--- a/src/Compatibility/ControlGallery/src/Core/GalleryPages/ImageSourcesGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Core/GalleryPages/ImageSourcesGallery.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 				new ImageSourcePickerItem
 				{
 					Text = "Stream",
-					Getter = () => ImageSource.FromStream(() => typeof(App).GetTypeInfo().Assembly.GetManifestResourceStream("Microsoft.Maui.Controls.Compatibility.ControlGallery.coffee.png"))
+					Getter = () => ImageSource.FromStream(() => typeof(App).Assembly.GetManifestResourceStream("Microsoft.Maui.Controls.Compatibility.ControlGallery.coffee.png"))
 				},
 				new ImageSourcePickerItem
 				{

--- a/src/Compatibility/ControlGallery/src/Core/TestCases.cs
+++ b/src/Compatibility/ControlGallery/src/Core/TestCases.cs
@@ -165,12 +165,12 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 
 				Intent = TableIntent.Settings;
 
-				var assembly = typeof(TestCases).GetTypeInfo().Assembly;
+				var assembly = typeof(TestCases).Assembly;
 
 				_issues =
-					(from typeInfo in assembly.DefinedTypes.Select(o => o.AsType().GetTypeInfo())
-					 where typeInfo.GetCustomAttribute<IssueAttribute>() != null
-					 let attribute = typeInfo.GetCustomAttribute<IssueAttribute>()
+					(from type in assembly.GetTypes()
+					 let attribute = type.GetCustomAttribute<IssueAttribute>()
+					 where attribute != null
 					 select new IssueModel
 					 {
 						 IssueTracker = attribute.IssueTracker,
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 						 IssueTestNumber = attribute.IssueTestNumber,
 						 Name = attribute.DisplayName,
 						 Description = attribute.Description,
-						 Action = ActivatePageAndNavigate(attribute, typeInfo.AsType())
+						 Action = ActivatePageAndNavigate(attribute, type)
 					 }).ToList();
 
 				VerifyNoDuplicates();

--- a/src/Compatibility/ControlGallery/src/Core/Tests/PlatformTestRunner.cs
+++ b/src/Compatibility/ControlGallery/src/Core/Tests/PlatformTestRunner.cs
@@ -15,11 +15,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Tests
 			testFilter = testFilter ?? TestFilter.Empty;
 
 			// "controls" is the cross-platform test assembly
-#if NETSTANDARD2_0
 			var controls = Assembly.GetExecutingAssembly();
-#else
-			var controls = typeof(PlatformTestRunner).GetTypeInfo().Assembly;
-#endif
 
 			var platformTestSettings = DependencyService.Resolve<IPlatformTestSettings>();
 

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1075.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue1075.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 				else
 				{
 					string selectedItem = picker.Items[picker.SelectedIndex];
-					FieldInfo colorField = typeof(Color).GetTypeInfo().GetDeclaredField(selectedItem);
+					FieldInfo colorField = typeof(Color).GetField(selectedItem);
 					boxView.Color = (Color)colorField.GetValue(null);
 				}
 			};

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3275.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue3275.cs
@@ -162,13 +162,13 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 
 			public AsyncDelegateCommand(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
 			{
-				var genericTypeInfo = typeof(T).GetTypeInfo();
+				var genericType = typeof(T);
 
 				// DelegateCommand allows object or Nullable<>.  
 				// note: Nullable<> is a struct so we cannot use a class constraint.
-				if (genericTypeInfo.IsValueType)
+				if (genericType.IsValueType)
 				{
-					if (!genericTypeInfo.IsGenericType || !typeof(Nullable<>).GetTypeInfo().IsAssignableFrom(genericTypeInfo.GetGenericTypeDefinition().GetTypeInfo()))
+					if (!genericType.IsGenericType || !typeof(Nullable<>).IsAssignableFrom(genericType.GetGenericTypeDefinition()))
 						throw new InvalidCastException("T for DelegateCommand<T> is not an object nor Nullable.");
 				}
 

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7817.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue7817.xaml.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 				}
 				if (newValue != null)
 				{
-					if (!((Type)newValue).GetTypeInfo().IsEnum)
+					if (!((Type)newValue).IsEnum)
 						throw new ArgumentException("EnumPicker: EnumType property must be enumeration type");
 
 					picker.ItemsSource = Enum.GetValues((Type)newValue);

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9360.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue9360.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 				contentPage.ToolbarItems.Add(new ToolbarItem() { Text = "BAD" });
 				contentPage.ToolbarItems.Add(new ToolbarItem()
 				{
-					IconImageSource = ImageSource.FromResource("Microsoft.Maui.Controls.ControlGallery.GalleryPages.crimson.jpg", typeof(Issue9360NavigationPage).GetTypeInfo().Assembly)
+					IconImageSource = ImageSource.FromResource("Microsoft.Maui.Controls.ControlGallery.GalleryPages.crimson.jpg", typeof(Issue9360NavigationPage).Assembly)
 				});
 
 				contentPage.ToolbarItems.Add(new ToolbarItem()

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/PerformanceGallery/PerformanceGallery.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/PerformanceGallery/PerformanceGallery.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 		{
 			try
 			{
-				var assembly = typeof(PerformanceGallery).GetTypeInfo().Assembly;
+				var assembly = typeof(PerformanceGallery).Assembly;
 				var txt = "Microsoft.Maui.Controls.ControlGallery.BuildNumber.txt";
 
 				using (Stream s = assembly.GetManifestResourceStream(txt))
@@ -126,8 +126,8 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 
 		static IEnumerable<Type> FindPerformanceScenarios()
 		{
-			return typeof(PerformanceGallery).GetTypeInfo().Assembly.DefinedTypes.Select(o => o.AsType())
-													.Where(type => typeof(PerformanceScenario).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()));
+			return typeof(PerformanceGallery).Assembly.GetTypes()
+				.Where(type => typeof(PerformanceScenario).IsAssignableFrom(type));
 		}
 
 		static IEnumerable<PerformanceScenario> InflatePerformanceScenarios()

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/PerformanceGallery/Scenarios/ImageScenarios.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/PerformanceGallery/Scenarios/ImageScenarios.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.Perf
 		{
 			//NOTE: copy image to disk in static ctor, so not to interfere with timing
 			tempFile = IOPath.Combine(IOPath.GetTempPath(), $"{nameof(ImageScenario4)}.png");
-			using (var embeddedStream = typeof(ImageScenario4).GetTypeInfo().Assembly.GetManifestResourceStream("Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.crimson.jpg"))
+			using (var embeddedStream = typeof(ImageScenario4).Assembly.GetManifestResourceStream("Microsoft.Maui.Controls.Compatibility.ControlGallery.GalleryPages.crimson.jpg"))
 			using (var fileStream = File.Create(tempFile))
 				embeddedStream.CopyTo(fileStream);
 		}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TestPages/TestPages.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery
 
 		public static void NavigateToIssue(Type type, IApp app)
 		{
-			var typeIssueAttribute = type.GetTypeInfo().GetCustomAttribute<IssueAttribute>();
+			var typeIssueAttribute = type.GetCustomAttribute<IssueAttribute>();
 
 			string cellName = "";
 			if (typeIssueAttribute.IssueTracker.ToString() != "None" &&

--- a/src/Compatibility/Core/src/Tizen/Shell/ShellItemRenderer.cs
+++ b/src/Compatibility/Core/src/Tizen/Shell/ShellItemRenderer.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 				last.Delete();
 
 				//The source of icon resources is https://materialdesignicons.com/
-				var assembly = typeof(ShellItemRenderer).GetTypeInfo().Assembly;
+				var assembly = typeof(ShellItemRenderer).Assembly;
 				var assemblyName = assembly.GetName().Name;
 				_moreTabItem = AppendTabsItem("More", ImageSource.FromResource(assemblyName + "." + _dotsIcon, assembly));
 				_tabsItems.Add(_moreTabItem);

--- a/src/Compatibility/Core/src/Tizen/Shell/ShellNavBar.cs
+++ b/src/Compatibility/Core/src/Tizen/Shell/ShellNavBar.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 				}
 				else
 				{
-					var assembly = typeof(ShellNavBar).GetTypeInfo().Assembly;
+					var assembly = typeof(ShellNavBar).Assembly;
 					var assemblyName = assembly.GetName().Name;
 					source = ImageSource.FromResource(assemblyName + "." + _backIconRes, assembly);
 				}
@@ -239,7 +239,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 				}
 				else
 				{
-					var assembly = typeof(ShellNavBar).GetTypeInfo().Assembly;
+					var assembly = typeof(ShellNavBar).Assembly;
 					var assemblyName = assembly.GetName().Name;
 					source = ImageSource.FromResource(assemblyName + "." + _menuIconRes, assembly);
 				}

--- a/src/Compatibility/Core/src/Tizen/StaticRegistrar.cs
+++ b/src/Compatibility/Core/src/Tizen/StaticRegistrar.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 				if (_handlers.TryGetValue(viewType, out handler))
 					return true;
 
-				viewType = viewType.GetTypeInfo().BaseType;
+				viewType = viewType.BaseType;
 			}
 			handler = null;
 			return false;

--- a/src/Compatibility/Core/src/Windows/ListViewRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/ListViewRenderer.cs
@@ -782,7 +782,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		{
 			bool areEqual = false;
 
-			if (Element.SelectedItem != null && Element.SelectedItem.GetType().GetTypeInfo().IsValueType)
+			if (Element.SelectedItem != null && Element.SelectedItem.GetType().IsValueType)
 				areEqual = Element.SelectedItem.Equals(List.SelectedItem);
 			else
 				areEqual = Element.SelectedItem == List.SelectedItem;

--- a/src/Controls/src/Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/RDSourceTypeConverter.cs
@@ -79,8 +79,7 @@ namespace Microsoft.Maui.Controls.XamlC
 			{
 				yield return Create(Ldtoken, currentModule.ImportReference(((ILRootNode)rootNode).TypeReference));
 				yield return Create(Call, currentModule.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
-				yield return Create(Call, currentModule.ImportMethodReference(("mscorlib", "System.Reflection", "IntrospectionExtensions"), methodName: "GetTypeInfo", parameterTypes: new[] { ("mscorlib", "System", "Type") }, isStatic: true));
-				yield return Create(Callvirt, currentModule.ImportPropertyGetterReference(("mscorlib", "System.Reflection", "TypeInfo"), propertyName: "Assembly", flatten: true));
+				yield return Create(Callvirt, currentModule.ImportPropertyGetterReference(("mscorlib", "System", "Type"), propertyName: "Assembly", flatten: true));
 			}
 			foreach (var instruction in node.PushXmlLineInfo(context))
 				yield return instruction; //lineinfo

--- a/src/Controls/src/Build.Tasks/CompiledValueProviders/StyleSheetProvider.cs
+++ b/src/Controls/src/Build.Tasks/CompiledValueProviders/StyleSheetProvider.cs
@@ -64,8 +64,7 @@ namespace Microsoft.Maui.Controls.XamlC
 
 				yield return Create(Ldtoken, module.ImportReference(((ILRootNode)rootNode).TypeReference));
 				yield return Create(Call, module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
-				yield return Create(Call, module.ImportMethodReference(("mscorlib", "System.Reflection", "IntrospectionExtensions"), methodName: "GetTypeInfo", parameterTypes: new[] { ("mscorlib", "System", "Type") }, isStatic: true));
-				yield return Create(Callvirt, module.ImportPropertyGetterReference(("mscorlib", "System.Reflection", "TypeInfo"), propertyName: "Assembly", flatten: true)); //assembly
+				yield return Create(Callvirt, module.ImportPropertyGetterReference(("mscorlib", "System", "Type"), propertyName: "Assembly", flatten: true)); //assembly
 
 				foreach (var instruction in node.PushXmlLineInfo(context))
 					yield return instruction; //lineinfo

--- a/src/Controls/src/Build.Tasks/NodeILExtensions.cs
+++ b/src/Controls/src/Build.Tasks/NodeILExtensions.cs
@@ -659,8 +659,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 				}
 				yield return Create(Ldtoken, context.Body.Method.DeclaringType);
 				yield return Create(Call, module.ImportMethodReference(("mscorlib", "System", "Type"), methodName: "GetTypeFromHandle", parameterTypes: new[] { ("mscorlib", "System", "RuntimeTypeHandle") }, isStatic: true));
-				yield return Create(Call, module.ImportMethodReference(("mscorlib", "System.Reflection", "IntrospectionExtensions"), methodName: "GetTypeInfo", parameterTypes: new[] { ("mscorlib", "System", "Type") }, isStatic: true));
-				yield return Create(Callvirt, module.ImportPropertyGetterReference(("mscorlib", "System.Reflection", "TypeInfo"), propertyName: "Assembly", flatten: true));
+				yield return Create(Callvirt, module.ImportPropertyGetterReference(("mscorlib", "System", "Type"), propertyName: "Assembly", flatten: true));
 				yield return Create(Newobj, module.ImportCtorReference(("Microsoft.Maui.Controls.Xaml", "Microsoft.Maui.Controls.Xaml.Internals", "XamlTypeResolver"), paramCount: 2));
 				yield return Create(Callvirt, addService);
 			}

--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -254,12 +254,12 @@ namespace Microsoft.Maui.Controls
 
 			bool fitsElementType =
 				relativeSource.Mode == RelativeBindingSourceMode.FindAncestor &&
-				relativeSource.AncestorType.GetTypeInfo().IsAssignableFrom(element.GetType().GetTypeInfo());
+				relativeSource.AncestorType.IsAssignableFrom(element.GetType());
 
 			bool fitsBindingContextType =
 				element.BindingContext != null &&
 				relativeSource.Mode == RelativeBindingSourceMode.FindAncestorBindingContext &&
-				relativeSource.AncestorType.GetTypeInfo().IsAssignableFrom(element.BindingContext.GetType().GetTypeInfo());
+				relativeSource.AncestorType.IsAssignableFrom(element.BindingContext.GetType());
 
 			if (!fitsElementType && !fitsBindingContextType)
 				return false;

--- a/src/Controls/src/Core/Command.cs
+++ b/src/Controls/src/Core/Command.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Controls
 			}
 
 			// Not a Nullable, if it's a value type then null is not valid
-			return !t.GetTypeInfo().IsValueType;
+			return !t.IsValueType;
 		}
 	}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -804,7 +804,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			bool areEqual = false;
 
-			if (Element.SelectedItem != null && Element.SelectedItem.GetType().GetTypeInfo().IsValueType)
+			if (Element.SelectedItem != null && Element.SelectedItem.GetType().IsValueType)
 				areEqual = Element.SelectedItem.Equals(List.SelectedItem);
 			else
 				areEqual = Element.SelectedItem == List.SelectedItem;

--- a/src/Controls/src/Core/Element_StyleSheets.cs
+++ b/src/Controls/src/Core/Element_StyleSheets.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls
 					while (t != typeof(BindableObject))
 					{
 						list.Add(t.Name);
-						t = t.GetTypeInfo().BaseType;
+						t = t.BaseType;
 					}
 					_styleSelectableNameAndBaseNames = list.ToArray();
 				}

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -69,29 +69,14 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource'][2]/Docs" />
 		public static ImageSource FromResource(string resource, Type resolvingType)
 		{
-			return FromResource(resource, resolvingType.GetTypeInfo().Assembly);
+			return FromResource(resource, resolvingType.Assembly);
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='FromResource'][1]/Docs" />
 		public static ImageSource FromResource(string resource, Assembly sourceAssembly = null)
 		{
-#if !NETSTANDARD1_0
 			sourceAssembly = sourceAssembly ?? Assembly.GetCallingAssembly();
-#else
-			if (sourceAssembly == null)
-			{
-				MethodInfo callingAssemblyMethod = typeof(Assembly).GetTypeInfo().GetDeclaredMethod("GetCallingAssembly");
-				if (callingAssemblyMethod != null)
-				{
-					sourceAssembly = (Assembly)callingAssemblyMethod.Invoke(null, new object[0]);
-				}
-				else
-				{
-					Microsoft.Maui.Controls.Application.Current?.FindMauiContext()?.CreateLogger<ImageSource>()?.LogWarning("Cannot find CallingAssembly, pass resolvingType to FromResource to ensure proper resolution");
-					return null;
-				}
-			}
-#endif
+
 			return FromStream(() => sourceAssembly.GetManifestResourceStream(resource));
 		}
 

--- a/src/Controls/src/Core/MergedStyle.cs
+++ b/src/Controls/src/Core/MergedStyle.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Maui.Controls
 						propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged());
 				_implicitStyles.Add(implicitStyleProperty);
 				Target.SetDynamicResource(implicitStyleProperty, type.FullName);
-				type = type.GetTypeInfo().BaseType;
+				type = type.BaseType;
 				if (s_stopAtTypes.Contains(type))
 					return;
 			}

--- a/src/Controls/src/Core/PlatformBindingHelpers.cs
+++ b/src/Controls/src/Core/PlatformBindingHelpers.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.Internals
 		static BindableProperty CreateBindableProperty<TPlatformView>(string targetProperty, Type propertyType = null, object defaultValue = null) where TPlatformView : class
 		{
 			propertyType = propertyType ?? typeof(object);
-			defaultValue = defaultValue ?? (propertyType.GetTypeInfo().IsValueType ? Activator.CreateInstance(propertyType) : null);
+			defaultValue = defaultValue ?? (propertyType.IsValueType ? Activator.CreateInstance(propertyType) : null);
 			return BindableProperty.Create(
 				targetProperty,
 				propertyType,

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Maui.Controls.Internals
 					if (visualRenderers.TryGetValue(_defaultVisualType, out handlerType))
 						return true;
 
-				viewType = viewType.GetTypeInfo().BaseType;
+				viewType = viewType.BaseType;
 			}
 
 			handlerType = (null, 0);
@@ -223,7 +223,7 @@ namespace Microsoft.Maui.Controls.Internals
 					  visualRenderers.ContainsKey(_defaultVisualType)))
 				{
 					// get RenderWith attribute for just this type, do not inherit attributes from base types
-					var attribute = viewType.GetTypeInfo().GetCustomAttributes<RenderWithAttribute>(false).FirstOrDefault();
+					var attribute = viewType.GetCustomAttributes<RenderWithAttribute>(false).FirstOrDefault();
 					if (attribute == null)
 					{
 						// TODO this doesn't appear to do anything. Register just returns as a NOOP if the renderer is null
@@ -236,7 +236,7 @@ namespace Microsoft.Maui.Controls.Internals
 						if (specificTypeRenderer.Name.StartsWith("_", StringComparison.Ordinal))
 						{
 							// TODO: Remove attribute2 once renderer names have been unified across all platforms
-							var attribute2 = specificTypeRenderer.GetTypeInfo().GetCustomAttribute<RenderWithAttribute>();
+							var attribute2 = specificTypeRenderer.GetCustomAttribute<RenderWithAttribute>();
 							if (attribute2 != null)
 							{
 								for (int i = 0; i < attribute2.SupportedVisuals.Length; i++)
@@ -256,7 +256,7 @@ namespace Microsoft.Maui.Controls.Internals
 							{
 								Register(viewType, null, new[] { visualType }); // Cache this result so we don't work through this chain again
 
-								viewType = viewType.GetTypeInfo().BaseType;
+								viewType = viewType.BaseType;
 								continue;
 							}
 						}
@@ -265,7 +265,7 @@ namespace Microsoft.Maui.Controls.Internals
 					}
 				}
 
-				viewType = viewType.GetTypeInfo().BaseType;
+				viewType = viewType.BaseType;
 			}
 		}
 	}
@@ -330,7 +330,7 @@ namespace Microsoft.Maui.Controls.Internals
 			var properties = new Dictionary<string, IList<StylePropertyAttribute>>();
 			if (DisableCSS)
 				return properties;
-			var assembly = typeof(StylePropertyAttribute).GetTypeInfo().Assembly;
+			var assembly = typeof(StylePropertyAttribute).Assembly;
 			var styleAttributes = assembly.GetCustomAttributesSafe(typeof(StylePropertyAttribute));
 			var stylePropertiesLength = styleAttributes?.Length ?? 0;
 			for (var i = 0; i < stylePropertiesLength; i++)

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Maui.Controls
 
 				var lineInfo = (serviceProvider.GetService(typeof(Xaml.IXmlLineInfoProvider)) as Xaml.IXmlLineInfoProvider)?.XmlLineInfo;
 				var rootTargetPath = XamlResourceIdAttribute.GetPathForType(rootObjectType);
-				var assembly = rootObjectType.GetTypeInfo().Assembly;
+				var assembly = rootObjectType.Assembly;
 
 				if (value.IndexOf(";assembly=", StringComparison.Ordinal) != -1)
 				{

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -295,14 +295,8 @@ namespace Microsoft.Maui.Controls
 				ApplyQueryAttributes(bindable.BindingContext, query, oldQuery);
 
 			var type = content.GetType();
-			var typeInfo = type.GetTypeInfo();
 
-#if NETSTANDARD1_0
-			var queryPropertyAttributes = typeInfo.GetCustomAttributes(typeof(QueryPropertyAttribute), true).ToArray();
-#else
-			var queryPropertyAttributes = typeInfo.GetCustomAttributes(typeof(QueryPropertyAttribute), true);
-#endif
-
+			var queryPropertyAttributes = type.GetCustomAttributes(typeof(QueryPropertyAttribute), true);
 			if (queryPropertyAttributes.Length == 0)
 				return;
 

--- a/src/Controls/src/Core/Style.cs
+++ b/src/Controls/src/Core/Style.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Maui.Controls
 				return false;
 			do
 			{
-				targetType = targetType.GetTypeInfo().BaseType;
+				targetType = targetType.BaseType;
 				if (TargetType == targetType)
 					return true;
 			} while (targetType != typeof(Element));

--- a/src/Controls/src/Core/VisualElement_StyleSheet.cs
+++ b/src/Controls/src/Core/VisualElement_StyleSheet.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 			for (int i = 0; i < attrList.Count; i++)
 			{
 				styleAttribute = attrList[i];
-				if (styleAttribute.TargetType.GetTypeInfo().IsAssignableFrom(GetType().GetTypeInfo()))
+				if (styleAttribute.TargetType.IsAssignableFrom(GetType()))
 					break;
 				styleAttribute = null;
 			}

--- a/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
+++ b/src/Controls/src/Core/Xaml/TypeConversionExtensions.cs
@@ -200,13 +200,13 @@ namespace Microsoft.Maui.Controls.Xaml
 				var ignoreCase = (serviceProvider?.GetService(typeof(IConverterOptions)) as IConverterOptions)?.IgnoreCase ?? false;
 
 				//If the type is nullable, as the value is not null, it's safe to assume we want the built-in conversion
-				if (toType.GetTypeInfo().IsGenericType && toType.GetGenericTypeDefinition() == typeof(Nullable<>))
+				if (toType.IsGenericType && toType.GetGenericTypeDefinition() == typeof(Nullable<>))
 					toType = Nullable.GetUnderlyingType(toType);
 
 				//Obvious Built-in conversions
 				try
 				{
-					if (toType.GetTypeInfo().IsEnum)
+					if (toType.IsEnum)
 						return Enum.Parse(toType, str, ignoreCase);
 					if (toType == typeof(SByte))
 						return SByte.Parse(str, CultureInfo.InvariantCulture);

--- a/src/Controls/src/Core/Xaml/XamlResourceIdAttribute.cs
+++ b/src/Controls/src/Core/Xaml/XamlResourceIdAttribute.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		internal static string GetResourceIdForType(Type type)
 		{
-			var assembly = type.GetTypeInfo().Assembly;
+			var assembly = type.Assembly;
 			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>())
 			{
 				if (xria.Type == type)
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		internal static string GetPathForType(Type type)
 		{
-			var assembly = type.GetTypeInfo().Assembly;
+			var assembly = type.Assembly;
 			foreach (var xria in assembly.GetCustomAttributes<XamlResourceIdAttribute>())
 			{
 				if (xria.Type == type)

--- a/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Controls/src/Xaml/ApplyPropertiesVisitor.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			else if (IsCollectionItem(node, parentNode) && parentNode is IElementNode)
 			{
 				// Collection element, implicit content, or implicit collection element.
-				var contentProperty = GetContentPropertyName(Context.Types[parentElement].GetTypeInfo());
+				var contentProperty = GetContentPropertyName(Context.Types[parentElement]);
 				if (contentProperty != null)
 				{
 					var name = new XmlName(((ElementNode)parentNode).NamespaceURI, contentProperty);
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 					return;
 				}
-				if (xpe == null && (contentProperty = GetContentPropertyName(Context.Types[parentElement].GetTypeInfo())) != null)
+				if (xpe == null && (contentProperty = GetContentPropertyName(Context.Types[parentElement])) != null)
 				{
 					var name = new XmlName(node.NamespaceURI, contentProperty);
 					if (Skips.Contains(name))
@@ -248,14 +248,14 @@ namespace Microsoft.Maui.Controls.Xaml
 			return parentList.CollectionItems.Contains(node);
 		}
 
-		internal static string GetContentPropertyName(TypeInfo typeInfo)
+		internal static string GetContentPropertyName(Type type)
 		{
-			while (typeInfo != null)
+			while (type != null)
 			{
-				var propName = GetContentPropertyName(typeInfo.CustomAttributes);
+				var propName = GetContentPropertyName(type.CustomAttributes);
 				if (propName != null)
 					return propName;
-				typeInfo = typeInfo?.BaseType?.GetTypeInfo();
+				type = type.BaseType;
 			}
 			return null;
 		}
@@ -269,7 +269,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				return;
 
 			XamlServiceProvider serviceProvider = null;
-			if (value.GetType().GetTypeInfo().GetCustomAttribute<AcceptEmptyServiceProviderAttribute>() == null)
+			if (value.GetType().GetCustomAttribute<AcceptEmptyServiceProviderAttribute>() == null)
 				serviceProvider = new XamlServiceProvider(node, Context);
 
 			if (serviceProvider != null && propertyName != XmlName.Empty)
@@ -312,7 +312,7 @@ namespace Microsoft.Maui.Controls.Xaml
 				localname = localname.Substring(dotIdx + 1);
 				XamlParseException xpe;
 				elementType = XamlParser.GetElementType(new XmlType(namespaceURI, typename, null), lineInfo,
-					rootElement.GetType().GetTypeInfo().Assembly, out xpe);
+					rootElement.GetType().Assembly, out xpe);
 
 				if (xpe != null)
 					throw xpe;
@@ -386,7 +386,7 @@ namespace Microsoft.Maui.Controls.Xaml
 
 			void registerSourceInfo(object target, string path)
 			{
-				var assemblyName = rootElement.GetType().GetTypeInfo().Assembly?.GetName().Name;
+				var assemblyName = rootElement.GetType().Assembly?.GetName().Name;
 				if (lineInfo != null)
 					VisualDiagnostics.RegisterSourceInfo(target, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), lineInfo.LineNumber, lineInfo.LinePosition);
 			}
@@ -415,7 +415,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			//If it's a BindableProberty, SetValue
 			if (xpe == null && TrySetValue(element, property, attached, value, lineInfo, serviceProvider, out xpe))
 			{
-				if (value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(rootElement) is string path)
+				if (value != null && !value.GetType().IsValueType && XamlFilePathAttribute.GetFilePathForObject(rootElement) is string path)
 					registerSourceInfo(value, path);
 				return true;
 			}
@@ -423,7 +423,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			//If we can assign that value to a normal property, let's do it
 			if (xpe == null && TrySetProperty(element, localName, value, lineInfo, serviceProvider, rootElement, out xpe))
 			{
-				if (value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(rootElement) is string path)
+				if (value != null && !value.GetType().IsValueType && XamlFilePathAttribute.GetFilePathForObject(rootElement) is string path)
 					registerSourceInfo(value, path);
 				return true;
 			}
@@ -431,7 +431,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			//If it's an already initialized property, add to it
 			if (xpe == null && TryAddToProperty(element, propertyName, value, xKey, lineInfo, serviceProvider, rootElement, out xpe))
 			{
-				if (value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(rootElement) is string path)
+				if (value != null && !value.GetType().IsValueType && XamlFilePathAttribute.GetFilePathForObject(rootElement) is string path)
 					registerSourceInfo(value, path);
 				return true;
 			}
@@ -825,7 +825,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		static IEnumerable<MethodInfo> GetAllRuntimeMethods(Type type)
 		{
 			return type.GetRuntimeMethods()
-				.Concat(type.GetTypeInfo().ImplementedInterfaces.SelectMany(t => t.GetRuntimeMethods()));
+				.Concat(type.GetInterfaces().SelectMany(t => t.GetRuntimeMethods()));
 		}
 
 		bool TrySetRuntimeName(XmlName propertyName, object source, object value, ValueNode node)
@@ -833,7 +833,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (propertyName != XmlName.xName)
 				return false;
 
-			var runTimeName = source.GetType().GetTypeInfo().GetCustomAttribute<RuntimeNamePropertyAttribute>();
+			var runTimeName = source.GetType().GetCustomAttribute<RuntimeNamePropertyAttribute>();
 			if (runTimeName == null)
 				return false;
 

--- a/src/Controls/src/Xaml/CreateValuesVisitor.cs
+++ b/src/Controls/src/Xaml/CreateValuesVisitor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		{
 			object value = null;
 
-			var type = XamlParser.GetElementType(node.XmlType, node, Context.RootElement?.GetType().GetTypeInfo().Assembly,
+			var type = XamlParser.GetElementType(node.XmlType, node, Context.RootElement?.GetType().Assembly,
 				out XamlParseException xpe);
 			if (xpe != null)
 			{
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					if (value == null && node.CollectionItems.Any() && node.CollectionItems.First() is ValueNode)
 					{
 						var serviceProvider = new XamlServiceProvider(node, Context);
-						var converted = ((ValueNode)node.CollectionItems.First()).Value.ConvertTo(type, () => type.GetTypeInfo(),
+						var converted = ((ValueNode)node.CollectionItems.First()).Value.ConvertTo(type, () => type,
 							serviceProvider, out Exception exception);
 						if (exception != null)
 						{
@@ -152,8 +152,8 @@ namespace Microsoft.Maui.Controls.Xaml
 			if (value is BindableObject bindableValue && node.NameScopeRef != (parentNode as IElementNode)?.NameScopeRef)
 				NameScope.SetNameScope(bindableValue, node.NameScopeRef.NameScope);
 
-			var assemblyName = (Context.RootAssembly ?? Context.RootElement?.GetType().GetTypeInfo().Assembly)?.GetName().Name;
-			if (assemblyName != null && value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(Context.RootElement) is string path)
+			var assemblyName = (Context.RootAssembly ?? Context.RootElement?.GetType().Assembly)?.GetName().Name;
+			if (assemblyName != null && value != null && !value.GetType().IsValueType && XamlFilePathAttribute.GetFilePathForObject(Context.RootElement) is string path)
 				VisualDiagnostics.RegisterSourceInfo(value, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
 
 		}
@@ -171,8 +171,8 @@ namespace Microsoft.Maui.Controls.Xaml
 					NameScope.SetNameScope(bindable, node.NameScopeRef?.NameScope);
 			}
 
-			var assemblyName = (Context.RootAssembly ?? Context.RootElement.GetType().GetTypeInfo().Assembly)?.GetName().Name;
-			if (rnode.Root != null && !rnode.Root.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(Context.RootElement) is string path)
+			var assemblyName = (Context.RootAssembly ?? Context.RootElement.GetType().Assembly)?.GetName().Name;
+			if (rnode.Root != null && !rnode.Root.GetType().IsValueType && XamlFilePathAttribute.GetFilePathForObject(Context.RootElement) is string path)
 				VisualDiagnostics.RegisterSourceInfo(rnode.Root, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
 		}
 

--- a/src/Controls/src/Xaml/MarkupExtensionParser.cs
+++ b/src/Controls/src/Xaml/MarkupExtensionParser.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			{
 				//implicit property
 				var t = markupExtension.GetType();
-				prop = ApplyPropertiesVisitor.GetContentPropertyName(t.GetTypeInfo());
+				prop = ApplyPropertiesVisitor.GetContentPropertyName(t);
 				if (prop == null)
 					return;
 				try

--- a/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnIdiomExtension.cs
@@ -53,8 +53,7 @@ namespace Microsoft.Maui.Controls.Xaml
 							  ?? throw new InvalidOperationException("Cannot determine property to provide the value for.");
 
 			var value = GetValue();
-			var info = propertyType.GetTypeInfo();
-			if (value == null && info.IsValueType)
+			if (value == null && propertyType.IsValueType)
 				return Activator.CreateInstance(propertyType);
 
 			if (Converter != null)

--- a/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/OnPlatformExtension.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			{
 				if (bp != null)
 					return bp.GetDefaultValue(valueProvider.TargetObject as BindableObject);
-				if (propertyType.GetTypeInfo().IsValueType)
+				if (propertyType.IsValueType)
 					return Activator.CreateInstance(propertyType);
 				return null;
 			}

--- a/src/Controls/src/Xaml/MarkupExtensions/RelativeSourceExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/RelativeSourceExtension.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					// Also, we assume FindAncestor is meant if the ancestor type is a visual 
 					// Element, otherwise assume FindAncestorBindingContext is intended. (The
 					// mode can also be explicitly set in XAML)
-					actualMode = typeof(Element).GetTypeInfo().IsAssignableFrom(AncestorType.GetTypeInfo())
+					actualMode = typeof(Element).IsAssignableFrom(AncestorType)
 						? RelativeBindingSourceMode.FindAncestor
 						: RelativeBindingSourceMode.FindAncestorBindingContext;
 				}

--- a/src/Controls/src/Xaml/MarkupExtensions/StyleSheetExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/StyleSheetExtension.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					return null;
 				var rootTargetPath = XamlResourceIdAttribute.GetPathForType(rootObjectType);
 				var resourcePath = ResourceDictionary.RDSourceTypeConverter.GetResourcePath(Source, rootTargetPath);
-				var assembly = rootObjectType.GetTypeInfo().Assembly;
+				var assembly = rootObjectType.Assembly;
 
 				return StyleSheet.FromResource(resourcePath, assembly, lineInfo);
 			}

--- a/src/Controls/src/Xaml/XamlCompilationAttribute.cs
+++ b/src/Controls/src/Xaml/XamlCompilationAttribute.cs
@@ -26,13 +26,13 @@ namespace Microsoft.Maui.Controls.Xaml
 	{
 		public static bool IsCompiled(this Type type)
 		{
-			var attr = type.GetTypeInfo().GetCustomAttribute<XamlCompilationAttribute>();
+			var attr = type.GetCustomAttribute<XamlCompilationAttribute>();
 			if (attr != null)
 				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
-			attr = type.GetTypeInfo().Module.GetCustomAttribute<XamlCompilationAttribute>();
+			attr = type.Module.GetCustomAttribute<XamlCompilationAttribute>();
 			if (attr != null)
 				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
-			attr = type.GetTypeInfo().Assembly.GetCustomAttribute<XamlCompilationAttribute>();
+			attr = type.Assembly.GetCustomAttribute<XamlCompilationAttribute>();
 			if (attr != null)
 				return attr.XamlCompilationOptions == XamlCompilationOptions.Compile;
 

--- a/src/Controls/src/Xaml/XamlFilePathAttribute.cs
+++ b/src/Controls/src/Xaml/XamlFilePathAttribute.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Maui.Controls.Xaml
 
 		public string FilePath { get; }
 
-		internal static string GetFilePathForObject(object view) => (view?.GetType().GetTypeInfo().GetCustomAttributes(typeof(XamlFilePathAttribute), false).FirstOrDefault() as XamlFilePathAttribute)?.FilePath;
+		internal static string GetFilePathForObject(object view) => (view?.GetType().GetCustomAttributes(typeof(XamlFilePathAttribute), false).FirstOrDefault() as XamlFilePathAttribute)?.FilePath;
 	}
 }

--- a/src/Controls/src/Xaml/XamlLoader.cs
+++ b/src/Controls/src/Xaml/XamlLoader.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.Controls.Xaml
 					Visit(rootnode, new HydrationContext
 					{
 						RootElement = view,
-						RootAssembly = rootAssembly ?? view.GetType().GetTypeInfo().Assembly,
+						RootAssembly = rootAssembly ?? view.GetType().Assembly,
 						ExceptionHandler = doNotThrow ? ehandler : (Action<Exception>)null
 					}, useDesignProperties);
 
@@ -217,7 +217,7 @@ namespace Microsoft.Maui.Controls.Xaml
 			//the check at the end is preferred (using ResourceLoader). keep this until all the previewers are updated
 
 			string xaml;
-			var assembly = type.GetTypeInfo().Assembly;
+			var assembly = type.Assembly;
 			var resourceId = XamlResourceIdAttribute.GetResourceIdForType(type);
 
 			var rlr = ResourceLoader.ResourceProvider2?.Invoke(new ResourceLoader.ResourceLoadingQuery
@@ -253,7 +253,7 @@ namespace Microsoft.Maui.Controls.Xaml
 		static readonly Dictionary<Type, string> XamlResources = new Dictionary<Type, string>();
 		static string LegacyGetXamlForType(Type type)
 		{
-			var assembly = type.GetTypeInfo().Assembly;
+			var assembly = type.Assembly;
 
 			string resourceId;
 			if (XamlResources.TryGetValue(type, out resourceId))

--- a/src/Core/src/Platform/ReflectionExtensions.cs
+++ b/src/Core/src/Platform/ReflectionExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Platform
 
 		public static bool IsInstanceOfType(this Type self, object o)
 		{
-			return self.GetTypeInfo().IsAssignableFrom(o.GetType().GetTypeInfo());
+			return self.IsAssignableFrom(o.GetType());
 		}
 
 		static IEnumerable<T> GetParts<T>(Type type, Func<TypeInfo, IEnumerable<T>> selector)


### PR DESCRIPTION
These calls are not necessary as of netstandard2.0. They were needed previously when targeting netstandard1.x, but Maui no longer needs to target those TFMs.

The remaining calls to GetTypeInfo are in one of these two patterns:
1. An object implementing IReflectableType
2. Uses of GetDeclared[Fields | Properties | Constructors], which doesn't have a direct replacement on Type. This is because GetDeclared will use NonPublic binding flags, and Type APIs default to public only.