### PR TITLE
Spike adding implictor styles to handle null colors

### DIFF
--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -53,6 +53,10 @@ namespace Microsoft.Maui.Controls
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Application>>(() => new PlatformConfigurationRegistry<Application>(this));
 
 			_lastAppTheme = PlatformAppTheme;
+
+			// This is for cases that don't call InitializeComponent()
+			if (Resources.MergedDictionaries.Count == 0)
+				Resources.MergedDictionaries.Add(DefaultStyles.CreateDefaultResourceDictionary());
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="//Member[@MemberName='Quit']/Docs" />
@@ -145,6 +149,7 @@ namespace Microsoft.Maui.Controls
 					return _resources;
 
 				_resources = new ResourceDictionary();
+				_resources.MergedDictionaries.Add(DefaultStyles.CreateDefaultResourceDictionary());
 				((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				return _resources;
 			}
@@ -152,6 +157,7 @@ namespace Microsoft.Maui.Controls
 			{
 				if (_resources == value)
 					return;
+
 				OnPropertyChanging();
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
@@ -160,6 +166,10 @@ namespace Microsoft.Maui.Controls
 				if (_resources != null)
 					((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				OnPropertyChanged();
+
+				// This is for cases that do call InitializeComponent()
+				if (_resources != null && _resources.MergedDictionaries.Count == 0)
+					_resources.MergedDictionaries.Add(DefaultStyles.CreateDefaultResourceDictionary());
 			}
 		}
 

--- a/src/Controls/src/Core/Application.cs
+++ b/src/Controls/src/Core/Application.cs
@@ -149,7 +149,6 @@ namespace Microsoft.Maui.Controls
 					return _resources;
 
 				_resources = new ResourceDictionary();
-				_resources.MergedDictionaries.Add(DefaultStyles.CreateDefaultResourceDictionary());
 				((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
 				return _resources;
 			}
@@ -168,6 +167,7 @@ namespace Microsoft.Maui.Controls
 				OnPropertyChanged();
 
 				// This is for cases that do call InitializeComponent()
+				// Because the Dictionary added in the ctor will get wiped out by the XAML parser
 				if (_resources != null && _resources.MergedDictionaries.Count == 0)
 					_resources.MergedDictionaries.Add(DefaultStyles.CreateDefaultResourceDictionary());
 			}

--- a/src/Controls/src/Core/HandlerImpl/ActivityIndicator.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ActivityIndicator.Impl.cs
@@ -1,8 +1,14 @@
-﻿namespace Microsoft.Maui.Controls
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ActivityIndicator.xml" path="Type[@FullName='Microsoft.Maui.Controls.ActivityIndicator']/Docs" />
 	public partial class ActivityIndicator : IActivityIndicator
 	{
-
+		Color IActivityIndicator.Color
+		{
+			get => Color ??
+				DefaultStyles.GetColor(this, ColorProperty)?.Value as Color;
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Button/Button.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.Impl.cs
@@ -56,5 +56,11 @@ namespace Microsoft.Maui.Controls
 		Color IButtonStroke.StrokeColor => (Color)GetValue(BorderColorProperty);
 
 		int IButtonStroke.CornerRadius => (int)GetValue(CornerRadiusProperty);
+
+		Color ITextStyle.TextColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetTextColor(this)?.Value as Color;
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Button/Button.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.Impl.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Maui.Controls
 		Color ITextStyle.TextColor
 		{
 			get => TextColor ??
-				DefaultStyles.GetTextColor(this)?.Value as Color;
+				DefaultStyles.GetColor(this, TextColorProperty)?.Value as Color;
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/CheckBox.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/CheckBox.Impl.cs
@@ -5,12 +5,15 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="Type[@FullName='Microsoft.Maui.Controls.CheckBox']/Docs" />
 	public partial class CheckBox : ICheckBox, IMapColorPropertyToPaint
 	{
-		/// <include file="../../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="//Member[@MemberName='Foreground']/Docs" />
-		public Paint Foreground { get; private set; }
+		Paint Foreground { get; set; }
 
 		void IMapColorPropertyToPaint.MapColorPropertyToPaint(Color color)
 		{
 			Foreground = color?.AsPaint();
+			Handler?.UpdateValue(nameof(ICheckBox.Foreground));
 		}
+
+		Paint ICheckBox.Foreground =>
+				Foreground ?? (DefaultStyles.GetColor(this, ColorProperty)?.Value as Color)?.AsPaint();
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/DatePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/DatePicker.Impl.cs
@@ -1,8 +1,15 @@
-﻿namespace Microsoft.Maui.Controls
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.DatePicker']/Docs" />
 	public partial class DatePicker : IDatePicker
 	{
 		Font ITextStyle.Font => this.ToFont();
+		Color ITextStyle.TextColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, TextColorProperty)?.Value as Color;
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
+++ b/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
@@ -24,18 +24,26 @@ namespace Microsoft.Maui.Controls
 
 		class LightTheme
 		{
-			public static Color TextColor = new Color(1.0f, 1.0f, 1.0f);
+			public static Color ButtonTextColor => Colors.Black;
+			public static Color TextColor => Colors.Black;
 #if ANDROID
 			public static Color ButtonBackgroundColor = new Color(44, 62, 80);
 #else
-			public static Color ButtonBackgroundColor => Colors.Black;
+			public static Color ButtonBackgroundColor => Colors.White;
 #endif
 		}
 
 		class DarkTheme
 		{
-			public static Color TextColor = Colors.Black;
-			public static Color ButtonBackgroundColor => Colors.White;
+#if ANDROID
+			public static Color ButtonBackgroundColor = new Color(44, 62, 80);
+			public static Color TextColor => Colors.White;
+			public static Color ButtonTextColor => Colors.Black;
+#else
+			public static Color ButtonBackgroundColor => Colors.Black;
+			public static Color ButtonTextColor => Colors.White;
+			public static Color TextColor => Colors.White;
+#endif
 		}
 
 		public static Setter GetTextColor(BindableObject view)
@@ -59,7 +67,11 @@ namespace Microsoft.Maui.Controls
 				{
 					var textColorSetting = new Setter();
 					textColorSetting.Property = TextElement.TextColorProperty;
-					textColorSetting.Value = GetThemeChoice(LightTheme.TextColor, DarkTheme.TextColor);
+
+					if (view is Button)
+						textColorSetting.Value = GetThemeChoice(LightTheme.ButtonTextColor, DarkTheme.ButtonTextColor);
+					else
+						textColorSetting.Value = GetThemeChoice(LightTheme.TextColor, DarkTheme.TextColor);
 
 					styleToUse = new Style(typeof(Button))
 					{
@@ -142,7 +154,6 @@ namespace Microsoft.Maui.Controls
 				var disabledBackgroundColor = new Setter()
 				{
 					Property = Button.BackgroundColorProperty,
-					// Update this once AppThemeBindings are fixed
 					Value = GetThemeChoice(LightTheme.ButtonBackgroundColor, DarkTheme.ButtonBackgroundColor).WithAlpha(0.12f)
 				};
 
@@ -154,7 +165,6 @@ namespace Microsoft.Maui.Controls
 				var disabledTextColor = new Setter()
 				{
 					Property = TextElement.TextColorProperty,
-					// Update this once AppThemeBindings are fixed
 					Value = new Color(0f, 0f, 0f).WithAlpha(0.38f)
 				};
 				disabledSetters.Setters.Add(disabledTextColor);

--- a/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
+++ b/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Maui.Graphics;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+
+namespace Microsoft.Maui.Controls
+{
+	// Once MAUI is capable of packaging styles into XAML files we will have implicit styles
+	// that we can add as the base for the DefaultDictionary
+	internal static class DefaultStyles
+	{
+		static Style ButtonDefaultStyle { get; set; }
+		static Dictionary<Type, Style> TextElementDefaultStyle { get; } = new Dictionary<Type, Style>();
+
+		static T GetThemeChoice<T>(T light, T dark)
+		{
+			if (Application.Current?.RequestedTheme == AppTheme.Dark)
+				return dark;
+
+			return light;
+		}
+
+		class LightTheme
+		{
+			public static Color TextColor = new Color(1.0f, 1.0f, 1.0f);
+#if ANDROID
+			public static Color ButtonBackgroundColor = new Color(44, 62, 80);
+#else
+			public static Color ButtonBackgroundColor => Colors.Black;
+#endif
+		}
+
+		class DarkTheme
+		{
+			public static Color TextColor = Colors.Black;
+			public static Color ButtonBackgroundColor => Colors.White;
+		}
+
+		public static Setter GetTextColor(BindableObject view)
+		{
+#if ANDROID || IOS
+			Style styleToUse = null;
+
+			if (view is ITextElement)
+			{
+				// trigger VSM creation
+				if (view is VisualElement ve)
+					_ = VisualStateManager.GetVisualStateGroups(ve);
+
+				var viewType = view.GetType();
+
+				if (TextElementDefaultStyle.TryGetValue(viewType, out Style existing))
+				{
+					styleToUse = existing;
+				}
+				else
+				{
+					var textColorSetting = new Setter();
+					textColorSetting.Property = TextElement.TextColorProperty;
+					textColorSetting.Value = GetThemeChoice(LightTheme.TextColor, DarkTheme.TextColor);
+
+					styleToUse = new Style(typeof(Button))
+					{
+						Setters =
+						{
+							textColorSetting
+						}
+					};
+
+					TextElementDefaultStyle[viewType] = styleToUse;
+				}
+			}
+
+			if (styleToUse?.Setters?.Count > 0)
+			{
+				foreach (var setter in styleToUse.Setters)
+					if (setter.Property == TextElement.TextColorProperty)
+						return setter;
+			}
+
+			return null;
+#else
+			return null;
+#endif
+		}
+
+
+		public static Setter GetBackgroundColor(BindableObject view)
+		{
+#if ANDROID || IOS
+			Style styleToUse = null;
+
+			if (view is Button button)
+			{
+				// trigger VSM creation
+				_ = VisualStateManager.GetVisualStateGroups(button);
+				if (ButtonDefaultStyle == null)
+				{
+					var backgroundColorSetter = new Setter();
+					backgroundColorSetter.Property = VisualElement.BackgroundColorProperty;
+					backgroundColorSetter.Value = GetThemeChoice(LightTheme.ButtonBackgroundColor, DarkTheme.ButtonBackgroundColor);
+
+					ButtonDefaultStyle = new Style(typeof(Button))
+					{
+						Setters =
+							{
+								backgroundColorSetter
+							}
+					};
+
+				}
+
+				styleToUse = ButtonDefaultStyle;
+			}
+
+			if (styleToUse?.Setters?.Count > 0)
+			{
+				foreach (var setter in styleToUse.Setters)
+					if (setter.Property == VisualElement.BackgroundColorProperty)
+						return setter;
+			}
+
+			return null;
+#else
+			return null;
+#endif
+		}
+
+		internal static VisualStateGroupList GetVisualStateManager(BindableObject bindable)
+		{
+#if IOS || ANDROID
+			var visualStateGroup = new VisualStateGroup() { Name = "CommonStates" };
+			var disabledSetters = new VisualState()
+			{
+				Name = "Disabled"
+			};
+
+			if (bindable is Button button)
+			{
+				var disabledBackgroundColor = new Setter()
+				{
+					Property = Button.BackgroundColorProperty,
+					// Update this once AppThemeBindings are fixed
+					Value = GetThemeChoice(LightTheme.ButtonBackgroundColor, DarkTheme.ButtonBackgroundColor).WithAlpha(0.12f)
+				};
+
+				disabledSetters.Setters.Add(disabledBackgroundColor);
+			}
+
+			if (bindable is ITextElement)
+			{
+				var disabledTextColor = new Setter()
+				{
+					Property = TextElement.TextColorProperty,
+					// Update this once AppThemeBindings are fixed
+					Value = new Color(0f, 0f, 0f).WithAlpha(0.38f)
+				};
+				disabledSetters.Setters.Add(disabledTextColor);
+			}
+
+			if (disabledSetters.Setters.Count > 0)
+			{
+				var visualStateGroupList = new VisualStateGroupList();
+
+				visualStateGroup.States.Add(new VisualState()
+				{
+					Name = "Normal"
+				});
+
+				visualStateGroup.States.Add(disabledSetters);
+
+				return new VisualStateGroupList() { visualStateGroup };
+			}
+#endif
+			return null;
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
+++ b/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Maui.Controls
 		{
 			public static Color TextColor => Colors.Black;
 			public static Color PickerTitleColor => Colors.White;
-
 			public static Color BackgroundColor = Colors.White;
 
 			// These all match the accent color set in android
@@ -107,6 +106,26 @@ namespace Microsoft.Maui.Controls
 			{
 				style = new Style(viewType);
 				DefaultStylesCache[viewType] = style;
+			}
+
+			return null;
+		}
+
+		public static AppThemeBinding GetAppThemeBinding(
+			Type viewType,
+			BindableProperty bindableProperty,
+			float withAlpha = 1f)
+		{
+			var dark = (GetColor(viewType, bindableProperty, AppTheme.Dark)?.Value as Color)?.WithAlpha(withAlpha);
+			var light = (GetColor(viewType, bindableProperty, AppTheme.Light)?.Value as Color)?.WithAlpha(withAlpha);
+
+			if (dark != null && light != null)
+			{
+				return new AppThemeBinding()
+				{
+					Dark = dark,
+					Light = light
+				};
 			}
 
 			return null;
@@ -225,6 +244,7 @@ namespace Microsoft.Maui.Controls
 
 		internal static VisualStateGroupList GetVisualStateManager(Type viewType, BindableObject bindable = null)
 		{
+
 #if IOS || ANDROID
 
 			// This means we are retrieving this for a style not a specific bindable
@@ -243,24 +263,26 @@ namespace Microsoft.Maui.Controls
 				Name = "Disabled"
 			};
 
-			if (viewType.IsAssignableFrom(typeof(Button)))
-			{
-				var disabledBackgroundColor = new Setter()
-				{
-					Property = Button.BackgroundColorProperty,
-					Value = GetThemeChoice(LightTheme.ButtonBackgroundColor, DarkTheme.ButtonBackgroundColor).WithAlpha(0.12f)
-				};
 
-				disabledSetters.Setters.Add(disabledBackgroundColor);
+			var disabledBackgroundThemeBinding = GetAppThemeBinding(viewType, VisualElement.BackgroundColorProperty, 0.12f);
+
+			if (disabledBackgroundThemeBinding != null)
+			{
+				disabledSetters.Setters.Add(new Setter()
+				{
+					Property = VisualElement.BackgroundColorProperty,
+					Value = disabledBackgroundThemeBinding
+				});
 			}
 
-			if (viewType.IsAssignableFrom(typeof(ITextElement)))
+			if (viewType.IsAssignableTo(typeof(ITextElement)))
 			{
 				var disabledTextColor = new Setter()
 				{
 					Property = TextElement.TextColorProperty,
 					Value = new Color(0f, 0f, 0f).WithAlpha(0.38f)
 				};
+
 				disabledSetters.Setters.Add(disabledTextColor);
 			}
 

--- a/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
+++ b/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
@@ -50,15 +50,14 @@ namespace Microsoft.Maui.Controls
 			public static Color SwitchThumbColor => AccentColor;
 			public static Color SliderThumbColor => AccentColor;
 #else
-			public static Color SwitchThumbColor => null;// new Color(0.2039216f, 0.5960785f, 0.8588235f, 1);
-
+			public static Color SwitchThumbColor => null;
 			public static Color SliderThumbColor => null;
 			public static Color ButtonBackgroundColor => Colors.White;
 			public static Color ButtonTextColor => new(0, 122, 255);
-			public static Color SwitchOnColor = new (120, 120, 128, 40);
+			public static Color SwitchOnColor => null;
 			public static Color ActivityIndicatorColor = new Color(0, 0, 0, 114);
 			public static Color SliderMinimumTrackColor => null;
-			public static Color SliderMaximumTrackColor => null;// new Color(0f, 0f, 0f);
+			public static Color SliderMaximumTrackColor => null;
 #endif
 		}
 
@@ -72,27 +71,32 @@ namespace Microsoft.Maui.Controls
 			//
 			// Here I've just picked the current blackish color we are using in MAUI
 			public static Color AccentColor = new Color(52, 152, 219);
-			public static Color ActivityIndicatorColor => AccentColor;
 			public static Color CheckBoxColor => AccentColor;
-			public static Color SliderThumbColor => AccentColor;
 			public static Color ProgressBarProgressColor => AccentColor;
 
 			public static Color PlaceholderElementPlaceholderColor = TextColor.WithAlpha(0.38f);
 			public static Color PickerTitleColor => TextColor;
 			public static Color TextColor => Colors.White;
-			public static Color SwitchThumbColor => AccentColor;
 
 			public static Color SearchBarCancelButtonColor => ButtonBackgroundColor;
-			public static Color SliderMinimumTrackColor => SliderThumbColor;
-			public static Color SliderMaximumTrackColor = SliderThumbColor.WithAlpha(0.50f);
 #if ANDROID
 			public static Color ButtonBackgroundColor = new Color(44, 62, 80);
 			public static Color ButtonTextColor => Colors.Black;
 			public static Color SwitchOnColor => null;
+			public static Color SliderMinimumTrackColor => SliderThumbColor;
+			public static Color SliderMaximumTrackColor = SliderThumbColor.WithAlpha(0.50f);
+			public static Color ActivityIndicatorColor => AccentColor;
+			public static Color SwitchThumbColor => AccentColor;
+			public static Color SliderThumbColor => AccentColor;
 #else
 			public static Color ButtonBackgroundColor => Colors.Black;
-			public static Color ButtonTextColor => Colors.White;
-			public static Color SwitchOnColor => AccentColor;
+			public static Color ButtonTextColor => new(0, 122, 255);
+			public static Color SwitchThumbColor => null;
+			public static Color SliderThumbColor => null;
+			public static Color SwitchOnColor => null;
+			public static Color ActivityIndicatorColor = new Color(0, 0, 0, 114);
+			public static Color SliderMinimumTrackColor => null;
+			public static Color SliderMaximumTrackColor => null;
 #endif
 		}
 
@@ -270,9 +274,10 @@ namespace Microsoft.Maui.Controls
 			};
 
 
+#if ANDROID
 			var disabledBackgroundThemeBinding = GetAppThemeBinding(viewType, VisualElement.BackgroundColorProperty, 0.12f);
 
-			if (disabledBackgroundThemeBinding != null)
+			if (disabledBackgroundThemeBinding != null && viewType.IsAssignableTo(typeof(Button)))
 			{
 				disabledSetters.Setters.Add(new Setter()
 				{
@@ -281,6 +286,7 @@ namespace Microsoft.Maui.Controls
 				});
 			}
 
+			
 			if (viewType.IsAssignableTo(typeof(ITextElement)))
 			{
 				var disabledTextColor = new Setter()
@@ -291,6 +297,20 @@ namespace Microsoft.Maui.Controls
 
 				disabledSetters.Setters.Add(disabledTextColor);
 			}
+#endif
+
+#if IOS
+			if (viewType.IsAssignableTo(typeof(Button)))
+			{
+				var disabledTextColor = new Setter()
+				{
+					Property = TextElement.TextColorProperty,
+					Value = new AppThemeBinding() { Dark = new Color(130, 130, 130).WithAlpha(89), Light = new Color(89, 130, 130).WithAlpha(89) }
+				};
+
+				disabledSetters.Setters.Add(disabledTextColor);
+			}
+#endif
 
 			if (disabledSetters.Setters.Count > 0)
 			{

--- a/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
+++ b/src/Controls/src/Core/HandlerImpl/DefaultStyles.cs
@@ -34,25 +34,31 @@ namespace Microsoft.Maui.Controls
 			//
 			// Here I've just picked the current blackish color we are using in MAUI
 			public static Color AccentColor = new Color(52, 152, 219);
-			public static Color ActivityIndicatorColor => AccentColor;
 			public static Color CheckBoxColor => AccentColor;
-			public static Color SliderThumbColor => AccentColor;
 			public static Color ProgressBarProgressColor => AccentColor;
-			public static Color SwitchThumbColor => AccentColor;
 
 			public static Color PlaceholderElementPlaceholderColor = TextColor.WithAlpha(0.50f);
 			public static Color SearchBarCancelButtonColor => ButtonBackgroundColor;
-			public static Color SliderMinimumTrackColor => Colors.Black;
-			public static Color SliderMaximumTrackColor = SliderThumbColor.WithAlpha(0.50f);
 
 #if ANDROID
 			public static Color ButtonBackgroundColor = new Color(44, 62, 80);
 			public static Color ButtonTextColor => Colors.White;
 			public static Color SwitchOnColor => null;
+			public static Color ActivityIndicatorColor => AccentColor;
+			public static Color SliderMaximumTrackColor = SliderThumbColor.WithAlpha(0.50f);
+			public static Color SliderMinimumTrackColor => Colors.Black;
+			public static Color SwitchThumbColor => AccentColor;
+			public static Color SliderThumbColor => AccentColor;
 #else
+			public static Color SwitchThumbColor => null;// new Color(0.2039216f, 0.5960785f, 0.8588235f, 1);
+
+			public static Color SliderThumbColor => null;
 			public static Color ButtonBackgroundColor => Colors.White;
-			public static Color ButtonTextColor => Colors.Black;
-			public static Color SwitchOnColor => AccentColor;
+			public static Color ButtonTextColor => new(0, 122, 255);
+			public static Color SwitchOnColor = new (120, 120, 128, 40);
+			public static Color ActivityIndicatorColor = new Color(0, 0, 0, 114);
+			public static Color SliderMinimumTrackColor => null;
+			public static Color SliderMaximumTrackColor => null;// new Color(0f, 0f, 0f);
 #endif
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/Editor/Editor.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor/Editor.Impl.cs
@@ -12,6 +12,18 @@ namespace Microsoft.Maui.Controls
 
 		Font ITextStyle.Font => this.ToFont();
 
+		Color ITextStyle.TextColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, TextColorProperty)?.Value as Color;
+		}
+
+		Color IPlaceholder.PlaceholderColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, PlaceholderColorProperty)?.Value as Color;
+		}
+
 		void IEditor.Completed()
 		{
 			(this as IEditorController).SendCompleted();

--- a/src/Controls/src/Core/HandlerImpl/Entry/Entry.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry/Entry.Impl.cs
@@ -1,9 +1,23 @@
-﻿namespace Microsoft.Maui.Controls
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../../docs/Microsoft.Maui.Controls/Entry.xml" path="Type[@FullName='Microsoft.Maui.Controls.Entry']/Docs" />
 	public partial class Entry : IEntry
 	{
 		Font ITextStyle.Font => this.ToFont();
+
+		Color ITextStyle.TextColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, TextColorProperty)?.Value as Color;
+		}
+
+		Color IPlaceholder.PlaceholderColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, PlaceholderColorProperty)?.Value as Color;
+		}
 
 		void IEntry.Completed()
 		{

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Impl.cs
@@ -1,8 +1,16 @@
+using Microsoft.Maui.Graphics;
+
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../../docs/Microsoft.Maui.Controls/Label.xml" path="Type[@FullName='Microsoft.Maui.Controls.Label']/Docs" />
 	public partial class Label : ILabel
 	{
+		Color ITextStyle.TextColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetTextColor(this)?.Value as Color;
+		}
+		
 		Font ITextStyle.Font => this.ToFont();
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Impl.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Maui.Controls
 		Color ITextStyle.TextColor
 		{
 			get => TextColor ??
-				DefaultStyles.GetTextColor(this)?.Value as Color;
+				DefaultStyles.GetColor(this, TextColorProperty)?.Value as Color;
 		}
-		
+
 		Font ITextStyle.Font => this.ToFont();
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Picker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Picker.Impl.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
@@ -7,12 +8,24 @@ namespace Microsoft.Maui.Controls
 	{
 		Font ITextStyle.Font => this.ToFont();
 
+		Color ITextStyle.TextColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, TextColorProperty)?.Value as Color;
+		}
+
+		Color IPicker.TitleColor
+		{
+			get => TitleColor ??
+				DefaultStyles.GetColor(this, TitleColorProperty)?.Value as Color;
+		}
+
 		IList<string> IPicker.Items => Items;
 
 		int IItemDelegate<string>.GetCount() => Items?.Count ?? ItemsSource?.Count ?? 0;
 
 		string IItemDelegate<string>.GetItem(int index)
-		{
+		{			
 			if (index < 0)
 				return "";
 			if (index < Items?.Count)

--- a/src/Controls/src/Core/HandlerImpl/ProgressBar.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ProgressBar.Impl.cs
@@ -1,8 +1,14 @@
-﻿namespace Microsoft.Maui.Controls
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/ProgressBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.ProgressBar']/Docs" />
 	public partial class ProgressBar : IProgress
 	{
-
+		Color IProgress.ProgressColor
+		{
+			get => ProgressColor ??
+				DefaultStyles.GetColor(this, ProgressColorProperty)?.Value as Color;
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Impl.cs
@@ -1,9 +1,29 @@
-﻿namespace Microsoft.Maui.Controls
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="Type[@FullName='Microsoft.Maui.Controls.SearchBar']/Docs" />
 	public partial class SearchBar : ISearchBar
 	{
 		Font ITextStyle.Font => this.ToFont();
+
+		Color ITextStyle.TextColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, TextColorProperty)?.Value as Color;
+		}
+
+		Color IPlaceholder.PlaceholderColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, PlaceholderColorProperty)?.Value as Color;
+		}
+
+		Color ISearchBar.CancelButtonColor
+		{
+			get => CancelButtonColor ??
+				DefaultStyles.GetColor(this, CancelButtonColorProperty)?.Value as Color;
+		}
 
 		bool ITextInput.IsTextPredictionEnabled => true;
 

--- a/src/Controls/src/Core/HandlerImpl/Slider.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Slider.Impl.cs
@@ -1,3 +1,5 @@
+using Microsoft.Maui.Graphics;
+
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/Slider.xml" path="Type[@FullName='Microsoft.Maui.Controls.Slider']/Docs" />
@@ -13,6 +15,24 @@ namespace Microsoft.Maui.Controls
 		void ISlider.DragStarted()
 		{
 			(this as ISliderController).SendDragStarted();
+		}
+
+		Color ISlider.MaximumTrackColor
+		{
+			get => MaximumTrackColor ??
+				DefaultStyles.GetColor(this, MaximumTrackColorProperty)?.Value as Color;
+		}
+
+		Color ISlider.MinimumTrackColor
+		{
+			get => MinimumTrackColor ??
+				DefaultStyles.GetColor(this, MinimumTrackColorProperty)?.Value as Color;
+		}
+
+		Color ISlider.ThumbColor
+		{
+			get => ThumbColor ??
+				DefaultStyles.GetColor(this, ThumbColorProperty)?.Value as Color;
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Switch.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Switch.Impl.cs
@@ -22,11 +22,17 @@ namespace Microsoft.Maui.Controls
 				return OnColor;
 #else
 				if (IsToggled)
-					return OnColor;
+					return OnColor ?? DefaultStyles.GetColor(this, OnColorProperty)?.Value as Color;
 
 				return null;
 #endif
 			}
+		}
+
+		Color ISwitch.ThumbColor
+		{
+			get => ThumbColor ??
+				DefaultStyles.GetColor(this, ThumbColorProperty)?.Value as Color;
 		}
 
 		bool ISwitch.IsOn

--- a/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/TimePicker.Impl.cs
@@ -1,8 +1,16 @@
-﻿namespace Microsoft.Maui.Controls
+﻿using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="Type[@FullName='Microsoft.Maui.Controls.TimePicker']/Docs" />
 	public partial class TimePicker : ITimePicker
 	{
 		Font ITextStyle.Font => this.ToFont();
+
+		Color ITextStyle.TextColor
+		{
+			get => TextColor ??
+				DefaultStyles.GetColor(this, TextColorProperty)?.Value as Color;
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -59,8 +59,11 @@ namespace Microsoft.Maui.Controls
 			{
 				if (!Brush.IsNullOrEmpty(Background))
 					return Background;
-				if (BackgroundColor.IsNotDefault())
-					return new SolidColorBrush(BackgroundColor);
+
+				var color = BackgroundColor ?? (DefaultStyles.GetColor(this, BackgroundColorProperty).Value as Color);
+
+				if (color.IsNotDefault())
+					return new SolidColorBrush(color);
 
 				return null;
 			}
@@ -212,7 +215,7 @@ namespace Microsoft.Maui.Controls
 				{
 					return Primitives.Dimension.Unset;
 				}
-				
+
 				ValidatePositive(value, nameof(IView.Width));
 				return value;
 			}
@@ -234,7 +237,7 @@ namespace Microsoft.Maui.Controls
 				{
 					return Primitives.Dimension.Unset;
 				}
-				
+
 				ValidatePositive(value, nameof(IView.Height));
 				return value;
 			}

--- a/src/Controls/src/Core/TextElement.cs
+++ b/src/Controls/src/Core/TextElement.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	static class TextElement
 	{
 		public static readonly BindableProperty TextColorProperty =
-			BindableProperty.Create(nameof(ITextElement.TextColor), typeof(Color), typeof(ITextElement), defaultValue: null, defaultValueCreator: DefaultTextColorValueCreator,
+			BindableProperty.Create(nameof(ITextElement.TextColor), typeof(Color), typeof(ITextElement), defaultValue: null, /*defaultValueCreator: DefaultTextColorValueCreator,*/
 									propertyChanged: OnTextColorPropertyChanged);
 
 		public static readonly BindableProperty CharacterSpacingProperty =

--- a/src/Controls/src/Core/TextElement.cs
+++ b/src/Controls/src/Core/TextElement.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	static class TextElement
 	{
 		public static readonly BindableProperty TextColorProperty =
-			BindableProperty.Create(nameof(ITextElement.TextColor), typeof(Color), typeof(ITextElement), null,
+			BindableProperty.Create(nameof(ITextElement.TextColor), typeof(Color), typeof(ITextElement), defaultValue: null, defaultValueCreator: DefaultTextColorValueCreator,
 									propertyChanged: OnTextColorPropertyChanged);
 
 		public static readonly BindableProperty CharacterSpacingProperty =
@@ -30,5 +30,8 @@ namespace Microsoft.Maui.Controls
 		{
 			((ITextElement)bindable).OnTextTransformChanged((TextTransform)oldValue, (TextTransform)newValue);
 		}
+
+		static object DefaultTextColorValueCreator(BindableObject bindable) =>
+			DefaultStyles.GetTextColor(bindable)?.Value;
 	}
 }

--- a/src/Controls/src/Core/TextElement.cs
+++ b/src/Controls/src/Core/TextElement.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 	static class TextElement
 	{
 		public static readonly BindableProperty TextColorProperty =
-			BindableProperty.Create(nameof(ITextElement.TextColor), typeof(Color), typeof(ITextElement), defaultValue: null, /*defaultValueCreator: DefaultTextColorValueCreator,*/
+			BindableProperty.Create(nameof(ITextElement.TextColor), typeof(Color), typeof(ITextElement), defaultValue: null,
 									propertyChanged: OnTextColorPropertyChanged);
 
 		public static readonly BindableProperty CharacterSpacingProperty =
@@ -30,8 +30,5 @@ namespace Microsoft.Maui.Controls
 		{
 			((ITextElement)bindable).OnTextTransformChanged((TextTransform)oldValue, (TextTransform)newValue);
 		}
-
-		static object DefaultTextColorValueCreator(BindableObject bindable) =>
-			DefaultStyles.GetTextColor(bindable)?.Value;
 	}
 }

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -228,7 +228,8 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty OpacityProperty = BindableProperty.Create("Opacity", typeof(double), typeof(VisualElement), 1d, coerceValue: (bindable, value) => ((double)value).Clamp(0, 1));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BackgroundColorProperty']/Docs" />
-		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(VisualElement), defaultValueCreator: DefaultBackgroundColorValueCreator);
+		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(VisualElement), defaultValue: null/*, 
+			defaultValueCreator: DefaultBackgroundColorValueCreator*/);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BackgroundProperty']/Docs" />
 		public static readonly BindableProperty BackgroundProperty = BindableProperty.Create(nameof(Background), typeof(Brush), typeof(VisualElement), Brush.Default,

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty OpacityProperty = BindableProperty.Create("Opacity", typeof(double), typeof(VisualElement), 1d, coerceValue: (bindable, value) => ((double)value).Clamp(0, 1));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BackgroundColorProperty']/Docs" />
-		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(VisualElement), null);
+		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(VisualElement), defaultValueCreator: DefaultBackgroundColorValueCreator);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BackgroundProperty']/Docs" />
 		public static readonly BindableProperty BackgroundProperty = BindableProperty.Create(nameof(Background), typeof(Brush), typeof(VisualElement), Brush.Default,
@@ -242,6 +242,9 @@ namespace Microsoft.Maui.Controls
 				if (newvalue != null)
 					(bindable as VisualElement)?.NotifyBackgroundChanges();
 			});
+
+		static object DefaultBackgroundColorValueCreator(BindableObject bindable) =>
+			DefaultStyles.GetBackgroundColor(bindable)?.Value;
 
 		void NotifyBackgroundChanges()
 		{

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Maui.Controls
 			});
 
 		static object DefaultBackgroundColorValueCreator(BindableObject bindable) =>
-			DefaultStyles.GetBackgroundColor(bindable)?.Value;
+			DefaultStyles.GetColor(bindable, VisualElement.BackgroundColorProperty)?.Value;
 
 		void NotifyBackgroundChanges()
 		{

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -228,8 +228,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty OpacityProperty = BindableProperty.Create("Opacity", typeof(double), typeof(VisualElement), 1d, coerceValue: (bindable, value) => ((double)value).Clamp(0, 1));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BackgroundColorProperty']/Docs" />
-		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(VisualElement), defaultValue: null/*, 
-			defaultValueCreator: DefaultBackgroundColorValueCreator*/);
+		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(VisualElement), defaultValue: null);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='BackgroundProperty']/Docs" />
 		public static readonly BindableProperty BackgroundProperty = BindableProperty.Create(nameof(Background), typeof(Brush), typeof(VisualElement), Brush.Default,
@@ -243,9 +242,6 @@ namespace Microsoft.Maui.Controls
 				if (newvalue != null)
 					(bindable as VisualElement)?.NotifyBackgroundChanges();
 			});
