### PR TITLE
Allow restricted permissions for Geolocation on Android

### DIFF
--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		public async Task<Location> GetLastKnownLocationAsync()
 		{
-			await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>();
+			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
 			AndroidLocation bestLocation = null;
 
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		{
 			_ = request ?? throw new ArgumentNullException(nameof(request));
 
-			await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>();
+			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
 			var enabledProviders = LocationManager.GetProviders(true);
 			var hasProviders = enabledProviders.Any(p => !ignoredProviders.Contains(p));

--- a/src/Essentials/src/Permissions/Permissions.shared.cs
+++ b/src/Essentials/src/Permissions/Permissions.shared.cs
@@ -33,6 +33,15 @@ namespace Microsoft.Maui.ApplicationModel
 				throw new PermissionException($"{typeof(TPermission).Name} permission was not granted: {status}");
 		}
 
+		internal static async Task EnsureGrantedOrRestrictedAsync<TPermission>()
+            where TPermission : BasePermission, new()
+        {
+            var status = await RequestAsync<TPermission>();
+
+            if (status != PermissionStatus.Granted && status != PermissionStatus.Restricted)
+                throw new PermissionException($"{typeof(TPermission).Name} permission was not granted or restricted: {status}");
+        }
+
 		public abstract partial class BasePermission
 		{
 			public BasePermission()


### PR DESCRIPTION
### Description of Change

Port of Xamarin.Essentials PR: https://github.com/xamarin/Essentials/pull/1976

> Allow restricted permissions for "gatekeepers" on android geolocation methods

### Issues Fixed

Original Xamarin.Essentials issue: https://github.com/xamarin/Essentials/issues/1972
