### PR TITLE
Exclude platform-specific items using metadata

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
@@ -71,38 +71,38 @@
   <!-- Add metadata indicating that the platform-specific files are not part of every build configuration. -->
   <ItemGroup Condition=" '$(SingleProject)' == 'true' ">
     <Compile Update="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)">
-      <LimitedConfigurationFile>true</LimitedConfigurationFile>
+      <ExcludeFromCurrentConfiguration>true</ExcludeFromCurrentConfiguration>
     </Compile>
   </ItemGroup>
 
   <!-- Add metadata for the files that are actually part of the current build configuration. -->
   <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android' ">
     <Compile Update="$(AndroidProjectFolder)**/*$(DefaultLanguageSourceExtension)">
-      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+      <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' ">
     <Compile Update="$(iOSProjectFolder)**/*$(DefaultLanguageSourceExtension)">
-      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+      <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'maccatalyst' ">
     <Compile Update="$(MacCatalystProjectFolder)**/*$(DefaultLanguageSourceExtension)">
-      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+      <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
     <Compile Update="$(WindowsProjectFolder)**/*$(DefaultLanguageSourceExtension)">
-      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+      <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'tizen' ">
     <Compile Update="$(TizenProjectFolder)**/*$(DefaultLanguageSourceExtension)">
-      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+      <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
   </ItemGroup>
 
@@ -119,7 +119,7 @@
     <ItemGroup>
       <!-- Remove everything that isn't part of this platform -->
       <Compile
-          Condition=" '%(Compile.LimitedConfigurationFile)' == 'true' and '%(Compile.IncludeInThisConfiguration)' != 'true' "
+          Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' "
           Remove="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
 
       <!-- Remove all Windows (WinUI) XAML Files from the Windows folder -->

--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
@@ -68,6 +68,44 @@
     <TizenSharedPrefix>$(TizenProjectFolder)shared</TizenSharedPrefix>
   </PropertyGroup>
 
+  <!-- Add metadata indicating that the platform-specific files are not part of every build configuration. -->
+  <ItemGroup Condition=" '$(SingleProject)' == 'true' ">
+    <Compile Update="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+      <LimitedConfigurationFile>true</LimitedConfigurationFile>
+    </Compile>
+  </ItemGroup>
+
+  <!-- Add metadata for the files that are actually part of the current build configuration. -->
+  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android' ">
+    <Compile Update="$(AndroidProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' ">
+    <Compile Update="$(iOSProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'maccatalyst' ">
+    <Compile Update="$(MacCatalystProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
+    <Compile Update="$(WindowsProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'tizen' ">
+    <Compile Update="$(TizenProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+      <IncludeInThisConfiguration>true</IncludeInThisConfiguration>
+    </Compile>
+  </ItemGroup>
+
   <!--
     Run before both _MauiInjectXamlCssAdditionalFiles and GenerateMSBuildEditorConfigFileShouldRun because
     if for some reason the _MauiInjectXamlCssAdditionalFiles target is not run, we still get in at the
@@ -79,23 +117,10 @@
 
     <!-- Removals -->
     <ItemGroup>
-      <Compile Remove="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-      <!-- Explicitly include the platform code -->
+      <!-- Remove everything that isn't part of this platform -->
       <Compile
-          Condition=" '$(TargetPlatformIdentifier)' == 'android' and '$(AndroidProjectFolder)' != '' "
-          Include="$(AndroidProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-      <Compile
-          Condition=" '$(TargetPlatformIdentifier)' == 'ios' and '$(iOSProjectFolder)' != '' "
-          Include="$(iOSProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-      <Compile
-          Condition=" '$(TargetPlatformIdentifier)' == 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' "
-          Include="$(MacCatalystProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-      <Compile
-          Condition=" '$(TargetPlatformIdentifier)' == 'windows' and '$(WindowsProjectFolder)' != '' "
-          Include="$(WindowsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-      <Compile
-          Condition=" '$(TargetPlatformIdentifier)' == 'tizen' and '$(TizenProjectFolder)' != '' "
-          Include="$(TizenProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
+          Condition=" '%(Compile.LimitedConfigurationFile)' == 'true' and '%(Compile.IncludeInThisConfiguration)' != 'true' "
+          Remove="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
 
       <!-- Remove all Windows (WinUI) XAML Files from the Windows folder -->
       <_MauiXamlToRemove

