### PR TITLE
[X] Process ContentProperty before Add()

### DIFF
--- a/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
+++ b/src/Controls/src/Build.Tasks/SetPropertiesVisitor.cs
@@ -145,6 +145,15 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					Context.IL.Append(parentVar.LoadAs(Module.GetTypeDefinition(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "ResourceDictionary")), Module));
 					Context.IL.Append(AddToResourceDictionary(parentVar, node, node, Context));
 				}
+				else if ((contentProperty = GetContentProperty(parentVar.VariableType)) != null)
+				{
+					var name = new XmlName(node.NamespaceURI, contentProperty);
+					if (skips.Contains(name))
+						return;
+					if (parentNode is IElementNode && ((IElementNode)parentNode).SkipProperties.Contains(propertyName))
+						return;
+					Context.IL.Append(SetPropertyValue(Context.Variables[(IElementNode)parentNode], name, node, Context, node));
+				}
 				// Collection element, implicit content, or implicit collection element.
 				else if (parentVar.VariableType.ImplementsInterface(Module.ImportReference(("mscorlib", "System.Collections", "IEnumerable")))
 						 && parentVar.VariableType.GetMethods(md => md.Name == "Add" && md.Parameters.Count == 1, Module).Any())
@@ -160,15 +169,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					if (adderRef.ReturnType.FullName != "System.Void")
 						Context.IL.Emit(Pop);
 				}
-				else if ((contentProperty = GetContentProperty(parentVar.VariableType)) != null)
-				{
-					var name = new XmlName(node.NamespaceURI, contentProperty);
-					if (skips.Contains(name))
-						return;
-					if (parentNode is IElementNode && ((IElementNode)parentNode).SkipProperties.Contains(propertyName))
-						return;
-					Context.IL.Append(SetPropertyValue(Context.Variables[(IElementNode)parentNode], name, node, Context, node));
-				}
+
 				else
 					throw new BuildException(BuildExceptionCode.ContentPropertyAttributeMissing, node, null, ((IElementNode)parentNode).XmlType.Name);
 			}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui6944.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui6944.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Microsoft.Maui.Controls.Xaml.UnitTests"
+             x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Maui6944">
+    <local:Maui6944Layout x:Name="layout">
+        <Label x:Name="label"/>
+    </local:Maui6944Layout>
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Maui6944.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Maui6944.xaml.cs
@@ -1,0 +1,52 @@
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.Core.UnitTests;
+using Microsoft.Maui.Devices;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Maui6944 : ContentPage
+	{
+		public Maui6944() => InitializeComponent();
+		public Maui6944(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Test
+		{
+			[SetUp] public void Setup() => AppInfo.SetCurrent(new MockAppInfo());
+			[TearDown] public void TearDown() => AppInfo.SetCurrent(null);
+
+			[Test]
+			public void ContentPropertyAttributeOnLayoutSubclass([Values(false, true)] bool useCompiledXaml)
+			{
+				var page = new Maui6944(useCompiledXaml);
+				Assert.That(page.layout, Is.Not.Null);
+				Assert.That(page.layout, Is.TypeOf<Maui6944Layout>());
+				Assert.That(page.layout.ChildContent, Is.EqualTo(page.label));
+			}
+		}
+	}
+
+	public class Maui6944Base : Grid
+	{
+	}
+
+	[ContentProperty("ChildContent")]
+	public class Maui6944Layout : Maui6944Base
+	{
+		public static readonly BindableProperty ChildContentProperty =
+			BindableProperty.Create(
+				nameof(ChildContent),
+				typeof(View), typeof(Maui6944Layout),
+				defaultValue: null);
+
+		public View ChildContent {
+			get => (View)GetValue(ChildContentProperty);
+			set => SetValue(ChildContentProperty, value);
+		}
+
+	}
+}


### PR DESCRIPTION
### Description of Change

We added IEnumerable interface, and Add() methods, to Layouts in MAUI.
As the XAML inflaters were trying to Add() before looking for a
ContentProperty,
 1/ ContentProperty on Layout (like Grid) is completely ignored (but
layouts works nonetheless, because of belt and suspenders).
 2/ overriding the ContentProperty is ignored (as found in #6944)

This PR changes the order of Add() and ContentProperty processing, and
restore the expected behavior, without breaking any other unit test.

### Issues Fixed

- fixes #6944
