### PR TITLE
Use control template for PresentedContent on a ContentPage, if available

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentPage.Impl.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls
 	public partial class ContentPage : IContentView, HotReload.IHotReloadableView
 	{
 		object IContentView.Content => Content;
-		IView IContentView.PresentedContent => Content;
+		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? Content;
 
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{


### PR DESCRIPTION
### Description of Change

ContentPage was checking for a ControlTemplate when determining its PresentedContent. This changes makes it check.

### Issues Fixed

Fixes #2302; Fixes #5976


