### PR TITLE
Merge the BackgroundImageSource into Background

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Brush.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Brush.Impl.cs
@@ -40,6 +40,9 @@ namespace Microsoft.Maui.Controls
 				}
 			}
 
+			if (paint is ImageSourcePaint imageSourcePaint && imageSourcePaint.ImageSource is ImageSource imageSource)
+				return new ImageBrush { ImageSource = imageSource };
+
 			return null;
 		}
 
@@ -76,6 +79,9 @@ namespace Microsoft.Maui.Controls
 					return new RadialGradientPaint { GradientStops = gradientStops, Center = center, Radius = radius };
 				}
 			}
+
+			if (brush is ImageBrush imageBrush)
+				return new ImageSourcePaint { ImageSource = imageBrush.ImageSource };
 
 			return null;
 		}

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -5,12 +5,21 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/Page.xml" path="Type[@FullName='Microsoft.Maui.Controls.Page']/Docs" />
-	public partial class Page : IView, IViewBackgroundImagePart, ITitledElement, IToolbarElement
+	public partial class Page : IView, ITitledElement, IToolbarElement
 	{
-		IImageSource IImageSourcePart.Source => BackgroundImageSource;
-		bool IImageSourcePart.IsAnimationPlaying => false;
-		void IImageSourcePart.UpdateIsLoading(bool isLoading)
+		Paint IView.Background
 		{
+			get
+			{
+				if (!Brush.IsNullOrEmpty(Background))
+					return Background;
+				if (!ImageSource.IsNullOrEmpty(BackgroundImageSource))
+					return new ImageSourcePaint(BackgroundImageSource);
+				if (BackgroundColor.IsNotDefault())
+					return new SolidColorBrush(BackgroundColor);
+
+				return null;
+			}
 		}
 
 		Toolbar _toolbar;

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.Controls
 			new PropertyMapper<IView, IViewHandler>(Element.ControlsElementMapper)
 			{
 				[nameof(BackgroundColor)] = MapBackgroundColor,
+				[nameof(Page.BackgroundImageSource)] = MapBackgroundImageSource,
 			};
 
 		internal static void RemapForControls()
@@ -19,6 +20,11 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='MapBackgroundColor']/Docs" />
 		public static void MapBackgroundColor(IViewHandler handler, IView view)
+		{
+			handler.UpdateValue(nameof(Background));
+		}
+
+		public static void MapBackgroundImageSource(IViewHandler handler, IView view)
 		{
 			handler.UpdateValue(nameof(Background));
 		}

--- a/src/Controls/src/Core/ImageBrush.cs
+++ b/src/Controls/src/Core/ImageBrush.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+namespace Microsoft.Maui.Controls
+{
+	[ContentProperty(nameof(ImageSource))]
+	class ImageBrush : Brush
+	{
+		public ImageBrush()
+		{
+		}
+
+		public ImageBrush(ImageSource imageSource)
+		{
+			ImageSource = imageSource;
+		}
+
+		public override bool IsEmpty =>
+			ImageSource?.IsEmpty ?? true;
+
+		public static readonly BindableProperty ImageSourceProperty = BindableProperty.Create(
+			nameof(ImageSource), typeof(ImageSource), typeof(ImageBrush), default(ImageSource));
+
+		public virtual ImageSource? ImageSource
+		{
+			get => (ImageSource?)GetValue(ImageSourceProperty);
+			set => SetValue(ImageSourceProperty, value);
+		}
+
+		public override bool Equals(object? obj) =>
+			obj is ImageBrush dest && ImageSource == dest.ImageSource;
+
+		public override int GetHashCode() =>
+			-1234567890 + (ImageSource?.GetHashCode() ?? 0);
+	}
+}

--- a/src/Controls/src/Core/ImageSource.cs
+++ b/src/Controls/src/Core/ImageSource.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSource.xml" path="//Member[@MemberName='IsEmpty']/Docs" />
 		public virtual bool IsEmpty => false;
 
