### PR TITLE
Revert "Add VC Redist dependency to Windows templates"

### DIFF
--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
@@ -14,8 +14,6 @@
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
 
   <Resources>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
@@ -14,8 +14,6 @@
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
 
   <Resources>


### PR DESCRIPTION
Reverts dotnet/maui#6318

This reverts adding the VS Redist dependencies to the Windows Package.appxmanifest. The dependency on C++ bits has been removed from the Win2D package as of version 1.0.3.1 which we [add through Microsoft.Maui.Graphics](https://github.com/dotnet/Microsoft.Maui.Graphics/pull/414)