### PR TITLE
Close Web Message Channel Ports in Android Blazor Hybrid

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// An implementation of <see cref="WebViewManager"/> that uses the Android WebKit WebView browser control
 	/// to render web content.
 	/// </summary>
-	public class AndroidWebKitWebViewManager : WebViewManager, IAsyncDisposable
+	public class AndroidWebKitWebViewManager : WebViewManager
 	{
 		// Using an IP address means that WebView doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since
@@ -78,9 +78,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			_webview.PostWebMessage(new WebMessage("capturePort", destPort), AndroidAppOriginUri);
 		}
 
-		public async new ValueTask DisposeAsync()
+		protected override async ValueTask DisposeAsyncCore()
 		{
-			await base.DisposeAsync();
+			await base.DisposeAsyncCore();
 
 			if (_nativeToJSPorts is not null)
 			{

--- a/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Android.Webkit;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +15,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// An implementation of <see cref="WebViewManager"/> that uses the Android WebKit WebView browser control
 	/// to render web content.
 	/// </summary>
-	public class AndroidWebKitWebViewManager : WebViewManager
+	public class AndroidWebKitWebViewManager : WebViewManager, IAsyncDisposable
 	{
 		// Using an IP address means that WebView doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since
@@ -22,6 +23,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
 		private static readonly AUri AndroidAppOriginUri = AUri.Parse(AppOrigin)!;
 		private readonly AWebView _webview;
+		private WebMessagePort[]? _nativeToJSPorts;
 
 		/// <summary>
 		/// Constructs an instance of <see cref="AndroidWebKitWebViewManager"/>.
@@ -62,18 +64,31 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 		internal void SetUpMessageChannel()
 		{
-			var nativeToJsPorts = _webview.CreateWebMessageChannel();
+			_nativeToJSPorts = _webview.CreateWebMessageChannel();
 
 			var nativeToJs = new BlazorWebMessageCallback(message =>
 			{
 				MessageReceived(new Uri(AppOrigin), message!);
 			});
 
-			var destPort = new[] { nativeToJsPorts[1] };
+			var destPort = new[] { _nativeToJSPorts[1] };
 
-			nativeToJsPorts[0].SetWebMessageCallback(nativeToJs);
+			_nativeToJSPorts[0].SetWebMessageCallback(nativeToJs);
 
 			_webview.PostWebMessage(new WebMessage("capturePort", destPort), AndroidAppOriginUri);
+		}
+
+		public async new ValueTask DisposeAsync()
+		{
+			await base.DisposeAsync();
+
+			if (_nativeToJSPorts is not null)
+			{
+				foreach (var port in _nativeToJSPorts)
+				{
+					port?.Close();
+				}
+			}
 		}
 
 		private class BlazorWebMessageCallback : WebMessagePort.WebMessageCallback


### PR DESCRIPTION
Spent some more time on this issue, but I'm not seeing the root cause anywhere.

Based on https://github.com/flutter/flutter/issues/2509#issuecomment-204604837, the exception we're seeing indicates we're failing to dispose of a particular Android / Java object somewhere, however it's unclear what that actual object is.

Based on the stacktrace it's the `UM` class, which seems to be an optimized/anonymyzed class within Android / Chrome(?)

```
04-05 14:40:38.062	pixel_5_-_api_30	Error	9911	System	java.lang.IllegalStateException: Warning: Router objects should be explicitly closed when no longer required otherwise you may leak handles.
	at UM.finalize(chromium-TrichromeWebViewGoogle.apk-stable-410410686:4)
```
(from Eilon) vs, I get:

```
2022-04-06 14:53:54.400 11032-11048/com.microsoft.maui.mauiblazorwebview.devicetests E/System: java.lang.IllegalStateException: Warning: Router objects should be explicitly closed when no longer required otherwise you may leak handles.
        at TM.finalize(chromium-TrichromeWebViewGoogle.apk-stable-410410681:4)
```

(note UM.Finalize vs. TM.Finalize) hence why I believe it's an internal, optimized, anonymous class. On the flutter PR we were looking at (https://github.com/flutter/flutter/issues/2950 / https://github.com/flutter/engine/pull/2646), it was clear the issue was with `mojo`, but that's not the case here.

Elsewhere online, others are seeing the same issue, but there doesn't seem to be any solutions. This looks like a potentially broader issue.

- https://stackoverflow.com/questions/65426547/possible-memory-leak-in-webview-postwebmessage
- https://stackoverflow.com/questions/66226138/jetpack-compose-webview-fails-to-show-pages-randomly

Note, the issue cannot be reproduced in the latest Android 12 / Android API 31. This leaves the distinct possibility this is a bug within Android / Chrome itself (complaining about a non issue perhaps?).

Regardless, during my investigation I did find one area where we're failing to dispose / close an Android object. Created this PR to resolve that:
- https://developer.android.com/reference/android/webkit/WebView?hl=en#createWebMessageChannel()
- https://developer.android.com/reference/android/webkit/WebMessagePort#close()

For: https://github.com/dotnet/maui/issues/5837