### PR TITLE
[android] Update to latest AndroidX packages with better Trimmable support.

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -2,47 +2,47 @@
   <ItemGroup>
     <PackageReference
         Update="Xamarin.AndroidX.AppCompat.AppCompatResources"
-        Version="1.4.1"
+        Version="1.4.1.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Browser"
-        Version="1.4.0"
+        Version="1.4.0.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Legacy.Support.V4"
-        Version="1.0.0.12"
+        Version="1.0.0.13"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Lifecycle.LiveData"
-        Version="2.4.1"
-    />
-    <PackageReference
-        Update="Xamarin.AndroidX.Navigation.UI"
-        Version="2.4.1"
-    />
-    <PackageReference
-        Update="Xamarin.AndroidX.Navigation.Fragment"
         Version="2.4.1.1"
     />
     <PackageReference
+        Update="Xamarin.AndroidX.Navigation.UI"
+        Version="2.4.1.1"
+    />
+    <PackageReference
+        Update="Xamarin.AndroidX.Navigation.Fragment"
+        Version="2.4.1.2"
+    />
+    <PackageReference
         Update="Xamarin.AndroidX.Navigation.Runtime"
-        Version="2.4.1"
+        Version="2.4.1.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Navigation.Common"
-        Version="2.4.1"
+        Version="2.4.1.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.MediaRouter"
-        Version="1.2.6"
+        Version="1.2.6.1"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Palette"
-        Version="1.0.0.12"
+        Version="1.0.0.13"
     />
     <PackageReference
         Update="Xamarin.AndroidX.RecyclerView"
-        Version="1.2.1.5"
+        Version="1.2.1.6"
     />
     <PackageReference
         Update="Xamarin.Build.Download"
@@ -50,7 +50,7 @@
     />
     <PackageReference
         Update="Xamarin.Google.Android.Material"
-        Version="1.5.0.1"
+        Version="1.5.0.2"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Migration"
@@ -59,7 +59,7 @@
     />
     <PackageReference
         Update="Xamarin.AndroidX.Window.WindowJava"
-        Version="1.0.0.7"
+        Version="1.0.0.8"
     />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/issues/519
Context: https://github.com/xamarin/AndroidX/pull/520

The AndroidX packages that MAUI currently uses all support trimming, however some of their new dependencies did not, such as `Xamarin.Kotlin.StdLib`.  This caused a size regression on Android because these new libraries were not being trimmed.

AndroidX dependencies have been updated with trimming support, and new packages have been released that update the dependency tree.

This PR updates MAUI to use these new AndroidX versions.