### PR TITLE
[Windows] Fix ListView menu events not working

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
@@ -460,8 +460,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				var flyoutItem = new UI.Xaml.Controls.MenuFlyoutItem();
 				flyoutItem.SetBinding(UI.Xaml.Controls.MenuFlyoutItem.TextProperty, "Text");
-				//WINUI FIX
-				//flyoutItem.Command = new MenuItemCommand(item);
+				flyoutItem.Command = new MenuItemCommand(item);
 				flyoutItem.DataContext = item;
 
 				flyout.Items.Add(flyoutItem);


### PR DESCRIPTION
### Description of Change

Hook FlyoutItem Command to fix ListView menu events not working on Windows.

![fix-6225](https://user-images.githubusercontent.com/6755973/164001050-a362d2fa-f2fa-4123-8328-f29ac0752d5f.gif)

### Issues Fixed

Fixes #6225 
