### PR TITLE
Add Geolocation iOS14+ Reduced Accuracy Support

### DIFF
--- a/src/Essentials/docs/Microsoft.Maui.Essentials/GeolocationRequest.xml
+++ b/src/Essentials/docs/Microsoft.Maui.Essentials/GeolocationRequest.xml
@@ -86,6 +86,24 @@
         <remarks></remarks>
       </Docs>
     </Member>
+    <Member MemberName="RequestFullAccuracy">
+      <MemberSignature Language="C#" Value="public bool RequestFullAccuracy { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property bool RequestFullAccuracy" />
+      <MemberSignature Language="DocId" Value="P:Microsoft.Maui.Essentials.GeolocationRequest.RequestFullAccuracy" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Microsoft.Maui.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets whether the full accuracy should be requested or coarse location.</summary>
+        <value>True will request full accuracy, false requests only the coarse location.</value>
+        <remarks>This functionality only applies to iOS.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Timeout">
       <MemberSignature Language="C#" Value="public TimeSpan Timeout { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance valuetype System.TimeSpan Timeout" />

--- a/src/Essentials/docs/Microsoft.Maui.Essentials/Location.xml
+++ b/src/Essentials/docs/Microsoft.Maui.Essentials/Location.xml
@@ -427,5 +427,23 @@
         <remarks></remarks>
       </Docs>
     </Member>
+    <Member MemberName="ReducedAccuracy">
+      <MemberSignature Language="C#" Value="public bool ReducedAccuracy { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property bool ReducedAccuracy" />
+      <MemberSignature Language="DocId" Value="P:Microsoft.Maui.Essentials.Location.ReducedAccuracy" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyName>Microsoft.Maui.Essentials</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Gets or sets whether this location has a reduced accuracy reading.</summary>
+        <value>True if the accuracy is reduced, false if the accuracy is not reduced.</value>
+        <remarks>This functionality only applies to iOS. On other platforms this will always be false.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			var clLocation = await tcs.Task;
 
-			return clLocation?.ToLocation();
+			return clLocation?.ToLocation(reducedAccuracy);
 
 			void HandleLocation(CLLocation location)
 			{

--- a/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			var reducedAccuracy = false;
 #if __IOS__
-            if (Platform.HasOSVersion(14, 0))
+            if (OperatingSystem.IsIOSVersionAtLeast(14, 0))
             {
                 reducedAccuracy = manager.AccuracyAuthorization == CLAccuracyAuthorization.ReducedAccuracy;
             }
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			var reducedAccuracy = false;
 #if __IOS__
-            if (Platform.HasOSVersion(14, 0))
+            if (OperatingSystem.IsIOSVersionAtLeast(14, 0))
             {
                 if (request.RequestFullAccuracy && manager.AccuracyAuthorization == CLAccuracyAuthorization.ReducedAccuracy)
                 {

--- a/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Maui.Devices.Sensors
             {
                 if (request.RequestFullAccuracy && manager.AccuracyAuthorization == CLAccuracyAuthorization.ReducedAccuracy)
                 {
-                    await manager.RequestTemporaryFullAccuracyAuthorizationAsync("XamarinEssentialsFullAccuracyUsageDescription");
+                    await manager.RequestTemporaryFullAccuracyAuthorizationAsync("TemporaryFullAccuracyUsageDescription");
                 }
 
                 reducedAccuracy = manager.AccuracyAuthorization == CLAccuracyAuthorization.ReducedAccuracy;

--- a/src/Essentials/src/Geolocation/GeolocationRequest.shared.cs
+++ b/src/Essentials/src/Geolocation/GeolocationRequest.shared.cs
@@ -70,6 +70,9 @@ namespace Microsoft.Maui.Devices.Sensors
 		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='DesiredAccuracy']/Docs" />
 		public GeolocationAccuracy DesiredAccuracy { get; set; }
 
+		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='RequestFullAccuracy']/Docs" />
+		public bool RequestFullAccuracy { get; set; }
+
 		/// <include file="../../docs/Microsoft.Maui.Essentials/GeolocationRequest.xml" path="//Member[@MemberName='ToString']/Docs" />
 		public override string ToString() =>
 			$"{nameof(DesiredAccuracy)}: {DesiredAccuracy}, {nameof(Timeout)}: {Timeout}";

--- a/src/Essentials/src/Types/Location.shared.cs
+++ b/src/Essentials/src/Types/Location.shared.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			Altitude = point.Altitude;
 			Accuracy = point.Accuracy;
 			VerticalAccuracy = point.VerticalAccuracy;
+			ReducedAccuracy = point.ReducedAccuracy;
 			Speed = point.Speed;
 			Course = point.Course;
 			IsFromMockProvider = point.IsFromMockProvider;
@@ -94,6 +95,9 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='VerticalAccuracy']/Docs" />
 		public double? VerticalAccuracy { get; set; }
+
+		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='ReducedAccuracy']/Docs" />
+		public bool ReducedAccuracy { get; set; }
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Location.xml" path="//Member[@MemberName='Speed']/Docs" />
 		public double? Speed { get; set; }

--- a/src/Essentials/src/Types/LocationExtensions.android.cs
+++ b/src/Essentials/src/Types/LocationExtensions.android.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Devices.Sensors
 					OperatingSystem.IsAndroidVersionAtLeast(26) && location.HasVerticalAccuracy
 						? location.VerticalAccuracyMeters
 						: null,
