### PR TITLE
Allow AbsoluteLayout children to auto size when height/width are not proportional

### DIFF
--- a/src/Core/src/Layouts/AbsoluteLayoutManager.cs
+++ b/src/Core/src/Layouts/AbsoluteLayoutManager.cs
@@ -132,8 +132,8 @@ namespace Microsoft.Maui.Layouts
 		{
 			if (boundsValue < 0)
 			{
-				// If the child view doesn't have bounds set by the AbsoluteLayout, then we'll measure using the full constraint value
-				return constraint;
+				// If the child view doesn't have bounds set by the AbsoluteLayout, then we'll let it auto-size
+				return double.PositiveInfinity;
 			}
 
 			if (proportional)


### PR DESCRIPTION
### Description of Change

When the height/width layout parameters from AbsoluteLayout are set to AutoSize, the current implementation still restricts the child to the width/height of the AbsoluteLayout, rather than allowing it to size itself.

These changes allow the child to size itself. 

Note that this will be a behavioral change from Forms, which has had the "not actually auto-sizing" bug for a while. In most situations this will not be noticeable, as the bugged sizing and correct sizing happen to be the same. For situations where the bugged sizing is preferred, it can be be achieved by setting values of 1 for WidthProportional and HeightProportional. 

For the moment, the Compatibility version of the AbsoluteLayout retains the old, bugged behavior.

### Issues Fixed

Fixes #6500
