### PR TITLE
Fix FlyoutIsPresented permutations

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Shell.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shell.Impl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Microsoft.Maui.Controls
@@ -19,6 +20,13 @@ namespace Microsoft.Maui.Controls
 			{
 				return GetEffectiveFlyoutBehavior();
 			}
+		}
+
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			base.OnPropertyChanged(propertyName);
+			if (propertyName == Shell.FlyoutIsPresentedProperty.PropertyName)
+				Handler?.UpdateValue(nameof(IFlyoutView.IsPresented));
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -89,7 +89,10 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapIsPresented(ShellHandler handler, IFlyoutView flyoutView)
 		{
-			handler.PlatformView.IsPaneOpen = flyoutView.IsPresented;
+			// WinUI Will close the pane inside of the apply template code
+			// so we wait until the control is loaded before applying IsPresented
+			if (handler.PlatformView.IsLoaded)
+				handler.PlatformView.IsPaneOpen = flyoutView.IsPresented;
 		}
 
 		public static void MapFlyoutWidth(ShellHandler handler, IFlyoutView flyoutView)

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
@@ -31,8 +31,16 @@ namespace Microsoft.Maui.Controls.Platform
 			IsPaneOpen = false;
 			MenuItemTemplateSelector = CreateShellFlyoutTemplateSelector();
 			MenuItemsSource = FlyoutItems;
+			this.Loaded += OnLoaded;
 		}
 
+		void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			// We can't reliably set IsPaneOpen to true until the control has loaded
+			// If we set it earlier than this then WinUI will transition it back to false
+			if (IsPaneOpen != Element.FlyoutIsPresented)
+				IsPaneOpen = Element.FlyoutIsPresented;
+		}
 
 		private protected override void UpdateFlyoutCustomContent()
 		{

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -451,14 +451,16 @@ namespace Microsoft.Maui.Controls
 		ShellNavigationState IShellController.GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, bool includeStack)
 			=> ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, includeStack ? shellSection.Stack.ToList() : null, includeStack ? shellSection.Navigation.ModalStack.ToList() : null);
 
-		void IShellController.OnFlyoutItemSelected(Element element)
-		{
-			(this as IShellController)
-				.OnFlyoutItemSelectedAsync(element)
-				.FireAndForget();
-		}
+		void OnFlyoutItemSelected(Element element, bool platformInitiated) =>
+			OnFlyoutItemSelectedAsync(element, platformInitiated).FireAndForget();
 
-		Task IShellController.OnFlyoutItemSelectedAsync(Element element)
+		void IShellController.OnFlyoutItemSelected(Element element) =>
+			OnFlyoutItemSelected(element, true);
+
+		Task IShellController.OnFlyoutItemSelectedAsync(Element element) =>
+			OnFlyoutItemSelectedAsync(element, true);
+
+		Task OnFlyoutItemSelectedAsync(Element element, bool platformInitiated)
 		{
 			ShellItem shellItem = null;
 			ShellSection shellSection = null;
@@ -492,7 +494,7 @@ namespace Microsoft.Maui.Controls
 			shellSection = shellSection ?? shellItem.CurrentItem;
 			shellContent = shellContent ?? shellSection?.CurrentItem;
 
-			if (FlyoutIsPresented && GetEffectiveFlyoutBehavior() != FlyoutBehavior.Locked)
+			if (platformInitiated && FlyoutIsPresented && GetEffectiveFlyoutBehavior() != FlyoutBehavior.Locked)
 				SetValueFromRenderer(FlyoutIsPresentedProperty, false);
 
 			if (shellSection == null)
@@ -551,9 +553,9 @@ namespace Microsoft.Maui.Controls
 			{
 				(sender as BindableObject).PropertyChanged -= OnShellItemPropertyChanged;
 				if (sender is ShellItem item)
-					((IShellController)this).OnFlyoutItemSelected(item);
+					OnFlyoutItemSelected(item, false);
 				else if (sender is ShellSection section)
-					((IShellController)this).OnFlyoutItemSelected(section.Parent);
+					OnFlyoutItemSelected(section.Parent, false);
 			}
 		}
 
