### PR TITLE
Don't do manifest things for unpackaged apps

### DIFF
--- a/.nuspec/AutoImport.InTree.props
+++ b/.nuspec/AutoImport.InTree.props
@@ -97,7 +97,7 @@
         Condition="Exists('$(ApplicationManifest)')" />
     <AppxManifest
         Include="$(PackageManifest)"
-        Condition="Exists('$(PackageManifest)')" />
+        Condition="'$(WindowsPackageType)' != 'None' and Exists('$(PackageManifest)')" />
     <ApplicationDefinition
         Condition="Exists('$(WindowsProjectFolder)App.xaml')"
         Include="$(WindowsProjectFolder)App.xaml">

--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
@@ -50,12 +50,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
+    <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnablePreviewMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">MSIX</WindowsPackageType>
     <ApplicationManifest Condition=" Exists('$(WindowsProjectFolder)app.manifest') ">$(WindowsProjectFolder)app.manifest</ApplicationManifest>
-    <PackageManifest Condition=" Exists('$(WindowsProjectFolder)Package.appxmanifest') ">$(WindowsProjectFolder)Package.appxmanifest</PackageManifest>
+    <PackageManifest Condition=" '$(WindowsPackageType)' != 'None' and Exists('$(WindowsProjectFolder)Package.appxmanifest') ">$(WindowsProjectFolder)Package.appxmanifest</PackageManifest>
     <EnableDefaultPageItems>False</EnableDefaultPageItems>
     <EnableDefaultApplicationDefinition>False</EnableDefaultApplicationDefinition>
     <_SingleProjectWindowsExcludes>$(WindowsProjectFolder)/**/.*/**</_SingleProjectWindowsExcludes>
-    <WindowsPackageType Condition="'$(EnablePreviewMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')">MSIX</WindowsPackageType>
   </PropertyGroup>
 
   <!--

--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
@@ -50,12 +50,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
-    <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnablePreviewMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">MSIX</WindowsPackageType>
     <ApplicationManifest Condition=" Exists('$(WindowsProjectFolder)app.manifest') ">$(WindowsProjectFolder)app.manifest</ApplicationManifest>
-    <PackageManifest Condition=" '$(WindowsPackageType)' != 'None' and Exists('$(WindowsProjectFolder)Package.appxmanifest') ">$(WindowsProjectFolder)Package.appxmanifest</PackageManifest>
+    <PackageManifest Condition=" Exists('$(WindowsProjectFolder)Package.appxmanifest') ">$(WindowsProjectFolder)Package.appxmanifest</PackageManifest>
     <EnableDefaultPageItems>False</EnableDefaultPageItems>
     <EnableDefaultApplicationDefinition>False</EnableDefaultApplicationDefinition>
     <_SingleProjectWindowsExcludes>$(WindowsProjectFolder)/**/.*/**</_SingleProjectWindowsExcludes>
+    <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnablePreviewMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">MSIX</WindowsPackageType>
   </PropertyGroup>
 
   <!--

--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -564,6 +564,7 @@
             DependsOnTargets="MauiGeneratePackageAppxManifest" />
 
     <Target Name="MauiGeneratePackageAppxManifest"
+            Condition="'$(WindowsPackageType)' != 'None'"
             DependsOnTargets="$(MauiGeneratePackageAppxManifestDependsOnTargets)"
             Inputs="$(MSBuildThisFileFullPath);$(_ResizetizerTaskAssemblyName);$(_ResizetizerInputsFile);$(_MauiSplashInputsFile);@(AppxManifest)"
             Outputs="$(_MauiManifestStampFile);$(_MauiIntermediateManifest)Package.appxmanifest">
@@ -572,7 +573,7 @@
             <_MauiWindowsApplicationId Condition="'$(_MauiWindowsApplicationId)' == '' and '$(ApplicationIdGuid)' != ''">$(ApplicationIdGuid)</_MauiWindowsApplicationId>
             <_MauiWindowsApplicationId Condition="'$(_MauiWindowsApplicationId)' == '' and '$(ApplicationId)' != ''">$(ApplicationId)</_MauiWindowsApplicationId>
         </PropertyGroup>
-        
+
         <GeneratePackageAppxManifest
             IntermediateOutputPath="$(_MauiIntermediateManifest)"
             AppxManifest="@(AppxManifest)"

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.props
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.props
@@ -130,7 +130,7 @@
         Condition="Exists('$(ApplicationManifest)')" />
     <AppxManifest
         Include="$(PackageManifest)"
-        Condition="Exists('$(PackageManifest)')" />
+        Condition="'$(WindowsPackageType)' != 'None' and Exists('$(PackageManifest)')" />
     <ApplicationDefinition
         Condition="Exists('$(WindowsProjectFolder)App.xaml')"
         Include="$(WindowsProjectFolder)App.xaml">


### PR DESCRIPTION
### Description of Change

Fix a few things for unpackaged apps.

Parts of resizetizer assume everything is an MSIX and actually overrides user values in some cases.

This PR first checks to see if the user wans unpackaged, and then goes ahead and respects that - only including the manifest if this is a packaged app.

Fixes #5881