### PR TITLE
Create Flyout.Details inside Fragment

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
@@ -1,9 +1,11 @@
 ﻿using System.Threading.Tasks;
 using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Handlers;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
+	[Collection(HandlerTestBase.RunInNewWindowCollection)]
 	public partial class EditorTests
 	{
 		AppCompatEditText GetPlatformControl(EditorHandler handler) =>

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Android.cs
@@ -12,6 +12,7 @@ using AView = Android.Views.View;
 
 namespace Microsoft.Maui.DeviceTests
 {
+	[Collection(HandlerTestBase.RunInNewWindowCollection)]
 	public partial class FlyoutPageTests
 	{
 		DrawerLayout FindPlatformFlyoutView(AView aView) =>

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -92,11 +92,10 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(flyoutView, dl);
 
 				flyoutPage.Detail = details2;
-				var detailView2 = details2.ToPlatform();
 
-				await detailView2.OnLoadedAsync();
+				await OnLoadedAsync(details2);
 				await detailView.OnUnloadedAsync();
-				dl = FindPlatformFlyoutView(detailView2);
+				dl = FindPlatformFlyoutView(details2.ToPlatform());
 				Assert.Equal(flyoutView, dl);
 				Assert.Null(FindPlatformFlyoutView(detailView));
 			});

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -52,6 +52,27 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Details View Updates w/NavigationPage")]
+		public async Task DetailsViewUpdatesWithNavigationPage()
+		{
+			SetupBuilder();
+			var flyoutPage = new FlyoutPage()
+			{
+				Detail = new NavigationPage(new ContentPage() { Title = "Detail" }),
+				Flyout = new ContentPage() { Title = "Flyout" }
+			};
+
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			{
+				var details2 = new NavigationPage(new ContentPage() { Title = "Detail" });
+
+				flyoutPage.Detail = details2;
+				await OnLoadedAsync(details2.CurrentPage);
+				var detailView2 = (details2.CurrentPage.Handler as IPlatformViewHandler)?.PlatformView;
+				Assert.NotNull(detailView2);
+				await detailView2.OnLoadedAsync();
+			});
+		}
 
 		[Fact(DisplayName = "Details View Updates")]
 		public async Task DetailsViewUpdates()

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Maui.DeviceTests
 				await OnLoadedAsync(details2.CurrentPage);
 				var detailView2 = (details2.CurrentPage.Handler as IPlatformViewHandler)?.PlatformView;
 				Assert.NotNull(detailView2);
