### PR TITLE
Use a stable value for the root type in xamlg

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 			var itemName = projItem.ManifestResourceName ?? projItem.RelativePath;
 			if (itemName == null)
 				return;
-			var uid = Crc64.ComputeHashString(itemName);
+			var uid = Crc64.ComputeHashString($"{compilation.AssemblyName}.{itemName}");
 
 			if (!TryParseXaml(text, uid, compilation, xmlnsDefinitionCache, out var rootType, out var rootClrNamespace, out var generateDefaultCtor, out var addXamlCompilationAttribute, out var hideFromIntellisense, out var XamlResourceIdOnly, out var baseType, out var namedFields, out var parseException))
 			{

--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -125,7 +125,14 @@ namespace Microsoft.Maui.Controls.SourceGen
 			var text = projItem.AdditionalText.GetText();
 			if (text == null)
 				return;
-			if (!TryParseXaml(text, compilation, xmlnsDefinitionCache, out var rootType, out var rootClrNamespace, out var generateDefaultCtor, out var addXamlCompilationAttribute, out var hideFromIntellisense, out var XamlResourceIdOnly, out var baseType, out var namedFields, out var parseException))
+
+			// Get a unique string for this xaml project item
+			var itemName = projItem.ManifestResourceName ?? projItem.RelativePath;
+			if (itemName == null)
+				return;
+			var uid = Crc64.ComputeHashString(itemName);
+
+			if (!TryParseXaml(text, uid, compilation, xmlnsDefinitionCache, out var rootType, out var rootClrNamespace, out var generateDefaultCtor, out var addXamlCompilationAttribute, out var hideFromIntellisense, out var XamlResourceIdOnly, out var baseType, out var namedFields, out var parseException))
 			{
 				if (parseException != null)
 					context.ReportDiagnostic(Diagnostic.Create(Descriptors.XamlParserError, null, parseException.Message));
@@ -210,8 +217,9 @@ namespace Microsoft.Maui.Controls.SourceGen
 			context.AddSource(hintName, SourceText.From(sb.ToString(), Encoding.UTF8));
 		}
 
-		static bool TryParseXaml(SourceText text, Compilation compilation, IList<XmlnsDefinitionAttribute> xmlnsDefinitionCache, out string? rootType, out string? rootClrNamespace, out bool generateDefaultCtor, out bool addXamlCompilationAttribute, out bool hideFromIntellisense, out bool xamlResourceIdOnly, out string? baseType, out IEnumerable<(string, string, string)>? namedFields, out Exception? exception)
+		static bool TryParseXaml(SourceText text, string uid, Compilation compilation, IList<XmlnsDefinitionAttribute> xmlnsDefinitionCache, out string? rootType, out string? rootClrNamespace, out bool generateDefaultCtor, out bool addXamlCompilationAttribute, out bool hideFromIntellisense, out bool xamlResourceIdOnly, out string? baseType, out IEnumerable<(string, string, string)>? namedFields, out Exception? exception)
 		{
+
 			rootType = null;
 			rootClrNamespace = null;
 			generateDefaultCtor = false;
@@ -264,7 +272,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 			else if (hasXamlCompilationProcessingInstruction)
 			{
 				rootClrNamespace = "__XamlGeneratedCode__";
-				rootType = $"__Type{Guid.NewGuid():N}";
+				rootType = $"__Type{uid}";
 				generateDefaultCtor = true;
 				addXamlCompilationAttribute = true;
 				hideFromIntellisense = true;

--- a/src/Controls/src/SourceGen/Controls.SourceGen.csproj
+++ b/src/Controls/src/SourceGen/Controls.SourceGen.csproj
@@ -23,6 +23,12 @@
     <Compile Include="..\Xaml\XmlName.cs" Link="XmlName.cs" />
     <Compile Include="..\Xaml\XmlnsHelper.cs" Link="XmlnsHelper.cs" />
     <Compile Include="..\Xaml\XmlTypeXamlExtensions.cs" Link="XmlTypeXamlExtensions.cs" />
+    <Compile Include="..\..\..\Core\src\Services\Crc64.cs">
+      <Link>Crc64.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\Core\src\Services\Crc64HashAlgorithm.cs">
+      <Link>Crc64HashAlgorithm.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previously a random new GUID was being generated for the root type - the hypothesis is that this may cause issues with c# hot reload.

In any case, a more deterministic value here is a positive.

