### PR TITLE
Remove Build Tasks that are now implicitly included

### DIFF
--- a/src/Workload/Shared/FrameworkList.targets
+++ b/src/Workload/Shared/FrameworkList.targets
@@ -3,8 +3,6 @@
   <ItemGroup>
     <_FrameworkListFile Condition=" !$(MSBuildProjectName.Contains('.Runtime')) " Include="$(IntermediateOutputPath)FrameworkList.xml" />
     <_FrameworkListFile Condition=" !$(MSBuildProjectName.Contains('.Ref')) " Include="$(IntermediateOutputPath)RuntimeList.xml" />
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging"  Version="6.0.0-beta.21169.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.21169.1" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="6.0.0-beta.21065.3" />


### PR DESCRIPTION
### Description of Change
These packages seem to now be implicitly included so are getting a "double packagereference" exception

`
1>C:\Program Files\dotnet\sdk\6.0.300-preview.22204.3\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.Shared.targets(152,5): warning NETSDK1023: A PackageReference for 'Microsoft.DotNet.Build.Tasks.Packaging' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs
`

### Issues Fixed

`dotnet cake --configuration=Release`
