### PR TITLE
Fix operator precedence

### DIFF
--- a/src/Core/src/Platform/iOS/DatePickerExtensions.cs
+++ b/src/Core/src/Platform/iOS/DatePickerExtensions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Platform
 			string format = datePicker.Format ?? string.Empty;
 
 			// Can't use VirtualView.Format because it won't display the correct format if the region and language are set differently
-			if (picker != null && string.IsNullOrWhiteSpace(format) || format.Equals("d", StringComparison.OrdinalIgnoreCase))
+			if (picker != null && (string.IsNullOrWhiteSpace(format) || format.Equals("d", StringComparison.OrdinalIgnoreCase)))
 			{
 				NSDateFormatter dateFormatter = new NSDateFormatter
 				{
@@ -74,13 +74,13 @@ namespace Microsoft.Maui.Platform
 				if (format.Equals("D", StringComparison.Ordinal) == true)
 				{
 					dateFormatter.DateStyle = NSDateFormatterStyle.Long;
-					var strDate = dateFormatter.StringFor(picker?.Date);
+					var strDate = dateFormatter.StringFor(picker.Date);
 					platformDatePicker.Text = strDate;
 				}
 				else
 				{
 					dateFormatter.DateStyle = NSDateFormatterStyle.Short;
-					var strDate = dateFormatter.StringFor(picker?.Date);
+					var strDate = dateFormatter.StringFor(picker.Date);
 					platformDatePicker.Text = strDate;
 				}
 			}


### PR DESCRIPTION
### Description of Change

This change fixed an obvious operator precedence issue. It appears to me that the intent of that condition is to ensure `picker` is not null and also allow two different cases for the format strings, but as is written, the code ensure `picker` is not null only when it hits the former case.

### Issues Fixed

Fixes #6402
