### PR TITLE
Remove the hard Tizen dependency

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -107,14 +107,6 @@ steps:
       displayName: 'Setup MSBuild Paths'
       condition: eq(variables['provisioningVS'], 'true')
 
-    - pwsh: |
-        [xml] $fileXml = Get-Content "eng\Versions.props"
-        $DotNetVersionBand = $fileXml.SelectSingleNode("Project/PropertyGroup/DotNetVersionBand").InnerText
-        echo "Installing .NET $DotNetVersion"
-        Invoke-WebRequest 'https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1' -OutFile 'workload-install.ps1'
-        .\workload-install.ps1 -t $DotNetVersion
-      displayName: 'Install Tizen'
-
   # Prepare Both
   - pwsh: ./build.ps1 --target provision
     displayName: 'Cake Provision'

--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -75,7 +75,7 @@
     </ItemGroup>
     <Copy SourceFiles="$(MauiRootDirectory)NuGet.config" DestinationFolder="$(DotNetTempDirectory)" />
     <Exec Command="dotnet nuget add source &quot;$(PackageOutputPath)&quot; --name artifacts --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" />
-    <Exec Command="&quot;$(MSBuildExtensionsPath)../../dotnet&quot; workload install tizen maui maui-tizen --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
+    <Exec Command="&quot;$(MSBuildExtensionsPath)../../dotnet&quot; workload install tizen maui --skip-manifest-update --verbosity diag --temp-dir &quot;$(DotNetTempDirectory)&quot; --configfile &quot;$(DotNetTempDirectory)NuGet.config&quot;" WorkingDirectory="$(MauiRootDirectory)" />
 
   </Target>
 

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -12,7 +12,8 @@
       "description": ".NET MAUI SDK for Mobile",
       "extends": [ 
         "maui-android",
-        "maui-ios"
+        "maui-ios",
+        "maui-tizen"
       ]
     },
     "maui-desktop": {
@@ -109,8 +110,7 @@
     "maui-tizen": {
       "description": ".NET MAUI SDK for Tizen",
       "extends": [
-        "maui-blazor",
-        "tizen"
+        "maui-blazor"
       ],
       "packs": [
           "Microsoft.Maui.Core.Ref.tizen",


### PR DESCRIPTION
### Description of Change

Currently, after installing the maui workloads, the dotnet sdk crashes because `maui-tizen` depends on `tizen`, which does not exist by default.

Preferably this won't crash the sdk, but since it does we can just make `maui-tizen` not depend on `tizen`. An attempt to use it will fail, but at least the SDK and types will be there.

CC: @rookiejava