### PR TITLE
#4013 fixed fontimagesource color and size loading issue

### DIFF
--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
@@ -280,9 +280,9 @@ public class PlatformInterop {
     {
         RequestManager glide = Glide.with(imageView);
 
-        FontModel fontModel = new FontModel(color, glyph, textSize, typeface);
-        
         MauiCustomViewTarget target = new MauiCustomViewTarget(imageView, callback, glide);
+        
+        FontModel fontModel = new FontModel(color, glyph, textSize, typeface);
 
         glide
             .load(fontModel)

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
@@ -281,7 +281,7 @@ public class PlatformInterop {
         RequestManager glide = Glide.with(imageView);
 
         MauiCustomViewTarget target = new MauiCustomViewTarget(imageView, callback, glide);
-        
+
         FontModel fontModel = new FontModel(color, glyph, textSize, typeface);
 
         glide

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
@@ -281,10 +281,13 @@ public class PlatformInterop {
         RequestManager glide = Glide.with(imageView);
 
         FontModel fontModel = new FontModel(color, glyph, textSize, typeface);
+        
+        MauiCustomViewTarget target = new MauiCustomViewTarget(imageView, callback, glide);
+
         glide
             .load(fontModel)
             .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
-            .into(imageView);
+            .into(target);
     }
 
     public static void loadImageFromFile(Context context, String file, ImageLoaderCallback callback)

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/PlatformInterop.java
@@ -280,14 +280,11 @@ public class PlatformInterop {
     {
         RequestManager glide = Glide.with(imageView);
 
-        MauiCustomViewTarget target = new MauiCustomViewTarget(imageView, callback, glide);
-
         FontModel fontModel = new FontModel(color, glyph, textSize, typeface);
-
         glide
             .load(fontModel)
             .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
-            .into(target);
+            .into(imageView);
     }
 
     public static void loadImageFromFile(Context context, String file, ImageLoaderCallback callback)

--- a/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiCustomViewTarget.java
+++ b/src/Core/AndroidNative/maui/src/main/java/com/microsoft/maui/glide/MauiCustomViewTarget.java
@@ -46,6 +46,7 @@ public class MauiCustomViewTarget extends CustomViewTarget<ImageView, Drawable> 
 
     @Override
     public void onResourceReady(@NonNull Drawable resource, @Nullable Transition<? super Drawable> transition) {
+        this.imageView.setImageDrawable(resource);
         callback.onComplete(true, resource, new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
FontImageSource color and size didn't load on android.
Changed glide.load target to imageView.


Fixes #4013 
