### PR TITLE
Reenable CA1416 in Essentials

### DIFF
--- a/src/Essentials/src/Browser/Browser.ios.cs
+++ b/src/Essentials/src/Browser/Browser.ios.cs
@@ -25,11 +25,12 @@ namespace Microsoft.Maui.ApplicationModel
 			return true;
 		}
 
-		[System.Runtime.Versioning.UnsupportedOSPlatform("ios11.0")]
 		private static async Task LaunchSafariViewController(Uri uri, BrowserLaunchOptions options)
 		{
 			var nativeUrl = new NSUrl(uri.AbsoluteUri);
+#pragma warning disable CA1416 // TODO: 'SFSafariViewController(NSUrl, bool)' is unsupported on: 'ios' 11.0 and later, there is an overload SFSafariViewController(NSUrl, SFSafariViewControllerConfiguration) supported from ios 11.0+
 			var sfViewController = new SFSafariViewController(nativeUrl, false);
+#pragma warning restore CA1416 // probably need to call the overloads depending on OS version
 			var vc = WindowStateManager.Default.GetCurrentUIViewController(true)!;
 
 			if (options.PreferredToolbarColor != null)

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>Microsoft.Maui.Essentials</RootNamespace>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <WarningsNotAsErrors>BI1234</WarningsNotAsErrors>
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
     <IsPackable>false</IsPackable>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Essentials/src/Permissions/Permissions.ios.tvos.macos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.tvos.macos.cs
@@ -33,17 +33,13 @@ namespace Microsoft.Maui.ApplicationModel
 				{
 					return status;
 				}
-#if __IOS__
-				else if (status == PermissionStatus.Limited)
+				else if (OperatingSystem.IsIOSVersionAtLeast(14) && status == PermissionStatus.Limited)
 				{
-#pragma warning disable CA1416 // TODO: the [SupportedOSPlatform("tvos14.0")] attribute above making this call site reachable in tvOS, the #ifdef is not handled properly in analyzer
 					PhotosUI.PHPhotoLibrary_PhotosUISupport.PresentLimitedLibraryPicker(
 						PHPhotoLibrary.SharedPhotoLibrary,
 						WindowStateManager.Default.GetCurrentUIViewController());
 					return status;
-#pragma warning restore CA1416 // see Case 3 of https://github.com/dotnet/roslyn-analyzers/issues/5938 for more info
 				}
-#endif
 
 				EnsureMainThread();
 

--- a/src/Essentials/src/Permissions/Permissions.ios.tvos.macos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.tvos.macos.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Maui.ApplicationModel
 	public static partial class Permissions
 	{
 		[SupportedOSPlatform("tvos14.0")]
-		//[SupportedOSPlatform("macos11.0")] this is causing warning within #if def below
-		[SupportedOSPlatform("ios14.0")] // The enum PHAccessLevel has these attributes
+		[SupportedOSPlatform("macos11.0")]
+		[SupportedOSPlatform("ios14.0")]
 		public partial class Photos : BasePlatformPermission
 		{
 			protected override Func<IEnumerable<string>> RequiredInfoPlistKeys =>
@@ -36,10 +36,12 @@ namespace Microsoft.Maui.ApplicationModel
 #if __IOS__
 				else if (status == PermissionStatus.Limited)
 				{
+#pragma warning disable CA1416 // TODO: the [SupportedOSPlatform("tvos14.0")] attribute above making this call site reachable in tvOS, the #ifdef is not handled properly in analyzer
 					PhotosUI.PHPhotoLibrary_PhotosUISupport.PresentLimitedLibraryPicker(
 						PHPhotoLibrary.SharedPhotoLibrary,
 						WindowStateManager.Default.GetCurrentUIViewController());
 					return status;
+#pragma warning restore CA1416 // see Case 3 of https://github.com/dotnet/roslyn-analyzers/issues/5938 for more info
 				}
 #endif
 

--- a/src/Essentials/src/Permissions/Permissions.ios.tvos.watchos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.tvos.watchos.cs
@@ -119,7 +119,9 @@ namespace Microsoft.Maui.ApplicationModel
 				if (!CLLocationManager.LocationServicesEnabled)
 					return PermissionStatus.Disabled;
 
+#pragma warning disable CA1416 // TODO: CLLocationManager.Status has [UnsupportedOSPlatform("ios14.0")], [UnsupportedOSPlatform("macos11.0")], [UnsupportedOSPlatform("tvos14.0")], [UnsupportedOSPlatform("watchos7.0")]
 				var status = CLLocationManager.Status;
+#pragma warning restore CA1416
 
 				return status switch
 				{

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Maui.Authentication
 
 			if (OperatingSystem.IsIOSVersionAtLeast(12) || OperatingSystem.IsTvOSVersionAtLeast(12))
 			{
+#pragma warning disable CA1416 // TODO: ASWebAuthenticationSession type has [UnsupportedOSPlatform("tvos")]
 				was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
 
 				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
@@ -82,6 +83,7 @@ namespace Microsoft.Maui.Authentication
 				{
 					ClearCookies();
 				}
+#pragma warning restore CA1416
 
 				using (was)
 				{
@@ -97,12 +99,14 @@ namespace Microsoft.Maui.Authentication
 
 			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))
 			{
+#pragma warning disable CA1416 // TODO: SFAuthenticationSession has [SupportedOSPlatform("ios11.0")] [UnsupportedOSPlatform("ios12.0")]
 				sf = new SFAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
 				using (sf)
 				{
 					sf.Start();
 					return await tcsResponse.Task;
 				}
+#pragma warning restore CA1416
 			}
 
 			// This is only on iOS9+ but we only support 10+ in Essentials anyway
@@ -137,15 +141,15 @@ namespace Microsoft.Maui.Authentication
 #if __IOS__
 			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))
 			{
+#pragma warning disable CA1416 // WKWebsiteDataStore.HttpCookieStore has [SupportedOSPlatform("ios11.0")]
 				WKWebsiteDataStore.DefaultDataStore.HttpCookieStore.GetAllCookies((cookies) =>
 				{
 					foreach (var cookie in cookies)
 					{
-#pragma warning disable CA1416 // Known false positive with lambda, here we can also assert the version
 						WKWebsiteDataStore.DefaultDataStore.HttpCookieStore.DeleteCookie(cookie, null);
-#pragma warning restore CA1416
 					}
 				});
+#pragma warning restore CA1416 // might be wrong annotation, added to https://github.com/xamarin/xamarin-macios/issues/14619
 			}
 #endif
 		}

--- a/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
+++ b/src/Essentials/src/WebAuthenticator/WebAuthenticator.ios.tvos.cs
@@ -68,12 +68,11 @@ namespace Microsoft.Maui.Authentication
 				sf = null;
 			}
 
