### PR TITLE
Use SizeToFit when measuring Editor on iOS with infinite constraints

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class EditorHandler : ViewHandler<IEditor, MauiTextView>
 	{
-		static readonly int BaseHeight = 30;
+		//static readonly int BaseHeight = 30;
 
 		protected override MauiTextView CreatePlatformView() => new MauiTextView();
 
@@ -29,8 +29,29 @@ namespace Microsoft.Maui.Handlers
 			platformView.TextSetOrChanged -= OnTextPropertySet;
 		}
 
-		public override Size GetDesiredSize(double widthConstraint, double heightConstraint) =>
-			new SizeRequest(new Size(widthConstraint, BaseHeight));
+		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			if (double.IsInfinity(widthConstraint) || double.IsInfinity(heightConstraint))
+			{
+				// If we drop an infinite value into base.GetDesiredSize for the Editor, we'll
+				// get an exception; it doesn't know what do to with it. So instead we'll size
+				// it to fit its current contents and use those values to replace infinite constraints
+
+				PlatformView.SizeToFit();
+
+				if (double.IsInfinity(widthConstraint))
+				{
+					widthConstraint = PlatformView.Frame.Size.Width;
+				}
+
+				if (double.IsInfinity(heightConstraint))
+				{
+					heightConstraint = PlatformView.Frame.Size.Height;
+				}
+			}
+
+			return base.GetDesiredSize(widthConstraint, heightConstraint);
+		}
 
 		public static void MapText(IEditorHandler handler, IEditor editor)
 		{

--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -9,8 +9,6 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class EditorHandler : ViewHandler<IEditor, MauiTextView>
 	{
-		//static readonly int BaseHeight = 30;
-
 		protected override MauiTextView CreatePlatformView() => new MauiTextView();
 
 		protected override void ConnectHandler(MauiTextView platformView)


### PR DESCRIPTION
### Description of Change

Editor on iOS doesn't like being measured using SizeThatFits with infinite constraints; these changes use SizeToFit when one or both constraints are infinite.

### Issues Fixed

Fixes #5749
