### PR TITLE
[Android] Fix crash adding/removing SwipeItems dynamically in the SwipeView

### DIFF
--- a/src/Controls/src/Core/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Maui.Controls
 {
@@ -100,11 +100,23 @@ namespace Microsoft.Maui.Controls
 				newItems.PropertyChanged += SwipeItemsPropertyChanged;
 			}
 
-			void SwipeItemsPropertyChanged(object sender, PropertyChangedEventArgs e) =>
-				SendChange((SwipeItems)sender);
+			void SwipeItemsPropertyChanged(object sender, PropertyChangedEventArgs e)
+			{
+				if (sender is SwipeItems swipeItems)
+					SendChange(swipeItems);
 
-			void SwipeItemsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) =>
-				SendChange((SwipeItems)sender);
+				if (sender is IEnumerable<ISwipeItem> enumerable)
+					SendChange(new SwipeItems(enumerable));
+			}
+
+			void SwipeItemsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+			{
+				if (sender is SwipeItems swipeItems)
+					SendChange(swipeItems);
+
+				if (sender is IEnumerable<ISwipeItem> enumerable)
+					SendChange(new SwipeItems(enumerable));
+			}
 
 			void SendChange(SwipeItems swipeItems)
 			{


### PR DESCRIPTION
### Description of Change

Detected this issue validating another SwipeView one. Fix crash adding/removing SwipeItems dynamically in the SwipeView.

To test it, launch the .NET MAUI Gallery and navigate to the SwipeView samples. Select the "Add/Remove SwipeItems" sample and tap the buttons to add and remove items. Without exceptions, the test has passed.


Fixes #6291