### PR TITLE
Create Window Specific Orientation Extensions

### DIFF
--- a/src/Controls/src/Core/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Maui.Controls
 					return false;
 
 				FlyoutLayoutBehavior behavior = FlyoutLayoutBehavior;
-				var orientation = DeviceDisplay.MainDisplayInfo.Orientation;
+				var orientation = this.Window?.GetOrientation() ?? DisplayOrientation.Unknown;
 
 				bool isSplitOnLandscape = (behavior == FlyoutLayoutBehavior.SplitOnLandscape || behavior == FlyoutLayoutBehavior.Default) && orientation.IsLandscape();
 				bool isSplitOnPortrait = behavior == FlyoutLayoutBehavior.SplitOnPortrait && orientation.IsPortrait();

--- a/src/Controls/src/Core/FlyoutPage.cs
+++ b/src/Controls/src/Core/FlyoutPage.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Maui.Controls
 					return false;
 
 				FlyoutLayoutBehavior behavior = FlyoutLayoutBehavior;
-				var orientation = this.Window?.GetOrientation() ?? DisplayOrientation.Unknown;
+				var orientation = Window.GetOrientation();
 
 				bool isSplitOnLandscape = (behavior == FlyoutLayoutBehavior.SplitOnLandscape || behavior == FlyoutLayoutBehavior.Default) && orientation.IsLandscape();
 				bool isSplitOnPortrait = behavior == FlyoutLayoutBehavior.SplitOnPortrait && orientation.IsPortrait();

--- a/src/Controls/tests/Core.UnitTests/FlyoutPageUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlyoutPageUnitTests.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void ThorwsInSetIsPresentOnSplitPortraitModeOnTablet()
+		public void ThrowsInSetIsPresentOnSplitPortraitModeOnTablet()
 		{
 			mockDeviceInfo.Idiom = DeviceIdiom.Tablet;
 			mockDeviceDisplay.SetMainDisplayOrientation(DisplayOrientation.Portrait);
@@ -290,7 +290,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			{
 				Flyout = new ContentPage { Content = new View(), IsPlatformEnabled = true, Title = "Foo" },
 				Detail = new ContentPage { Content = new View(), IsPlatformEnabled = true },
-				IsPlatformEnabled = true,
 				FlyoutLayoutBehavior = FlyoutLayoutBehavior.SplitOnPortrait
 			};
 

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -7,13 +7,18 @@ namespace Microsoft.Maui
 {
 	public static partial class WindowExtensions
 	{
-		internal static DisplayOrientation GetOrientation(this IWindow window) =>
-			window.Handler?.MauiContext?.GetPlatformWindow()?.Resources?.Configuration?.Orientation switch
+		internal static DisplayOrientation GetOrientation(this IWindow? window)
+		{
+			if (window == null)
+				return DeviceDisplay.Current.MainDisplayInfo.Orientation;
+
+			return window.Handler?.MauiContext?.GetPlatformWindow()?.Resources?.Configuration?.Orientation switch
 			{
 				Orientation.Landscape => DisplayOrientation.Landscape,
 				Orientation.Portrait => DisplayOrientation.Portrait,
 				Orientation.Square => DisplayOrientation.Portrait,
 				_ => DisplayOrientation.Unknown
 			};
+		}
 	}
 }

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Android.App;
+using Android.Content.Res;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Platform;
+
+namespace Microsoft.Maui
+{
+	public static partial class WindowExtensions
+	{
+		internal static DisplayOrientation GetOrientation(this IWindow window) =>
+			window.Handler?.MauiContext?.GetPlatformWindow()?.Resources?.Configuration?.Orientation switch
+			{
+				Orientation.Landscape => DisplayOrientation.Landscape,
+				Orientation.Portrait => DisplayOrientation.Portrait,
+				Orientation.Square => DisplayOrientation.Portrait,
+				_ => DisplayOrientation.Unknown
+			};
+	}
+}

--- a/src/Core/src/Platform/Standard/WindowExtensions.cs
+++ b/src/Core/src/Platform/Standard/WindowExtensions.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Maui.Devices;
+
+namespace Microsoft.Maui
+{
+	public static partial class WindowExtensions
+	{
+		internal static DisplayOrientation GetOrientation(this IWindow window) =>
+			DisplayOrientation.Unknown;
+	}
+}

--- a/src/Core/src/Platform/Standard/WindowExtensions.cs
+++ b/src/Core/src/Platform/Standard/WindowExtensions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Maui
 {
 	public static partial class WindowExtensions
 	{
-		internal static DisplayOrientation GetOrientation(this IWindow window) =>
-			DisplayOrientation.Unknown;
+		internal static DisplayOrientation GetOrientation(this IWindow? window) =>
+			DeviceDisplay.Current.MainDisplayInfo.Orientation;
 	}
 }

--- a/src/Core/src/Platform/Tizen/WindowExtensions.cs
+++ b/src/Core/src/Platform/Tizen/WindowExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using ElmSharp;
+using Microsoft.Maui.ApplicationModel;
 using Tizen.UIExtensions.Common;
 using Tizen.UIExtensions.ElmSharp;
 using ELayout = ElmSharp.Layout;
@@ -110,5 +111,19 @@ namespace Microsoft.Maui.Platform
 				s_windowCloseRequestHandler[window].Invoke();
 		}
 
