### PR TITLE
Fix for 3848 - FlexLayout doesn't measure content

### DIFF
--- a/src/Core/src/Layouts/FlexLayoutManager.cs
+++ b/src/Core/src/Layouts/FlexLayoutManager.cs
@@ -34,23 +34,25 @@ namespace Microsoft.Maui.Layouts
 
 		public Size Measure(double widthConstraint, double heightConstraint)
 		{
-			double width = 0;
-			double height = 0;
+			double measuredHeight = 0;
+			double measuredWidth = 0;
 
-			if (!double.IsInfinity(widthConstraint))
+			foreach (var child in FlexLayout)
 			{
-				width = widthConstraint;
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					continue;
+				}
+
+				var frame = FlexLayout.GetFlexFrame(child);
+				measuredHeight = Math.Max(measuredHeight, frame.Bottom);
+				measuredWidth = Math.Max(measuredWidth, frame.Right);
 			}
 
-			if (!double.IsInfinity(heightConstraint))
-			{
-				height = heightConstraint;
-			}
+			var finalHeight = LayoutManager.ResolveConstraints(heightConstraint, FlexLayout.Height, measuredHeight, FlexLayout.MinimumHeight, FlexLayout.MaximumHeight);
+			var finalWidth = LayoutManager.ResolveConstraints(widthConstraint, FlexLayout.Width, measuredWidth, FlexLayout.MinimumWidth, FlexLayout.MaximumWidth);
 
-			height = LayoutManager.ResolveConstraints(height, FlexLayout.Height, height, FlexLayout.MinimumHeight, FlexLayout.MaximumHeight);
-			width = LayoutManager.ResolveConstraints(width, FlexLayout.Width, width, FlexLayout.MinimumWidth, FlexLayout.MaximumWidth);
-
-			return new Size(width, height);
+			return new Size(finalWidth, finalHeight);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

I've fixed `FlexLayoutManager.Measure` so that it measures its children's frames to work out the bounding box of the content. The current implementation ignores the children completely.

This code sample behaves as expected and is sized correctly based on the content:
```
<StackLayout>
    <Label>Top</Label>
    <FlexLayout Grid.Row="0" Grid.Column="1" Wrap="Wrap" AlignContent="Start" AlignItems="Start">
        <BoxView BackgroundColor="AliceBlue" HeightRequest="40" WidthRequest="24" />
        <BoxView BackgroundColor="BlanchedAlmond" HeightRequest="24" WidthRequest="24" />
        <BoxView BackgroundColor="Chartreuse" HeightRequest="32" WidthRequest="24" />
        <BoxView BackgroundColor="DeepPink" HeightRequest="16" WidthRequest="24" />
        <BoxView BackgroundColor="Firebrick" HeightRequest="24" WidthRequest="24" />
        <BoxView BackgroundColor="Gold" HeightRequest="40" WidthRequest="24" />
        <BoxView BackgroundColor="HotPink" HeightRequest="16" WidthRequest="24" />
        <BoxView BackgroundColor="AliceBlue" HeightRequest="40" WidthRequest="24" />
        <BoxView BackgroundColor="BlanchedAlmond" HeightRequest="24" WidthRequest="24" />
        <BoxView BackgroundColor="Chartreuse" HeightRequest="32" WidthRequest="24" />
        <BoxView BackgroundColor="DeepPink" HeightRequest="16" WidthRequest="24" />
        <BoxView BackgroundColor="Firebrick" HeightRequest="24" WidthRequest="24" />
        <BoxView BackgroundColor="Gold" HeightRequest="40" WidthRequest="24" />
        <BoxView BackgroundColor="HotPink" HeightRequest="16" WidthRequest="24" />
    </FlexLayout>
    <Label>Bottom</Label>
</StackLayout>
```

The implementation was inspired and informed by StackLayoutManager.Measure.

### Issues Fixed

- Fixes #3848
- Fixes #3852
