### PR TITLE
Maui Windows unpackaged app fails to start

### DIFF
--- a/src/Compatibility/Core/src/Windows/ImageElementManager.cs
+++ b/src/Compatibility/Core/src/Windows/ImageElementManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.UI.Xaml;
@@ -12,25 +11,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
 	public static class ImageElementManager
 	{
-		static bool _nativeAnimationSupport = false;
-		static ImageElementManager()
-		{
-			// Workaround https://github.com/microsoft/WindowsAppSDK/issues/2382.
-			// ApiInformation.IsPropertyPresent and IsMethodPresent will throw in an unpackaged app.
-			if (AppInfo.PackagingModel == AppPackagingModel.Unpackaged)
-			{
-				_nativeAnimationSupport = true;
-			}
-			else
-			{
-				if (global::Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "AutoPlay"))
-					if (global::Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "IsPlaying"))
-						if (global::Windows.Foundation.Metadata.ApiInformation.IsMethodPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "Play"))
-							if (global::Windows.Foundation.Metadata.ApiInformation.IsMethodPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "Stop"))
-								_nativeAnimationSupport = true;
-			}
-		}
-
 		public static void Init(IImageVisualElementRenderer renderer)
 		{
 			renderer.ElementPropertyChanged += OnElementPropertyChanged;
@@ -68,15 +48,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 
 			if (renderer.GetImage()?.Source is BitmapImage bitmapImage)
 			{
-				if (_nativeAnimationSupport)
-				{
-					if (controller.IsAnimationPlaying && !bitmapImage.IsPlaying)
-						bitmapImage.Play();
-					else if (!controller.IsAnimationPlaying && bitmapImage.IsPlaying)
-						bitmapImage.Stop();
+				if (controller.IsAnimationPlaying && !bitmapImage.IsPlaying)
+					bitmapImage.Play();
+				else if (!controller.IsAnimationPlaying && bitmapImage.IsPlaying)
+					bitmapImage.Stop();
 
-					bitmapImage.RegisterPropertyChangedCallback(BitmapImage.IsPlayingProperty, OnIsPlaying);
-				}
+				bitmapImage.RegisterPropertyChangedCallback(BitmapImage.IsPlayingProperty, OnIsPlaying);
 			}
 		}
 
@@ -165,7 +142,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 				if (renderer.IsDisposed)
 					return;
 
-				if (imagesource is BitmapImage bitmapImage && _nativeAnimationSupport)
+				if (imagesource is BitmapImage bitmapImage)
 					bitmapImage.AutoPlay = false;
 
 				if (Control != null)

--- a/src/Compatibility/Core/src/Windows/ImageElementManager.cs
+++ b/src/Compatibility/Core/src/Windows/ImageElementManager.cs
@@ -1,12 +1,12 @@
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.Maui.Controls.Internals;
-using Microsoft.Maui.Controls.Compatibility.Platform.UWP;
 using WStretch = Microsoft.UI.Xaml.Media.Stretch;
-using Microsoft.Maui.Controls.Platform;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 {
@@ -15,11 +15,20 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		static bool _nativeAnimationSupport = false;
 		static ImageElementManager()
 		{
-			if (global::Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "AutoPlay"))
-				if (global::Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "IsPlaying"))
-					if (global::Windows.Foundation.Metadata.ApiInformation.IsMethodPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "Play"))
-						if (global::Windows.Foundation.Metadata.ApiInformation.IsMethodPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "Stop"))
-							_nativeAnimationSupport = true;
+			// Workaround https://github.com/microsoft/WindowsAppSDK/issues/2382.
+			// ApiInformation.IsPropertyPresent and IsMethodPresent will throw in an unpackaged app.
+			if (AppInfo.PackagingModel == AppPackagingModel.Unpackaged)
+			{
+				_nativeAnimationSupport = true;
+			}
+			else
+			{
+				if (global::Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "AutoPlay"))
+					if (global::Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "IsPlaying"))
+						if (global::Windows.Foundation.Metadata.ApiInformation.IsMethodPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "Play"))
+							if (global::Windows.Foundation.Metadata.ApiInformation.IsMethodPresent("Microsoft.UI.Xaml.Media.Imaging.BitmapImage", "Stop"))
+								_nativeAnimationSupport = true;
+			}
 		}
 
 		public static void Init(IImageVisualElementRenderer renderer)

