### PR TITLE
Set Image ClipRect at origin when using AspectFill

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -52,10 +52,10 @@ namespace Microsoft.Maui.Handlers
 			if (PlatformView.GetScaleType() == ImageView.ScaleType.CenterCrop)
 			{
 				// If the image is center cropped (AspectFill), then the size of the image likely exceeds
-				// the view size in some dimension. So we need to clip to the to the view's bounds.
+				// the view size in some dimension. So we need to clip to the view's bounds.
 
 				var (left, top, right, bottom) = PlatformView.Context!.ToPixels(frame);
-				var clipRect = new Android.Graphics.Rect(left, top, right, bottom);
+				var clipRect = new Android.Graphics.Rect(0, 0, right - left, bottom - top);
 				PlatformView.ClipBounds = clipRect;
 			}
 			else


### PR DESCRIPTION
When using AspectFill, Android needs to enable clipping for the image. Unfortunately, the ClipRect wasn't being aligned with the origin of the image. These changes align it from 0,0 so it doesn't cut off parts of the image.

Fixes #6365


