### PR TITLE
Add Try/Catch wrapper around iOS StatusBar rendering

### DIFF
--- a/src/Essentials/src/Screenshot/Screenshot.ios.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.ios.cs
@@ -49,12 +49,19 @@ namespace Microsoft.Maui.Media
 			}
 
 			// Render the status bar with the correct frame size
-			TryHideStatusClockView(UIApplication.SharedApplication);
-			var statusbarWindow = GetStatusBarWindow(UIApplication.SharedApplication);
-			if (statusbarWindow != null/* && metrics.StatusBar != null*/)
+			try
 			{
-				statusbarWindow.Frame = window.Frame;
-				statusbarWindow.Layer.RenderInContext(ctx);
+				TryHideStatusClockView(UIApplication.SharedApplication);
+				var statusbarWindow = GetStatusBarWindow(UIApplication.SharedApplication);
+				if (statusbarWindow != null/* && metrics.StatusBar != null*/)
+				{
+					statusbarWindow.Frame = window.Frame;
+					statusbarWindow.Layer.RenderInContext(ctx);
+				}
+			}
+			catch
+			{
+				// FIXME: test/handle this case
 			}
 
 			var image = UIGraphics.GetImageFromCurrentImageContext();


### PR DESCRIPTION
### Description of Change

"Fixes" https://github.com/dotnet/maui/issues/5693

This adds a try/catch wrapper around getting the status bar for the Window on iOS. The original obj/c error will still throw, but it will still let us render the screen with the status bar hidden.

We need a longer term task to add better error handling in here (since I don't believe there is a logger available here in Essentials).

<img width="577" alt="スクリーンショット 2022-04-18 午後4 22 38" src="https://user-images.githubusercontent.com/898335/163872483-13fa58fa-c805-4a72-8e8e-6373506a8e50.png">