+		internal static Devices.DisplayOrientation GetOrientation(this IWindow window)
+		{
+			int displayWidth = PlatformUtils.GetFeatureInfo<int>("screen.width");
+			int displayHeight = PlatformUtils.GetFeatureInfo<int>("screen.height");
+
+			if (displayHeight >= displayWidth)
+			{
+				return Devices.DisplayOrientation.Portrait;
+			}
+			else
+			{
+				return Devices.DisplayOrientation.Landscape;
+			}
+		}
 	}
 }

--- a/src/Core/src/Platform/Tizen/WindowExtensions.cs
+++ b/src/Core/src/Platform/Tizen/WindowExtensions.cs
@@ -111,14 +111,17 @@ namespace Microsoft.Maui.Platform
 				s_windowCloseRequestHandler[window].Invoke();
 		}
 
-		internal static Devices.DisplayOrientation GetOrientation(this IWindow window) =>
-			window.Handler?.MauiContext?.GetPlatformWindow()?.Rotation switch
+		internal static Devices.DisplayOrientation GetOrientation(this IWindow window)
+		{
+			bool isTV = Elementary.GetProfile() == "tv";
+			return window.Handler?.MauiContext?.GetPlatformWindow()?.Rotation switch
 			{
-				0 => Devices.DisplayOrientation.Portrait,
-				90 => Devices.DisplayOrientation.Landscape,
-				180 => Devices.DisplayOrientation.Portrait,
-				270 => Devices.DisplayOrientation.Landscape,
+				0 => isTV ? Devices.DisplayOrientation.Landscape : Devices.DisplayOrientation.Portrait,
+				90 => isTV ? Devices.DisplayOrientation.Portrait : Devices.DisplayOrientation.Landscape,
+				180 => isTV ? Devices.DisplayOrientation.Landscape : Devices.DisplayOrientation.Portrait,
+				270 => isTV ? Devices.DisplayOrientation.Portrait : Devices.DisplayOrientation.Landscape,
 				_ => Devices.DisplayOrientation.Unknown
 			};
+		}
 	}
 }

--- a/src/Core/src/Platform/Tizen/WindowExtensions.cs
+++ b/src/Core/src/Platform/Tizen/WindowExtensions.cs
@@ -111,8 +111,11 @@ namespace Microsoft.Maui.Platform
 				s_windowCloseRequestHandler[window].Invoke();
 		}
 
-		internal static Devices.DisplayOrientation GetOrientation(this IWindow window)
+		internal static Devices.DisplayOrientation GetOrientation(this IWindow? window)
 		{
+			if (window == null)
+				return Devices.DeviceDisplay.Current.MainDisplayInfo.Orientation;
+
 			bool isTV = Elementary.GetProfile() == "tv";
 			return window.Handler?.MauiContext?.GetPlatformWindow()?.Rotation switch
 			{

--- a/src/Core/src/Platform/Tizen/WindowExtensions.cs
+++ b/src/Core/src/Platform/Tizen/WindowExtensions.cs
@@ -111,19 +111,14 @@ namespace Microsoft.Maui.Platform
 				s_windowCloseRequestHandler[window].Invoke();
 		}
 
-		internal static Devices.DisplayOrientation GetOrientation(this IWindow window)
-		{
-			int displayWidth = PlatformUtils.GetFeatureInfo<int>("screen.width");
-			int displayHeight = PlatformUtils.GetFeatureInfo<int>("screen.height");
-
-			if (displayHeight >= displayWidth)
+		internal static Devices.DisplayOrientation GetOrientation(this IWindow window) =>
+			window.Handler?.MauiContext?.GetPlatformWindow()?.Rotation switch
 			{
-				return Devices.DisplayOrientation.Portrait;
-			}
-			else
-			{
-				return Devices.DisplayOrientation.Landscape;
-			}
-		}
+				0 => Devices.DisplayOrientation.Portrait,
+				90 => Devices.DisplayOrientation.Landscape,
+				180 => Devices.DisplayOrientation.Portrait,
+				270 => Devices.DisplayOrientation.Landscape,
+				_ => Devices.DisplayOrientation.Unknown
+			};
 	}
 }

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -62,8 +62,11 @@ namespace Microsoft.Maui.Platform
 			return UI.Windowing.AppWindow.GetFromWindowId(windowId);
 		}
 