-
-		static object DefaultBackgroundColorValueCreator(BindableObject bindable) =>
-			DefaultStyles.GetColor(bindable, VisualElement.BackgroundColorProperty)?.Value;
 
 		void NotifyBackgroundChanges()
 		{

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.CreateAttached("VisualStateGroups", typeof(VisualStateGroupList), typeof(VisualElement),
 				defaultValue: null, propertyChanged: VisualStateGroupsPropertyChanged,
 				defaultValueCreator: bindable =>
-						DefaultStyles.GetVisualStateManager(bindable) ??
+						//DefaultStyles.GetVisualStateManager(bindable) ??
 						new VisualStateGroupList(true) { VisualElement = (VisualElement)bindable });
 
 		static void VisualStateGroupsPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty VisualStateGroupsProperty =
 			BindableProperty.CreateAttached("VisualStateGroups", typeof(VisualStateGroupList), typeof(VisualElement),
 				defaultValue: null, propertyChanged: VisualStateGroupsPropertyChanged,
-				defaultValueCreator: bindable => new VisualStateGroupList(true) { VisualElement = (VisualElement)bindable });
+				defaultValueCreator: bindable =>
+						DefaultStyles.GetVisualStateManager(bindable) ??
+						new VisualStateGroupList(true) { VisualElement = (VisualElement)bindable });
 
 		static void VisualStateGroupsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Maui.Controls
 			BindableProperty.CreateAttached("VisualStateGroups", typeof(VisualStateGroupList), typeof(VisualElement),
 				defaultValue: null, propertyChanged: VisualStateGroupsPropertyChanged,
 				defaultValueCreator: bindable =>
-						//DefaultStyles.GetVisualStateManager(bindable) ??
 						new VisualStateGroupList(true) { VisualElement = (VisualElement)bindable });
 
 		static void VisualStateGroupsPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Core/src/Core/IPlaceholder.cs
