### PR TITLE
Remove downcasts in BlazorWebView

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -98,8 +98,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
-			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
-			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
+			VirtualView.SendBlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
+			VirtualView.SendBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = PlatformView,
 			});

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -98,8 +98,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
-			VirtualView.SendBlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
-			VirtualView.SendBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
+			VirtualView.BlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
+			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = PlatformView,
 			});

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			// This method never gets called for navigation to a new window ('_blank'),
 			// so we know we can safely invoke the UrlLoading event.
 			var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri);
-			_webViewHandler.UrlLoading?.Invoke(callbackArgs);
+			_webViewHandler.SendUrlLoading(callbackArgs);
 
 			if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenExternally)
 			{

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			// This method never gets called for navigation to a new window ('_blank'),
 			// so we know we can safely invoke the UrlLoading event.
 			var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, AppOriginUri);
-			_webViewHandler.SendUrlLoading(callbackArgs);
+			_webViewHandler.UrlLoading(callbackArgs);
 
 			if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenExternally)
 			{

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -33,13 +33,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <inheritdoc />
 		public RootComponentsCollection RootComponents { get; }
 
-		/// <inheritdoc />
+		/// <summary>
+		/// Allows customizing how links are opened.
+		/// By default, opens internal links in the webview and external links in an external app.
+		/// </summary>
 		public event EventHandler<UrlLoadingEventArgs>? UrlLoading;
 
-		/// <inheritdoc />
+		/// <summary>
+		/// Raised before the web view is initialized. On some platforms this enables customizing the web view configuration.
+		/// </summary>
 		public event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
 
-		/// <inheritdoc />
+		/// <summary>
+		/// Raised after the web view is initialized but before any component has been rendered. The event arguments provide the instance of the platform-specific web view control.
+		/// </summary>
 		public event EventHandler<BlazorWebViewInitializedEventArgs>? BlazorWebViewInitialized;
 
 		/// <inheritdoc />
@@ -49,15 +56,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			return ((BlazorWebViewHandler)(Handler!)).CreateFileProvider(contentRootDir);
 		}
 
-		internal void NotifyUrlLoading(UrlLoadingEventArgs args)
-		{
+		void IBlazorWebView.SendUrlLoading(UrlLoadingEventArgs args) =>
 			UrlLoading?.Invoke(this, args);
-		}
 
-		internal void NotifyBlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args) =>
+		void IBlazorWebView.SendBlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args) =>
 			BlazorWebViewInitializing?.Invoke(this, args);
 
-		internal void NotifyBlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args) =>
+		void IBlazorWebView.SendBlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args) =>
 			BlazorWebViewInitialized?.Invoke(this, args);
 	}
 }

--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -56,13 +56,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			return ((BlazorWebViewHandler)(Handler!)).CreateFileProvider(contentRootDir);
 		}
 
-		void IBlazorWebView.SendUrlLoading(UrlLoadingEventArgs args) =>
+		void IBlazorWebView.UrlLoading(UrlLoadingEventArgs args) =>
 			UrlLoading?.Invoke(this, args);
 
-		void IBlazorWebView.SendBlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args) =>
+		void IBlazorWebView.BlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args) =>
 			BlazorWebViewInitializing?.Invoke(this, args);
 
-		void IBlazorWebView.SendBlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args) =>
+		void IBlazorWebView.BlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args) =>
 			BlazorWebViewInitialized?.Invoke(this, args);
 	}
 }

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 #if !NETSTANDARD
 		private string? HostPage { get; set; }
 
-		internal void SendUrlLoading(UrlLoadingEventArgs args) =>
+		internal void UrlLoading(UrlLoadingEventArgs args) =>
 			VirtualView.UrlLoading(args);
 
 		private RootComponentsCollection? _rootComponents;

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			[nameof(IBlazorWebView.HostPage)] = MapHostPage,
 			[nameof(IBlazorWebView.RootComponents)] = MapRootComponents,
-			[nameof(IBlazorWebView.UrlLoading)] = MapNotifyUrlLoading,
 		};
 
 		/// <summary>
@@ -62,24 +61,11 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 #endif
 		}
 
-		/// <summary>
-		/// Maps the <see cref="BlazorWebView.NotifyUrlLoading"/> property to the specified handler.
-		/// </summary>
-		/// <param name="handler">The <see cref="BlazorWebViewHandler"/>.</param>
-		/// <param name="webView">The <see cref="IBlazorWebView"/>.</param>
-		public static void MapNotifyUrlLoading(BlazorWebViewHandler handler, IBlazorWebView webView)
-		{
-#if !NETSTANDARD
-			if (webView is BlazorWebView bwv)
-			{
-				handler.UrlLoading = bwv.NotifyUrlLoading;
-			}
-#endif
-		}
-
 #if !NETSTANDARD
 		private string? HostPage { get; set; }
