### PR TITLE
Fix Blazor Template for VS Windows

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.in.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.in.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json.schemastore.org/template",
     "author": "Microsoft",
-    "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "WinUI", "Tizen", "Blazor" ],
+    "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "Windows", "Tizen", "Blazor" ],
     "identity": "Microsoft.Maui.BlazorApp",
     "groupIdentity": "Microsoft.Maui.BlazorApp",
     "name": ".NET MAUI Blazor App (Preview)",


### PR DESCRIPTION
<img width="761" alt="image" src="https://user-images.githubusercontent.com/898335/165633840-96458218-78fd-40f4-a9dd-8ce08f112b7b.png">

MAUI Blazor is missing from the VS Project list, because we're listing it as "WinUI" rather than "Windows". Switching it should fix it.