### PR TITLE
[ListView] Reuse already created ViewCellContainer for infinite height GetDesiredSize scenario

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
@@ -203,6 +203,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return key;
 		}
 
+		// This is used by the `ListViewRenderer.GetDesiredSize` call to retrieve an already created ViewCellContainer
+		// This helps us fake cell reuse so we aren't creating extra views during the measure pass.
+		internal ConditionalFocusLayout GetConvertViewForMeasuringInfiniteHeight(int position)
+		{
+			if (_layoutsCreated.TryGetValue(position, out ConditionalFocusLayout foundValue))
+				return foundValue;
+
+			return null;
+		}
+
 		public override AView GetView(int position, AView convertView, ViewGroup parent)
 		{
 			Cell cell = null;

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
@@ -219,6 +219,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				UpdateVerticalScrollBarVisibility();
 		}
 
+		/*
+		 * With Xamarin.Forms we never passed in an infinite height. The height was always constrained to something.
+		 * In MAUI if the Maui.ListView is inside a VerticalStackLayout then it basically has infinite height to occupy.
+		 * One of the quirks of the Androids platform ListView control is that if you give it infinite height
+		 * It will only measure the top cell. If you google "ListView only renders first cell" you'll find a bunch of hits
+		 * where people have put an Android.ListView inside an Android.ScrollView and the fix is to remove the Android.ScrollView
+		 * Our problem here is basically the same. So, in order to preserve behavior here from XF and make this work the same as 
+		 * Windows/iOS we measure every single cell and then return that as the height.
+		 * This will most likely cause the user to be frustrated that the ListView doesn't scroll :-) but at least now
+		 * it's consistent between platforms and for cases where it doesn't need to scroll (TableView).
+		 * */
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			if (double.IsInfinity(heightConstraint))
@@ -248,6 +259,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						if (cell.Handler?.PlatformView is AView aView)
 							currentParent = aView.Parent as AView;
 
+						currentParent ??= _adapter.GetConvertViewForMeasuringInfiniteHeight(i);
 						AView listItem = _adapter.GetView(i, currentParent, Control);
 						int widthSpec;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -185,6 +185,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			public void Update(ViewCell cell)
 			{
+				// This cell could have a handler that was used for the measure pass for the Listview height calculations
+				//cell.View.Handler.DisconnectHandler();
+
 				Performance.Start(out string reference);
 				var viewHandlerType = _viewHandler.MauiContext.Handlers.GetHandlerType(cell.View.GetType());
 				var reflectableType = _viewHandler as System.Reflection.IReflectableType;

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.ListView)]
+	public partial class ListViewTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<ViewCell, ViewCellRenderer>();
+					handlers.AddHandler<ListView, ListViewRenderer>();
+					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+		}
+
+		[Fact(DisplayName = "ReAssigning ListView in VSL Crashes")]
+		public async Task ReAssigninListViewInVSLCrashes()
+		{
+			SetupBuilder();
+			var listView = new ListView()
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					return new ViewCell()
+					{
+						View = new VerticalStackLayout()
+							{
+								new Label()
+								{
+									Text = "Cat"
+								}
+							}
+					};
+				})
+			};
+
+			var layout = new VerticalStackLayout()
+			{
+				listView
+			};
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (handler) =>
+			{
+				listView.ItemsSource = Enumerable.Range(1, 1);
+				await Task.Delay(100);
+				listView.ItemsSource = Enumerable.Range(1, 2);
+				await Task.Delay(100);
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -12,6 +12,7 @@
 		public const string Gesture = "Gesture";
 		public const string Label = "Label";
 		public const string Layout = "Layout";
+		public const string ListView = "ListView";
 		public const string Modal = "Modal";
 		public const string NavigationPage = "NavigationPage";
 		public const string Page = "Page";


### PR DESCRIPTION
### Description of Change

When we have to measure all cells inside the ListView to figure out the layout height we need to make sure to reuse any already created cells if another layout cycle is triggered or if the user assigns a new set of items.

### Issues Fixed
Fixes #6377 
Fixes #6822