### PR TITLE
Change iOS Shell pop to just use GotoAsync

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellItemRenderer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		ShellItem _shellItem;
 		static UIColor _defaultMoreTextLabelTextColor;
 
-		IShellSectionRenderer CurrentRenderer { get; set; }
+		internal IShellSectionRenderer CurrentRenderer { get; private set; }
 
 		public ShellItemRenderer(IShellContext context)
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRenderer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		[Export("navigationBar:shouldPopItem:")]
 		[Internals.Preserve(Conditional = true)]
-		public bool ShouldPopItem(UINavigationBar navigationBar, UINavigationItem item) =>
+		public bool ShouldPopItem(UINavigationBar _, UINavigationItem __) =>
 			SendPop();
 
 		internal bool SendPop()
@@ -130,27 +130,27 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				}
 			}
 
-			bool allowPop = ShouldPop();
+			
+			// Do not remove, wonky behavior on some versions of iOS if you dont dispatch
+			// Shane: ^ not sure if this is true anymore because of how
+			// we now route this through "GoToAsync"
+			CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(async () =>
+			{
+				var navItemsCount = NavigationBar.Items.Length;
 
-			if (allowPop)
-			{
-				// Do not remove, wonky behavior on some versions of iOS if you dont dispatch
-				CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+				await _context.Shell.GoToAsync("..", true);
+
+				// This means the navigation was cancelled
+				if (NavigationBar.Items.Length == navItemsCount)
 				{
-					_popCompletionTask = new TaskCompletionSource<bool>();
-					SendPoppedOnCompletion(_popCompletionTask.Task);
-					PopViewController(true);
-				});
-			}
-			else
-			{
-				for (int i = 0; i < NavigationBar.Subviews.Length; i++)
-				{
-					var child = NavigationBar.Subviews[i];
-					if (child.Alpha != 1)
-						UIView.Animate(.2f, () => child.Alpha = 1);
+					for (int i = 0; i < NavigationBar.Subviews.Length; i++)
+					{
+						var child = NavigationBar.Subviews[i];
+						if (child.Alpha != 1)
+							UIView.Animate(.2f, () => child.Alpha = 1);
+					}
 				}
-			}
+			});
 
 			return false;
 		}

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -119,6 +119,9 @@ namespace Microsoft.Maui.Controls
 			await poppingCompleted;
 
 			RemovePage(page);
+
+			if (Parent?.Parent is IShellController shellController)
+				shellController.UpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 		async void IShellSectionController.SendPoppingToRoot(Task finishedPopping)

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -139,6 +139,8 @@ namespace Microsoft.Maui.Controls
 
 			for (int i = 1; i < oldStack.Count; i++)
 				RemovePage(oldStack[i]);
+
+			(Parent?.Parent as IShellController)?.UpdateCurrentState(ShellNavigationSource.PopToRoot);
 		}
 
 		[Obsolete]

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -120,8 +120,7 @@ namespace Microsoft.Maui.Controls
 
 			RemovePage(page);
 
-			if (Parent?.Parent is IShellController shellController)
-				shellController.UpdateCurrentState(ShellNavigationSource.Pop);
+			(Parent?.Parent as IShellController)?.UpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 		async void IShellSectionController.SendPoppingToRoot(Task finishedPopping)

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.iOS.cs
@@ -1,0 +1,117 @@
+﻿#if !IOS
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Shell)]
+	public partial class ShellTests
+	{
+		protected Task CheckFlyoutState(ShellRenderer renderer, bool result) =>
+			throw new NotImplementedException();
+
+
+		[Fact(DisplayName = "Clicking BackButton Fires Correct Navigation Events")]
+		public async Task ShellWithFlyoutDisabledDoesntRenderFlyout()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new ContentPage());
+			});
+
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				var secondPage = new ContentPage();
+				await shell.Navigation.PushAsync(new ContentPage())
+					.WaitAsync(TimeSpan.FromSeconds(2));
+
+				IShellContext shellContext = handler;
+				var sectionRenderer = (shellContext.CurrentShellItemRenderer as ShellItemRenderer)
+					.CurrentRenderer as ShellSectionRenderer;
+
+				int navigatingFired = 0;
+				int navigatedFired = 0;
+				var finishedNavigation = new TaskCompletionSource<bool>();
+				ShellNavigationSource? shellNavigationSource = null;
+
+				shell.Navigating += ShellNavigating;
+				shell.Navigated += ShellNavigated;
+				sectionRenderer.SendPop();
+				await finishedNavigation.Task.WaitAsync(TimeSpan.FromSeconds(2));
+				Assert.Equal(1, navigatingFired);
+				Assert.Equal(1, navigatedFired);
+				Assert.Equal(ShellNavigationSource.PopToRoot, shellNavigationSource.Value);
+
+				void ShellNavigated(object sender, ShellNavigatedEventArgs e)
+				{
+					navigatedFired++;
+					shellNavigationSource = e.Source;
+					finishedNavigation.SetResult(true);
+				}
+
+				void ShellNavigating(object sender, ShellNavigatingEventArgs e)
+				{
+					navigatingFired++;
+				}
+			});
+		}
+
+		[Fact(DisplayName = "Cancel BackButton Navigation")]
+		public async Task CancelBackButtonNavigation()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new ContentPage());
+			});
+
+
+			await CreateHandlerAndAddToWindow<ShellRenderer>(shell, async (handler) =>
+			{
+				var secondPage = new ContentPage();
+				await shell.Navigation.PushAsync(new ContentPage())
+					.WaitAsync(TimeSpan.FromSeconds(2));
+
+				IShellContext shellContext = handler;
+				var sectionRenderer = (shellContext.CurrentShellItemRenderer as ShellItemRenderer)
+					.CurrentRenderer as ShellSectionRenderer;
+
+				int navigatingFired = 0;
+				int navigatedFired = 0;
+				ShellNavigationSource? shellNavigationSource = null;
+
+				shell.Navigating += ShellNavigating;
+				shell.Navigated += ShellNavigated;
+				var finishedNavigation = new TaskCompletionSource<bool>();
+				sectionRenderer.SendPop();
+
+				// Give Navigated time to fire just in case
+				await Task.Delay(100);
+				Assert.Equal(1, navigatingFired);
+				Assert.Equal(0, navigatedFired);
+				Assert.False(shellNavigationSource.HasValue);
+
+				void ShellNavigated(object sender, ShellNavigatedEventArgs e)
+				{
+					navigatedFired++;
+				}
+
+				void ShellNavigating(object sender, ShellNavigatingEventArgs e)
+				{
+					navigatingFired++;
+					e.Cancel();
+				}
+			});
+		}
+	}
+}
+#endif


### PR DESCRIPTION
### Description of Change

When clicking the BackButton the pop isn't propagating through shell correctly so the navigation events are never triggering. This modifies iOS so the pop navigation just runs through `GotoAsync`.

### Issues Fixed

Fixes #6855