+++ b/src/Core/src/Core/IPlaceholder.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Maui
 		/// <summary>
 		/// Gets or sets the placeholder text color.
 		/// </summary>
-		Color PlaceholderColor { get; set; }
+		Color PlaceholderColor { get; }
 	}
 }

--- a/src/Core/src/Platform/Android/ContextExtensions.cs
+++ b/src/Core/src/Platform/Android/ContextExtensions.cs
@@ -280,21 +280,22 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
+		internal static Color GetPrimaryColor(this Context context)
+		{
+			var result = context?.GetThemeAttrColor(global::Android.Resource.Attribute.ColorPrimary);
+			if (result != null)
+				return Color.FromUint((uint)result.Value);
+
+			return Color.FromArgb("#2c3e50");
+		}
+
 		internal static Color GetAccentColor(this Context context)
 		{
-			Color? rc = null;
-			using (var value = new TypedValue())
-			{
-				if (context.Theme != null)
-				{
-					if (context.Theme.ResolveAttribute(global::Android.Resource.Attribute.ColorAccent, value, true)) // Android 5.0+
-					{
-						rc = Color.FromUint((uint)value.Data);
-					}
-				}
-			}
+			var result = context?.GetThemeAttrColor(global::Android.Resource.Attribute.ColorAccent);
+			if (result != null)
+				return Color.FromUint((uint)result.Value);
 
-			return rc ?? Color.FromArgb("#ff33b5e5");
+			return Color.FromArgb("#ff33b5e5");
 		}
 
 		public static int GetActionBarHeight(this Context context)