-			if (OperatingSystem.IsIOSVersionAtLeast(12) || OperatingSystem.IsTvOSVersionAtLeast(12))
+			if (OperatingSystem.IsIOSVersionAtLeast(12))
 			{
-#pragma warning disable CA1416 // TODO: ASWebAuthenticationSession type has [UnsupportedOSPlatform("tvos")]
 				was = new ASWebAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
 
-				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
+				if (OperatingSystem.IsIOSVersionAtLeast(13))
 				{
 					var ctx = new ContextProvider(WindowStateManager.Default.GetCurrentUIWindow());
 					was.PresentationContextProvider = ctx;
@@ -83,7 +82,6 @@ namespace Microsoft.Maui.Authentication
 				{
 					ClearCookies();
 				}
-#pragma warning restore CA1416
 
 				using (was)
 				{
@@ -97,16 +95,14 @@ namespace Microsoft.Maui.Authentication
 			if (prefersEphemeralWebBrowserSession)
 				ClearCookies();
 
-			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))
+			if (OperatingSystem.IsIOSVersionAtLeast(11))
 			{
-#pragma warning disable CA1416 // TODO: SFAuthenticationSession has [SupportedOSPlatform("ios11.0")] [UnsupportedOSPlatform("ios12.0")]
 				sf = new SFAuthenticationSession(WebUtils.GetNativeUrl(url), scheme, AuthSessionCallback);
 				using (sf)
 				{
 					sf.Start();
 					return await tcsResponse.Task;
 				}
-#pragma warning restore CA1416
 			}
 
 			// This is only on iOS9+ but we only support 10+ in Essentials anyway
@@ -139,17 +135,17 @@ namespace Microsoft.Maui.Authentication
 			NSUrlCache.SharedCache.RemoveAllCachedResponses();
 
 #if __IOS__
-			if (OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11))
+			if (OperatingSystem.IsIOSVersionAtLeast(11))
 			{
-#pragma warning disable CA1416 // WKWebsiteDataStore.HttpCookieStore has [SupportedOSPlatform("ios11.0")]
 				WKWebsiteDataStore.DefaultDataStore.HttpCookieStore.GetAllCookies((cookies) =>
 				{
 					foreach (var cookie in cookies)
 					{
+#pragma warning disable CA1416 // Known false positive with lambda, here we can also assert the version
 						WKWebsiteDataStore.DefaultDataStore.HttpCookieStore.DeleteCookie(cookie, null);
+#pragma warning restore CA1416
 					}
 				});
-#pragma warning restore CA1416 // might be wrong annotation, added to https://github.com/xamarin/xamarin-macios/issues/14619
 			}
 #endif
 		}


### PR DESCRIPTION
### Enable CA1416 in Essentials project and handle warnings

CA1416 was accidentally disabled in the project, therefore some warnings were hidden, reenabling it

Related to and fixes https://github.com/dotnet/maui/pull/6237