-		internal Action<UrlLoadingEventArgs>? UrlLoading;
+
+		internal void SendUrlLoading(UrlLoadingEventArgs args) =>
+			VirtualView.SendUrlLoading(args);
 
 		private RootComponentsCollection? _rootComponents;
 

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		private string? HostPage { get; set; }
 
 		internal void SendUrlLoading(UrlLoadingEventArgs args) =>
-			VirtualView.SendUrlLoading(args);
+			VirtualView.UrlLoading(args);
 
 		private RootComponentsCollection? _rootComponents;
 

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -26,22 +26,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		JSComponentConfigurationStore JSComponents { get; }
 
 		/// <summary>
-		/// Allows customizing how links are opened.
-		/// By default, opens internal links in the webview and external links in an external app.
-		/// </summary>
-		event EventHandler<UrlLoadingEventArgs>? UrlLoading;
-
-		/// <summary>
-		/// Raised before the web view is initialized. On some platforms this enables customizing the web view configuration.
-		/// </summary>
-		event EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
-
-		/// <summary>
-		/// Raised after the web view is initialized but before any component has been rendered. The event arguments provide the instance of the platform-specific web view control.
-		/// </summary>
-		event EventHandler<BlazorWebViewInitializedEventArgs>? BlazorWebViewInitialized;
-
-		/// <summary>
 		/// Creates a file provider for static assets used in the <see cref="BlazorWebView"/>. The default implementation
 		/// serves files from a platform-specific location. Override this method to return a custom <see cref="IFileProvider"/> to serve assets such
 		/// as <c>wwwroot/index.html</c>. Call the base method and combine its return value with a <see cref="CompositeFileProvider"/>
@@ -49,6 +33,24 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// </summary>
 		/// <param name="contentRootDir">The base directory to use for all requested assets, such as <c>wwwroot</c>.</param>
 		/// <returns>Returns a <see cref="IFileProvider"/> for static assets.</returns>
-		public IFileProvider CreateFileProvider(string contentRootDir);
+		IFileProvider CreateFileProvider(string contentRootDir);
+
+		/// <summary>
+		/// Notifies the control that the UrlLoading event should be raised with the specified <paramref name="args"/>.
+		/// </summary>
+		/// <param name="args">The arguments for the event.</param>
+		void SendUrlLoading(UrlLoadingEventArgs args);
+
+		/// <summary>
+		/// Notifies the control that the BlazorWebViewInitializing event should be raised with the specified <paramref name="args"/>.
+		/// </summary>
+		/// <param name="args">The arguments for the event.</param>
+		void SendBlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args);
+
+		/// <summary>
+		/// Notifies the control that the BlazorWebViewInitialized event should be raised with the specified <paramref name="args"/>.
+		/// </summary>
+		/// <param name="args">The arguments for the event.</param>
+		void SendBlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args);
 	}
 }

--- a/src/BlazorWebView/src/Maui/IBlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/IBlazorWebView.cs
@@ -39,18 +39,18 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// Notifies the control that the UrlLoading event should be raised with the specified <paramref name="args"/>.
 		/// </summary>
 		/// <param name="args">The arguments for the event.</param>
-		void SendUrlLoading(UrlLoadingEventArgs args);
+		void UrlLoading(UrlLoadingEventArgs args);
 
 		/// <summary>
 		/// Notifies the control that the BlazorWebViewInitializing event should be raised with the specified <paramref name="args"/>.
 		/// </summary>
 		/// <param name="args">The arguments for the event.</param>
-		void SendBlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args);
+		void BlazorWebViewInitializing(BlazorWebViewInitializingEventArgs args);
 
 		/// <summary>
 		/// Notifies the control that the BlazorWebViewInitialized event should be raised with the specified <paramref name="args"/>.
 		/// </summary>
 		/// <param name="args">The arguments for the event.</param>
-		void SendBlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args);
+		void BlazorWebViewInitialized(BlazorWebViewInitializedEventArgs args);
 	}
 }

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -19,13 +19,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -19,13 +19,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -53,7 +53,6 @@ override Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView.OnKey
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.AspNetCore.Components.WebView.Maui.BlazorAndroidWebView! platformView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -45,7 +45,6 @@ Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtension
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -45,7 +45,6 @@ Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtension
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> WebKit.WKWebView!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(WebKit.WKWebView! platformView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -50,7 +50,6 @@ override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.Disco
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -50,7 +50,6 @@ override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.Disco
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -15,13 +15,13 @@ Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler() -> void
 Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewHandler(Microsoft.Maui.PropertyMapper? mapper) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection!
-Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitialized(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendBlazorWebViewInitializing(Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs! args) -> void
+Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView.SendUrlLoading(Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs! args) -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.get -> System.Type?
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.ComponentType.set -> void
@@ -44,7 +44,6 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> 
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> object!
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
-static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddMauiBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			var config = new WKWebViewConfiguration();
 
-			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs()
+			VirtualView.SendBlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs()
 			{
 				Configuration = config
 			});
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-			((BlazorWebView)VirtualView).NotifyBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
+			VirtualView.SendBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = webview
 			});

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		{
 			var config = new WKWebViewConfiguration();
 
-			VirtualView.SendBlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs()
+			VirtualView.BlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs()
 			{
 				Configuration = config
 			});
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				AutosizesSubviews = true
 			};
 
