### PR TITLE
Improved Shell benchmark

### DIFF
--- a/src/Core/tests/Benchmarks/Benchmarks/ShellBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/ShellBenchmarker.cs
@@ -7,10 +7,12 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 	[MemoryDiagnoser]
 	public class ShellBenchmarker
 	{
-		[Benchmark]
-		public async Task GoTo()
+		Shell shell;
+
+		[GlobalSetup]
+		public void Setup()
 		{
-			var shell = new Shell();
+			shell = new Shell();
 
 			var one = new ShellItem { Route = "one" };
 			var two = new ShellItem { Route = "two" };
@@ -22,7 +24,11 @@ namespace Microsoft.Maui.Handlers.Benchmarks
 
 			shell.Items.Add(one);
 			shell.Items.Add(two);
-
+		}
+		
+		[Benchmark]
+		public async Task GoTo()
+		{
 			await shell.GoToAsync(new ShellNavigationState("//two/tabtwo/content"));
 		}
 	}


### PR DESCRIPTION
### Description of Change

The benchmark method name `GoTo` passes the idea that we want to measure the Shell Navigation, but we're measuring more than that.

At this PR I moved the Shell initialization to a global method, to make sure that the benchmark will measure just the `GoToAsync` method. Before this change, the benchmark was measuring the shell initialization + navigation.

`Main` branch

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22000
Intel Core i5-10500H CPU 2.50GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=6.0.300-preview.22204.3
  [Host]     : .NET Core 6.0.4 (CoreCLR 6.0.422.16404, CoreFX 6.0.422.16404), X64 RyuJIT
  DefaultJob : .NET Core 6.0.4 (CoreCLR 6.0.422.16404, CoreFX 6.0.422.16404), X64 RyuJIT


```
| Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|-------:|-------:|------:|----------:|
|   GoTo | 66.74 μs | 0.569 μs | 0.475 μs | 8.9111 | 0.7324 |     - |  54.64 KB |



This branch

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22000
Intel Core i5-10500H CPU 2.50GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=6.0.300-preview.22204.3
  [Host]     : .NET Core 6.0.4 (CoreCLR 6.0.422.16404, CoreFX 6.0.422.16404), X64 RyuJIT
  DefaultJob : .NET Core 6.0.4 (CoreCLR 6.0.422.16404, CoreFX 6.0.422.16404), X64 RyuJIT


```
| Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
|   GoTo | 10.01 μs | 0.128 μs | 0.120 μs | 1.6479 |     - |     - |   10.1 KB |

As you can see the values changed a lot, indicating that we are measuring more than the navigation.

### Issues Fixed

There's no issue for this, I can create one if needed.
