### PR TITLE
Disconnect from PropertyChanged when handler removed

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
@@ -10,6 +10,7 @@ using Google.Android.Material.AppBar;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
 using LP = Android.Views.ViewGroup.LayoutParams;
+using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
 
 namespace Microsoft.Maui.Controls
 {
@@ -33,6 +34,11 @@ namespace Microsoft.Maui.Controls
 					_platformTitleView.Child = null;
 
 				_platformTitleViewHandler?.DisconnectHandler();
+
+				Controls.Platform.ToolbarExtensions.DisposeMenuItems(
+					oldHandler?.PlatformView as AToolbar,
+					ToolbarItems, 
+					OnToolbarItemPropertyChanged);
 			}
 		}
 

--- a/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ToolbarExtensions.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Maui.Controls.Platform
 		}
 
 		const int DefaultDisabledToolbarAlpha = 127;
-		public static void DisposeMenuItems(this AToolbar toolbar, IEnumerable<ToolbarItem> toolbarItems, PropertyChangedEventHandler toolbarItemChanged)
+		public static void DisposeMenuItems(this AToolbar? toolbar, IEnumerable<ToolbarItem> toolbarItems, PropertyChangedEventHandler toolbarItemChanged)
 		{
 			if (toolbarItems == null)
 				return;

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -109,6 +109,39 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+
+		[Fact(DisplayName = "Pushing the Same Page Disconnects Previous Toolbar Items")]
+		public async Task PushingTheSamePageUpdatesToolbar()
+		{
+			SetupBuilder();
+			bool canExecute = false;
+			var command = new Command(() => { }, () => canExecute);
+			var pushedPage = new ContentPage()
+			{
+				ToolbarItems =
+				{
+					new ToolbarItem()
+					{
+						Command = command
+					}
+				}
+			};
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new ContentPage();
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await shell.Navigation.PushAsync(pushedPage);
+				await shell.Navigation.PopAsync();
+				canExecute = true;
+				await shell.Navigation.PushAsync(pushedPage);
+				command.ChangeCanExecute();
+			});
+		}
+
 		[Fact(DisplayName = "Set Has Back Button")]
 		public async Task SetHasBackButton()
 		{


### PR DESCRIPTION
### Description of Change

When popping a page off the stack in shell we need to disconnect the ToolbarItems from propagating changes to the platform

### Issues Fixed
Fixes #6940
