### PR TITLE
Fix nullable annotations for `Preferences`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,7 +87,7 @@
     <PackageVersion>$(DotNetVersionBand)-dev</PackageVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts</PackageOutputPath>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
   </ItemGroup>
   <!-- This target is replaced by GitInfo when restored. Allows Versions.targets to rely on it before restore. -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,6 +87,9 @@
     <PackageVersion>$(DotNetVersionBand)-dev</PackageVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts</PackageOutputPath>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
+  </ItemGroup>
   <!-- This target is replaced by GitInfo when restored. Allows Versions.targets to rely on it before restore. -->
   <Target Name="GitVersion" />
   <Target Name="GitInfo" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,9 +87,6 @@
     <PackageVersion>$(DotNetVersionBand)-dev</PackageVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts</PackageOutputPath>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
-  </ItemGroup>
   <!-- This target is replaced by GitInfo when restored. Allows Versions.targets to rely on it before restore. -->
   <Target Name="GitVersion" />
   <Target Name="GitInfo" />

--- a/src/Essentials/src/Preferences/Preferences.shared.cs
+++ b/src/Essentials/src/Preferences/Preferences.shared.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Maui.Storage
 			Clear(null);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][7]/Docs" />
+#if !NETSTANDARD
 		[return: NotNullIfNotNull("defaultValue")]
+#endif
 		public static string? Get(string key, string? defaultValue) =>
 			Get(key, defaultValue, null);
 
@@ -98,7 +100,9 @@ namespace Microsoft.Maui.Storage
 			Current.Clear(sharedName);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][14]/Docs" />
+#if !NETSTANDARD
 		[return: NotNullIfNotNull("defaultValue")]
+#endif
 		public static string? Get(string key, string? defaultValue, string? sharedName) =>
 			Current.Get<string?>(key, defaultValue, sharedName);
 

--- a/src/Essentials/src/Preferences/Preferences.shared.cs
+++ b/src/Essentials/src/Preferences/Preferences.shared.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui.Storage
 {
@@ -16,7 +17,7 @@ namespace Microsoft.Maui.Storage
 		T Get<T>(string key, T defaultValue, string? sharedName = null);
 	}
 
-/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Preferences']/Docs" />
+	/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="Type[@FullName='Microsoft.Maui.Essentials.Preferences']/Docs" />
 	public static class Preferences
 	{
 		// overloads
@@ -34,7 +35,8 @@ namespace Microsoft.Maui.Storage
 			Clear(null);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][7]/Docs" />
-		public static string Get(string key, string defaultValue) =>
+		[return: NotNullIfNotNull("defaultValue")]
+		public static string? Get(string key, string? defaultValue) =>
 			Get(key, defaultValue, null);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][1]/Docs" />
@@ -58,7 +60,7 @@ namespace Microsoft.Maui.Storage
 			Get(key, defaultValue, null);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][7]/Docs" />
-		public static void Set(string key, string value) =>
+		public static void Set(string key, string? value) =>
 			Set(key, value, null);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][1]/Docs" />
@@ -96,8 +98,9 @@ namespace Microsoft.Maui.Storage
 			Current.Clear(sharedName);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][14]/Docs" />
-		public static string Get(string key, string defaultValue, string? sharedName) =>
-			Current.Get<string>(key, defaultValue, sharedName);
+		[return: NotNullIfNotNull("defaultValue")]
+		public static string? Get(string key, string? defaultValue, string? sharedName) =>
+			Current.Get<string?>(key, defaultValue, sharedName);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][8]/Docs" />
 		public static bool Get(string key, bool defaultValue, string? sharedName) =>
@@ -120,8 +123,8 @@ namespace Microsoft.Maui.Storage
 			Current.Get<long>(key, defaultValue, sharedName);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][14]/Docs" />
-		public static void Set(string key, string value, string? sharedName) =>
-			Current.Set<string>(key, value, sharedName);
+		public static void Set(string key, string? value, string? sharedName) =>
+			Current.Set<string?>(key, value, sharedName);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][8]/Docs" />
 		public static void Set(string key, bool value, string? sharedName) =>


### PR DESCRIPTION
### Description of Change

Setting and Getting `null` is totally valid (I'm using this functionality in my app), so existing annotations are incorrect.
Updated annotations to reflect underlying logic.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
~~Do I need to create an issue for such a small change?~~
