### PR TITLE
Throw exception if users uses incompatible pages

### DIFF
--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -84,6 +84,15 @@ namespace Microsoft.Maui.Controls
 			if (result == null)
 				throw new InvalidOperationException($"No Content found for {nameof(ShellContent)}, Title:{Title}, Route {Route}");
 
+			if (result is TabbedPage)
+				throw new NotSupportedException($"Shell is currently not compatible with TabbedPage. Please use TabBar, Tab or switch to using NavigationPage for your {Application.Current}.MainPage");
+
+			if (result is FlyoutPage)
+				throw new NotSupportedException("Shell is currently not compatible with FlyoutPage.");
+
+			if (result is NavigationPage)
+				throw new NotSupportedException("Shell is currently not compatible with NavigationPage. Shell has Navigation built in and doesn't require a NavigationPage.");
+
 			if (GetValue(QueryAttributesProperty) is ShellRouteParameters delayedQueryParams)
 				result.SetValue(QueryAttributesProperty, delayedQueryParams);
 


### PR DESCRIPTION
### Description of Change
Currently Shell isn't compatible with [`TabbedPage`, `FlyoutPage`, `NavigationPage`](https://github.com/dotnet/maui/issues/6389). This PR adds an exception message that will help guide the user opposed to just crashing with a confusing error message

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6349 
