### PR TITLE
Set GenerateDocumentationFile=true for MAUI Essentials

### DIFF
--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -8,6 +8,8 @@
     <NoWarn>$(NoWarn);CA1416</NoWarn>
     <IsPackable>false</IsPackable>
     <IsTrimmable>true</IsTrimmable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">

--- a/src/Essentials/src/Screenshot/Screenshot.shared.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.shared.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Maui.Media
 		int Height { get; }
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/IScreenshotResult.xml" path="//Member[@MemberName='OpenReadAsync']/Docs" />
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 		Task<Stream> OpenReadAsync(ScreenshotFormat format = ScreenshotFormat.Png, int quality = 100);
+#pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/IScreenshotResult.xml" path="//Member[@MemberName='CopyToAsync']/Docs" />
 		Task CopyToAsync(Stream destination, ScreenshotFormat format = ScreenshotFormat.Png, int quality = 100);

--- a/src/Essentials/src/Share/Share.shared.cs
+++ b/src/Essentials/src/Share/Share.shared.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Maui.ApplicationModel.DataTransfer
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
 		public ShareMultipleFilesRequest(IEnumerable<ShareFile> files) =>
 			Files = files.ToList();
 
@@ -190,7 +190,7 @@ namespace Microsoft.Maui.ApplicationModel.DataTransfer
 		{
 		}
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][3]/Docs" />
+		/// <include file="../../docs/Microsoft.Maui.Essentials/ShareMultipleFilesRequest.xml" path="//Member[@MemberName='.ctor'][5]/Docs" />
 		public ShareMultipleFilesRequest(string title, IEnumerable<ShareFile> files)
 			: this(files) => Title = title;
 

--- a/src/Workload/Microsoft.Maui.Essentials.Ref/Microsoft.Maui.Essentials.Ref.csproj
+++ b/src/Workload/Microsoft.Maui.Essentials.Ref/Microsoft.Maui.Essentials.Ref.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Essentials/src/bin/$(Configuration)/%(Tfm)/ref/Microsoft.Maui.Essentials.dll')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Essentials/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Essentials.xml')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="ref/%(FullTfm)/%(FileName)%(Extension)" />
     <_PackageFiles Include="@(None)" PackagePath="ref/%(FullTfm)" TargetPath="ref/%(FullTfm)" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change

Similar to https://github.com/dotnet/maui/pull/6874, this enables XML doc comments for MAUI Essentials, which also has a ton of XML docs, but they're not published.

### Issues Fixed

Partial fix for https://github.com/dotnet/maui/issues/5341