-				await detailView2.OnLoadedAsync();
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -17,6 +17,9 @@ using TabbedViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.TabbedR
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.Modal)]
+#if ANDROID
+	[Collection(HandlerTestBase.RunInNewWindowCollection)]
+#endif
 	public partial class ModalTests : HandlerTestBase
 	{
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -13,6 +13,7 @@ using Xunit;
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.NavigationPage)]
+	[Collection(HandlerTestBase.RunInNewWindowCollection)]
 	public partial class NavigationPageTests : HandlerTestBase
 	{
 		// We only want to fire BackButtonVisible Toolbar events if the user

--- a/src/Controls/tests/DeviceTests/Elements/PlatformBehaviorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/PlatformBehaviorTests.cs
@@ -21,6 +21,9 @@ using PlatformView = System.Object;
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.Behavior)]
+#if ANDROID
+	[Collection(HandlerTestBase.RunInNewWindowCollection)]
+#endif
 	public partial class PlatformBehaviorTests : HandlerTestBase
 	{
 		[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -11,6 +11,7 @@ using Xunit;
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.Shell)]
+	[Collection(HandlerTestBase.RunInNewWindowCollection)]
 	public partial class ShellTests
 	{
 		[Fact(DisplayName = "Shell with Flyout Disabled Doesn't Render Flyout")]

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
@@ -10,6 +10,9 @@ using NavigationViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.Nav
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.VisualElement)]
+#if ANDROID
+	[Collection(HandlerTestBase.RunInNewWindowCollection)]
+#endif
 	public partial class VisualElementTests : HandlerTestBase
 	{
 		void SetupBuilder()

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -17,6 +17,12 @@ namespace Microsoft.Maui.DeviceTests
 		MauiApp _mauiApp;
 		IMauiContext _mauiContext;
 
+		// In order to run any page level tests android needs to add itself to the decor view inside a new fragment
+		// that way all the lifecycle events related to being attached to the window will fire
+		// adding/removing that many fragments in parallel to the decor view was causing the tests to be unreliable
+		// That being said...
+		// There's definitely a chance that the code written to manage this process could be improved		
+		public const string RunInNewWindowCollection = "Serialize test because it has to add itself to the main window";
 		public void EnsureHandlerCreated(Action<MauiAppBuilder> additionalCreationActions = null)
 		{
 			if (_isCreated)

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Maui.Handlers
 	public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, View>
 	{
 		View? _flyoutView;
-		View? _detailView;
 		const uint DefaultScrimColor = 0x99000000;
 		View? _navigationRoot;
 		LinearLayoutCompat? _sideBySideView;
 		DrawerLayout DrawerLayout => (DrawerLayout)PlatformView;
+		ScopedFragment? _detailViewFragment;
 
 		protected override View CreatePlatformView()
 		{
@@ -49,26 +49,38 @@ namespace Microsoft.Maui.Handlers
 		void UpdateDetailsFragmentView()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			var newDetailsView = VirtualView.Detail?.ToPlatform(MauiContext);
 
-			if (_detailView == newDetailsView)
+			if (_detailViewFragment != null && _detailViewFragment?.DetailView == VirtualView.Detail)
 				return;
 
-			if (newDetailsView != null)
-				newDetailsView.RemoveFromParent();
+			if (VirtualView.Detail?.Handler is IPlatformViewHandler pvh)
+				pvh.DisconnectHandler();
 
-			_detailView = newDetailsView;
-
-			if (_detailView != null)
+			if(VirtualView.Detail == null)
 			{
+				if (_detailViewFragment != null)
+				{
+					MauiContext
+						.GetFragmentManager()
+						.BeginTransaction()
+						.Remove(_detailViewFragment)
+						.SetReorderingAllowed(true)
+						.Commit();
+				}
+			}
+			else
+			{
+				_detailViewFragment = new ScopedFragment(VirtualView.Detail, MauiContext);
 				MauiContext
 					.GetFragmentManager()
 					.BeginTransaction()
-					.Replace(Resource.Id.navigationlayout_content, new ViewFragment(_detailView))
+					.Replace(Resource.Id.navigationlayout_content, _detailViewFragment)
 					.SetReorderingAllowed(true)
 					.Commit();
 			}
 		}
+
+
 
 		void UpdateDetail()
 		{
@@ -223,8 +235,7 @@ namespace Microsoft.Maui.Handlers
 		void UpdateFlyoutBehavior()
 		{
 			var behavior = VirtualView.FlyoutBehavior;
-			var details = _detailView;
-			if (details == null)
+			if (_detailViewFragment?.DetailView?.Handler?.PlatformView == null)
 				return;
 
 			switch (behavior)

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Android.cs
@@ -80,8 +80,6 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-
-
 		void UpdateDetail()
 		{
 			LayoutViews();

--- a/src/Core/src/Platform/Android/Navigation/ScopedFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/ScopedFragment.cs
@@ -1,0 +1,25 @@
+﻿using Android.OS;
+using Android.Views;
+using AndroidX.Fragment.App;
+
+namespace Microsoft.Maui.Platform
+{
+	class ScopedFragment : Fragment
+	{
+		readonly IMauiContext _mauiContext;
+
+		public IView DetailView { get; private set; }
+
+		public ScopedFragment(IView detailView, IMauiContext mauiContext)
+		{
+			DetailView = detailView;
+			_mauiContext = mauiContext;
+		}
+
+		public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+		{
+			var pageMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
+			return DetailView.ToPlatform(pageMauiContext);
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -304,7 +304,6 @@ namespace Microsoft.Maui.Platform
 		{
 			if (view != null)
 				PlatformInterop.RemoveFromParent(view);
-				PlatformInterop.RemoveFromParent(view);
 		}
 
 		internal static Rect GetPlatformViewBounds(this IView view)

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -101,13 +101,8 @@ namespace Microsoft.Maui.Platform
 			if (view is IReplaceableView replaceableView && replaceableView.ReplacedView != view)
 				return replaceableView.ReplacedView.ToPlatform();
 
-			if (view.Handler == null)
-			{
-				var mauiContext = view.Parent?.Handler?.MauiContext ??
-					throw new InvalidOperationException($"{nameof(MauiContext)} should have been set on parent.");
 
-				return view.ToPlatform(mauiContext);
-			}
+			_ = view.Handler ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set on parent.");
 
 			if (view.Handler is IViewHandler viewHandler)
 			{


### PR DESCRIPTION
### Description of Change

Host the details content inside its own fragment container. If the root container is a NavigationPage then the Jet Navigation parts need to have their own Fragment space (ChildSupportManager) to operate. This makes it so you can swap out the `Detail` with another `NavigationPage`

### Issues Fixed

Fixes #5541 
