### PR TITLE
Fix WinUI fully templated RadioButton

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Frame.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Frame.Impl.cs
@@ -31,39 +31,5 @@ namespace Microsoft.Maui.Controls
 				return null;
 			}
 		}
-
-		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
-		{
-			Thickness contentMargin = (Content as IView)?.Margin ?? Thickness.Zero;
-			Thickness padding = Padding;
-			Thickness margin = Margin;
-
-			// Account for the Frame's margins and padding and use the rest of the available space to measure the actual Content
-			var contentWidthConstraint = widthConstraint - margin.HorizontalThickness - padding.HorizontalThickness;
-			var contentHeightConstraint = heightConstraint - margin.VerticalThickness - padding.VerticalThickness;
-			var contentSize = (this as IContentView).CrossPlatformMeasure(contentWidthConstraint, contentHeightConstraint);
-
-			// We'll use ResolveConstraints to make sure we're sticking within any explicit Height/Width values or externally
-			// imposed constraints
-			var width = (this as IView).Width;
-			var height = (this as IView).Height;
-
-			var desiredWidth = ResolveConstraints(widthConstraint, width, contentSize.Width + margin.HorizontalThickness);
-			var desiredHeight = ResolveConstraints(heightConstraint, height, contentSize.Height + margin.VerticalThickness);
-
-			DesiredSize = new Size(desiredWidth + margin.HorizontalThickness, desiredHeight + margin.VerticalThickness);
-
-			return DesiredSize;
-		}
-
-		protected override Size ArrangeOverride(Rect bounds)
-		{
-			Frame = this.ComputeFrame(bounds);
-			Handler?.PlatformArrange(Frame);
-
-			(this as IContentView).CrossPlatformArrange(new Rect(Point.Zero, Frame.Size));
-
-			return Frame.Size;
-		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Windows.cs
@@ -1,0 +1,25 @@
+﻿#nullable enable
+
+using Microsoft.UI.Xaml;
+using Windows.Foundation;
+
+namespace Microsoft.Maui.Controls
+{
+	public partial class RadioButton
+	{
+		public static void MapContent(RadioButtonHandler handler, RadioButton radioButton)
+		{
+			if (radioButton.ResolveControlTemplate() != null)
+			{
+				handler.PlatformView.Style =
+					UI.Xaml.Application.Current.Resources["RadioButtonControlStyle"] as UI.Xaml.Style;
+			}
+			else
+			{
+				handler.PlatformView.ClearValue(FrameworkElement.StyleProperty);
+			}
+
+			RadioButtonHandler.MapContent(handler, radioButton);
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Controls
 		public static IPropertyMapper<RadioButton, RadioButtonHandler> ControlsRadioButtonMapper =
 			   new PropertyMapper<RadioButton, RadioButtonHandler>(RadioButtonHandler.Mapper)
 			   {
-#if IOS || ANDROID
+#if IOS || ANDROID || WINDOWS
 				   [nameof(IRadioButton.Content)] = MapContent
 #endif
 			   };

--- a/src/Controls/src/Core/Platform/Windows/Styles/RadioButtonControlStyle.xaml
+++ b/src/Controls/src/Core/Platform/Windows/Styles/RadioButtonControlStyle.xaml
@@ -1,0 +1,15 @@
+<ResourceDictionary
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:maui="using:Microsoft.Maui.Platform">
+
+    <Style TargetType="RadioButton" x:Key="RadioButtonControlStyle">
+		<Setter Property="Template">
+			<Setter.Value>
+                <ControlTemplate TargetType="RadioButton">
+                    <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" />                     
+                </ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+</ResourceDictionary> 

--- a/src/Controls/src/Core/Platform/Windows/Styles/Resources.xaml
+++ b/src/Controls/src/Core/Platform/Windows/Styles/Resources.xaml
@@ -5,6 +5,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="MauiControlsPageControlStyle.xaml" />
+        <ResourceDictionary Source="RadioButtonControlStyle.xaml" />
         <ResourceDictionary Source="ShellStyles.xaml" />
         <ResourceDictionary Source="../CollectionView/ItemsViewStyles.xaml" />
         <ResourceDictionary Source="../TabbedPage/TabbedPageStyle.xaml" />


### PR DESCRIPTION
### Description of Change

When fully templated WinUI needs to swap out the platform control for a `ContentPanel` so it's fully rendered from MAUI controls and not using the platform button at all
