### PR TITLE
Generate MSIX when publishing

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -8,6 +8,7 @@
     <WinUISDKReferences Condition=" '$(WinUISDKReferences)' == '' and '$(EnableMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">false</WinUISDKReferences>
     <GenerateLibraryLayout Condition=" '$(GenerateLibraryLayout)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">true</GenerateLibraryLayout>
     <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
+    <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
     <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>
     <_SingleProjectRIDSpecified Condition="'$(RuntimeIdentifier)' != '' or '$(RuntimeIdentifiers)' != ''">true</_SingleProjectRIDSpecified>
   </PropertyGroup>


### PR DESCRIPTION
### Description of Change

Produce a MSIX when publishing a MSIX app. This does not attempt to produce a MSIX when publishing an unpackaged app.

I did not condition this on the Configuration (Debug/Release) because I still want to produce a debug app. If you do `dotnet publish`, then you are obviously wanting to publish.

This new `PublishAppxPackage` value is not an instruction, but rather a value that something else looks at:

```xml
<GenerateMsixAfterTarget Condition="
    '$(GenerateMsixAfterTarget)'=='' and
    '$(PublishAppxPackage)'=='true'">Publish</GenerateMsixAfterTarget>
```
```xml
  <Target Name="GenerateMsixPackage"
          Condition="'$(_GenerateMsixPackage)'=='true' "
          AfterTargets="$(GenerateMsixAfterTarget)"
          DependsOnTargets="$(GenerateMsixPackageDependsOn)" />

```

### Issues Fixed

Fixes #5884 