### PR TITLE
Include route parameters when switching flyouts

### DIFF
--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -583,7 +583,33 @@ namespace Microsoft.Maui.Controls
 				}
 				else
 				{
-					return GoToAsync(state);
+					var navStack = shellSection.Navigation.NavigationStack;
+					var topNavStackPage = navStack.Count > 0 ? navStack[navStack.Count -1] : null;
+
+					var queryParametersTarget =
+						topNavStackPage as BindableObject ??
+						(shellContent?.Content as BindableObject) ??
+						shellContent;
+
+					ShellRouteParameters routeParameters = null;
+
+					if (queryParametersTarget?.GetValue(ShellContent.QueryAttributesProperty) is
+						ShellRouteParameters shellRouteParameters)
+					{
+						routeParameters = shellRouteParameters;
+					}
+
+					var navParameters = new ShellNavigationParameters()
+					{
+						TargetState = state,
+						Animated = false,
+						EnableRelativeShellRoutes = false,
+						DeferredArgs = null,
+						Parameters = routeParameters
+					};
+
+					return _navigationManager
+						.GoToAsync(navParameters);
 				}
 			}
 

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -546,10 +546,9 @@ namespace Microsoft.Maui.Controls
 				shellSection.PropertyChanged += OnShellItemPropertyChanged;
 			else
 			{
-				var state = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, shellSection.Navigation.NavigationStack, null);
-
 				if (this.CurrentItem == null)
 				{
+					var state = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, shellSection.Navigation.NavigationStack, null);
 					var requestBuilder = new RouteRequestBuilder(new List<string>()
 					{
 						shellItem.Route,
@@ -583,30 +582,7 @@ namespace Microsoft.Maui.Controls
 				}
 				else
 				{
-					var navStack = shellSection.Navigation.NavigationStack;
-					var topNavStackPage = navStack.Count > 0 ? navStack[navStack.Count -1] : null;
-
-					var queryParametersTarget =
-						topNavStackPage as BindableObject ??
-						(shellContent?.Content as BindableObject) ??
-						shellContent;
-
-					ShellRouteParameters routeParameters = null;
-
-					if (queryParametersTarget?.GetValue(ShellContent.QueryAttributesProperty) is
-						ShellRouteParameters shellRouteParameters)
-					{
-						routeParameters = shellRouteParameters;
-					}
-
-					var navParameters = new ShellNavigationParameters()
-					{
-						TargetState = state,
-						Animated = false,
-						EnableRelativeShellRoutes = false,
-						DeferredArgs = null,
-						Parameters = routeParameters
-					};
+					var navParameters = ShellNavigationManager.GetNavigationParameters(shellItem, shellSection, shellContent, shellSection.Navigation.NavigationStack, null);
 
 					return _navigationManager
 						.GoToAsync(navParameters);

--- a/src/Controls/src/Core/Shell/ShellNavigationManager.cs
+++ b/src/Controls/src/Core/Shell/ShellNavigationManager.cs
@@ -461,6 +461,43 @@ namespace Microsoft.Maui.Controls
 			return lookupDict;
 		}
 
+		public static ShellNavigationParameters GetNavigationParameters(
+			ShellItem shellItem,
+			ShellSection shellSection, 
+			ShellContent shellContent, 
+			IReadOnlyList<Page> sectionStack, 
+			IReadOnlyList<Page> modalStack)
+		{
+			var state = GetNavigationState(shellItem, shellSection, shellContent, sectionStack, modalStack);
+			var navStack = shellSection.Navigation.NavigationStack;
+
+			var topNavStackPage =
+				(modalStack?.Count > 0 ? modalStack[modalStack.Count - 1] : null) ??
+				(navStack?.Count > 0 ? navStack[navStack.Count - 1] : null);
+
+			var queryParametersTarget =
+				topNavStackPage as BindableObject ??
+				(shellContent?.Content as BindableObject) ??
+				shellContent;
+
+			ShellRouteParameters routeParameters = null;
+
+			if (queryParametersTarget?.GetValue(ShellContent.QueryAttributesProperty) is
+				ShellRouteParameters shellRouteParameters)
+			{
+				routeParameters = shellRouteParameters;
+			}
+
+			return new ShellNavigationParameters()
+			{
+				TargetState = state,
+				Animated = false,
+				EnableRelativeShellRoutes = false,
+				DeferredArgs = null,
+				Parameters = routeParameters
+			};
+		}
+
 		public static ShellNavigationState GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, IReadOnlyList<Page> sectionStack, IReadOnlyList<Page> modalStack)
 		{
 			List<string> routeStack = new List<string>();

--- a/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellParameterPassingTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -150,6 +151,56 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var testPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ShellTestPage;
 			Assert.AreEqual("4321", testPage.SomeQueryParameter);
+		}
+
+		[Test]
+		public async Task NavigationBetweenFlyoutItemsRetainsQueryString()
+		{
+			var testPage1 = new ShellTestPage();
+			var testPage2 = new ShellTestPage();
+
+			var flyoutItem1 = CreateShellItem<FlyoutItem>(testPage1, shellItemRoute: "flyoutItem1");
+			var flyoutItem2 = CreateShellItem<FlyoutItem>(testPage2, shellItemRoute: "flyoutItem2");
+
+			var shell = new TestShell(flyoutItem1, flyoutItem2);
+			var complexParameter = new object();
+
+			IShellController shellController = shell;
+			await shell.GoToAsync(new ShellNavigationState($"//flyoutItem2?{nameof(ShellTestPage.SomeQueryParameter)}=1234"), false,
+				new Dictionary<string, object>()
+				{
+					{nameof(ShellTestPage.ComplexObject), complexParameter }
+				});
+
+			Assert.AreEqual("1234", testPage2.SomeQueryParameter);
+			Assert.AreEqual(complexParameter, testPage2.ComplexObject);
+			await shellController.OnFlyoutItemSelectedAsync(flyoutItem1);
+			await shellController.OnFlyoutItemSelectedAsync(flyoutItem2);
+			Assert.AreEqual("1234", testPage2.SomeQueryParameter);
+			Assert.AreEqual(complexParameter, testPage2.ComplexObject);
+		}
+
+		[Test]
+		public async Task NavigationBetweenFlyoutItemWithPushedPageRetainsQueryString()
+		{
+			var testPage1 = new ShellTestPage();
+			var testPage2 = new ShellTestPage();
+
+			var flyoutItem1 = CreateShellItem<FlyoutItem>(testPage1, shellItemRoute: "flyoutItem1");
+			var flyoutItem2 = CreateShellItem<FlyoutItem>(testPage2, shellItemRoute: "flyoutItem2");
+			Routing.RegisterRoute("details", typeof(ShellTestPage));
+
+
+			var shell = new TestShell(flyoutItem1, flyoutItem2);
+
+			IShellController shellController = shell;
+			await shell.GoToAsync(new ShellNavigationState($"//flyoutItem2/details?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+
+			await shellController.OnFlyoutItemSelectedAsync(flyoutItem1);
+			await shellController.OnFlyoutItemSelectedAsync(flyoutItem2);
+
+			var testPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ShellTestPage;
+			Assert.AreEqual("1234", testPage.SomeQueryParameter);
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change

When switching between flyouts be sure to include the incoming contents route parameters so they aren't lost.

### Issues Fixed

Fixes #6698