+		public static bool IsNullOrEmpty(ImageSource imageSource) =>
+			imageSource == null || imageSource.IsEmpty;
+
 		private protected CancellationTokenSource CancellationTokenSource
 		{
 			get { return _cancellationTokenSource; }

--- a/src/Core/src/Core/IViewBackgroundImagePart.cs
+++ b/src/Core/src/Core/IViewBackgroundImagePart.cs
@@ -1,7 +1,0 @@
-﻿namespace Microsoft.Maui
-{
-	public interface IViewBackgroundImagePart : IImageSourcePart
-	{
-
-	}
-}

--- a/src/Core/src/Handlers/View/ViewHandler.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Android.cs
@@ -146,20 +146,6 @@ namespace Microsoft.Maui.Handlers
 			MapToolbar(handler, te);
 		}
 
-		public static void MapBackgroundImageSource(IViewHandler handler, IView view)
-		{
-			if (view is not IViewBackgroundImagePart viewBackgroundImagePart)
-				return;
-
-			if (handler.PlatformView is not PlatformView platformView)
-				return;
-
-			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
-
-			platformView.UpdateBackgroundImageSourceAsync(viewBackgroundImagePart, provider)
-				.FireAndForget(handler);
-		}
-
 		internal static void MapToolbar(IElementHandler handler, IToolbarElement te)
 		{
 			if (te.Toolbar == null)

--- a/src/Core/src/Handlers/View/ViewHandler.Standard.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Standard.cs
@@ -22,8 +22,6 @@
 
 		public static void MapAnchorY(IViewHandler handler, IView view) { }
 
-		public static void MapBackgroundImageSource(IViewHandler handler, IView view) { }
-
 		public virtual bool NeedsContainer => false;
 	}
 }

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -87,20 +87,6 @@ namespace Microsoft.Maui.Handlers
 				MapToolbar(handler, tb);
 		}
 
-		public static void MapBackgroundImageSource(IViewHandler handler, IView view)
-		{
-			if (view is not IViewBackgroundImagePart viewBackgroundImagePart)
-				return;
-
-			if (handler.PlatformView is not PlatformView platformView)
-				return;
-
-			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
-
-			platformView.UpdateBackgroundImageSourceAsync(viewBackgroundImagePart, provider)
- 				.FireAndForget(handler);
-		}
-
 		internal static void MapToolbar(IElementHandler handler, IToolbarElement toolbarElement)
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(handler.MauiContext)} null");

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Maui.Handlers
 				[nameof(IToolbarElement.Toolbar)] = MapToolbar,
 #endif
 				[nameof(IView.InputTransparent)] = MapInputTransparent,
-				[nameof(IViewBackgroundImagePart.Source)] = MapBackgroundImageSource
 			};
 
 		public static CommandMapper<IView, IViewHandler> ViewCommandMapper = new()
@@ -198,7 +197,20 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapBackground(IViewHandler handler, IView view)
 		{
-			((PlatformView?)handler.PlatformView)?.UpdateBackground(view);
+			if (handler.PlatformView is not PlatformView platformView)
+				return;
+
+			if (view.Background is ImageSourcePaint image)
+			{
+				var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
+
+				platformView.UpdateBackgroundImageSourceAsync(image.ImageSource, provider)
+					.FireAndForget(handler);
+			}
+			else
+			{
+				platformView.UpdateBackground(view);
+			}
 		}
 
 		public static void MapFlowDirection(IViewHandler handler, IView view)

--- a/src/Core/src/Handlers/View/ViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.iOS.cs
@@ -60,20 +60,6 @@ namespace Microsoft.Maui.Handlers
 			UpdateTransformation(handler, view);
 		}
 
-		public static void MapBackgroundImageSource(IViewHandler handler, IView view)
-		{
-			if (view is not IViewBackgroundImagePart viewBackgroundImagePart)
-				return;
-
-			if (handler.PlatformView is not PlatformView platformView)
-				return;
-
-			var provider = handler.GetRequiredService<IImageSourceServiceProvider>();
-
-			platformView.UpdateBackgroundImageSourceAsync(viewBackgroundImagePart, provider)
-				.FireAndForget(handler);
-		}
-
 		internal static void UpdateTransformation(IViewHandler handler, IView view)
 		{
 			handler.ToPlatform().UpdateTransformation(view);

--- a/src/Core/src/ImageSources/ImageSourcePaint.cs
+++ b/src/Core/src/ImageSources/ImageSourcePaint.cs
@@ -1,0 +1,19 @@
+﻿#nullable enable
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui
+{
+	class ImageSourcePaint : Paint
+	{
+		public ImageSourcePaint()
+		{
+		}
+
+		public ImageSourcePaint(IImageSource imageSource)
+		{
+			ImageSource = imageSource;
+		}
+
+		public IImageSource? ImageSource { get; set; }
+	}
+}

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Maui.Platform
 			PlatformInterop.RequestLayoutIfNeeded(platformView);
 		}
 
