### PR TITLE
Propagate layout requests up the tree for Content/Layout Views

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -173,6 +173,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
+		public override void SetNeedsLayout()
+		{
+			base.SetNeedsLayout();
+			Superview?.SetNeedsLayout();
+		}
+
 		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
 		class FrameView : Microsoft.Maui.Platform.ContentView
 		{

--- a/src/Core/src/Platform/iOS/ContentView.cs
+++ b/src/Core/src/Platform/iOS/ContentView.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Maui.Platform
 			CrossPlatformArrange?.Invoke(bounds);
 		}
 
+		public override void SetNeedsLayout()
+		{
+			base.SetNeedsLayout();
+			Superview?.SetNeedsLayout();
+		}
+
 		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
 		internal Func<Rect, Size>? CrossPlatformArrange { get; set; }
 	}

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -33,9 +33,14 @@ namespace Microsoft.Maui.Platform
 			base.LayoutSubviews();
 
 			var bounds = AdjustForSafeArea(Bounds).ToRectangle();
-
 			CrossPlatformMeasure?.Invoke(bounds.Width, bounds.Height);
 			CrossPlatformArrange?.Invoke(bounds);
+		}
+
+		public override void SetNeedsLayout()
+		{
+			base.SetNeedsLayout();
+			Superview?.SetNeedsLayout();
 		}
 
 		public override void SubviewAdded(UIView uiview)

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -40,32 +40,20 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateVisibility(this UIView platformView, Visibility visibility)
 		{
-			var shouldLayout = false;
-
 			switch (visibility)
 			{
 				case Visibility.Visible:
-					shouldLayout = platformView.Inflate();
+					platformView.Inflate();
 					platformView.Hidden = false;
 					break;
 				case Visibility.Hidden:
-					shouldLayout = platformView.Inflate();
+					platformView.Inflate();
 					platformView.Hidden = true;
 					break;
 				case Visibility.Collapsed:
 					platformView.Hidden = true;
 					platformView.Collapse();
-					shouldLayout = true;
 					break;
-			}
-
-			// If the view is just switching between Visible and Hidden, then a re-layout isn't necessary. The return value
-			// from Inflate will tell us if the view was previously collapsed. If the view is switching to or from a collapsed
-			// state, then we'll have to ask for a re-layout.
-
-			if (shouldLayout)
-			{
-				platformView.Superview?.SetNeedsLayout();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

Makes the backing views for layouts/content on iOS propagate layout requests to their parents, if available. So layout changes which require resizing/remeasuring actually work.

Also removes unnecessary SetNeedsLayout call when switching visibility.

### Issues Fixed

Fixes #6420 
Fixes #7217