### PR TITLE
Use known row/column width/height when doing initial measure

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
-    <MauiSplashScreen Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" BaseSize="168,208" />
+    <MauiImage Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" BaseSize="168,208" />
   </ItemGroup>
 
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />

--- a/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appicon_foreground.svg" IsAppIcon="true" />
     <MauiImage Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" BaseSize="168,208" />
+    <MauiSplashScreen Include="Resources\Images\dotnet_bot.svg" Color="#FFFFFF" BaseSize="168,208" />
   </ItemGroup>
 
   <Import Project="$(MauiSrcDirectory)Maui.InTree.props" Condition=" '$(UseMaui)' != 'true' " />

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -560,44 +560,87 @@ namespace Microsoft.Maui.Layouts
 						width += _columns[n].Size;
 					}
 
+					if (width == 0 || height == 0)
+					{
+						continue;
+					}
+
 					_childrenToLayOut[cell.ViewIndex].Measure(width, height);
 				}
 			}
 
 			double AvailableWidth(Cell cell)
 			{
-				var alreadyUsed = GridWidth();
-				var available = _gridWidthConstraint - alreadyUsed;
-
 				// Because our cell may overlap columns that are already measured (and counted in GridWidth()),
 				// we'll need to add the size of those columns back into our available space
 				double cellColumnsWidth = 0;
 
+				// So we'll have to tally up the known widths of those rows. While we do that, we'll
+				// keep track of whether all the columns spanned by this cell are absolute widths
+				bool absolute = true;
+
 				for (int c = cell.Column; c < cell.Column + cell.ColumnSpan; c++)
 				{
 					cellColumnsWidth += _columns[c].Size;
+
+					if (!_columns[c].IsAbsolute)
+					{
+						absolute = false;
+					}
 				}
 
 				cellColumnsWidth += (cell.ColumnSpan - 1) * _columnSpacing;
+
+				if (absolute)
+				{
+					// If all the spanned columns were absolute, then we know the exact available width for 
+					// the view that's in this cell
+					return cellColumnsWidth;
+				}
+
+				// Since some of the columns weren't already specified, we'll need to work out what's left
+				// of the Grid's width for this cell
+
+				var alreadyUsed = GridWidth();
+				var available = _gridWidthConstraint - alreadyUsed;
 
 				return available + cellColumnsWidth;
 			}
 
 			double AvailableHeight(Cell cell)
 			{
-				var alreadyUsed = GridHeight();
-				var available = _gridHeightConstraint - alreadyUsed;
-
 				// Because our cell may overlap rows that are already measured (and counted in GridHeight()),
 				// we'll need to add the size of those rows back into our available space
 				double cellRowsHeight = 0;
 
+				// So we'll have to tally up the known heights of those rows. While we do that, we'll
+				// keep track of whether all the rows spanned by this cell are absolute heights
+				bool absolute = true;
+
 				for (int c = cell.Row; c < cell.Row + cell.RowSpan; c++)
 				{
 					cellRowsHeight += _rows[c].Size;
+
+					if (!_rows[c].IsAbsolute)
+					{
+						absolute = false;
+					}
 				}
 
 				cellRowsHeight += (cell.RowSpan - 1) * _rowSpacing;
+
+				if (absolute)
+				{
+					// If all the spanned rows were absolute, then we know the exact available height for 
+					// the view that's in this cell
+					return cellRowsHeight;
+				}
+
+				// Since some of the rows weren't already specified, we'll need to work out what's left
+				// of the Grid's height for this cell
+
+				var alreadyUsed = GridHeight();
+				var available = _gridHeightConstraint - alreadyUsed;
 
 				return available + cellRowsHeight;
 			}
@@ -716,6 +759,7 @@ namespace Microsoft.Maui.Layouts
 
 			public abstract bool IsAuto { get; }
 			public abstract bool IsStar { get; }
+			public abstract bool IsAbsolute { get; }
 
 			public abstract GridLength GridLength { get; }
 		}
@@ -726,6 +770,7 @@ namespace Microsoft.Maui.Layouts
 
 			public override bool IsAuto => ColumnDefinition.Width.IsAuto;
 			public override bool IsStar => ColumnDefinition.Width.IsStar;
+			public override bool IsAbsolute => ColumnDefinition.Width.IsAbsolute;
 			public override GridLength GridLength => ColumnDefinition.Width;
 
 			public Column(IGridColumnDefinition columnDefinition)
