### PR TITLE
Ensure that Grid is propagating the BindingContext to the row/col definitions

### DIFF
--- a/src/Controls/src/Core/Layout/Grid.cs
+++ b/src/Controls/src/Core/Layout/Grid.cs
@@ -369,6 +369,8 @@ namespace Microsoft.Maui.Controls
 			_rowDefs = null;
 			_colDefs = null;
 
+			UpdateRowColumnBindingContexts();
+
 			InvalidateMeasure();
 		}
 
@@ -376,6 +378,29 @@ namespace Microsoft.Maui.Controls
 		{
 			base.InvalidateMeasure();
 			(this as IView)?.InvalidateMeasure();
+		}
+
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+			UpdateRowColumnBindingContexts();
+		}
+
+		void UpdateRowColumnBindingContexts()
+		{
+			var bindingContext = BindingContext;
+
+			RowDefinitionCollection rowDefs = RowDefinitions;
+			for (var i = 0; i < rowDefs.Count; i++)
+			{
+				SetInheritedBindingContext(rowDefs[i], bindingContext);
+			}
+
+			ColumnDefinitionCollection colDefs = ColumnDefinitions;
+			for (var i = 0; i < colDefs.Count; i++)
+			{
+				SetInheritedBindingContext(colDefs[i], bindingContext);
+			}
 		}
 
 		class GridInfo

--- a/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/GridLayoutTests.cs
@@ -128,5 +128,61 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 		{
 			handler.Received().Invoke(Arg.Is(nameof(IView.InvalidateMeasure)), Arg.Any<object>());
 		}
+
+		[Test]
+		public void RowDefinitionsGetBindingContext() 
+		{
+			var def = new RowDefinition();
+			var def2 = new RowDefinition();
+
+			var grid = new Grid()
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					def
+				}
+			};
+
+			var context = new object();
+
+			Assert.That(def.BindingContext, Is.Null);
+			Assert.That(def2.BindingContext, Is.Null);
+
+			grid.BindingContext = context;
+
+			Assert.That(def.BindingContext, Is.EqualTo(context));
+
+			grid.RowDefinitions.Add(def2);
+
+			Assert.That(def2.BindingContext, Is.EqualTo(context));
+		}
+
+		[Test]
+		public void ColumnDefinitionsGetBindingContext()
+		{
+			var def = new ColumnDefinition();
+			var def2 = new ColumnDefinition();
+
+			var grid = new Grid()
+			{
+				ColumnDefinitions = new ColumnDefinitionCollection
+				{
+					def
+				}
+			};
+
+			var context = new object();
+
+			Assert.That(def.BindingContext, Is.Null);
+			Assert.That(def2.BindingContext, Is.Null);
+
+			grid.BindingContext = context;
+
+			Assert.That(def.BindingContext, Is.EqualTo(context));
+
+			grid.ColumnDefinitions.Add(def2);
+
+			Assert.That(def2.BindingContext, Is.EqualTo(context));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Grid isn't propagating its BindingContext to the Row/Column Definitions - these changes ensure that it does.

### Issues Fixed

Fixes #4609