### PR TITLE
Add a vscode workspace and some build tasks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+      "ms-dotnettools.csharp",
+      "ms-vscode.mono-debug",
+      "visualstudioexptteam.vscodeintellicode",
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,18 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug",
+            "name": "Debug with Comet",
             "type": "comet",
             "request": "launch",
             "preLaunchTask": "comet: Build"
-        }
+        },
+        {
+            "name": "Debug with Xamarin",
+            "type": "mono",
+            "request": "attach",
+            "address": "localhost",
+            "port": 10000,  
+            "preLaunchTask": "Run Sample"
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,81 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "windows":{ "command": ".\\build.cmd"},
+            "linux":{"command": "./build.sh"},
+            "osx":{"command": "./build.sh"},
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            },
+            "problemMatcher": ["$msCompile", "$func-java-watch"]
+        },
+        {
+            "label": "Build Platform Sample",
+            "type": "shell",
+            "command": "./bin/dotnet/dotnet build ${input:project} -c ${input:configuration}",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+           // "dependsOn":[ "Build" ],
+            "problemMatcher": ["$msCompile"]
+        },
+        {
+            "label": "Run Sample",
+            "type": "shell",
+            "command": "./bin/dotnet/dotnet build ${input:project} -t:Run -f ${input:framework} -c ${input:configuration} -p:AndroidAttachDebugger=${input:attach}",
+            "group": {
+                "kind": "none",
+                "isDefault": false
+            },
+            //"dependsOn":[ "Build" ],
+            "problemMatcher": ["$msCompile"]
+        }
+    ],
+    "inputs": [
+        {
+            // Add additional projects here. They will be available in the drop down
+            // in vscode.
+            "id": "project",
+            "type": "pickString",
+            "default": "src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj",
+            "description": "Pick the Project you want to build.",
+            "options": [
+                "src/Controls/samples/Controls.Sample.SingleProject/Maui.Controls.Sample.SingleProject.csproj",
+            ]
+        },
+        {
+            // Add additional projects here. They will be available in the drop down
+            // in vscode.
+            "id": "framework",
+            "type": "pickString",
+            "default": "net6.0-android",
+            "description": "Pick the framework you want to target.",
+            "options": [
+                "net6.0-android",
+                "net6.0-ios",
+            ]
+        },
+        {
+            "id": "attach",
+            "type": "pickString",
+            "default": "Build",
+            "description": "Attach Debugger?",
+            "options": [
+                "true",
+                "false",
+            ]
+        },
+        {
+            "id": "configuration",
+            "type": "pickString",
+            "default": "Debug",
+            "description": "The Build Configuration",
+            "options": [ "Debug", "Release"]
+        },
+    ]
+}

--- a/maui.code-workspace
+++ b/maui.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Add a workspace and tasks for vscode. There is already support for
using `comet`  for debugging, but not everyone uses `comet`. This
adds a set of tasks for building and debugging via the standard
C#/Mono support in vscode. It also adds an extensions list which will
inform the user which extensions need installing.