### PR TITLE
Handle content hiding separately for hot restart scenarios

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -58,7 +58,7 @@
   </Target>
 
   <!-- Targets temporarily remove Content items in various folders so that they don't conflict with iOS/MacCatalyst SDK tasks -->
-  <Target Name="HideContentFromiOSBundleResources" BeforeTargets="_CollectBundleResources;_CollectHotRestartBundleResources">
+  <Target Name="HideContentFromiOSBundleResources" BeforeTargets="_CollectBundleResources">
     <ItemGroup>
       <!-- Find all files outside the wwwroot folder -->
       <_NonWWWRootContent Include="@(Content)" Exclude="wwwroot/**/*" />
@@ -71,9 +71,28 @@
       <Content Remove="@(_TemporaryHiddenContent)" />
     </ItemGroup>
   </Target>
+  <Target Name="RestoreHiddeniOSContent" AfterTargets="_CollectBundleResources" BeforeTargets="ResolveCurrentProjectStaticWebAssetsInputs">
+    <ItemGroup>
+      <!-- Restore the previously removed Content items -->
+      <Content Include="@(_TemporaryHiddenContent)" />
+    </ItemGroup>
+  </Target>
 
-  <!-- Restore hidden Content items for iOS/MacCatalyst -->
-  <Target Name="RestoreHiddeniOSContent" AfterTargets="_CollectBundleResources;_CollectHotRestartBundleResources" BeforeTargets="ResolveCurrentProjectStaticWebAssetsInputs">
+  <!-- Handle hiding and restoring <Content /> from the iOS build in hot reload scenarios. -->
+  <Target Name="HideContentFromiOSHotRestartBundleResources" BeforeTargets="_CollectHotRestartBundleResources">
+    <ItemGroup>
+      <!-- Find all files outside the wwwroot folder -->
+      <_NonWWWRootContent Include="@(Content)" Exclude="wwwroot/**/*" />
+      <!-- Create a list of all content that *is* in the wwwroot folder (to preserve ItemGroup metadata) -->
+      <_TemporaryHiddenContent Include="@(Content)" Exclude="@(_NonWWWRootContent)" />
+      <!-- Add Scoped CSS files in the app to the list of hidden items -->
+      <_TemporaryHiddenContent Include="Pages\**\*.razor.css" />
+      <_TemporaryHiddenContent Include="Shared\**\*.razor.css" />
+      <!-- Temporarily remove the items -->
+      <Content Remove="@(_TemporaryHiddenContent)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="RestoreHiddeniOSHotRestartContent" AfterTargets="_CollectHotRestartBundleResources" BeforeTargets="ResolveCurrentProjectStaticWebAssetsInputs">
     <ItemGroup>
       <!-- Restore the previously removed Content items -->
       <Content Include="@(_TemporaryHiddenContent)" />


### PR DESCRIPTION
### Description of Change

We've been receiving bug reports that an issue that was resolved by changes to MSBuild in https://github.com/dotnet/maui/commit/114d30fd8cb603247e47603e8f095447550bdd32 still persists in hot reload scenarios or iOS. Both the `_CollectBundleResources` and `_CollectHotRestartBundleResources` targets are run during a hot restart build but because of the constraint on target ordering outlined [here](https://docs.microsoft.com/en-us/visualstudio/msbuild/target-build-order?view=vs-2022) the hiding/restoring only happens on the first target that is run (`_CollectBundleResources`).

> A target is never run twice during a build, even if a subsequent target in the build depends on it. Once a target has been run, its contribution to the build is complete.

So the current ordering is:

- Problematic content is hidden
- `_CollectBundleResources` runs
- Problematic content is restored

To resolve this issue, we need to invoke the hiding/restore targets independently for the `_CollectBundleResources` and `_CollectHotRestartBundleResources`. The new sequence is as follows:

- `HideContentFromiOSBundleResources` hides the content
- `_CollectBundleResources runs`
- `RestoreHiddeniOSContent` restores the content
- `HideContentFromiOSHotRestartBundleResources` hides the content
- `_CollectHotRestartBundleResources` runs
- `RestoreHiddeniOSHotRestartContent` restores the content

### Issues Fixed

Fixes https://github.com/dotnet/maui/issues/5245
