### PR TITLE
[Android] Render Border without set a Stroke

### DIFF
--- a/src/Core/src/Graphics/MauiDrawable.Android.cs
+++ b/src/Core/src/Graphics/MauiDrawable.Android.cs
@@ -164,17 +164,20 @@ namespace Microsoft.Maui.Graphics
 			if (paint is SolidPaint solidPaint)
 				SetBorderBrush(solidPaint);
 
-			if (paint is LinearGradientPaint linearGradientPaint)
+			else if (paint is LinearGradientPaint linearGradientPaint)
 				SetBorderBrush(linearGradientPaint);
 
-			if (paint is RadialGradientPaint radialGradientPaint)
+			else if (paint is RadialGradientPaint radialGradientPaint)
 				SetBorderBrush(radialGradientPaint);
 
-			if (paint is ImagePaint imagePaint)
+			else if (paint is ImagePaint imagePaint)
 				SetBorderBrush(imagePaint);
 
-			if (paint is PatternPaint patternPaint)
+			else if (paint is PatternPaint patternPaint)
 				SetBorderBrush(patternPaint);
+			
+			else
+				SetEmptyBorderBrush();
 		}
 
 		public void SetBorderBrush(SolidPaint solidPaint)
@@ -218,6 +221,27 @@ namespace Microsoft.Maui.Graphics
 			InvalidateSelf();
 		}
 
+		public void SetEmptyBorderBrush()
+		{
+			_invalidatePath = true;
+
+			if (_backgroundColor != null)
+			{
+				_borderColor = _backgroundColor.Value;
+				_stroke = null;
+			}
+			else
+			{
+				_borderColor = null;
+
+				if (_background != null)
+					SetBorderBrush(_background);
+			}
+
+			InitializeBorderIfNeeded();
+			InvalidateSelf();
+		}
+	
 		public void SetBorderBrush(ImagePaint imagePaint)
 		{
 			throw new NotImplementedException();
@@ -473,7 +497,7 @@ namespace Microsoft.Maui.Graphics
 		{
 			InitializeBorderIfNeeded();
 
-			return _shape != null && (_stroke != null || _borderColor != null);
+			return _shape != null;
 		}
 
 		void InitializeBorderIfNeeded()

--- a/src/Core/src/Platform/Android/StrokeExtensions.cs
+++ b/src/Core/src/Platform/Android/StrokeExtensions.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Maui.Platform
 
 		internal static void UpdateMauiDrawable(this AView platformView, IBorderStroke border)
 		{
-			bool hasBorder = border.Shape != null && border.Stroke != null;
+			bool hasBorder = border.Shape != null;
 
 			if (!hasBorder)
 				return;

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateBackground(this ContentViewGroup platformView, IBorderStroke border)
 		{
-			bool hasBorder = border.Shape != null && border.Stroke != null;
+			bool hasBorder = border.Shape != null;
 
 			if (hasBorder)
 				platformView.UpdateBorderStroke(border);

--- a/src/Core/tests/DeviceTests/Handlers/Border/BorderHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Border/BorderHandlerTests.Android.cs
@@ -1,12 +1,34 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Handlers;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class BorderHandlerTests
 	{
+		[Theory(DisplayName = "Border render without Stroke")]
+		[InlineData(0xFF0000)]
+		[InlineData(0x00FF00)]
+		[InlineData(0x0000FF)]
+		public async Task BorderRenderWithoutStroke(uint color)
+		{
+			var expected = Color.FromUint(color);
+
+			var border = new BorderStub()
+			{
+				Content = new LabelStub { Text = "Without Stroke", TextColor = Colors.White },
+				Shape = new RoundRectangleShapeStub { CornerRadius = new CornerRadius(12) },
+				Background = new SolidPaintStub(expected),
+				Stroke = null,
+				StrokeThickness = 2,
+				Height = 100,
+				Width = 300
+			};
+
+			await ValidateHasColor(border, expected);
+		}
+
 		ContentViewGroup GetNativeBorder(BorderHandler borderHandler) =>
 			borderHandler.PlatformView;
 


### PR DESCRIPTION
### Description of Change

Render Border without set a Stroke.

![Screenshot_1652779203](https://user-images.githubusercontent.com/6755973/168778560-bff59cdc-fd4e-41fe-9d88-2353f856a25c.png)

![image](https://user-images.githubusercontent.com/6755973/168778590-bbe43145-0f0f-4bc9-9046-e25414f9cb76.png)

### Issues Fixed

Fixes #7238 
