### PR TITLE
[Android] Fix issue with View as EmptyView of CollectionView

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGallery.cs
@@ -21,6 +21,8 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.EmptyViewGalleries
 						descriptionLabel,
 						GalleryBuilder.NavButton("EmptyView (null ItemsSource)", () =>
 							new EmptyViewNullGallery(), Navigation),
+						GalleryBuilder.NavButton("EmptyView (null ItemsSource) View", () =>
+							new EmptyViewNullGallery(false), Navigation),
 						GalleryBuilder.NavButton("EmptyView (String)", () =>
 							new EmptyViewStringGallery(), Navigation),
 						GalleryBuilder.NavButton("EmptyView (View)", () =>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewNullGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewNullGallery.xaml
@@ -7,9 +7,6 @@
 				<CollectionView.ItemsLayout>
 					<GridItemsLayout Span="3" Orientation="Vertical"></GridItemsLayout>
 				</CollectionView.ItemsLayout>
-				<CollectionView.EmptyView>
-					Nothing to display.
-				</CollectionView.EmptyView>
 			</CollectionView>
     </ContentPage.Content>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewNullGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewNullGallery.xaml.cs
@@ -12,9 +12,18 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.EmptyViewGalleries
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class EmptyViewNullGallery : ContentPage
 	{
-		public EmptyViewNullGallery()
+		public EmptyViewNullGallery(bool useOnlyText = true)
 		{
 			InitializeComponent();
+			string emptyViewText = "Nothing to display.";
+			CollectionView.EmptyView = useOnlyText ? emptyViewText :
+													 new Grid { Children = { new Label
+													 {
+														 Text = emptyViewText,
+														 HorizontalOptions = LayoutOptions.Center,
+														 VerticalOptions = LayoutOptions.Center,
+														 FontAttributes = FontAttributes.Bold
+													 } } };
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/EmptyViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/EmptyViewAdapter.cs
@@ -272,13 +272,15 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		int GetHeight(ViewGroup parent)
 		{
+			//this was using parent.MeasuredHeight on XF but that reports 0 now.
 			var headerFooterHeight = parent.Context.ToPixels(_headerHeight + _footerHeight);
-			return Math.Abs((int)(parent.MeasuredHeight - headerFooterHeight));
+			return Math.Abs((int)(parent.Height - headerFooterHeight));
 		}
 
 		int GetWidth(ViewGroup parent)
 		{
-			return parent.MeasuredWidth;
+			//this was using MeasuredWidth on XF but that reports 0 now.
+			return parent.Width;
 		}
 
 		void UpdateHeaderFooterHeight(object item, bool isHeader)


### PR DESCRIPTION
### Description of Change

When using EmptyView with a MAUI view it wasn't sizing property because the MeasureWidth and MeasureHeight of the RecyclerView was always 0. This was working fine on Forms but could be related with how we now layout on MAUI our stuff natively.

### Issues Fixed

Fixes #3012 