--- a/src/Core/src/Platform/Windows/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ImageViewExtensions.cs
@@ -1,12 +1,8 @@
 ﻿#nullable enable
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.UI.Xaml;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Foundation.Metadata;
 using WImage = Microsoft.UI.Xaml.Controls.Image;
-using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
 
 namespace Microsoft.Maui.Platform
 {
@@ -18,11 +14,20 @@ namespace Microsoft.Maui.Platform
 
 		static ImageViewExtensions()
 		{
-			IsAnimationSupported =
-				ApiInformation.IsPropertyPresent(BitmapImageTypeName, nameof(BitmapImage.IsAnimatedBitmap)) &&
-				ApiInformation.IsPropertyPresent(BitmapImageTypeName, nameof(BitmapImage.IsPlaying)) &&
-				ApiInformation.IsPropertyPresent(BitmapImageTypeName, nameof(BitmapImage.Play)) &&
-				ApiInformation.IsPropertyPresent(BitmapImageTypeName, nameof(BitmapImage.Stop));
+			// Workaround https://github.com/microsoft/WindowsAppSDK/issues/2382.
+			// ApiInformation.IsPropertyPresent and IsMethodPresent will throw in an unpackaged app.
+			if (AppInfo.PackagingModel == AppPackagingModel.Unpackaged)
+			{
+				IsAnimationSupported = true;
+			}
+			else
+			{
+				IsAnimationSupported =
+					ApiInformation.IsPropertyPresent(BitmapImageTypeName, nameof(BitmapImage.IsAnimatedBitmap)) &&
+					ApiInformation.IsPropertyPresent(BitmapImageTypeName, nameof(BitmapImage.IsPlaying)) &&
+					ApiInformation.IsMethodPresent(BitmapImageTypeName, nameof(BitmapImage.Play)) &&
+					ApiInformation.IsMethodPresent(BitmapImageTypeName, nameof(BitmapImage.Stop));
+			}
 		}
 
 		public static void Clear(this WImage imageView)

--- a/src/Core/src/Platform/Windows/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ImageViewExtensions.cs
@@ -1,35 +1,11 @@
 ﻿#nullable enable
-using Microsoft.Maui.ApplicationModel;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Windows.Foundation.Metadata;
 using WImage = Microsoft.UI.Xaml.Controls.Image;
 
 namespace Microsoft.Maui.Platform
 {
 	public static class ImageViewExtensions
 	{
-		const string BitmapImageTypeName = "Microsoft.UI.Xaml.Media.Imaging.BitmapImage";
-
-		static bool IsAnimationSupported;
-
-		static ImageViewExtensions()
-		{
-			// Workaround https://github.com/microsoft/WindowsAppSDK/issues/2382.
-			// ApiInformation.IsPropertyPresent and IsMethodPresent will throw in an unpackaged app.
-			if (AppInfo.PackagingModel == AppPackagingModel.Unpackaged)
-			{
-				IsAnimationSupported = true;
-			}
-			else
-			{
-				IsAnimationSupported =
-					ApiInformation.IsPropertyPresent(BitmapImageTypeName, nameof(BitmapImage.IsAnimatedBitmap)) &&
-					ApiInformation.IsPropertyPresent(BitmapImageTypeName, nameof(BitmapImage.IsPlaying)) &&
-					ApiInformation.IsMethodPresent(BitmapImageTypeName, nameof(BitmapImage.Play)) &&
-					ApiInformation.IsMethodPresent(BitmapImageTypeName, nameof(BitmapImage.Stop));
-			}
-		}
-
 		public static void Clear(this WImage imageView)
 		{
 			imageView.Source = null;
@@ -42,9 +18,6 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateIsAnimationPlaying(this WImage imageView, IImageSourcePart image)
 		{
-			if (!IsAnimationSupported)
-				return;
-
 			if (imageView.Source is BitmapImage bitmapImage && bitmapImage.IsAnimatedBitmap)
 			{
 				if (image.IsAnimationPlaying)


### PR DESCRIPTION
Due to https://github.com/microsoft/WindowsAppSDK/issues/2382, ApiInformation IsPropertyPresent and IsMethodPresent throw in unpackaged apps. Working around this problem by assuming BitmapImages support animation in unpackaged apps.

Fix #5927