-			VirtualView.SendBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
+			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = webview
 			});

--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					// Invoke the UrlLoading event to allow overriding the default link handling behavior
 					var uri = new Uri(requestUrl.ToString());
 					var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, BlazorWebViewHandler.AppOriginUri);
-					_webView.UrlLoading?.Invoke(callbackArgs);
+					_webView.SendUrlLoading(callbackArgs);
 					strategy = callbackArgs.UrlLoadingStrategy;
 				}
 

--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					// Invoke the UrlLoading event to allow overriding the default link handling behavior
 					var uri = new Uri(requestUrl.ToString());
 					var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, BlazorWebViewHandler.AppOriginUri);
-					_webView.SendUrlLoading(callbackArgs);
+					_webView.UrlLoading(callbackArgs);
 					strategy = callbackArgs.UrlLoadingStrategy;
 				}
 

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		{
 			var args = new BlazorWebViewInitializingEventArgs();
 #if WEBVIEW2_MAUI
-			_blazorWebViewHandler.VirtualView.SendBlazorWebViewInitializing(args);
+			_blazorWebViewHandler.VirtualView.BlazorWebViewInitializing(args);
 			_coreWebView2Environment = await CoreWebView2Environment.CreateWithOptionsAsync(
 				browserExecutableFolder: args.BrowserExecutableFolder,
 				userDataFolder: args.UserDataFolder,
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			ApplyDefaultWebViewSettings(developerTools);
 
 #if WEBVIEW2_MAUI
-			_blazorWebViewHandler.VirtualView.SendBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
+			_blazorWebViewHandler.VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = _webview,
 			});
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 #if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
 				_urlLoading?.Invoke(callbackArgs);
 #elif WEBVIEW2_MAUI
-				_blazorWebViewHandler.SendUrlLoading(callbackArgs);
+				_blazorWebViewHandler.UrlLoading(callbackArgs);
 #endif
 
 				if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenExternally)

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		{
 			var args = new BlazorWebViewInitializingEventArgs();
 #if WEBVIEW2_MAUI
-			((BlazorWebView)_blazorWebViewHandler.VirtualView).NotifyBlazorWebViewInitializing(args);
+			_blazorWebViewHandler.VirtualView.SendBlazorWebViewInitializing(args);
 			_coreWebView2Environment = await CoreWebView2Environment.CreateWithOptionsAsync(
 				browserExecutableFolder: args.BrowserExecutableFolder,
 				userDataFolder: args.UserDataFolder,
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			ApplyDefaultWebViewSettings(developerTools);
 
 #if WEBVIEW2_MAUI
-			((BlazorWebView)_blazorWebViewHandler.VirtualView).NotifyBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
+			_blazorWebViewHandler.VirtualView.SendBlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{
 				WebView = _webview,
 			});
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 #if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
 				_urlLoading?.Invoke(callbackArgs);
 #elif WEBVIEW2_MAUI
-				_blazorWebViewHandler.UrlLoading?.Invoke(callbackArgs);
+				_blazorWebViewHandler.SendUrlLoading(callbackArgs);
 #endif
 
 				if (callbackArgs.UrlLoadingStrategy == UrlLoadingStrategy.OpenExternally)


### PR DESCRIPTION
Instead, put "SendXyz" methods on the IBlazorWebView interface to enable the handlers to raise events on the control. The control has events for users to wire-up, or alternative systems can implement the interface with another event/command pattern if desired.

Motivation:
* The concrete class `BlazorWebView` is what a MAUI user will program against. As such, it has friendly "events" that they can handle and perform various customizations
* The `IBlazorWebView` interface is the minimum set of APIs needed for a **Handler** to interact with a concrete usable type, such as MAUI's built-in `BlazorWebView`, or perhaps some other variation that could be used in Comet or in some hypothetical future version of Hybrid Blazor Bindings. In such non-MAUI places, using events or even structuring the properties the way they are is not necessarily the best model, so they can choose to implement those features however they want (or even omit some that they don't want to use)
* The handlers must talk _only_ to the interface. This enables others to build their own handlers that talk to the interface and can be used with any concrete implementation. For example, a new Tizen BlazorWebViewHandler would talk to the interface and be 100% usable with the existing BlazorWebView MAUI control.

Related: #5904, #5905