### PR TITLE
Static content hot reload (CSS only for now)

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		internal bool TryGetResponseContentInternal(string uri, bool allowFallbackOnHostPage, out int statusCode, out string statusMessage, out Stream content, out IDictionary<string, string> headers)
 		{
 			var defaultResult = TryGetResponseContent(uri, allowFallbackOnHostPage, out statusCode, out statusMessage, out content, out headers);
-			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(AppOrigin, uri, ref statusCode, ref content, headers);
+			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(uri, ref statusCode, ref content, headers);
 			return defaultResult || hotReloadedResult;
 		}	
 

--- a/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
@@ -59,8 +59,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			_webview.PostWebMessage(new WebMessage(message), AndroidAppOriginUri);
 		}
 
-		internal bool TryGetResponseContentInternal(string uri, bool allowFallbackOnHostPage, out int statusCode, out string statusMessage, out Stream content, out IDictionary<string, string> headers) =>
-			TryGetResponseContent(uri, allowFallbackOnHostPage, out statusCode, out statusMessage, out content, out headers);
+		internal bool TryGetResponseContentInternal(string uri, bool allowFallbackOnHostPage, out int statusCode, out string statusMessage, out Stream content, out IDictionary<string, string> headers)
+		{
+			var defaultResult = TryGetResponseContent(uri, allowFallbackOnHostPage, out statusCode, out statusMessage, out content, out headers);
+			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(AppOrigin, uri, ref statusCode, ref content, headers);
+			return defaultResult || hotReloadedResult;
+		}	
 
 		internal void SetUpMessageChannel()
 		{

--- a/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Android/AndroidWebKitWebViewManager.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
 		private static readonly AUri AndroidAppOriginUri = AUri.Parse(AppOrigin)!;
 		private readonly AWebView _webview;
+		private readonly string _contentRootRelativeToAppRoot;
 		private WebMessagePort[]? _nativeToJSPorts;
 
 		/// <summary>
@@ -32,8 +33,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="services">A service provider containing services to be used by this class and also by application code.</param>
 		/// <param name="dispatcher">A <see cref="Dispatcher"/> instance that can marshal calls to the required thread or sync context.</param>
 		/// <param name="fileProvider">Provides static content to the webview.</param>
+		/// <param name="contentRootRelativeToAppRoot">Path to the directory containing application content files.</param>
 		/// <param name="hostPageRelativePath">Path to the host page within the <paramref name="fileProvider"/>.</param>
-		public AndroidWebKitWebViewManager(AWebView webview!!, IServiceProvider services, Dispatcher dispatcher, IFileProvider fileProvider, JSComponentConfigurationStore jsComponents, string hostPageRelativePath)
+		public AndroidWebKitWebViewManager(AWebView webview!!, IServiceProvider services, Dispatcher dispatcher, IFileProvider fileProvider, JSComponentConfigurationStore jsComponents, string contentRootRelativeToAppRoot, string hostPageRelativePath)
 			: base(services, dispatcher, new Uri(AppOrigin), fileProvider, jsComponents, hostPageRelativePath)
 		{
 #if WEBVIEW2_MAUI
@@ -45,6 +47,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			}
 #endif
 			_webview = webview;
+			_contentRootRelativeToAppRoot = contentRootRelativeToAppRoot;
 		}
 
 		/// <inheritdoc />
@@ -62,7 +65,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		internal bool TryGetResponseContentInternal(string uri, bool allowFallbackOnHostPage, out int statusCode, out string statusMessage, out Stream content, out IDictionary<string, string> headers)
 		{
 			var defaultResult = TryGetResponseContent(uri, allowFallbackOnHostPage, out statusCode, out statusMessage, out content, out headers);
-			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(uri, ref statusCode, ref content, headers);
+			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(_contentRootRelativeToAppRoot, uri, ref statusCode, ref content, headers);
 			return defaultResult || hotReloadedResult;
 		}	
 

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				contentRootDir,
 				hostPageRelativePath);
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebKitWebViewClient.AppOrigin);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			VirtualView.BlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -97,6 +97,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				new MauiDispatcher(Services!.GetRequiredService<IDispatcher>()),
 				fileProvider,
 				VirtualView.JSComponents,
+				contentRootDir,
 				hostPageRelativePath);
 
 			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebKitWebViewClient.AppOrigin);

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -99,6 +99,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
+			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+
 			VirtualView.BlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs
 			{

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebKitWebViewClient.AppOrigin);
 
 			VirtualView.BlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs

--- a/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebViewHandler.Android.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
-			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			VirtualView.BlazorWebViewInitializing(new BlazorWebViewInitializingEventArgs());
 			VirtualView.BlazorWebViewInitialized(new BlazorWebViewInitializedEventArgs

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		// Using an IP address means that WebView doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since
 		// we intercept all the requests within this origin.
-		internal static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
+		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
 
 		private static readonly Uri AppOriginUri = new(AppOrigin);
 

--- a/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/WebKitWebViewClient.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		// Using an IP address means that WebView doesn't wait for any DNS resolution,
 		// making it substantially faster. Note that this isn't real HTTP traffic, since
 		// we intercept all the requests within this origin.
-		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
+		internal static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
 
 		private static readonly Uri AppOriginUri = new(AppOrigin);
 

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				contentRootDir,
 				this);
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				contentRootDir,
 				this);
 
-			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -69,8 +69,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				new MauiDispatcher(Services!.GetRequiredService<IDispatcher>()),
 				fileProvider,
 				VirtualView.JSComponents,
-				hostPageRelativePath,
 				contentRootDir,
+				hostPageRelativePath,
 				this);
 
 			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin);

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -73,6 +73,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				contentRootDir,
 				this);
 
+			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+
 			if (RootComponents != null)
 			{
 				foreach (var rootComponent in RootComponents)

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebViewHandler.Windows.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				hostPageRelativePath,
 				this);
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			_hostPageRelativePath = hostPagePathWithinFileProvider;
 			_contentRootRelativeToAppRoot = contentRootRelativeToAppRoot;
 		}
-		
+
 		/// <inheritdoc />
 		protected override async Task HandleWebResourceRequest(CoreWebView2WebResourceRequestedEventArgs eventArgs)
 		{

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				}
 				
 				var hotReloadedContent = Stream.Null;
-				if (StaticContentHotReloadManager.TryReplaceResponseContent(AppOrigin, requestUri, ref statusCode, ref hotReloadedContent, headers))
+				if (StaticContentHotReloadManager.TryReplaceResponseContent(requestUri, ref statusCode, ref hotReloadedContent, headers))
 				{
 					stream = new InMemoryRandomAccessStream();
 					var memStream = new MemoryStream();

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				contentRootDir,
 				hostPageRelativePath);
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, AppOrigin);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, AppOrigin);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
-			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			if (RootComponents != null)
 			{

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -136,6 +136,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				VirtualView.JSComponents,
 				hostPageRelativePath);
 
+			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+
 			if (RootComponents != null)
 			{
 				foreach (var rootComponent in RootComponents)

--- a/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
+++ b/src/BlazorWebView/src/Maui/iOS/BlazorWebViewHandler.iOS.cs
@@ -134,6 +134,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 				new MauiDispatcher(Services!.GetRequiredService<IDispatcher>()),
 				fileProvider,
 				VirtualView.JSComponents,
+				contentRootDir,
 				hostPageRelativePath);
 
 			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, AppOrigin);

--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// </summary>
 	internal class IOSWebViewManager : WebViewManager
 	{
+		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
 		private readonly BlazorWebViewHandler _blazorMauiWebViewHandler;
 		private readonly WKWebView _webview;
 
@@ -55,8 +56,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			_webview.LoadRequest(request);
 		}
 
-		internal bool TryGetResponseContentInternal(string uri, bool allowFallbackOnHostPage, out int statusCode, out string statusMessage, out Stream content, out IDictionary<string, string> headers) =>
-			TryGetResponseContent(uri, allowFallbackOnHostPage, out statusCode, out statusMessage, out content, out headers);
+		internal bool TryGetResponseContentInternal(string uri, bool allowFallbackOnHostPage, out int statusCode, out string statusMessage, out Stream content, out IDictionary<string, string> headers)
+		{
+			var defaultResult = TryGetResponseContent(uri, allowFallbackOnHostPage, out statusCode, out statusMessage, out content, out headers);
+			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(AppOrigin, uri, ref statusCode, ref content, headers);
+			return defaultResult || hotReloadedResult;
+		}
 
 		/// <inheritdoc />
 		protected override void SendMessage(string message)