+				ReducedAccuracy = false,
 				Course = location.HasBearing ? location.Bearing : default(double?),
 				Speed = location.HasSpeed ? location.Speed : default(double?),
 				IsFromMockProvider =

--- a/src/Essentials/src/Types/LocationExtensions.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/Types/LocationExtensions.ios.tvos.watchos.macos.cs
@@ -18,13 +18,14 @@ namespace Microsoft.Maui.Devices.Sensors
 				Longitude = placemark.Location.Coordinate.Longitude,
 				Altitude = placemark.Location.Altitude,
 				AltitudeReferenceSystem = AltitudeReferenceSystem.Geoid,
-				Timestamp = DateTimeOffset.UtcNow
+				Timestamp = DateTimeOffset.UtcNow,
+                ReducedAccuracy = false,
 			};
 
 		internal static IEnumerable<Location> ToLocations(this IEnumerable<CLPlacemark> placemarks) =>
 			placemarks?.Select(a => a.ToLocation());
 
-		internal static Location ToLocation(this CLLocation location) =>
+		internal static Location ToLocation(this CLLocation location, bool reducedAccuracy) =>
 			new Location
 			{
 				Latitude = location.Coordinate.Latitude,
@@ -32,6 +33,7 @@ namespace Microsoft.Maui.Devices.Sensors
 				Altitude = location.VerticalAccuracy < 0 ? default(double?) : location.Altitude,
 				Accuracy = location.HorizontalAccuracy,
 				VerticalAccuracy = location.VerticalAccuracy,
+				ReducedAccuracy = reducedAccuracy,
 				Timestamp = location.Timestamp.ToDateTime(),
 #if __IOS__ || __WATCHOS__
 #pragma warning disable CA1416 // https://github.com/xamarin/xamarin-macios/issues/14619

--- a/src/Essentials/src/Types/LocationExtensions.uwp.cs
+++ b/src/Essentials/src/Types/LocationExtensions.uwp.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Maui.Devices.Sensors
 				Altitude = location.Coordinate.Point.Position.Altitude,
 				Accuracy = location.Coordinate.Accuracy,
 				VerticalAccuracy = location.Coordinate.AltitudeAccuracy,
+				ReducedAccuracy = false,
 				Speed = (!location.Coordinate.Speed.HasValue || double.IsNaN(location.Coordinate.Speed.Value)) ? default : location.Coordinate.Speed,
 				Course = (!location.Coordinate.Heading.HasValue || double.IsNaN(location.Coordinate.Heading.Value)) ? default : location.Coordinate.Heading,
 				IsFromMockProvider = false,
@@ -49,6 +50,7 @@ namespace Microsoft.Maui.Devices.Sensors
 				Altitude = coordinate.Point.Position.Altitude,
 				Accuracy = coordinate.Accuracy,
 				VerticalAccuracy = coordinate.AltitudeAccuracy,
+				ReducedAccuracy = false,
 				Speed = (!coordinate.Speed.HasValue || double.IsNaN(coordinate.Speed.Value)) ? default : coordinate.Speed,
 				Course = (!coordinate.Heading.HasValue || double.IsNaN(coordinate.Heading.Value)) ? default : coordinate.Heading,
 				AltitudeReferenceSystem = coordinate.Point.AltitudeReferenceSystem.ToEssentials()

--- a/src/Essentials/test/DeviceTests/Tests/Geolocation_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Geolocation_Tests.cs
@@ -70,11 +70,13 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			});
 
 			var request = new GeolocationRequest(GeolocationAccuracy.Best);
+			request.RequestFullAccuracy = true;
 			var location = await Geolocation.GetLocationAsync(request);
 
 			Assert.NotNull(location);
 
 			Assert.True(location.Accuracy > 0);
+			Assert.False(location.ReducedAccuracy);
 			Assert.NotEqual(0.0, location.Latitude);
 			Assert.NotEqual(0.0, location.Longitude);
 


### PR DESCRIPTION
### Description of Change

Port of this PR in Xamarin.Essentials: https://github.com/xamarin/Essentials/pull/1739

> iOS 14 added the ability for users to grant location permission with reduced accuracy.
In such cases the requested accuracy is ignored and the coarse location is returned.
>
> This PR adds:
>
> A property indicating if the retrieved location has reduced accuracy (if true, the accuracy was intentionally reduced by the user through permission settings)
A property to ask the user for temporary full accuracy authorization in the location request
Platform notes:
> 
> The ReducedAccuracy property always returns false on non-iOS platforms
As [described in the Apple documentation](https://developer.apple.com/documentation/corelocation/cllocationmanager/3600217-requesttemporaryfullaccuracyauth); on iOS the temporary full accuracy request requires a purpose description to be added to the `NSLocationTemporaryUsageDescriptionDictionary` in the app's plist file. The key `XamarinEssentialsFullAccuracyUsageDescription` was used for this purpose.

#### API Changes
Added:

* bool Location.ReducedAccuracy { get; set; }
* bool GeolocationRequest.RequestFullAccuracy { get; set; }

### Issues Fixed

Original Xamarin.Essentials issue: https://github.com/xamarin/Essentials/issues/1523