### PR TITLE
Animated gifs cannot/should not be resized

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -280,6 +280,11 @@
                 Condition="'%(ImportedMauiItem.ItemGroupName)' == 'MauiSplashScreen'" />
         </ItemGroup>
 
+        <!-- Make sure animated gifs are not resized by default -->
+        <ItemGroup>
+            <MauiImage Update="@(MauiImage)" Resize="False" Condition="'%(MauiImage.Extension)' == '.gif' and '%(MauiImage.Resize)' == ''" />
+        </ItemGroup>
+
         <!-- Map @(MauiIcon) to @(MauiImage IsAppIcon=true) -->
         <ItemGroup>
             <MauiImage Include="@(MauiIcon)" IsAppIcon="True" />


### PR DESCRIPTION
### Description of Change

Technically they can, but we don't want to do that as the spec is hard and there are too many options. And, SkiaSharp doesn't do that easily so rather don't.

This PR makes sure that we don't try by default.

A local workaround for this is to add `Resize="False"` to any gifs in the .csproj:

```xml
<MauiImage Update="Resources\Images\*.gif" Resize="False" />
```

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #5034 