### PR TITLE
[Windows] Apply default WinUI 3 Styles

### DIFF
--- a/src/Controls/samples/Controls.Sample/AppResources.xaml
+++ b/src/Controls/samples/Controls.Sample/AppResources.xaml
@@ -41,7 +41,7 @@
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />
         <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource LightBorderColor}, Dark={StaticResource DarkBorderColor}}" />
         <Setter Property="Padding" Value="12" />
-        <Setter Property="Margin" Value="12, 0, 12, 12" />
+        <Setter Property="Margin" Value="0" />
     </Style>
 
     <Style x:Key="GalleryItemTitleStyle" TargetType="Label">

--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.xaml
@@ -35,7 +35,7 @@
                 <Setter Property="Stroke" Value="{StaticResource SectionItemBorderColor}" />
                 <Setter Property="HeightRequest" Value="120" />
                 <Setter Property="Padding" Value="12" />
-                <Setter Property="Margin" Value="0, 0, 12, 12" />
+                <Setter Property="Margin" Value="0" />
                 <Setter Property="FlexLayout.Basis" Value="50%"/>
                 <Setter Property="FlexLayout.Grow" Value="0"/>
             </Style>

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						ItemTemplate = (Microsoft.UI.Xaml.DataTemplate)WApp.Current.Resources["CellTemplate"],
 						HeaderTemplate = (Microsoft.UI.Xaml.DataTemplate)WApp.Current.Resources["View"],
 						FooterTemplate = (Microsoft.UI.Xaml.DataTemplate)WApp.Current.Resources["View"],
-						ItemContainerStyle = (Microsoft.UI.Xaml.Style)WApp.Current.Resources["FormsListViewItem"],
+						ItemContainerStyle = (Microsoft.UI.Xaml.Style)WApp.Current.Resources["MauiListViewItem"],
 						GroupStyleSelector = (GroupStyleSelector)WApp.Current.Resources["ListViewGroupSelector"]
 					};
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewStyles.xaml
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewStyles.xaml
@@ -146,48 +146,19 @@
             </platform:EntryCellTextBox.HeaderTemplate>
         </platform:EntryCellTextBox>
     </DataTemplate>
-    
-    <Style x:Key="FormsListViewItem" TargetType="ListViewItem">
+
+    <Style x:Key="MauiListViewItem" TargetType="ListViewItem" BasedOn="{StaticResource DefaultListViewItemStyle}">
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="IsHoldingEnabled" Value="True" />
-        <Setter Property="Padding" Value="0" />
+        <Setter Property="Padding" Value="12, 0, 0, 0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />
         <Setter Property="MinHeight" Value="0" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="ListViewItem">
-                    <ListViewItemPresenter
-						CheckBrush="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
-						ContentMargin="{TemplateBinding Padding}"
-						CheckMode="Inline"
-						ContentTransitions="{TemplateBinding ContentTransitions}"
-						CheckBoxBrush="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
-						DragForeground="{ThemeResource ListViewItemDragForegroundThemeBrush}"
-						DragOpacity="{ThemeResource ListViewItemDragThemeOpacity}"
-						DragBackground="{ThemeResource ListViewItemDragBackgroundThemeBrush}"
-						DisabledOpacity="{ThemeResource ListViewItemDisabledThemeOpacity}"
-						FocusBorderBrush="{ThemeResource SystemControlForegroundAltHighBrush}"
-						FocusSecondaryBorderBrush="{ThemeResource SystemControlForegroundBaseHighBrush}"
-						HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-						PointerOverForeground="{ThemeResource SystemControlHighlightAltBaseHighBrush}"
-						PressedBackground="{ThemeResource SystemControlHighlightListMediumBrush}"
-						PlaceholderBackground="{ThemeResource ListViewItemPlaceholderBackgroundThemeBrush}"
-						PointerOverBackground="{ThemeResource SystemControlHighlightListLowBrush}"
-						ReorderHintOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
-						SelectedPressedBackground="{ThemeResource SystemControlHighlightListAccentHighBrush}"
-						SelectionCheckMarkVisualEnabled="True"
-						SelectedForeground="{ThemeResource SystemControlHighlightAltBaseHighBrush}"
-						SelectedPointerOverBackground="{ThemeResource SystemControlHighlightListAccentMediumBrush}"
-						SelectedBackground="{ThemeResource SystemControlHighlightListAccentLowBrush}"
-						VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
     </Style>
+    
 </ResourceDictionary>

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/Windows/TableViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/Windows/TableViewRenderer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 					SetNativeControl(new Microsoft.UI.Xaml.Controls.ListView
 					{
-						ItemContainerStyle = (Microsoft.UI.Xaml.Style)Microsoft.UI.Xaml.Application.Current.Resources["FormsListViewItem"],
+						ItemContainerStyle = (Microsoft.UI.Xaml.Style)Microsoft.UI.Xaml.Application.Current.Resources["MauiListViewItem"],
 						ItemTemplate = (Microsoft.UI.Xaml.DataTemplate)Microsoft.UI.Xaml.Application.Current.Resources["CellTemplate"],
 						GroupStyle = { new GroupStyle { HidesIfEmpty = false, HeaderTemplate = (Microsoft.UI.Xaml.DataTemplate)Microsoft.UI.Xaml.Application.Current.Resources["TableSection"] } },
 						HeaderTemplate = (Microsoft.UI.Xaml.DataTemplate)Microsoft.UI.Xaml.Application.Current.Resources["TableRoot"],


### PR DESCRIPTION
### Description of Change

Apply default WinUI 3 Styles.

![fix-6209](https://user-images.githubusercontent.com/6755973/167395462-307d16d3-f87b-40f5-8a41-5e7411ed2a12.gif)

### Issues Fixed

Verified #1738
Fixes #6209

About #1738, currently we have the following resources:
![image](https://user-images.githubusercontent.com/6755973/167395629-07d32d9d-afa6-4085-8377-200fe347b314.png)

- MauiComboBoxStyle: This resource include a style to allow CharacterSpacing and other details to be used in the title. However, the Picker use directly Microsoft.UI.Xaml.Controls.ComboBox.
- MauiSliderStyle: Contains a style for the Slider Thumb using an image. The Slider use directly Microsoft.UI.Xaml.Controls.Slider .
- MauiStepperStyle: There is not something like the Xamarin.Forms UWP Stepper in WinUI. This resource contains a style to define the Stepper using a Grid with two buttons.
- WindowRootStyle: Here we have some styles to allow to customize the AppBarTitle etc.