### PR TITLE
Fix Opacity for Wrapper Views

### DIFF
--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -208,7 +208,10 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapOpacity(IViewHandler handler, IView view)
 		{
-			((PlatformView?)handler.PlatformView)?.UpdateOpacity(view);
+			if(handler.HasContainer)
+				((PlatformView?)handler.ContainerView)?.UpdateOpacity(view);
+			else
+				((PlatformView?)handler.PlatformView)?.UpdateOpacity(view);
 		}
 
 		public static void MapAutomationId(IViewHandler handler, IView view)


### PR DESCRIPTION
If here is a container/wrapper view. The opacity should be applied there. If not, the background/border will still appear after a fade out.