--- a/src/Core/src/Platform/Android/SwitchExtensions.cs
+++ b/src/Core/src/Platform/Android/SwitchExtensions.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui.Platform
 			{
 				if (trackColor != null)
 					aSwitch.TrackDrawable?.SetColorFilter(trackColor, FilterMode.SrcAtop);
+				else
+					aSwitch.TrackDrawable?.ClearColorFilter();
 			}
 			else
 				aSwitch.TrackDrawable?.ClearColorFilter();
@@ -27,6 +29,8 @@ namespace Microsoft.Maui.Platform
 
 			if (thumbColor != null)
 				aSwitch.ThumbDrawable?.SetColorFilter(thumbColor, FilterMode.SrcAtop);
+			else
+				aSwitch.ThumbDrawable?.ClearColorFilter();
 		}
 
 		public static Drawable GetDefaultSwitchTrackDrawable(this ASwitch aSwitch) =>

--- a/src/Core/src/Platform/iOS/SliderExtensions.cs
+++ b/src/Core/src/Platform/iOS/SliderExtensions.cs
@@ -26,18 +26,24 @@ namespace Microsoft.Maui.Platform
 		{
 			if (slider.MinimumTrackColor != null)
 				uiSlider.MinimumTrackTintColor = slider.MinimumTrackColor.ToPlatform();
+			else
+				uiSlider.MinimumTrackTintColor = null;
 		}
 
 		public static void UpdateMaximumTrackColor(this UISlider uiSlider, ISlider slider)
 		{
 			if (slider.MaximumTrackColor != null)
 				uiSlider.MaximumTrackTintColor = slider.MaximumTrackColor.ToPlatform();
+			else
+				uiSlider.MaximumTrackTintColor = null;
 		}
 
 		public static void UpdateThumbColor(this UISlider uiSlider, ISlider slider)
 		{
 			if (slider.ThumbColor != null)
 				uiSlider.ThumbTintColor = slider.ThumbColor.ToPlatform();
+			else
+				uiSlider.ThumbTintColor = null;
 		}
 
 		public static async Task UpdateThumbImageSourceAsync(this UISlider uiSlider, ISlider slider, IImageSourceServiceProvider provider)

