### PR TITLE
Trigger the Font update for IFontElement controls

### DIFF
--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -292,6 +292,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/DatePicker.cs
+++ b/src/Controls/src/Core/DatePicker.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -126,28 +126,32 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(FontAutoScalingEnabledProperty, value);
 		}
 
-		protected void UpdateAutoSizeOption()
-		{
-			if (AutoSize == EditorAutoSizeOption.TextChanges && this.IsShimmed())
-			{
-				InvalidateMeasure();
-			}
-		}
-
 		void IFontElement.OnFontFamilyChanged(string oldValue, string newValue) =>
-			UpdateAutoSizeOption();
+			HandleFontChanged();
 
 		void IFontElement.OnFontSizeChanged(double oldValue, double newValue) =>
-			UpdateAutoSizeOption();
+			HandleFontChanged();
 
 		double IFontElement.FontSizeDefaultValueCreator() =>
 			this.GetDefaultFontSize();
 
 		void IFontElement.OnFontAttributesChanged(FontAttributes oldValue, FontAttributes newValue) =>
-			UpdateAutoSizeOption();
+			HandleFontChanged();
 
 		void IFontElement.OnFontAutoScalingEnabledChanged(bool oldValue, bool newValue) =>
+			HandleFontChanged();
+
+		void HandleFontChanged()
+		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			UpdateAutoSizeOption();
+		}
+
+		void UpdateAutoSizeOption()
+		{
+			if (AutoSize == EditorAutoSizeOption.TextChanges && this.IsShimmed())
+				InvalidateMeasure();
+		}
 
 		public event EventHandler Completed;
 

--- a/src/Controls/src/Core/Entry.cs
+++ b/src/Controls/src/Core/Entry.cs
@@ -192,6 +192,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -259,6 +259,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -245,6 +245,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/SearchBar.cs
+++ b/src/Controls/src/Core/SearchBar.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/src/Core/TimePicker.cs
+++ b/src/Controls/src/Core/TimePicker.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Maui.Controls
 
 		void HandleFontChanged()
 		{
+			Handler?.UpdateValue(nameof(ITextStyle.Font));
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/FontElementUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FontElementUnitTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Maui.Controls.Internals;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public abstract class FontElementUnitTests<TView> : BaseTestFixture
+		where TView : IView, new()
+	{
+		[Test]
+		[TestCase(nameof(IFontElement.FontAttributes), FontAttributes.Bold)]
+		[TestCase(nameof(IFontElement.FontAutoScalingEnabled), false)]
+		[TestCase(nameof(IFontElement.FontFamily), "Arial")]
+		[TestCase(nameof(IFontElement.FontSize), 10)]
+		public void FontPropertyTriggersFontProperty(string propertyName, object value)
+		{
+			var handler = new FontElementHandlerStub();
+
+			var button = new TView();
+			button.Handler = handler;
+			handler.Updates.Clear();
+
+			button.GetType().GetProperty(propertyName).SetValue(button, value, null);
+
+			Assert.AreEqual(2, handler.Updates.Count);
+			Assert.AreEqual(new[] { propertyName, nameof(ITextStyle.Font) }, handler.Updates);
+		}
+	}
+
+	[TestFixture]
+	public class ButtonFontElementUnitTests : FontElementUnitTests<Button> { }
+
+	[TestFixture]
+	public class DatePickerFontElementUnitTests : FontElementUnitTests<DatePicker> { }
+
+	[TestFixture]
+	public class EditorFontElementUnitTests : FontElementUnitTests<Editor> { }
+
+	[TestFixture]
+	public class EntryFontElementUnitTests : FontElementUnitTests<Entry> { }
+
+	[TestFixture]
+	public class LabelFontElementUnitTests : FontElementUnitTests<Label> { }
+
+	[TestFixture]
+	public class PickerFontElementUnitTests : FontElementUnitTests<Picker> { }
+
+	[TestFixture]
+	public class RadioButtonFontElementUnitTests : FontElementUnitTests<RadioButton> { }
+
+	[TestFixture]
+	public class SearchBarFontElementUnitTests : FontElementUnitTests<SearchBar> { }
+
+	[TestFixture]
+	public class TimePickerFontElementUnitTests : FontElementUnitTests<TimePicker> { }
+}

--- a/src/Controls/tests/Core.UnitTests/TestClasses/FontElementHandlerStub.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/FontElementHandlerStub.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	class FontElementHandlerStub : ViewHandler<IView, object>
+	{
+		static readonly IPropertyMapper<IView, FontElementHandlerStub> Mapper =
+			new PropertyMapper<IView, FontElementHandlerStub>
+			{
+				[nameof(IFontElement.FontAttributes)] = (h, v) => h.MapProperty(nameof(IFontElement.FontAttributes)),
+				[nameof(IFontElement.FontAutoScalingEnabled)] = (h, v) => h.MapProperty(nameof(IFontElement.FontAutoScalingEnabled)),
+				[nameof(IFontElement.FontFamily)] = (h, v) => h.MapProperty(nameof(IFontElement.FontFamily)),
+				[nameof(IFontElement.FontSize)] = (h, v) => h.MapProperty(nameof(IFontElement.FontSize)),
+				[nameof(ITextStyle.Font)] = (h, v) => h.MapProperty(nameof(ITextStyle.Font)),
+			};
+
+		public FontElementHandlerStub()
+			: base(Mapper)
+		{
+		}
+
+		public List<string> Updates { get; set; } = new List<string>();
+
+		protected override object CreatePlatformView() => new object();
+
+		void MapProperty(string propertyName) =>
+			Updates.Add(propertyName);
+	}
+}


### PR DESCRIPTION
### Description of Change

The cleanup in #5664 inadvertently removed the secret property that we rely on #6650.

This PR adds back that update, but in a less convoluted way.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6650
