### PR TITLE
Fix TitleView swapping behavior on Android/WinUI

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -198,6 +198,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				_drawerLayout.RemoveDrawerListener(_drawerToggle);
 				_drawerToggle?.Dispose();
 
+				_toolbar?.Handler?.DisconnectHandler();
+				_toolbar = null;
 				_platformToolbar.RemoveAllViews();
 			}
 

--- a/src/Controls/src/Core/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPageToolbar.cs
@@ -230,7 +230,8 @@ namespace Microsoft.Maui.Controls
 
 		Color GetBarTextColor() => _currentNavigationPage?.BarTextColor;
 		Color GetIconColor() => (_currentPage != null) ? NavigationPage.GetIconColor(_currentPage) : null;
-		string GetTitle() => _currentPage?.Title;
+		string GetTitle() => GetTitleView() != null ? String.Empty : _currentPage?.Title;
+
 		VisualElement GetTitleView()
 		{
 			if (_currentNavigationPage == null)

--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -11,71 +11,80 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal static class ToolbarExtensions
 	{
-		public static void UpdateIsVisible(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateIsVisible(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
-			nativeToolbar.Visibility = (toolbar.IsVisible) ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
+			platformToolbar.Visibility = (toolbar.IsVisible) ? UI.Xaml.Visibility.Visible : UI.Xaml.Visibility.Collapsed;
 		}
 
-		public static void UpdateTitleIcon(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateTitleIcon(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
 			_ = toolbar?.Handler?.MauiContext ?? throw new ArgumentNullException(nameof(toolbar.Handler.MauiContext));
 			toolbar.TitleIcon.LoadImage(toolbar.Handler.MauiContext, (result) =>
 			{
 				if (result != null)
 				{
-					nativeToolbar.TitleIconImageSource = result.Value;
+					platformToolbar.TitleIconImageSource = result.Value;
 					toolbar.Handler.UpdateValue(nameof(Toolbar.IconColor));
 				}
 				else
-					nativeToolbar.TitleIconImageSource = null;
+					platformToolbar.TitleIconImageSource = null;
 			});
 		}
 
-		public static void UpdateBackButton(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateBackButton(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
-			nativeToolbar.IsBackEnabled =
+			platformToolbar.IsBackEnabled =
 				toolbar.BackButtonEnabled && toolbar.BackButtonVisible;
 
-			nativeToolbar
+			platformToolbar
 				.IsBackButtonVisible = (toolbar.BackButtonVisible) ? NavigationViewBackButtonVisible.Visible : NavigationViewBackButtonVisible.Collapsed;
 
 			toolbar.Handler?.UpdateValue(nameof(Toolbar.BarBackground));
 		}
 
-		public static void UpdateBarBackground(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateBarBackground(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
-			nativeToolbar.Background = toolbar.BarBackground?.ToBrush();
+			platformToolbar.Background = toolbar.BarBackground?.ToBrush();
 		}
 
-		public static void UpdateTitleView(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateTitleView(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
 			_ = toolbar.Handler?.MauiContext ?? throw new ArgumentNullException(nameof(toolbar.Handler.MauiContext));
 
-			nativeToolbar.TitleView = toolbar.TitleView?.ToPlatform(toolbar.Handler.MauiContext);
+			platformToolbar.TitleView = toolbar.TitleView?.ToPlatform(toolbar.Handler.MauiContext);
+
+			if (toolbar.TitleView is IView view)
+			{
+				platformToolbar.TitleViewMargin = view.Margin.ToPlatform();
+			}
+			else
+			{
+				platformToolbar.TitleViewMargin = new UI.Xaml.Thickness(0);
+			}
 		}
 
-		public static void UpdateIconColor(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateIconColor(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
 			// This property wasn't wired up in Controls
 		}
 
-		public static void UpdateTitle(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateTitle(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
-			nativeToolbar.Title = toolbar.Title;
+			platformToolbar.Title = toolbar.Title;
 		}
 
-		public static void UpdateBarTextColor(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateBarTextColor(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
 			if (toolbar.BarTextColor != null)
-				nativeToolbar.TitleColor = toolbar.BarTextColor.ToPlatform();
+				platformToolbar.TitleColor = toolbar.BarTextColor.ToPlatform();
 		}
 
-		public static void UpdateToolbarDynamicOverflowEnabled(this MauiToolbar nativeToolbar, Toolbar toolbar)
+		public static void UpdateToolbarDynamicOverflowEnabled(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
-			if (nativeToolbar.CommandBar == null)
+			if (platformToolbar.CommandBar == null)
 				return;
 
-			nativeToolbar.CommandBar.IsDynamicOverflowEnabled = toolbar.DynamicOverflowEnabled;
+			platformToolbar.CommandBar.IsDynamicOverflowEnabled = toolbar.DynamicOverflowEnabled;
 		}
 	}
 }

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -94,10 +94,6 @@ namespace Microsoft.Maui.Controls
 
 			UpdateTitle();
 
-			TitleView = _shell.GetEffectiveValue<VisualElement>(
-				Shell.TitleViewProperty,
-				Shell.GetTitleView(_shell));
-
 			if (_currentPage != null &&
 				_currentPage.IsSet(Shell.NavBarIsVisibleProperty))
 			{
@@ -169,8 +165,17 @@ namespace Microsoft.Maui.Controls
 
 		internal void UpdateTitle()
 		{
-			Page currentPage = _shell.GetCurrentShellPage() as Page;
+			TitleView = _shell.GetEffectiveValue<VisualElement>(
+				Shell.TitleViewProperty,
+				Shell.GetTitleView(_shell));
 
+			if (TitleView != null)
+			{
+				Title = String.Empty;
+				return;
+			}
+
+			Page currentPage = _shell.GetCurrentShellPage() as Page;
 			if (currentPage?.IsSet(Page.TitleProperty) == true)
 			{
 				Title = currentPage.Title ?? String.Empty;

--- a/src/Controls/src/Core/Toolbar.cs
+++ b/src/Controls/src/Core/Toolbar.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Maui.Controls
 		bool _backButtonVisible;
 		bool _backButtonEnabled = true;
 		bool _drawerToggleVisible;
+		Maui.IElement _parent;
+		IElementHandler _handler;
 
 		public Toolbar(Maui.IElement parent)
 		{
@@ -43,10 +45,20 @@ namespace Microsoft.Maui.Controls
 		public bool BackButtonEnabled { get => _backButtonEnabled; set => SetProperty(ref _backButtonEnabled, value); }
 		public virtual bool DrawerToggleVisible { get => _drawerToggleVisible; set => SetProperty(ref _drawerToggleVisible, value); }
 		public bool IsVisible { get => _isVisible; set => SetProperty(ref _isVisible, value); }
-		public IElementHandler Handler { get; set; }
+		public IElementHandler Handler
+		{
+			get => _handler;
+			set
+			{
+				if (_handler == value)
+					return;
 
-		Maui.IElement _parent;
+				OnHandlerChanging(_handler, value);
+				_handler = value;
+			}
+		}
 
+		partial void OnHandlerChanging(IElementHandler oldHandler, IElementHandler newHandler);
 		public event PropertyChangedEventHandler PropertyChanged;
 
 		public Maui.IElement Parent => _parent;

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -188,5 +188,26 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.AreEqual(page.BindingContext, backButtonBehavior.BindingContext);
 		}
+
+		[Test]
+		public async Task TitleAndTitleViewAreMutuallyExclusive()
+		{
+			var contentPage = new ContentPage() { Title = "Test Title" };
+			var titleView = new VerticalStackLayout();
+
+			TestShell testShell = new TestShell(contentPage);
+			var window = new Window()
+			{
+				Page = testShell
+			};
+
+			var toolbar = testShell.Toolbar;
+			Assert.AreEqual("Test Title", toolbar.Title);
+			Shell.SetTitleView(contentPage, titleView);
+			Assert.IsEmpty(toolbar.Title);
+			Assert.AreEqual(titleView, toolbar.TitleView);
+			Shell.SetTitleView(contentPage, null);
+			Assert.AreEqual("Test Title", toolbar.Title);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
@@ -38,6 +38,25 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
+		public async Task TitleAndTitleViewAreMutuallyExclusive()
+		{
+			var window = new Window();
+			IToolbarElement toolbarElement = window;
+			var contentPage = new ContentPage() { Title = "Test Title" };
+			var navigationPage = new NavigationPage(contentPage);
+			window.Page = navigationPage;
+
+			var titleView = new VerticalStackLayout();
+			var toolbar = (Toolbar)toolbarElement.Toolbar;
+			Assert.AreEqual("Test Title", toolbar.Title);
+			NavigationPage.SetTitleView(contentPage, titleView);
+			Assert.IsEmpty(toolbar.Title);
+			Assert.AreEqual(titleView, toolbar.TitleView);
+			NavigationPage.SetTitleView(contentPage, null);
+			Assert.AreEqual("Test Title", toolbar.Title);
+		}
+
+		[Test]
 		public async Task InsertPageBeforeRootPageShowsBackButton()
 		{
 			var window = new Window();

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -122,6 +122,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			var page1 = new ContentPage();
 			var page2 = new ContentPage();
+			var page3 = new ContentPage();
 
 			var titleView1 = new VerticalStackLayout();
 			var titleView2 = new Label();
@@ -150,7 +151,7 @@ namespace Microsoft.Maui.DeviceTests
 						new ShellContent()
 						{
 							Route = "Item3",
-							Content = new ContentPage()
+							Content = page3
 						},
 					}
 				});
@@ -158,6 +159,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
 			{
+				await OnLoadedAsync(page1);
 				// GotoAsync which switching tabs/flyout items currently
 				// doesn't resolve after navigated has finished which is why we have the
 				// delays
@@ -165,15 +167,19 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(titleView1.ToPlatform(), GetTitleView(handler));
 				await shell.GoToAsync("//Item2");
 				await Task.Delay(200);
+				await OnLoadedAsync(page2);
 				Assert.Equal(titleView2.ToPlatform(), GetTitleView(handler));
 				await shell.GoToAsync("//Item1");
 				await Task.Delay(200);
+				await OnLoadedAsync(page1);
 				Assert.Equal(titleView1.ToPlatform(), GetTitleView(handler));
 				await shell.GoToAsync("//Item2");
 				await Task.Delay(200);
+				await OnLoadedAsync(page2);
 				Assert.Equal(titleView2.ToPlatform(), GetTitleView(handler));
 				await shell.GoToAsync("//Item3");
 				await Task.Delay(200);
+				await OnLoadedAsync(page3);
 				Assert.Equal(shellTitleView.ToPlatform(), GetTitleView(handler));
 			});
 		}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Maui.DeviceTests
 		protected AView GetTitleView(IElementHandler handler)
 		{
 			var toolbar = GetPlatformToolbar(handler);
-			var container = toolbar.GetFirstChildOfType<Controls.Toolbar.Container>();
+			var container = toolbar?.GetFirstChildOfType<Controls.Toolbar.Container>();
 
 			if (container != null && container.ChildCount > 0)
 				return container.GetChildAt(0);

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -108,6 +108,17 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		protected AView GetTitleView(IElementHandler handler)
+		{
+			var toolbar = GetPlatformToolbar(handler);
+			var container = toolbar.GetFirstChildOfType<Controls.Toolbar.Container>();
+
+			if (container != null && container.ChildCount > 0)
+				return container.GetChildAt(0);
+
+			return null;
+		}
+
 		protected MaterialToolbar GetPlatformToolbar(IElementHandler handler)
 		{
 			if (handler is Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer sr)

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -145,5 +145,11 @@ namespace Microsoft.Maui.DeviceTests
 			MauiToolbar windowHeader = (MauiToolbar)navView.Header;
 			return windowHeader;
 		}
+
+		protected object GetTitleView(IElementHandler handler)
+		{
+			var toolbar = GetPlatformToolbar(handler);
+			return toolbar.TitleView;
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.iOS.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.iOS.cs
@@ -78,5 +78,10 @@ namespace Microsoft.Maui.DeviceTests
 
 			throw new NotImplementedException();
 		}
+
+		protected object GetTitleView(IElementHandler handler)
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -60,6 +60,12 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		internal UI.Xaml.Thickness TitleViewMargin
+		{
+			get => titleView.Margin;
+			set => titleView.Margin = value;
+		}
+
 		internal object? TitleView
 		{
 			get => titleView.Content;


### PR DESCRIPTION
### Description of Change

- Fix Android so swapping out TitleView doesn't crash
- fix margins on WinUI and Android when set on TitleView
- Fix WinUI so that the Title hides if the TitleView is set

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6148
Fixes #5944 
