### PR TITLE
Properties moved to UseMauiCore need to work in the repo

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.Debug.targets
+++ b/.nuspec/Microsoft.Maui.Controls.Debug.targets
@@ -4,6 +4,7 @@
 		<_MauiForceXamlCForDebug>True</_MauiForceXamlCForDebug>
 	</PropertyGroup>
 
+	<Import Project="$(MSBuildThisFileDirectory)Microsoft.Maui.Core.targets" />
 	<Import Project="$(MSBuildThisFileDirectory)Microsoft.Maui.Controls.targets" />
 	<UsingTask TaskName="Microsoft.Maui.Controls.Build.Tasks.DebugXamlCTask" AssemblyFile="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll" />
 	

--- a/.nuspec/Microsoft.Maui.Core.props
+++ b/.nuspec/Microsoft.Maui.Core.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <PropertyGroup Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
+    <EnableMsixTooling Condition=" '$(EnableMsixTooling)' == '' ">true</EnableMsixTooling>
+    <EnablePreviewMsixTooling Condition=" '$(EnablePreviewMsixTooling)' == '' ">$(EnableMsixTooling)</EnablePreviewMsixTooling>
+    <GenerateLibraryLayout Condition=" '$(GenerateLibraryLayout)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">true</GenerateLibraryLayout>
+    <WinUISDKReferences Condition=" '$(WinUISDKReferences)' == '' and '$(EnableMsixTooling)' == 'true' ">false</WinUISDKReferences>
+  </PropertyGroup>
+
+</Project>

--- a/.nuspec/Microsoft.Maui.Core.targets
+++ b/.nuspec/Microsoft.Maui.Core.targets
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>

--- a/src/Compatibility/ControlGallery/src/Core/Source.Build.targets
+++ b/src/Compatibility/ControlGallery/src/Core/Source.Build.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="..\.nuspec\Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
+  <Import Project="..\.nuspec\Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="..\.nuspec\Microsoft.Maui.Controls.DefaultItems.targets" />

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/_Directory.Build.props
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/_Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\AutoImport.InTree.props" />
+  <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Core.props" />
   <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.props" />
   <Import Project="..\..\..\..\..\..\..\..\..\Directory.Build.props" />
 </Project> 

--- a/src/Controls/tests/Xaml.UnitTests/MSBuild/_Directory.Build.targets
+++ b/src/Controls/tests/Xaml.UnitTests/MSBuild/_Directory.Build.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
+  <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="..\..\..\..\..\..\..\..\..\.nuspec\Microsoft.Maui.Controls.DefaultItems.targets" />

--- a/src/Maui.InTree.props
+++ b/src/Maui.InTree.props
@@ -1,4 +1,5 @@
 <Project>
   <Import Project="$(_MauiBuildTasksLocation)AutoImport.InTree.props"/>
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.props"/>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.props"/>
 </Project>

--- a/src/Maui.InTree.targets
+++ b/src/Maui.InTree.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
+  <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.DefaultItems.targets" />

--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <None Remove="**/*.in.*" />
     <None Update="@(None)" PackagePath="" />
+    <_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Core.props" />
+    <_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Core.targets" />
     <_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.props" />
     <_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.targets" />
     <_Files Include="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.SingleProject.props" />

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Core.Sdk.After.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Core.Sdk.After.targets
@@ -13,4 +13,6 @@
   -->
   <Import Project="WinUI.targets" Condition=" '$(TargetPlatformIdentifier)' == 'windows' and '$(WindowsAppSDKWinUI)' == 'true'" />
 
+  <Import Project="Microsoft.Maui.Core.targets" />
+
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Core.Sdk.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Core.Sdk.targets
@@ -4,13 +4,7 @@
     <UsingMicrosoftMauiCoreSdk>true</UsingMicrosoftMauiCoreSdk>
   </PropertyGroup>
 
-  <!-- Set some property defaults that MAUI requires - especially for dotnet build to work -->
-  <PropertyGroup Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
-    <EnableMsixTooling Condition=" '$(EnableMsixTooling)' == '' ">true</EnableMsixTooling>
-    <EnablePreviewMsixTooling Condition=" '$(EnablePreviewMsixTooling)' == '' ">$(EnableMsixTooling)</EnablePreviewMsixTooling>
-    <GenerateLibraryLayout Condition=" '$(GenerateLibraryLayout)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">true</GenerateLibraryLayout>
-    <WinUISDKReferences Condition=" '$(WinUISDKReferences)' == '' and '$(EnableMsixTooling)' == 'true' ">false</WinUISDKReferences>
-  </PropertyGroup>
+  <Import Project="Microsoft.Maui.Core.props" />
 
   <!-- Imported last -->
   <PropertyGroup>


### PR DESCRIPTION
### Description of Change

As part of #6767, I did not restart VS enough times so some changes did not apply in the IDE.

This PR makes sure the repo has access to the properties in the new file by including it in the InTree props/targets

### Issues Fixed

Related to #6767