### PR TITLE
[Windows] [Shell] Fix Flyout Background so it gets set in Locked behavior mode

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -28,10 +28,16 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (platformView is MauiNavigationView mauiNavigationView)
 				mauiNavigationView.OnApplyTemplateFinished += OnApplyTemplateFinished;
 
+			platformView.Loaded += OnLoaded;
 			platformView.PaneOpened += OnPaneOpened;
 			platformView.PaneOpening += OnPaneOpening;
 			platformView.PaneClosing += OnPaneClosing;
 			platformView.ItemInvoked += OnMenuItemInvoked;
+		}
+
+		private void OnLoaded(object sender, UI.Xaml.RoutedEventArgs e)
+		{
+			UpdateValue(nameof(Shell.FlyoutBackground));
 		}
 
 		protected override void DisconnectHandler(ShellView platformView)

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			if (platformView is MauiNavigationView mauiNavigationView)
 				mauiNavigationView.OnApplyTemplateFinished -= OnApplyTemplateFinished;
 
+			platformView.Loaded -= OnLoaded;
 			platformView.PaneOpened -= OnPaneOpened;
 			platformView.PaneOpening -= OnPaneOpening;
 			platformView.PaneClosing -= OnPaneClosing;

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Maui.Controls.Platform
 			// If we set it earlier than this then WinUI will transition it back to false
 			if (IsPaneOpen != Element.FlyoutIsPresented)
 				IsPaneOpen = Element.FlyoutIsPresented;
+
+			UpdateFlyoutBackdrop();
 		}
 
 		private protected override void UpdateFlyoutCustomContent()
@@ -67,6 +69,7 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			_shellSplitView = new ShellSplitView(RootSplitView);
 			_shellSplitView.FlyoutBackdrop = _flyoutBackdrop;
+			UpdateFlyoutBackdrop();
 			TogglePaneButton?.SetAutomationPropertiesAutomationId("OK");
 
 			base.OnApplyTemplateCore();

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
@@ -69,10 +69,10 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			_shellSplitView = new ShellSplitView(RootSplitView);
 			_shellSplitView.FlyoutBackdrop = _flyoutBackdrop;
-			UpdateFlyoutBackdrop();
 			TogglePaneButton?.SetAutomationPropertiesAutomationId("OK");
 
 			base.OnApplyTemplateCore();
+			UpdateFlyoutBackdrop();
 		}
 
 		internal void UpdateFlyoutPosition()


### PR DESCRIPTION
### Description of Change

On Windows, the background color was not getting applied to the Flyout menu when started up with Locked behavior.
Now, by updating the value on loaded, it does! Yay :)

### Issues Fixed

Fixes #6552
Fixes #6244