### PR TITLE
Update iOS / Mac Catalyst Blazor Hybrid APIs

### DIFF
--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
@@ -22,8 +22,6 @@ Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> stri
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -46,8 +44,6 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> 
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
@@ -22,8 +22,6 @@ Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> stri
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.IOSWebViewManager(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! blazorMauiWebViewHandler, WebKit.WKWebView! webview, System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -46,8 +44,6 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> 
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.IOSWebViewManager.SendMessage(string! message) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void

--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// An implementation of <see cref="WebViewManager"/> that uses the <see cref="WKWebView"/> browser control
 	/// to render web content.
 	/// </summary>
-	public class IOSWebViewManager : WebViewManager
+	internal class IOSWebViewManager : WebViewManager
 	{
 		private readonly BlazorWebViewHandler _blazorMauiWebViewHandler;
 		private readonly WKWebView _webview;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/5908

Made `IOSWebViewManager` internal and did basic runtime validation using the `SingleProject` app on iOS and Mac Catalyst.

Note:

https://github.com/dotnet/maui/blob/02300feeb5c256f86d257a713e8d13ea626959fa/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs#L18

could NOT be made internal as it is a partial class of:

https://github.com/dotnet/maui/blob/02300feeb5c256f86d257a713e8d13ea626959fa/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs#L10

which I believe has to be public (basing this off of https://github.com/dotnet/maui/issues/5905) and attempts to compile with the BlazorWebViewHandler as internal.

> If we can't make any of them internal, discuss with the team since we would want to do something about making their other public members internal.

Given this, do we want to re-review what we should or should not make internal within the individual `BlazorWebViewHandler.*` handlers?

