### PR TITLE
Always use the MSIX tooling

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
     <OutputType Condition="'$(OutputType)' == 'Exe'">WinExe</OutputType>
-    <EnablePreviewMsixTooling Condition="'$(EnablePreviewMsixTooling)' == '' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')">true</EnablePreviewMsixTooling>
+    <EnablePreviewMsixTooling Condition="'$(EnablePreviewMsixTooling)' == ''">true</EnablePreviewMsixTooling>
     <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnablePreviewMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">MSIX</WindowsPackageType>
     <WinUISDKReferences Condition=" '$(WinUISDKReferences)' == '' and '$(EnablePreviewMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">false</WinUISDKReferences>
     <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>

--- a/src/Templates/src/templates/maui-lib/MauiLib1.csproj
+++ b/src/Templates/src/templates/maui-lib/MauiLib1.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>DOTNET_TFM;DOTNET_TFM-android;DOTNET_TFM-ios;DOTNET_TFM-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);DOTNET_TFM-windows10.0.19041.0</TargetFrameworks>
 		<RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MauiLib1</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>


### PR DESCRIPTION
### Description of Change

Make sure to use the new tooling everywhere.

If we try using the default tooling for class libraries, it tries to load net framework tasks in a dotnet build scenario.

### Issues Fixed

Fixes #5886