-		public static async Task UpdateBackgroundImageSourceAsync(this AView platformView, IViewBackgroundImagePart viewBackgroundImagePart, IImageSourceServiceProvider? provider)
+		public static async Task UpdateBackgroundImageSourceAsync(this AView platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
 		{
 			if (provider == null)
 				return;
@@ -306,12 +306,10 @@ namespace Microsoft.Maui.Platform
 			if (context == null)
 				return;
 
-			IImageSource? backgroundImageSource = viewBackgroundImagePart.Source;
-
-			if (backgroundImageSource != null)
+			if (imageSource != null)
 			{
-				var service = provider.GetRequiredImageSourceService(backgroundImageSource);
-				var result = await service.GetDrawableAsync(backgroundImageSource, context);
+				var service = provider.GetRequiredImageSourceService(imageSource);
+				var result = await service.GetDrawableAsync(imageSource, context);
 				Drawable? backgroundImageDrawable = result?.Value;
 
 				if (platformView.IsAlive())

--- a/src/Core/src/Platform/Standard/ViewExtensions.cs
+++ b/src/Core/src/Platform/Standard/ViewExtensions.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Microsoft.Maui.Platform
 {
 	public static partial class ViewExtensions
@@ -9,6 +11,9 @@ namespace Microsoft.Maui.Platform
 		public static void Unfocus(this object platformView, IView view) { }
 
 		public static void UpdateVisibility(this object platformView, IView view) { }
+
+		public static Task UpdateBackgroundImageSourceAsync(this object platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
+			=> Task.CompletedTask;
 
 		public static void UpdateBackground(this object platformView, IView view) { }
 

--- a/src/Core/src/Platform/Tizen/ViewExtensions.cs
+++ b/src/Core/src/Platform/Tizen/ViewExtensions.cs
@@ -71,8 +71,9 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static async Task UpdateBackgroundImageSourceAsync(this EvasObject platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
+		public static Task UpdateBackgroundImageSourceAsync(this EvasObject platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
 		{
+			return Task.CompletedTask;
 		}
 
 		public static void UpdateBorder(this EvasObject platformView, IView view)

--- a/src/Core/src/Platform/Tizen/ViewExtensions.cs
+++ b/src/Core/src/Platform/Tizen/ViewExtensions.cs
@@ -71,6 +71,10 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		public static async Task UpdateBackgroundImageSourceAsync(this EvasObject platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
+		{
+		}
+
 		public static void UpdateBorder(this EvasObject platformView, IView view)
 		{
 			var border = (view as IBorder)?.Border;

--- a/src/Core/src/Platform/Windows/ControlExtensions.cs
+++ b/src/Core/src/Platform/Windows/ControlExtensions.cs
@@ -36,11 +36,11 @@ namespace Microsoft.Maui.Platform
 		public static void UpdateBackground(this Panel platformControl, Paint? paint, UI.Xaml.Media.Brush? defaultBrush = null) =>
 			platformControl.UpdateProperty(Panel.BackgroundProperty, paint.IsNullOrEmpty() ? defaultBrush : paint?.ToPlatform());
 
-		public static async Task UpdateBackgroundImageSourceAsync(this Panel platformView, IViewBackgroundImagePart viewBackgroundImagePart, IImageSourceServiceProvider? provider)	
-			=> await platformView.UpdateBackgroundImageAsync(viewBackgroundImagePart, provider);
+		public static async Task UpdateBackgroundImageSourceAsync(this Panel platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
+			=> await platformView.UpdateBackgroundImageAsync(imageSource, provider);
 
-		public static async Task UpdateBackgroundImageSourceAsync(this Control platformView, IViewBackgroundImagePart viewBackgroundImagePart, IImageSourceServiceProvider? provider)
-			=> await platformView.UpdateBackgroundImageAsync(viewBackgroundImagePart, provider);
+		public static async Task UpdateBackgroundImageSourceAsync(this Control platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
+			=> await platformView.UpdateBackgroundImageAsync(imageSource, provider);
 
 		public static void UpdateForegroundColor(this Control platformControl, Color color, UI.Xaml.Media.Brush? defaultBrush = null) =>
 			platformControl.Foreground = color?.ToPlatform() ?? defaultBrush ?? platformControl.Foreground;
@@ -60,15 +60,13 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this Control nativeControl, ITextStyle text) =>
 			nativeControl.CharacterSpacing = text.CharacterSpacing.ToEm();
-		
-		internal static async Task UpdateBackgroundImageAsync(this FrameworkElement platformView, IViewBackgroundImagePart viewBackgroundImagePart, IImageSourceServiceProvider? provider)
+
+		internal static async Task UpdateBackgroundImageAsync(this FrameworkElement platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
 		{
 			if (platformView == null || provider == null)
 				return;
 
-			var backgroundImageSource = viewBackgroundImagePart.Source;
-
-			if (backgroundImageSource == null)
+			if (imageSource == null)
 			{
 				if (platformView is Panel panel)
 					panel.Background = null;
@@ -78,13 +76,13 @@ namespace Microsoft.Maui.Platform
 				return;
 			}
 
-			if (provider != null && backgroundImageSource != null)
+			if (provider != null && imageSource != null)
 			{
-				var service = provider.GetRequiredImageSourceService(backgroundImageSource);
-				var nativeBackgroundImageSource = await service.GetImageSourceAsync(backgroundImageSource);
-				
+				var service = provider.GetRequiredImageSourceService(imageSource);
+				var nativeBackgroundImageSource = await service.GetImageSourceAsync(imageSource);
+
 				var background = new ImageBrush { ImageSource = nativeBackgroundImageSource?.Value };
-			
+
 				if (platformView is Panel panel)
 					panel.Background = background;
 

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -242,12 +242,12 @@ namespace Microsoft.Maui.Platform
 				panel.UpdateBackground(view.Background);
 		}
 
-		public static async Task UpdateBackgroundImageSourceAsync(this FrameworkElement platformView, IViewBackgroundImagePart viewBackgroundImagePart, IImageSourceServiceProvider? provider)
+		public static async Task UpdateBackgroundImageSourceAsync(this FrameworkElement platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
 		{
 			if (platformView is Control control)
-				await control.UpdateBackgroundImageSourceAsync(viewBackgroundImagePart, provider);
+				await control.UpdateBackgroundImageSourceAsync(imageSource, provider);
 			else if (platformView is Panel panel)
-				await panel.UpdateBackgroundImageSourceAsync(viewBackgroundImagePart, provider);
+				await panel.UpdateBackgroundImageSourceAsync(imageSource, provider);
 		}
 
 		internal static void UpdatePlatformViewBackground(this LayoutPanel layoutPanel, ILayout layout)

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -264,17 +264,15 @@ namespace Microsoft.Maui.Platform
 			platformView.Frame = new CoreGraphics.CGRect(currentFrame.X, currentFrame.Y, view.Width, view.Height);
 		}
 
-		public static async Task UpdateBackgroundImageSourceAsync(this UIView platformView, IViewBackgroundImagePart viewBackgroundImagePart, IImageSourceServiceProvider? provider)
+		public static async Task UpdateBackgroundImageSourceAsync(this UIView platformView, IImageSource? imageSource, IImageSourceServiceProvider? provider)
 		{
 			if (provider == null)
 				return;
 
-			var backgroundImageSource = viewBackgroundImagePart.Source;
-
-			if (backgroundImageSource != null)
+			if (imageSource != null)
 			{
-				var service = provider.GetRequiredImageSourceService(backgroundImageSource);
-				var result = await service.GetImageAsync(backgroundImageSource);
+				var service = provider.GetRequiredImageSourceService(imageSource);
+				var result = await service.GetImageAsync(imageSource);
 				var backgroundImage = result?.Value;
 
 				if (backgroundImage == null)


### PR DESCRIPTION
### Description of Change

This PR moves the bits towards a single, unified `Background` property like all the other XAML flavours. Currently, the new types are internal until we can figure out the best way - maybe just make it public later and add XamlC?

 - Enhances #3396 
 - Fixes the issue where windows did not support initial backgrounds anymore
 - Related to https://github.com/dotnet/maui/issues/6821

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes an issue where windows did not set the page background color as the background image would unset things.
