### PR TITLE
Don't destroy fragments when switching tabs

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
@@ -84,7 +84,11 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				SectionController.ItemsCollectionChanged -= OnItemsCollectionChanged;
 				_shellSection = null;
+
 				_items = null;
+
+				_createdShellContent?.Clear();
+				_createdShellContent = null;
 			}
 
 			base.Dispose(disposing);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
@@ -1,5 +1,6 @@
 // error CS0618: 'FragmentStatePagerAdapter' is obsolete:
 #pragma warning disable 618
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Android.OS;
 using AndroidX.AppCompat.App;
@@ -15,6 +16,9 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		ShellSection _shellSection;
 		IShellSectionController SectionController => (IShellSectionController)_shellSection;
 		IMauiContext _mauiContext;
+		IList<ShellContent> _items;
+		Dictionary<long, ShellContent> _createdShellContent = new Dictionary<long, ShellContent>();
+		long _id;
 
 		public ShellFragmentStateAdapter(
 			ShellSection shellSection,
@@ -24,26 +28,49 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_mauiContext = mauiContext;
 			_shellSection = shellSection;
 			SectionController.ItemsCollectionChanged += OnItemsCollectionChanged;
+			_items = SectionController.GetItems();
 		}
 
 		protected virtual void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			_items = SectionController.GetItems();
+			var removeList = new List<long>();
+
+			foreach (var created in _createdShellContent)
+				if (!_items.Contains(created.Value))
+					removeList.Add(created.Key);
+
+			foreach (var remove in removeList)
+				_createdShellContent.Remove(remove);
+
 			NotifyDataSetChanged();
 		}
 
 		public int CountOverride { get; set; }
 
-		public override int ItemCount => SectionController.GetItems().Count;
+		public override int ItemCount => _items.Count;
 
 		public override Fragment CreateFragment(int position)
 		{
-			var shellContent = SectionController.GetItems()[position];
+			var shellContent = _items[position];
 			return new ShellFragmentContainer(shellContent, _mauiContext) { Arguments = Bundle.Empty };
 		}
 
 		public override long GetItemId(int position)
 		{
-			return SectionController.GetItems()[position].GetHashCode();
+			var shellContent = _items[position];
+			foreach (var item in _createdShellContent)
+				if (item.Value == shellContent)
+					return item.Key;
+
+			var id = _id;
+			_createdShellContent.Add(_id++, shellContent);
+			return id;
+		}
+
+		public override bool ContainsItem(long itemId)
+		{
+			return _createdShellContent.ContainsKey(itemId);
 		}
 
 		protected override void Dispose(bool disposing)
@@ -57,6 +84,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				SectionController.ItemsCollectionChanged -= OnItemsCollectionChanged;
 				_shellSection = null;
+				_items = null;
 			}
 
 			base.Dispose(disposing);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (initialUpdate)
 			{
-				t.SetReorderingAllowed(true);
+				t.SetReorderingAllowedEx(true);
 			}
 
 			t.CommitAllowingStateLossEx();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			TaskCompletionSource<bool> result = new TaskCompletionSource<bool>();
 			bool isForCurrentTab = shellSection == ShellSection;
-
+			bool initialUpdate = _fragmentMap.Count == 0;
 			if (!_fragmentMap.ContainsKey(ShellSection))
 			{
 				_fragmentMap[ShellSection] = GetOrCreateFragmentForTab(ShellSection);
@@ -264,8 +264,12 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				result.TrySetResult(true);
 			}
 
-			t.CommitAllowingStateLossEx();
+			if (initialUpdate)
+			{
+				t.SetReorderingAllowed(true);
+			}
 
+			t.CommitAllowingStateLossEx();
 			_currentFragment = target;
 
 
@@ -373,15 +377,18 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void RemoveAllButCurrent(Fragment skip)
 		{
-			var trans = ChildFragmentManager.BeginTransactionEx();
+			FragmentTransaction trans = null;
 			foreach (var kvp in _fragmentMap)
 			{
 				var f = kvp.Value.Fragment;
 				if (kvp.Value == _currentFragment || kvp.Value.Fragment == skip || !f.IsAdded)
 					continue;
+
+				trans ??= ChildFragmentManager.BeginTransactionEx();
 				trans.Remove(f);
 			};
-			trans.CommitAllowingStateLossEx();
+
+			trans?.CommitAllowingStateLossEx();
 		}
 
 		void RemoveAllPushedPages(ShellSection shellSection, bool keepCurrent)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -230,6 +230,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				transaction.SetTransitionEx((int)global::Android.App.FragmentTransit.FragmentOpen);
 
 			transaction.ReplaceEx(_frameLayout.Id, fragment);
+
+			// Don't force the commit if this is our first load 
+			if (previousView == null)
+			{
+				transaction
+					.SetReorderingAllowed(true);
+			}
+
 			transaction.CommitAllowingStateLossEx();
 
 			void OnDestroyed(object sender, EventArgs args)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (previousView == null)
 			{
 				transaction
-					.SetReorderingAllowed(true);
+					.SetReorderingAllowedEx(true);
 			}
 
 			transaction.CommitAllowingStateLossEx();

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		TabLayout _tablayout;
 		IShellTabLayoutAppearanceTracker _tabLayoutAppearanceTracker;
 		AToolbar _toolbar;
+		ShellFragmentStateAdapter _adapter;
 		IShellToolbarAppearanceTracker _toolbarAppearanceTracker;
 		IShellToolbarTracker _toolbarTracker;
 		ViewPager2 _viewPager;
@@ -85,9 +86,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_shellContext = shellContext;
 		}
 
