### PR TITLE
Create custom Automation Peer for MauiButton

### DIFF
--- a/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -11,38 +10,7 @@ namespace Microsoft.Maui.Handlers
 		PointerEventHandler? _pointerPressedHandler;
 		PointerEventHandler? _pointerReleasedHandler;
 
-		protected override Button CreatePlatformView() =>
-			new Button
-			{
-				AllowFocusOnInteraction = false,
-				VerticalAlignment = VerticalAlignment.Stretch,
-				HorizontalAlignment = HorizontalAlignment.Stretch,
-				Content = new StackPanel
-				{
-					HorizontalAlignment = HorizontalAlignment.Center,
-					VerticalAlignment = VerticalAlignment.Center,
-					Orientation = Orientation.Horizontal,
-					Margin = WinUIHelpers.CreateThickness(0),
-					Children =
-					{
-						new Image
-						{
-							VerticalAlignment = VerticalAlignment.Center,
-							HorizontalAlignment = HorizontalAlignment.Center,
-							Stretch = Stretch.Uniform,
-							Margin = WinUIHelpers.CreateThickness(0),
-							Visibility = UI.Xaml.Visibility.Collapsed,
-						},
-						new TextBlock
-						{
-							VerticalAlignment = VerticalAlignment.Center,
-							HorizontalAlignment = HorizontalAlignment.Center,
-							Margin = WinUIHelpers.CreateThickness(0),
-							Visibility = UI.Xaml.Visibility.Collapsed,
-						}
-					}
-				}
-			};
+		protected override Button CreatePlatformView() => new MauiButton();
 
 		protected override void ConnectHandler(Button platformView)
 		{

--- a/src/Core/src/Platform/Windows/MauiButton.cs
+++ b/src/Core/src/Platform/Windows/MauiButton.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using WThickness = Microsoft.UI.Xaml.Thickness;
+
+namespace Microsoft.Maui.Platform
+{
+	public class MauiButton : Button
+	{
+		public MauiButton()
+		{
+			AllowFocusOnInteraction = false;
+			VerticalAlignment = VerticalAlignment.Stretch;
+			HorizontalAlignment = HorizontalAlignment.Stretch;
+			Content = new StackPanel
+			{
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Center,
+				Orientation = Orientation.Horizontal,
+				Margin = new WThickness(0),
+				Children =
+				{
+					new Image
+					{
+						VerticalAlignment = VerticalAlignment.Center,
+						HorizontalAlignment = HorizontalAlignment.Center,
+						Stretch = Stretch.Uniform,
+						Margin = new WThickness(0),
+						Visibility = UI.Xaml.Visibility.Collapsed,
+					},
+					new TextBlock
+					{
+						VerticalAlignment = VerticalAlignment.Center,
+						HorizontalAlignment = HorizontalAlignment.Center,
+						Margin = new WThickness(0),
+						Visibility = UI.Xaml.Visibility.Collapsed,
+					}
+				}
+			};
+		}
+
+		protected override AutomationPeer OnCreateAutomationPeer()
+		{
+			return new MauiButtonAutomationPeer(this);
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiButtonAutomationPeer.cs
+++ b/src/Core/src/Platform/Windows/MauiButtonAutomationPeer.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.Maui.Platform
+{
+	public class MauiButtonAutomationPeer : ButtonAutomationPeer
+	{
+		public MauiButtonAutomationPeer(Button owner) : base(owner)
+		{
+		}
+
+		protected override IList<AutomationPeer>? GetChildrenCore()
+		{
+			return null;
+		}
+
+		protected override AutomationPeer? GetLabeledByCore()
+		{
+			foreach (var item in base.GetChildrenCore())
+			{
+				if (item is TextBlockAutomationPeer tba)
+					return tba;
+			}
+
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

- Create a MauiButton since we already have a bunch of custom logic inside CreatePlatformView that a user would need to replicate our button. This also lets us create a custom AutomationPeer which you can only do through inheritance
- This lets us remove all the children from the accessibility tree and use the TextBlock as the labelfor the button. Prior to this behavior Narrator would select the button and provide no useful description and would then navigate to the TextBlock inside the Button.