--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// </summary>
 	internal class IOSWebViewManager : WebViewManager
 	{
-		private static readonly string AppOrigin = $"https://{BlazorWebView.AppHostAddress}/";
 		private readonly BlazorWebViewHandler _blazorMauiWebViewHandler;
 		private readonly WKWebView _webview;
 
@@ -59,7 +58,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		internal bool TryGetResponseContentInternal(string uri, bool allowFallbackOnHostPage, out int statusCode, out string statusMessage, out Stream content, out IDictionary<string, string> headers)
 		{
 			var defaultResult = TryGetResponseContent(uri, allowFallbackOnHostPage, out statusCode, out statusMessage, out content, out headers);
-			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(AppOrigin, uri, ref statusCode, ref content, headers);
+			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(uri, ref statusCode, ref content, headers);
 			return defaultResult || hotReloadedResult;
 		}
 

--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	{
 		private readonly BlazorWebViewHandler _blazorMauiWebViewHandler;
 		private readonly WKWebView _webview;
+		private readonly string _contentRootRelativeToAppRoot;
 
 		/// <summary>
 		/// Initializes a new instance of <see cref="IOSWebViewManager"/>
@@ -30,8 +31,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="dispatcher">A <see cref="Dispatcher"/> instance instance that can marshal calls to the required thread or sync context.</param>
 		/// <param name="fileProvider">Provides static content to the webview.</param>
 		/// <param name="jsComponents">Describes configuration for adding, removing, and updating root components from JavaScript code.</param>
+		/// <param name="contentRootRelativeToAppRoot">Path to the directory containing application content files.</param>
 		/// <param name="hostPageRelativePath">Path to the host page within the fileProvider.</param>
-		public IOSWebViewManager(BlazorWebViewHandler blazorMauiWebViewHandler!!, WKWebView webview!!, IServiceProvider provider, Dispatcher dispatcher, IFileProvider fileProvider, JSComponentConfigurationStore jsComponents, string hostPageRelativePath)
+		public IOSWebViewManager(BlazorWebViewHandler blazorMauiWebViewHandler!!, WKWebView webview!!, IServiceProvider provider, Dispatcher dispatcher, IFileProvider fileProvider, JSComponentConfigurationStore jsComponents, string contentRootRelativeToAppRoot, string hostPageRelativePath)
 			: base(provider, dispatcher, new Uri(BlazorWebViewHandler.AppOrigin), fileProvider, jsComponents, hostPageRelativePath)
 		{
 			if (provider.GetService<MauiBlazorMarkerService>() is null)
@@ -43,6 +45,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			_blazorMauiWebViewHandler = blazorMauiWebViewHandler;
 			_webview = webview;
+			_contentRootRelativeToAppRoot = contentRootRelativeToAppRoot;
 
 			InitializeWebView();
 		}
@@ -58,7 +61,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		internal bool TryGetResponseContentInternal(string uri, bool allowFallbackOnHostPage, out int statusCode, out string statusMessage, out Stream content, out IDictionary<string, string> headers)
 		{
 			var defaultResult = TryGetResponseContent(uri, allowFallbackOnHostPage, out statusCode, out statusMessage, out content, out headers);
-			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(uri, ref statusCode, ref content, headers);
+			var hotReloadedResult = StaticContentHotReloadManager.TryReplaceResponseContent(_contentRootRelativeToAppRoot, uri, ref statusCode, ref content, headers);
 			return defaultResult || hotReloadedResult;
 		}
 

--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -20,14 +20,9 @@ namespace Microsoft.AspNetCore.Components.WebView
 		private readonly static Regex ContentUrlRegex = new Regex("^_content/(?<AssemblyName>[^/]+)/(?<RelativePath>.*)");
 		private static event ContentUpdatedHandler? OnContentUpdated;
 
-		private static string ApplicationAssemblyName { get; } =
-#if MAUI
-			Application.Context.PackageName;
-#else
-			Assembly.GetEntryAssembly()!.GetName().Name!;
-#endif
+		private static string? ApplicationAssemblyName { get; } = Assembly.GetEntryAssembly()?.GetName().Name;
 
-		private static readonly Dictionary<(string AssemblyName, string RelativePath), (string? ContentType, byte[] Content)> _updatedContent = new()
+		private static readonly Dictionary<(string? AssemblyName, string RelativePath), (string? ContentType, byte[] Content)> _updatedContent = new()
 		{
 			{ (ApplicationAssemblyName, "_framework/static-content-hot-reload.js"), ("text/javascript", Encoding.UTF8.GetBytes(@"
 	export function notifyCssUpdated() {
@@ -43,6 +38,18 @@ namespace Microsoft.AspNetCore.Components.WebView
 		public static void UpdateContent(string assemblyName, string relativePath, byte[] content)
 		{
 			_updatedContent[(assemblyName, relativePath)] = (ContentType: null, Content: content);
+
+			// On some platforms (Android), the information about the application assembly name is lost
+			// at compile-time. As a workaround, we treat the app assembly name as null, and treat all
+			// hot reloaded files as being in both an RCL and the app assembly. This works fine if the
+			// names don't clash, but means that RCL files can override an app file if the name does clash.
+			// TODO: Either have the tooling tell us whether this is the main application project, or
+			//       have MAUI somehow retain the information about application assembly name to runtime.
+			if (ApplicationAssemblyName is null)
+			{
+				_updatedContent[(null, relativePath)] = (ContentType: null, Content: content);
+			}
+
 			OnContentUpdated?.Invoke(assemblyName, relativePath);
 		}
 
@@ -75,7 +82,7 @@ namespace Microsoft.AspNetCore.Components.WebView
 			return false;
 		}
 		
-		private static (string AssemblyName, string RelativePath) GetAssemblyNameAndRelativePath(string requestAbsoluteUri, string appContentRoot)
+		private static (string? AssemblyName, string RelativePath) GetAssemblyNameAndRelativePath(string requestAbsoluteUri, string appContentRoot)
 		{
 			var requestPath = new Uri(requestAbsoluteUri).AbsolutePath.Substring(1);
 			if (ContentUrlRegex.Match(requestPath) is { Success: true } match)

--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -1,26 +1,43 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
 [assembly: MetadataUpdateHandler(typeof(Microsoft.AspNetCore.Components.WebView.StaticContentHotReloadManager))]
 
 namespace Microsoft.AspNetCore.Components.WebView
 {
-	internal sealed class StaticContentHotReloadManager
+	internal static class StaticContentHotReloadManager
 	{
-		public static readonly StaticContentHotReloadManager Default = new();
+		private delegate void ContentUpdatedHandler(string url);
+		private static event ContentUpdatedHandler? OnContentUpdated;
 
-		private delegate void ContentUpdateHandler(string assemblyName, string relativePath, byte[] contents);
-		private event ContentUpdateHandler? OnContentUpdate;
+		private static readonly Dictionary<string, (string? ContentType, byte[] Content)> _updatedContent = new(StringComparer.Ordinal)
+		{
+			{ "_framework/static-content-hot-reload.js", (ContentType: "text/javascript", Content: Encoding.UTF8.GetBytes(@"
+	export function notifyContentUpdated(url) {
+		console.log('IN notifyContentUpdated');
+		console.log(url);
+	}
+")) },
+		};
 
 		/// <summary>
 		/// MetadataUpdateHandler event. This is invoked by the hot reload host via reflection.
 		/// </summary>
-		public static void UpdateContent(string assemblyName, string relativePath, byte[] contents)
-			=> Default.OnContentUpdate?.Invoke(assemblyName, relativePath, contents);
+		public static void UpdateContent(string assemblyName, string relativePath, byte[] content)
+		{
+			var url = GetUrlForStaticContent(assemblyName, relativePath);
+			_updatedContent[url] = (ContentType: null, Content: content);
+			OnContentUpdated?.Invoke(url);
+		}
 
-		public void AttachToWebViewManagerIfEnabled(WebViewManager manager)
+		public static void AttachToWebViewManagerIfEnabled(WebViewManager manager)
 		{
 			if (MetadataUpdater.IsSupported)
 			{
@@ -28,27 +45,101 @@ namespace Microsoft.AspNetCore.Components.WebView
 			}
 		}
 
+		public static bool TryReplaceResponseContent(string appOrigin, string requestUri, ref int responseStatusCode, ref Stream responseContent, IDictionary<string, string> responseHeaders)
+		{
+			if (!MetadataUpdater.IsSupported
+				|| !(new Uri(requestUri) is Uri requestUriParsed)
+				|| !(new Uri(appOrigin) is Uri appOriginUri)
+				|| !appOriginUri.IsBaseOf(requestUriParsed))
+			{
+				return false;
+			}
+
+			var relativeUri = appOriginUri.MakeRelativeUri(requestUriParsed).ToString();
+			if (_updatedContent.TryGetValue(relativeUri, out var values))
+			{
+				responseStatusCode = 200;
+				responseContent = new MemoryStream(values.Content);
+				if (!string.IsNullOrEmpty(values.ContentType))
+				{
+					responseHeaders["Content-Type"] = values.ContentType;
+				}
+
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+		
+		private static string GetUrlForStaticContent(string assemblyName, string relativePath)
+		{
+			// This logic might not cover every circumstance if the developer customizes the host page path
+			// or is doing something custom with static web assets. However it should cover any mainstream
+			// case with single projects and RCLs. We may have to allow for other cases in the future, or
+			// may have to receive different information from tooling.
+
+			// Since scoped CSS bundles might not have a wwwroot prefix, normalize by removing it.
+			// Whether this is really needed depends on tooling implementations that are not yet known.
+			const string wwwrootPrefix = "wwwroot/";
+			if (relativePath.StartsWith(wwwrootPrefix, StringComparison.Ordinal))
+			{
+				relativePath = relativePath.Substring(wwwrootPrefix.Length);
+			}
+
+			if (relativePath.StartsWith("/"))
+			{
+				relativePath = relativePath.Substring(1);
+			}
+
+			// SWA convention for RCLs
+			if (!string.Equals(assemblyName, Assembly.GetEntryAssembly()!.GetName().Name, StringComparison.Ordinal))
+			{
+				relativePath = $"_content/{assemblyName}/{relativePath}";
+			}
+
+			return relativePath;
+		}
+
 		// To provide a consistent way of transporting the data across all platforms,
 		// we can use the existing IJSRuntime. In turn we can get an instance of this
 		// that's always attached to the currently-loaded page (if it's a Blazor page)
 		// by injecting this headless root component.
-		private class StaticContentUpdater : IComponent, IDisposable
+		private sealed class StaticContentUpdater : IComponent, IDisposable
 		{
 			[Inject] private IJSRuntime JSRuntime { get; set; } = default!;
+			[Inject] private ILoggerFactory LoggerFactory { get; set; } = default!;
+			private ILogger _logger = default!;
 
 			public void Attach(RenderHandle renderHandle)
 			{
-				Default.OnContentUpdate += HandleContentUpdate;
+				_logger = LoggerFactory.CreateLogger<StaticContentUpdater>();
+				OnContentUpdated += NotifyContentUpdated;
 			}
 
 			public void Dispose()
 			{
-				Default.OnContentUpdate -= HandleContentUpdate;
+				OnContentUpdated -= NotifyContentUpdated;
 			}
 
-			private void HandleContentUpdate(string assemblyName, string relativePath, byte[] contents)
+			private void NotifyContentUpdated(string url)
 			{
-				throw new NotImplementedException();
+				// It handles its own errors
+				_ = NotifyContentUpdatedAsync(url);
+			}
+
+			private async Task NotifyContentUpdatedAsync(string url)
+			{
+				try
+				{
+					await using var module = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_framework/static-content-hot-reload.js");
+					await module.InvokeVoidAsync("notifyContentUpdated", url);
+				}
+				catch (Exception ex)
+				{
+					_logger.LogError(ex, $"Failed to notify about static content update to {url}.");
+				}
 			}
 
 			public Task SetParametersAsync(ParameterView parameters)

--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection.Metadata;
-using Microsoft.AspNetCore.Components.Rendering;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
 
 [assembly: MetadataUpdateHandler(typeof(Microsoft.AspNetCore.Components.WebView.StaticContentHotReloadManager))]
 
@@ -10,31 +11,48 @@ namespace Microsoft.AspNetCore.Components.WebView
 	{
 		public static readonly StaticContentHotReloadManager Default = new();
 
-		public bool MetadataUpdateSupported => MetadataUpdater.IsSupported;
-
-		public event Action<(string AssemblyName, string RelativePath, byte[] Contents)>? OnContentUpdate;
+		private delegate void ContentUpdateHandler(string assemblyName, string relativePath, byte[] contents);
+		private event ContentUpdateHandler? OnContentUpdate;
 
 		/// <summary>
 		/// MetadataUpdateHandler event. This is invoked by the hot reload host via reflection.
 		/// </summary>
 		public static void UpdateContent(string assemblyName, string relativePath, byte[] contents)
-			=> Default.OnContentUpdate?.Invoke((assemblyName, relativePath, contents));
+			=> Default.OnContentUpdate?.Invoke(assemblyName, relativePath, contents);
 
 		public void AttachToWebViewManagerIfEnabled(WebViewManager manager)
 		{
-			// To provide a consistent way of transporting the data across all platforms,
-			// we can use the existing IJSRuntime. In turn we can get an instance of this
-			// that's always attached to the currently-loaded page (if it's a Blazor page)
-			// by injecting a headless root component.
-			manager.AddRootComponentAsync(typeof(StaticContentUpdater), "body::after", ParameterView.Empty);
+			if (MetadataUpdater.IsSupported)
+			{
+				manager.AddRootComponentAsync(typeof(StaticContentUpdater), "body::after", ParameterView.Empty);
+			}
 		}
 
-		private class StaticContentUpdater : ComponentBase
+		// To provide a consistent way of transporting the data across all platforms,
+		// we can use the existing IJSRuntime. In turn we can get an instance of this
+		// that's always attached to the currently-loaded page (if it's a Blazor page)
+		// by injecting this headless root component.
+		private class StaticContentUpdater : IComponent, IDisposable
 		{
-			protected override void BuildRenderTree(RenderTreeBuilder builder)
+			[Inject] private IJSRuntime JSRuntime { get; set; } = default!;
+
+			public void Attach(RenderHandle renderHandle)
 			{
-				builder.AddContent(0, "HELLO THERE FROM THE INJECTED COMPONENT");
+				Default.OnContentUpdate += HandleContentUpdate;
 			}
+
+			public void Dispose()
+			{
+				Default.OnContentUpdate -= HandleContentUpdate;
+			}
+
+			private void HandleContentUpdate(string assemblyName, string relativePath, byte[] contents)
+			{
+				throw new NotImplementedException();
+			}
+
+			public Task SetParametersAsync(ParameterView parameters)
+				=> Task.CompletedTask;
 		}
 	}
 }

--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reflection.Metadata;
+using Microsoft.AspNetCore.Components.Rendering;
+
+[assembly: MetadataUpdateHandler(typeof(Microsoft.AspNetCore.Components.WebView.StaticContentHotReloadManager))]
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+	internal sealed class StaticContentHotReloadManager
+	{
+		public static readonly StaticContentHotReloadManager Default = new();
+
+		public bool MetadataUpdateSupported => MetadataUpdater.IsSupported;
+
+		public event Action<(string AssemblyName, string RelativePath, byte[] Contents)>? OnContentUpdate;
+
+		/// <summary>
+		/// MetadataUpdateHandler event. This is invoked by the hot reload host via reflection.
+		/// </summary>
+		public static void UpdateContent(string assemblyName, string relativePath, byte[] contents)
+			=> Default.OnContentUpdate?.Invoke((assemblyName, relativePath, contents));
+
+		public void AttachToWebViewManagerIfEnabled(WebViewManager manager)
+		{
+			// To provide a consistent way of transporting the data across all platforms,
+			// we can use the existing IJSRuntime. In turn we can get an instance of this
+			// that's always attached to the currently-loaded page (if it's a Blazor page)
+			// by injecting a headless root component.
+			manager.AddRootComponentAsync(typeof(StaticContentUpdater), "body::after", ParameterView.Empty);
+		}
+
+		private class StaticContentUpdater : ComponentBase
+		{
+			protected override void BuildRenderTree(RenderTreeBuilder builder)
+			{
+				builder.AddContent(0, "HELLO THERE FROM THE INJECTED COMPONENT");
+			}
+		}
+	}
+}

--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -22,9 +22,8 @@ namespace Microsoft.AspNetCore.Components.WebView
 
 		private static readonly string StaticContentHotReloadModuleSource = @"
 	export function notifyContentUpdated(url) {
-		console.log('IN notifyContentUpdated');
-		console.log(url);
-		debugger;
+		const tagsToUpdate = Array.from(document.querySelectorAll('link[rel=stylesheet]')).filter(x => x.href === url);
+		tagsToUpdate.forEach(tag => tag.href += '');
 	}
 ";
 

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		/// <summary>
 		/// Gets the application's base URI. Defaults to <c>https://0.0.0.0/</c>
 		/// </summary>
-		protected static readonly string AppOrigin = $"https://{AppHostAddress}/";
+		protected internal static readonly string AppOrigin = $"https://{AppHostAddress}/";
 
 		private static readonly Uri AppOriginUri = new(AppOrigin);
 
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 			if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers))
 			{
-				StaticContentHotReloadManager.TryReplaceResponseContent(AppOrigin, requestUri, ref statusCode, ref content, headers);
+				StaticContentHotReloadManager.TryReplaceResponseContent(requestUri, ref statusCode, ref content, headers);
 
 				var headerString = GetHeaderString(headers);
 				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content, statusCode, statusMessage, headerString);

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		/// <summary>
 		/// Gets the application's base URI. Defaults to <c>https://0.0.0.0/</c>
 		/// </summary>
-		protected internal static readonly string AppOrigin = $"https://{AppHostAddress}/";
+		protected static readonly string AppOrigin = $"https://{AppHostAddress}/";
 
 		private static readonly Uri AppOriginUri = new(AppOrigin);
 

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -63,6 +63,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 		private readonly WebView2Control _webview;
 		private readonly Task _webviewReadyTask;
+		private readonly string _contentRootRelativeToAppRoot;
 
 #if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
 		private protected CoreWebView2Environment? _coreWebView2Environment;
@@ -79,7 +80,8 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		/// <param name="dispatcher">A <see cref="Dispatcher"/> instance that can marshal calls to the required thread or sync context.</param>
 		/// <param name="fileProvider">Provides static content to the webview.</param>
 		/// <param name="jsComponents">Describes configuration for adding, removing, and updating root components from JavaScript code.</param>
-		/// <param name="hostPageRelativePath">Path to the host page within the <paramref name="fileProvider"/>.</param>
+		/// <param name="contentRootRelativeToAppRoot">Path to the app's content root relative to the application root directory.</param>
+		/// <param name="hostPagePathWithinFileProvider">Path to the host page within the <paramref name="fileProvider"/>.</param>
 		/// <param name="urlLoading">Callback invoked when a url is about to load.</param>
 		/// <param name="blazorWebViewInitializing">Callback invoked before the webview is initialized.</param>
 		/// <param name="blazorWebViewInitialized">Callback invoked after the webview is initialized.</param>
@@ -89,11 +91,12 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			Dispatcher dispatcher,
 			IFileProvider fileProvider,
 			JSComponentConfigurationStore jsComponents,
-			string hostPageRelativePath,
+			string contentRootRelativeToAppRoot,
+			string hostPagePathWithinFileProvider,
 			Action<UrlLoadingEventArgs> urlLoading,
 			Action<BlazorWebViewInitializingEventArgs> blazorWebViewInitializing,
 			Action<BlazorWebViewInitializedEventArgs> blazorWebViewInitialized)
-			: base(services, dispatcher, AppOriginUri, fileProvider, jsComponents, hostPageRelativePath)
+			: base(services, dispatcher, AppOriginUri, fileProvider, jsComponents, hostPagePathWithinFileProvider)
 
 		{
 #if WEBVIEW2_WINFORMS
@@ -117,6 +120,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			_blazorWebViewInitializing = blazorWebViewInitializing;
 			_blazorWebViewInitialized = blazorWebViewInitialized;
 			_developerTools = services.GetRequiredService<BlazorWebViewDeveloperTools>();
+			_contentRootRelativeToAppRoot = contentRootRelativeToAppRoot;
 
 			// Unfortunately the CoreWebView2 can only be instantiated asynchronously.
 			// We want the external API to behave as if initalization is synchronous,
@@ -135,7 +139,8 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		/// <param name="dispatcher">A <see cref="Dispatcher"/> instance that can marshal calls to the required thread or sync context.</param>
 		/// <param name="fileProvider">Provides static content to the webview.</param>
 		/// <param name="jsComponents">Describes configuration for adding, removing, and updating root components from JavaScript code.</param>
-		/// <param name="hostPageRelativePath">Path to the host page within the <paramref name="fileProvider"/>.</param>
+		/// <param name="contentRootRelativeToAppRoot">Path to the app's content root relative to the application root directory.</param>
+		/// <param name="hostPagePathWithinFileProvider">Path to the host page within the <paramref name="fileProvider"/>.</param>
 		/// <param name="blazorWebViewHandler">The <see cref="BlazorWebViewHandler" />.</param>
 		internal WebView2WebViewManager(
 			WebView2Control webview!!,
@@ -143,10 +148,11 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			Dispatcher dispatcher,
 			IFileProvider fileProvider,
 			JSComponentConfigurationStore jsComponents,
-			string hostPageRelativePath,
+			string contentRootRelativeToAppRoot,
+			string hostPagePathWithinFileProvider,
 			BlazorWebViewHandler blazorWebViewHandler
 		)
-			: base(services, dispatcher, new Uri(AppOrigin), fileProvider, jsComponents, hostPageRelativePath)
+			: base(services, dispatcher, new Uri(AppOrigin), fileProvider, jsComponents, hostPagePathWithinFileProvider)
 		{
 			if (services.GetService<MauiBlazorMarkerService>() is null)
 			{
@@ -157,6 +163,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 			_webview = webview;
 			_blazorWebViewHandler = blazorWebViewHandler;
+			_contentRootRelativeToAppRoot = contentRootRelativeToAppRoot;
 
 			// Unfortunately the CoreWebView2 can only be instantiated asynchronously.
 			// We want the external API to behave as if initalization is synchronous,
@@ -271,7 +278,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 			if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers))
 			{
-				StaticContentHotReloadManager.TryReplaceResponseContent(requestUri, ref statusCode, ref content, headers);
+				StaticContentHotReloadManager.TryReplaceResponseContent(_contentRootRelativeToAppRoot, requestUri, ref statusCode, ref content, headers);
 
 				var headerString = GetHeaderString(headers);
 				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content, statusCode, statusMessage, headerString);

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -271,8 +271,9 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 			if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers))
 			{
-				var headerString = GetHeaderString(headers);
+				StaticContentHotReloadManager.TryReplaceResponseContent(AppOrigin, requestUri, ref statusCode, ref content, headers);
 
+				var headerString = GetHeaderString(headers);
 				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content, statusCode, statusMessage, headerString);
 			}
 #elif WEBVIEW2_MAUI

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
-			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -184,6 +184,8 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
+			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+
 			foreach (var rootComponent in RootComponents)
 			{
 				// Since the page isn't loaded yet, this will always complete synchronously

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin, contentRootRelativePath);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -169,6 +169,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			}
 			var hostPageFullPath = Path.GetFullPath(Path.Combine(appRootDir, HostPage!)); // HostPage is nonnull because RequiredStartupPropertiesSet is checked above
 			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath)!;
+			var contentRootRelativePath = Path.GetRelativePath(appRootDir, contentRootDirFullPath);
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDirFullPath, hostPageFullPath);
 
 			var fileProvider = CreateFileProvider(contentRootDirFullPath);
@@ -179,12 +180,13 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				ComponentsDispatcher,
 				fileProvider,
 				RootComponents.JSComponents,
+				contentRootRelativePath,
 				hostPageRelativePath,
 				(args) => UrlLoading?.Invoke(this, args),
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin, contentRootRelativePath);
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin);
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -234,7 +234,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin);
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -234,7 +234,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
-			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -234,6 +234,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
+			StaticContentHotReloadManager.Default.AttachToWebViewManagerIfEnabled(_webviewManager);
+
 			foreach (var rootComponent in RootComponents)
 			{
 				// Since the page isn't loaded yet, this will always complete synchronously

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -220,6 +220,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 			var hostPageFullPath = Path.GetFullPath(Path.Combine(appRootDir, HostPage));
 			var contentRootDirFullPath = Path.GetDirectoryName(hostPageFullPath)!;
 			var hostPageRelativePath = Path.GetRelativePath(contentRootDirFullPath, hostPageFullPath);
+			var contentRootDirRelativePath = Path.GetRelativePath(appRootDir, contentRootDirFullPath);
 
 			var fileProvider = CreateFileProvider(contentRootDirFullPath);
 
@@ -229,12 +230,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				ComponentsDispatcher,
 				fileProvider,
 				RootComponents.JSComponents,
+				contentRootDirRelativePath,
 				hostPageRelativePath,
 				(args) => UrlLoading?.Invoke(this, args),
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin, contentRootDirRelativePath);
 
 			foreach (var rootComponent in RootComponents)
 			{

--- a/src/BlazorWebView/src/Wpf/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Wpf/BlazorWebView.cs
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
 				(args) => BlazorWebViewInitializing?.Invoke(this, args),
 				(args) => BlazorWebViewInitialized?.Invoke(this, args));
 
-			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager, WebView2WebViewManager.AppOrigin, contentRootDirRelativePath);
+			StaticContentHotReloadManager.AttachToWebViewManagerIfEnabled(_webviewManager);
 
 			foreach (var rootComponent in RootComponents)
 			{


### PR DESCRIPTION
A `MetadataUpdateHandler` that receives calls to `UpdateContent` and, if it's a CSS file, changes the corresponding content in all current and future `BlazorWebView` browser instances, and retains this change even if the page is reloaded.

This is complicated by two main things:

1. We have multiple levels of overriding how static content is obtained. This also varies by platform. Since we need the hot-reloaded content to take priority over any other platform-specific content provision logic, I had to hook into each platform-specific `*WebViewManager`'s request handler and make it check for hot-reloaded content before going through the normal chain of file providers.
2. The tooling works in terms of project names and relative file paths, not in terms of URLs. The mapping from `(project,path)` to `url` is also a function of whether or not `project` is an RCL and if not, what is the content root for each webview. Performing this mapping therefore requires threading through more information about content roots and some level of hardcoding conventions (e.g., for RCLs, we assume the URLs are of the form `_content/RCL/path` and the content root within the RCL project is always `wwwroot`).
    * It might be possible to improve this further by knowing about the SWA manifest at runtime, but AFAIK the current implementation will cover current requirements, and I'm trying not to mess with the layering even more. We can revisit this in the future if needed.

To limit the complexity, I had the JS-side logic simply refresh *all* stylesheets whenever we hear that any of them has changed. Technically we could limit it to only the one that has changed, but this involves passing through a bunch more info and doing more (project,path)/URL conversions in the opposite direction, which introduces further risk of this not working in some situation where things are customized. I did implement that logic (see the commit 58655844d723 where I undid it) but wasn't happy about the level of sophistication this caused. Again, we could change the decision in the future if needed.