### PR TITLE
[Housekeeping] Use IPropertyMapper in some pending handlers

### DIFF
--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class IndicatorViewHandler : IIndicatorViewHandler
 	{
-		public static PropertyMapper<IIndicatorView, IIndicatorViewHandler> Mapper = new(ViewMapper)
+		public static IPropertyMapper<IIndicatorView, IIndicatorViewHandler> Mapper = new PropertyMapper<IIndicatorView, IIndicatorViewHandler>(ViewMapper)
 		{
 			[nameof(IIndicatorView.Count)] = MapCount,
 			[nameof(IIndicatorView.Position)] = MapPosition,
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		}
 
-		public IndicatorViewHandler(PropertyMapper mapper) : base(mapper ?? Mapper)
+		public IndicatorViewHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class NavigationViewHandler : INavigationViewHandler
 	{
-		public static PropertyMapper<IStackNavigationView, INavigationViewHandler> Mapper = new(ViewMapper)
+		public static IPropertyMapper<IStackNavigationView, INavigationViewHandler> Mapper = new PropertyMapper<IStackNavigationView, INavigationViewHandler>(ViewMapper)
 		{
 		};
 
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		}
 
-		public NavigationViewHandler(PropertyMapper? mapper = null) : base(mapper ?? Mapper, CommandMapper)
+		public NavigationViewHandler(IPropertyMapper? mapper = null) : base(mapper ?? Mapper, CommandMapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class RefreshViewHandler : IRefreshViewHandler
 	{
-		public static PropertyMapper<IRefreshView, IRefreshViewHandler> Mapper = new PropertyMapper<IRefreshView, IRefreshViewHandler>(ViewHandler.ViewMapper)
+		public static IPropertyMapper<IRefreshView, IRefreshViewHandler> Mapper = new PropertyMapper<IRefreshView, IRefreshViewHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(IRefreshView.IsRefreshing)] = MapIsRefreshing,
 			[nameof(IRefreshView.Content)] = MapContent,
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		}
 
-		public RefreshViewHandler(PropertyMapper? mapper = null) : base(mapper ?? Mapper)
+		public RefreshViewHandler(IPropertyMapper? mapper = null) : base(mapper ?? Mapper)
 		{
 		}
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class WebViewHandler : IWebViewHandler
 	{
-		public static PropertyMapper<IWebView, IWebViewHandler> Mapper = new PropertyMapper<IWebView, IWebViewHandler>(ViewHandler.ViewMapper)
+		public static IPropertyMapper<IWebView, IWebViewHandler> Mapper = new PropertyMapper<IWebView, IWebViewHandler>(ViewHandler.ViewMapper)
 		{
 			[nameof(IWebView.Source)] = MapSource,
 #if __ANDROID__


### PR DESCRIPTION
### Description of Change

For consistency and extensibility options, use `IPropertyMapper` in some pending handlers. With this changes we use IPropertyMapper in all the handlers.