### PR TITLE
No longer make NETSTANDARD == NET6_0

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
+++ b/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
@@ -79,11 +79,6 @@
     <MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
 
-  <!-- .NET Standard or .NET 6 -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net$(_MauiDotNetVersion)' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-  </PropertyGroup>
-
   <!-- Android -->
   <PropertyGroup Condition=" '$(_MauiTargetPlatformIsAndroid)' == 'True' ">
     <DefineConstants>$(DefineConstants);MONOANDROID</DefineConstants>

--- a/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
+++ b/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
@@ -79,6 +79,11 @@
     <MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets</MonoAndroidAssetsPrefix>
   </PropertyGroup>
 
+  <!-- .NET Standard or .NET 6 -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net$(_MauiDotNetVersion)' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+
   <!-- Android -->
   <PropertyGroup Condition=" '$(_MauiTargetPlatformIsAndroid)' == 'True' ">
     <DefineConstants>$(DefineConstants);MONOANDROID</DefineConstants>

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="webView">The <see cref="IBlazorWebView"/>.</param>
 		public static void MapHostPage(BlazorWebViewHandler handler, IBlazorWebView webView)
 		{
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 			handler.HostPage = webView.HostPage;
 			handler.StartWebViewCoreIfPossible();
 #endif
@@ -59,13 +59,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="webView">The <see cref="IBlazorWebView"/>.</param>
 		public static void MapRootComponents(BlazorWebViewHandler handler, IBlazorWebView webView)
 		{
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 			handler.RootComponents = webView.RootComponents;
 			handler.StartWebViewCoreIfPossible();
 #endif
 		}
 
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 		private string? HostPage { get; set; }
 
 		internal void UrlLoading(UrlLoadingEventArgs args) =>

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="webView">The <see cref="IBlazorWebView"/>.</param>
 		public static void MapHostPage(BlazorWebViewHandler handler, IBlazorWebView webView)
 		{
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 			handler.HostPage = webView.HostPage;
 			handler.StartWebViewCoreIfPossible();
 #endif
@@ -59,13 +59,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="webView">The <see cref="IBlazorWebView"/>.</param>
 		public static void MapRootComponents(BlazorWebViewHandler handler, IBlazorWebView webView)
 		{
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 			handler.RootComponents = webView.RootComponents;
 			handler.StartWebViewCoreIfPossible();
 #endif
 		}
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 		private string? HostPage { get; set; }
 
 		internal void UrlLoading(UrlLoadingEventArgs args) =>

--- a/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
+++ b/src/BlazorWebView/src/Maui/BlazorWebViewHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="webView">The <see cref="IBlazorWebView"/>.</param>
 		public static void MapHostPage(BlazorWebViewHandler handler, IBlazorWebView webView)
 		{
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 			handler.HostPage = webView.HostPage;
 			handler.StartWebViewCoreIfPossible();
 #endif
@@ -59,13 +59,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 		/// <param name="webView">The <see cref="IBlazorWebView"/>.</param>
 		public static void MapRootComponents(BlazorWebViewHandler handler, IBlazorWebView webView)
 		{
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 			handler.RootComponents = webView.RootComponents;
 			handler.StartWebViewCoreIfPossible();
 #endif
 		}
 
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 		private string? HostPage { get; set; }
 
 		internal void UrlLoading(UrlLoadingEventArgs args) =>

--- a/src/Compatibility/Core/src/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.cs
@@ -25,7 +25,7 @@ using static Microsoft.Maui.Controls.Compatibility.Platform.Tizen.Platform;
 using PlatformView = ElmSharp.EvasObject;
 using Microsoft.Maui.Controls.Compatibility.Platform.Tizen;
 using ViewHandler = Microsoft.Maui.Handlers.ViewHandler<Microsoft.Maui.IView, ElmSharp.EvasObject>;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 using ViewHandler = Microsoft.Maui.Handlers.ViewHandler<Microsoft.Maui.IView, System.Object>;
 #elif WINDOWS

--- a/src/Compatibility/Core/src/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.cs
@@ -25,7 +25,7 @@ using static Microsoft.Maui.Controls.Compatibility.Platform.Tizen.Platform;
 using PlatformView = ElmSharp.EvasObject;
 using Microsoft.Maui.Controls.Compatibility.Platform.Tizen;
 using ViewHandler = Microsoft.Maui.Handlers.ViewHandler<Microsoft.Maui.IView, ElmSharp.EvasObject>;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 using ViewHandler = Microsoft.Maui.Handlers.ViewHandler<Microsoft.Maui.IView, System.Object>;
 #elif WINDOWS

--- a/src/Compatibility/Core/src/RendererToHandlerShim.cs
+++ b/src/Compatibility/Core/src/RendererToHandlerShim.cs
@@ -25,7 +25,7 @@ using static Microsoft.Maui.Controls.Compatibility.Platform.Tizen.Platform;
 using PlatformView = ElmSharp.EvasObject;
 using Microsoft.Maui.Controls.Compatibility.Platform.Tizen;
 using ViewHandler = Microsoft.Maui.Handlers.ViewHandler<Microsoft.Maui.IView, ElmSharp.EvasObject>;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 using ViewHandler = Microsoft.Maui.Handlers.ViewHandler<Microsoft.Maui.IView, System.Object>;
 #elif WINDOWS

--- a/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaGraphicsViewHandler.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaGraphicsViewHandler.cs
@@ -2,7 +2,7 @@
 using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 using Microsoft.Maui.Graphics.Skia.Views;
 #else
 using SkiaGraphicsView = System.Object;
@@ -36,7 +36,7 @@ namespace Maui.Controls.Sample.Controls
 
 		public static void MapDrawable(SkiaGraphicsViewHandler handler, IGraphicsView graphicsView)
 		{
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 			handler.PlatformView.Drawable = graphicsView.Drawable;
 #endif
 		}

--- a/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaGraphicsViewHandler.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaGraphicsViewHandler.cs
@@ -2,7 +2,7 @@
 using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 using Microsoft.Maui.Graphics.Skia.Views;
 #else
 using SkiaGraphicsView = System.Object;
@@ -36,7 +36,7 @@ namespace Maui.Controls.Sample.Controls
 
 		public static void MapDrawable(SkiaGraphicsViewHandler handler, IGraphicsView graphicsView)
 		{
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 			handler.PlatformView.Drawable = graphicsView.Drawable;
 #endif
 		}

--- a/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaGraphicsViewHandler.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaGraphicsViewHandler.cs
@@ -2,7 +2,7 @@
 using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 using Microsoft.Maui.Graphics.Skia.Views;
 #else
 using SkiaGraphicsView = System.Object;
@@ -36,7 +36,7 @@ namespace Maui.Controls.Sample.Controls
 
 		public static void MapDrawable(SkiaGraphicsViewHandler handler, IGraphicsView graphicsView)
 		{
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 			handler.PlatformView.Drawable = graphicsView.Drawable;
 #endif
 		}

--- a/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaShapeViewHandler.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaShapeViewHandler.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Graphics;
 
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 using Microsoft.Maui.Graphics.Skia.Views;
 #else
 using SkiaGraphicsView = System.Object;
@@ -45,7 +45,7 @@ namespace Maui.Controls.Sample.Controls
 
 		public static void MapShape(SkiaShapeViewHandler handler, IShapeView shapeView)
 		{
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 			handler.PlatformView.Drawable = new ShapeDrawable(shapeView);
 #endif
 		}
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample.Controls
 		{
 #if __IOS__ || __MACCATALYST__
 			handler.PlatformView.SetNeedsDisplay();
-#elif !NETSTANDARD
+#elif !(NETSTANDARD || !PLATFORM)
 			handler.PlatformView.Invalidate();
 #endif
 		}

--- a/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaShapeViewHandler.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaShapeViewHandler.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Graphics;
 
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 using Microsoft.Maui.Graphics.Skia.Views;
 #else
 using SkiaGraphicsView = System.Object;
@@ -45,7 +45,7 @@ namespace Maui.Controls.Sample.Controls
 
 		public static void MapShape(SkiaShapeViewHandler handler, IShapeView shapeView)
 		{
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 			handler.PlatformView.Drawable = new ShapeDrawable(shapeView);
 #endif
 		}
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample.Controls
 		{
 #if __IOS__ || __MACCATALYST__
 			handler.PlatformView.SetNeedsDisplay();
-#elif !NETSTANDARD && !NET6_0
+#elif !NETSTANDARD
 			handler.PlatformView.Invalidate();
 #endif
 		}

--- a/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaShapeViewHandler.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/SkiaSharpHandlers/SkiaShapeViewHandler.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Graphics;
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 using Microsoft.Maui.Graphics.Skia.Views;
 #else
 using SkiaGraphicsView = System.Object;
@@ -45,7 +45,7 @@ namespace Maui.Controls.Sample.Controls
 
 		public static void MapShape(SkiaShapeViewHandler handler, IShapeView shapeView)
 		{
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 			handler.PlatformView.Drawable = new ShapeDrawable(shapeView);
 #endif
 		}
@@ -54,7 +54,7 @@ namespace Maui.Controls.Sample.Controls
 		{
 #if __IOS__ || __MACCATALYST__
 			handler.PlatformView.SetNeedsDisplay();
-#elif !NETSTANDARD
+#elif !NETSTANDARD && !NET6_0
 			handler.PlatformView.Invalidate();
 #endif
 		}

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -33,10 +33,6 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == '$(_MauiDotNetTfm)'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -33,6 +33,10 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(_MauiDotNetTfm)'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />

--- a/src/Controls/src/Core/Interactivity/PlatformBehavior.cs
+++ b/src/Controls/src/Core/Interactivity/PlatformBehavior.cs
@@ -10,7 +10,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NET6_0 || NETSTANDARD
+#elif NET6_0 || (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Controls/src/Core/Interactivity/PlatformBehavior.cs
+++ b/src/Controls/src/Core/Interactivity/PlatformBehavior.cs
@@ -10,7 +10,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || NET6_0
+#elif NET6_0 || NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Controls/src/Core/Interactivity/PlatformBehavior.cs
+++ b/src/Controls/src/Core/Interactivity/PlatformBehavior.cs
@@ -10,7 +10,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NET6_0 || NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Controls/src/Core/Platform/PlatformConfigurationExtensions.cs
+++ b/src/Controls/src/Core/Platform/PlatformConfigurationExtensions.cs
@@ -6,12 +6,12 @@ using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Android;
 using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Windows;
 #elif TIZEN
 using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Tizen;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 
 
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 namespace Microsoft.Maui.Controls.Platform
 {
 	public static class PlatformConfigurationExtensions

--- a/src/Controls/src/Core/Platform/PlatformConfigurationExtensions.cs
+++ b/src/Controls/src/Core/Platform/PlatformConfigurationExtensions.cs
@@ -6,12 +6,12 @@ using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Android;
 using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Windows;
 #elif TIZEN
 using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Tizen;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 
 
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 namespace Microsoft.Maui.Controls.Platform
 {
 	public static class PlatformConfigurationExtensions

--- a/src/Controls/src/Core/Platform/PlatformConfigurationExtensions.cs
+++ b/src/Controls/src/Core/Platform/PlatformConfigurationExtensions.cs
@@ -6,12 +6,12 @@ using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Android;
 using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Windows;
 #elif TIZEN
 using CurrentPlatform = Microsoft.Maui.Controls.PlatformConfiguration.Tizen;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 namespace Microsoft.Maui.Controls.Platform
 {
 	public static class PlatformConfigurationExtensions

--- a/src/Controls/src/Core/Platform/PlatformEffect.cs
+++ b/src/Controls/src/Core/Platform/PlatformEffect.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Controls/src/Core/Platform/PlatformEffect.cs
+++ b/src/Controls/src/Core/Platform/PlatformEffect.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Controls/src/Core/Platform/PlatformEffect.cs
+++ b/src/Controls/src/Core/Platform/PlatformEffect.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 			var path = GetPath();
 
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 
 			// TODO: not using this.GetPath().Bounds.Size;
 			//       since default GetBoundsByFlattening(0.001) returns incorrect results for curves

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 			var path = GetPath();
 
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 
 			// TODO: not using this.GetPath().Bounds.Size;
 			//       since default GetBoundsByFlattening(0.001) returns incorrect results for curves

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 			var path = GetPath();
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 
 			// TODO: not using this.GetPath().Bounds.Size;
 			//       since default GetBoundsByFlattening(0.001) returns incorrect results for curves

--- a/src/Controls/tests/DeviceTests/Elements/PlatformBehaviorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/PlatformBehaviorTests.cs
@@ -14,7 +14,7 @@ using PlatformView = AppKit.NSView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif NET6_0 || NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Controls/tests/DeviceTests/Elements/PlatformBehaviorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/PlatformBehaviorTests.cs
@@ -14,7 +14,7 @@ using PlatformView = AppKit.NSView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif NETSTANDARD || NET6_0
+#elif NET6_0 || NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Controls/tests/DeviceTests/Elements/PlatformBehaviorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/PlatformBehaviorTests.cs
@@ -14,7 +14,7 @@ using PlatformView = AppKit.NSView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif NET6_0 || NETSTANDARD
+#elif NET6_0 || (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ProgressBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressRing;
 #elif TIZEN
 using PlatformView = ElmSharp.ProgressBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ProgressBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressRing;
 #elif TIZEN
 using PlatformView = ElmSharp.ProgressBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ProgressBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressRing;
 #elif TIZEN
 using PlatformView = ElmSharp.ProgressBar;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ActivityIndicator/IActivityIndicatorHandler.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/IActivityIndicatorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ProgressBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressRing;
 #elif TIZEN
 using PlatformView = ElmSharp.ProgressBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ActivityIndicator/IActivityIndicatorHandler.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/IActivityIndicatorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ProgressBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressRing;
 #elif TIZEN
 using PlatformView = ElmSharp.ProgressBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ActivityIndicator/IActivityIndicatorHandler.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/IActivityIndicatorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ProgressBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressRing;
 #elif TIZEN
 using PlatformView = ElmSharp.ProgressBar;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Application/ApplicationHandler.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Handlers
 		ILogger? Logger =>
 			_logger ??= MauiContext?.Services.CreateLogger<ApplicationHandler>();
 
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 		protected override PlatformView CreatePlatformElement() =>
 			MauiContext?.Services.GetService<PlatformView>() ?? throw new InvalidOperationException($"MauiContext did not have a valid application.");
 #endif

--- a/src/Core/src/Handlers/Application/ApplicationHandler.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Handlers
 		ILogger? Logger =>
 			_logger ??= MauiContext?.Services.CreateLogger<ApplicationHandler>();
 
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 		protected override PlatformView CreatePlatformElement() =>
 			MauiContext?.Services.GetService<PlatformView>() ?? throw new InvalidOperationException($"MauiContext did not have a valid application.");
 #endif

--- a/src/Core/src/Handlers/Application/ApplicationHandler.cs
+++ b/src/Core/src/Handlers/Application/ApplicationHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Handlers
 		ILogger? Logger =>
 			_logger ??= MauiContext?.Services.CreateLogger<ApplicationHandler>();
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 		protected override PlatformView CreatePlatformElement() =>
 			MauiContext?.Services.GetService<PlatformView>() ?? throw new InvalidOperationException($"MauiContext did not have a valid application.");
 #endif

--- a/src/Core/src/Handlers/Border/BorderHandler.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.BorderView;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Border/BorderHandler.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.BorderView;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Border/BorderHandler.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.BorderView;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Border/IBorderHandler.cs
+++ b/src/Core/src/Handlers/Border/IBorderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.BorderView;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Border/IBorderHandler.cs
+++ b/src/Core/src/Handlers/Border/IBorderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.BorderView;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Border/IBorderHandler.cs
+++ b/src/Core/src/Handlers/Border/IBorderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.BorderView;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Button/ButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.Button.MaterialButton;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Button;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Button/ButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.Button.MaterialButton;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Button;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Button/ButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.Button.MaterialButton;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Button;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Button/IButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/IButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.Button.MaterialButton;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Button;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Button/IButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/IButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.Button.MaterialButton;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Button;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Button/IButtonHandler.cs
+++ b/src/Core/src/Handlers/Button/IButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.Button.MaterialButton;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Button;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatCheckBox;
 using PlatformView = Microsoft.UI.Xaml.Controls.CheckBox;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatCheckBox;
 using PlatformView = Microsoft.UI.Xaml.Controls.CheckBox;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatCheckBox;
 using PlatformView = Microsoft.UI.Xaml.Controls.CheckBox;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/CheckBox/ICheckboxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/ICheckboxHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatCheckBox;
 using PlatformView = Microsoft.UI.Xaml.Controls.CheckBox;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/CheckBox/ICheckboxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/ICheckboxHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatCheckBox;
 using PlatformView = Microsoft.UI.Xaml.Controls.CheckBox;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/CheckBox/ICheckboxHandler.cs
+++ b/src/Core/src/Handlers/CheckBox/ICheckboxHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatCheckBox;
 using PlatformView = Microsoft.UI.Xaml.Controls.CheckBox;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
+++ b/src/Core/src/Handlers/ContentView/ContentViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ContentView/IContentViewHandler.cs
+++ b/src/Core/src/Handlers/ContentView/IContentViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ContentView/IContentViewHandler.cs
+++ b/src/Core/src/Handlers/ContentView/IContentViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ContentView/IContentViewHandler.cs
+++ b/src/Core/src/Handlers/ContentView/IContentViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.Maui.Platform.ContentPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.CalendarDatePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.CalendarDatePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.CalendarDatePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/DatePicker/IDatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/IDatePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.CalendarDatePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/DatePicker/IDatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/IDatePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.CalendarDatePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/DatePicker/IDatePickerHandler.cs
+++ b/src/Core/src/Handlers/DatePicker/IDatePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiDatePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.CalendarDatePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Editor/EditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Editor/IEditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/IEditorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Editor/IEditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/IEditorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Editor/IEditorHandler.cs
+++ b/src/Core/src/Handlers/Editor/IEditorHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ElementHandlerExtensions.cs
+++ b/src/Core/src/Handlers/ElementHandlerExtensions.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 using System;

--- a/src/Core/src/Handlers/ElementHandlerExtensions.cs
+++ b/src/Core/src/Handlers/ElementHandlerExtensions.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 using System;

--- a/src/Core/src/Handlers/ElementHandlerExtensions.cs
+++ b/src/Core/src/Handlers/ElementHandlerExtensions.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 using System;

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Entry/EntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Entry/IEntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/IEntryHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Entry/IEntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/IEntryHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Entry/IEntryHandler.cs
+++ b/src/Core/src/Handlers/Entry/IEntryHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatEditText;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.RootNavigationView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.RootNavigationView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.RootNavigationView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/FlyoutView/IFlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/IFlyoutViewHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.RootNavigationView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/FlyoutView/IFlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/IFlyoutViewHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.RootNavigationView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/FlyoutView/IFlyoutViewHandler.cs
+++ b/src/Core/src/Handlers/FlyoutView/IFlyoutViewHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.RootNavigationView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Image/IImageHandler.cs
+++ b/src/Core/src/Handlers/Image/IImageHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Image;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Image/IImageHandler.cs
+++ b/src/Core/src/Handlers/Image/IImageHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Image;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Image/IImageHandler.cs
+++ b/src/Core/src/Handlers/Image/IImageHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.ImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Image;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Android.Widget.ImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Image;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Android.Widget.ImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Image;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Android.Widget.ImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Image;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ImageButton/IImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/IImageButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.ImageView.ShapeableImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiImageButton;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ImageButton/IImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/IImageButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.ImageView.ShapeableImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiImageButton;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ImageButton/IImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/IImageButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.ImageView.ShapeableImageView;
 using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiImageButton;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -15,7 +15,7 @@ using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformImageView = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformView = Microsoft.Maui.Platform.MauiImageButton;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 using PlatformImageView = System.Object;
 using PlatformView = System.Object;

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -15,7 +15,7 @@ using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformImageView = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformView = Microsoft.Maui.Platform.MauiImageButton;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 using PlatformImageView = System.Object;
 using PlatformView = System.Object;

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -15,7 +15,7 @@ using PlatformView = Microsoft.UI.Xaml.Controls.Button;
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformImageView = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformView = Microsoft.Maui.Platform.MauiImageButton;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 using PlatformImageView = System.Object;
 using PlatformView = System.Object;

--- a/src/Core/src/Handlers/IndicatorView/IIndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IIndicatorViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.IndicatorView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/IndicatorView/IIndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IIndicatorViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.IndicatorView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/IndicatorView/IIndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IIndicatorViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.IndicatorView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.IndicatorView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.IndicatorView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
+++ b/src/Core/src/Handlers/IndicatorView/IndicatorViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 using PlatformView = Microsoft.Maui.Platform.MauiPageControl;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.IndicatorView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Label/ILabelHandler.cs
+++ b/src/Core/src/Handlers/Label/ILabelHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatTextView;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBlock;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Label;
-#elif NETSTANDARD || (NET6_0 && !IOS && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Label/ILabelHandler.cs
+++ b/src/Core/src/Handlers/Label/ILabelHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatTextView;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBlock;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Label;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Label/ILabelHandler.cs
+++ b/src/Core/src/Handlers/Label/ILabelHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatTextView;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBlock;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Label;
-#elif NETSTANDARD || (NET6_0 && !IOS && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatTextView;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBlock;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Label;
-#elif NETSTANDARD || (NET6_0 && !IOS && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatTextView;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBlock;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Label;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.AppCompatTextView;
 using PlatformView = Microsoft.UI.Xaml.Controls.TextBlock;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Label;
-#elif NETSTANDARD || (NET6_0 && !IOS && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Layout/ILayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/ILayoutHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
 using PlatformView = Microsoft.Maui.Platform.LayoutPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.LayoutCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Layout/ILayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/ILayoutHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
 using PlatformView = Microsoft.Maui.Platform.LayoutPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.LayoutCanvas;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Layout/ILayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/ILayoutHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
 using PlatformView = Microsoft.Maui.Platform.LayoutPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.LayoutCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
 using PlatformView = Microsoft.Maui.Platform.LayoutPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.LayoutCanvas;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
 using PlatformView = Microsoft.Maui.Platform.LayoutPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.LayoutCanvas;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.LayoutViewGroup;
 using PlatformView = Microsoft.Maui.Platform.LayoutPanel;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.LayoutCanvas;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBar/IMenuBarHandler.cs
+++ b/src/Core/src/Handlers/MenuBar/IMenuBarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBar;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBar/IMenuBarHandler.cs
+++ b/src/Core/src/Handlers/MenuBar/IMenuBarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBar;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBar/IMenuBarHandler.cs
+++ b/src/Core/src/Handlers/MenuBar/IMenuBarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBar;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBar/MenuBarHandler.cs
+++ b/src/Core/src/Handlers/MenuBar/MenuBarHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBar;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBar/MenuBarHandler.cs
+++ b/src/Core/src/Handlers/MenuBar/MenuBarHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBar;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBar/MenuBarHandler.cs
+++ b/src/Core/src/Handlers/MenuBar/MenuBarHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBar;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBarItem/IMenuBarItemHandler.cs
+++ b/src/Core/src/Handlers/MenuBarItem/IMenuBarItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBarItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBarItem/IMenuBarItemHandler.cs
+++ b/src/Core/src/Handlers/MenuBarItem/IMenuBarItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBarItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBarItem/IMenuBarItemHandler.cs
+++ b/src/Core/src/Handlers/MenuBarItem/IMenuBarItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBarItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.cs
+++ b/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBarItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.cs
+++ b/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBarItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.cs
+++ b/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuBarItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutItem/IMenuFlyoutItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutItem/IMenuFlyoutItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutItem/IMenuFlyoutItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutItem/IMenuFlyoutItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutItem/IMenuFlyoutItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutItem/IMenuFlyoutItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutItem/MenuFlyoutItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutItem/MenuFlyoutItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutItem/MenuFlyoutItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutItem/MenuFlyoutItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutItem/MenuFlyoutItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutItem/MenuFlyoutItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutSubItem/IMenuFlyoutSubItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/IMenuFlyoutSubItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutSubItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutSubItem/IMenuFlyoutSubItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/IMenuFlyoutSubItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutSubItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutSubItem/IMenuFlyoutSubItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/IMenuFlyoutSubItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutSubItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutSubItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutSubItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.MenuFlyoutSubItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/NavigationPage/INavigationViewHandler.cs
+++ b/src/Core/src/Handlers/NavigationPage/INavigationViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.Frame;
 #elif TIZEN
 using PlatformView = ElmSharp.Naviframe;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/NavigationPage/INavigationViewHandler.cs
+++ b/src/Core/src/Handlers/NavigationPage/INavigationViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.Frame;
 #elif TIZEN
 using PlatformView = ElmSharp.Naviframe;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/NavigationPage/INavigationViewHandler.cs
+++ b/src/Core/src/Handlers/NavigationPage/INavigationViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.Frame;
 #elif TIZEN
 using PlatformView = ElmSharp.Naviframe;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.Frame;
 #elif TIZEN
 using PlatformView = ElmSharp.Naviframe;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.Frame;
 #elif TIZEN
 using PlatformView = ElmSharp.Naviframe;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.Frame;
 #elif TIZEN
 using PlatformView = ElmSharp.Naviframe;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Picker/IPickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/IPickerHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.ComboBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Picker/IPickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/IPickerHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.ComboBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Picker/IPickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/IPickerHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.ComboBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.ComboBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.ComboBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiPicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.ComboBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ProgressBar/IProgressBarHandler.cs
+++ b/src/Core/src/Handlers/ProgressBar/IProgressBarHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIProgressView;
 using PlatformView = Android.Widget.ProgressBar;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ProgressBar/IProgressBarHandler.cs
+++ b/src/Core/src/Handlers/ProgressBar/IProgressBarHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIProgressView;
 using PlatformView = Android.Widget.ProgressBar;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ProgressBar/IProgressBarHandler.cs
+++ b/src/Core/src/Handlers/ProgressBar/IProgressBarHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIProgressView;
 using PlatformView = Android.Widget.ProgressBar;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressBar;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.cs
+++ b/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = UIKit.UIProgressView;
 using PlatformView = Android.Widget.ProgressBar;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.cs
+++ b/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = UIKit.UIProgressView;
 using PlatformView = Android.Widget.ProgressBar;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.cs
+++ b/src/Core/src/Handlers/ProgressBar/ProgressBarHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = UIKit.UIProgressView;
 using PlatformView = Android.Widget.ProgressBar;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Controls.ProgressBar;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RadioButton/IRadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/IRadioButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.RadioButton;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiRadioButton;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RadioButton/IRadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/IRadioButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.RadioButton;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiRadioButton;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RadioButton/IRadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/IRadioButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.RadioButton;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiRadioButton;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.RadioButton;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiRadioButton;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.RadioButton;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiRadioButton;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
+++ b/src/Core/src/Handlers/RadioButton/RadioButtonHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.RadioButton;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiRadioButton;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RefreshView/IRefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/IRefreshViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeRefreshLayout;
 using PlatformView = Microsoft.UI.Xaml.Controls.RefreshContainer;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RefreshView/IRefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/IRefreshViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeRefreshLayout;
 using PlatformView = Microsoft.UI.Xaml.Controls.RefreshContainer;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RefreshView/IRefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/IRefreshViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeRefreshLayout;
 using PlatformView = Microsoft.UI.Xaml.Controls.RefreshContainer;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeRefreshLayout;
 using PlatformView = Microsoft.UI.Xaml.Controls.RefreshContainer;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeRefreshLayout;
 using PlatformView = Microsoft.UI.Xaml.Controls.RefreshContainer;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeRefreshLayout;
 using PlatformView = Microsoft.UI.Xaml.Controls.RefreshContainer;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ScrollView/IScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/IScrollViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiScrollView;
 using PlatformView = Microsoft.UI.Xaml.Controls.ScrollViewer;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.ScrollView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ScrollView/IScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/IScrollViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiScrollView;
 using PlatformView = Microsoft.UI.Xaml.Controls.ScrollViewer;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.ScrollView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ScrollView/IScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/IScrollViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiScrollView;
 using PlatformView = Microsoft.UI.Xaml.Controls.ScrollViewer;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.ScrollView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiScrollView;
 using PlatformView = Microsoft.UI.Xaml.Controls.ScrollViewer;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.ScrollView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiScrollView;
 using PlatformView = Microsoft.UI.Xaml.Controls.ScrollViewer;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.ScrollView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiScrollView;
 using PlatformView = Microsoft.UI.Xaml.Controls.ScrollViewer;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.ScrollView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SearchBar/ISearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/ISearchBarHandler.cs
@@ -11,7 +11,7 @@ using QueryEditor = Microsoft.UI.Xaml.Controls.AutoSuggestBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.SearchBar;
 using QueryEditor = Tizen.UIExtensions.ElmSharp.EditfieldEntry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 using QueryEditor = System.Object;
 #endif

--- a/src/Core/src/Handlers/SearchBar/ISearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/ISearchBarHandler.cs
@@ -11,7 +11,7 @@ using QueryEditor = Microsoft.UI.Xaml.Controls.AutoSuggestBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.SearchBar;
 using QueryEditor = Tizen.UIExtensions.ElmSharp.EditfieldEntry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 using QueryEditor = System.Object;
 #endif

--- a/src/Core/src/Handlers/SearchBar/ISearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/ISearchBarHandler.cs
@@ -11,7 +11,7 @@ using QueryEditor = Microsoft.UI.Xaml.Controls.AutoSuggestBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.SearchBar;
 using QueryEditor = Tizen.UIExtensions.ElmSharp.EditfieldEntry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 using QueryEditor = System.Object;
 #endif

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SearchView;
 using PlatformView = Microsoft.UI.Xaml.Controls.AutoSuggestBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.SearchBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SearchView;
 using PlatformView = Microsoft.UI.Xaml.Controls.AutoSuggestBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.SearchBar;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SearchView;
 using PlatformView = Microsoft.UI.Xaml.Controls.AutoSuggestBox;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.SearchBar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
 using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
 using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/IShapeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
 using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
 using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
 using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
+++ b/src/Core/src/Handlers/ShapeView/ShapeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
 using PlatformView = Microsoft.Maui.Graphics.Win2D.W2DGraphicsView;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiShapeView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Slider/ISliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/ISliderHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.SeekBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.Slider;
 #elif TIZEN
 using PlatformView = ElmSharp.Slider;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Slider/ISliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/ISliderHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.SeekBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.Slider;
 #elif TIZEN
 using PlatformView = ElmSharp.Slider;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Slider/ISliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/ISliderHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Widget.SeekBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.Slider;
 #elif TIZEN
 using PlatformView = ElmSharp.Slider;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Slider/SliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Widget.SeekBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.Slider;
 #elif TIZEN
 using PlatformView = ElmSharp.Slider;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Slider/SliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Widget.SeekBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.Slider;
 #elif TIZEN
 using PlatformView = ElmSharp.Slider;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Slider/SliderHandler.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Widget.SeekBar;
 using PlatformView = Microsoft.UI.Xaml.Controls.Slider;
 #elif TIZEN
 using PlatformView = ElmSharp.Slider;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Stepper/IStepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/IStepperHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIStepper;
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Stepper/IStepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/IStepperHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIStepper;
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Stepper/IStepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/IStepperHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIStepper;
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Stepper/StepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIStepper;
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Stepper/StepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIStepper;
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Stepper/StepperHandler.cs
+++ b/src/Core/src/Handlers/Stepper/StepperHandler.cs
@@ -4,7 +4,7 @@ using PlatformView = UIKit.UIStepper;
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
 #elif WINDOWS
 using PlatformView = Microsoft.Maui.Platform.MauiStepper;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemMenuItem/ISwipeItemMenuItemHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/ISwipeItemMenuItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemMenuItem/ISwipeItemMenuItemHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/ISwipeItemMenuItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemMenuItem/ISwipeItemMenuItemHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/ISwipeItemMenuItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemMenuItem/SwipeItemMenuItemHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeItem;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemView/ISwipeItemViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemView/ISwipeItemViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemView/ISwipeItemViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemView/ISwipeItemViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemView/ISwipeItemViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemView/ISwipeItemViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemView/SwipeItemViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemView/SwipeItemViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemView/SwipeItemViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemView/SwipeItemViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeItemView/SwipeItemViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeItemView/SwipeItemViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.ContentViewGroup;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.ContentCanvas;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeView/ISwipeViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeView/ISwipeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeControl;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeView/ISwipeViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeView/ISwipeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeControl;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeView/ISwipeViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeView/ISwipeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeControl;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeView/SwipeViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeView/SwipeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeControl;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeView/SwipeViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeView/SwipeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeControl;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/SwipeView/SwipeViewHandler.cs
+++ b/src/Core/src/Handlers/SwipeView/SwipeViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiSwipeView;
 using PlatformView = Microsoft.UI.Xaml.Controls.SwipeControl;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Switch/ISwitchHandler.cs
+++ b/src/Core/src/Handlers/Switch/ISwitchHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SwitchCompat;
 using PlatformView = Microsoft.UI.Xaml.Controls.ToggleSwitch;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Switch/ISwitchHandler.cs
+++ b/src/Core/src/Handlers/Switch/ISwitchHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SwitchCompat;
 using PlatformView = Microsoft.UI.Xaml.Controls.ToggleSwitch;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Switch/ISwitchHandler.cs
+++ b/src/Core/src/Handlers/Switch/ISwitchHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SwitchCompat;
 using PlatformView = Microsoft.UI.Xaml.Controls.ToggleSwitch;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Switch/SwitchHandler.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SwitchCompat;
 using PlatformView = Microsoft.UI.Xaml.Controls.ToggleSwitch;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Switch/SwitchHandler.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SwitchCompat;
 using PlatformView = Microsoft.UI.Xaml.Controls.ToggleSwitch;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Switch/SwitchHandler.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = AndroidX.AppCompat.Widget.SwitchCompat;
 using PlatformView = Microsoft.UI.Xaml.Controls.ToggleSwitch;
 #elif TIZEN
 using PlatformView = ElmSharp.Check;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TabbedView/TabbedViewHandler.cs
+++ b/src/Core/src/Handlers/TabbedView/TabbedViewHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TabbedView/TabbedViewHandler.cs
+++ b/src/Core/src/Handlers/TabbedView/TabbedViewHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TabbedView/TabbedViewHandler.cs
+++ b/src/Core/src/Handlers/TabbedView/TabbedViewHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TimePicker/ITimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/ITimePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.TimePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TimePicker/ITimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/ITimePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.TimePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TimePicker/ITimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/ITimePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.TimePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.TimePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.TimePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
+++ b/src/Core/src/Handlers/TimePicker/TimePickerHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiTimePicker;
 using PlatformView = Microsoft.UI.Xaml.Controls.TimePicker;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Entry;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
 using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif TIZEN
 using PlatformView =ElmSharp.Toolbar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
 using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif TIZEN
 using PlatformView =ElmSharp.Toolbar;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
 using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif TIZEN
 using PlatformView =ElmSharp.Toolbar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
 using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif TIZEN
 using PlatformView =ElmSharp.Toolbar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
 using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif TIZEN
 using PlatformView =ElmSharp.Toolbar;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Google.Android.Material.AppBar.MaterialToolbar;
 using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif TIZEN
 using PlatformView =ElmSharp.Toolbar;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Handlers
 		}
 #endif
 
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 		private protected abstract void OnConnectHandler(PlatformView platformView);
 
 		partial void ConnectingHandler(PlatformView? platformView);

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Handlers
 		}
 #endif
 
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 		private protected abstract void OnConnectHandler(PlatformView platformView);
 
 		partial void ConnectingHandler(PlatformView? platformView);

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Handlers
 		}
 #endif
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 		private protected abstract void OnConnectHandler(PlatformView platformView);
 
 		partial void ConnectingHandler(PlatformView? platformView);

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHandler, IViewHandler
 		where TVirtualView : class, IView
-#if !NETSTANDARD || IOS || ANDROID || WINDOWS || TIZEN
+#if !(NETSTANDARD || !PLATFORM) || IOS || ANDROID || WINDOWS || TIZEN
 		where TPlatformView : PlatformView
 #else
 		where TPlatformView : class

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHandler, IViewHandler
 		where TVirtualView : class, IView
-#if !NETSTANDARD || IOS || ANDROID || WINDOWS || TIZEN
+#if !(NETSTANDARD || NET6_0) || IOS || ANDROID || WINDOWS || TIZEN
 		where TPlatformView : PlatformView
 #else
 		where TPlatformView : class

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.cs
@@ -7,7 +7,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Handlers
 {
 	public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHandler, IViewHandler
 		where TVirtualView : class, IView
-#if !(NETSTANDARD || NET6_0) || IOS || ANDROID || WINDOWS || TIZEN
+#if !NETSTANDARD || IOS || ANDROID || WINDOWS || TIZEN
 		where TPlatformView : PlatformView
 #else
 		where TPlatformView : class

--- a/src/Core/src/Handlers/WebView/IWebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/IWebViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Webkit.WebView;
 using PlatformView = Microsoft.UI.Xaml.Controls.WebView2;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiWebView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/WebView/IWebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/IWebViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Webkit.WebView;
 using PlatformView = Microsoft.UI.Xaml.Controls.WebView2;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiWebView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/WebView/IWebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/IWebViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Webkit.WebView;
 using PlatformView = Microsoft.UI.Xaml.Controls.WebView2;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiWebView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Webkit.WebView;
 using PlatformView = Microsoft.UI.Xaml.Controls.WebView2;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiWebView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Webkit.WebView;
 using PlatformView = Microsoft.UI.Xaml.Controls.WebView2;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiWebView;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/WebView/WebViewHandler.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Webkit.WebView;
 using PlatformView = Microsoft.UI.Xaml.Controls.WebView2;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiWebView;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Window/IWindowHandler.cs
+++ b/src/Core/src/Handlers/Window/IWindowHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.App.Activity;
 using PlatformView = Microsoft.UI.Xaml.Window;
 #elif TIZEN
 using PlatformView = ElmSharp.Window;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Window/IWindowHandler.cs
+++ b/src/Core/src/Handlers/Window/IWindowHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.App.Activity;
 using PlatformView = Microsoft.UI.Xaml.Window;
 #elif TIZEN
 using PlatformView = ElmSharp.Window;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Window/IWindowHandler.cs
+++ b/src/Core/src/Handlers/Window/IWindowHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.App.Activity;
 using PlatformView = Microsoft.UI.Xaml.Window;
 #elif TIZEN
 using PlatformView = ElmSharp.Window;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		}
 
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 		protected override PlatformView CreatePlatformElement() =>
 			MauiContext?.Services.GetService<PlatformView>() ?? throw new InvalidOperationException($"MauiContext did not have a valid window.");
 #endif

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		}
 
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 		protected override PlatformView CreatePlatformElement() =>
 			MauiContext?.Services.GetService<PlatformView>() ?? throw new InvalidOperationException($"MauiContext did not have a valid window.");
 #endif

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Handlers
 		{
 		}
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 		protected override PlatformView CreatePlatformElement() =>
 			MauiContext?.Services.GetService<PlatformView>() ?? throw new InvalidOperationException($"MauiContext did not have a valid window.");
 #endif

--- a/src/Core/src/ImageSources/ImageSourceExtensions.cs
+++ b/src/Core/src/ImageSources/ImageSourceExtensions.cs
@@ -12,7 +12,7 @@ using PlatformImage = Android.Graphics.Drawables.Drawable;
 using PlatformImage = Microsoft.UI.Xaml.Media.ImageSource;
 #elif TIZEN
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 #endif
 

--- a/src/Core/src/ImageSources/ImageSourceExtensions.cs
+++ b/src/Core/src/ImageSources/ImageSourceExtensions.cs
@@ -12,7 +12,7 @@ using PlatformImage = Android.Graphics.Drawables.Drawable;
 using PlatformImage = Microsoft.UI.Xaml.Media.ImageSource;
 #elif TIZEN
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 #endif
 

--- a/src/Core/src/ImageSources/ImageSourceExtensions.cs
+++ b/src/Core/src/ImageSources/ImageSourceExtensions.cs
@@ -12,7 +12,7 @@ using PlatformImage = Android.Graphics.Drawables.Drawable;
 using PlatformImage = Microsoft.UI.Xaml.Media.ImageSource;
 #elif TIZEN
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 #endif
 

--- a/src/Core/src/ImageSources/ImageSourceServiceResult.cs
+++ b/src/Core/src/ImageSources/ImageSourceServiceResult.cs
@@ -8,7 +8,7 @@ using PlatformView = Android.Graphics.Drawables.Drawable;
 using PlatformView = Microsoft.UI.Xaml.Media.ImageSource;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/ImageSources/ImageSourceServiceResult.cs
+++ b/src/Core/src/ImageSources/ImageSourceServiceResult.cs
@@ -8,7 +8,7 @@ using PlatformView = Android.Graphics.Drawables.Drawable;
 using PlatformView = Microsoft.UI.Xaml.Media.ImageSource;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/ImageSources/ImageSourceServiceResult.cs
+++ b/src/Core/src/ImageSources/ImageSourceServiceResult.cs
@@ -8,7 +8,7 @@ using PlatformView = Android.Graphics.Drawables.Drawable;
 using PlatformView = Microsoft.UI.Xaml.Media.ImageSource;
 #elif TIZEN
 using PlatformView = Tizen.UIExtensions.ElmSharp.Image;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -20,7 +20,7 @@ using PlatformView = ElmSharp.EvasObject;
 using BasePlatformType = System.Object;
 using PlatformWindow = ElmSharp.Window;
 using PlatformApplication = Tizen.Applications.CoreUIApplication;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 using BasePlatformType = System.Object;
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -20,7 +20,7 @@ using PlatformView = ElmSharp.EvasObject;
 using BasePlatformType = System.Object;
 using PlatformWindow = ElmSharp.Window;
 using PlatformApplication = Tizen.Applications.CoreUIApplication;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 using BasePlatformType = System.Object;
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;

--- a/src/Core/src/Platform/ElementExtensions.cs
+++ b/src/Core/src/Platform/ElementExtensions.cs
@@ -20,7 +20,7 @@ using PlatformView = ElmSharp.EvasObject;
 using BasePlatformType = System.Object;
 using PlatformWindow = ElmSharp.Window;
 using PlatformApplication = Tizen.Applications.CoreUIApplication;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 using BasePlatformType = System.Object;
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -14,7 +14,7 @@ using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -14,7 +14,7 @@ using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformView = ElmSharp.EvasObject;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Platform/ImageSourcePartLoader.cs
+++ b/src/Core/src/Platform/ImageSourcePartLoader.cs
@@ -14,7 +14,7 @@ using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformImage = Tizen.UIExtensions.ElmSharp.Image;
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformImage = System.Object;
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Platform/ViewExtensions.cs
+++ b/src/Core/src/Platform/ViewExtensions.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 using System.IO;
 
-#if NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#if (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;
 #endif
 #if IOS || MACCATALYST

--- a/src/Core/src/Platform/ViewExtensions.cs
+++ b/src/Core/src/Platform/ViewExtensions.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 using System.IO;
 
-#if (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#if NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;
 #endif
 #if IOS || MACCATALYST

--- a/src/Core/src/Platform/ViewExtensions.cs
+++ b/src/Core/src/Platform/ViewExtensions.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 using System.IO;
 
-#if NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#if (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;
 #endif
 #if IOS || MACCATALYST

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -7,7 +7,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -7,7 +7,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -7,7 +7,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/SemanticExtensions.cs
+++ b/src/Core/src/SemanticExtensions.cs
@@ -13,7 +13,7 @@ using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 using ElmSharp;
 using ElmSharp.Accessible;
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/SemanticExtensions.cs
+++ b/src/Core/src/SemanticExtensions.cs
@@ -13,7 +13,7 @@ using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 using ElmSharp;
 using ElmSharp.Accessible;
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/SemanticExtensions.cs
+++ b/src/Core/src/SemanticExtensions.cs
@@ -13,7 +13,7 @@ using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 using ElmSharp;
 using ElmSharp.Accessible;
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/ViewExtensions.cs
+++ b/src/Core/src/ViewExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 using System.IO;
-#if NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#if (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;
 #endif
 #if IOS || MACCATALYST

--- a/src/Core/src/ViewExtensions.cs
+++ b/src/Core/src/ViewExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 using System.IO;
-#if (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#if NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;
 #endif
 #if IOS || MACCATALYST

--- a/src/Core/src/ViewExtensions.cs
+++ b/src/Core/src/ViewExtensions.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 using System.IO;
-#if NETSTANDARD || (NET6_0 && !IOS && !ANDROID && !TIZEN)
+#if (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using IPlatformViewHandler = Microsoft.Maui.IViewHandler;
 #endif
 #if IOS || MACCATALYST

--- a/src/Core/src/WindowOverlay/WindowOverlay.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.cs
@@ -11,7 +11,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/WindowOverlay/WindowOverlay.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.cs
@@ -11,7 +11,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/src/WindowOverlay/WindowOverlay.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.cs
@@ -11,7 +11,7 @@ using PlatformView = Android.Views.View;
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
 using PlatformView = ElmSharp.EvasObject;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif NETSTANDARD
+#elif (NETSTANDARD || !PLATFORM)
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif NETSTANDARD || NET6_0
+#elif NETSTANDARD
 using PlatformView = System.Object;
 #endif
 

--- a/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBaseHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = UIKit.UIView;
 using PlatformView = Android.Views.View;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
-#elif NETSTANDARD
+#elif NETSTANDARD || NET6_0
 using PlatformView = System.Object;
 #endif
 

--- a/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Storage
 
 	partial class SecureStorageImplementation
 	{
-#if !NETSTANDARD
+#if !(NETSTANDARD || !PLATFORM)
 		// Special Alias that is only used for Secure Storage. All others should use: Preferences.GetPrivatePreferencesSharedName
 		internal static readonly string Alias = Preferences.GetPrivatePreferencesSharedName("preferences");
 #endif

--- a/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Storage
 
 	partial class SecureStorageImplementation
 	{
-#if !NETSTANDARD && !NET6_0
+#if !NETSTANDARD
 		// Special Alias that is only used for Secure Storage. All others should use: Preferences.GetPrivatePreferencesSharedName
 		internal static readonly string Alias = Preferences.GetPrivatePreferencesSharedName("preferences");
 #endif

--- a/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
+++ b/src/Essentials/src/SecureStorage/SecureStorage.shared.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Maui.Storage
 
 	partial class SecureStorageImplementation
 	{
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET6_0
 		// Special Alias that is only used for Secure Storage. All others should use: Preferences.GetPrivatePreferencesSharedName
 		internal static readonly string Alias = Preferences.GetPrivatePreferencesSharedName("preferences");
 #endif

--- a/src/Essentials/src/Types/Shared/Exceptions.shared.cs
+++ b/src/Essentials/src/Types/Shared/Exceptions.shared.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui.ApplicationModel
 {
 	static class ExceptionUtils
 	{
-#if NETSTANDARD || NET6_0
+#if (NETSTANDARD || !PLATFORM) || NET6_0
 		internal static NotImplementedInReferenceAssemblyException NotSupportedOrImplementedException =>
 			new NotImplementedInReferenceAssemblyException();
 #else

--- a/src/TestUtils/src/DeviceTests.Runners/TestWindow.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/TestWindow.cs
@@ -10,7 +10,7 @@ using PlatformView = UIKit.UIWindow;
 using PlatformView = Android.App.Activity;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Window;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestWindow.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/TestWindow.cs
@@ -10,7 +10,7 @@ using PlatformView = UIKit.UIWindow;
 using PlatformView = Android.App.Activity;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Window;
-#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
+#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 

--- a/src/TestUtils/src/DeviceTests.Runners/TestWindow.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/TestWindow.cs
@@ -10,7 +10,7 @@ using PlatformView = UIKit.UIWindow;
 using PlatformView = Android.App.Activity;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.Window;
-#elif (NETSTANDARD || NET6_0) || (NET6_0 && !IOS && !ANDROID)
+#elif NETSTANDARD || (NET6_0 && !IOS && !ANDROID)
 using PlatformView = System.Object;
 #endif
 


### PR DESCRIPTION
### Description of Change

In a previous PR, we added some attributes under the `#if !NETSTANDARD` condition and expected it to not be there for netstandard, but exist for net6.0 and net6.0-platform: https://github.com/dotnet/maui/pull/6013

However, due to the fact that we previously and long ago needed the net6.0 and netstandard TFMs to have the same code as we still shipped netstandard, we had declared that NET6_0 == NETSTANDARD:

```xml
<PropertyGroup Condition="'$(TargetFramework)' == '$(_MauiDotNetTfm)'">
  <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
</PropertyGroup>
```

This PR does a find/replace of `NETSTANDARD` with `(NETSTANDARD || !PLATFORM)` so that it is obvious. Some of the conditions are a bit weird and need to be revisited, but this is how it was and for this PR not to change anything I have kept it like that.

### Issues Fixed


Fixes #7050
