### PR TITLE
WinForms/WPF/MAUI-Windows API review changes

### DIFF
--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -33,8 +33,6 @@ Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath, string! contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! webViewHandler) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -43,12 +41,9 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
-Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
-override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -33,8 +33,6 @@ Microsoft.AspNetCore.Components.WebView.Maui.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Maui.RootComponentsCollection.RootComponentsCollection(Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents) -> void
-Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager
-Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.WinUIWebViewManager(Microsoft.UI.Xaml.Controls.WebView2! webview, System.IServiceProvider! services, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath, string! contentRootDir, Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! webViewHandler) -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -43,12 +41,9 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
-Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
-override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.HandleWebResourceRequest(Microsoft.Web.WebView2.Core.CoreWebView2WebResourceRequestedEventArgs! eventArgs) -> System.Threading.Tasks.Task!
-override Microsoft.AspNetCore.Components.WebView.Maui.WinUIWebViewManager.QueueBlazorStart() -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapNotifyUrlLoading(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapRootComponents(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Components.WebView.WebView2;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Web.WebView2.Core;
 using Windows.ApplicationModel;
-using Windows.Storage;
 using Windows.Storage.Streams;
 using WebView2Control = Microsoft.UI.Xaml.Controls.WebView2;
 
@@ -17,7 +16,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// An implementation of <see cref="WebViewManager"/> that uses the Edge WebView2 browser control
 	/// to render web content in WinUI applications.
 	/// </summary>
-	public class WinUIWebViewManager : WebView2WebViewManager
+	internal class WinUIWebViewManager : WebView2WebViewManager
 	{
 		private readonly WebView2Control _webview;
 		private readonly string _hostPageRelativePath;
@@ -36,7 +35,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 		}
 
-#pragma warning disable RS0022
 		/// <summary>
 		/// Initializes a new instance of <see cref="WinUIWebViewManager"/>
 		/// </summary>
@@ -63,7 +61,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			_hostPageRelativePath = hostPageRelativePath;
 			_contentRootDir = contentRootDir;
 		}
-#pragma warning restore RS0022
 
 		/// <inheritdoc />
 		protected override async Task HandleWebResourceRequest(CoreWebView2WebResourceRequestedEventArgs eventArgs)

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
 		/// <param name="services">The <see cref="IServiceCollection"/>.</param>
 		/// <returns>The <see cref="IServiceCollection"/>.</returns>
 #if WEBVIEW2_WINFORMS
-		public static IServiceCollection AddWindowsFormsBlazorWebView(this IServiceCollection services)
+		public static IWindowsFormsBlazorWebViewBuilder AddWindowsFormsBlazorWebView(this IServiceCollection services)
 #elif WEBVIEW2_WPF
 		public static IServiceCollection AddWpfBlazorWebView(this IServiceCollection services)
 #elif WEBVIEW2_MAUI
@@ -39,12 +39,14 @@ namespace Microsoft.Extensions.DependencyInjection
 #if WEBVIEW2_MAUI
 			services.TryAddSingleton<MauiBlazorMarkerService>();
 			services.ConfigureMauiHandlers(static handlers => handlers.AddHandler<IBlazorWebView, BlazorWebViewHandler>());
+			return services;
 #elif WEBVIEW2_WINFORMS
 			services.TryAddSingleton<WindowsFormsBlazorMarkerService>();
+			return new WindowsFormsBlazorWebViewBuilder(services);
 #elif WEBVIEW2_WPF
 			services.TryAddSingleton<WpfBlazorMarkerService>();
-#endif
 			return services;
+#endif
 		}
 
 		/// <summary>

--- a/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs
+++ b/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
 #if WEBVIEW2_WINFORMS
 		public static IWindowsFormsBlazorWebViewBuilder AddWindowsFormsBlazorWebView(this IServiceCollection services)
 #elif WEBVIEW2_WPF
