### PR TITLE
Update URL for MAUI support

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: .NET MAUI Community Support
-    url: https://techcommunity.microsoft.com/t5/app-development/bd-p/app-dev
+    url: https://docs.microsoft.com/answers/topics/dotnet-maui.html
     about: Please ask and answer questions here.


### PR DESCRIPTION
### Description of Change

The way I see it, the tech community space is for discussions, announcements, not for support. Q&A would be the more appropriate platform for support.

### Issues Fixed

This is a small repo workflow suggestion, so I didn't file an issue, but let me know if it's required for this sort of change.