### PR TITLE
Don't set the Switch.IsOn unnecessarily

### DIFF
--- a/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Handlers
 
 		void OnCheckedChanged(bool isOn)
 		{
-			if (VirtualView == null)
+			if (VirtualView is null || VirtualView.IsOn == isOn)
 				return;
 
 			VirtualView.IsOn = isOn;

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Tizen.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Handlers
 
 		void OnStateChanged(object? sender, EventArgs e)
 		{
-			if (VirtualView == null || PlatformView == null)
+			if (VirtualView is null || PlatformView is null || VirtualView.IsOn == PlatformView.IsChecked)
 				return;
 
 			VirtualView.IsOn = PlatformView.IsChecked;

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Windows.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Maui.Handlers
 
 		void OnToggled(object sender, UI.Xaml.RoutedEventArgs e)
 		{
-			if (VirtualView == null || PlatformView == null)
+			if (VirtualView is null || PlatformView is null || VirtualView.IsOn == PlatformView.IsOn)
 				return;
 
 			VirtualView.IsOn = PlatformView.IsOn;

--- a/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
@@ -43,11 +43,10 @@ namespace Microsoft.Maui.Handlers
 
 		void OnControlValueChanged(object? sender, EventArgs e)
 		{
-			if (VirtualView == null)
+			if (VirtualView is null || PlatformView is null || VirtualView.IsOn == PlatformView.On)
 				return;
 
-			if (PlatformView != null)
-				VirtualView.IsOn = PlatformView.On;
+			VirtualView.IsOn = PlatformView.On;
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -47,10 +47,11 @@
     <Compile Remove="Handlers\*\*.cs" />
     <Compile Include="Handlers\ActivityIndicator\*.cs" />
     <Compile Include="Handlers\Button\*.cs" />
-    <Compile Include="Handlers\Navigation\*.cs" />
-    <Compile Include="Handlers\View\*.cs" />
     <Compile Include="Handlers\Layout\*.cs" />
+    <Compile Include="Handlers\Navigation\*.cs" />
     <Compile Include="Handlers\RadioButton\*.cs" />
+    <Compile Include="Handlers\Switch\*.cs" />
+    <Compile Include="Handlers\View\*.cs" />
     <Compile Include="Handlers\Window\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.TestUtils.DeviceTests.Runners;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -42,6 +45,9 @@ namespace Microsoft.Maui.DeviceTests
 					fonts.AddFont("LobsterTwo-Italic.ttf", "Lobster Two Italic");
 					fonts.AddFont("LobsterTwo-BoldItalic.ttf", "Lobster Two BoldItalic");
 				});
+
+			appBuilder.Services.AddSingleton<IDispatcherProvider>(svc => TestDispatcher.Provider);
+			appBuilder.Services.AddScoped<IDispatcher>(svc => TestDispatcher.Current);
 
 			_mauiApp = appBuilder.Build();
 			_servicesProvider = _mauiApp.Services;

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Windows.cs
@@ -136,14 +136,20 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.NotEqual(inputTransparent, uie);
 		}
 
-		protected Maui.Graphics.Rect GetPlatformViewBounds(IViewHandler viewHandler) =>
-			((FrameworkElement)viewHandler.PlatformView).GetPlatformViewBounds();
+		protected Task<Maui.Graphics.Rect> GetPlatformViewBounds(IViewHandler viewHandler)
+		{
+			var fe = (FrameworkElement)viewHandler.PlatformView;
+			return fe.AttachAndRun(() => fe.GetPlatformViewBounds());
+		}
 
 		protected System.Numerics.Matrix4x4 GetViewTransform(IViewHandler viewHandler) =>
 			((FrameworkElement)viewHandler.PlatformView).GetViewTransform();
 
-		protected Maui.Graphics.Rect GetBoundingBox(IViewHandler viewHandler) =>
-			((FrameworkElement)viewHandler.PlatformView).GetBoundingBox();
+		protected Task<Maui.Graphics.Rect> GetBoundingBox(IViewHandler viewHandler)
+		{
+			var fe = (FrameworkElement)viewHandler.PlatformView;
+			return fe.AttachAndRun(() => fe.GetBoundingBox());
+		}
 
 		protected string GetAutomationId(IViewHandler viewHandler) =>
 			AutomationProperties.GetAutomationId((FrameworkElement)viewHandler.PlatformView);

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Maui.DeviceTests
 		protected THandler CreateHandler(IView view, IMauiContext mauiContext = null) =>
 			CreateHandler<THandler>(view, mauiContext);
 
-		protected async Task<THandler> CreateHandlerAsync(IView view)
+		protected Task<THandler> CreateHandlerAsync(IView view)
 		{
-			return await InvokeOnMainThreadAsync(() =>
+			return InvokeOnMainThreadAsync(() =>
 			{
 				return CreateHandler(view);
 			});
@@ -37,10 +37,10 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected Task<TValue> GetValueAsync<TValue>(IView view, Func<THandler, Task<TValue>> func)
 		{
-			return InvokeOnMainThreadAsync(async () =>
+			return InvokeOnMainThreadAsync(() =>
 			{
 				var handler = CreateHandler(view);
-				return await func(handler);
+				return func(handler);
 			});
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.Windows.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Color = Microsoft.Maui.Graphics.Color;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class SwitchHandlerTests
+	{
+		void SetIsOn(SwitchHandler switchHandler, bool value) =>
+			GetNativeSwitch(switchHandler).IsOn = value;
+
+		ToggleSwitch GetNativeSwitch(SwitchHandler switchHandler) =>
+			(ToggleSwitch)switchHandler.PlatformView;
+
+		bool GetNativeIsOn(SwitchHandler switchHandler) =>
+			GetNativeSwitch(switchHandler).IsOn;
+
+		Task ValidateTrackColor(ISwitch switchStub, Color color, Action action = null) =>
+			ValidateHasColor(switchStub, color, action);
+
+		Task ValidateThumbColor(ISwitch switchStub, Color color, Action action = null) =>
+			ValidateHasColor(switchStub, color, action);
+
+		Task ValidateHasColor(ISwitch switchStub, Color color, Action action = null)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var nativeSwitch = GetNativeSwitch(CreateHandler(switchStub));
+				action?.Invoke();
+				return nativeSwitch.AssertContainsColor(color);
+			});
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.cs
@@ -21,6 +21,22 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(switchStub, () => switchStub.IsOn, GetNativeIsOn, switchStub.IsOn);
 		}
 
+		[Fact(DisplayName = "Is Toggled Does Not Set Same Value")]
+		public async Task IsToggledDoesNotSetSameValue()
+		{
+			var fireCount= 0;
+
+			var switchStub = new SwitchStub()
+			{
+				IsOn = true,
+				IsOnDelegate = () => fireCount++
+			};
+
+			await InvokeOnMainThreadAsync(() => CreateHandler(switchStub));
+
+			Assert.Equal(0, fireCount);
+		}
+
 		[Theory(DisplayName = "Track Color Initializes Correctly")]
 		[InlineData(true)]
 		//[InlineData(false)] // Track color is not always visible when off

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -50,6 +50,13 @@ namespace Microsoft.Maui.DeviceTests
 				return Task.FromResult(true);
 			});
 
+		public static Task<T> AttachAndRun<T>(this FrameworkElement view, Func<T> action) =>
+			view.AttachAndRun(() =>
+			{
+				var result = action();
+				return Task.FromResult(result);
+			});
+
 		public static Task AttachAndRun(this FrameworkElement view, Func<Task> action) =>
 			view.AttachAndRun(async () =>
 			{


### PR DESCRIPTION
### Description of Change

This PR only sends updates to the plat layer if the values have actually changed. This avoids the platform views sending new values during binding time and things that may actually cause property changes.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6346
