### PR TITLE
[X] Properly restore styleValue after ClearValue

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -445,6 +445,11 @@ namespace Microsoft.Maui.Controls
 				context.Attributes |= BindableContextAttributes.IsSetFromStyle;
 			// else omitted on purpose
 
+			//if we're updating a dynamic resource from style, set the default backup value
+			if (   (context.Attributes & (BindableContextAttributes.IsDynamicResource | BindableContextAttributes.IsSetFromStyle)) != 0
+				&& (attributes & SetValueFlags.ClearDynamicResource) == 0)
+				SetBackupStyleValue(property, value);
+
 			bool currentlyApplying = _applying;
 
 			if ((context.Attributes & BindableContextAttributes.IsBeingSet) != 0)

--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -623,9 +623,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		void OnResourceChanged(BindableProperty property, object value)
-		{
-			SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearTwoWayBindings);
-		}
+			=> SetValueCore(property, value, SetValueFlags.ClearOneWayBindings | SetValueFlags.ClearTwoWayBindings);
 
 		public event EventHandler<ParentChangingEventArgs> ParentChanging;
 		public event EventHandler ParentChanged;

--- a/src/Controls/src/Core/Style.cs
+++ b/src/Controls/src/Core/Style.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Controls.Internals;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Style.xml" path="Type[@FullName='Microsoft.Maui.Controls.Style']/Docs" />
-	[ContentProperty("Setters")]
+	[ContentProperty(nameof(Setters))]
 	public sealed class Style : IStyle
 	{
 		internal const string StyleClassPrefix = "Microsoft.Maui.Controls.StyleClass.";
@@ -181,11 +181,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		bool ValidateBasedOn(Style value)
-		{
-			if (value == null)
-				return true;
-			return value.TargetType.IsAssignableFrom(TargetType);
-		}
+			=> value is null || value.TargetType.IsAssignableFrom(TargetType);
 
 		void CleanUpWeakReferences()
 		{

--- a/src/Controls/tests/Core.UnitTests/StyleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/StyleTests.cs
@@ -983,5 +983,31 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			await Task.WhenAll(tasks);
 		}
+
+		[Test]
+		//https://github.com/dotnet/maui/issues/4617
+		public void ClearValueShouldntUnapplyStyles()
+		{
+			var button = new Button();
+			var layout = new StackLayout
+			{
+				Resources = new ResourceDictionary {
+					{ "Pinker", Colors.HotPink},
+					new Style (typeof(Button)){ Setters = {
+						new Setter{ Property=Button.BackgroundColorProperty, Value = new DynamicResource("Pinker")}
+						}
+					}
+				},
+				Children = { button },
+			};
+
+			Assert.That(button.BackgroundColor, Is.EqualTo(Colors.HotPink));
+			button.ClearValue(Button.BackgroundColorProperty);
+			Assert.That(button.BackgroundColor, Is.EqualTo(Colors.HotPink));
+			button.BackgroundColor = Colors.Red;
+			Assert.That(button.BackgroundColor, Is.EqualTo(Colors.Red));
+			button.ClearValue(Button.BackgroundColorProperty);
+			Assert.That(button.BackgroundColor, Is.EqualTo(Colors.HotPink));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Some values from DynamicResource set from Style weren't cached, and we
had no value to fallback to after a ClearValue. This fixes the issue.

- fixes #4617
