### PR TITLE
Respect BarTextColor in Windows MenuBar

### DIFF
--- a/src/Controls/src/Core/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPageToolbar.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Maui.Controls
 			TitleIcon = NavigationPage.GetTitleIconImageSource(currentPage);
 
 			BarBackground = navigationPage.BarBackground;
-			if (Brush.IsNullOrEmpty(navigationPage.BarBackground) &&
+			if (Brush.IsNullOrEmpty(BarBackground) &&
 				navigationPage.BarBackgroundColor != null)
 			{
 				BarBackground = new SolidColorBrush(navigationPage.BarBackgroundColor);

--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -75,8 +75,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void UpdateBarTextColor(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
-			if (toolbar.BarTextColor != null)
-				platformToolbar.TitleColor = toolbar.BarTextColor.ToPlatform();
+			Color barTextColor = toolbar.BarTextColor;
+			if (barTextColor != null)
+				platformToolbar.SetBarTextColor(barTextColor.ToPlatform());
 		}
 
 		public static void UpdateToolbarDynamicOverflowEnabled(this MauiToolbar platformToolbar, Toolbar toolbar)

--- a/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/ToolbarExtensions.cs
@@ -75,9 +75,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void UpdateBarTextColor(this MauiToolbar platformToolbar, Toolbar toolbar)
 		{
-			Color barTextColor = toolbar.BarTextColor;
-			if (barTextColor != null)
-				platformToolbar.SetBarTextColor(barTextColor.ToPlatform());
+			platformToolbar.SetBarTextColor(toolbar.BarTextColor?.ToPlatform());
 		}
 
 		public static void UpdateToolbarDynamicOverflowEnabled(this MauiToolbar platformToolbar, Toolbar toolbar)

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -86,7 +86,10 @@ namespace Microsoft.Maui.Platform
 
 		internal void SetBarTextColor(WBrush? brush)
 		{
-			title.Foreground = brush;
+			if (brush != null)
+			{
+				title.Foreground = brush;
+			}
 
 			_menuBarForeground = brush;
 			UpdateMenuBarForeground();

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -1,8 +1,8 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WBrush = Microsoft.UI.Xaml.Media.Brush;
-using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
 using WImage = Microsoft.UI.Xaml.Controls.Image;
+using WImageSource = Microsoft.UI.Xaml.Media.ImageSource;
 
 namespace Microsoft.Maui.Platform
 {
@@ -83,10 +83,12 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal WBrush? TitleColor
+		internal void SetBarTextColor(WBrush brush)
 		{
-			get => title.Foreground;
-			set => title.Foreground = value;
+			title.Foreground = brush;
+
+			menuContent.Foreground = brush;
+			UpdateMenuBarForeground();
 		}
 
 		internal CommandBar CommandBar => commandBar;
@@ -179,20 +181,32 @@ namespace Microsoft.Maui.Platform
 		internal void SetMenuBar(MenuBar? menuBar)
 		{
 			_menuBar = menuBar;
-			UpdateMenuBar();
-		}
 
-		void UpdateMenuBar()
-		{
-			if (menuContent == null)
-				return;
 
 			menuContent.Content = _menuBar;
+			UpdateMenuBarForeground();
 
 			if (_menuBar == null || _menuBar.Items.Count == 0)
 				menuContent.Visibility = UI.Xaml.Visibility.Collapsed;
 			else
 				menuContent.Visibility = UI.Xaml.Visibility.Visible;
+		}
+
+		void UpdateMenuBarForeground()
+		{
+			if (_menuBar is null)
+				return;
+
+			WBrush menuForegroundBrush = menuContent.Foreground;
+
+			// MenuBarItems currently don't respect the Foreground property due to https://github.com/microsoft/microsoft-ui-xaml/issues/7070
+			// Work around this by setting the Button's colors in the MenuBar's ResourceDictionary
+
+			ResourceDictionary dictionary = _menuBar.Resources;
+			dictionary["ButtonForeground"] = menuForegroundBrush;
+			dictionary["ButtonForegroundPointerOver"] = menuForegroundBrush;
+			dictionary["ButtonForegroundPressed"] = menuForegroundBrush;
+			dictionary["ButtonForegroundDisabled"] = menuForegroundBrush;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Platform
 				new PropertyMetadata(true));
 
 		MenuBar? _menuBar;
+		WBrush? _menuBarForeground;
 		private Button? _navigationViewBackButton;
 		private Button? _togglePaneButton;
 		private Graphics.Color? _iconColor;
@@ -83,11 +84,11 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal void SetBarTextColor(WBrush brush)
+		internal void SetBarTextColor(WBrush? brush)
 		{
 			title.Foreground = brush;
 
-			menuContent.Foreground = brush;
+			_menuBarForeground = brush;
 			UpdateMenuBarForeground();
 		}
 
@@ -182,7 +183,6 @@ namespace Microsoft.Maui.Platform
 		{
 			_menuBar = menuBar;
 
-
 			menuContent.Content = _menuBar;
 			UpdateMenuBarForeground();
 
@@ -197,16 +197,25 @@ namespace Microsoft.Maui.Platform
 			if (_menuBar is null)
 				return;
 
-			WBrush menuForegroundBrush = menuContent.Foreground;
-
 			// MenuBarItems currently don't respect the Foreground property due to https://github.com/microsoft/microsoft-ui-xaml/issues/7070
 			// Work around this by setting the Button's colors in the MenuBar's ResourceDictionary
 
 			ResourceDictionary dictionary = _menuBar.Resources;
-			dictionary["ButtonForeground"] = menuForegroundBrush;
-			dictionary["ButtonForegroundPointerOver"] = menuForegroundBrush;
-			dictionary["ButtonForegroundPressed"] = menuForegroundBrush;
-			dictionary["ButtonForegroundDisabled"] = menuForegroundBrush;
+			WBrush? menuForegroundBrush = _menuBarForeground;
+			if (menuForegroundBrush is null)
+			{
+				dictionary.Remove("ButtonForeground");
+				dictionary.Remove("ButtonForegroundPointerOver");
+				dictionary.Remove("ButtonForegroundPressed");
+				dictionary.Remove("ButtonForegroundDisabled");
+			}
+			else
+			{
+				dictionary["ButtonForeground"] = menuForegroundBrush;
+				dictionary["ButtonForegroundPointerOver"] = menuForegroundBrush;
+				dictionary["ButtonForegroundPressed"] = menuForegroundBrush;
+				dictionary["ButtonForegroundDisabled"] = menuForegroundBrush;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Windows MauiToolbar is not respecting the BarTextColor in the MenuBar. Currently, BarTextColor is only setting the Title's Foreground. If someone sets the BarBackgroundColor, and the BarTextColor is ignored, you can get a menu bar that is not readable.

The fix is to propagate the BarTextColor to the MenuBar. However, the fix isn't as simple due to https://github.com/microsoft/microsoft-ui-xaml/issues/7070. Working around that issue by setting the Button's Foreground colors in the MenuBar's ResourceDictionary.

Fix #5554
