### PR TITLE
Less verbose Windows lifecycle logging

### DIFF
--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -222,8 +222,8 @@ namespace Maui.Controls.Sample
 #elif WINDOWS
 					// Log everything in this one
 					events.AddWindows(windows => windows
-						.OnPlatformMessage((a, b) => 
-							LogEvent(nameof(WindowsLifecycle.OnPlatformMessage)))
+						// .OnPlatformMessage((a, b) => 
+						//	LogEvent(nameof(WindowsLifecycle.OnPlatformMessage)))
 						.OnActivated((a, b) => LogEvent(nameof(WindowsLifecycle.OnActivated)))
 						.OnClosed((a, b) => LogEvent(nameof(WindowsLifecycle.OnClosed)))
 						.OnLaunched((a, b) => LogEvent(nameof(WindowsLifecycle.OnLaunched)))


### PR DESCRIPTION
The OnPlatformMessage fires a _lot_ on windows and ends up making the app feel sluggish for things like moving it or resizing, because it's effectively writing out the message loop to the console.

Commenting this out to remove that noise and make things snappier :)
