### PR TITLE
[Android] Set ViewIdResourceName for UI Automators

### DIFF
--- a/src/Core/src/Platform/Android/SemanticExtensions.cs
+++ b/src/Core/src/Platform/Android/SemanticExtensions.cs
@@ -89,6 +89,14 @@ namespace Microsoft.Maui.Platform
 
 			if (!string.IsNullOrWhiteSpace(newText))
 				info.Text = newText;
+
+			if (!string.IsNullOrWhiteSpace(virtualView.AutomationId) &&
+				platformView?.Context != null)
+			{
+				// This is used by Appium and other automation testing frameworks
+				// to locate views
+				info.ViewIdResourceName = $"{platformView.Context.PackageName}:id/{virtualView.AutomationId}";
+			}
 		}
 
 		public static void UpdateSemantics(this View platformView, IView view)


### PR DESCRIPTION
### Description of Change
Call `setViewIdResourceName` with our AutomationId. This lets UI Automation tools, like Appium, search for elements without depending on the contentDesc. Ideally we can remove setting `contentDesc` completely but we'll need to test with Xamarin.UITest first

### Issues Fixed
Fixes #4714
Fixes #3260