### PR TITLE
Fix margin related measuring with CV

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -69,11 +69,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			//View.Arrange(new Rectangle(Point.Zero, size));
 			//Arrange doesn't seem to work as expected
 
-			var mauiControlsView = View as View;
-			if (mauiControlsView == null)
+			if (View?.Handler is not IPlatformViewHandler handler)
 				return;
 
-			mauiControlsView.Layout(new Rect(Point.Zero, size));
+			handler.LayoutVirtualView(l, t, r, b);
 
 			UpdateContentLayout();
 		}
@@ -104,16 +103,17 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				? double.PositiveInfinity
 				: Context.FromPixels(pixelHeight);
 
-			SizeRequest measure = (View as VisualElement).Measure(width, height, MeasureFlags.IncludeMargins);
+
+			var measure = View.Measure(width, height);
 
 			if (pixelWidth == 0)
 			{
-				pixelWidth = (int)Context.ToPixels(measure.Request.Width);
+				pixelWidth = (int)Context.ToPixels(measure.Width);
 			}
 
 			if (pixelHeight == 0)
 			{
-				pixelHeight = (int)Context.ToPixels(measure.Request.Height);
+				pixelHeight = (int)Context.ToPixels(measure.Height);
 			}
 
 			_reportMeasure?.Invoke(new Size(pixelWidth, pixelHeight));
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		void UpdateContentLayout()
 		{
 			VisualElement mauiControlsView = View as VisualElement;
-			AView aview = Content.ContainerView ?? Content.PlatformView;
+			AView aview = Content.ToPlatform();
 
 			if (mauiControlsView == null || aview == null)
 				return;

--- a/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/SizedItemContentView.cs
@@ -42,11 +42,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var heightSpec = Context.CreateMeasureSpec(targetHeight, double.IsInfinity(targetHeight) ? double.NaN : targetHeight
 					, targetHeight);
 
-				pvh.PlatformView.Measure(widthSpec, heightSpec);
+				var size = pvh.MeasureVirtualView(widthSpec, heightSpec);
 
-				SetMeasuredDimension(
-					pvh.PlatformView.MeasuredWidth,
-					pvh.PlatformView.MeasuredHeight);
+				SetMeasuredDimension((int)size.Width, (int)size.Height);
 			}
 		}
 	}

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -225,8 +225,8 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			var frameworkElement = Content as FrameworkElement;
-
 			var formsElement = _renderer.VirtualView as VisualElement;
+			var margin = _renderer.VirtualView.Margin;
 
 			if (ItemHeight != default || ItemWidth != default)
 			{
@@ -234,7 +234,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 				var wsize = new WSize(ItemWidth, ItemHeight);
 
-				frameworkElement.Margin = WinUIHelpers.CreateThickness(ItemSpacing.Left, ItemSpacing.Top, ItemSpacing.Right, ItemSpacing.Bottom);
+				frameworkElement.Margin = 
+					WinUIHelpers.CreateThickness(
+						margin.Left + ItemSpacing.Left,
+						margin.Top + ItemSpacing.Top,
+						margin.Right + ItemSpacing.Right,
+						margin.Bottom + ItemSpacing.Bottom);
 
 				if (CanMeasureContent(frameworkElement))
 					frameworkElement.Measure(wsize);
@@ -252,6 +257,12 @@ namespace Microsoft.Maui.Controls.Platform
 				formsElement.Layout(new Rect(0, 0, width, height));
 
 				var wsize = new WSize(width, height);
+
+				frameworkElement.Margin = WinUIHelpers.CreateThickness(
+					margin.Left,
+					margin.Top,
+					margin.Right,
+					margin.Bottom);
 
 				if (CanMeasureContent(frameworkElement))
 					frameworkElement.Measure(wsize);


### PR DESCRIPTION
### Description of Change

- Android was calling the old Layout method which includes the margins on the bounds. This would then cause the Layout to fill the margin space created. 

- WinUI just needed some additional margins added on the `ItemContentControl`. 

### Issues Fixed
Fixes #5621

### Results

```XAML
<CollectionView x:Name="cvMe">
    <CollectionView.ItemTemplate>
        <DataTemplate>
            <StackLayout Margin="20,50,0,0" Background="Purple">
                <Label Text="I am a label with a margin" TextColor="White"></Label>
            </StackLayout>
        </DataTemplate>
    </CollectionView.ItemTemplate>
</CollectionView>
```

WINUI (this was also broken on Forms)
![image](https://user-images.githubusercontent.com/5375137/166334739-97c1738d-a315-4668-b532-be63e875080d.png)

ANDROID
![image](https://user-images.githubusercontent.com/5375137/166334898-fb0b1c52-7983-462a-ad4a-e10dd500aa43.png)

