### PR TITLE
Update AdaptiveTrigger to support multi-window

### DIFF
--- a/src/Controls/src/Core/AdaptiveTrigger.cs
+++ b/src/Controls/src/Core/AdaptiveTrigger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls
@@ -6,10 +7,13 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml" path="Type[@FullName='Microsoft.Maui.Controls.AdaptiveTrigger']/Docs" />
 	public sealed class AdaptiveTrigger : StateTriggerBase
 	{
+		VisualElement _visualElement;
+		Page _page;
+		Window _window;
+
 		/// <include file="../../docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml" path="//Member[@MemberName='.ctor']/Docs" />
 		public AdaptiveTrigger()
 		{
-			UpdateState();
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml" path="//Member[@MemberName='MinWindowHeight']/Docs" />
@@ -22,12 +26,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml" path="//Member[@MemberName='MinWindowHeightProperty']/Docs" />
 		public static readonly BindableProperty MinWindowHeightProperty =
 			BindableProperty.Create(nameof(MinWindowHeight), typeof(double), typeof(AdaptiveTrigger), -1d,
-				propertyChanged: OnMinWindowHeightChanged);
-
-		static void OnMinWindowHeightChanged(BindableObject bindable, object oldvalue, object newvalue)
-		{
-			((AdaptiveTrigger)bindable).UpdateState();
-		}
+				propertyChanged: OnMinWindowDimensionChanged);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml" path="//Member[@MemberName='MinWindowWidth']/Docs" />
 		public double MinWindowWidth
@@ -38,43 +37,94 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AdaptiveTrigger.xml" path="//Member[@MemberName='MinWindowWidthProperty']/Docs" />
 		public static readonly BindableProperty MinWindowWidthProperty =
-			BindableProperty.Create(nameof(MinWindowWidthProperty), typeof(double), typeof(AdaptiveTrigger), -1d,
-				propertyChanged: OnMinWindowWidthChanged);
+			BindableProperty.Create(nameof(MinWindowWidth), typeof(double), typeof(AdaptiveTrigger), -1d,
+				propertyChanged: OnMinWindowDimensionChanged);
 
-		static void OnMinWindowWidthChanged(BindableObject bindable, object oldvalue, object newvalue)
-		{
+		static void OnMinWindowDimensionChanged(BindableObject bindable, object oldvalue, object newvalue) =>
 			((AdaptiveTrigger)bindable).UpdateState();
-		}
 
 		protected override void OnAttached()
 		{
 			base.OnAttached();
 
-			if (!DesignMode.IsDesignModeEnabled)
-			{
-				UpdateState();
-				Application.Current.MainPage.SizeChanged += OnSizeChanged;
-			}
+			AttachEvents();
+
+			UpdateState(true);
 		}
 
 		protected override void OnDetached()
 		{
 			base.OnDetached();
 
-			Application.Current.MainPage.SizeChanged -= OnSizeChanged;
+			DetachEvents();
 		}
 
-		void OnSizeChanged(object sender, EventArgs e)
+		void AttachEvents()
+		{
+			DetachEvents();
+
+			_visualElement = VisualState?.VisualStateGroup?.VisualElement;
+			if (_visualElement is not null)
+				_visualElement.PropertyChanged += OnVisualElementPropertyChanged;
+
+			_window = _visualElement.Window;
+			if (_window is not null)
+				_window.PropertyChanged += OnVisualElementPropertyChanged;
+
+			_page = _window.Page;
+			if (_page is not null)
+				_page.SizeChanged += OnPageSizeChanged;
+		}
+
+		void DetachEvents()
+		{
+			if (_visualElement is not null)
+				_visualElement.PropertyChanged -= OnVisualElementPropertyChanged;
+			_visualElement = null;
+
+			if (_window is not null)
+				_window.PropertyChanged -= OnVisualElementPropertyChanged;
+			_window = null;
+
+			if (_page is not null)
+				_page.SizeChanged -= OnPageSizeChanged;
+			_page = null;
+		}
+
+		void OnVisualElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == VisualElement.WindowProperty.PropertyName)
+			{
+				AttachEvents();
+				UpdateState();
+			}
+		}
+
+		void OnWindowPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == Window.PageProperty.PropertyName)
+			{
+				AttachEvents();
+				UpdateState();
+			}
+		}
+
+		void OnPageSizeChanged(object sender, EventArgs e)
 		{
 			UpdateState();
 		}
 
