### PR TITLE
Make Android sizing of ShapeViews consistent with iOS and Windows

### DIFF
--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Android.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui.Handlers
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Handlers
 {
 	public partial class ShapeViewHandler : ViewHandler<IShapeView, MauiShapeView>
 	{

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.Android.cs
@@ -66,5 +66,22 @@
 		{
 			handler.PlatformView?.InvalidateShape(shapeView);
 		}
+
+		public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			var result = base.GetDesiredSize(widthConstraint, heightConstraint);
+
+			if (double.IsNaN(VirtualView.Width))
+			{
+				result.Width = 0;
+			}
+
+			if (double.IsNaN(VirtualView.Height))
+			{
+				result.Height = 0;
+			}
+
+			return result;
+		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -8,6 +8,7 @@ override Microsoft.Maui.FontSize.Equals(object? obj) -> bool
 override Microsoft.Maui.FontSize.GetHashCode() -> int
 override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
 override Microsoft.Maui.Handlers.RadioButtonHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
+override Microsoft.Maui.Handlers.ShapeViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
 override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool

--- a/src/Core/tests/DeviceTests/Handlers/ShapeView/ShapeViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ShapeView/ShapeViewHandlerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -160,5 +162,60 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidateHasColor(polyline, expected);
 		}
+		
+		[Theory]
+		[ClassData(typeof(IntrinsicSizeTestCases))]
+		public async Task ShapesDoNotHaveIntrinsicSize(IShapeView shape)
+		{
+			var size = await InvokeOnMainThreadAsync(() => CreateHandler(shape).GetDesiredSize(100, 100));
+			Assert.Equal(0, size.Width);
+			Assert.Equal(0, size.Height);
+		}
+	}
+
+	public class IntrinsicSizeTestCases : IEnumerable<object[]>
+	{
+		public IntrinsicSizeTestCases()
+		{
+			var rectangle = new ShapeViewStub()
+			{
+				Shape = new RectangleStub(),
+				Fill = new SolidPaintStub(Colors.Red),
+				Height = double.NaN, // Have to explicitly reset this because StubBase sets H,W to 50/50
+				Width = double.NaN
+			};
+
+			var polygon = new ShapeViewStub()
+			{
+				Shape = new PolygonStub { Points = new PointCollectionStub() { new Point(10, 10), new Point(100, 50), new Point(50, 90) } },
+				Fill = new SolidPaintStub(Colors.Lime),
+				Stroke = new SolidPaintStub(Colors.Black),
+				StrokeThickness = 4,
+				Height = double.NaN,
+				Width = double.NaN
+			};
+
+			var line = new ShapeViewStub()
+			{
+				Shape = new LineStub { X1 = 0, Y1 = 0, X2 = 90, Y2 = 0 },
+				Stroke = new SolidPaintStub(Colors.Purple),
+				StrokeThickness = 0.6,
+				Height = double.NaN,
+				Width = double.NaN
+			};
+
+			_data = new()
+			{
+				new object[] { rectangle },
+				new object[] { polygon },
+				new object[] { line }
+			};
+		}
+
+		private readonly List<object[]> _data;
+
+		public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/ShapeView/ShapeViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ShapeView/ShapeViewHandlerTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var rectangle = new ShapeViewStub()
 			{
-				Shape = new RectangleStub(),
+				Shape = new RectangleShapeStub(),
 				Fill = new SolidPaintStub(Colors.Red),
 				Height = double.NaN, // Have to explicitly reset this because StubBase sets H,W to 50/50
 				Width = double.NaN
@@ -187,7 +187,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			var polygon = new ShapeViewStub()
 			{
-				Shape = new PolygonStub { Points = new PointCollectionStub() { new Point(10, 10), new Point(100, 50), new Point(50, 90) } },
+				Shape = new PolygonShapeStub { Points = new PointCollectionStub() { new Point(10, 10), new Point(100, 50), new Point(50, 90) } },
 				Fill = new SolidPaintStub(Colors.Lime),
 				Stroke = new SolidPaintStub(Colors.Black),
 				StrokeThickness = 4,
@@ -197,7 +197,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			var line = new ShapeViewStub()
 			{
-				Shape = new LineStub { X1 = 0, Y1 = 0, X2 = 90, Y2 = 0 },
+				Shape = new LineShapeStub { X1 = 0, Y1 = 0, X2 = 90, Y2 = 0 },
 				Stroke = new SolidPaintStub(Colors.Purple),
 				StrokeThickness = 0.6,
 				Height = double.NaN,

--- a/src/Core/tests/DeviceTests/Handlers/ShapeView/ShapeViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ShapeView/ShapeViewHandlerTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidateHasColor(polyline, expected);
 		}
-		
+
 		[Theory]
 		[ClassData(typeof(IntrinsicSizeTestCases))]
 		public async Task ShapesDoNotHaveIntrinsicSize(IShapeView shape)


### PR DESCRIPTION
### Description of Change

Given no explicit width or height, ShapeViews on Android attempt to fill the given space; on iOS/Windows, they have no size. 
These changes make Android's measure of ShapeViews consistent with Windows/iOS when the width/height are not explicitly specified.

### Issues Fixed

Fixes #5119

