### PR TITLE
[iOS] Fix crashing converting GradientPaint to GradientBrush

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Brush.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Brush.Impl.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Controls
 				for (int i = 0; i < gradientStopCollection.Length; i++)
 				{
 					var gs = gradientStopCollection[i];
-					gradientStops[i] = new GradientStop(gs.Color, gs.Offset);
+					gradientStops.Insert(i, new GradientStop(gs.Color, gs.Offset));
 				}
 
 				if (gradientPaint is LinearGradientPaint linearGradientPaint)


### PR DESCRIPTION
### Description of Change

Fix crashing converting GradientPaint to GradientBrush on iOS.

### Issues Fixed

Fixes #5812 
