### PR TITLE
Base the Modal Size and position off the root window view

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -236,10 +236,7 @@ namespace Microsoft.Maui.Controls.Platform
 				// amount as the view it's covering. This will make it so the
 				// ModalContainer takes into account the statusbar or lack thereof
 				var rootView = GetWindowRootView();
-				var visibleContentPosition = rootView.GetLocationOnScreenPx();
-				int y = 0;
-				if (visibleContentPosition.HasValue)
-					y = (int)visibleContentPosition.Value.Y;
+				int y = (int)rootView.GetLocationOnScreenPx().Y;
 
 				if (this.LayoutParameters is ViewGroup.MarginLayoutParams mlp &&
 					mlp.TopMargin != y)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Maui.Controls.Platform
 
 		bool _navAnimationInProgress;
 		internal const string CloseContextActionsSignalName = "Xamarin.CloseContextActions";
-		IPageController CurrentPageController => _navModel.CurrentPage;
 		Page CurrentPage => _navModel.CurrentPage;
 
 		// AFAICT this is specific to ListView and Context Items
@@ -100,7 +99,7 @@ namespace Microsoft.Maui.Controls.Platform
 		// to be sure to disable all focusability
 		AView GetCurrentRootView()
 		{
-			return MauiContext
+			return WindowMauiContext
 					?.GetNavigationRootManager()
 					?.RootView ??
 					throw new InvalidOperationException("Current Root View cannot be null");
@@ -118,14 +117,14 @@ namespace Microsoft.Maui.Controls.Platform
 
 			await presentModal;
 
-			GetCurrentRootView().SendAccessibilityEvent(global::Android.Views.Accessibility.EventTypes.ViewFocused);
+			GetCurrentRootView()
+				.SendAccessibilityEvent(global::Android.Views.Accessibility.EventTypes.ViewFocused);
 		}
 
 		Task PresentModal(Page modal, bool animated)
 		{
 			var parentView = GetModalParentView();
-			var modalContainer = new ModalContainer(MauiContext, modal, parentView);
-
+			var modalContainer = new ModalContainer(WindowMauiContext, modal, parentView);
 
 			var source = new TaskCompletionSource<bool>();
 			NavAnimationInProgress = true;
@@ -195,16 +194,21 @@ namespace Microsoft.Maui.Controls.Platform
 			public Page? Modal { get; private set; }
 			ModalFragment _modalFragment;
 			FragmentManager? _fragmentManager;
-
 			NavigationRootManager? NavigationRootManager => _modalFragment.NavigationRootManager;
 
+			AView GetWindowRootView() =>
+				 _windowMauiContext
+						?.GetNavigationRootManager()
+						?.RootView ??
+						throw new InvalidOperationException("Current Root View cannot be null");
+
 			public ModalContainer(
-				IMauiContext mauiContext,
+				IMauiContext windowMauiContext,
 				Page modal,
 				ViewGroup parentView)
-				: base(mauiContext?.Context ?? throw new ArgumentNullException($"{nameof(mauiContext.Context)}"))
+				: base(windowMauiContext?.Context ?? throw new ArgumentNullException($"{nameof(windowMauiContext.Context)}"))
 			{
-				_windowMauiContext = mauiContext;
+				_windowMauiContext = windowMauiContext;
 				Modal = modal;
 
 				_backgroundView = new AView(_windowMauiContext.Context);
@@ -213,11 +217,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 				Id = AView.GenerateViewId();
 
-				Modal.PropertyChanged += OnModalPagePropertyChanged;
-
 				_modalFragment = new ModalFragment(_windowMauiContext, modal);
 				_fragmentManager = _windowMauiContext.GetFragmentManager();
-
 
 				parentView.AddView(this);
 
@@ -225,6 +226,26 @@ namespace Microsoft.Maui.Controls.Platform
 					.BeginTransaction()
 					.Add(this.Id, _modalFragment)
 					.Commit();
+
+				UpdateMargin();
+			}
+
+			void UpdateMargin()
+			{
+				// This sets up the modal container to be offset from the top of window the same
+				// amount as the view it's covering. This will make it so the
+				// ModalContainer takes into account the statusbar or lack thereof
+				var rootView = GetWindowRootView();
+				var visibleContentPosition = rootView.GetLocationOnScreenPx();
+				int y = 0;
+				if (visibleContentPosition.HasValue)
+					y = (int)visibleContentPosition.Value.Y;
+
+				if (this.LayoutParameters is ViewGroup.MarginLayoutParams mlp &&
+					mlp.TopMargin != y)
+				{
+					mlp.TopMargin = y;
+				}
 			}
 
 			public override bool OnTouchEvent(MotionEvent? e)
@@ -241,15 +262,15 @@ namespace Microsoft.Maui.Controls.Platform
 					return;
 				}
 
-				var rootView = NavigationRootManager.RootView;
+				var rootView = GetWindowRootView();
+				UpdateMargin();
 
-				if (widthMeasureSpec.GetMode() == MeasureSpecMode.AtMost)
-					widthMeasureSpec = MeasureSpecMode.Exactly.MakeMeasureSpec(widthMeasureSpec.GetSize());
+				widthMeasureSpec = MeasureSpecMode.Exactly.MakeMeasureSpec(rootView.MeasuredWidth);
+				heightMeasureSpec = MeasureSpecMode.Exactly.MakeMeasureSpec(rootView.MeasuredHeight);
+				NavigationRootManager
+					.RootView
+					.Measure(widthMeasureSpec, heightMeasureSpec);
 
