### PR TITLE
[Windows] Avoid Released event fired twice

### DIFF
--- a/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
@@ -130,7 +130,6 @@ namespace Microsoft.Maui.Handlers
 		void OnClick(object sender, RoutedEventArgs e)
 		{
 			VirtualView?.Clicked();
-			VirtualView?.Released();
 		}
 
 		void OnPointerPressed(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
### Description of Change

Avoid Released event fired twice on Windows.

### Issues Fixed

Fixes #6095 
