### PR TITLE
Lay out ScrollView inset view at correct size on Android

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Android.cs
@@ -40,8 +40,7 @@ namespace Microsoft.Maui.Handlers
 
 			if (FindInsetPanel(this) is ContentViewGroup paddingLayer)
 			{
-				var (l, t, r, b) = Context.ToPixels(frame);
-				paddingLayer.Layout(0, 0, r - l, b - t);
+				paddingLayer.Layout(0, 0, paddingLayer.MeasuredWidth, paddingLayer.MeasuredHeight);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

When the ScrollView on Android needs an inset view to support margin/padding, `Layout()` is being called on the inset view with the dimensions of the MauiScrollView, rather than the measured dimensions of the inset. This means the inset matches the size of the MauiScrollView, rather than exceeding them (and being scrollable).

This change calls `Layout()` with the measured content size, rather than the MauiScrollView size.

### Issues Fixed

Fixes #6602




