### PR TITLE
Add a locked flyout immediately to the view

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Android.Views;
+using AndroidX.DrawerLayout.Widget;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Platform.Compatibility;
@@ -50,6 +52,39 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			}
 		}
+
+		[Fact(DisplayName = "FlyoutItems Render When FlyoutBehavior Starts As Locked")]
+		public async Task FlyoutItemsRendererWhenFlyoutBehaviorStartsAsLocked()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new FlyoutItem() { Items = { new ContentPage() }, Title = "Flyout Item" };
+				shell.FlyoutBehavior = FlyoutBehavior.Locked;
+			});
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				await Task.Delay(1000);
+				IShellContext shellContext = handler;
+				DrawerLayout dl = shellContext.CurrentDrawerLayout;
+
+				var flyout = dl.GetChildAt(0);
+				RecyclerViewContainer flyoutContainer = null;
+
+				if (dl.GetChildAt(1) is ViewGroup vg1 &&
+					vg1.GetChildAt(0) is RecyclerViewContainer rvc)
+				{
+					flyoutContainer = rvc;
+				}
+
+				_ = flyoutContainer ?? throw new Exception("Unable to locate RecyclerViewContainer");
+
+				Assert.True(flyoutContainer.MeasuredWidth > 0);
+				Assert.True(flyoutContainer.MeasuredHeight > 0);
+			});
+		}
+
 
 		[Fact(DisplayName = "Shell with Flyout Disabled Doesn't Render Flyout")]
 		public async Task ShellWithFlyoutDisabledDoesntRenderFlyout()

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -48,6 +48,27 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "FlyoutContent Renderers When FlyoutBehavior Starts As Locked")]
+		public async Task FlyoutContentRenderersWhenFlyoutBehaviorStartsAsLocked()
+		{
+			SetupBuilder();
+			var flyoutContent = new VerticalStackLayout() { Children = { new Label() { Text = "Rendered" } } };
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new FlyoutItem() { Items = { new ContentPage() } };
+				shell.FlyoutContent = flyoutContent;
+				shell.FlyoutBehavior = FlyoutBehavior.Locked;
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await OnLayoutPassCompleted(flyoutContent);
+
+				Assert.NotNull(flyoutContent.Handler);
+				Assert.True(flyoutContent.Frame.Width > 0);
+				Assert.True(flyoutContent.Frame.Height > 0);
+			});
+		}
 
 		[Fact(DisplayName = "Flyout Starts as Open correctly")]
 		public async Task FlyoutIsPresented()

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -243,5 +243,26 @@ namespace Microsoft.Maui.DeviceTests
 			OnLoaded(frameworkElement, () => taskCompletionSource.SetResult(true));
 			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
+
+		protected Task OnLayoutPassCompleted(VisualElement frameworkElement, TimeSpan? timeOut = null)
+		{
+			if (frameworkElement.Frame.Height * frameworkElement.Frame.Width == 0)
+				return Task.CompletedTask;
+
+			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+			frameworkElement.BatchCommitted += OnBatchCommitted;
+
+			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
+
+			void OnBatchCommitted(object sender, Controls.Internals.EventArg<VisualElement> e)
+			{
+				if (frameworkElement.Frame.Height * frameworkElement.Frame.Width == 0)
+					return;
+
+				frameworkElement.BatchCommitted -= OnBatchCommitted;
+				taskCompletionSource.SetResult(true);
+			}
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected Task OnLayoutPassCompleted(VisualElement frameworkElement, TimeSpan? timeOut = null)
 		{
-			if (frameworkElement.Frame.Height * frameworkElement.Frame.Width == 0)
+			if (frameworkElement.Frame.Height * frameworkElement.Frame.Width != 0)
 				return Task.CompletedTask;
 
 			timeOut = timeOut ?? TimeSpan.FromSeconds(2);


### PR DESCRIPTION
### Description of Change

We optimized shell so that if you don't have a visible flyout it waits until the flyout will be visible before adding it to the view and doing a layout pass. This broke shell if you start out with it locked

### Issues Fixed
Fixes #6701
