### PR TITLE
Move some of the require props into Core and fix #6529

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -2,11 +2,7 @@
 
   <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
     <OutputType Condition="'$(OutputType)' == 'Exe'">WinExe</OutputType>
-    <EnableMsixTooling Condition="'$(EnableMsixTooling)' == ''">true</EnableMsixTooling>
-    <EnablePreviewMsixTooling Condition="'$(EnablePreviewMsixTooling)' == ''">$(EnableMsixTooling)</EnablePreviewMsixTooling>
     <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnableMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">MSIX</WindowsPackageType>
-    <WinUISDKReferences Condition=" '$(WinUISDKReferences)' == '' and '$(EnableMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">false</WinUISDKReferences>
-    <GenerateLibraryLayout Condition=" '$(GenerateLibraryLayout)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">true</GenerateLibraryLayout>
     <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
     <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
     <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Core.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Core.Sdk.After.targets
@@ -5,6 +5,12 @@
     <MSBuildWarningsAsMessages Condition=" '$(TargetPlatformIdentifier)' == 'Android' ">$(MSBuildWarningsAsMessages);XA4218</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
-  <Import Project="WinUI.targets" Condition=" '$(TargetPlatformIdentifier)' == 'windows' " />
+  <!--
+    This double check seems excessive, but importing the WinUI.targets when building for windows is not
+    sufficient. The WASDK targets assume everything is WinUI and thus just passes along the TFM of the app.
+    As a result, if you have a net6.0 class library, the app will call MSBuild on that library - with the Windows TFM!
+    This results in the $(TargetPlatformIdentifier) condition being met - even though there are no WASK targets to run!
+  -->
+  <Import Project="WinUI.targets" Condition=" '$(TargetPlatformIdentifier)' == 'windows' and '$(WindowsAppSDKWinUI)' == 'true'" />
 
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Core.Sdk.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Core.Sdk.targets
@@ -4,6 +4,14 @@
     <UsingMicrosoftMauiCoreSdk>true</UsingMicrosoftMauiCoreSdk>
   </PropertyGroup>
 
+  <!-- Set some property defaults that MAUI requires - especially for dotnet build to work -->
+  <PropertyGroup Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
+    <EnableMsixTooling Condition=" '$(EnableMsixTooling)' == '' ">true</EnableMsixTooling>
+    <EnablePreviewMsixTooling Condition=" '$(EnablePreviewMsixTooling)' == '' ">$(EnableMsixTooling)</EnablePreviewMsixTooling>
+    <GenerateLibraryLayout Condition=" '$(GenerateLibraryLayout)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">true</GenerateLibraryLayout>
+    <WinUISDKReferences Condition=" '$(WinUISDKReferences)' == '' and '$(EnableMsixTooling)' == 'true' ">false</WinUISDKReferences>
+  </PropertyGroup>
+
   <!-- Imported last -->
   <PropertyGroup>
     <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Microsoft.Maui.Core.Sdk.After.targets</AfterMicrosoftNETSdkTargets>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.NetCore.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.NetCore.targets
@@ -355,7 +355,7 @@
 
   </Target>
 
-<Target Name="GetPriOutputs"
+  <Target Name="GetPriOutputs"
           Condition="'$(AppxGeneratePriEnabled)'=='true'"
           Returns="@(PriOutputs);@(ProjectPriFile)"
           DependsOnTargets="$(GetPriOutputsDependsOn)">


### PR DESCRIPTION
### Description of Change

Previously we just assumed that when the project was a maui project (that always brings in WASDK) and the TFM is windows (always the WASDK) that we can use things. However, the app will lie to us and ALWAYS tell us we are a windows library - even if we are net6.0.

This PR fixes some things, but mainly makes sure that when it is importing the WinUI workarounds it is also referencing WASDK. So, when the app lies to us, we can see the truth!

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6529
