### PR TITLE
Disable the AndroidLinkResources optimization

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.targets
+++ b/.nuspec/Microsoft.Maui.Controls.targets
@@ -11,7 +11,6 @@
 		<SkipMicrosoftUIXamlCheckTargetPlatformVersion Condition="'$(SkipMicrosoftUIXamlCheckTargetPlatformVersion)'==''">true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
 		<SkipMicrosoftUIXamlCheckTargetPlatformVersion Condition="'$(SkipMicrosoftUIXamlCheckTargetPlatformVersion)'=='false'"></SkipMicrosoftUIXamlCheckTargetPlatformVersion>
 		<AndroidUseDefaultAotProfile Condition="'$(AndroidEnableProfiledAot)' == 'true' and '$(AndroidUseDefaultAotProfile)' == ''">false</AndroidUseDefaultAotProfile>
-		<AndroidLinkResources Condition=" '$(AndroidLinkResources)' == '' And '$(Configuration)' == 'Release' ">True</AndroidLinkResources>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Description of Change

Disable the optimization as it causes a crash with libraries that use the resources - such as SkiaSharp. This could be any library that has Android controls defined in C# and use android styles.

However, if an app is not using any controls like this, they can still manually enable this feature and get all the wins!

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Related to #7037
