### PR TITLE
Use Android AppCompat Everywhere

### DIFF
--- a/src/Core/src/Platform/Android/MauiDatePicker.cs
+++ b/src/Core/src/Platform/Android/MauiDatePicker.cs
@@ -4,13 +4,13 @@ using Android.Runtime;
 using Android.Text;
 using Android.Util;
 using Android.Views;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Graphics.Drawable;
 using static Android.Views.View;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiDatePicker : EditText, IOnClickListener
+	public class MauiDatePicker : AppCompatEditText, IOnClickListener
 	{
 		public MauiDatePicker(Context? context) : base(context)
 		{

--- a/src/Core/src/Platform/Android/MauiPicker.cs
+++ b/src/Core/src/Platform/Android/MauiPicker.cs
@@ -1,7 +1,7 @@
 ﻿using Android.Content;
 using Android.Runtime;
 using Android.Views;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Graphics.Drawable;
 using ARect = Android.Graphics.Rect;
 
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Platform
 		}
 	}
 
-	public class MauiPickerBase : EditText
+	public class MauiPickerBase : AppCompatEditText
 	{
 		public MauiPickerBase(Context? context) : base(context)
 		{

--- a/src/Core/src/Platform/Android/MauiTimePicker.cs
+++ b/src/Core/src/Platform/Android/MauiTimePicker.cs
@@ -4,13 +4,13 @@ using Android.Runtime;
 using Android.Text;
 using Android.Util;
 using Android.Views;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Graphics.Drawable;
 using static Android.Views.View;
 
 namespace Microsoft.Maui.Platform
 {
-	public class MauiTimePicker : EditText, IOnClickListener
+	public class MauiTimePicker : AppCompatEditText, IOnClickListener
 	{
 		public MauiTimePicker(Context? context) : base(context)
 		{


### PR DESCRIPTION
### Description of Change

Went through the Android code to track down places where we are not using AppCompat controls yet. Luckily it doesn't seem to be that much. Added the AppCompat ones here and we should be all AppCompat now!

Needed for instance to be compliant with the Emoji Policy (see https://github.com/xamarin/Xamarin.Forms/issues/15245)

### Issues Fixed

NA