--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.targets
@@ -68,40 +68,36 @@
     <TizenSharedPrefix>$(TizenProjectFolder)shared</TizenSharedPrefix>
   </PropertyGroup>
 
-  <!-- Add metadata indicating that the platform-specific files are not part of every build configuration. -->
   <ItemGroup Condition=" '$(SingleProject)' == 'true' ">
+    <!-- Add metadata indicating that the platform-specific files are not part of every build configuration. -->
     <Compile Update="$(PlatformsProjectFolder)**/*$(DefaultLanguageSourceExtension)">
       <ExcludeFromCurrentConfiguration>true</ExcludeFromCurrentConfiguration>
     </Compile>
-  </ItemGroup>
 
-  <!-- Add metadata for the files that are actually part of the current build configuration. -->
-  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'android' ">
-    <Compile Update="$(AndroidProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+    <!-- Add metadata for the files that are actually part of the current build configuration. -->
+    <Compile
+        Condition=" '$(TargetPlatformIdentifier)' == 'android' "
+        Update="$(AndroidProjectFolder)**/*$(DefaultLanguageSourceExtension)">
       <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' ">
-    <Compile Update="$(iOSProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+    <Compile
+        Condition=" '$(TargetPlatformIdentifier)' == 'ios' "
+        Update="$(iOSProjectFolder)**/*$(DefaultLanguageSourceExtension)">
       <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'maccatalyst' ">
-    <Compile Update="$(MacCatalystProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+    <Compile
+        Condition=" '$(TargetPlatformIdentifier)' == 'maccatalyst' "
+        Update="$(MacCatalystProjectFolder)**/*$(DefaultLanguageSourceExtension)">
       <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
-    <Compile Update="$(WindowsProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+    <Compile
+        Condition=" '$(TargetPlatformIdentifier)' == 'windows' "
+        Update="$(WindowsProjectFolder)**/*$(DefaultLanguageSourceExtension)">
       <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'tizen' ">
-    <Compile Update="$(TizenProjectFolder)**/*$(DefaultLanguageSourceExtension)">
+    <Compile
+        Condition=" '$(TargetPlatformIdentifier)' == 'tizen' "
+        Update="$(TizenProjectFolder)**/*$(DefaultLanguageSourceExtension)">
       <ExcludeFromCurrentConfiguration>false</ExcludeFromCurrentConfiguration>
     </Compile>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change

Currently the platform-specific files are included for every platform in the MSBuild evaluation, and then at build the  `_MauiRemovePlatformCompileItems` target removes _all_ these items and then adds back the ones for the current platform.

This works for an actual build but screws up VS, as the Project System doesn't properly handle a `Compile` item that is present in evaluation but removed during a build. The end result is that the platform-specific files are not actually treated as platform-specific, leading to a number of user-visible issues:

1. Platform-specific files incorrectly show all target frameworks in the Nav Bar
2. Spurious errors in the Error List
3. Squiggles in the editor, unless the user changes the Nav Bar to the "correct" target framework
4. Possibly they will not see actual errors in their code (e.g. if you use a Windows-only API in an Android-specific file, but the Nav Bar is set to Windows, you won't get an squiggle about that)
5. The spurious errors block Hot Reload as the Language Service thinks the project is very broken and will not attempt to apply changes

To work around this problem the Project System will now check items for special metadata indicating that they should be ignored. If an item is marked with `ExcludeFromCurrentConfiguration=true` the Project System will pretend it does not exist in the evaluation data for the current build configuration. And as the file no longer exists in the evaluation data, it no longer matters that the Project System does not properly handle the removal in the target.

Here we mark all items under the Platforms folder with `ExcludeFromCurrentConfiguration=true`, and then mark the items corresponding to the current platform with `ExcludeFromCurrentConfiguration=false`. The `_MauiRemovePlatformCompileItems` target is also updated to remove items based on the metadata rather than the folder structure.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

_Note that these issues also require a corresponding change in the [dotnet/project-system](https://github.com/dotnet/project-system) repo._

Fixes #4726.
Fixes #5294.
