### PR TITLE
Set GenerateDocumentationFile=true for Core and Controls.Core

### DIFF
--- a/src/Controls/src/Core/AnimationExtensions.cs
+++ b/src/Controls/src/Core/AnimationExtensions.cs
@@ -138,9 +138,11 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Animate&lt;T&gt;'][1]/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public static void Animate<T>(this IAnimatable self, string name, Func<double, T> transform, Action<T> callback,
 			uint rate = 16, uint length = 250, Easing easing = null,
 			Action<T, bool> finished = null, Func<bool> repeat = null, IAnimationManager animationManager = null)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			if (transform == null)
 				throw new ArgumentNullException(nameof(transform));
@@ -157,7 +159,9 @@ namespace Microsoft.Maui.Controls
 
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='AnimateKinetic']/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public static void AnimateKinetic(this IAnimatable self, string name, Func<double, double, bool> callback, double velocity, double drag, Action finished = null, IAnimationManager animationManager = null)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			animationManager ??= self.GetAnimationManager();
 

--- a/src/Controls/src/Core/Command.cs
+++ b/src/Controls/src/Core/Command.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][2]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="//Member[@MemberName='.ctor'][4]/Docs" />
 		public Command(Action<T> execute, Func<T, bool> canExecute)
 			: base(o =>
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/CellControl.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (Cell == null)
 				return;
 
-			/// 🚀 subscribe topropertychanged
+			// 🚀 subscribe topropertychanged
 			// make sure we do not subscribe twice (because this could happen in SetSource(Cell oldCell, Cell newCell))
 			Cell.PropertyChanged -= _propertyChangedHandler;
 			Cell.PropertyChanged += _propertyChangedHandler;
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 
 			Cell.SendDisappearing();
-			/// 🚀 unsubscribe from propertychanged
+			// 🚀 unsubscribe from propertychanged
 			Cell.PropertyChanged -= _propertyChangedHandler;
 		}
 

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -7,6 +7,8 @@
     <IsPackable>false</IsPackable>
     <_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' And '$(MSBuildRuntimeType)' == 'Full'">True</_MauiDesignDllBuild>
     <GitInfoReportImportance>high</GitInfoReportImportance>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -217,13 +217,17 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert'][1]/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			return DisplayAlert(title, message, null, cancel, flowDirection);
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayAlert'][2]/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			if (string.IsNullOrEmpty(cancel))
 				throw new ArgumentNullException("cancel");

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -385,14 +385,18 @@ namespace Microsoft.Maui.Controls.Internals
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll'][1]/Docs" />
 		[Obsolete]
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public static void RegisterAll(Type[] attrTypes, IFontRegistrar fontRegistrar = null)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			RegisterAll(attrTypes, default(InitializationFlags), fontRegistrar);
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterAll'][2]/Docs" />
 		[Obsolete]
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public static void RegisterAll(Type[] attrTypes, InitializationFlags flags, IFontRegistrar fontRegistrar = null)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			RegisterAll(
 				AppDomain.CurrentDomain.GetAssemblies(),

--- a/src/Controls/src/Core/Routing.cs
+++ b/src/Controls/src/Core/Routing.cs
@@ -146,7 +146,9 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Routing.xml" path="//Member[@MemberName='GetOrCreateContent']/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public static Element GetOrCreateContent(string route, IServiceProvider services = null)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			Element result = null;
 

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -678,13 +678,17 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][1]/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public Task GoToAsync(ShellNavigationState state, IDictionary<string, object> parameters)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			return _navigationManager.GoToAsync(state, null, false, parameters: new ShellRouteParameters(parameters));
 		}
 
 		/// <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GoToAsync'][2]/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public Task GoToAsync(ShellNavigationState state, bool animate, IDictionary<string, object> parameters)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			return _navigationManager.GoToAsync(state, animate, false, parameters: new ShellRouteParameters(parameters));
 		}

