### PR TITLE
Remove closure from AddSpecific and AddWeakSpecific

### DIFF
--- a/src/Core/src/MauiContext.cs
+++ b/src/Core/src/MauiContext.cs
@@ -34,19 +34,18 @@ namespace Microsoft.Maui
 		internal void AddSpecific<TService>(TService instance)
 			where TService : class
 		{
-			_services.AddSpecific(typeof(TService), () => instance);
+			_services.AddSpecific(typeof(TService), static state => state, instance);
 		}
 
 		internal void AddWeakSpecific<TService>(TService instance)
 			where TService : class
 		{
-			var weak = new WeakReference(instance);
-			_services.AddSpecific(typeof(TService), () => weak.Target);
+			_services.AddSpecific(typeof(TService), static state => ((WeakReference)state).Target, new WeakReference(instance));
 		}
 
 		class WrappedServiceProvider : IServiceProvider
 		{
-			readonly ConcurrentDictionary<Type, Func<object?>> _scopeStatic = new();
+			readonly ConcurrentDictionary<Type, (object, Func<object, object?>)> _scopeStatic = new();
 
 			public WrappedServiceProvider(IServiceProvider serviceProvider)
 			{
@@ -57,15 +56,18 @@ namespace Microsoft.Maui
 
 			public object? GetService(Type serviceType)
 			{
-				if (_scopeStatic.TryGetValue(serviceType, out var getter))
-					return getter.Invoke();
+				if (_scopeStatic.TryGetValue(serviceType, out var scope))
+				{
+					var (state, getter) = scope;
+					return getter.Invoke(state);
+				}
 
 				return Inner.GetService(serviceType);
 			}
 
-			public void AddSpecific(Type type, Func<object?> getter)
+			public void AddSpecific(Type type, Func<object, object?> getter, object state)
 			{
-				_scopeStatic[type] = getter;
+				_scopeStatic[type] = (state, getter);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change

Currently, the WrappedServiceProvider does use a `Func<object>` as the common "interface" to store accessors to the instance that is added as a specific override for the current context. I'm assuming this is done to support weak references. The downside of this that it allocates closures. As an example

```csharp
var foo = new object();
AddSpecific(() => foo);
```

decompiles to

```
    [CompilerGenerated]
    private sealed class <>c__DisplayClass0_0
    {
        public object foo;

        internal object <M>b__0()
        {
            return foo;
        }
    }

<>c__DisplayClass0_0 <>c__DisplayClass0_ = new <>c__DisplayClass0_0();
<>c__DisplayClass0_.foo = new object();
AddSpecific(new Func<object>(<>c__DisplayClass0_.<M>b__0));
```

while with the change we get

```
[Serializable]
    [CompilerGenerated]
    private sealed class <>c
    {
        public static readonly <>c <>9 = new <>c();

        public static Func<object, object> <>9__0_1;

        internal object <M>b__0_1(object state)
        {
            return state;
        }
    }

AddSpecific(<>c.<>9__0_1 ?? (<>c.<>9__0_1 = new Func<object, object>(<>c.<>9.<M>b__0_1)),
```

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
