### PR TITLE
Setup WinUI to run window scoped tests in new window

### DIFF
--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <MauiImage Include="Resources\Images\*" />
-    <Compile Remove="Stubs\MauiAppNewWindowStub.cs" />
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
     <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
   </ItemGroup>
@@ -36,7 +35,6 @@
   <!-- include/exclude the *.<platform>.cs files -->
   <ItemGroup>
     <None Include="@(Compile)" />
-    <None Include="Stubs\MauiAppNewWindowStub.cs" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">
     <Compile Remove="**\*.Android.cs" />

--- a/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+++ b/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <MauiImage Include="Resources\Images\*" />
+    <Compile Remove="Stubs\MauiAppNewWindowStub.cs" />
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
     <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
   </ItemGroup>
@@ -35,6 +36,7 @@
   <!-- include/exclude the *.<platform>.cs files -->
   <ItemGroup>
     <None Include="@(Compile)" />
+    <None Include="Stubs\MauiAppNewWindowStub.cs" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">
     <Compile Remove="**\*.Android.cs" />

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.Windows.cs
@@ -15,6 +15,7 @@ using WWindow = Microsoft.UI.Xaml.Window;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Handlers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Maui.DeviceTests.Stubs;
 
 namespace Microsoft.Maui.DeviceTests
 {

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -7,6 +7,7 @@ using Google.Android.Material.AppBar;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Platform;
 using Xunit;
 

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -13,6 +13,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.DeviceTests.Stubs;
 
 namespace Microsoft.Maui.DeviceTests
 {

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.DeviceTests.Stubs;
 
 #if ANDROID || IOS
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		static Drawable _decorDrawable;
-		Task RunWindowTest<THandler>(IWindow window, Func<THandler, Task> action)
+		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests)
 			where THandler : class, IElementHandler
 		{
 			return InvokeOnMainThreadAsync(async () =>
@@ -60,18 +60,7 @@ namespace Microsoft.Maui.DeviceTests
 						.Commit();
 
 					await viewFragment.FinishedLoading;
-
-					if (window.Content is Shell shell)
-						await OnLoadedAsync(shell.CurrentPage);
-
-					if (typeof(THandler).IsAssignableFrom(window.Handler.GetType()))
-						await action((THandler)window.Handler);
-					else if (typeof(THandler).IsAssignableFrom(window.Content.Handler.GetType()))
-						await action((THandler)window.Content.Handler);
-					else if (window.Content is ContentPage cp && typeof(THandler).IsAssignableFrom(cp.Content.Handler.GetType()))
-						await action((THandler)cp.Content.Handler);
-					else
-						throw new Exception($"I can't work with {typeof(THandler)}");
+					await runTests.Invoke();
 				}
 				finally
 				{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(async () =>
 			{
-				var testingRootPanel = (WFrameworkElement)MauiProgram.CurrentWindow.Content;
 				var applicationContext = MauiContext.MakeApplicationScope(UI.Xaml.Application.Current);
 
 				var appStub = new MauiAppNewWindowStub(window);

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -1,21 +1,16 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using NativeAutomationProperties = Microsoft.UI.Xaml.Automation.AutomationProperties;
-using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 using WNavigationViewItem = Microsoft.UI.Xaml.Controls.NavigationViewItem;
 using WFrameworkElement = Microsoft.UI.Xaml.FrameworkElement;
 using WWindow = Microsoft.UI.Xaml.Window;
-using Microsoft.Maui.Hosting;
-using Microsoft.Maui.Handlers;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Platform;
 using System.Threading.Tasks;
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
-using WPoint = Windows.Foundation.Point;
 using WAppBarButton = Microsoft.UI.Xaml.Controls.AppBarButton;
 using Xunit;
 
@@ -27,65 +22,30 @@ namespace Microsoft.Maui.DeviceTests
 			((AccessibilityView)((DependencyObject)viewHandler.PlatformView).GetValue(NativeAutomationProperties.AccessibilityViewProperty))
 			== AccessibilityView.Content;
 
-		Task RunWindowTest<THandler>(IWindow window, Func<THandler, Task> action)
+
+		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests)
 			where THandler : class, IElementHandler
 		{
 			return InvokeOnMainThreadAsync(async () =>
 			{
-				var testingRootPanel = (WPanel)MauiProgram.CurrentWindow.Content;
-				IElementHandler newWindowHandler = null;
-				NavigationRootManager navigationRootManager = null;
+				var testingRootPanel = (WFrameworkElement)MauiProgram.CurrentWindow.Content;
+				var applicationContext = MauiContext.MakeApplicationScope(UI.Xaml.Application.Current);
+
+				var appStub = new MauiAppNewWindowStub(window);
+				UI.Xaml.Application.Current.SetApplicationHandler(appStub, applicationContext);
+				WWindow newWindow = null;
 				try
 				{
-					var scopedContext = new MauiContext(MauiContext.Services);
-					scopedContext.AddWeakSpecific(MauiProgram.CurrentWindow);
-					var mauiContext = scopedContext.MakeScoped(true);
-					navigationRootManager = mauiContext.GetNavigationRootManager();
-
-					MauiContext
-						.Services
-						.GetRequiredService<WWindow>()
-						.SetWindowHandler(window, mauiContext);
-
-					newWindowHandler = window.Handler;
-					var content = window.Content.Handler.ToPlatform();
-					await content.OnLoadedAsync();
-					await Task.Delay(10);
-
-					if (typeof(THandler).IsAssignableFrom(newWindowHandler.GetType()))
-						await action((THandler)newWindowHandler);
-					else if (typeof(THandler).IsAssignableFrom(window.Content.Handler.GetType()))
-						await action((THandler)window.Content.Handler);
-					else if (window.Content is ContentPage cp && typeof(THandler).IsAssignableFrom(cp.Content.Handler.GetType()))
-						await action((THandler)cp.Content.Handler);
-					else
-						throw new Exception($"I can't work with {typeof(THandler)}");
-
+					ApplicationExtensions.CreatePlatformWindow(UI.Xaml.Application.Current, appStub, new Handlers.OpenWindowRequest());
+					newWindow = window.Handler.PlatformView as WWindow;
+					await runTests.Invoke();
 				}
 				finally
 				{
-					if (navigationRootManager != null)
-						navigationRootManager.Disconnect();
-
-					if (newWindowHandler != null)
-						newWindowHandler.DisconnectHandler();
-
-					// Set the root window panel back to the testing panel
-					if (testingRootPanel != null && MauiProgram.CurrentWindow.Content != testingRootPanel)
-					{
-						MauiProgram.CurrentWindow.Content = testingRootPanel;
-						await testingRootPanel.OnLoadedAsync();
-						await Task.Delay(10);
-					}
-
-					// reset the appbar title to our test runner
-					MauiProgram
-						.CurrentWindow
-						.GetWindow()
-						.Handler
-						.MauiContext
-						.GetNavigationRootManager()
-						.UpdateAppTitleBar(true);
+					window.Handler.DisconnectHandler();
+					await Task.Delay(10);
+					newWindow?.Close();
+					appStub.Handler.DisconnectHandler();
 				}
 			});
 		}
@@ -176,7 +136,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			return true;
 		}
-    
+
 		protected object GetTitleView(IElementHandler handler)
 		{
 			var toolbar = GetPlatformToolbar(handler);

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using WAppBarButton = Microsoft.UI.Xaml.Controls.AppBarButton;
 using Xunit;
+using Microsoft.Maui.DeviceTests.Stubs;
 
 namespace Microsoft.Maui.DeviceTests
 {

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
@@ -68,6 +69,7 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(VerticalStackLayout), typeof(LayoutHandler));
 					handlers.AddHandler(typeof(Controls.Window), typeof(WindowHandlerStub));
 					handlers.AddHandler(typeof(Controls.ContentPage), typeof(PageHandler));
+					handlers.AddHandler(typeof(MauiAppNewWindowStub), typeof(ApplicationHandler));
 				});
 
 			appBuilder.Services.AddSingleton<IDispatcherProvider>(svc => TestDispatcher.Provider);
@@ -82,7 +84,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		public void Dispose()
 		{
-			((IDisposable)_mauiApp).Dispose();
+			((IDisposable)_mauiApp)?.Dispose();
 
 			_mauiApp = null;
 			_mauiContext = null;
@@ -141,8 +143,8 @@ namespace Microsoft.Maui.DeviceTests
 #else
 				// Windows cannot measure without the view being loaded
 				// iOS needs more love when I get an IDE again
-				var w = view.Width;
-				var h = view.Height;
+				var w = view.Width.Equals(double.NaN) ? -1 : view.Width;
+				var h = view.Height.Equals(double.NaN) ? -1 : view.Height;
 #endif
 
 				view.Arrange(new Rect(0, 0, w, h));
@@ -174,6 +176,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		static SemaphoreSlim _takeOverMainContentSempahore = new SemaphoreSlim(1);
 		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action)
 			where THandler : class, IElementHandler
 		{
@@ -194,7 +197,37 @@ namespace Microsoft.Maui.DeviceTests
 					window = new Controls.Window(new ContentPage() { Content = (View)view });
 				}
 
-				await RunWindowTest<THandler>(window, (handler) => action(handler as THandler));
+				try
+				{
+					await _takeOverMainContentSempahore.WaitAsync();
+
+					await SetupWindowForTests<THandler>(window, async () =>
+					{
+						IView content = window.Content;
+
+						if (content is IPageContainer<Page> pc)
+							content = pc.CurrentPage;
+
+						await OnLoadedAsync(content as VisualElement);
+#if WINDOWS
+
+						await Task.Delay(10);
+#endif
+
+						if (typeof(THandler).IsAssignableFrom(window.Handler.GetType()))
+							await action((THandler)window.Handler);
+						else if (typeof(THandler).IsAssignableFrom(window.Content.Handler.GetType()))
+							await action((THandler)window.Content.Handler);
+						else if (window.Content is ContentPage cp && typeof(THandler).IsAssignableFrom(cp.Content.Handler.GetType()))
+							await action((THandler)cp.Content.Handler);
+						else
+							throw new Exception($"I can't work with {typeof(THandler)}");
+					});
+				}
+				finally
+				{
+					_takeOverMainContentSempahore.Release();
+				}
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.iOS.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.iOS.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.DeviceTests
 			return platformView.AccessibilityElementsHidden;
 		}
 
-		Task RunWindowTest<THandler>(IWindow window, Func<THandler, Task> action)
+		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests)
 			where THandler : class, IElementHandler
 		{
 			return InvokeOnMainThreadAsync(async () =>
@@ -31,21 +31,7 @@ namespace Microsoft.Maui.DeviceTests
 				try
 				{
 					_ = window.ToHandler(MauiContext);
-					IView content = window.Content;
-
-					if (content is IPageContainer<Page> pc)
-						content = pc.CurrentPage;
-
-					await OnLoadedAsync(content as VisualElement);
-
-					if (typeof(THandler).IsAssignableFrom(window.Handler.GetType()))
-						await action((THandler)window.Handler);
-					else if (typeof(THandler).IsAssignableFrom(window.Content.Handler.GetType()))
-						await action((THandler)window.Content.Handler);
-					else if (window.Content is ContentPage cp && typeof(THandler).IsAssignableFrom(cp.Content.Handler.GetType()))
-						await action((THandler)cp.Content.Handler);
-					else
-						throw new Exception($"I can't work with {typeof(THandler)}");
+					await runTests.Invoke();
 				}
 				finally
 				{
@@ -91,7 +77,7 @@ namespace Microsoft.Maui.DeviceTests
 		protected object GetTitleView(IElementHandler handler)
 		{
 			var activeVC = GetVisibleViewController(handler);
-			if ( activeVC.NavigationItem.TitleView is
+			if (activeVC.NavigationItem.TitleView is
 				ShellPageRendererTracker.TitleViewContainer tvc)
 			{
 				return tvc.View.Handler.PlatformView;

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.iOS.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.iOS.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Controls.Platform.Compatibility;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Platform;
 using UIKit;
 

--- a/src/Controls/tests/DeviceTests/Stubs/MauiAppNewWindowStub.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/MauiAppNewWindowStub.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Maui.UnitTests
+namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	class MauiAppNewWindowStub : IApplication
 	{

--- a/src/Controls/tests/DeviceTests/Stubs/MauiAppNewWindowStub.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/MauiAppNewWindowStub.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Maui.UnitTests
+{
+	class MauiAppNewWindowStub : IApplication
+	{
+		readonly IWindow _window;
+
+		public MauiAppNewWindowStub(IWindow window)
+		{
+			_window = window;
+		}
+
+		public IReadOnlyList<IWindow> Windows => new List<IWindow>() { _window };
+
+		public IElementHandler Handler { get; set; }
+
+		public IElement Parent => null;
+
+		public void CloseWindow(IWindow window)
+		{
+			Handler?.Invoke(nameof(IApplication.CloseWindow), window);
+		}
+
+		public IWindow CreateWindow(IActivationState activationState)
+		{
+			return _window;
+		}
+
+		public void OpenWindow(IWindow window)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void ThemeChanged()
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
@@ -5,7 +5,7 @@ using Microsoft.Maui.Platform;
 using static Microsoft.Maui.DeviceTests.HandlerTestBase;
 using AActivity = Android.App.Activity;
 
-namespace Microsoft.Maui.DeviceTests
+namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class WindowHandlerStub : ElementHandler<IWindow, AActivity>, IWindowHandler
 	{

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Windows.cs
@@ -3,49 +3,15 @@ using Microsoft.Maui.Platform;
 using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 using WWindow = Microsoft.UI.Xaml.Window;
 using Microsoft.Maui.Handlers;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.DeviceTests
 {
-	public class WindowHandlerStub : ElementHandler<IWindow, UI.Xaml.Window>, IWindowHandler
+	public class WindowHandlerStub : WindowHandler
 	{
-		public static IPropertyMapper<IWindow, WindowHandlerStub> WindowMapper = new PropertyMapper<IWindow, WindowHandlerStub>(WindowHandler.Mapper)
-		{
-			[nameof(IWindow.Content)] = MapContent
-		};
-
-		private static void MapContent(WindowHandlerStub handler, IWindow window)
-		{
-			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			var windowManager = handler.MauiContext.GetNavigationRootManager();
-			windowManager.Disconnect();
-			windowManager.Connect(handler.VirtualView.Content.ToPlatform(handler.MauiContext));
-			var rootPanel = handler.PlatformView.Content as WPanel;
-
-			if (rootPanel == null)
-				return;
-
-			if (!rootPanel.Children.Contains(windowManager.RootView))
-				rootPanel.Children.Add(windowManager.RootView);
-		}
-
-		protected override void DisconnectHandler(UI.Xaml.Window platformView)
-		{
-			var windowManager = MauiContext.GetNavigationRootManager();
-			var rootPanel = platformView.Content as WPanel;
-			rootPanel.Children.Remove(windowManager.RootView);
-			windowManager.Disconnect();
-
-			base.DisconnectHandler(platformView);
-		}
-
 		public WindowHandlerStub()
-			: base(WindowMapper)
+			: base()
 		{
-		}
-
-		protected override WWindow CreatePlatformElement()
-		{
-			return MauiProgram.CurrentWindow;
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Windows.cs
@@ -5,7 +5,7 @@ using WWindow = Microsoft.UI.Xaml.Window;
 using Microsoft.Maui.Handlers;
 using Microsoft.UI.Xaml;
 
-namespace Microsoft.Maui.DeviceTests
+namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class WindowHandlerStub : WindowHandler
 	{

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.iOS.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using UIKit;
 
-namespace Microsoft.Maui.DeviceTests
+namespace Microsoft.Maui.DeviceTests.Stubs
 {
 	public class WindowHandlerStub : ElementHandler<IWindow, UIWindow>, IWindowHandler
 	{

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Maui.Handlers
 				?.GetNavigationRootManager()
 				?.Disconnect();
 
-			platformView.Content = null;
+			if (platformView.Dispatcher != null)
+				platformView.Content = null;
 
 			base.DisconnectHandler(platformView);
 		}


### PR DESCRIPTION
### Description of Change

https://github.com/dotnet/maui/pull/7172 broke a few things that assumed the root of a WinUI app would be a Panel. This PR starts the journey of fixing the fall out of those changes. I've logged additional issues for fixing the pending issues so that this PR doesn't gain too much behavior change.

- Fix NaN exception for basic handler tests.
- For tests that needed to simulate running in an isolated space we were just adding those views to the root panel view. This PR now just opens them in a brand new window.
- [Flyout Page tests currently fail when ran with other testing because of how the code works for retrieving orientation](https://github.com/dotnet/maui/issues/7306)
- [Modal is currently broken on WinUI](https://github.com/dotnet/maui/issues/7307)
