### PR TITLE
[Android] Always make sure to stop observing the old adapter

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -227,11 +227,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			var oldItemViewAdapter = ItemsViewAdapter;
 
+			_emptyCollectionObserver.Stop(oldItemViewAdapter);
+
 			ItemsViewAdapter = CreateAdapter();
 
 			if (GetAdapter() != _emptyViewAdapter)
 			{
-				_emptyCollectionObserver.Stop(oldItemViewAdapter);
 				_itemsUpdateScrollObserver.Stop(oldItemViewAdapter);
 
 				SetAdapter(null);


### PR DESCRIPTION
### Description of Change

With mappers the UpdateItemsSource and UpdateItems adapter are called more times, and sometiems in a different order from Forms. 
We need to make sure when creating a new Adapter that we stop observing the old one.

### Issues Fixed

Fixes #6119 
