### PR TITLE
Fix Newtonsoft.Json assembly version conflict warning in Resizetizer.UnitTests.csproj

### DIFF
--- a/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
+++ b/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.7.0" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SkiaSharp" Version="2.88.0-preview.256" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
It was using an earlier version of Newtonsoft.Json (dependency of Microsoft.TestPlatform.TestHost) than the rest of the repo which caused this warning:

```
warning MSB3277: Found conflicts between different versions of "Newtonsoft.Json" that could not be resolved. [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277: There was a conflict between "Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" and "Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed". [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:     "Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" was chosen because it was primary and "Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" was not. [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:     References which depend on "Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" [/Users/alexander/.nuget/packages/newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll]. [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:         /Users/alexander/.nuget/packages/newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:           Project file item includes which caused reference "/Users/alexander/.nuget/packages/newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll". [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:             /Users/alexander/.nuget/packages/newtonsoft.json/9.0.1/lib/netstandard1.0/Newtonsoft.Json.dll [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:     References which depend on "Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" []. [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:         /Users/alexander/dev/maui/src/SingleProject/Resizetizer/src/bin/Debug/netstandard2.0/Microsoft.Maui.Resizetizer.dll [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:           Project file item includes which caused reference "/Users/alexander/dev/maui/src/SingleProject/Resizetizer/src/bin/Debug/netstandard2.0/Microsoft.Maui.Resizetizer.dll". [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
warning MSB3277:             /Users/alexander/dev/maui/src/SingleProject/Resizetizer/src/bin/Debug/netstandard2.0/Microsoft.Maui.Resizetizer.dll [/Users/alexander/dev/maui/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj]
```
