### PR TITLE
Make Microsoft.Maui.Platform.PlatformVersion internal

### DIFF
--- a/src/Core/src/Platform/Android/PlatformVersion.cs
+++ b/src/Core/src/Platform/Android/PlatformVersion.cs
@@ -3,7 +3,7 @@ using Android.OS;
 
 namespace Microsoft.Maui.Platform
 {
-	public static partial class PlatformVersion
+	internal static partial class PlatformVersion
 	{
 		public static bool IsAtLeast(BuildVersionCodes buildVersionCode) => OperatingSystem.IsAndroidVersionAtLeast((int)buildVersionCode);
 
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Platform
 		public static bool Supports(int platformApi) => OperatingSystem.IsAndroidVersionAtLeast(platformApi);
 	}
 
-	public static class PlatformApis
+	internal static class PlatformApis
 	{
 		public const int BlendModeColorFilter = 29;
 		public const int SeekBarSetMin = 26;

--- a/src/Core/src/Platform/Windows/PlatformVersion.cs
+++ b/src/Core/src/Platform/Windows/PlatformVersion.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Maui.Platform
 {
-	public static class PlatformVersion
+	internal static class PlatformVersion
 	{
 		// https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.window.current?view=winui-3.0
 		// The currently activated window for UWP apps. Null for Desktop apps.

--- a/src/Core/src/Platform/iOS/PlatformVersion.cs
+++ b/src/Core/src/Platform/iOS/PlatformVersion.cs
@@ -5,7 +5,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Platform
 {
-	public static class PlatformVersion
+	internal static class PlatformVersion
 	{
 		public static bool IsAtLeast(int version)
 		{
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Platform
 		}
 	}
 
-	public static class PlatformApis
+	internal static class PlatformApis
 	{
 		public const string RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden = "RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden";
 		public const int UIActivityIndicatorViewStyleMedium = 13;

--- a/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Screenshot_Tests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		static bool CanExecuteTest()
 		{
 #if __IOS__
-			return PlatformVersion.IsAtLeast(13);
+			return OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13);
 #else
 			return true;
 #endif

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 		public static FontWeight GetFontWeight(this Typeface typeface) =>
-			PlatformVersion.IsAtLeast(28)
+			OperatingSystem.IsAndroidVersionAtLeast(28)
 				? (FontWeight)typeface.Weight
 				: typeface.IsBold ? FontWeight.Bold : FontWeight.Regular;
 	}


### PR DESCRIPTION
We want people to use the OperationSystem APIs from the BCL instead. Make the class internal so we don't expose it publicly and we can clean up our own usages later on.
