### PR TITLE
[Android] SelectableItemsViewAdapter: update SelectableViewHolder on selection changes

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SelectionGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/SelectionGallery.cs
@@ -35,6 +35,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 							new FilterSelection(), Navigation),
 						GalleryBuilder.NavButton("Selection Synchronization", () =>
 							new SelectionSynchronization(), Navigation),
+						GalleryBuilder.NavButton("Visual states", () =>
+							new VisualStatesGallery(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml
@@ -9,7 +9,7 @@
                 VerticalOptions="FillAndExpand"
                 SelectionMode="Single"
                 ItemSizingStrategy="MeasureFirstItem"
-                EmptyView="No items defined" SelectionChanged="SelChangedLol">
+                EmptyView="No items defined">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid ColumnDefinitions="*,Auto" BackgroundColor="White">
@@ -40,7 +40,7 @@
                 VerticalOptions="FillAndExpand"
                 SelectionMode="Multiple"
                 ItemSizingStrategy="MeasureFirstItem"
-                EmptyView="No items defined" SelectionChanged="SelChangedLol">
+                EmptyView="No items defined">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid ColumnDefinitions="*,Auto" BackgroundColor="White">

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries.VisualStatesGallery" >
+    <VerticalStackLayout>
+        <Label Text="Single Selection" />
+        <CollectionView
+                ItemsSource="{Binding SingleSelectionItems}"
+                VerticalOptions="FillAndExpand"
+                SelectionMode="Single"
+                ItemSizingStrategy="MeasureFirstItem"
+                EmptyView="No items defined" SelectionChanged="SelChangedLol">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid ColumnDefinitions="*,Auto" BackgroundColor="White">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup Name="CommonStates">
+                                <VisualState Name="Normal" />
+                                <VisualState Name="Selected">
+                                    <VisualState.Setters>
+                                        <Setter Property="BackgroundColor" Value="Yellow" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid Grid.ColumnSpan="2" Margin="10,0,10,0"
+                                    RowDefinitions="Auto" ColumnDefinitions="*,*">
+                            <Label Text="{Binding ItemName}" Grid.Column="0"
+                                    LineBreakMode="NoWrap" 
+                                    FontSize="Large" />
+                        </Grid>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+        <Label Text="Multi Selection" />
+        <CollectionView
+                ItemsSource="{Binding MultiSelectionItems}"
+                VerticalOptions="FillAndExpand"
+                SelectionMode="Multiple"
+                ItemSizingStrategy="MeasureFirstItem"
+                EmptyView="No items defined" SelectionChanged="SelChangedLol">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid ColumnDefinitions="*,Auto" BackgroundColor="White">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup Name="CommonStates">
+                                <VisualState Name="Normal" />
+                                <VisualState Name="Selected">
+                                    <VisualState.Setters>
+                                        <Setter Property="BackgroundColor" Value="Yellow" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid Grid.ColumnSpan="2" Margin="10,0,10,0"
+                                    RowDefinitions="Auto" ColumnDefinitions="*,*">
+                            <Label Text="{Binding ItemName}" Grid.Column="0"
+                                    LineBreakMode="NoWrap" 
+                                    FontSize="Large" />
+                        </Grid>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml.cs
@@ -32,12 +32,6 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
 			new LineItem() { ItemName = "Item 3" },
 			new LineItem() { ItemName = "Item 4" },
 		};
-
-		public void SelChangedLol(object sender, SelectionChangedEventArgs args)
-		{
-			var collectionView = (CollectionView)sender;
-			System.Diagnostics.Debug.Print($"SEL: {collectionView.SelectedItem}");
-		}
 	}
 
 	public class LineItem

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/SelectionGalleries/VisualStatesGallery.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.SelectionGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class VisualStatesGallery : ContentPage
+	{
+		public VisualStatesGallery()
+		{
+			InitializeComponent();
+			BindingContext = this;
+		}
+
+		public LineItem[] SingleSelectionItems { get; } = new LineItem[]
+		{
+			new LineItem() { ItemName = "Item 1" },
+			new LineItem() { ItemName = "Item 2" },
+			new LineItem() { ItemName = "Item 3" },
+		};
+
+		public LineItem[] MultiSelectionItems { get; } = new LineItem[]
+		{
+			new LineItem() { ItemName = "Item 1" },
+			new LineItem() { ItemName = "Item 2" },
+			new LineItem() { ItemName = "Item 3" },
+			new LineItem() { ItemName = "Item 4" },
+		};
+
+		public void SelChangedLol(object sender, SelectionChangedEventArgs args)
+		{
+			var collectionView = (CollectionView)sender;
+			System.Diagnostics.Debug.Print($"SEL: {collectionView.SelectedItem}");
+		}
+	}
+
+	public class LineItem
+	{
+		public string ItemName { get; set; }
+
+		public override string ToString() => ItemName;
+	}
+}

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/SelectableItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/SelectableItemsViewAdapter.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					return;
 				case SelectionMode.Single:
 					ItemsView.SelectedItem = ItemsSource.GetItem(adapterPosition);
+					RefreshViewHolderSelection();
 					return;
 				case SelectionMode.Multiple:
 					var item = ItemsSource.GetItem(adapterPosition);
@@ -149,7 +150,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 					{
 						selectedItems.Add(item);
 					}
+					RefreshViewHolderSelection();
 					return;
+			}
+
+			void RefreshViewHolderSelection()
+			{
+				for (int position = 0; position < _currentViewHolders.Count; position++)
+				{
+					_currentViewHolders[position].IsSelected = PositionIsSelected(position);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change

`UpdateMauiSelection` should update `SelectableViewHolder.IsSelected` according to the new selection in order to trigger `VisualStateManager`, otherwise `VisualState`-s are not applied on Android.

![AndroidSelection](https://user-images.githubusercontent.com/6835152/164083164-5a55ba51-0ef8-4c59-8197-8722f07f0abd.gif)

### Issues Fixed

Fixes #5449
