### PR TITLE
Remove `Current` from HapticFeedback

### DIFF
--- a/src/Essentials/src/HapticFeedback/HapticFeedback.shared.cs
+++ b/src/Essentials/src/HapticFeedback/HapticFeedback.shared.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 namespace Microsoft.Maui.Devices
 {
@@ -14,9 +14,7 @@ namespace Microsoft.Maui.Devices
 	{
 		/// <include file="../../docs/Microsoft.Maui.Essentials/HapticFeedback.xml" path="//Member[@MemberName='Perform']/Docs" />
 		public static void Perform(HapticFeedbackType type = HapticFeedbackType.Click) =>
-			Current.Perform(type);
-
-		public static IHapticFeedback Current => Devices.HapticFeedback.Default;
+			Default.Perform(type);
 
 		static IHapticFeedback? defaultImplementation;
 


### PR DESCRIPTION
### Description of Change

Removes the `Current` property from `HapticFeedback` as it seemed redundant and `Default` made the most sense in this context

### Issues Fixed

Fixes #6799 
