### PR TITLE
Leave the content panel active on the Windows scrollview at all times

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Windows.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
 	{
-		const string InsetPanelTag = "MAUIContentInsetPanel";
+		const string ContentPanelTag = "MAUIScrollViewContentPanel";
 
 		protected override ScrollViewer CreatePlatformView()
 		{
@@ -35,25 +35,10 @@ namespace Microsoft.Maui.Handlers
 		{
 			widthConstraint = Math.Max(widthConstraint, 0);
 			heightConstraint = Math.Max(heightConstraint, 0);
-
+		
 			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
-
-			if (GetInsetPanel(PlatformView) == null)
-			{
-				VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
-			}
-
+	
 			return result;
-		}
-
-		public override void PlatformArrange(Rect rect)
-		{
-			base.PlatformArrange(rect);
-
-			if (GetInsetPanel(PlatformView) == null)
-			{
-				VirtualView.CrossPlatformArrange(rect);
-			}
 		}
 
 		public static void MapContent(IScrollViewHandler handler, IScrollView scrollView)
@@ -61,16 +46,7 @@ namespace Microsoft.Maui.Handlers
 			if (handler.PlatformView == null || handler.MauiContext == null)
 				return;
 
-			if (NeedsInsetPanel(scrollView))
-			{
-				UpdateInsetPanel(scrollView, handler);
-			}
-			else
-			{
-				var scrollViewer = handler.PlatformView;
-				RemoveInsetPanel(scrollViewer);
-				scrollViewer.UpdateContent(scrollView.PresentedContent, handler.MauiContext);
-			}
+			UpdateContentPanel(scrollView, handler);
 		}
 
 		public static void MapHorizontalScrollBarVisibility(IScrollViewHandler handler, IScrollView scrollView)
@@ -114,40 +90,21 @@ namespace Microsoft.Maui.Handlers
 			Problem 2: The ScrollViewer will force any content to start at the origin (0,0), even if we ask 
 			to arrange it at an offset. This defeats our content's Margin properties. 
 
-			To handle this, we detect whether the content has a Margin or the cross-platform ScrollView has a Padding;
-			if so, we insert a container ContentPanel which always lays out at the origin but provides both the Padding
-			and the Margin for the content. The extra layer is only inserted if necessary, and is removed if the Padding
-			and Margin are set to zero. The extra layer uses the native ContentPanel control we already provide
-			as the backing control for ContentView, Page, etc. 
+			To handle this, we insert a container ContentPanel which always lays out at the origin but provides both 
+			the Padding and the Margin for the content. The extra layer uses the native ContentPanel control we already 
+			provide as the backing control for ContentView, Page, etc. 
+
+			The extra layer also provides a place to call CrossPlatformArrange for the content, since we 
+			can't subclass ScrollViewer.
 
 			The methods below exist to support inserting/updating the padding/margin panel.
 		 */
 
-		static bool NeedsInsetPanel(IScrollView scrollView)
-		{
-			if (scrollView.PresentedContent == null)
-			{
-				return false;
-			}
-
-			if (scrollView.Padding != Thickness.Zero)
-			{
-				return true;
-			}
-
-			if (scrollView.PresentedContent.Margin != Thickness.Zero)
-			{
-				return true;
-			}
-
-			return false;
-		}
-
-		static ContentPanel? GetInsetPanel(ScrollViewer scrollViewer) 
+		static ContentPanel? GetContentPanel(ScrollViewer scrollViewer) 
 		{
 			if (scrollViewer.Content is ContentPanel contentPanel)
 			{
-				if (contentPanel.Tag is string tag && tag == InsetPanelTag)
+				if (contentPanel.Tag is string tag && tag == ContentPanelTag)
 				{
 					return contentPanel;
 				}
@@ -156,19 +113,7 @@ namespace Microsoft.Maui.Handlers
 			return null;
 		}
 
-		static void RemoveInsetPanel(ScrollViewer scrollViewer) 
-		{
-			if (GetInsetPanel(scrollViewer) is ContentPanel currentPaddingLayer)
-			{
-				if (currentPaddingLayer.Children.Count > 0)
-				{
-					currentPaddingLayer.Children.Clear();
-					scrollViewer.Content = null;
-				}
-			}
-		}
-
-		static void UpdateInsetPanel(IScrollView scrollView, IScrollViewHandler handler)
+		static void UpdateContentPanel(IScrollView scrollView, IScrollViewHandler handler)
 		{
 			if (scrollView.PresentedContent == null || handler.MauiContext == null)
 			{
@@ -178,7 +123,7 @@ namespace Microsoft.Maui.Handlers
 			var scrollViewer = handler.PlatformView;
 			var nativeContent = scrollView.PresentedContent.ToPlatform(handler.MauiContext);
 
-			if (GetInsetPanel(scrollViewer) is ContentPanel currentPaddingLayer)
+			if (GetContentPanel(scrollViewer) is ContentPanel currentPaddingLayer)
 			{
 				if (currentPaddingLayer.Children.Count == 0 || currentPaddingLayer.Children[0] != nativeContent)
 				{
@@ -188,11 +133,11 @@ namespace Microsoft.Maui.Handlers
 			}
 			else
 			{
-				InsertInsetPanel(scrollViewer, scrollView, nativeContent);
+				InsertContentPanel(scrollViewer, scrollView, nativeContent);
 			}
 		}
 
-		static void InsertInsetPanel(ScrollViewer scrollViewer, IScrollView scrollView, FrameworkElement nativeContent)
+		static void InsertContentPanel(ScrollViewer scrollViewer, IScrollView scrollView, FrameworkElement nativeContent)
 		{
 			if (scrollView.PresentedContent == null)
 			{
@@ -203,7 +148,7 @@ namespace Microsoft.Maui.Handlers
 			{
 				CrossPlatformMeasure = IncludeScrollViewInsets(scrollView.CrossPlatformMeasure, scrollView),
 				CrossPlatformArrange = scrollView.CrossPlatformArrange,
-				Tag = InsetPanelTag
+				Tag = ContentPanelTag
 			};
 
 			scrollViewer.Content = null;


### PR DESCRIPTION
### Description of Change

Because the Windows ScrollViewer is sealed, there's no option to call the cross-platform arrangement code for the content within ArrangeOverride as we do with other content controls. Previously, we simple called the cross-platform arrangement method from the handler during PlatformArrange, which technically means that the child controls are getting multiple arrange calls. However, in some circumstances (like those in #4951), this can end up triggering a layout cycle. 

We already had a ContentPanel in place to handle margin/padding situations that the native ScrollViewer doesn't support, and when that ContentPanel is in place there's no need to call the cross-platform arrangement method from PlatformArrange (because the ContentPanel handles it). This is why the bug in #4951 wasn't observed if the ScrollView had Padding or the content of the ScrollView had a margin. 

So rather than only swapping in the ContentPanel when padding/margin require it, these changes simply make the ContentPanel a constant; the ContentPanel handles the cross-platform arrangement calls at the appropriate time and prevents the multiple-arrange scenario which causes the layout cycles. This also has the benefit of simplifying the ScrollViewHandler code on Windows a bit.

### Issues Fixed

Fixes #4951
