### PR TITLE
Fix overlapping text with Label spans

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
@@ -219,17 +219,6 @@ namespace Microsoft.Maui.Controls.Platform
 					value, Context?.Resources?.DisplayMetrics ?? Android.App.Application.Context.Resources!.DisplayMetrics);
 
 				paint.LetterSpacing = CharacterSpacing;
-
-				if (HorizontalTextAlignment.HasValue)
-				{
-					paint.TextAlign = HorizontalTextAlignment.Value switch
-					{
-						TextAlignment.Start => Paint.Align.Left,
-						TextAlignment.Center => Paint.Align.Center,
-						TextAlignment.End => Paint.Align.Right,
-						_ => Paint.Align.Left
-					};
-				}
 			}
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -224,5 +224,46 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(expectedLines, platformValue);
 		}
+
+		[Theory]
+		[InlineData(TextAlignment.Center)]
+		[InlineData(TextAlignment.Start)]
+		[InlineData(TextAlignment.End)]
+		public async Task FormattedStringSpanTextHasCorrectLayoutWhenAligned(TextAlignment alignment)
+		{
+			var formattedLabel = new Label
+			{
+				WidthRequest = 200,
+				HeightRequest = 50,
+				HorizontalTextAlignment = alignment,
+				FormattedText = new FormattedString
+				{
+					Spans =
+					{
+						new Span { Text = "short" },
+						new Span { Text = " long second string"}
+					}
+				},
+			};
+
+			var normalLabel = new Label
+			{
+				WidthRequest = 200,
+				HeightRequest = 50,
+				HorizontalTextAlignment = alignment,
+				Text = "short long second string"
+			};
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var formattedHandler = CreateHandler<LabelHandler>(formattedLabel);
+				var formattedBitmap = await formattedHandler.PlatformView.ToBitmap();
+
+				var normalHandler = CreateHandler<LabelHandler>(normalLabel);
+				var normalBitmap = await normalHandler.PlatformView.ToBitmap();
+
+				await normalBitmap.AssertEqual(formattedBitmap);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -132,7 +132,17 @@ namespace Microsoft.Maui.DeviceTests
 				}
 #endif
 
-				view.Arrange(new Rect(Point.Zero, view.Measure(view.Width, view.Height)));
+#if WINDOWS
+				// windows cannot measure without being loaded
+				var w = view.Width;
+				var h = view.Height;
+#else
+				var size = view.Measure(view.Width, view.Height);
+				var w = size.Width;
+				var h = size.Height;
+#endif
+
+				view.Arrange(new Rect(0, 0, w, h));
 				viewHandler.PlatformArrange(view.Frame);
 			}
 

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.DeviceTests
 				}
 #endif
 
-				view.Arrange(new Rect(0, 0, view.Width, view.Height));
+				view.Arrange(new Rect(Point.Zero, view.Measure(view.Width, view.Height)));
 				viewHandler.PlatformArrange(view.Frame);
 			}
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -62,14 +62,16 @@ namespace Microsoft.Maui.DeviceTests
 			if (view.Parent is Border wrapper)
 				view = wrapper;
 
-			Grid grid;
-			var window = new Window
+			if (view.Parent == null)
 			{
-				Content = new Grid
+				Grid grid;
+				var window = new Window
 				{
-					HorizontalAlignment = HorizontalAlignment.Center,
-					VerticalAlignment = VerticalAlignment.Center,
-					Children =
+					Content = new Grid
+					{
+						HorizontalAlignment = HorizontalAlignment.Center,
+						VerticalAlignment = VerticalAlignment.Center,
+						Children =
 					{
 						(grid = new Grid
 						{
@@ -81,19 +83,28 @@ namespace Microsoft.Maui.DeviceTests
 							}
 						})
 					}
-				}
-			};
-			window.Activate();
+					}
+				};
+				window.Activate();
 
-			try
-			{
-				var result = await action();
-				return result;
+				try
+				{
+					return await Run(action);
+				}
+				finally
+				{
+					grid.Children.Clear();
+					window.Close();
+				}
 			}
