### PR TITLE
[Windows] Fix grouped ListView ScrollTo crash 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -619,8 +619,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			var semanticLocation = new SemanticZoomLocation { Item = c };
 
-			// async scrolling
-			await Control.Dispatcher.RunAsync(global::Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+			// NOTE: For now, WinUI Dispatcher and CoreDisptacher are null. We use DispatcherQueue instead.
+			Control.DispatcherQueue.TryEnqueue(UI.Dispatching.DispatcherQueuePriority.Normal, () =>
 			{
 				switch (toPosition)
 				{


### PR DESCRIPTION
### Description of Change

Fix grouped ListView ScrollTo crash on Windows.

### Issues Fixed

Fixes #7145 
