### PR TITLE
Observe explicit width/height when measuring ContentView's content

### DIFF
--- a/src/Core/src/Layouts/LayoutExtensions.cs
+++ b/src/Core/src/Layouts/LayoutExtensions.cs
@@ -156,6 +156,16 @@ namespace Microsoft.Maui.Layouts
 		{
 			var content = contentView.PresentedContent;
 
+			if (Dimension.IsExplicitSet(contentView.Width))
+			{
+				widthConstraint = contentView.Width;
+			}
+
+			if (Dimension.IsExplicitSet(contentView.Height))
+			{
+				heightConstraint = contentView.Height;
+			}
+
 			var contentSize = Size.Zero;
 
 			if (content != null)


### PR DESCRIPTION
### Description of Change

The extension method handling content measurement for IContentViews is ignoring explicit width/height values on the IContentView. These changes measure the content while keeping the explicit sizes in mind.

### Issues Fixed

Fixes #4081
