### PR TITLE
Prevent ScrollView on Android and Windows from entering a bad layout state

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView.Impl.cs
@@ -83,8 +83,6 @@ namespace Microsoft.Maui.Controls
 			Frame = this.ComputeFrame(bounds);
 			Handler?.PlatformArrange(Frame);
 
-			(this as IContentView).CrossPlatformArrange(new Rect(Point.Zero, Frame.Size));
-
 			return Frame.Size;
 		}
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.DisconnectHandler(platformView);
 			platformView.ScrollChange -= ScrollChange;
+			platformView.CrossPlatformArrange = null;
 		}
 
 		public override void PlatformArrange(Rect frame)

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.ConnectHandler(platformView);
 			platformView.ScrollChange += ScrollChange;
+			platformView.CrossPlatformArrange = VirtualView.CrossPlatformArrange;
 		}
 
 		protected override void DisconnectHandler(MauiScrollView platformView)
@@ -32,16 +33,15 @@ namespace Microsoft.Maui.Handlers
 			platformView.ScrollChange -= ScrollChange;
 		}
 
-		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		public override void PlatformArrange(Rect frame)
 		{
-			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
+			base.PlatformArrange(frame);
 
-			if (FindInsetPanel(this) == null)
+			if (FindInsetPanel(this) is ContentViewGroup paddingLayer)
 			{
-				VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
+				var (l, t, r, b) = Context.ToPixels(frame);
+				paddingLayer.Layout(0, 0, r - l, b - t);
 			}
-
-			return result;
 		}
 
 		void ScrollChange(object? sender, AndroidX.Core.Widget.NestedScrollView.ScrollChangeEventArgs e)
@@ -183,7 +183,6 @@ namespace Microsoft.Maui.Handlers
 			var paddingShim = new ContentViewGroup(handler.MauiContext.Context)
 			{
 				CrossPlatformMeasure = IncludeScrollViewInsets(scrollView.CrossPlatformMeasure, scrollView),
-				CrossPlatformArrange = scrollView.CrossPlatformArrange,
 				Tag = InsetPanelTag
 			};
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -46,6 +46,16 @@ namespace Microsoft.Maui.Handlers
 			return result;
 		}
 
+		public override void PlatformArrange(Rect rect)
+		{
+			base.PlatformArrange(rect);
+
+			if (GetInsetPanel(PlatformView) == null)
+			{
+				VirtualView.CrossPlatformArrange(rect);
+			}
+		}
+
 		public static void MapContent(IScrollViewHandler handler, IScrollView scrollView)
 		{
 			if (handler.PlatformView == null || handler.MauiContext == null)

--- a/src/Core/src/Platform/Android/ContentViewGroup.cs
+++ b/src/Core/src/Platform/Android/ContentViewGroup.cs
@@ -66,20 +66,14 @@ namespace Microsoft.Maui.Platform
 			SetMeasuredDimension((int)platformWidth, (int)platformHeight);
 		}
 
-		protected override void OnLayout(bool changed, int l, int t, int r, int b)
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
 		{
 			if (CrossPlatformArrange == null || Context == null)
 			{
 				return;
 			}
 
-			var deviceIndependentLeft = Context.FromPixels(l);
-			var deviceIndependentTop = Context.FromPixels(t);
-			var deviceIndependentRight = Context.FromPixels(r);
-			var deviceIndependentBottom = Context.FromPixels(b);
-
-			var destination = Rect.FromLTRB(0, 0,
-				deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
+			var destination = Context!.ToCrossPlatformRectInReferenceFrame(left, top, right, bottom);
 
 			CrossPlatformArrange(destination);
 		}

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -295,7 +295,6 @@ namespace Microsoft.Maui.Platform
 			return rc ?? Color.FromArgb("#ff33b5e5");
 		}
 
-
 		public static int GetActionBarHeight(this Context context)
 		{
 			_actionBarHeight ??= (int)context.GetThemeAttributePixels(Resource.Attribute.actionBarSize);
@@ -332,5 +331,16 @@ namespace Microsoft.Maui.Platform
 
 		public static float GetDisplayDensity(this Context context) =>
 			context.Resources?.DisplayMetrics?.Density ?? 1.0f;
+
+		public static Rect ToCrossPlatformRectInReferenceFrame(this Context context, int left, int top, int right, int bottom) 
+		{
+			var deviceIndependentLeft = context.FromPixels(left);
+			var deviceIndependentTop = context.FromPixels(top);
+			var deviceIndependentRight = context.FromPixels(right);
+			var deviceIndependentBottom = context.FromPixels(bottom);
+
+			return Rect.FromLTRB(0, 0,
+				deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -132,13 +132,7 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			var deviceIndependentLeft = Context.FromPixels(l);
-			var deviceIndependentTop = Context.FromPixels(t);
-			var deviceIndependentRight = Context.FromPixels(r);
-			var deviceIndependentBottom = Context.FromPixels(b);
-
-			var destination = Rectangle.FromLTRB(0, 0,
-				deviceIndependentRight - deviceIndependentLeft, deviceIndependentBottom - deviceIndependentTop);
+			var destination = Context!.ToCrossPlatformRectInReferenceFrame(l, t, r, b);
 
 			CrossPlatformArrange(destination);
 

--- a/src/Core/src/Platform/Android/MauiScrollView.cs
+++ b/src/Core/src/Platform/Android/MauiScrollView.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Android.Animation;
 using Android.Content;
 using Android.Graphics;
@@ -193,6 +191,15 @@ namespace Microsoft.Maui.Platform
 			{
 				_hScrollView.Layout(0, 0, right - left, bottom - top);
 			}
+
+			if (CrossPlatformArrange == null)
+			{
+				return;
+			}
+
+			var destination = Context!.ToCrossPlatformRectInReferenceFrame(left, top, right, bottom);
+
+			CrossPlatformArrange(destination);
 		}
 
 		public void ScrollTo(int x, int y, bool instant, Action finished)
@@ -269,6 +276,8 @@ namespace Microsoft.Maui.Platform
 
 			animator.Start();
 		}
+
+		internal Func<Graphics.Rect, Graphics.Size>? CrossPlatformArrange { get; set; }
 	}
 
 	internal class MauiHorizontalScrollView : HorizontalScrollView, IScrollBarView


### PR DESCRIPTION
### Description of Change

When no padding/margin are specified, the Windows and Android ScrollViews can reach a layout state where requests for subsequent layout updates are ignored. These changes prevent that from happening.

### Issues Fixed

Fixes #5717

