### PR TITLE
Remove the padding around checkboxes

### DIFF
--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Android.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Android.cs
@@ -1,6 +1,7 @@
 ﻿using Android.Views;
 using Android.Widget;
 using AndroidX.AppCompat.Widget;
+using Google.Android.Material.CheckBox;
 
 namespace Microsoft.Maui.Handlers
 {
@@ -8,7 +9,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override AppCompatCheckBox CreatePlatformView()
 		{
-			var platformCheckBox = new AppCompatCheckBox(Context)
+			var platformCheckBox = new MaterialCheckBox(Context)
 			{
 				SoundEffectsEnabled = false
 			};

--- a/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Windows.cs
+++ b/src/Core/src/Handlers/CheckBox/CheckBoxHandler.Windows.cs
@@ -1,11 +1,49 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.Maui.Handlers
 {
 	public partial class CheckBoxHandler : ViewHandler<ICheckBox, CheckBox>
 	{
-		protected override CheckBox CreatePlatformView() => new CheckBox();
+		protected override CheckBox CreatePlatformView()
+		{
+			var checkBox = new CheckBox();
+
+			AdjustCheckBoxForNoText(checkBox);
+
+			return checkBox;
+		}
+
+		static void AdjustCheckBoxForNoText(CheckBox checkBox)
+		{
+			checkBox.MinWidth = 0;
+			checkBox.MinHeight = 0;
+			checkBox.Padding = new UI.Xaml.Thickness(0);
+
+			checkBox.Loaded += OnCheckBoxLoaded;
+
+			static void OnCheckBoxLoaded(object sender, RoutedEventArgs e)
+			{
+				if (sender is not CheckBox checkBox)
+					return;
+
+				checkBox.Loaded -= OnCheckBoxLoaded;
+
+				if (VisualTreeHelper.GetChildrenCount(checkBox) <= 0)
+					return;
+
+				var root = VisualTreeHelper.GetChild(checkBox, 0);
+				if (root is not Grid rootGrid)
+					return;
+
+				var checkBoxHeight = Application.Current.Resources.TryGet<double>("CheckBoxHeight");
+				var checkBoxSize = Application.Current.Resources.TryGet<double>("CheckBoxSize");
+				var margin = (checkBoxHeight - checkBoxSize) / 2.0;
+
+				rootGrid.Margin = new UI.Xaml.Thickness(margin);
+			}
+		}
 
 		protected override void ConnectHandler(CheckBox platformView)
 		{

--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -9,6 +9,7 @@
         <item name="appBarLayoutStyle">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
         <item name="bottomNavigationViewStyle">@style/Widget.Design.BottomNavigationView</item>
         <item name="materialButtonStyle">@style/MauiMaterialButton</item>
+        <item name="checkboxStyle">@style/MauiCheckBox</item>
         <item name="android:textAllCaps">false</item>
     </style>
     <style name="Maui.MainTheme.NoActionBar" parent="Maui.MainTheme">
@@ -52,7 +53,13 @@
       <item name="android:insetLeft">0dp</item>
       <item name="android:insetRight">0dp</item>
     </style>
-  
+
+    <style name="MauiCheckBox" parent="Widget.Material3.CompoundButton.CheckBox">
+      <!-- remove all the min sizes as MAUI manages it -->
+      <item name="android:minWidth">0dp</item>
+      <item name="android:minHeight">0dp</item>
+    </style>
+
   <!-- 
     The collectionViewScrollBars style will be used as the default style for ItemsViewRenderer (the base renderer
     for CollectionView and CarouselView. We have to use a style to set up the scrollbars because there is currently

--- a/src/Core/src/Platform/Windows/ResourceDictionaryExtensions.cs
+++ b/src/Core/src/Platform/Windows/ResourceDictionaryExtensions.cs
@@ -1,12 +1,21 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Platform
 {
 	internal static class ResourceDictionaryExtensions
 	{
-		public static void AddLibraryResources(this UI.Xaml.ResourceDictionary resources, string key, string uri)
+		public static T? TryGet<T>(this UI.Xaml.ResourceDictionary? resources, string key)
+		{
+			if (resources?.ContainsKey(key) == true && resources[key] is T typed)
+				return typed;
+			return default;
+		}
+
+		public static void AddLibraryResources(this UI.Xaml.ResourceDictionary? resources, string key, string uri)
 		{
 			if (resources == null)
 				return;
@@ -24,7 +33,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		public static void AddLibraryResources<T>(this UI.Xaml.ResourceDictionary resources)
+		public static void AddLibraryResources<T>(this UI.Xaml.ResourceDictionary? resources)
 			where T : UI.Xaml.ResourceDictionary, new()
 		{
 			var dictionaries = resources?.MergedDictionaries;
@@ -56,7 +65,7 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static void SetValueForAllKey(this UI.Xaml.ResourceDictionary resources, IEnumerable<string> keys, object value)
+		internal static void SetValueForAllKey(this UI.Xaml.ResourceDictionary resources, IEnumerable<string> keys, object? value)
 		{
 			foreach (string key in keys)
 			{

--- a/src/Core/src/Platform/iOS/MauiCheckBox.cs
+++ b/src/Core/src/Platform/iOS/MauiCheckBox.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Maui.Platform
 		Color? _tintColor;
 		bool _isChecked;
 		bool _isEnabled;
-		float _minimumViewSize;
 		bool _disposed;
 
 		public EventHandler? CheckedChanged;
@@ -31,7 +30,7 @@ namespace Microsoft.Maui.Platform
 		{
 			ContentMode = UIViewContentMode.Center;
 			ImageView.ContentMode = UIViewContentMode.ScaleAspectFit;
-			HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
+			HorizontalAlignment = UIControlContentHorizontalAlignment.Center;
 			VerticalAlignment = UIControlContentVerticalAlignment.Center;
 #pragma warning disable CA1416 // TODO: both has [UnsupportedOSPlatform("ios15.0")]
 			AdjustsImageWhenDisabled = false;
@@ -46,18 +45,7 @@ namespace Microsoft.Maui.Platform
 			CheckedChanged?.Invoke(this, EventArgs.Empty);
 		}
 
-		internal float MinimumViewSize
-		{
-			get { return _minimumViewSize; }
-			set
-			{
-				_minimumViewSize = value;
-				var xOffset = (value - DefaultSize + LineWidth) / 4;
-#pragma warning disable CA1416 // TODO: 'ContentEdgeInsets' has [UnsupportedOSPlatform("ios15.0")]
-				ContentEdgeInsets = new UIEdgeInsets(0, xOffset, 0, 0);
-#pragma warning restore CA1416
-			}
-		}
+		internal float MinimumViewSize { get; set; }
 
 		public bool IsChecked
 		{


### PR DESCRIPTION
### Description of Change

Since platform checkboxes are designed with the check box and the label as a single control, most have a bit of padding between them.

This PR removes the padding and unifies the size behaviour to just be the check box and some margin..

```xaml
<VerticalStackLayout Spacing="20" Padding="20">
    <HorizontalStackLayout HorizontalOptions="Start" Background="Silver">
        <CheckBox />
        <Label Text="Hello World" VerticalOptions="Center" />
    </HorizontalStackLayout>
</VerticalStackLayout>
```

| Platform | Before | After |
| -: | :-: | :-: |
| **Android** | ![image](https://user-images.githubusercontent.com/1096616/169587173-ef664c37-913d-4899-8a19-82826292a412.png) | ![image](https://user-images.githubusercontent.com/1096616/169587726-9926ce36-27c5-4fda-baf5-8608a1e7f784.png) |
| **Windows** | ![image](https://user-images.githubusercontent.com/1096616/169587323-21ea845b-44d4-47c5-9272-dbbbffee5fdc.png) | ![image](https://user-images.githubusercontent.com/1096616/169597920-26143334-1d09-4b43-9578-2fef9db3cbb2.png) |
| **iOS** | ![image](https://user-images.githubusercontent.com/1096616/169650703-76120ae1-d10e-4376-878b-af85bbd010cb.png) | ![image](https://user-images.githubusercontent.com/1096616/169652910-51806e01-1967-48f0-b165-98a031a7f2b9.png) |

> NOTE: The Android and Windows checkboxes are square-ish and have a view bunds of about 32px in size. iOS and Mac Catalyst are round and have a view size of 44px (Apple recommended values) - but a circle size of 18px - which results in a bit more padding. However, this is the values we always had so I am leaving it, but the size can be reduced to 32px and the circle will stay centered.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #7352
