### PR TITLE
Add Windows Icon to .exe and set Window Icon at runtime

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -586,7 +586,14 @@
             </ContentWithTargetPath>
 
             <FileWrites Include="@(_ResizetizerCollectedImages)" />
+
+            <_MauiAppIconFile Include="@(_ResizetizerCollectedImages)"
+                              Condition="'%(Extension)' == '.ico'" />
         </ItemGroup>
+
+        <PropertyGroup Condition="'$(_ResizetizerIsUWPApp)' == 'True' Or '$(_ResizetizerIsWindowsAppSdk)' == 'True'">
+            <ApplicationIcon Condition="'$(ApplicationIcon)' == ''">%(_MauiAppIconFile.Identity)</ApplicationIcon>
+        </PropertyGroup>
 
         <!-- WPF -->
         <ItemGroup Condition="'$(_ResizetizerIsWPFApp)' == 'True'">

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -153,6 +153,14 @@ namespace Microsoft.Maui.Resizetizer
 				foreach (var assetGenerated in assetsGenerated)
 					resizedImages.Add(assetGenerated);
 			}
+			else if (PlatformType == "uwp")
+			{
+				LogDebugMessage($"Windows Icon Generator");
+
+				var windowsIconGen = new WindowsIconGenerator(img, IntermediateOutputPath, this);
+
+				resizedImages.Add(windowsIconGen.Generate());
+			}
 			else if (PlatformType == "tizen")
 			{
 				var updator = new TizenIconManifestUpdater(appIconName, appIconDpis, this);

--- a/src/SingleProject/Resizetizer/src/SkiaSharpAppIconTools.cs
+++ b/src/SingleProject/Resizetizer/src/SkiaSharpAppIconTools.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using SkiaSharp;
 
@@ -40,7 +41,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		public string AppIconName { get; }
 
-		public ResizedImageInfo Resize(DpiPath dpi, string destination)
+		public ResizedImageInfo Resize(DpiPath dpi, string destination, Func<Stream> getStream = null)
 		{
 			var sw = new Stopwatch();
 			sw.Start();
@@ -113,8 +114,16 @@ namespace Microsoft.Maui.Resizetizer
 				}
 
 				// Save (encode)
-				using var wrapper = File.Create(destination);
-				tempBitmap.Encode(wrapper, SKEncodedImageFormat.Png, 100);
+				if (getStream is not null)
+				{
+					var stream = getStream();
+					tempBitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
+				}
+				else
+				{
+					using var wrapper = File.Create(destination);
+					tempBitmap.Encode(wrapper, SKEncodedImageFormat.Png, 100);
+				}
 			}
 
 			sw.Stop();

--- a/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
@@ -21,13 +21,16 @@ namespace Microsoft.Maui.Resizetizer
 
 		public ResizedImageInfo Generate()
 		{
+			string destinationFolder = IntermediateOutputPath;
+
 			string fileName = Path.GetFileNameWithoutExtension(Info.OutputName);
-			string destination = Path.ChangeExtension(Path.Combine(IntermediateOutputPath, fileName), "ico");
+			string destination = Path.Combine(destinationFolder, $"{fileName}.ico");
+			Directory.CreateDirectory(destinationFolder);
 
 			Logger.Log($"Generating ICO: {destination}");
 
 			var tools = new SkiaSharpAppIconTools(Info, Logger);
-			var dpi = new DpiPath(Path.GetFileNameWithoutExtension(fileName), 1.0m, size: new SKSize(64, 64));
+			var dpi = new DpiPath(fileName, 1.0m, size: new SKSize(64, 64));
 
 			MemoryStream memoryStream = new MemoryStream();
 			tools.Resize(dpi, destination, () => memoryStream);

--- a/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
@@ -1,0 +1,60 @@
+﻿using System.IO;
+using SkiaSharp;
+
+namespace Microsoft.Maui.Resizetizer
+{
+	/// <summary>
+	/// Generates a .ico file for the image.
+	/// </summary>
+	internal class WindowsIconGenerator
+	{
+		public WindowsIconGenerator(ResizeImageInfo info, string intermediateOutputPath, ILogger logger)
+		{
+			Info = info;
+			Logger = logger;
+			IntermediateOutputPath = intermediateOutputPath;
+		}
+
+		public ResizeImageInfo Info { get; private set; }
+		public string IntermediateOutputPath { get; private set; }
+		public ILogger Logger { get; private set; }
+
+		public ResizedImageInfo Generate()
+		{
+			string fileName = Path.GetFileNameWithoutExtension(Info.OutputName);
+			string destination = Path.ChangeExtension(Path.Combine(IntermediateOutputPath, fileName), "ico");
+
+			Logger.Log($"Generating ICO: {destination}");
+
+			var tools = new SkiaSharpAppIconTools(Info, Logger);
+			var dpi = new DpiPath(Path.GetFileNameWithoutExtension(fileName), 1.0m, size: new SKSize(64, 64));
+
+			MemoryStream memoryStream = new MemoryStream();
+			tools.Resize(dpi, destination, () => memoryStream);
+			memoryStream.Position = 0;
+			
+			int numberOfImages = 1;
+			using BinaryWriter writer = new BinaryWriter(File.Create(destination));
+			writer.Write((short)0x0); // Reserved. Must always be 0.
+			writer.Write((short)0x1); // Specifies image type: 1 for icon (.ICO) image
+			writer.Write((short)numberOfImages); // Specifies number of images in the file.
+
+			writer.Write((byte)dpi.Size.Value.Width);
+			writer.Write((byte)dpi.Size.Value.Height);
+			writer.Write((byte)0x0); // Specifies number of colors in the color palette
+			writer.Write((byte)0x0); // Reserved. Should be 0
+			writer.Write((short)0x1); // Specifies color planes. Should be 0 or 1
+			writer.Write((short)0x8); // Specifies bits per pixel.
+			writer.Write((int)memoryStream.Length); // Specifies the size of the image's data in bytes
+			
+			int offset = 6 + (16 * numberOfImages); // + length of previous images
+			writer.Write(offset); // Specifies the offset of BMP or PNG data from the beginning of the ICO/CUR file
+
+			// write png data for each image
+			memoryStream.CopyTo(writer.BaseStream);
+			writer.Flush();
+
+			return new ResizedImageInfo { Dpi = dpi, Filename = destination };
+		}
+	}
+}


### PR DESCRIPTION
- Generate an .ico file during ResizetizeImages for Windows exe projects.
- Set the ApplicationIcon property, which will embed the ico file into the application's .exe.
- When a Window is created at runtime, read the Icon from the .exe and set it on the Window to show the icon in Alt+Tab and other places.

Fixes #5915