-				var measureHeight = heightMeasureSpec.GetSize() - Context.GetNavigationBarHeight();
-				heightMeasureSpec = MeasureSpecMode.Exactly.MakeMeasureSpec(measureHeight);
-
-				rootView.Measure(widthMeasureSpec, heightMeasureSpec);
 				SetMeasuredDimension(rootView.MeasuredWidth, rootView.MeasuredHeight);
 			}
 
@@ -258,12 +279,11 @@ namespace Microsoft.Maui.Controls.Platform
 				if (Context == null || NavigationRootManager?.RootView == null)
 					return;
 
-				var statusBarHeight = Context.GetStatusBarHeight();
 				NavigationRootManager
 					.RootView
-					.Layout(l, t + statusBarHeight, r, b);
+					.Layout(0, 0, r - l, b - t);
 
-				_backgroundView.Layout(0, statusBarHeight, r - l, b - t);
+				_backgroundView.Layout(0, 0, r - l, b - t);
 			}
 
 			void OnModalPagePropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -293,7 +313,6 @@ namespace Microsoft.Maui.Controls.Platform
 					Modal.Toolbar.Handler = null;
 
 				Modal.Handler = null;
-
 
 				_fragmentManager
 					.BeginTransaction()

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Tizen.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Tizen.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal partial class ModalNavigationManager
 	{
-		ModalStack _modalStack => MauiContext.GetModalStack();
+		ModalStack _modalStack => WindowMauiContext.GetModalStack();
 		IPageController CurrentPageController => _navModel.CurrentPage;
 
 		partial void OnPageAttachedHandler()
 		{
-			MauiContext.GetPlatformWindow().SetBackButtonPressedHandler(OnBackButtonPressed);
+			WindowMauiContext.GetPlatformWindow().SetBackButtonPressedHandler(OnBackButtonPressed);
 		}
 
 		public  Task<Page> PopModalAsync(bool animated)
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.Platform
 			CurrentPageController?.SendDisappearing();
 			_navModel.PushModal(modal);
 
-			var nativeView = modal.ToPlatform(MauiContext);
+			var nativeView = modal.ToPlatform(WindowMauiContext);
 
 			_modalStack.Push(nativeView);
 

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Windows.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Maui.Controls.Platform
 				if (!popping)
 				{
 					var modalContext =
-						MauiContext
+						WindowMauiContext
 							.MakeScoped(registerNewNavigationRoot: true);
 
 					newPage.Toolbar ??= new Toolbar(newPage);

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		Window _window;
 		public IReadOnlyList<Page> ModalStack => _navModel.Modals;
-		IMauiContext MauiContext => _window.MauiContext;
+		IMauiContext WindowMauiContext => _window.MauiContext;
 		NavigationModel _navModel = new NavigationModel();
 		NavigationModel? _previousNavModel = null;
 		Page? _previousPage;

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.iOS.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls.Platform
 					return pvh.ViewController;
 				}
 
-				return MauiContext.
+				return WindowMauiContext.
 						GetPlatformWindow()?
 						.RootViewController;
 			}
@@ -80,7 +80,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		async Task PresentModal(Page modal, bool animated)
 		{
-			modal.ToPlatform(MauiContext);
+			modal.ToPlatform(WindowMauiContext);
 			var wrapper = new ModalWrapper(modal.Handler as IPlatformViewHandler);
 
 			if (ModalStack.Count > 1)

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
-		internal static Point? GetLocationOnScreen(this View view)
+		internal static Point GetLocationOnScreen(this View view)
 		{
 			int[] location = new int[2];
 			view.GetLocationOnScreen(location);
@@ -572,7 +572,7 @@ namespace Microsoft.Maui.Platform
 			return (element.ToPlatform())?.GetLocationOnScreen();
 		}
 
-		internal static Point? GetLocationOnScreenPx(this View view)
+		internal static Point GetLocationOnScreenPx(this View view)
 		{
 			int[] location = new int[2];
 			view.GetLocationOnScreen(location);

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -556,5 +556,35 @@ namespace Microsoft.Maui.Platform
 
 			return null;
 		}
+
+		internal static Point? GetLocationOnScreen(this View view)
+		{
+			int[] location = new int[2];
+			view.GetLocationOnScreen(location);
+			return new Point(view.Context.FromPixels(location[0]), view.Context.FromPixels(location[1]));
+		}
+
+		internal static Point? GetLocationOnScreen(this IElement element)
+		{
+			if (element.Handler?.MauiContext == null)
+				return null;
+
+			return (element.ToPlatform())?.GetLocationOnScreen();
+		}
+
+		internal static Point? GetLocationOnScreenPx(this View view)
+		{
+			int[] location = new int[2];
+			view.GetLocationOnScreen(location);
+			return new Point(location[0], location[1]);
+		}
+
+		internal static Point? GetLocationOnScreenPx(this IElement element)
+		{
+			if (element.Handler?.MauiContext == null)
+				return null;
+
+			return (element.ToPlatform())?.GetLocationOnScreenPx();
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

There are a [lot](https://stackoverflow.com/questions/20264268/how-do-i-get-the-height-and-width-of-the-android-navigation-bar-programmatically/50775459#50775459) of factors that go into figuring out your visible window space. These also change as you move around APIs. 

This fix just uses the positioning of the main window view to figure out where the modal should be located.

### Issues Fixed

Fixes #6532
