### PR TITLE
Modify Package.appxmanifest templates to include placeholder values and overwrite these values in the GeneratePackageAppxManifest task

### DIFF
--- a/src/SingleProject/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/SingleProject/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -220,6 +220,14 @@ namespace Microsoft.Maui.Resizetizer
 					}
 				}
 
+				// BackgroundColor=""
+				{
+					var xname = "BackgroundColor";
+					var attr = visual.Attribute(xname);
+					if (attr == null || string.IsNullOrEmpty(attr.Value))
+						visual.SetAttributeValue(xname, "transparent");
+				}
+
 				if (appIconInfo != null)
 				{
 					// Square150x150Logo=""

--- a/src/SingleProject/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/SingleProject/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Maui.Resizetizer
 {
 	public class GeneratePackageAppxManifest : Task
 	{
+		const string DefaultPlaceholder = "$placeholder$";
+		const string PngPlaceholder = "$placeholder$.png";
+		const string PackageNamePlaceholder = "maui-package-name-placeholder";
+		const string PackageVersionPlaceholder = "0.0.0.0";
+
 		const string ErrorInvalidApplicationId = "ApplicationId '{0}' was not a valid GUID. Windows apps use a GUID for an application ID instead of the reverse domain used by Android and/or iOS apps. Either set the <ApplicationIdGuid> property to a valid GUID or use a condition on <ApplicationId> for Windows apps.";
 		const string ErrorVersionNumberCombination = "ApplicationDisplayVersion '{0}' was not a valid 3 part semver version number and/or ApplicationVersion '{1}' was not a valid integer.";
 
@@ -87,7 +92,7 @@ namespace Microsoft.Maui.Resizetizer
 				{
 					var xname = "Name";
 					var attr = identity.Attribute(xname);
-					if (attr == null || string.IsNullOrEmpty(attr.Value))
+					if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PackageNamePlaceholder)
 					{
 						if (!Guid.TryParse(ApplicationId, out _))
 						{
@@ -104,7 +109,7 @@ namespace Microsoft.Maui.Resizetizer
 				{
 					var xname = "Version";
 					var attr = identity.Attribute(xname);
-					if (attr == null || string.IsNullOrEmpty(attr.Value))
+					if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PackageVersionPlaceholder)
 					{
 						if (!TryMergeVersionNumbers(ApplicationDisplayVersion, ApplicationVersion, out var finalVersion))
 						{
@@ -137,7 +142,7 @@ namespace Microsoft.Maui.Resizetizer
 				{
 					var xname = xmlns + "DisplayName";
 					var xelem = properties.Element(xname);
-					if (xelem == null || string.IsNullOrEmpty(xelem.Value))
+					if (xelem == null || string.IsNullOrEmpty(xelem.Value) || xelem.Value == DefaultPlaceholder)
 						properties.SetElementValue(xname, ApplicationTitle);
 				}
 
@@ -146,7 +151,7 @@ namespace Microsoft.Maui.Resizetizer
 				{
 					var xname = xmlns + "Logo";
 					var xelem = properties.Element(xname);
-					if (xelem == null || string.IsNullOrEmpty(xelem.Value))
+					if (xelem == null || string.IsNullOrEmpty(xelem.Value) || xelem.Value == PngPlaceholder)
 					{
 						var dpi = DpiPath.Windows.StoreLogo[0];
 						var path = Path.Combine(dpi.Path, appIconInfo.OutputName + dpi.NameSuffix + imageExtension);
@@ -202,7 +207,7 @@ namespace Microsoft.Maui.Resizetizer
 					{
 						var xname = "DisplayName";
 						var attr = visual.Attribute(xname);
-						if (attr == null || string.IsNullOrEmpty(attr.Value))
+						if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == DefaultPlaceholder)
 							visual.SetAttributeValue(xname, ApplicationTitle);
 					}
 
@@ -210,17 +215,9 @@ namespace Microsoft.Maui.Resizetizer
 					{
 						var xname = "Description";
 						var attr = visual.Attribute(xname);
-						if (attr == null || string.IsNullOrEmpty(attr.Value))
+						if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == DefaultPlaceholder)
 							visual.SetAttributeValue(xname, ApplicationTitle);
 					}
-				}
-
-				// BackgroundColor=""
-				{
-					var xname = "BackgroundColor";
-					var attr = visual.Attribute(xname);
-					if (attr == null || string.IsNullOrEmpty(attr.Value))
-						visual.SetAttributeValue(xname, "transparent");
 				}
 
 				if (appIconInfo != null)
@@ -229,7 +226,7 @@ namespace Microsoft.Maui.Resizetizer
 					{
 						var xname = "Square150x150Logo";
 						var attr = visual.Attribute(xname);
-						if (attr == null || string.IsNullOrEmpty(attr.Value))
+						if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PngPlaceholder)
 						{
 							var dpi = DpiPath.Windows.MediumTile[0];
 							var path = Path.Combine(dpi.Path, appIconInfo.OutputName + dpi.NameSuffix + imageExtension);
@@ -241,7 +238,7 @@ namespace Microsoft.Maui.Resizetizer
 					{
 						var xname = "Square44x44Logo";
 						var attr = visual.Attribute(xname);
-						if (attr == null || string.IsNullOrEmpty(attr.Value))
+						if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PngPlaceholder)
 						{
 							var dpi = DpiPath.Windows.Logo[0];
 							var path = Path.Combine(dpi.Path, appIconInfo.OutputName + dpi.NameSuffix + imageExtension);
@@ -265,7 +262,7 @@ namespace Microsoft.Maui.Resizetizer
 					{
 						var xname = "Wide310x150Logo";
 						var attr = tile.Attribute(xname);
-						if (attr == null || string.IsNullOrEmpty(attr.Value))
+						if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PngPlaceholder)
 						{
 							var dpi = DpiPath.Windows.WideTile[0];
 							var path = Path.Combine(dpi.Path, appIconInfo.OutputName + dpi.NameSuffix + imageExtension);
@@ -277,7 +274,7 @@ namespace Microsoft.Maui.Resizetizer
 					{
 						var xname = "Square71x71Logo";
 						var attr = tile.Attribute(xname);
-						if (attr == null || string.IsNullOrEmpty(attr.Value))
+						if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PngPlaceholder)
 						{
 							var dpi = DpiPath.Windows.SmallTile[0];
 							var path = Path.Combine(dpi.Path, appIconInfo.OutputName + dpi.NameSuffix + imageExtension);
@@ -289,7 +286,7 @@ namespace Microsoft.Maui.Resizetizer
 					{
 						var xname = "Square310x310Logo";
 						var attr = tile.Attribute(xname);
-						if (attr == null || string.IsNullOrEmpty(attr.Value))
+						if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PngPlaceholder)
 						{
 							var dpi = DpiPath.Windows.LargeTile[0];
 							var path = Path.Combine(dpi.Path, appIconInfo.OutputName + dpi.NameSuffix + imageExtension);
@@ -339,7 +336,7 @@ namespace Microsoft.Maui.Resizetizer
 					{
 						var xname = "Image";
 						var attr = splash.Attribute(xname);
-						if (attr == null || string.IsNullOrEmpty(attr.Value))
+						if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PngPlaceholder)
 						{
 							var dpi = DpiPath.Windows.SplashScreen[0];
 							var path = Path.Combine(dpi.Path, splashInfo.OutputName + dpi.NameSuffix + imageExtension);

--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
@@ -5,10 +5,12 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Publisher="CN=User Name" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
 
   <Properties>
+    <DisplayName>$placeholder$</DisplayName>
     <PublisherDisplayName>User Name</PublisherDisplayName>
+    <Logo>$placeholder$.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -22,7 +24,15 @@
 
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements />
+      <uap:VisualElements
+        DisplayName="$placeholder$"
+        Description="$placeholder$"
+        Square150x150Logo="$placeholder$.png"
+        Square44x44Logo="$placeholder$.png"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Square71x71Logo="$placeholder$.png" Wide310x150Logo="$placeholder$.png" Square310x310Logo="$placeholder$.png" />
+        <uap:SplashScreen Image="$placeholder$.png" />
+      </uap:VisualElements>
     </Application>
   </Applications>
 

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
@@ -5,10 +5,12 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Publisher="CN=User Name" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
 
   <Properties>
+    <DisplayName>$placeholder$</DisplayName>
     <PublisherDisplayName>User Name</PublisherDisplayName>
+    <Logo>$placeholder$.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -22,7 +24,15 @@
 
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements />
+      <uap:VisualElements
+        DisplayName="$placeholder$"
+        Description="$placeholder$"
+        Square150x150Logo="$placeholder$.png"
+        Square44x44Logo="$placeholder$.png"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Square71x71Logo="$placeholder$.png" Wide310x150Logo="$placeholder$.png" Square310x310Logo="$placeholder$.png" />
+        <uap:SplashScreen Image="$placeholder$.png" />
+      </uap:VisualElements>
     </Application>
   </Applications>
 


### PR DESCRIPTION
### Description of Change

### Problem
When users attempt to open the MSIX Packaging Wizard, they are being prompted with the following error message:
![image](https://user-images.githubusercontent.com/59936622/166803504-6b0c00bd-8bb2-4e1d-8934-ee48a2103410.png)

This error message is appearing because the MAUI Package.appxmanifest templates are missing several values that the [ManifestValidator](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=/src/vsproject/PackageAndDeploy/AppxManifestDesigner.UAP/ManifestData/Manager/Validation/ManifestValidator.cs) expects to be there.

We can see the missing values by opening the Package.appxmanifest editor:
![image](https://user-images.githubusercontent.com/59936622/166805498-ad191191-e16f-4442-989d-c006f4f790f1.png)

### Solution
This PR introduces changes to the MAUI Package.appmanifest templates that ensure the file can be successfully validated. This is accomplished through the addition of "placeholder" values in the manifest templates. I've also modified the `GeneratePackageAppxManifest` task so that these values are overwritten appropriately. What this means is that if the task finds the placeholder value in the manifest, it ignores it in favor of the values from the project file.

For most of the manifest properties, we could simply use the value `$placeholder$`, which is an existing convention in the template. However, there are three scenarios where using this value is not possible:
- **Package Name:** For this property, the validator will not accept special characters such as `$`. Therefore, I chose a value that is so unique that we can reasonably expect no one will ever use it: `maui-package-name-placeholder`.
- **Package Version:** For this property, the validator will not accept anything other than a version number, e.g. `1.0.0.0`. Therefore, I chose the value `0.0.0.0`, which I believe is not likely to be a common version number. An alternative we can use could be something like `999.999.999.999`.
- **Png Files:** For the logo and splash screen properties, the validator expects the suffix `.png`. Therefore, I created a placeholder value of `$placeholder$.png`. It is also important to note that the validator does not validate that these "file paths" actually exist.

### Issues Fixed
Fixes [Bug 1526392: Unable to Publish Windows MAUI app from VS when using generated Package.appxmanifest](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1526392)

**Note:** The goal is to get this fix into 17.3 Preview 1 if possible, 17.3 Preview 1.1 if not.