### PR TITLE
fix width constraint when measuring stacklayout children

### DIFF
--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Maui.Layouts
 
 			double measuredHeight = 0;
 			double measuredWidth = 0;
+			double childWidthConstraint = widthConstraint - padding.HorizontalThickness;
 
 			for (int n = 0; n < Stack.Count; n++)
 			{
@@ -25,7 +26,7 @@ namespace Microsoft.Maui.Layouts
 					continue;
 				}
 
-				var measure = child.Measure(widthConstraint, double.PositiveInfinity);
+				var measure = child.Measure(childWidthConstraint, double.PositiveInfinity);
 				measuredHeight += measure.Height;
 				measuredWidth = Math.Max(measuredWidth, measure.Width);
 			}


### PR DESCRIPTION


### Description of Change
Substract stacklayout padding from width constraint when measuring stacklayout children

Fixes dotnet/maui#4142

There may be some other issue somewhere because it seems to only happens with grid, but this fix here might be part of the solution.


My understanding of layout system is very limited , i've seen old information about xamarin.forms but i can't tell from what i read if the system is still working the same or not.
https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/layouts/custom 
https://www.youtube.com/watch?v=sxjOqNZFhKU


I think some controls is using the size computed by Measure to draw itself, and ignore the width passed in `VerticalStackLayoutManager.ArrangeChildren` (which seems correct there).


The following is very simple code (just replace MainPage from template) to reproduce the issue and see the effect of the fix:
```xaml
<ContentPage
  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
  x:Class="MyApp.MainPage"
  NavigationPage.HasNavigationBar="True"
  NavigationPage.HasBackButton="True"
    Title="Test">
    <ScrollView>
        <VerticalStackLayout x:Name="MyStack" Spacing="20" Padding="20">
            <Grid ColumnDefinitions="*" BackgroundColor="Green" Padding="10">
                <Frame BackgroundColor="Yellow" CornerRadius="0"  BorderColor="Red"/>
            </Grid>
            <Grid ColumnDefinitions="*" BackgroundColor="Green" Padding="10">
                <BoxView BackgroundColor="Yellow" CornerRadius="0" HeightRequest="50" />
            </Grid>
            <Frame BackgroundColor="Yellow" CornerRadius="0" BorderColor="Red"/>

        </VerticalStackLayout>
    </ScrollView>
</ContentPage>

```
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes dotnet/maui#4142

