### PR TITLE
Ignore content measurement requests with zero values

### DIFF
--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.Platform
 
 		protected override global::Windows.Foundation.Size MeasureOverride(global::Windows.Foundation.Size availableSize)
 		{
-			if (CrossPlatformMeasure == null)
+			if (CrossPlatformMeasure == null || (availableSize.Width * availableSize.Height == 0))
 			{
 				return base.MeasureOverride(availableSize);
 			}


### PR DESCRIPTION
### Description of Change

For some reason, Windows will occasionally attempt to measure the ContentPanel at a size of zero,zero. This measurement call doesn't come from any of our layout passes, but it disrupts all of the subsequent desired size values.

This change just passes the zero values on the the base MeasureOverride and does not make another cross-platform measure pass when they occur. This at least fixes the issue for the moment; hopefully at some point in the future we can determine why the platform attempts to make these zero,zero measurements.

### Issues Fixed

Fixes #6808
