### PR TITLE
Fix Windows local dotnet builds

### DIFF
--- a/src/Workload/Shared/FrameworkList.targets
+++ b/src/Workload/Shared/FrameworkList.targets
@@ -43,7 +43,7 @@
       <!-- Look for WinUI .pri files a directory above ref/*.dll files -->
       <Content
           Include="@(_AssemblyFiles->'%(RootDir)%(Directory)../%(FileName).pri')"
-          TargetPath=""
+          TargetPath="%(PackagePath)\%(FileName).pri"
           Link=""
           Condition="Exists('%(RootDir)%(Directory)../%(FileName).pri')"
       />

--- a/src/Workload/Shared/FrameworkList.targets
+++ b/src/Workload/Shared/FrameworkList.targets
@@ -44,6 +44,7 @@
       <Content
           Include="@(_AssemblyFiles->'%(RootDir)%(Directory)../%(FileName).pri')"
           TargetPath=""
+          Link=""
           Condition="Exists('%(RootDir)%(Directory)../%(FileName).pri')"
       />
     </ItemGroup>


### PR DESCRIPTION
### Description of Change

This PR makes sure to also clear out the Link property and then set a correct TargetPath.

The previous way was to base off the .dll and then change the extension - and this means that the target path was set to dll, and so was the link. As a result, the .pri always copied over the .dll. The clearing of the TargetPath did nothing really except to tell msbuild to use the Link, which was also a dll. 

### Testing

The final nupkg should be unchanged.