### PR TITLE
[Housekeeping] Update samples in Gallery to use BackgroundColor and Background properties everywhere

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/BoxViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/BoxViewPage.xaml
@@ -26,7 +26,25 @@
                 HeightRequest="160"
                 VerticalOptions="Center"
                 HorizontalOptions="Center" />
-
+            
+            <Label
+                Text="Background"
+                Style="{StaticResource Headline}" />
+            <BoxView 
+                WidthRequest="160"
+                HeightRequest="160"
+                VerticalOptions="Center"
+                HorizontalOptions="Center">
+                <BoxView.Background>
+                    <LinearGradientBrush EndPoint="1,0">
+                        <GradientStop Color="Yellow" 
+                                      Offset="0.1" />
+                        <GradientStop Color="Green"                                   
+                                      Offset="1.0" />
+                    </LinearGradientBrush>
+                </BoxView.Background>
+            </BoxView>
+            
             <Label
                 Text="Using CornerRadius"
                 Style="{StaticResource Headline}"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
@@ -75,6 +75,20 @@
                     BackgroundColor="Blue"
                     Text="Button"/>
                 <Label
+                    Text="Background"
+                    Style="{StaticResource Headline}" />
+                <Button 
+                    Text="Background">
+                    <Button.Background>
+                        <LinearGradientBrush EndPoint="1,0">
+                            <GradientStop Color="Yellow"
+                                          Offset="0.1" />
+                            <GradientStop Color="Green"
+                                          Offset="1.0" />
+                        </LinearGradientBrush>
+                    </Button.Background>
+                </Button>
+                <Label
                     Text="TextColor"
                     Style="{StaticResource Headline}"/>
                 <Button

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/DatePickerPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/DatePickerPage.xaml
@@ -12,6 +12,24 @@
                 Style="{StaticResource Headline}"/>
             <DatePicker/>
             <Label
+                Text="BackgroundColor"
+                Style="{StaticResource Headline}"/>
+            <DatePicker
+                BackgroundColor="Blue" />
+            <Label
+                Text="Background"
+                Style="{StaticResource Headline}" />
+            <DatePicker>
+                <DatePicker.Background>
+                    <LinearGradientBrush EndPoint="1,0">
+                        <GradientStop Color="Yellow"   
+                                      Offset="0.1" />
+                        <GradientStop Color="Green"
+                                      Offset="1.0" />
+                    </LinearGradientBrush>
+                </DatePicker.Background>
+            </DatePicker>
+            <Label
                 Text="Default with date"
                 Style="{StaticResource Headline}"/>
             <DatePicker Date="06/21/2018"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EditorPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EditorPage.xaml
@@ -64,11 +64,25 @@
                 <Editor 
                     Completed="OnEditorCompleted"/>
                 <Label
-                    Text="Background"
+                    Text="BackgroundColor"
                     Style="{StaticResource Headline}" />
                 <Editor 
                     Text="Text"
-                    Background="Orange"/>
+                    BackgroundColor="Orange"/>
+                <Label
+                    Text="Background"
+                    Style="{StaticResource Headline}" />
+                <Editor 
+                    Text="Background">
+                    <Editor.Background>
+                        <LinearGradientBrush EndPoint="1,0">
+                            <GradientStop Color="Yellow"
+                                          Offset="0.1" />
+                            <GradientStop Color="Green"
+                                          Offset="1.0" />
+                        </LinearGradientBrush>
+                    </Editor.Background>
+                </Editor>
                 <Label
                     Text="Keyboard Numeric"
                     Style="{StaticResource Headline}" />

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/EntryPage.xaml
@@ -95,11 +95,25 @@
                 <Entry 
                     Completed="OnEntryCompleted"/>
                 <Label
+                    Text="BackgroundColor"
+                    Style="{StaticResource Headline}" />
+                <Entry 
+                    Text="BackgroundColor"
+                    BackgroundColor="Orange"/>
+                <Label
                     Text="Background"
                     Style="{StaticResource Headline}" />
                 <Entry 
-                    Text="Text"
-                    Background="Orange"/>
+                    Text="Background">
+                    <Entry.Background>
+                        <LinearGradientBrush EndPoint="1,0">
+                            <GradientStop Color="Yellow"
+                                          Offset="0.1" />
+                            <GradientStop Color="Green"
+                                          Offset="1.0" />
+                        </LinearGradientBrush>
+                    </Entry.Background>
+                </Entry>
                 <Label
                     Text="Keyboard Numeric"
                     Style="{StaticResource Headline}" />

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
@@ -24,8 +24,7 @@
                 <Label
                     Text="Font Image Source"
                     Style="{StaticResource Headline}"/>
-                <Image
-                    
+                <Image   
                     Background="Green">
                     <Image.Source>
                         <FontImageSource

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/LabelPage.xaml
@@ -20,6 +20,26 @@
                     TextColor="Red"
                     Text="TextColor"/>
                 <Label
+                    Text="BackgroundColor"
+                    Style="{StaticResource Headline}"/>
+                <Label
+                    BackgroundColor="Blue"
+                    Text="Button"/>
+                <Label
+                    Text="Background"
+                    Style="{StaticResource Headline}" />
+                <Label 
+                    Text="Background">
+                    <Label.Background>
+                        <LinearGradientBrush EndPoint="1,0">
+                            <GradientStop Color="Yellow"  
+                                          Offset="0.1" />
+                            <GradientStop Color="Green"
+                                          Offset="1.0" />
+                        </LinearGradientBrush>
+                    </Label.Background>
+                </Label>
+                <Label
                     Text="Html text"
                     Style="{StaticResource Headline}"/>
                 <Label

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SearchBarPage.xaml
@@ -83,6 +83,20 @@
                     Style="{StaticResource Headline}"/>
                 <SearchBar
                     BackgroundColor="LightBlue"/>
