### PR TITLE
[templates] add Android INTERNET permission

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Android/AndroidManifest.xml
@@ -2,4 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Android/AndroidManifest.xml
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Android/AndroidManifest.xml
@@ -2,4 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
Fixes #6576

Debug builds on Android automatically add the `INTERNET` permission,
because otherwise debugging wouldn't work! This definitely adds some
confusion if you switch to a `Release` build and start getting
exceptions in your `HttpClient` calls.

We should just add the `INTERNET` premission to the Android templates,
as nearly every modern app will use the internet. Customers can simply
remove the permission if they don't want it.