### PR TITLE
[Windows] Set WinUI picker description to title

### DIFF
--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -46,9 +46,10 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapReload(IPickerHandler handler, IPicker picker, object? args) => Reload(handler);
 
-		public static void MapTitle(IPickerHandler handler, IPicker picker) 
+		public static void MapTitle(IPickerHandler handler, IPicker picker)
 		{
 			handler.PlatformView?.UpdateTitle(picker);
+			handler.UpdateValue(nameof(IView.Semantics));
 		}
 
 		public static void MapTitleColor(IPickerHandler handler, IPicker picker)
@@ -66,12 +67,12 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateSelectedIndex(picker);
 		}
 
-		public static void MapCharacterSpacing(IPickerHandler handler, IPicker picker) 
+		public static void MapCharacterSpacing(IPickerHandler handler, IPicker picker)
 		{
 			handler.PlatformView?.UpdateCharacterSpacing(picker);
 		}
 
-		public static void MapFont(IPickerHandler handler, IPicker picker) 
+		public static void MapFont(IPickerHandler handler, IPicker picker)
 		{
 			var fontManager = handler.GetRequiredService<IFontManager>();
 
@@ -90,7 +91,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			handler.PlatformView?.UpdateHorizontalTextAlignment(picker);
 		}
-		
+
 		public static void MapVerticalTextAlignment(IPickerHandler handler, IPicker picker)
 		{
 			handler.PlatformView?.UpdateVerticalTextAlignment(picker);

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -137,27 +137,18 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateSemantics(this FrameworkElement platformView, IView view)
 		{
-			var semantics = view.GetSemantics();
+			var semantics = view.Semantics;
+
+			if (view is IPicker picker && string.IsNullOrEmpty(semantics?.Description))
+				AutomationProperties.SetName(platformView, picker.Title);
+			else if (semantics != null)
+				AutomationProperties.SetName(platformView, semantics.Description);
 
 			if (semantics == null)
 				return;
 
-			AutomationProperties.SetName(platformView, semantics.Description);
 			AutomationProperties.SetHelpText(platformView, semantics.Hint);
 			AutomationProperties.SetHeadingLevel(platformView, (UI.Xaml.Automation.Peers.AutomationHeadingLevel)((int)semantics.HeadingLevel));
-		}
-
-		internal static Semantics? GetSemantics(this IView view)
-		{
-			var semantics = view.Semantics;
-
-			if (view is IPicker picker && string.IsNullOrEmpty(semantics?.Description))
-			{
-				semantics ??= new Semantics();
-				semantics.Description = picker.Title;
-			}
-
-			return semantics;
 		}
 
 		internal static void UpdateProperty(this FrameworkElement platformControl, DependencyProperty property, Color color)

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateSemantics(this FrameworkElement platformView, IView view)
 		{
-			var semantics = view.Semantics;
+			var semantics = view.GetSemantics();
 
 			if (semantics == null)
 				return;
@@ -145,6 +145,19 @@ namespace Microsoft.Maui.Platform
 			AutomationProperties.SetName(platformView, semantics.Description);
 			AutomationProperties.SetHelpText(platformView, semantics.Hint);
 			AutomationProperties.SetHeadingLevel(platformView, (UI.Xaml.Automation.Peers.AutomationHeadingLevel)((int)semantics.HeadingLevel));
+		}
+
+		internal static Semantics? GetSemantics(this IView view)
+		{
+			var semantics = view.Semantics;
+
+			if (view is IPicker picker && string.IsNullOrEmpty(semantics?.Description))
+			{
+				semantics ??= new Semantics();
+				semantics.Description = picker.Title;
+			}
+
+			return semantics;
 		}
 
 		internal static void UpdateProperty(this FrameworkElement platformControl, DependencyProperty property, Color color)


### PR DESCRIPTION
### Description of Change

Set picker title to be read out when WinUI picker receives screen reader focus
(before this PR, the picker title did not get read out at all in any circumstance)

### Issues Fixed

Fixes #6928