+                <Label
+                    Text="Background"
+                    Style="{StaticResource Headline}" />
+                <SearchBar 
+                    Text="Background">
+                    <SearchBar.Background>
+                        <LinearGradientBrush EndPoint="1,0">
+                            <GradientStop Color="Yellow"                              
+                                          Offset="0.1" />
+                            <GradientStop Color="Green"
+                                          Offset="1.0" />
+                        </LinearGradientBrush>
+                    </SearchBar.Background>
+                </SearchBar>
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
@@ -8,7 +8,24 @@
         <VerticalStackLayout Margin="12">
             <Label Text="Default" Style="{StaticResource Headline}"/>
             <Slider/>
-            
+            <Label
+                Text="BackgroundColor"
+                Style="{StaticResource Headline}"/>
+            <Slider
+                BackgroundColor="Blue"/>
+            <Label
+                Text="Background"
+                Style="{StaticResource Headline}" />
+            <Slider>
+                <Slider.Background>
+                    <LinearGradientBrush EndPoint="1,0">
+                        <GradientStop Color="Yellow"
+                                      Offset="0.1" />
+                        <GradientStop Color="Green"
+                                      Offset="1.0" />
+                    </LinearGradientBrush>
+                </Slider.Background>
+            </Slider>
             <Label Text="Minimum (5) and Maximum (15)" Style="{StaticResource Headline}"/>
             <Slider x:Name="MinMaxSlider" Maximum="15" Minimum="5" ValueChanged="OnValueChanged"/>
             <Label FontSize="Micro" Text="{Binding Source={x:Reference MinMaxSlider}, Path=Value}"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/StepperPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/StepperPage.xaml
@@ -17,10 +17,23 @@
             <Stepper
                 IsEnabled="False"/>
             <Label
-                Text="Background"
+                Text="BackgroundColor"
                 Style="{StaticResource Headline}"/>
             <Stepper
-                Background="Red"/>
+                BackgroundColor="Red"/>
+            <Label
+                Text="Background"
+                Style="{StaticResource Headline}" />
+            <Stepper>
+                <Stepper.Background>
+                    <LinearGradientBrush EndPoint="1,0">
+                        <GradientStop Color="Yellow"   
+                                      Offset="0.1" />
+                        <GradientStop Color="Green"
+                                      Offset="1.0" />
+                    </LinearGradientBrush>
+                </Stepper.Background>
+            </Stepper>
             <Label
                 Text="Minimum (25) and Maximum (25)"
                 Style="{StaticResource Headline}"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwitchPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwitchPage.xaml
@@ -12,6 +12,24 @@
                 Style="{StaticResource Headline}"/>
             <Switch/>
             <Label
+                Text="BackgroundColor"
+                Style="{StaticResource Headline}" />
+            <Switch
+                BackgroundColor="Blue"/>
+            <Label
+                Text="Background"
+                Style="{StaticResource Headline}" />
+            <Switch>
+                <Switch.Background>
+                    <LinearGradientBrush EndPoint="1,0">
+                        <GradientStop Color="Yellow"   
+                                      Offset="0.1" />
+                        <GradientStop Color="Green"
+                                      Offset="1.0" />
+                    </LinearGradientBrush>
+                </Switch.Background>
+            </Switch>
+            <Label
                 Text="Disabled"
                 Style="{StaticResource Headline}"/>
             <Switch

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/TimePickerPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/TimePickerPage.xaml
@@ -12,6 +12,24 @@
                 Style="{StaticResource Headline}"/>
             <TimePicker/>
             <Label
+                Text="BackgroundColor"
+                Style="{StaticResource Headline}"/>
+            <TimePicker
+                BackgroundColor="Blue" />
+            <Label
+                Text="Background"
+                Style="{StaticResource Headline}" />
+            <TimePicker>
+                <DatePicker.Background>
+                    <LinearGradientBrush EndPoint="1,0">
+                        <GradientStop Color="Yellow"   
+                                      Offset="0.1" />
+                        <GradientStop Color="Green"
+                                      Offset="1.0" />
+                    </LinearGradientBrush>
+                </DatePicker.Background>
+            </TimePicker>
+            <Label
                 Text="Default with time"
                 Style="{StaticResource Headline}"/>
             <TimePicker Time="4:15:26"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/BrushesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/BrushesPage.xaml
@@ -72,10 +72,10 @@
                     <Frame.Background>
                         <!-- StartPoint defaults to (0,0) -->
                         <LinearGradientBrush EndPoint="1,0">
-                            <GradientStop Color="Yellow"
-                                      Offset="0.1" />
+                            <GradientStop Color="Yellow"   
+                                          Offset="0.1" />
                             <GradientStop Color="Green"
-                                      Offset="1.0" />
+                                          Offset="1.0" />
                         </LinearGradientBrush>
                     </Frame.Background>
                 </Frame>


### PR DESCRIPTION
### Description of Change

Update samples in Gallery to use BackgroundColor and Background properties everywhere to validate that are working correctly.

![image](https://user-images.githubusercontent.com/6755973/163130377-7a9f01d5-78d2-46a2-9fdd-8db82b6bf4f9.png)

Cannot reproduce #6029, this PR just update the .NET MAUI Gallery to include a BackgroundColor sample everywhere.

### Issues Fixed

Fixes #6029 
