### PR TITLE
Fix AmbigousMatchException between duplicated types Core and Controls

### DIFF
--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -10,7 +10,7 @@ using Microsoft.Maui.Controls.Internals;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Element.xml" path="Type[@FullName='Microsoft.Maui.Controls.Element']/Docs" />
-	public abstract partial class Element : BindableObject, IElement, INameScope, IElementController, IVisualTreeElement
+	public abstract partial class Element : BindableObject, IElementDefinition, INameScope, IElementController, IVisualTreeElement
 	{
 		internal static readonly ReadOnlyCollection<Element> EmptyChildren = new ReadOnlyCollection<Element>(Array.Empty<Element>());
 
@@ -164,7 +164,7 @@ namespace Microsoft.Maui.Controls
 
 		Dictionary<BindableProperty, string> DynamicResources => _dynamicResources ?? (_dynamicResources = new Dictionary<BindableProperty, string>());
 
-		void IElement.AddResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
+		void IElementDefinition.AddResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
 		{
 			_changeHandlers = _changeHandlers ?? new List<Action<object, ResourcesChangedEventArgs>>(2);
 			_changeHandlers.Add(onchanged);
@@ -186,7 +186,7 @@ namespace Microsoft.Maui.Controls
 
 				if (RealParent != null)
 				{
-					((IElement)RealParent).RemoveResourcesChangedListener(OnParentResourcesChanged);
+					((IElementDefinition)RealParent).RemoveResourcesChangedListener(OnParentResourcesChanged);
 
 					if (value != null && (RealParent is Layout || RealParent is IControlTemplated))
 						Application.Current?.FindMauiContext()?.CreateLogger<Element>()?.LogWarning($"{this} is already a child of {RealParent}. Remove {this} from {RealParent} before adding to {value}.");
@@ -196,7 +196,7 @@ namespace Microsoft.Maui.Controls
 				if (RealParent != null)
 				{
 					OnParentResourcesChanged(RealParent.GetMergedResources());
-					((IElement)RealParent).AddResourcesChangedListener(OnParentResourcesChanged);
+					((IElementDefinition)RealParent).AddResourcesChangedListener(OnParentResourcesChanged);
 				}
 
 				object context = value != null ? value.BindingContext : null;
@@ -220,7 +220,7 @@ namespace Microsoft.Maui.Controls
 
 		internal bool IsTemplateRoot { get; set; }
 
-		void IElement.RemoveResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
+		void IElementDefinition.RemoveResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
 		{
 			if (_changeHandlers == null)
 				return;

--- a/src/Controls/src/Core/ElementTemplate.cs
+++ b/src/Controls/src/Core/ElementTemplate.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Controls.Internals;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ElementTemplate.xml" path="Type[@FullName='Microsoft.Maui.Controls.ElementTemplate']/Docs" />
-	public class ElementTemplate : IElement
+	public class ElementTemplate : IElementDefinition
 	{
 		List<Action<object, ResourcesChangedEventArgs>> _changeHandlers;
 		Element _parent;
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ElementTemplate.xml" path="//Member[@MemberName='LoadTemplate']/Docs" />
 		public Func<object> LoadTemplate { get; set; }
 
-		void IElement.AddResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
+		void IElementDefinition.AddResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
 		{
 			_changeHandlers = _changeHandlers ?? new List<Action<object, ResourcesChangedEventArgs>>(1);
 			_changeHandlers.Add(onchanged);
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Controls
 		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		internal Type Type => _type;
 
-		Element IElement.Parent
+		Element IElementDefinition.Parent
 		{
 			get { return _parent; }
 			set
@@ -55,14 +55,14 @@ namespace Microsoft.Maui.Controls
 				if (_parent == value)
 					return;
 				if (_parent != null)
-					((IElement)_parent).RemoveResourcesChangedListener(OnResourcesChanged);
+					((IElementDefinition)_parent).RemoveResourcesChangedListener(OnResourcesChanged);
 				_parent = value;
 				if (_parent != null)
-					((IElement)_parent).AddResourcesChangedListener(OnResourcesChanged);
+					((IElementDefinition)_parent).AddResourcesChangedListener(OnResourcesChanged);
 			}
 		}
 
-		void IElement.RemoveResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
+		void IElementDefinition.RemoveResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
 		{
 			if (_changeHandlers == null)
 				return;

--- a/src/Controls/src/Core/GestureElement.cs
+++ b/src/Controls/src/Core/GestureElement.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls
 			{
 				void AddItems()
 				{
-					foreach (IElement item in args.NewItems.OfType<IElement>())
+					foreach (IElementDefinition item in args.NewItems.OfType<IElementDefinition>())
 					{
 						ValidateGesture(item as IGestureRecognizer);
 						item.Parent = this;
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls
 
 				void RemoveItems()
 				{
-					foreach (IElement item in args.OldItems.OfType<IElement>())
+					foreach (IElementDefinition item in args.OldItems.OfType<IElementDefinition>())
 						item.Parent = null;
 				}
 
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Controls
 						RemoveItems();
 						break;
 					case NotifyCollectionChangedAction.Reset:
-						foreach (IElement item in _gestureRecognizers.OfType<IElement>())
+						foreach (IElementDefinition item in _gestureRecognizers.OfType<IElementDefinition>())
 							item.Parent = this;
 						break;
 				}

--- a/src/Controls/src/Core/IElementDefinition.cs
+++ b/src/Controls/src/Core/IElementDefinition.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Controls.Internals;
 
 namespace Microsoft.Maui.Controls
 {
-	internal interface IElement
+	internal interface IElementDefinition
 	{
 		Element Parent { get; set; }
 

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Maui.Controls
 		{
 			if (args.Action != NotifyCollectionChangedAction.Add)
 				return;
-			foreach (IElement item in args.NewItems)
+			foreach (IElementDefinition item in args.NewItems)
 				item.Parent = this;
 		}
 

--- a/src/Controls/src/Core/ResourcesExtensions.cs
+++ b/src/Controls/src/Core/ResourcesExtensions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 {
 	static class ResourcesExtensions
 	{
-		public static IEnumerable<KeyValuePair<string, object>> GetMergedResources(this IElement element)
+		public static IEnumerable<KeyValuePair<string, object>> GetMergedResources(this IElementDefinition element)
 		{
 			Dictionary<string, object> resources = null;
 			while (element != null)
@@ -48,7 +48,7 @@ namespace Microsoft.Maui.Controls
 			return resources;
 		}
 
-		public static bool TryGetResource(this IElement element, string key, out object value)
+		public static bool TryGetResource(this IElementDefinition element, string key, out object value)
 		{
 			while (element != null)
 			{

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -81,9 +81,9 @@ namespace Microsoft.Maui.Controls
 		{
 			_gestureRecognizers.CollectionChanged += (sender, args) =>
 			{
-				void AddItems(IEnumerable<IElement> elements)
+				void AddItems(IEnumerable<IElementDefinition> elements)
 				{
-					foreach (IElement item in elements)
+					foreach (IElementDefinition item in elements)
 					{
 						ValidateGesture(item as IGestureRecognizer);
 						item.Parent = this;
@@ -91,9 +91,9 @@ namespace Microsoft.Maui.Controls
 					}
 				}
 
-				void RemoveItems(IEnumerable<IElement> elements)
+				void RemoveItems(IEnumerable<IElementDefinition> elements)
 				{
-					foreach (IElement item in elements)
+					foreach (IElementDefinition item in elements)
 					{
 						item.Parent = null;
 						GestureController.CompositeGestureRecognizers.Remove(item as IGestureRecognizer);
@@ -103,28 +103,28 @@ namespace Microsoft.Maui.Controls
 				switch (args.Action)
 				{
 					case NotifyCollectionChangedAction.Add:
-						AddItems(args.NewItems.OfType<IElement>());
+						AddItems(args.NewItems.OfType<IElementDefinition>());
 						break;
 					case NotifyCollectionChangedAction.Remove:
-						RemoveItems(args.OldItems.OfType<IElement>());
+						RemoveItems(args.OldItems.OfType<IElementDefinition>());
 						break;
 					case NotifyCollectionChangedAction.Replace:
-						AddItems(args.NewItems.OfType<IElement>());
-						RemoveItems(args.OldItems.OfType<IElement>());
+						AddItems(args.NewItems.OfType<IElementDefinition>());
+						RemoveItems(args.OldItems.OfType<IElementDefinition>());
 						break;
 					case NotifyCollectionChangedAction.Reset:
 
-						List<IElement> remove = new List<IElement>();
-						List<IElement> add = new List<IElement>();
+						List<IElementDefinition> remove = new List<IElementDefinition>();
+						List<IElementDefinition> add = new List<IElementDefinition>();
 
-						foreach (IElement item in _gestureRecognizers.OfType<IElement>())
+						foreach (IElementDefinition item in _gestureRecognizers.OfType<IElementDefinition>())
 						{
 							if (!_gestureRecognizers.Contains((IGestureRecognizer)item))
 								add.Add(item);
 							item.Parent = this;
 						}
 
-						foreach (IElement item in GestureController.CompositeGestureRecognizers.OfType<IElement>())
+						foreach (IElementDefinition item in GestureController.CompositeGestureRecognizers.OfType<IElementDefinition>())
 						{
 							if (_gestureRecognizers.Contains((IGestureRecognizer)item))
 								item.Parent = this;

--- a/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ResourceDictionaryTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			elt.Parent = parent;
 
-			((IElement)elt).AddResourcesChangedListener((sender, e) =>
+			((IElementDefinition)elt).AddResourcesChangedListener((sender, e) =>
 			{
 				Assert.AreEqual(1, e.Values.Count());
 				var kvp = e.Values.First();
@@ -169,7 +169,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			elt.Parent = parent;
 
-			((IElement)elt).AddResourcesChangedListener((sender, e) => Assert.Fail());
+			((IElementDefinition)elt).AddResourcesChangedListener((sender, e) => Assert.Fail());
 			parent.Resources["bar"] = "BAZ";
 			Assert.Pass();
 		}
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 			};
 
-			((IElement)elt).AddResourcesChangedListener((sender, e) =>
+			((IElementDefinition)elt).AddResourcesChangedListener((sender, e) =>
 			{
 				Assert.AreEqual(2, e.Values.Count());
 				Assert.AreEqual("FOO", e.Values.First(kvp => kvp.Key == "foo").Value);
@@ -218,7 +218,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			elt.Parent = parent;
 
-			((IElement)elt).AddResourcesChangedListener((sender, e) =>
+			((IElementDefinition)elt).AddResourcesChangedListener((sender, e) =>
 			{
 				Assert.AreEqual(3, e.Values.Count());
 				Assert.Pass();
@@ -264,7 +264,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 			};
 
-			((IElement)elt).AddResourcesChangedListener((sender, e) =>
+			((IElementDefinition)elt).AddResourcesChangedListener((sender, e) =>
 			{
 				Assert.AreEqual(2, e.Values.Count());
 				Assert.Pass();


### PR DESCRIPTION
### Description of Change

Avoid AmbigousMatchException between duplicated types in Microsoft.Maui and Microsoft.Maui.Controls. Renamed IElement from Microsoft.Maui.Controls.

There are similar cases like:
- LayoutAlignment (Why not an unique type in Core using the Flags attribute?)

### Issues Fixed

Fixes #4300 