--- a/src/Controls/src/Core/SwipeView.cs
+++ b/src/Controls/src/Core/SwipeView.cs
@@ -145,7 +145,9 @@ namespace Microsoft.Maui.Controls
 		public event EventHandler<CloseRequestedEventArgs> CloseRequested;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/SwipeView.xml" path="//Member[@MemberName='Open']/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public void Open(OpenSwipeItem openSwipeItem, bool animated = true)
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		{
 			OpenRequested?.Invoke(this, new OpenRequestedEventArgs(openSwipeItem, animated));
 			((ISwipeView)this).RequestOpen(new SwipeViewOpenRequest(openSwipeItem, animated));

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -5,6 +5,8 @@
     <AssemblyName>Microsoft.Maui</AssemblyName>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
   <ItemGroup>

--- a/src/Core/src/Core/IScrollView.cs
+++ b/src/Core/src/Core/IScrollView.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Maui
 		/// </summary>
 		/// <param name="horizontalOffset">Represents the horizontal offset.</param>
 		/// <param name="verticalOffset">Represents the vertical offset.</param>
+		/// <param name="instant"></param>
 		void RequestScrollTo(double horizontalOffset, double verticalOffset, bool instant);
 	}
 }

--- a/src/Core/src/Primitives/Font.cs
+++ b/src/Core/src/Primitives/Font.cs
@@ -78,11 +78,15 @@ namespace Microsoft.Maui
 		}
 
 		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='OfSize'][1]/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public static Font OfSize(string? name, double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 			new(name, size, fontSlant, weight, enableScaling);
 
 		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='SystemFontOfSize'][1]/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		public static Font SystemFontOfSize(double size, FontWeight weight = FontWeight.Regular, FontSlant fontSlant = FontSlant.Default, bool enableScaling = true) =>
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 			new(null, size, fontSlant, weight, enableScaling);
 
 		/// <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='SystemFontOfWeight']/Docs" />

--- a/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.iOS.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Maui
 			/// <summary>
 			/// Initializes a new instance of the <see cref="PassthroughView"/> class.
 			/// </summary>
-			/// <param name="overlay">The Window Overlay.</param>
+			/// <param name="windowOverlay">The Window Overlay.</param>
 			/// <param name="frame">Base Frame.</param>
 			public PassthroughView(WindowOverlay windowOverlay, CGRect frame)
 				: base(frame)

--- a/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Ref/Microsoft.Maui.Controls.Ref.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Compatibility/Core/src/bin/$(Configuration)/%(Tfm)/ref/Microsoft.Maui.Controls.Compatibility.dll')" />
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/%(Tfm)/ref/Microsoft.Maui.Controls.dll')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Controls.xml')" />
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Xaml/bin/$(Configuration)/%(Tfm)/ref/Microsoft.Maui.Controls.Xaml.dll')" />
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core.Design/bin/$(Configuration)/net472/Microsoft.Maui.Controls.DesignTools.dll')" SubFolder="/Design" />
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Xaml.Design/bin/$(Configuration)/net472/Microsoft.Maui.Controls.Xaml.DesignTools.dll')" SubFolder="/Design" />

--- a/src/Workload/Microsoft.Maui.Core.Ref/Microsoft.Maui.Core.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Core.Ref/Microsoft.Maui.Core.Ref.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Core/src/bin/$(Configuration)/%(Tfm)/ref/Microsoft.Maui.dll')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Core/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.xml')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="ref/%(FullTfm)/%(FileName)%(Extension)" />
     <_PackageFiles Include="@(None)" PackagePath="ref/%(FullTfm)" TargetPath="ref/%(FullTfm)" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change

This way the XML docs will be generated for these projects, and thus available to end-users. Without this change, even though we _have_ XML docs for many types/members, they don't end up seen in end-user projects!

Also included:
- Fixes several invalid doc comments
- Disables certain doc warnings/errors due to incomplete/missing docs

### Issues Fixed

Partial fix for #5341

* Why only Core and Controls.Core? Because those have by far the most important APIs that users will see, and also they have the most complete XML docs that I've seen so far. I'm happy to include more projects if it seems worthwhile.

### GA Triage

I realize that bug https://github.com/dotnet/maui/issues/5341 is listed for servicing, but I think having literally 0 doc comments for GA is a big hit, especially considering that so many APIs are brand new to users. While the XML docs in .NET MAUI are certainly not complete, there still are a TON of docs, and it's a shame that they're not visible at all to any users.

Right now this is what you get in a .NET MAUI app:
![image](https://user-images.githubusercontent.com/202643/167029408-b5be5422-9008-4cf2-b6ec-24fd03f59ec3.png)

And in theory, with this change, this is what you'll see:
![image](https://user-images.githubusercontent.com/202643/167029418-24126b76-df3b-4aeb-9a8c-68883d377641.png)

(Why only in theory? It's hard to verify from within the repo whether the authoring is entirely correct, but the same authoring already works for other projects (e.g. BlazorWebView), so it's likely all that's needed.)