### PR TITLE
Avoid unnecessary final measure call on Auto/Auto cell

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -547,6 +547,11 @@ namespace Microsoft.Maui.Layouts
 			{
 				foreach (var cell in _cells)
 				{
+					if (!cell.NeedsFinalMeasure)
+					{
+						continue;
+					}
+
 					double width = 0;
 					double height = 0;
 
@@ -564,7 +569,7 @@ namespace Microsoft.Maui.Layouts
 					{
 						continue;
 					}
-
+					
 					_childrenToLayOut[cell.ViewIndex].Measure(width, height);
 				}
 			}
@@ -712,6 +717,10 @@ namespace Microsoft.Maui.Layouts
 			public bool IsRowSpanAuto => HasFlag(RowGridLengthType, GridLengthType.Auto);
 			public bool IsColumnSpanStar => HasFlag(ColumnGridLengthType, GridLengthType.Star);
 			public bool IsRowSpanStar => HasFlag(RowGridLengthType, GridLengthType.Star);
+
+			// If any part of the Cell's spans are Absolute or Star, then the Cell will need a measure at the final size. 
+			// If the cell is entirely Auto, then it doesn't need another measure call. 
+			public bool NeedsFinalMeasure => ((ColumnGridLengthType | RowGridLengthType) ^ GridLengthType.Auto) > 0;
 
 			bool HasFlag(GridLengthType a, GridLengthType b)
 			{


### PR DESCRIPTION
### Description of Change

Proposing this as an alternative to #6542. This version doesn't require special-casing the button image and invalidating the parent.

The Button Image behavior described in #5601 only happens if the layout is a Grid and the Button is in a cell with Auto/Auto for the sizing. This is happening because the Button is receiving unneeded extra measurement calls at the specific default size determined for the Auto/Auto cell before the actual image has been loaded, and the internal bookkeeping for the MAUIButton doesn't think it needs to invalidate its layout once the image is loaded.

This change eliminates the extra measure call in that situation (and, as a bonus, skips that duplicate measure call in general). 

### Issues Fixed

Fixes #5601

