### PR TITLE
Avoid having every access of Bounds or Frame allocate a new Rect

### DIFF
--- a/src/BlazorWebView/tests/MauiDeviceTests/HandlerTestBase.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/HandlerTestBase.cs
@@ -59,11 +59,8 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests
 			handler.SetVirtualView(view);
 			view.Handler = handler;
 
-#if IOS
-			view.Arrange(new Rect(0, 0, double.PositiveInfinity, double.PositiveInfinity));
-#else
-			view.Arrange(new Rect(0, 0, view.Width, view.Height));
-#endif
+			var size = view.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			view.Arrange(new Rect(0, 0, size.Width, size.Height));
 			handler.PlatformArrange(view.Frame);
 
 			return handler;

--- a/src/BlazorWebView/tests/MauiDeviceTests/HandlerTestBase.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/HandlerTestBase.cs
@@ -59,7 +59,11 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests
 			handler.SetVirtualView(view);
 			view.Handler = handler;
 
+#if IOS
+			view.Arrange(new Rect(0, 0, double.PositiveInfinity, double.PositiveInfinity));
+#else
 			view.Arrange(new Rect(0, 0, view.Width, view.Height));
+#endif
 			handler.PlatformArrange(view.Frame);
 
 			return handler;

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -15,26 +15,20 @@ namespace Microsoft.Maui.Controls
 		EventHandler? _unloaded;
 		bool _watchingPlatformLoaded;
 
+		Rect _frame = Rect.Zero;
+
 		/// <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Frame']/Docs" />
 		public Rect Frame
 		{
-			get => Bounds;
+			get => _frame;
 			set
 			{
-				if (value.X == X && value.Y == Y && value.Height == Height && value.Width == Width)
+				if (_frame == value)
 					return;
 
-				BatchBegin();
+				_frame = value;
 
-				X = value.X;
-				Y = value.Y;
-				Width = value.Width;
-				Height = value.Height;
-
-				SizeAllocated(Width, Height);
-				SizeChanged?.Invoke(this, EventArgs.Empty);
-
-				BatchCommit();
+				UpdateBoundsComponents(value);
 			}
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 		EventHandler? _unloaded;
 		bool _watchingPlatformLoaded;
 
-		Rect _frame = Rect.Zero;
+		Rect _frame = new Rect(0, 0, -1, -1);
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Frame']/Docs" />
 		public Rect Frame
@@ -25,8 +25,6 @@ namespace Microsoft.Maui.Controls
 			{
 				if (_frame == value)
 					return;
-
-				_frame = value;
 
 				UpdateBoundsComponents(value);
 			}

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -441,16 +441,10 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Bounds']/Docs" />
 		public Rect Bounds
 		{
-			get { return new Rect(X, Y, Width, Height); }
+			get { return _frame; }
 			private set
 			{
-				if (value.X == X && value.Y == Y && value.Height == Height && value.Width == Width)
-					return;
-				BatchBegin();
-				X = value.X;
-				Y = value.Y;
-				SetSize(value.Width, value.Height);
-				BatchCommit();
+				Frame = value;
 			}
 		}
 
@@ -1199,16 +1193,19 @@ namespace Microsoft.Maui.Controls
 			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, ((IVisualTreeElement)this).GetVisualChildren());
 		}
 
-		void SetSize(double width, double height)
+		void UpdateBoundsComponents(Rect bounds) 
 		{
-			if (Width == width && Height == height)
-				return;
+			BatchBegin();
 
-			Width = width;
-			Height = height;
+			X = bounds.X;
+			Y = bounds.Y;
+			Width = bounds.Width;
+			Height = bounds.Height;
 
-			SizeAllocated(width, height);
+			SizeAllocated(Width, Height);
 			SizeChanged?.Invoke(this, EventArgs.Empty);
+
+			BatchCommit();
 		}
 
 		public class FocusRequestArgs : EventArgs

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1017,7 +1017,7 @@ namespace Microsoft.Maui.Controls
 
 		bool IsMocked() 
 		{
-			return _mockX != -1 && _mockY != -1 && _mockWidth != -1 && _mockHeight != -1;
+			return _mockX != -1 || _mockY != -1 || _mockWidth != -1 || _mockHeight != -1;
 		}
 
 		internal virtual void OnConstraintChanged(LayoutConstraint oldConstraint, LayoutConstraint newConstraint) => ComputeConstrainsForChildren();

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Bounds']/Docs" />
 		public Rect Bounds
 		{
-			get { return _frame; }
+			get { return IsMocked() ? new Rect(_mockX, _mockY, _mockWidth, _mockHeight) : _frame; }
 			private set
 			{
 				Frame = value;
@@ -1015,6 +1015,11 @@ namespace Microsoft.Maui.Controls
 #endif
 		}
 
+		bool IsMocked() 
+		{
+			return _mockX != -1 && _mockY != -1 && _mockWidth != -1 && _mockHeight != -1;
+		}
+
 		internal virtual void OnConstraintChanged(LayoutConstraint oldConstraint, LayoutConstraint newConstraint) => ComputeConstrainsForChildren();
 
 		internal virtual void OnIsPlatformEnabledChanged()
@@ -1195,6 +1200,8 @@ namespace Microsoft.Maui.Controls
 
 		void UpdateBoundsComponents(Rect bounds) 
 		{
+			_frame = bounds;
+
 			BatchBegin();
 
 			X = bounds.X;

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -134,6 +134,10 @@ namespace Microsoft.Maui.DeviceTests
 				var size = view.Measure(view.Width, view.Height);
 				var w = size.Width;
 				var h = size.Height;
+#elif IOS
+				var size = view.Measure(double.PositiveInfinity, double.PositiveInfinity);
+				var w = size.Width;
+				var h = size.Height;
 #else
 				// Windows cannot measure without the view being loaded
 				// iOS needs more love when I get an IDE again


### PR DESCRIPTION
### Description of Change

Every access of Frame (or Bounds) in VisualElement was creating a new Rect by accessing four BindableProperties, which is not ideal from a performance perspective.

These changes track the Frame/Bounds Rect locally, and consolidate the updating of the X/Y/Width/Height bindable properties in one method.



