### PR TITLE
[WinUI] Make EmptyViewContentControl be on top so it gets click events

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemsViewStyles.xaml
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemsViewStyles.xaml
@@ -136,8 +136,7 @@
                 <ControlTemplate TargetType="local:FormsGridView">
                     <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}">
                         <Grid>
-                            <ContentControl x:Name="EmptyViewContentControl" 
-                                            HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"/>
+                          
                             <ScrollViewer x:Name="ScrollViewer"
                             TabNavigation="{TemplateBinding TabNavigation}"
                             HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
@@ -160,6 +159,8 @@
                                 FooterTransitions="{TemplateBinding FooterTransitions}"
                                 Padding="{TemplateBinding Padding}" />
                             </ScrollViewer>
+                            <ContentControl x:Name="EmptyViewContentControl" 
+                                            HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"/>
                         </Grid>
                     </Border>
                 </ControlTemplate>


### PR DESCRIPTION
### Description of Change

The  EmptyViewContentControl  was bellow the scrollviewer so it wasn't getting events, moving upper will work fine since the 
EmptyViewContentControl  is changed on code so it's Collapsed when we have items, allowing events to go to the ScrollView

### Issues Fixed

Fixes #3013 

To test : Make sure "Clicked" is printed on debug output

Add to the EmptyViewViewGallery.xaml

``` 
<Button Text="Does this work" Clicked="ButtonClicked" Background="White" TextColor="Blue"/>
```

On EmptyViewViewGallery.xaml.cs

```
void ButtonClicked(object sender, EventArgs e) => System.Diagnostics.Debug.WriteLine("Clicked");
```