### PR TITLE
Allow closing of windows when using a MainPage

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application.Impl.cs
@@ -65,7 +65,8 @@ namespace Microsoft.Maui.Controls
 
 		internal void RemoveWindow(Window window)
 		{
-			if (_singleWindowMainPage != null)
+			// Do not attempt to close the "MainPage" window
+			if (_singleWindowMainPage != null && window.Page == _singleWindowMainPage)
 				return;
 
 			// Window was closed, stop tracking it
@@ -81,9 +82,6 @@ namespace Microsoft.Maui.Controls
 				InternalChildren.Remove(windowElement);
 				windowElement.Parent = null;
 				OnChildRemoved(windowElement, oldIndex);
-
-				if (_singleWindowMainPage != null)
-					window.Page = null;
 			}
 
 			_windows.Remove(window);

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -5,12 +5,9 @@
     <RootNamespace>Microsoft.Maui.Essentials</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <WarningsNotAsErrors>BI1234</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
     <IsPackable>false</IsPackable>
-    <GenerateReferenceAssemblySource>true</GenerateReferenceAssemblySource>
-    <!--<GenAPIAdditionalParameters>- -api-only</GenAPIAdditionalParameters>-->
     <IsTrimmable>true</IsTrimmable>
-    <GenerateReferenceAssemblySource>true</GenerateReferenceAssemblySource>
-    <GenAPIAdditionalParameters>--api-only --writer CSDecl</GenAPIAdditionalParameters>
   </PropertyGroup>
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
@@ -18,7 +15,6 @@
     <PackageReference Remove="*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="6.0.0-*" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Maui.Graphics" />
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />
     <None Include="..\..\..\Assets\xamarin.essentials_128x128.png" PackagePath="icon.png" Pack="true" />


### PR DESCRIPTION
### Description of Change

The initial work in #4860, there was work to avoid clearing up the window that is still being used.

This PR reduces the prevention to only prevent the closure of the MainPage window.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6103
Related to: #4860