-		void UpdateState()
+		void UpdateState(bool knownAttached = false)
 		{
-			var scaledScreenSize = DeviceDisplay.MainDisplayInfo.GetScaledScreenSize();
+			if (!knownAttached && !IsAttached)
+				return;
 
-			var w = scaledScreenSize.Width;
-			var h = scaledScreenSize.Height;
+			var w = _page.Width;
+			var h = _page.Height;
+
+			if (w == -1 || h == -1)
+				return;
+
 			var mw = MinWindowWidth;
 			var mh = MinWindowHeight;
 

--- a/src/Controls/src/Core/AdaptiveTrigger.cs
+++ b/src/Controls/src/Core/AdaptiveTrigger.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls
 {

--- a/src/Controls/src/Core/DisplayInfoExtensions.cs
+++ b/src/Controls/src/Core/DisplayInfoExtensions.cs
@@ -6,8 +6,13 @@ namespace Microsoft.Maui.Controls
 {
 	static class DisplayInfoExtensions
 	{
-		public static Size GetScaledScreenSize(this DisplayInfo info) =>
-			new Size(info.Width / info.Density, info.Height / info.Density);
+		public static Size GetScaledScreenSize(this DisplayInfo info)
+		{
+			if (info.Density == 0)
+				return Size.Zero;
+
+			return new Size(info.Width / info.Density, info.Height / info.Density);
+		}
 
 		public static double DisplayRound(this DisplayInfo info, double value) =>
 			Math.Round(value);

--- a/src/Controls/tests/Core.UnitTests/AdaptiveTriggerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AdaptiveTriggerTests.cs
@@ -1,0 +1,68 @@
+using System;
+using Microsoft.Maui.Controls.Compatibility;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	[TestFixture]
+	public class AdaptiveTriggerTests : BaseTestFixture
+	{
+		[Test]
+		public void ResizingWindowPageActivatesTrigger()
+		{
+			var redBrush = new SolidColorBrush(Colors.Red);
+			var greenBrush = new SolidColorBrush(Colors.Green);
+			var blueBrush = new SolidColorBrush(Colors.Blue);
+
+			var label = new Label { Background = redBrush };
+
+			VisualStateManager.SetVisualStateGroups(label, new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					States =
+					{
+						new VisualState
+						{
+							Name = "Large",
+							StateTriggers = { new AdaptiveTrigger { MinWindowWidth = 300 } },
+							Setters = { new Setter { Property = Label.BackgroundProperty, Value = greenBrush } }
+						},
+						new VisualState
+						{
+							Name = "Small",
+							StateTriggers = { new AdaptiveTrigger { MinWindowWidth = 0 } },
+							Setters = { new Setter { Property = Label.BackgroundProperty, Value = blueBrush } }
+						}
+					}
+				}
+			});
+
+			var page = new ContentPage
+			{
+				Frame = new Rect(0, 0, 100, 100),
+				Content = label,
+			};
+
+			var window = new Window
+			{
+				Page = page
+			};
+
+			label.IsPlatformEnabled = true;
+			page.IsPlatformEnabled = true;
+
+			Assert.That(label.Background, Is.EqualTo(blueBrush));
+
+			page.Frame = new Rect(0, 0, 500, 100);
+
+			Assert.That(label.Background, Is.EqualTo(greenBrush));
+
+			page.Frame = new Rect(0, 0, 100, 100);
+
+			Assert.That(label.Background, Is.EqualTo(blueBrush));
+		}
+	}
+}

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.android.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.android.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Maui.Devices
 			return new DisplayInfo(
 				width: displayMetrics?.WidthPixels ?? 0,
 				height: displayMetrics?.HeightPixels ?? 0,
-				density: displayMetrics?.Density ?? 0,
+				density: displayMetrics?.Density ?? 1,
 				orientation: CalculateOrientation(),
 				rotation: CalculateRotation(display),
 				rate: display?.RefreshRate ?? 0);

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
@@ -3,7 +3,6 @@ using System;
 using System.Runtime.InteropServices;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.UI.Windowing;
-using Microsoft.UI.Xaml;
 using Windows.Graphics.Display;
 using Windows.System.Display;
 
@@ -102,13 +101,22 @@ namespace Microsoft.Maui.Devices
 
 			var w = vDevMode.dmPelsWidth;
 			var h = vDevMode.dmPelsHeight;
-			var dpi = GetDpiForWindow(windowHandle) / DeviceDisplay.BaseLogicalDpi;
+
+			var dpi = (double)GetDpiForWindow(windowHandle);
+			if (dpi != 0)
+				dpi /= DeviceDisplay.BaseLogicalDpi;
+			else
+				dpi = 1.0;
+
+			var orientation = GetWindowOrientationWin32(appWindow) == DisplayOrientations.Landscape
+				? DisplayOrientation.Landscape
+				: DisplayOrientation.Portrait;
 
 			return new DisplayInfo(
 				width: perpendicular ? h : w,
 				height: perpendicular ? w : h,
 				density: dpi,
-				orientation: GetWindowOrientationWin32(appWindow) == DisplayOrientations.Landscape ? DisplayOrientation.Landscape : DisplayOrientation.Portrait,
+				orientation: orientation,
 				rotation: rotation,
 				rate: vDevMode.dmDisplayFrequency);
 		}


### PR DESCRIPTION
### Description of Change

The `AdaptiveTrigger` implementation assumed a single window that was loaded via the `Application.MainPage` property - which is not the case with multiple windows.

This PR updates the code to rather look for the element's window, and use that size.

### Issues Fixed


Fixes #5946
Supersedes #6337
