### PR TITLE
Disable ViewPager2 interaction if there are no tabs

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
@@ -232,9 +232,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			_tablayout.Visibility = (SectionController.GetItems().Count > 1) ? ViewStates.Visible : ViewStates.Gone;
 			if (_tablayout.Visibility == ViewStates.Gone)
+			{
+				SetViewPager2UserInputEnabled(false);
 				_viewPager.ImportantForAccessibility = ImportantForAccessibility.No;
+			}
 			else
+			{
+				SetViewPager2UserInputEnabled(true);
 				_viewPager.ImportantForAccessibility = ImportantForAccessibility.Auto;
+			}
+		}
+
+		protected virtual void SetViewPager2UserInputEnabled(bool value)
+		{
+			_viewPager.UserInputEnabled = value;
 		}
 
 		protected virtual void OnShellItemPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change

If the user doesn't have any tabs then we need to disable `UserInteraction` on the ViewPager2. If we don't then it makes horizontal scrolling on any child elements (CarouselView, WebView, etc...) not possible.

The longer term fix will be to build this behavior into each of those controls so that they can work successfully inside tabs but for now this fixes people who aren't using any tabs. 
### Issues Fixed


Fixes #6877
Fixes #6062
