### PR TITLE
Don't directly reference the tizen nuget

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
+++ b/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
@@ -132,7 +132,7 @@
     <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" />
   </ItemGroup>
   <ItemGroup Condition=" '$(_MauiTargetPlatformIsTizen)' == 'True' ">
-    <PackageReference Include="Tizen.UIExtensions.ElmSharp" />
+    <PackageReference Include="Tizen.UIExtensions.ElmSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Maui.Graphics.Skia" />
   </ItemGroup>
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -72,7 +72,6 @@
   <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true') and ('$(TargetPlatformIdentifier)' == 'windows') ">
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="@MicrosoftWindowsSDKBuildToolsPackageVersion@" IsImplicitlyDefined="true" PrivateAssets="all" />
   </ItemGroup>
-
   <ItemGroup Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true') and ('$(TargetPlatformIdentifier)' == 'tizen') ">
     <PackageReference Include="Tizen.UIExtensions.ElmSharp" Version="@SamsungTizenUIExtensionsElmSharpPackageVersion@" IsImplicitlyDefined="true" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change

Since we don't yet have a stable tizen nuget, we can't depend on it.

See also #7030 