### PR TITLE
[Windows] Avoid highlight default color in Label Spans

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/FormattedStringExtensions.cs
@@ -1,12 +1,10 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
-using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -33,19 +31,28 @@ namespace Microsoft.Maui.Controls.Platform
 				heights.Add(textBlock.FindDefaultLineHeight(run));
 				textBlock.Inlines.Add(run);
 				int length = run.Text.Length;
+
 				if (background != null || textColor != null)
 				{
 					TextHighlighter textHighlighter = new TextHighlighter { Ranges = { new TextRange(currentTextIndex, length) } };
+
 					if (background != null)
 					{
 						textHighlighter.Background = background.ToPlatform();
 					}
+					else
+					{
+						textHighlighter.Background = Colors.Transparent.ToPlatform();
+					}
+
 					if (textColor != null)
 					{
 						textHighlighter.Foreground = textColor.ToPlatform();
 					}
+
 					textBlock.TextHighlighters.Add(textHighlighter);
 				}
+
 				currentTextIndex += length;
 			}
 		}


### PR DESCRIPTION
### Description of Change

Avoid highlight default color (Yellow) in Windows Label Spans.

![image](https://user-images.githubusercontent.com/6755973/163791998-0d91638e-e990-44c5-af8c-6d835c289f47.png)

### Issues Fixed

Fixes #6129 