-
 		public override AView OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 		{
+			if (_rootView != null)
+			{
+				return _rootView;
+			}
+
 			var shellSection = ShellSection;
 			if (shellSection == null)
 				return null;
@@ -107,10 +112,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_tablayout = PlatformInterop.CreateShellTabLayout(context, appbar, actionBarHeight);
 
 			var pagerContext = MauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
-			var adapter = new ShellFragmentStateAdapter(shellSection, ChildFragmentManager, pagerContext);
+			_adapter = new ShellFragmentStateAdapter(shellSection, ChildFragmentManager, pagerContext);
 			var pageChangedCallback = new ViewPagerPageChanged(this);
-			_viewPager = PlatformInterop.CreateShellViewPager(context, root, _tablayout, this, adapter, pageChangedCallback);
-
+			_viewPager = PlatformInterop.CreateShellViewPager(context, root, _tablayout, this, _adapter, pageChangedCallback);
+			_viewPager.SaveEnabled = false;
 			Page currentPage = null;
 			int currentIndex = -1;
 			var currentItem = shellSection.CurrentItem;
@@ -165,46 +170,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
-		void Destroy()
-		{
-			if (_rootView != null)
-			{
-				UnhookEvents();
-
-				_shellContext?.Shell?.Toolbar?.Handler?.DisconnectHandler();
-
-				//_viewPager.RemoveOnPageChangeListener(this);
-				var adapter = _viewPager.Adapter;
-				_viewPager.Adapter = null;
-				adapter.Dispose();
-
-				_tablayout.LayoutChange -= OnTabLayoutChange;
-				_toolbarAppearanceTracker.Dispose();
-				_tabLayoutAppearanceTracker.Dispose();
-				_toolbarTracker.Dispose();
-				_tablayout.Dispose();
-				_toolbar.Dispose();
-				_viewPager.Dispose();
-				_rootView.Dispose();
-			}
-
-			_toolbarAppearanceTracker = null;
-			_tabLayoutAppearanceTracker = null;
-			_toolbarTracker = null;
-			_tablayout = null;
-			_toolbar = null;
-			_viewPager = null;
-			_rootView = null;
-
-		}
-
-		// Use OnDestroy instead of OnDestroyView because OnDestroyView will be
-		// called before the animation completes. This causes tons of tiny issues.
-		public override void OnDestroy()
-		{
-			Destroy();
-			base.OnDestroy();
-		}
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)
@@ -214,7 +179,35 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (disposing)
 			{
-				Destroy();
+
+				if (_rootView != null)
+				{
+					UnhookEvents();
+
+					_shellContext?.Shell?.Toolbar?.Handler?.DisconnectHandler();
+
+					var adapter = _viewPager.Adapter;
+					_viewPager.Adapter = null;
+					_adapter?.Dispose();
+
+					_tablayout.LayoutChange -= OnTabLayoutChange;
+					_toolbarAppearanceTracker.Dispose();
+					_tabLayoutAppearanceTracker.Dispose();
+					_toolbarTracker.Dispose();
+					_tablayout.Dispose();
+					_toolbar.Dispose();
+					_viewPager.Dispose();
+					_rootView.Dispose();
+				}
+
+				_adapter = null;
+				_toolbarAppearanceTracker = null;
+				_tabLayoutAppearanceTracker = null;
+				_toolbarTracker = null;
+				_tablayout = null;
+				_toolbar = null;
+				_viewPager = null;
+				_rootView = null;
 			}
 		}
 

--- a/src/Controls/src/Core/Platform/Android/Extensions/FragmentManagerExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/FragmentManagerExtensions.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Maui.Controls.Platform
 			return fragmentTransaction.SetTransition(transit);
 		}
 
+		public static FragmentTransaction SetReorderingAllowedEx(this FragmentTransaction fragmentTransaction, bool reorderingAllowed)
+		{
+			return fragmentTransaction.SetReorderingAllowed(reorderingAllowed);
+		}
+
 		public static int CommitAllowingStateLossEx(this FragmentTransaction fragmentTransaction)
 		{
 			return fragmentTransaction.CommitAllowingStateLoss();

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Maui.Controls
 					(sender as Page).ParentSet -= OnPresentedPageParentSet;
 				}
 			}
-			else
+			else if (IsVisibleContent && page.IsVisible)
 			{
 				page.SendAppearing();
 			}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -114,6 +114,43 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Handlers not recreated when changing tabs")]
+		public async Task HandlersNotRecreatedWhenChangingTabs()
+		{
+			SetupBuilder();
+
+			var page1 = new ContentPage();
+			var page2 = new ContentPage();
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new TabBar()
+				{
+					Items =
+					{
+						new ShellContent()
+						{
+							Route = "Item1",
+							Content = page1
+						},
+						new ShellContent()
+						{
+							Route = "Item2",
+							Content = page2
+						},
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				var initialHandler = page1.Handler;
+				await shell.GoToAsync("//Item2");
+				await shell.GoToAsync("//Item1");
+				Assert.Equal(initialHandler, page1.Handler);
+			});
+		}
+
 		[Theory]
 		[ClassData(typeof(ShellBasicNavigationTestCases))]
 		public async Task BasicShellNavigationStructurePermutations(ShellItem[] shellItems)


### PR DESCRIPTION
### Description of Change

- Don't recreate the entire ShellSection renderer view when you navigate back to it. Just return the previously created view
- Wire up `ShellFragmentStateAdapter` so that it better keeps track of created fragments

### Issues Fixed


Fixes #5615
Fixes #5877 
