### PR TITLE
[Tizen] Fix GetPath to return a correct path

### DIFF
--- a/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.Tizen.cs
+++ b/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.Tizen.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Maui
 				{
 					if (File.Exists(file))
 					{
-						return resPath;
+						return file;
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Change
 Tizen FileImageSourceService has GetPath method, it return wrong path if file extension was omitted. it was fixed

### Issues Fixed
<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->
Fixes #