-		public static IServiceCollection AddWpfBlazorWebView(this IServiceCollection services)
+		public static IWpfBlazorWebViewBuilder AddWpfBlazorWebView(this IServiceCollection services)
 #elif WEBVIEW2_MAUI
 		public static IServiceCollection AddMauiBlazorWebView(this IServiceCollection services)
 #else
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.DependencyInjection
 			return new WindowsFormsBlazorWebViewBuilder(services);
 #elif WEBVIEW2_WPF
 			services.TryAddSingleton<WpfBlazorMarkerService>();
-			return services;
+			return new WpfBlazorWebViewBuilder(services);
 #endif
 		}
 

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 	/// An implementation of <see cref="WebViewManager"/> that uses the Edge WebView2 browser control
 	/// to render web content.
 	/// </summary>
-	public class WebView2WebViewManager : WebViewManager
+	internal class WebView2WebViewManager : WebViewManager
 	{
 		// Using an IP address means that WebView2 doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		private readonly Task _webviewReadyTask;
 
 #if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
-		private protected CoreWebView2Environment _coreWebView2Environment;
+		private protected CoreWebView2Environment? _coreWebView2Environment;
 		private readonly Action<UrlLoadingEventArgs> _urlLoading;
 		private readonly Action<BlazorWebViewInitializingEventArgs> _blazorWebViewInitializing;
 		private readonly Action<BlazorWebViewInitializedEventArgs> _blazorWebViewInitialized;
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			{
 				var headerString = GetHeaderString(headers);
 
-				eventArgs.Response = _coreWebView2Environment.CreateWebResourceResponse(content, statusCode, statusMessage, headerString);
+				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content, statusCode, statusMessage, headerString);
 			}
 #elif WEBVIEW2_MAUI
 			// No-op here because all the work is done in the derived WinUIWebViewManager
@@ -288,7 +288,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		{
 		}
 
-		private void CoreWebView2_NavigationStarting(object sender, CoreWebView2NavigationStartingEventArgs args)
+		private void CoreWebView2_NavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs args)
 		{
 			if (Uri.TryCreate(args.Uri, UriKind.RelativeOrAbsolute, out var uri))
 			{
@@ -309,7 +309,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			}
 		}
 
-		private void CoreWebView2_NewWindowRequested(object sender, CoreWebView2NewWindowRequestedEventArgs args)
+		private void CoreWebView2_NewWindowRequested(object? sender, CoreWebView2NewWindowRequestedEventArgs args)
 		{
 			// Intercept _blank target <a> tags to always open in device browser.
 			// The ExternalLinkCallback is not invoked.
@@ -349,7 +349,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		}
 
 #if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