-		internal static DisplayOrientation GetOrientation(this IWindow window)
+		internal static DisplayOrientation GetOrientation(this IWindow? window)
 		{
+			if (window == null)
+				return DeviceDisplay.Current.MainDisplayInfo.Orientation;
+
 			var appWindow = window.Handler?.MauiContext?.GetPlatformWindow()?.GetAppWindow();
 
 			if (appWindow == null)

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Maui.Devices;
 using System.Threading.Tasks;
 using Microsoft.Maui.Media;
 using WinRT.Interop;
+using Windows.Graphics.Display;
 
 namespace Microsoft.Maui.Platform
 {
@@ -59,6 +60,26 @@ namespace Microsoft.Maui.Platform
 
 			var windowId = UI.Win32Interop.GetWindowIdFromWindow(hwnd);
 			return UI.Windowing.AppWindow.GetFromWindowId(windowId);
+		}
+
+		internal static DisplayOrientation GetOrientation(this IWindow window)
+		{
+			var appWindow = window.Handler?.MauiContext?.GetPlatformWindow()?.GetAppWindow();
+
+			if (appWindow == null)
+				return DisplayOrientation.Unknown;
+
+			DisplayOrientations orientationEnum;
+			int theScreenWidth = appWindow.Size.Width;
+			int theScreenHeight = appWindow.Size.Height;
+			if (theScreenWidth > theScreenHeight)
+				orientationEnum = DisplayOrientations.Landscape;
+			else
+				orientationEnum = DisplayOrientations.Portrait;
+
+			return orientationEnum == DisplayOrientations.Landscape
+				? DisplayOrientation.Landscape
+				: DisplayOrientation.Portrait;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -31,11 +31,7 @@ namespace Microsoft.Maui.Platform
 		public static float GetDisplayDensity(this UIWindow uiWindow) =>
 			(float)(uiWindow.Screen?.Scale ?? new nfloat(1.0f));
 
-#pragma warning disable CA1416 // UIApplication.StatusBarOrientation has [UnsupportedOSPlatform("ios9.0")]. (Deprecated but still works)
-		internal static DisplayOrientation GetOrientation(this IWindow window) =>
-			UIApplication.SharedApplication.StatusBarOrientation.IsLandscape()
-				? DisplayOrientation.Landscape
-				: DisplayOrientation.Portrait;
-#pragma warning restore CA1416
+		internal static DisplayOrientation GetOrientation(this IWindow? window) =>
+			DeviceDisplay.Current.MainDisplayInfo.Orientation;
 	}
 }

--- a/src/Core/src/Platform/iOS/WindowExtensions.cs
+++ b/src/Core/src/Platform/iOS/WindowExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui.Devices;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
@@ -29,5 +30,12 @@ namespace Microsoft.Maui.Platform
 
 		public static float GetDisplayDensity(this UIWindow uiWindow) =>
 			(float)(uiWindow.Screen?.Scale ?? new nfloat(1.0f));
+
+#pragma warning disable CA1416 // UIApplication.StatusBarOrientation has [UnsupportedOSPlatform("ios9.0")]. (Deprecated but still works)
+		internal static DisplayOrientation GetOrientation(this IWindow window) =>
+			UIApplication.SharedApplication.StatusBarOrientation.IsLandscape()
+				? DisplayOrientation.Landscape
+				: DisplayOrientation.Portrait;
+#pragma warning restore CA1416
 	}
 }


### PR DESCRIPTION
### Description of Change

Create extensions inside core from the essentials code that's able to base orientation on a passed in window.  The FlyoutPage uses orientation information to determine initial layout. We are moving the WinUI tests to run in separate windows so the FlyoutPage needs to be able to base that information off the window it's attached to. 

I thought about moving all the essentials bits to extension methods inside essentials and then calling into that but it felt like that would just start mudding up the essentials code. At some point I assume essentials will have better multi window hooks

### Issues Fixed

Fixes #7306
