### PR TITLE
Fix backbutton visibility when popping

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			if (_flyoutBehavior == behavior)
 				return;
+
 			_flyoutBehavior = behavior;
 
 			if (Page != null)
@@ -80,8 +81,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_platformToolbar.SetNavigationOnClickListener(this);
 			((IShellController)ShellContext.Shell).AddFlyoutBehaviorObserver(this);
 			ShellContext.Shell.Toolbar.PropertyChanged += OnToolbarPropertyChanged;
+			ShellContext.Shell.Navigated += OnShellNavigated;
 		}
-
 
 		void IShellToolbarTracker.SetToolbar(IToolbar toolbar)
 		{
@@ -183,6 +184,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				((IShellController)ShellContext.Shell)?.RemoveFlyoutBehaviorObserver(this);
 				ShellContext.Shell.Toolbar.PropertyChanged -= OnToolbarPropertyChanged;
+				ShellContext.Shell.Navigated -= OnShellNavigated;
 				UpdateTitleView(ShellContext.AndroidContext, _platformToolbar, null);
 
 				if (_searchView != null)
@@ -263,6 +265,18 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				{
 					shellToolbar.ApplyChanges();
 				}
+			}
+		}
+
+		void OnShellNavigated(object sender, ShellNavigatedEventArgs e)
+		{
+			if (_disposed || Page == null)
+				return;
+
+			if (ShellContext?.Shell?.Toolbar is ShellToolbar shellToolbar &&
+					Page == ShellContext?.Shell?.CurrentPage)
+			{
+				UpdateLeftBarButtonItem();
 			}
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -43,6 +43,25 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Back Button Visibility Changes with push/pop")]
+		public async Task BackButtonVisibilityChangesWithPushPop()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new ContentPage();
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				Assert.False(IsBackButtonVisible(handler));
+				await shell.Navigation.PushAsync(new ContentPage());
+				Assert.True(IsBackButtonVisible(handler));
+				await shell.Navigation.PopAsync();
+				Assert.False(IsBackButtonVisible(handler));
+			});
+		}
+
 		[Fact(DisplayName = "Set Has Back Button")]
 		public async Task SetHasBackButton()
 		{
@@ -52,10 +71,7 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				return new Shell()
 				{
-					Items =
-					{
-						new ContentPage()
-					}
+					Items = { new ContentPage() }
 				};
 			});
 
@@ -86,10 +102,7 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				return new Shell()
 				{
-					Items =
-						{
-							new ContentPage()
-						}
+					Items = { new ContentPage() }
 				};
 			});
 


### PR DESCRIPTION
### Description of Change

Shell toolbar handling was converted over to use all the same logic as the NavigationPage. Unfortunately there are still a couple parts like the drawer button which can't be handled by the NavigationPage logic. This code triggers that special shell code after the user has navigated to ensure the toolbar is setup correctly
