### PR TITLE
Unsubscribing from wrong incoming page

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellPageRendererTracker.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			{
 				oldPage.Appearing -= PageAppearing;
 				oldPage.PropertyChanged -= OnPagePropertyChanged;
-				newPage.Loaded -= OnPageLoaded;
+				oldPage.Loaded -= OnPageLoaded;
 				((INotifyCollectionChanged)oldPage.ToolbarItems).CollectionChanged -= OnToolbarItemsChanged;
 			}
 


### PR DESCRIPTION
### Description of Change

Fixes exception when popping a page on Shell

This only causes a crash on iOS. It looks like catalyst swallows the exception and just keeps on truckin'