### PR TITLE
[iOS] Use Picker Title when selected item cleared

### DIFF
--- a/src/Core/src/Platform/iOS/PickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/PickerExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Platform
 			platformPicker.TextColor = picker.TextColor?.ToPlatform();
 
 		public static void UpdateSelectedIndex(this MauiPicker platformPicker, IPicker picker) =>
-			platformPicker.SetSelectedIndex(picker, picker.SelectedIndex);
+			platformPicker.UpdatePicker(picker, picker.SelectedIndex);
 
 		internal static void SetTitleColor(this MauiPicker platformPicker, IPicker picker)
 		{
@@ -39,9 +39,9 @@ namespace Microsoft.Maui.Platform
 			platformPicker.AttributedPlaceholder = nsAttributedString;
 		}
 
-		internal static void UpdatePicker(this MauiPicker platformPicker, IPicker picker)
+		internal static void UpdatePicker(this MauiPicker platformPicker, IPicker picker, int? newSelectedIndex = null)
 		{
-			var selectedIndex = picker.SelectedIndex;
+			var selectedIndex = newSelectedIndex ?? picker.SelectedIndex;
 
 			// Revert to placeholder/title if nothing selected
 			platformPicker.Text = selectedIndex == -1
@@ -54,14 +54,7 @@ namespace Microsoft.Maui.Platform
 			if (picker.GetCount() == 0)
 				return;
 
-			platformPicker.SetSelectedIndex(picker, selectedIndex);
-		}
-
-		internal static void SetSelectedIndex(this MauiPicker platformPicker, IPicker picker, int selectedIndex = 0)
-		{
 			picker.SelectedIndex = selectedIndex;
-
-			var pickerView = platformPicker.UIPickerView;
 
 			if (pickerView?.Model is PickerSource source)
 			{

--- a/src/Core/src/Platform/iOS/PickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/PickerExtensions.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Maui.Platform
 		{
 			var selectedIndex = picker.SelectedIndex;
 
-			platformPicker.Text = selectedIndex == -1 ? "" : picker.GetItem(selectedIndex);
+			// Revert to placeholder/title if nothing selected
+			platformPicker.Text = selectedIndex == -1
+				? (picker.Title ?? string.Empty)
+				: picker.GetItem(selectedIndex);
 
 			var pickerView = platformPicker.UIPickerView;
 			pickerView?.ReloadAllComponents();


### PR DESCRIPTION
This was just setting the title to empty but it should consider the Title (Placeholder) when there's no selected item again.

Fixes #672 