### PR TITLE
Allow the image handler to measure more accurately WRT aspect ratio

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler.Android.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Android.cs
@@ -7,7 +7,18 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ImageHandler : ViewHandler<IImage, ImageView>
 	{
-		protected override ImageView CreatePlatformView() => new AppCompatImageView(Context);
+		protected override ImageView CreatePlatformView() 
+		{ 
+			var imageView = new AppCompatImageView(Context);
+
+			// Enable view bounds adjustment on measure.
+			// This allows the ImageView's OnMeasure method to account for the image's intrinsic
+			// aspect ratio during measurement, which gives us more useful values during constrained
+			// measurement passes.
+			imageView.SetAdjustViewBounds(true);
+
+			return imageView;
+		}
 
 		protected override void DisconnectHandler(ImageView platformView)
 		{


### PR DESCRIPTION
### Description of Change

Allows the Android ImageView measure call to account for the intrinsic aspect ratio of the image when measuring with constraints. Otherwise, the image measurement will always come back with the intrinsic size of the image, which is almost never what we want when downscaling an image to fit a space.

### Issues Fixed

Fixes #2000 for Android; does not address iOS.
