### PR TITLE
[Android] Disconnect old handler before updating view cell

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -185,6 +185,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			public void Update(ViewCell cell)
 			{
+				// This cell could have a handler that was used for the measure pass for the Listview height calculations
+				cell.View.Handler.DisconnectHandler();
+
 				Performance.Start(out string reference);
 				var viewHandlerType = _viewHandler.MauiContext.Handlers.GetHandlerType(cell.View.GetType());
 				var reflectableType = _viewHandler as System.Reflection.IReflectableType;


### PR DESCRIPTION
### Description of Change

To fix some Listview issues related with infinite height we try to create and measure the ViewCells and it's content before they are rendering on the screen. This can cause a handler to be attached to its container and not removed after this step. So we need to make sure we disconnect the handler before updating a reused cell.

### Issues Fixed


Fixes #6377 
Fixes #6822
