### PR TITLE
Add User-Agent when downloading image streams

### DIFF
--- a/src/Controls/src/Core/UriImageSource.cs
+++ b/src/Controls/src/Core/UriImageSource.cs
@@ -115,6 +115,10 @@ namespace Microsoft.Maui.Controls
 			{
 				using var client = new HttpClient();
 
+				// TODO: USER-AGENT should be configurable by the user.
+				//       Also, is this a reasonable default? Perhaps we could include the name of the application?
+				client.DefaultRequestHeaders.Add("User-Agent", ".NET MAUI App");
+
 				// Do not remove this await otherwise the client will dispose before
 				// the stream even starts
 				return await StreamWrapper.GetStreamAsync(uri, cancellationToken, client).ConfigureAwait(false);


### PR DESCRIPTION
### Description of Change

Fetching an image stream without setting User-Agent may run into problems with site policies. 
For example with wikimedia links it may result in:
 `403  Forbidden. Please comply with the User-Agent policy: https://meta.wikimedia.org/wiki/User-Agent_policy`

### Issues Fixed

Fixes #2601