-		private static string GetWebView2UserDataFolder()
+		private static string? GetWebView2UserDataFolder()
 		{
 			if (Assembly.GetEntryAssembly() is { } mainAssembly)
 			{

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -21,9 +22,9 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 	public class BlazorWebView : ContainerControl
 	{
 		private readonly WebView2Control _webview;
-		private WebView2WebViewManager _webviewManager;
-		private string _hostPage;
-		private IServiceProvider _services;
+		private WebView2WebViewManager? _webviewManager;
+		private string? _hostPage;
+		private IServiceProvider? _services;
 
 		/// <summary>
 		/// Creates a new instance of <see cref="BlazorWebView"/>.
@@ -53,10 +54,9 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		public WebView2Control WebView => _webview;
 
 		/// <summary>
-		/// Returns the current <see cref="WebView2WebViewManager"/> used by this control. This property is <c>null</c>
-		/// until after the XYZ event is raised.
+		/// Returns the current <see cref="WebView2WebViewManager"/> used by this control.
 		/// </summary>
-		public WebView2WebViewManager WebViewManager => _webviewManager;
+		public WebView2WebViewManager WebViewManager => _webviewManager!;
 
 		private WindowsFormsDispatcher ComponentsDispatcher { get; }
 
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// </summary>
 		[Category("Behavior")]
 		[Description(@"Path to the host page within the application's static files. Example: wwwroot\index.html.")]
-		public string HostPage
+		public string? HostPage
 		{
 			get => _hostPage;
 			set
@@ -102,9 +102,10 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// </summary>
 		[Browsable(false)]
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		[DisallowNull]
 		public IServiceProvider Services
 		{
-			get => _services;
+			get => _services!;
 			set
 			{
 				_services = value;
@@ -118,21 +119,21 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// </summary>
 		[Category("Action")]
 		[Description("Allows customizing how links are opened. By default, opens internal links in the webview and external links in an external app.")]
-		public EventHandler<UrlLoadingEventArgs> UrlLoading;
+		public EventHandler<UrlLoadingEventArgs>? UrlLoading;
 
 		/// <summary>
 		/// Allows customizing the web view before it is created.
 		/// </summary>
 		[Category("Action")]
 		[Description("Allows customizing the web view before it is created.")]
-		public EventHandler<BlazorWebViewInitializingEventArgs> BlazorWebViewInitializing;
+		public EventHandler<BlazorWebViewInitializingEventArgs>? BlazorWebViewInitializing;
 
 		/// <summary>
 		/// Allows customizing the web view after it is created.
 		/// </summary>
 		[Category("Action")]
 		[Description("Allows customizing the web view after it is created.")]
-		public EventHandler<BlazorWebViewInitializedEventArgs> BlazorWebViewInitialized;
+		public EventHandler<BlazorWebViewInitializedEventArgs>? BlazorWebViewInitialized;
 
 		private void OnHostPagePropertyChanged() => StartWebViewCoreIfPossible();
 
@@ -165,14 +166,14 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			var entryAssemblyLocation = Assembly.GetEntryAssembly()?.Location;
 			if (!string.IsNullOrEmpty(entryAssemblyLocation))
 			{
-				appRootDir = Path.GetDirectoryName(entryAssemblyLocation);
+				appRootDir = Path.GetDirectoryName(entryAssemblyLocation)!;
 			}
 			else
 			{
 				appRootDir = Environment.CurrentDirectory;
 			}
-			var hostPageFullPath = Path.GetFullPath(Path.Combine(appRootDir, HostPage));
-			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath);
+			var hostPageFullPath = Path.GetFullPath(Path.Combine(appRootDir, HostPage!)); // HostPage is nonnull because RequiredStartupPropertiesSet is checked above
+			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath)!;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDirFullPath, hostPageFullPath);
 
 			var fileProvider = CreateFileProvider(contentRootDirFullPath);
@@ -196,7 +197,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			_webviewManager.Navigate("/");
 		}
 
-		private void HandleRootComponentsCollectionChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
+		private void HandleRootComponentsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs)
 		{
 			// If we haven't initialized yet, this is a no-op
 			if (_webviewManager != null)
@@ -204,8 +205,8 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				// Dispatch because this is going to be async, and we want to catch any errors
 				_ = ComponentsDispatcher.InvokeAsync(async () =>
 				{
-					var newItems = eventArgs.NewItems.Cast<RootComponent>();
-					var oldItems = eventArgs.OldItems.Cast<RootComponent>();
+					var newItems = (eventArgs.NewItems ?? Array.Empty<object>()).Cast<RootComponent>();
+					var oldItems = (eventArgs.OldItems ?? Array.Empty<object>()).Cast<RootComponent>();
 
 					foreach (var item in newItems.Except(oldItems))
 					{

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -53,11 +53,6 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public WebView2Control WebView => _webview;
 
-		/// <summary>
-		/// Returns the current <see cref="WebView2WebViewManager"/> used by this control.
-		/// </summary>
-		public WebView2WebViewManager WebViewManager => _webviewManager!;
-
 		private WindowsFormsDispatcher ComponentsDispatcher { get; }
 
 		/// <inheritdoc />

--- a/src/BlazorWebView/src/WindowsForms/IWindowsFormsBlazorWebViewBuilder.cs
+++ b/src/BlazorWebView/src/WindowsForms/IWindowsFormsBlazorWebViewBuilder.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
+{
+	/// <summary>
+	/// A builder for WindowsForms Blazor WebViews.
+	/// </summary>
+	public interface IWindowsFormsBlazorWebViewBuilder
+	{
+		/// <summary>
+		/// Gets the builder service collection.
+		/// </summary>
+		IServiceCollection Services { get; }
+	}
+}

--- a/src/BlazorWebView/src/WindowsForms/Microsoft.AspNetCore.Components.WebView.WindowsForms.csproj
+++ b/src/BlazorWebView/src/WindowsForms/Microsoft.AspNetCore.Components.WebView.WindowsForms.csproj
@@ -9,7 +9,7 @@
     <Description>Build Windows Forms applications with Blazor and WebView2.</Description>
     <DefineConstants>$(DefineConstants);WEBVIEW2_WINFORMS</DefineConstants>
     <UseWindowsForms>true</UseWindowsForms>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/BlazorWebView/src/WindowsForms/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/WindowsForms/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
@@ -1,16 +1,10 @@
-﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -20,31 +14,38 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> 
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebViewInitializing -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.get -> string?
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.get -> System.IServiceProvider
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.get -> System.IServiceProvider!
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.set -> void
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebViewManager.get -> Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2!
+Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebViewManager.get -> Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager!
 Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent
-Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.ComponentType.get -> System.Type
-Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
-Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.RootComponent(string selector, System.Type componentType, System.Collections.Generic.IDictionary<string, object> parameters) -> void
-Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.ComponentType.get -> System.Type!
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.RootComponent(string! selector, System.Type! componentType, System.Collections.Generic.IDictionary<string!, object?>? parameters) -> void
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.Selector.get -> string!
 Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions
 Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection.RootComponentsCollection() -> void
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
-override Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.CreateControlsInstance() -> System.Windows.Forms.Control.ControlCollection
+override Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.CreateControlsInstance() -> System.Windows.Forms.Control.ControlCollection!
 override Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Dispose(bool disposing) -> void
 override Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.OnCreateControl() -> void
-static Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions.Add<TComponent>(this Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection components, string selector, System.Collections.Generic.IDictionary<string, object> parameters = null) -> void
-static Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions.Remove(this Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection components, string selector) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWindowsFormsBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-virtual Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+static Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions.Add<TComponent>(this Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection! components, string! selector, System.Collections.Generic.IDictionary<string!, object?>? parameters = null) -> void
+static Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions.Remove(this Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection! components, string! selector) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWindowsFormsBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+virtual Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void

--- a/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
@@ -11,7 +11,6 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
-Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebView() -> void
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.BlazorWebViewInitialized -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>?

--- a/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/WindowsForms/PublicAPI.Unshipped.txt
@@ -23,7 +23,8 @@ Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.get 
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.Services.set -> void
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.UrlLoading -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>?
 Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2!
-Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.WebViewManager.get -> Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager!
+Microsoft.AspNetCore.Components.WebView.WindowsForms.IWindowsFormsBlazorWebViewBuilder
+Microsoft.AspNetCore.Components.WebView.WindowsForms.IWindowsFormsBlazorWebViewBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent
 Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.ComponentType.get -> System.Type!
 Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
@@ -40,7 +41,7 @@ override Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.OnCr
 static Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions.Add<TComponent>(this Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection! components, string! selector, System.Collections.Generic.IDictionary<string!, object?>? parameters = null) -> void
 static Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentCollectionExtensions.Remove(this Microsoft.AspNetCore.Components.WebView.WindowsForms.RootComponentsCollection! components, string! selector) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWindowsFormsBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWindowsFormsBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.AspNetCore.Components.WebView.WindowsForms.IWindowsFormsBlazorWebViewBuilder!
 virtual Microsoft.AspNetCore.Components.WebView.WindowsForms.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.WinForms.WebView2
 ~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string

--- a/src/BlazorWebView/src/WindowsForms/RootComponent.cs
+++ b/src/BlazorWebView/src/WindowsForms/RootComponent.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebView.WebView2;
-using Microsoft.Web.WebView2.Core;
-using WebView2Control = Microsoft.Web.WebView2.WinForms.WebView2;
 
 namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 {
@@ -21,7 +19,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// <param name="selector">The CSS selector string that specifies where in the document the component should be placed. This must be unique among the root components within the <see cref="BlazorWebView"/>.</param>
 		/// <param name="componentType">The type of the root component. This type must implement <see cref="IComponent"/>.</param>
 		/// <param name="parameters">An optional dictionary of parameters to pass to the root component.</param>
-		public RootComponent(string selector, Type componentType, IDictionary<string, object> parameters)
+		public RootComponent(string selector, Type componentType, IDictionary<string, object?>? parameters)
 		{
 			if (string.IsNullOrWhiteSpace(selector))
 			{
@@ -47,7 +45,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// <summary>
 		/// Gets an optional dictionary of parameters to pass to the root component.
 		/// </summary>
-		public IDictionary<string, object> Parameters { get; }
+		public IDictionary<string, object?>? Parameters { get; }
 
 		internal Task AddToWebViewManagerAsync(WebViewManager webViewManager)
 		{

--- a/src/BlazorWebView/src/WindowsForms/RootComponentCollectionExtensions.cs
+++ b/src/BlazorWebView/src/WindowsForms/RootComponentCollectionExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 		/// <param name="components">The collection to which the component should be added.</param>
 		/// <param name="selector">The selector to which the component will be associated.</param>
 		/// <param name="parameters">The optional creation parameters for the component.</param>
-		public static void Add<TComponent>(this RootComponentsCollection components, string selector, IDictionary<string, object> parameters = null)
+		public static void Add<TComponent>(this RootComponentsCollection components, string selector, IDictionary<string, object?>? parameters = null)
 			where TComponent : IComponent
 		{
 			components.Add(new RootComponent(selector, typeof(TComponent), parameters));

--- a/src/BlazorWebView/src/WindowsForms/WindowsFormsBlazorWebViewBuilder.cs
+++ b/src/BlazorWebView/src/WindowsForms/WindowsFormsBlazorWebViewBuilder.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
+{
+	internal class WindowsFormsBlazorWebViewBuilder : IWindowsFormsBlazorWebViewBuilder
+	{
+		public IServiceCollection Services { get; }
+
+		public WindowsFormsBlazorWebViewBuilder(IServiceCollection services)
+		{
+			Services = services;
+		}
+	}
+}

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
@@ -12,7 +11,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.AspNetCore.Components.WebView.WebView2;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using WebView2Control = Microsoft.Web.WebView2.Wpf.WebView2;
 
@@ -77,8 +75,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		#endregion
 
 		private const string WebViewTemplateChildName = "WebView";
-		private WebView2Control _webview;
-		private WebView2WebViewManager _webviewManager;
+		private WebView2Control? _webview;
+		private WebView2WebViewManager? _webviewManager;
 		private bool _isDisposed;
 
 		/// <summary>
@@ -105,7 +103,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		/// is controlled by the <see cref="BlazorWebView"/> that is hosting it.
 		/// </remarks>
 		[Browsable(false)]
-		public WebView2Control WebView => _webview;
+		public WebView2Control WebView => _webview!;
 
 		/// <summary>
 		/// Path to the host page within the application's static files. For example, <code>wwwroot\index.html</code>.
@@ -213,20 +211,20 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			var entryAssemblyLocation = Assembly.GetEntryAssembly()?.Location;
 			if (!string.IsNullOrEmpty(entryAssemblyLocation))
 			{
-				appRootDir = Path.GetDirectoryName(entryAssemblyLocation);
+				appRootDir = Path.GetDirectoryName(entryAssemblyLocation)!;
 			}
 			else
 			{
 				appRootDir = Environment.CurrentDirectory;
 			}
 			var hostPageFullPath = Path.GetFullPath(Path.Combine(appRootDir, HostPage));
-			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath);
+			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath)!;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDirFullPath, hostPageFullPath);
 
 			var fileProvider = CreateFileProvider(contentRootDirFullPath);
 
 			_webviewManager = new WebView2WebViewManager(
-				_webview,
+				_webview!,
 				Services,
 				ComponentsDispatcher,
 				fileProvider,
@@ -246,7 +244,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 
 		private WpfDispatcher ComponentsDispatcher { get; }
 
-		private void HandleRootComponentsCollectionChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
+		private void HandleRootComponentsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs)
 		{
 			CheckDisposed();
 
@@ -256,8 +254,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				// Dispatch because this is going to be async, and we want to catch any errors
 				_ = ComponentsDispatcher.InvokeAsync(async () =>
 				{
-					var newItems = eventArgs.NewItems.Cast<RootComponent>();
-					var oldItems = eventArgs.OldItems.Cast<RootComponent>();
+					var newItems = (eventArgs.NewItems ?? Array.Empty<RootComponent>()).Cast<RootComponent>();
+					var oldItems = (eventArgs.OldItems ?? Array.Empty<RootComponent>()).Cast<RootComponent>();
 
 					foreach (var item in newItems.Except(oldItems))
 					{

--- a/src/BlazorWebView/src/Wpf/IWpfBlazorWebViewBuilder.cs
+++ b/src/BlazorWebView/src/Wpf/IWpfBlazorWebViewBuilder.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Components.WebView.Wpf
+{
+	/// <summary>
+	/// A builder for WPF Blazor WebViews.
+	/// </summary>
+	public interface IWpfBlazorWebViewBuilder
+	{
+		/// <summary>
+		/// Gets the builder service collection.
+		/// </summary>
+		IServiceCollection Services { get; }
+	}
+}

--- a/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
+++ b/src/BlazorWebView/src/Wpf/Microsoft.AspNetCore.Components.WebView.Wpf.csproj
@@ -9,7 +9,7 @@
     <Description>Build WPF applications with Blazor and WebView2.</Description>
     <DefineConstants>$(DefineConstants);WEBVIEW2_WPF</DefineConstants>
     <UseWPF>true</UseWPF>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Shipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -11,7 +11,6 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
-Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebView() -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitialized.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>!

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -1,16 +1,10 @@
-﻿Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.BlazorWebViewInitializedEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs
 Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BlazorWebViewInitializingEventArgs() -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
-Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs
-Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri
+Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.Url.get -> System.Uri!
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.get -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs.UrlLoadingStrategy.set -> void
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
@@ -20,40 +14,47 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> 
 Microsoft.AspNetCore.Components.WebView.WebView2.WebView2WebViewManager
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebView() -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitialized.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs>
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitialized.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs!>!
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitialized.set -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializing.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializing.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs!>!
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializing.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.DisposeAsync() -> System.Threading.Tasks.ValueTask
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.get -> string
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.get -> string!
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPage.set -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.Services.get -> System.IServiceProvider
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponents.get -> Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection!
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.Services.get -> System.IServiceProvider!
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.Services.set -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs>
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>!
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.set -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2
+Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2!
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent
-Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.ComponentType.get -> System.Type
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.ComponentType.get -> System.Type!
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.ComponentType.set -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string, object>
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Parameters.get -> System.Collections.Generic.IDictionary<string!, object?>?
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.RootComponent() -> void
-Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Selector.get -> string
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Selector.get -> string!
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.Selector.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection
-Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore
+Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection.JSComponents.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponentsCollection.RootComponentsCollection() -> void
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
 override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnApplyTemplate() -> void
-override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnInitialized(System.EventArgs e) -> void
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWpfBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
-static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializedProperty -> System.Windows.DependencyProperty
-static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializingProperty -> System.Windows.DependencyProperty
-static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPageProperty -> System.Windows.DependencyProperty
-static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponentsProperty -> System.Windows.DependencyProperty
-static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ServicesProperty -> System.Windows.DependencyProperty
-static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoadingProperty -> System.Windows.DependencyProperty
-virtual Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.CreateFileProvider(string contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider
+override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnInitialized(System.EventArgs! e) -> void
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWpfBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializedProperty -> System.Windows.DependencyProperty!
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializingProperty -> System.Windows.DependencyProperty!
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPageProperty -> System.Windows.DependencyProperty!
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.RootComponentsProperty -> System.Windows.DependencyProperty!
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.ServicesProperty -> System.Windows.DependencyProperty!
+static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoadingProperty -> System.Windows.DependencyProperty!
+virtual Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.CreateFileProvider(string! contentRootDir) -> Microsoft.Extensions.FileProviders.IFileProvider!
 virtual Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializedEventArgs.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.BrowserExecutableFolder.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.get -> Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.EnvironmentOptions.set -> void
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.get -> string
+~Microsoft.AspNetCore.Components.WebView.BlazorWebViewInitializingEventArgs.UserDataFolder.set -> void

--- a/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Wpf/PublicAPI.Unshipped.txt
@@ -27,6 +27,8 @@ Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.Services.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.get -> System.EventHandler<Microsoft.AspNetCore.Components.WebView.UrlLoadingEventArgs!>!
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.UrlLoading.set -> void
 Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.WebView.get -> Microsoft.Web.WebView2.Wpf.WebView2!
+Microsoft.AspNetCore.Components.WebView.Wpf.IWpfBlazorWebViewBuilder
+Microsoft.AspNetCore.Components.WebView.Wpf.IWpfBlazorWebViewBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.ComponentType.get -> System.Type!
 Microsoft.AspNetCore.Components.WebView.Wpf.RootComponent.ComponentType.set -> void
@@ -42,7 +44,7 @@ Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtension
 override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnApplyTemplate() -> void
 override Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.OnInitialized(System.EventArgs! e) -> void
 static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddBlazorWebViewDeveloperTools(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWpfBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions.AddWpfBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.AspNetCore.Components.WebView.Wpf.IWpfBlazorWebViewBuilder!
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializedProperty -> System.Windows.DependencyProperty!
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.BlazorWebViewInitializingProperty -> System.Windows.DependencyProperty!
 static readonly Microsoft.AspNetCore.Components.WebView.Wpf.BlazorWebView.HostPageProperty -> System.Windows.DependencyProperty!

--- a/src/BlazorWebView/src/Wpf/RootComponent.cs
+++ b/src/BlazorWebView/src/Wpf/RootComponent.cs
@@ -17,17 +17,17 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 		/// Gets or sets the CSS selector string that specifies where in the document the component should be placed.
 		/// This must be unique among the root components within the <see cref="BlazorWebView"/>.
 		/// </summary>
-		public string Selector { get; set; }
+		public string Selector { get; set; } = default!;
 
 		/// <summary>
 		/// Gets or sets the type of the root component. This type must implement <see cref="IComponent"/>.
 		/// </summary>
-		public Type ComponentType { get; set; }
+		public Type ComponentType { get; set; } = default!;
 
 		/// <summary>
 		/// Gets or sets an optional dictionary of parameters to pass to the root component.
 		/// </summary>
-		public IDictionary<string, object> Parameters { get; set; }
+		public IDictionary<string, object?>? Parameters { get; set; }
 
 		internal Task AddToWebViewManagerAsync(WebViewManager webViewManager)
 		{

--- a/src/BlazorWebView/src/Wpf/WpfBlazorWebViewBuilder.cs
+++ b/src/BlazorWebView/src/Wpf/WpfBlazorWebViewBuilder.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Components.WebView.Wpf
+{
+	internal class WpfBlazorWebViewBuilder : IWpfBlazorWebViewBuilder
+	{
+		public IServiceCollection Services { get; }
+
+		public WpfBlazorWebViewBuilder(IServiceCollection services)
+		{
+			Services = services;
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/5906
Fixes https://github.com/dotnet/maui/issues/5909
Fixes https://github.com/dotnet/maui/issues/5910

The approach to nullability I've taken is similar to what we do in ASP.NET Core. That is, in most cases we're honest about nullability, but in cases where for intended usage scenarios a certain thing is not going to be null, it's typed as not-null (example: things that always get initialized as not-null by the framework before application code is expected to run).