--- a/src/Core/src/Platform/iOS/SwitchExtensions.cs
+++ b/src/Core/src/Platform/iOS/SwitchExtensions.cs
@@ -24,6 +24,10 @@ namespace Microsoft.Maui.Platform
 
 			if (view.TrackColor != null)
 				uIView.BackgroundColor = uiSwitch.OnTintColor;
+			else if (uiSwitch.On)
+				uIView.BackgroundColor = null;
+			else
+				uIView.BackgroundColor = new Graphics.Color(120, 120, 128, 40).ToPlatform();
 		}
 
 		public static void UpdateThumbColor(this UISwitch uiSwitch, ISwitch view)
@@ -35,7 +39,7 @@ namespace Microsoft.Maui.Platform
 			if (thumbColor != null)
 				uiSwitch.ThumbTintColor = thumbColor?.ToPlatform();
 			else
-				uiSwitch.ThumbTintColor = null;
+				uiSwitch.ThumbTintColor = thumbColor?.ToPlatform();
 		}
 
 		internal static UIView GetTrackSubview(this UISwitch uISwitch)

--- a/src/Core/src/Platform/iOS/SwitchExtensions.cs
+++ b/src/Core/src/Platform/iOS/SwitchExtensions.cs
@@ -20,11 +20,7 @@ namespace Microsoft.Maui.Platform
 			if (view.TrackColor != null)
 				uiSwitch.OnTintColor = view.TrackColor.ToPlatform();
 