@@ -802,16 +804,19 @@ namespace Microsoft.Maui.Controls
 		void Initialize()
 		{
 			if (CurrentItem != null)
-				SetCurrentItem();
+				SetCurrentItem()
+					.FireAndForget();
 
 			((ShellElementCollection)Items).VisibleItemsChangedInternal += (s, e) =>
 			{
-				SetCurrentItem();
+				SetCurrentItem()
+					.FireAndForget();
+
 				SendStructureChanged();
 				SendFlyoutItemsChanged();
 			};
 
-			async void SetCurrentItem()
+			async Task SetCurrentItem()
 			{
 				var shellItems = ShellController.GetItems();
 
@@ -872,7 +877,7 @@ namespace Microsoft.Maui.Controls
 				}
 
 				if (shellItem != null)
-					ShellController.OnFlyoutItemSelected(shellItem);
+					await OnFlyoutItemSelectedAsync(shellItem, false).ConfigureAwait(false);
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -1455,6 +1455,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual("Shell Title", (window as IWindow).Title);
 		}
 
+		[Test]
+		public void FlyoutIsPresentedRemainsTrueAfterShellIsInitialized()
+		{
+			TestShell testShell = new TestShell()
+			{
+				FlyoutIsPresented = true
+			};
+
+			testShell.Items.Add(CreateShellItem<FlyoutItem>());
+
+			Assert.IsTrue(testShell.FlyoutIsPresented);
+		}
+
 		public void ShellToolbarNotVisibleWithBasicContentPage()
 		{
 			TestShell testShell = new TestShell(new ContentPage());

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -1,14 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
-using Microsoft.Maui.Handlers;
-using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
 
@@ -18,6 +11,12 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.Shell)]
 	public partial class ShellTests : HandlerTestBase
 	{
+		protected Task CheckFlyoutState(ShellHandler handler, bool desiredState)
+		{
+			Assert.Equal(desiredState, handler.PlatformView.IsPaneOpen);
+			return Task.CompletedTask;
+		}
+
 		[Fact(DisplayName = "Back Button Enabled/Disabled")]
 		public async Task BackButtonEnabledAndDisabled()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -43,6 +43,26 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+
+		[Fact(DisplayName = "Flyout Starts as Open correctly")]
+		public async Task FlyoutIsPresented()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new FlyoutItem() { Items = { new ContentPage() } };
+				shell.FlyoutIsPresented = true;
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await CheckFlyoutState(handler, true);
+				shell.FlyoutIsPresented = false;
+				await CheckFlyoutState(handler, false);
+			});
+		}
+
+
 		[Fact(DisplayName = "Back Button Visibility Changes with push/pop")]
 		public async Task BackButtonVisibilityChangesWithPushPop()
 		{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -99,11 +99,6 @@ namespace Microsoft.Maui.DeviceTests
 					{
 						aca.SetSupportActionBar(null);
 					}
-
-					// Ideally this wouldn't be needed but I haven't found the right platform
-					// component I can key into for knowing when the world can move on
-					await Task.Delay(1000);
-					fragmentManager.ExecutePendingTransactions();
 				}
 			});
 		}
@@ -190,8 +185,8 @@ namespace Microsoft.Maui.DeviceTests
 				ScopedMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager, registerNewNavigationRoot: true);
 				_ = _window.ToHandler(ScopedMauiContext);
 				var rootView = ScopedMauiContext.GetNavigationRootManager().RootView;
-
-				rootView.LayoutParameters = new LinearLayoutCompat.LayoutParams(500, 500);
+				var decorView = RequireActivity().Window.DecorView;
+				rootView.LayoutParameters = new LinearLayoutCompat.LayoutParams(decorView.MeasuredWidth, decorView.MeasuredHeight);
 				return rootView;
 			}
 


### PR DESCRIPTION
### Description of Change

- FlyoutIsPresented was incorrectly being toggled back to false on initialization
- WinUI needed to wait until after the control is loaded before setting the pane to open otherwise it would just revert back to close after the template was applied
- Fixed android timing so if the user tries to close the flyout too quickly before the control has rendered it leaves the flyout in a weird state

### Issues Fixed

Fixes #5653
