### PR TITLE
Fix Project Template Dark colors

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -24,8 +24,8 @@
     </Style>
 
     <Style TargetType="Button">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Primary}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
+        <Setter Property="TextColor" Value="{StaticResource White}" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource Gray600}}" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="CornerRadius" Value="8"/>


### PR DESCRIPTION
### Description of Change

This is the actual behavior.

Light
<img src="https://user-images.githubusercontent.com/6755973/168581366-af4e1a51-469d-452d-97ea-880a2d37c226.png" width="300">

Dark
<img src="https://user-images.githubusercontent.com/6755973/168254222-93521726-5cf9-47a5-bfb8-52cf89b0fdd1.png" width="300">

Maybe it's correct, only with the calculator having so many buttons it looks strange.

With the changes in this PR:
<img src="https://user-images.githubusercontent.com/6755973/168581221-24fd60c4-7a76-483e-9b8d-bb062579293e.png" width="300">

Is this correct? Maybe something like this is better (taking into account the colors in the light theme)?
<img src="https://user-images.githubusercontent.com/6755973/168581322-cfc533ce-823f-4395-8d2b-8590b137a87e.png" width="300">

### Issues Fixed

Fixes #7135 
