### PR TITLE
Allow un-setting of Core Width/Height with -1 via Controls Width/HeightRequest

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -207,6 +207,12 @@ namespace Microsoft.Maui.Controls
 
 				// Access once up front to avoid multiple GetValue calls
 				var value = WidthRequest;
+
+				if (value == -1)
+				{
+					return Primitives.Dimension.Unset;
+				}
+				
 				ValidatePositive(value, nameof(IView.Width));
 				return value;
 			}
@@ -223,6 +229,12 @@ namespace Microsoft.Maui.Controls
 
 				// Access once up front to avoid multiple GetValue calls
 				var value = HeightRequest;
+
+				if (value == -1)
+				{
+					return Primitives.Dimension.Unset;
+				}
+				
 				ValidatePositive(value, nameof(IView.Height));
 				return value;
 			}

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Maui.Primitives;
+using NUnit.Framework;
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class VisualElementTests 
+	{
+		[Test(Description = "If WidthRequest has been set and is reset to -1, the Core Width should return to being Unset")]
+		public void SettingWidthRequestToNegativeOneShouldResetWidth() 
+		{
+			var visualElement = new Label();
+			var coreView = visualElement as IView;
+
+			Assert.That(coreView.Width, Is.EqualTo(Dimension.Unset));
+			Assert.False(visualElement.IsSet(VisualElement.WidthRequestProperty));
+
+			double testWidth = 100;
+			visualElement.WidthRequest = testWidth;
+
+			Assert.That(coreView.Width, Is.EqualTo(testWidth));
+			Assert.True(visualElement.IsSet(VisualElement.WidthRequestProperty));
+			Assert.That(visualElement.WidthRequest, Is.EqualTo(testWidth));
+
+			// -1 is the legacy "unset" value for WidthRequest; we want to support setting it back to -1 as a way 
+			// to "reset" it to the "unset" value.
+			visualElement.WidthRequest = -1;
+
+			Assert.That(coreView.Width, Is.EqualTo(Dimension.Unset));
+			Assert.That(visualElement.WidthRequest, Is.EqualTo(-1));
+		}
+
+		[Test(Description = "If HeightRequest has been set and is reset to -1, the Core Height should return to being Unset")]
+		public void SettingHeightRequestToNegativeOneShouldResetWidth()
+		{
+			var visualElement = new Label();
+			var coreView = visualElement as IView;
+
+			Assert.That(coreView.Height, Is.EqualTo(Dimension.Unset));
+			Assert.False(visualElement.IsSet(VisualElement.HeightRequestProperty));
+
+			double testHeight = 100;
+			visualElement.HeightRequest = testHeight;
+
+			Assert.That(coreView.Height, Is.EqualTo(testHeight));
+			Assert.True(visualElement.IsSet(VisualElement.HeightRequestProperty));
+			Assert.That(visualElement.HeightRequest, Is.EqualTo(testHeight));
+
+			// -1 is the legacy "unset" value for HeightRequest; we want to support setting it back to -1 as a way 
+			// to "reset" it to the "unset" value.
+			visualElement.HeightRequest = -1;
+
+			Assert.That(coreView.Height, Is.EqualTo(Dimension.Unset));
+			Assert.That(visualElement.HeightRequest, Is.EqualTo(-1));
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

For backward compatibility, allow setting of WidthRequest/HeightRequest to -1 to un-set the Core Width/Height.

### Issues Fixed

Fixes #6107
