### PR TITLE
Only set AccessibilityTraits for heading when it matters

### DIFF
--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -19,9 +19,15 @@ namespace Microsoft.Maui.Platform
 				platformView.IsAccessibilityElement = true;
 
 			if (semantics.IsHeading)
-				platformView.AccessibilityTraits |= UIAccessibilityTrait.Header;
+			{
+				if ((platformView.AccessibilityTraits & UIAccessibilityTrait.Header) != UIAccessibilityTrait.Header)
+					platformView.AccessibilityTraits |= UIAccessibilityTrait.Header;
+			}
 			else
-				platformView.AccessibilityTraits &= ~UIAccessibilityTrait.Header;
+			{
+				if ((platformView.AccessibilityTraits & UIAccessibilityTrait.Header) == UIAccessibilityTrait.Header)
+					platformView.AccessibilityTraits &= ~UIAccessibilityTrait.Header;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Only set the header flag if you need to. This needs to be more permanently fixed
https://github.com/dotnet/maui/issues/6750


