### PR TITLE
Swap out virtual view when navigating to new Shell Item

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ShellSection.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ShellSection.Impl.cs
@@ -11,15 +11,20 @@ namespace Microsoft.Maui.Controls
 		// This code only runs for shell bits that are running through a proper
 		// ShellHandler
 		TaskCompletionSource<object>? _handlerBasedNavigationCompletionSource;
+		internal Task? PendingNavigationTask => _handlerBasedNavigationCompletionSource?.Task;
 
 		void IStackNavigation.RequestNavigation(NavigationRequest eventArgs)
 		{
+			if (_handlerBasedNavigationCompletionSource != null)
+				throw new InvalidOperationException("Pending Navigations still processing");
+
 			_handlerBasedNavigationCompletionSource = new TaskCompletionSource<object>();
 			Handler.Invoke(nameof(IStackNavigation.RequestNavigation), eventArgs);
 		}
 
 		void IStackNavigation.NavigationFinished(IReadOnlyList<IView> newStack)
 		{
+			_ = _handlerBasedNavigationCompletionSource ?? throw new InvalidOperationException("Mismatched Navigation finished");
 			var source = _handlerBasedNavigationCompletionSource;
 			_handlerBasedNavigationCompletionSource = null;
 			source?.SetResult(true);

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -44,9 +44,23 @@ namespace Microsoft.Maui.Controls.Handlers
 		ShellSection? _shellSection;
 		public override void SetVirtualView(Maui.IElement view)
 		{
-			if(_shellSection != null)
+			if (_shellSection != null)
 			{
 				((IShellSectionController)_shellSection).NavigationRequested -= OnNavigationRequested;
+			}
+
+			// If we've already connected to the navigation manager
+			// then we need to make sure to disconnect and connect up to 
+			// the new incoming virtual view
+			if (_navigationManager?.NavigationView != null &&
+				_navigationManager.NavigationView != view)
+			{
+				_navigationManager.Disconnect(_navigationManager.NavigationView, PlatformView);
+
+				if (view is IStackNavigation stackNavigation)
+				{
+					_navigationManager.Connect(stackNavigation, PlatformView);
+				}
 			}
 
 			base.SetVirtualView(view);

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Maui.Controls
 				shellSection.PropertyChanged += OnShellItemPropertyChanged;
 			else
 			{
-				var state = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, null, null);
+				var state = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, shellSection.Navigation.NavigationStack, null);
 
 				if (this.CurrentItem == null)
 				{

--- a/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellNavigatingTests.cs
@@ -913,6 +913,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsTrue(shell.CurrentPage is ContentPage);
 		}
 
+		[Test]
+		public async Task NavigatedFiresAfterSwitchingFlyoutItemsBothWithPushedPages()
+		{
+			var shellContent1 = new ShellContent() { Content = new ContentPage() };
+			var shellContent2 = new ShellContent() { Content = new ContentPage() };
+
+			var shell = new TestShell(shellContent1, shellContent2);
+			IShellController shellController = shell;
+			await shell.Navigation.PushAsync(new ContentPage());
+			await shellController.OnFlyoutItemSelectedAsync(shellContent2);
+			await shell.Navigation.PushAsync(new ContentPage());
+			await shellController.OnFlyoutItemSelectedAsync(shellContent1);
+
+			Assert.AreEqual(2, shell.Items[0].Items[0].Navigation.NavigationStack.Count);
+			Assert.AreEqual(2, shell.Items[1].Items[0].Navigation.NavigationStack.Count);
+		}
+
 		public class NavigationMonitoringTab : Tab
 		{
 			public List<string> NavigationsFired = new List<string>();

--- a/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Button/ButtonTests.Windows.cs
@@ -18,6 +18,6 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		TextTrimming GetPlatformLineBreakMode(ButtonHandler buttonHandler) =>
-			(GetPlatformButton(buttonHandler).Content as TextBlock)!.TextTrimming;
+			(GetPlatformButton(buttonHandler).Content as FrameworkElement)!.GetFirstDescendant<TextBlock>()!.TextTrimming;
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -151,6 +151,41 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Navigation Routes Correctly After Switching Flyout Items")]
+		public async Task NavigatedFiresAfterSwitchingFlyoutItems()
+		{
+			SetupBuilder();
+
+			var shellContent1 = new ShellContent() { Content = new ContentPage() };
+			var shellContent2 = new ShellContent() { Content = new ContentPage() };
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(shellContent1);
+				shell.Items.Add(shellContent2);
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				IShellController shellController = shell;
+				var currentItem = shell.CurrentItem;
+				Assert.NotNull(currentItem.Handler);
+
+				await shellController.OnFlyoutItemSelectedAsync(shellContent2);
+				await shell.Navigation.PushAsync(new ContentPage());
+				await shell.GoToAsync("..");
+
+#if WINDOWS
+				Assert.NotNull(shell.Handler);
+				Assert.NotNull(shell.CurrentItem.Handler);
+				Assert.NotNull(shell.CurrentItem.CurrentItem.Handler);
+				Assert.Null(currentItem.Handler);
+				Assert.Null(currentItem.CurrentItem.Handler);
+#endif
+
+			});
+		}
+
 		[Theory]
 		[ClassData(typeof(ShellBasicNavigationTestCases))]
 		public async Task BasicShellNavigationStructurePermutations(ShellItem[] shellItems)

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -169,7 +169,10 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				IShellController shellController = shell;
 				var currentItem = shell.CurrentItem;
+				// For now on iOS/Android we're just making sure nothing crashes
+#if WINDOWS
 				Assert.NotNull(currentItem.Handler);
+#endif
 
 				await shellController.OnFlyoutItemSelectedAsync(shellContent2);
 				await shell.Navigation.PushAsync(new ContentPage());

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Maui.DeviceTests
 			var handler = element.Handler;
 			var rootManager = handler.MauiContext.GetNavigationRootManager();
 			var position = element.GetLocationRelativeTo(rootManager.AppTitleBar);
-			var distance = rootManager.AppTitleBar.Height - position.Value.Y;
+			var distance = rootManager.AppTitleBar.ActualHeight - position.Value.Y;
 			return distance;
 		}
 

--- a/src/Core/src/Platform/Windows/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Windows/StackNavigationManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Platform
 		IMauiContext _mauiContext;
 		Frame? _navigationFrame;
 		protected NavigationRootManager WindowManager => _mauiContext.GetNavigationRootManager();
-		private protected IStackNavigation? NavigationView { get; private set; }
+		internal IStackNavigation? NavigationView { get; private set; }
 		public IReadOnlyList<IView> NavigationStack { get; set; } = new List<IView>();
 		public IMauiContext MauiContext => _mauiContext;
 		public IView CurrentPage


### PR DESCRIPTION
### Description of Change

When navigating to a new `FlyoutItem` the shell handlers weren't properly setting up the new active `ShellSection`. So NavigationRequests were being routed to the wrong `VirtualView`

Check/complete any pending navigations before processing through `GotoAsync`

### Issues Fixed

Fixes #5714
Fixes #5965