-			finally
+			else
 			{
-				grid.Children.Clear();
-				window.Close();
+				return await Run(action);
+			}
+
+			static async Task<T> Run(Func<Task<T>> action)
+			{
+				return await action();
 			}
 		}
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -12,18 +12,19 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public static partial class AssertionExtensions
 	{
-		public static string CreateColorAtPointError(this UIImage bitmap, UIColor expectedColor, int x, int y)
-		{
-			var data = bitmap.AsPNG();
-			var imageAsString = data.GetBase64EncodedString(Foundation.NSDataBase64EncodingOptions.None);
-			return $"Expected {expectedColor} at point {x},{y} in renderered view. This is what it looked like:<img>{imageAsString}</img>";
-		}
+		public static string CreateColorAtPointError(this UIImage bitmap, UIColor expectedColor, int x, int y) =>
+			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
 
-		public static string CreateColorError(this UIImage bitmap, string message)
+		public static string CreateColorError(this UIImage bitmap, string message) =>
+			$"{message} This is what it looked like:<img>{bitmap.ToBase64String()}</img>";
+
+		public static string CreateEqualError(this UIImage bitmap, UIImage other, string message) =>
+			$"{message} This is what it looked like: <img>{bitmap.ToBase64String()}</img> and <img>{other.ToBase64String()}</img>";
+
+		public static string ToBase64String(this UIImage bitmap)
 		{
 			var data = bitmap.AsPNG();
-			var imageAsString = data.GetBase64EncodedString(Foundation.NSDataBase64EncodingOptions.None);
-			return $"{message}. This is what it looked like:<img>{imageAsString}</img>";
+			return data.GetBase64EncodedString(NSDataBase64EncodingOptions.None);
 		}
 
 		public static Task AttachAndRun(this UIView view, Action action) =>
@@ -54,7 +55,7 @@ namespace Microsoft.Maui.DeviceTests
 			return result;
 		}
 
-		public static Task<UIImage> ToUIImage(this UIView view)
+		public static Task<UIImage> ToBitmap(this UIView view)
 		{
 			if (view.Superview is WrapperView wrapper)
 				view = wrapper;
@@ -157,43 +158,43 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static async Task<UIImage> AssertColorAtPoint(this UIView view, UIColor expectedColor, int x, int y)
 		{
-			var bitmap = await view.ToUIImage();
+			var bitmap = await view.ToBitmap();
 			return bitmap.AssertColorAtPoint(expectedColor, x, y);
 		}
 
 		public static async Task<UIImage> AssertColorAtCenter(this UIView view, UIColor expectedColor)
 		{
-			var bitmap = await view.ToUIImage();
+			var bitmap = await view.ToBitmap();
 			return bitmap.AssertColorAtCenter(expectedColor);
 		}
 
 		public static async Task<UIImage> AssertColorAtBottomLeft(this UIView view, UIColor expectedColor)
 		{
-			var bitmap = await view.ToUIImage();
+			var bitmap = await view.ToBitmap();
 			return bitmap.AssertColorAtBottomLeft(expectedColor);
 		}
 
 		public static async Task<UIImage> AssertColorAtBottomRight(this UIView view, UIColor expectedColor)
 		{
-			var bitmap = await view.ToUIImage();
+			var bitmap = await view.ToBitmap();
 			return bitmap.AssertColorAtBottomRight(expectedColor);
 		}
 
 		public static async Task<UIImage> AssertColorAtTopLeft(this UIView view, UIColor expectedColor)
 		{
-			var bitmap = await view.ToUIImage();
+			var bitmap = await view.ToBitmap();
 			return bitmap.AssertColorAtTopLeft(expectedColor);
 		}
 
 		public static async Task<UIImage> AssertColorAtTopRight(this UIView view, UIColor expectedColor)
 		{
-			var bitmap = await view.ToUIImage();
+			var bitmap = await view.ToBitmap();
 			return bitmap.AssertColorAtTopRight(expectedColor);
 		}
 
 		public static async Task<UIImage> AssertContainsColor(this UIView view, UIColor expectedColor)
 		{
-			var bitmap = await view.ToUIImage();
+			var bitmap = await view.ToBitmap();
 			return bitmap.AssertContainsColor(expectedColor);
 		}
 
@@ -215,6 +216,34 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.True(false, CreateColorError(bitmap, $"Color {expectedColor} not found."));
 			return bitmap;
+		}
+
+		public static Task AssertEqual(this UIImage bitmap, UIImage other)
+		{
+			Assert.NotNull(bitmap);
+			Assert.NotNull(other);
+
+			Assert.Equal(bitmap.Size, other.Size);
+
+			Assert.True(IsMatching(), CreateEqualError(bitmap, other, $"Images did not match."));
+
+			return Task.CompletedTask;
+
+			bool IsMatching()
+			{
+				for (int x = 0; x < bitmap.Size.Width; x++)
+				{
+					for (int y = 0; y < bitmap.Size.Height; y++)
+					{
+						var first = bitmap.ColorAtPoint(x, y);
+						var second = other.ColorAtPoint(x, y);
+
+						if (!ColorComparison.ARGBEquivalent(first, second))
+							return false;
+					}
+				}
+				return true;
+			}
 		}
 
 		public static UILineBreakMode ToPlatform(this LineBreakMode mode) =>


### PR DESCRIPTION
### Description of Change

Currently, the alignment for each span is being set causing the text to overlap. The alignment is not necessary as the label actually aligns all the text correctly, we just need to set colors and things.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #4838
