### PR TITLE
Fix Maui.Controls.Sample Blazor dynamic root components trimming problem.

### DIFF
--- a/src/BlazorWebView/src/Maui/RootComponentsCollection.cs
+++ b/src/BlazorWebView/src/Maui/RootComponentsCollection.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components.Web;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -13,7 +12,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// Initializes a new instance of <see cref="RootComponentsCollection"/>.
 		/// </summary>
 		/// <param name="jsComponents">Configuration to enable JS component support.</param>
-		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicMethods, typeof(JSComponentConfigurationStore))]
 		public RootComponentsCollection(JSComponentConfigurationStore jsComponents)
 		{
 			JSComponents = jsComponents;

--- a/src/BlazorWebView/src/Maui/RootComponentsCollection.cs
+++ b/src/BlazorWebView/src/Maui/RootComponentsCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components.Web;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
@@ -12,6 +13,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// Initializes a new instance of <see cref="RootComponentsCollection"/>.
 		/// </summary>
 		/// <param name="jsComponents">Configuration to enable JS component support.</param>
+		[DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicMethods, typeof(JSComponentConfigurationStore))]
 		public RootComponentsCollection(JSComponentConfigurationStore jsComponents)
 		{
 			JSComponents = jsComponents;

--- a/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Blazor/BlazorPage.xaml.cs
@@ -14,7 +14,7 @@ namespace Maui.Controls.Sample.Pages
 			InitializeComponent();
 
 #if NET6_0_OR_GREATER
-			bwv.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component");
+			bwv.RootComponents.RegisterForJavaScript<MyDynamicComponent>("my-dynamic-root-component", javaScriptInitializer: "myDynamicRootComponentInitializer");
 #endif
 		}
 	}


### PR DESCRIPTION
### Description of Change

Updated the `Maui.Controls.Sample` project to use the correct `JSComponentConfigurationExtensions.RegisterForJavaScript()` overload that permits adding root components via JavaScript in a linker-friendly manner.

### Issues Fixed

Fixes #6965 
