### PR TITLE
Cache checkbox locally

### DIFF
--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Platform
 			}
 
 			if (handler == null)
-				throw new Exception($"Handler not found for view {view}.");
+				throw new HandlerNotFoundException($"Handler not found for view {view}.");
 
 			handler.SetMauiContext(context);
 
@@ -101,6 +101,10 @@ namespace Microsoft.Maui.Platform
 					handler.SetVirtualView(view);
 			}
 			catch (ToPlatformException)
+			{
+				throw;
+			}
+			catch (HandlerNotFoundException)
 			{
 				throw;
 			}

--- a/src/Core/src/Platform/HandlerNotFoundException.cs
+++ b/src/Core/src/Platform/HandlerNotFoundException.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Microsoft.Maui.Platform
+{
+	class HandlerNotFoundException : System.Exception
+	{
+		public HandlerNotFoundException()
+		{
+		}
+
+		public HandlerNotFoundException(string message) : base(message)
+		{
+		}
+
+		public HandlerNotFoundException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		protected HandlerNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiCheckBox.cs
+++ b/src/Core/src/Platform/iOS/MauiCheckBox.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Maui.Platform
 
 		static UIImage? Checked;
 		static UIImage? Unchecked;
+		UIImage? CheckedDisabledAndTinted;
+		UIImage? UncheckedDisabledAndTinted;
+
 		UIAccessibilityTrait _accessibilityTraits;
 
 		Color? _tintColor;
@@ -91,6 +94,8 @@ namespace Microsoft.Maui.Platform
 				if (_tintColor == value)
 					return;
 
+				CheckedDisabledAndTinted = null;
+				UncheckedDisabledAndTinted = null;
 				_tintColor = value;
 				CheckBoxTintUIColor = CheckBoxTintColor?.ToPlatform();
 			}
@@ -136,43 +141,44 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		protected virtual UIImage GetCheckBoximage()
+		protected virtual UIImage GetCheckBoxImage()
 		{
 			// Ideally I would use the static images here but when disabled it always tints them grey
 			// and I don't know how to make it not tint them gray
 			if (!Enabled && CheckBoxTintColor != null)
 			{
 				if (IsChecked)
-					return CreateCheckBox(CreateCheckMark()).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+				{
+					return CheckedDisabledAndTinted ??=
+						CreateCheckBox(CreateCheckMark()).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+				}
 
-				return CreateCheckBox(null).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+				return UncheckedDisabledAndTinted ??=
+					CreateCheckBox(null).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 			}
 
-			if (Checked == null)
-				Checked = CreateCheckBox(CreateCheckMark()).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
-
-			if (Unchecked == null)
-				Unchecked = CreateCheckBox(null).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+			Checked ??= CreateCheckBox(CreateCheckMark()).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+			Unchecked ??= CreateCheckBox(null).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
 
 			return IsChecked ? Checked : Unchecked;
 		}
 
-		internal virtual UIBezierPath CreateBoxPath(CGRect backgroundRect) => UIBezierPath.FromOval(backgroundRect);
-		internal virtual UIBezierPath CreateCheckPath() => new UIBezierPath
+		UIBezierPath CreateBoxPath(CGRect backgroundRect) => UIBezierPath.FromOval(backgroundRect);
+		UIBezierPath CreateCheckPath() => new UIBezierPath
 		{
 			LineWidth = (nfloat)0.077,
 			LineCapStyle = CGLineCap.Round,
 			LineJoinStyle = CGLineJoin.Round
 		};
 
-		internal virtual void DrawCheckMark(UIBezierPath path)
+		void DrawCheckMark(UIBezierPath path)
 		{
 			path.MoveTo(new CGPoint(0.72f, 0.22f));
 			path.AddLineTo(new CGPoint(0.33f, 0.6f));
 			path.AddLineTo(new CGPoint(0.15f, 0.42f));
 		}
 
-		internal virtual UIImage CreateCheckBox(UIImage? check)
+		UIImage CreateCheckBox(UIImage? check)
 		{
 			UIGraphics.BeginImageContextWithOptions(new CGSize(DefaultSize, DefaultSize), false, 0);
 			var context = UIGraphics.GetCurrentContext();
@@ -208,7 +214,7 @@ namespace Microsoft.Maui.Platform
 			return img;
 		}
 
-		internal UIImage CreateCheckMark()
+		UIImage CreateCheckMark()
 		{
 			UIGraphics.BeginImageContextWithOptions(new CGSize(DefaultSize, DefaultSize), false, 0);
 			var context = UIGraphics.GetCurrentContext();
@@ -263,7 +269,7 @@ namespace Microsoft.Maui.Platform
 
 		void UpdateDisplay()
 		{
-			SetImage(GetCheckBoximage(), UIControlState.Normal);
+			SetImage(GetCheckBoxImage(), UIControlState.Normal);
 			SetNeedsDisplay();
 		}
 


### PR DESCRIPTION
### Description of Change

When we initially did checkbox, we didn't cache the images used for disabled because it would always tint them grey. Well, now it seems to always tint them gray no matter how many different StackOverflow posts I found. So, I modified the code to not recreate the images every time and cause a layout loop. I logged the issue [here](https://github.com/dotnet/maui/issues/6839) about the tinting.

The code for testing this issue is
```C#
MainPage = new ContentPage
{
	Content = new StackLayout()
	{
		Children =
		{
			new CheckBox() { Color = Colors.Purple },
			new CheckBox() {  Color = Colors.Purple, IsEnabled = false },
		}
	}
};
```

Which is another disappointment with this PR :-) When placed in our test runners this code runs fine and doesn't cause a layout loop. 

- I removed a bunch of internal methods that weren't used anywhere
- I made the exception for a missing handler more clear.  This came up as I was attempting to write a unit test

### Issues Fixed
Fixes #6687
