### PR TITLE
Remove sdk versions from android manifests in templates

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>


### PR DESCRIPTION
Fixes #5882

These aren't needed as they are inferred from the `TargetFrameworkVersion` (for `targetSdkVersion`) and `SupportedOSPlatformVersion` (for `minSdkVersion`)

