### PR TITLE
Made IResourceProvider public

### DIFF
--- a/src/Controls/src/Core/IResourcesProvider.cs
+++ b/src/Controls/src/Core/IResourcesProvider.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.Maui.Controls
 {
-	interface IResourcesProvider
+	public interface IResourcesProvider
 	{
 		bool IsResourcesCreated { get; }
 		ResourceDictionary Resources { get; set; }


### PR DESCRIPTION
### Description of Change

Made IResourceProvider public to be able to register this interface to the DI Container, so we no longer need to reference Application.Current directly and are still able to unit test our code properly.

### Issues Fixed

Fixes #6045