@@ -744,6 +789,7 @@ namespace Microsoft.Maui.Layouts
 
 			public override bool IsAuto => RowDefinition.Height.IsAuto;
 			public override bool IsStar => RowDefinition.Height.IsStar;
+			public override bool IsAbsolute => RowDefinition.Height.IsAbsolute;
 			public override GridLength GridLength => RowDefinition.Height;
 
 			public Row(IGridRowDefinition rowDefinition)

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, col: 1);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.NegativeInfinity);
+			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
 
 			// Column width is 100, viewSize is less than that, so it should be able to layout out at full size
 			AssertArranged(view0, 0, 0, 100, 10);
@@ -207,7 +207,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view3, row: 1, col: 1);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.NegativeInfinity);
+			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
 
 			// Verify that the views are getting measured at all, and that they're being measured at 
 			// the appropriate sizes
@@ -245,7 +245,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, col: 1);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.NegativeInfinity);
+			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
 
 			// Column width is 100, viewSize is less, so it should be able to layout at full size
 			AssertArranged(view0, 0, 0, 100, viewSize.Height);
@@ -271,7 +271,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 1);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.NegativeInfinity);
+			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
 
 			// Row height is 100, so full view should fit
 			AssertArranged(view0, 0, 0, viewSize.Width, 100);
@@ -1718,7 +1718,6 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view1, new Rect(0, 220, 100, 100));
 		}
 
-
 		[Fact(DisplayName = "Grids with RTL FlowDirection should order columns from the right")]
 		public void RtlShouldReverseColumnOrder()
 		{
@@ -1763,6 +1762,28 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Since column 0 has no width, we expect view1 to start at 0,10 
 			AssertArranged(view1, 0, 10, 200, 190);
 		}
+		
+		[Fact]
+		[Category(GridAbsoluteSizing)]
+		public void AbsoluteRowsConstrainMeasureHeight()
+		{
+			var grid = CreateGridLayout(rows: "50");
+
+			var viewSize = new Size(10, 10);
+
+			var view0 = CreateTestView(viewSize);
+
+			SubstituteChildren(grid, view0);
+
+			// Assuming no constraints on space
+			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+
+			// Verify that the view is getting measured at the appropriate height (50)
+			view0.Received().Measure(Arg.Any<double>(), Arg.Is<double>(50));
+
+			// And only at that height
+			view0.DidNotReceive().Measure(Arg.Any<double>(), Arg.Is<double>((h) => h != 50));
+		}
 
 		[Fact]
 		[Category(GridStarSizing), Category(GridAutoSizing)]
@@ -1786,6 +1807,27 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			// Since row 0 has no height, we expect view1 to start at 10,0 
 			AssertArranged(view1, 10, 0, 190, 200);
+		}
+		
+		[Category(GridAbsoluteSizing)]
+		public void AbsoluteColumnsConstrainMeasureWidth()
+		{
+			var grid = CreateGridLayout(columns: "50");
+
+			var viewSize = new Size(10, 10);
+
+			var view0 = CreateTestView(viewSize);
+
+			SubstituteChildren(grid, view0);
+
+			// Assuming no constraints on space
+			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+
+			// Verify that the view is getting measured at the appropriate width (50)
+			view0.Received().Measure(Arg.Is<double>(50), Arg.Any<double>());
+
+			// And only at that width
+			view0.DidNotReceive().Measure(Arg.Is<double>((h) => h != 50), Arg.Any<double>());
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1738,7 +1738,6 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, 110, 0, 100, 100);
 		}
 
-
 		[Fact]
 		[Category(GridStarSizing), Category(GridAutoSizing)]
 		public void AutoStarColumnSpansDoNotAffectAutoColumnSize()
@@ -1808,7 +1807,8 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Since row 0 has no height, we expect view1 to start at 10,0 
 			AssertArranged(view1, 10, 0, 190, 200);
 		}
-		
+
+		[Fact]
 		[Category(GridAbsoluteSizing)]
 		public void AbsoluteColumnsConstrainMeasureWidth()
 		{


### PR DESCRIPTION
### Description of Change

When determining the available height/width for part of a measurement to determine the size of a partially auto cell, uses the known height/width of absolute cells.

Skips final measure when width/height are zero anyway (usually as a result of images not being loaded yet).

### Issues Fixed

Fixes #5344
