### PR TITLE
Also allow things to build with dotnet

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -127,7 +127,7 @@ Task("dotnet-templates")
 
                 var type = forceDotNetBuild ? "DotNet" : "MSBuild";
                 var name = template.Replace("-", "_").Replace(" ", "_");
-                var projectName = $"{templatesTest}{name}{forceDotNetBuild}";
+                var projectName = $"{templatesTest}{name}_{type}";
                 StartProcess(dn, $"new {template} -o \"{projectName}\"");
 
                 // Build

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -119,17 +119,19 @@ Task("dotnet-templates")
 
         foreach (var template in new [] { "maui", "maui-blazor", "mauilib" })
         {
-            var name = template.Replace("-", "_").Replace(" ", "_");
-            StartProcess(dn, $"new {template} -o \"{templatesTest}{name}\"");
-
-            // Design-time build without restore
-            foreach (var framework in frameworks)
+            foreach (var forceDotNetBuild in new [] { true, false })
             {
-                RunMSBuildWithDotNet($"{templatesTest}{name}", designTime, target: "Compile", restore: false, warningsAsError: true, targetFramework: framework);
-            }
+                // macOS does not support msbuild
+                if (!IsRunningOnWindows() && !forceDotNetBuild)
+                    continue;
 
-            // Build
-            RunMSBuildWithDotNet($"{templatesTest}{name}", properties, warningsAsError: true);
+                var type = forceDotNetBuild ? "DotNet" : "MSBuild";
+                var name = template.Replace("-", "_").Replace(" ", "_");
+                StartProcess(dn, $"new {template} -o \"{templatesTest}{name}{forceDotNetBuild}\"");
+
+                // Build
+                RunMSBuildWithDotNet($"{templatesTest}{name}", properties, warningsAsError: true, forceDotNetBuild: forceDotNetBuild);
+            }
         }
 
         try
@@ -489,18 +491,22 @@ void RunMSBuildWithDotNet(
     string target = "Build",
     bool warningsAsError = false,
     bool restore = true,
-    string targetFramework = null)
+    string targetFramework = null,
+    bool forceDotNetBuild = false)
 {
+    var useDotNetBuild = forceDotNetBuild || !IsRunningOnWindows() || target == "Run";
+
     var name = System.IO.Path.GetFileNameWithoutExtension(sln);
+    var type = useDotNetBuild ? "dotnet" : "msbuild";
     var binlog = string.IsNullOrEmpty(targetFramework) ?
-        $"\"{logDirectory}/{name}-{configuration}-{target}.binlog\"" :
-        $"\"{logDirectory}/{name}-{configuration}-{target}-{targetFramework}.binlog\"";
+        $"\"{logDirectory}/{name}-{configuration}-{target}-{type}.binlog\"" :
+        $"\"{logDirectory}/{name}-{configuration}-{target}-{targetFramework}-{type}.binlog\"";
     
     if(localDotnet)
         SetDotNetEnvironmentVariables();
 
     // If we're not on Windows, use ./bin/dotnet/dotnet
-    if (!IsRunningOnWindows() || target == "Run")
+    if (useDotNetBuild)
     {
         var msbuildSettings = new DotNetCoreMSBuildSettings()
             .SetConfiguration(configuration)

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -127,10 +127,11 @@ Task("dotnet-templates")
 
                 var type = forceDotNetBuild ? "DotNet" : "MSBuild";
                 var name = template.Replace("-", "_").Replace(" ", "_");
-                StartProcess(dn, $"new {template} -o \"{templatesTest}{name}{forceDotNetBuild}\"");
+                var projectName = $"{templatesTest}{name}{forceDotNetBuild}";
+                StartProcess(dn, $"new {template} -o \"{projectName}\"");
 
                 // Build
-                RunMSBuildWithDotNet($"{templatesTest}{name}", properties, warningsAsError: true, forceDotNetBuild: forceDotNetBuild);
+                RunMSBuildWithDotNet(projectName, properties, warningsAsError: true, forceDotNetBuild: forceDotNetBuild);
             }
         }
 

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiApp._1</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>DOTNET_TFM;DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 		<RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MauiLib1</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>DOTNET_TFM;DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 		<RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MauiLib1</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiApp._1</RootNamespace>
 		<UseMaui>true</UseMaui>


### PR DESCRIPTION
### Description of Change

 - Build the templates using dotnet build to make sure all is working as expected
 - Remove the MSBuild restriction from the templates

### TODO

There appears to be an issue building windows class libraries in dotnet still, so we can keep the condition for now and remove it later. Tracked here: https://github.com/dotnet/maui/issues/5886