### PR TITLE
[src/Templates] Remove preview language

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.in.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.in.json
@@ -4,7 +4,7 @@
     "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "Windows", "Tizen", "Blazor" ],
     "identity": "Microsoft.Maui.BlazorApp",
     "groupIdentity": "Microsoft.Maui.BlazorApp",
-    "name": ".NET MAUI Blazor App (Preview)",
+    "name": ".NET MAUI Blazor App",
     "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, WinUI, and Tizen using Blazor",
     "shortName": "maui-blazor",
     "tags": {

--- a/src/Templates/src/templates/maui-contentpage-csharp/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentpage-csharp/.template.config/template.json
@@ -3,7 +3,7 @@
     "author": "Microsoft",
     "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "WinUI", "Tizen", "Xaml", "Code" ],
     "identity": "Microsoft.Maui.CSharpContentPage",
-    "name": ".NET MAUI ContentPage (C#) (Preview)",
+    "name": ".NET MAUI ContentPage (C#)",
     "shortName": "maui-page-csharp",
     "tags": {
       "language": "C#",

--- a/src/Templates/src/templates/maui-contentpage-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentpage-xaml/.template.config/template.json
@@ -3,7 +3,7 @@
     "author": "Microsoft",
     "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "WinUI", "Tizen", "Xaml", "Code" ],
     "identity": "Microsoft.Maui.XamlContentPage",
-    "name": ".NET MAUI ContentPage (XAML) (Preview)",
+    "name": ".NET MAUI ContentPage (XAML)",
     "shortName": "maui-page-xaml",
     "tags": {
       "language": "C#",

--- a/src/Templates/src/templates/maui-contentview-csharp/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentview-csharp/.template.config/template.json
@@ -3,7 +3,7 @@
     "author": "Microsoft",
     "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "WinUI", "Tizen", "Xaml", "Code" ],
     "identity": "Microsoft.Maui.CSharpContentView",
-    "name": ".NET MAUI ContentView (C#) (Preview)",
+    "name": ".NET MAUI ContentView (C#)",
     "shortName": "maui-view-csharp",
     "tags": {
       "language": "C#",

--- a/src/Templates/src/templates/maui-contentview-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-contentview-xaml/.template.config/template.json
@@ -3,7 +3,7 @@
     "author": "Microsoft",
     "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "WinUI", "Tizen", "Xaml", "Code" ],
     "identity": "Microsoft.Maui.XamlContentView",
-    "name": ".NET MAUI ContentView (XAML) (Preview)",
+    "name": ".NET MAUI ContentView (XAML)",
     "shortName": "maui-view-xaml",
     "tags": {
         "language": "C#",

--- a/src/Templates/src/templates/maui-lib/.template.config/template.in.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/template.in.json
@@ -4,7 +4,7 @@
     "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "Windows", "Tizen" ],
     "identity": "Microsoft.Maui.MauiLib",
     "groupIdentity": "Microsoft.Maui.Library",
-    "name": ".NET MAUI Class Library (Preview)",
+    "name": ".NET MAUI Class Library",
     "description": "A project for creating a .NET MAUI class library",
     "shortName": "mauilib",
     "tags": {

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.in.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.in.json
@@ -4,7 +4,7 @@
     "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "Windows", "Tizen" ],
     "identity": "Microsoft.Maui.MauiApp",
     "groupIdentity": "Microsoft.Maui.App",
-    "name": ".NET MAUI App (Preview)",
+    "name": ".NET MAUI App",
     "description": "A project for creating a .NET MAUI application for iOS, Android, Mac Catalyst, WinUI and Tizen",
     "shortName": "maui",
     "tags": {

--- a/src/Templates/src/templates/maui-resourcedictionary-xaml/.template.config/template.json
+++ b/src/Templates/src/templates/maui-resourcedictionary-xaml/.template.config/template.json
@@ -3,7 +3,7 @@
     "author": "Microsoft",
     "classifications": [ "MAUI", "Android", "iOS", "macOS", "Mac Catalyst", "WinUI", "Xaml", "Code" ],
     "identity": "Microsoft.Maui.XamlResourceDictionary",
-    "name": ".NET MAUI ResourceDictionary (XAML) (Preview)",
+    "name": ".NET MAUI ResourceDictionary (XAML)",
     "shortName": "maui-dict-xaml",
     "tags": {
         "language": "C#",


### PR DESCRIPTION
Removes the "(Preview)" string from the title of the .NET templates.

Fixes https://github.com/dotnet/maui/issues/6617