### PR TITLE
[Android] Fix usage of SimpleViewHolder on COllectionView Header and Footer

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DemoFilteredItemSource.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/DemoFilteredItemSource.cs
@@ -16,6 +16,16 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 		{
 			_source = new List<CollectionViewGalleryTestItem>();
 
+			AddItems(_source, count);
+
+			Items = new ObservableCollection<CollectionViewGalleryTestItem>(_source);
+
+			_filter = filter ?? ItemMatches;
+		}
+
+
+		public void AddItems(IList<CollectionViewGalleryTestItem> list, int count)
+		{
 			string[] images =
 			{
 				"cover1.jpg",
@@ -29,18 +39,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 
 			for (int n = 0; n < count; n++)
 			{
-				_source.Add(new CollectionViewGalleryTestItem(DateTime.Now.AddDays(n),
+				list.Add(new CollectionViewGalleryTestItem(DateTime.Now.AddDays(n),
 					$"{images[n % images.Length]}, {n}", images[n % images.Length], n));
 			}
-			Items = new ObservableCollection<CollectionViewGalleryTestItem>(_source);
-
-			_filter = filter ?? ItemMatches;
-		}
-
-		private bool ItemMatches(string filter, CollectionViewGalleryTestItem item)
-		{
-			filter = filter ?? "";
-			return item.Caption.Contains(filter, StringComparison.OrdinalIgnoreCase);
 		}
 
 		public void FilterItems(string filter)
@@ -61,6 +62,11 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 					}
 				}
 			}
+		}
+		bool ItemMatches(string filter, CollectionViewGalleryTestItem item)
+		{
+			filter = filter ?? "";
+			return item.Caption.Contains(filter, StringComparison.OrdinalIgnoreCase);
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml
@@ -22,11 +22,22 @@
             <CollectionView.Footer>
 
                 <Grid>
-                    <Image Source="cover1.jpg" Aspect="AspectFill" HeightRequest="80"></Image>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <Image Source="cover1.jpg" Aspect="AspectFill" HeightRequest="80" Grid.Row="0" Grid.ColumnSpan="2"></Image>
                     <Label Text="{Binding FooterText}" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" Rotation="10" 
-                           FontAttributes="Bold" FontSize="20" />
+                           FontAttributes="Bold" FontSize="20" Grid.Row="0" Grid.ColumnSpan="2"/>
+                    <Button Text="Add 2 Items" Grid.Row="1" Grid.Column="0" HorizontalOptions="Center"
+                            Command="{Binding AddCommand}" />
+                    <Button Text="Clear All Items" Grid.Row="1" Grid.Column="1" HorizontalOptions="Center"
+                            Command="{Binding ClearCommand}" />
                 </Grid>
-
             </CollectionView.Footer>
 
         </CollectionView>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
 
@@ -7,7 +9,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class HeaderFooterView : ContentPage
 	{
-		readonly HeaderFooterViewModel _viewModel = new HeaderFooterViewModel(3);
+		readonly HeaderFooterViewModel _viewModel = new HeaderFooterViewModel(0);
 
 		public HeaderFooterView()
 		{
@@ -24,8 +26,18 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 		{
 		}
 
+		public ICommand AddCommand => new Command(async () => await AddItemsAsync());
+
+		public ICommand ClearCommand => new Command(() => Items.Clear());
+
 		public string HeaderText => "This Is A Header";
 
 		public string FooterText => "This Is A Footer";
+
+		async Task AddItemsAsync()
+		{
+			await Task.Delay(TimeSpan.FromSeconds(1));
+			AddItems(Items, 2);
+		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -127,7 +127,7 @@ namespace Maui.Controls.Sample
 				{
 					PageType.Template => typeof(TemplatePage),
 					PageType.Shell => typeof(AppShell),
-					PageType.Main => typeof(Pages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterView),
+					PageType.Main => typeof(CustomNavigationPage),
 					PageType.FlyoutPage => typeof(CustomFlyoutPage),
 					PageType.TabbedPage => typeof(Pages.TabbedPageGallery),
 					PageType.Blazor =>

--- a/src/Controls/samples/Controls.Sample/Startup.cs
+++ b/src/Controls/samples/Controls.Sample/Startup.cs
@@ -127,7 +127,7 @@ namespace Maui.Controls.Sample
 				{
 					PageType.Template => typeof(TemplatePage),
 					PageType.Shell => typeof(AppShell),
-					PageType.Main => typeof(CustomNavigationPage),
+					PageType.Main => typeof(Pages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterView),
 					PageType.FlyoutPage => typeof(CustomFlyoutPage),
 					PageType.TabbedPage => typeof(Pages.TabbedPageGallery),
 					PageType.Blazor =>

--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			Content = CreateHandler(view, itemsView);
 			var platformView = Content.ContainerView ?? Content.PlatformView;
+			//make sure we don't belong to a previous Holder
+			platformView.RemoveFromParent();
 			AddView(platformView);
 
 			//TODO: RUI IS THIS THE BEST WAY TO CAST? 


### PR DESCRIPTION
### Description of Change

Our previous implementation on Forms was creating always a new native element before adding it to SimpleViewHolder, but now we reuse the handler so we need to remove it first from the old ItemContentView before adding it to our new ItemContentView

### Issues Fixed

Fixes #5332 
