### PR TITLE
Fix WebView2 Runtime download link for Blazor MAUI

### DIFF
--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -207,16 +207,14 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			}
 			catch (FileNotFoundException)
 			{
-				// This type of exception is thrown when the WebView2 Runtime is not installed.
-				return false;
-			}
-			finally
-			{
 				// This method needs to be invoked even if the WebView2 Runtime is not installed,
 				// since it is reponsible for creating the warning label and WebView2 Runtime
 				// download link.
 				await _webview.EnsureCoreWebView2Async();
+				return false;
 			}
+
+			await _webview.EnsureCoreWebView2Async();
 
 			var developerTools = _blazorWebViewHandler.DeveloperTools;
 #elif WEBVIEW2_WINFORMS || WEBVIEW2_WPF

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		internal static readonly Uri AppOriginUri = new(AppOrigin);
 
 		private readonly WebView2Control _webview;
-		private readonly Task _webviewReadyTask;
+		private readonly Task<bool> _webviewReadyTask;
 		private readonly string _contentRootRelativeToAppRoot;
 
 #if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			// Unfortunately the CoreWebView2 can only be instantiated asynchronously.
 			// We want the external API to behave as if initalization is synchronous,
 			// so keep track of a task we can await during LoadUri.
-			_webviewReadyTask = InitializeWebView2();
+			_webviewReadyTask = TryInitializeWebView2();
 		}
 #elif WEBVIEW2_MAUI
 		private protected CoreWebView2Environment? _coreWebView2Environment;
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			// Unfortunately the CoreWebView2 can only be instantiated asynchronously.
 			// We want the external API to behave as if initalization is synchronous,
 			// so keep track of a task we can await during LoadUri.
-			_webviewReadyTask = InitializeWebView2();
+			_webviewReadyTask = TryInitializeWebView2();
 		}
 #endif
 
@@ -177,8 +177,12 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		{
 			_ = Dispatcher.InvokeAsync(async () =>
 			{
-				await _webviewReadyTask;
-				_webview.Source = absoluteUri;
+				var isWebviewInitialized = await _webviewReadyTask;
+
+				if (isWebviewInitialized)
+				{
+					_webview.Source = absoluteUri;
+				}
 			});
 		}
 
@@ -186,18 +190,33 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 		protected override void SendMessage(string message)
 			=> _webview.CoreWebView2.PostWebMessageAsString(message);
 
-		private async Task InitializeWebView2()
+		private async Task<bool> TryInitializeWebView2()
 		{
 			var args = new BlazorWebViewInitializingEventArgs();
 #if WEBVIEW2_MAUI
 			_blazorWebViewHandler.VirtualView.BlazorWebViewInitializing(args);
-			_coreWebView2Environment = await CoreWebView2Environment.CreateWithOptionsAsync(
-				browserExecutableFolder: args.BrowserExecutableFolder,
-				userDataFolder: args.UserDataFolder,
-				options: args.EnvironmentOptions)
-				.AsTask()
-				.ConfigureAwait(true);
-			await _webview.EnsureCoreWebView2Async();
+
+			try
+			{
+				_coreWebView2Environment = await CoreWebView2Environment.CreateWithOptionsAsync(
+					browserExecutableFolder: args.BrowserExecutableFolder,
+					userDataFolder: args.UserDataFolder,
+					options: args.EnvironmentOptions)
+					.AsTask()
+					.ConfigureAwait(true);
+			}
+			catch (FileNotFoundException)
+			{
+				// This type of exception is thrown when the WebView2 Runtime is not installed.
+				return false;
+			}
+			finally
+			{
+				// This method needs to be invoked even if the WebView2 Runtime is not installed,
+				// since it is reponsible for creating the warning label and WebView2 Runtime
+				// download link.
+				await _webview.EnsureCoreWebView2Async();
+			}
 
 			var developerTools = _blazorWebViewHandler.DeveloperTools;
 #elif WEBVIEW2_WINFORMS || WEBVIEW2_WPF
@@ -241,15 +260,15 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			// The code inside blazor.webview.js is meant to be agnostic to specific webview technologies,
 			// so the following is an adaptor from blazor.webview.js conventions to WebView2 APIs
 			await _webview.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(@"
-                window.external = {
-                    sendMessage: message => {
-                        window.chrome.webview.postMessage(message);
-                    },
-                    receiveMessage: callback => {
-                        window.chrome.webview.addEventListener('message', e => callback(e.data));
-                    }
-                };
-            ")
+				window.external = {
+					sendMessage: message => {
+						window.chrome.webview.postMessage(message);
+					},
+					receiveMessage: callback => {
+						window.chrome.webview.addEventListener('message', e => callback(e.data));
+					}
+				};
+			")
 #if WEBVIEW2_MAUI
 				.AsTask()
 #endif
@@ -258,6 +277,8 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 			QueueBlazorStart();
 
 			_webview.CoreWebView2.WebMessageReceived += (s, e) => MessageReceived(new Uri(e.Source), e.TryGetWebMessageAsString());
+
+			return true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Description of Change

The WinUI 3 `WebView2` control displays a download link for the WebView2 Runtime when it is not installed on the host machine. However, the `BlazorWebView` control (which wraps the WinUI 3 `WebView2` control on Blazor MAUI Windows) did not display the link under the same conditions. This PR fixes the bug that prevented the link from displaying.

Before:
![before](https://user-images.githubusercontent.com/10456961/165178238-1005aebf-de2a-4115-9d50-d32ea6129bbd.png)

After:
![after](https://user-images.githubusercontent.com/10456961/165178252-ec4d46a4-1710-4c41-ae76-dcfaa5ff8257.png)

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6421