-			UIView uIView;
-			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
-				uIView = uiSwitch.Subviews[0].Subviews[0];
-			else
-				uIView = uiSwitch.Subviews[0].Subviews[0].Subviews[0];
+			UIView uIView = uiSwitch.GetTrackSubview();
 
 			if (view.TrackColor != null)
 				uIView.BackgroundColor = uiSwitch.OnTintColor;
@@ -38,6 +34,8 @@ namespace Microsoft.Maui.Platform
 			Graphics.Color thumbColor = view.ThumbColor;
 			if (thumbColor != null)
 				uiSwitch.ThumbTintColor = thumbColor?.ToPlatform();
+			else
+				uiSwitch.ThumbTintColor = null;
 		}
 
 		internal static UIView GetTrackSubview(this UISwitch uISwitch)


### PR DESCRIPTION
### Description of Change

Because of the inability to define default styles in [xaml](https://github.com/dotnet/maui/issues/6350) this PR attempts to just codify a set of defaults that will act the same as an included XAML file. 

The end goal will be to have something like [this](https://github.com/dotnet/maui/blob/main/src/Templates/src/templates/maui-mobile/Resources/Colors.xaml) implicitly included into your MAUI project. 

Then if users want to change theme colors they only have to modify a small set of colors to affect the entire application. 