### PR TITLE
Fix MAUI Blazor crash for multi-window Windows apps

### DIFF
--- a/src/BlazorWebView/src/Maui/BlazorWebView.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebView.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 	/// <summary>
 	/// A <see cref="View"/> that can render Blazor content.
 	/// </summary>
-	public class BlazorWebView : View, IBlazorWebView
+	public partial class BlazorWebView : View, IBlazorWebView
 	{
 		internal const string AppHostAddress = "0.0.0.0";
 

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -44,6 +44,8 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.OnPropertyChanged(string? propertyName = null) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.OnPropertyChanging(string? propertyName = null) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void

--- a/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/BlazorWebView/src/Maui/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -44,6 +44,8 @@ Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.CancelLoad = 2 -> Mic
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally = 0 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenInWebView = 1 -> Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy
 Microsoft.Extensions.DependencyInjection.BlazorWebViewServiceCollectionExtensions
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.OnPropertyChanged(string? propertyName = null) -> void
+override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.OnPropertyChanging(string? propertyName = null) -> void
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.CreatePlatformView() -> Microsoft.UI.Xaml.Controls.WebView2!
 override Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.DisconnectHandler(Microsoft.UI.Xaml.Controls.WebView2! platformView) -> void
 static Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.MapHostPage(Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler! handler, Microsoft.AspNetCore.Components.WebView.Maui.IBlazorWebView! webView) -> void

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebView.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebView.Windows.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Microsoft.AspNetCore.Components.WebView.Maui
+{
+	public partial class BlazorWebView
+	{
+		/// <inheritdoc/>
+		protected override void OnPropertyChanging(string? propertyName = null)
+		{
+			if (propertyName == nameof(Window) && Window is not null)
+				Window.Destroying -= Window_Destroying;
+		}
+
+		/// <inheritdoc/>
+		protected override void OnPropertyChanged(string? propertyName = null)
+		{
+			if (propertyName == nameof(Window) && Window is not null)
+				Window.Destroying += Window_Destroying;
+		}
+
+		private void Window_Destroying(object? sender, EventArgs e)
+		{
+			// see: https://github.com/microsoft/microsoft-ui-xaml/issues/6872
+			((BlazorWebViewHandler)Handler!).PlatformView.Close();
+		}
+	}
+}

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebView.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebView.Windows.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <inheritdoc/>
 		protected override void OnPropertyChanging(string? propertyName = null)
 		{
+			base.OnPropertyChanging(propertyName);
+
 			if (propertyName == nameof(Window) && Window is not null)
 				Window.Destroying -= Window_Destroying;
 		}
@@ -14,6 +16,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <inheritdoc/>
 		protected override void OnPropertyChanged(string? propertyName = null)
 		{
+			base.OnPropertyChanged(propertyName);
+
 			if (propertyName == nameof(Window) && Window is not null)
 				Window.Destroying += Window_Destroying;
 		}

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebView.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebView.Windows.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		private void Window_Destroying(object? sender, EventArgs e)
 		{
 			// see: https://github.com/microsoft/microsoft-ui-xaml/issues/6872
-			((BlazorWebViewHandler)Handler!).PlatformView.Close();
+			((BlazorWebViewHandler)Handler)?.PlatformView.Close();
 		}
 	}
 }

--- a/src/BlazorWebView/src/Maui/Windows/BlazorWebView.Windows.cs
+++ b/src/BlazorWebView/src/Maui/Windows/BlazorWebView.Windows.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		private void Window_Destroying(object? sender, EventArgs e)
 		{
 			// see: https://github.com/microsoft/microsoft-ui-xaml/issues/6872
-			((BlazorWebViewHandler)Handler)?.PlatformView.Close();
+			((BlazorWebViewHandler?)Handler)?.PlatformView.Close();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

There is currently a [WinUI 3 bug](https://github.com/microsoft/microsoft-ui-xaml/issues/6872) causing the `WebView2` control to throw an exception when its parent window is closed. This primarily affects multi-window scenarios. This PR introduces a workaround to prevent MAUI Windows apps from crashing when a window hosting a `BlazorWebView` control is closed.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #5722
