### PR TITLE
Fix swapping root page from Shell to Non Shell

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Maui.Controls
 	{
 		public static IPropertyMapper<IWindow, WindowHandler> ControlsWindowMapper = new PropertyMapper<IWindow, WindowHandler>(WindowHandler.Mapper)
 		{
+#if ANDROID
+			[nameof(IWindow.Content)] = MapContent
+#endif
 		};
 
 		internal static void RemapForControls()

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Set Has Navigation Bar")]
-		public async Task SettHasNavigationBar()
+		public async Task SetHasNavigationBar()
 		{
 			SetupBuilder();
 			var navPage = new NavigationPage(new ContentPage());

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -49,6 +49,25 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Swap Shell Root Page for NavigationPage")]
+		public async Task SwapShellRootPageForNavigationPage()
+		{
+			SetupBuilder();
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new ContentPage();
+			});
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, async (handler) =>
+			{
+				var newPage = new ContentPage();
+				(handler.VirtualView as Window).Page = new NavigationPage(newPage);
+				await OnNavigatedToAsync(newPage);
+				await OnFrameSetToNotEmpty(newPage);
+				Assert.True(newPage.Frame.Height > 0);
+			});
+		}
+
 		[Fact(DisplayName = "FlyoutContent Renderers When FlyoutBehavior Starts As Locked")]
 		public async Task FlyoutContentRenderersWhenFlyoutBehaviorStartsAsLocked()
 		{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -16,6 +16,8 @@ using AView = Android.Views.View;
 using AViewGroup = Android.Views.ViewGroup;
 using ImportantForAccessibility = Android.Views.ImportantForAccessibility;
 using Xunit;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -127,6 +129,11 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected MaterialToolbar GetPlatformToolbar(IElementHandler handler)
 		{
+			if (handler is IWindowHandler wh)
+			{
+				handler = wh.VirtualView.Content.Handler;
+			}
+
 			if (handler is Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer sr)
 			{
 				var shell = handler.VirtualView as Shell;
@@ -196,15 +203,14 @@ namespace Microsoft.Maui.DeviceTests
 			public override AView OnCreateView(ALayoutInflater inflater, AViewGroup container, Bundle savedInstanceState)
 			{
 				ScopedMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager, registerNewNavigationRoot: true);
-				_ = _window.ToHandler(ScopedMauiContext);
+				var handler = (WindowHandlerStub)_window.ToHandler(ScopedMauiContext);
         
-				var rootView = ScopedMauiContext.GetNavigationRootManager().RootView;
 				var decorView = RequireActivity().Window.DecorView;
-				rootView.LayoutParameters = new LinearLayoutCompat.LayoutParams(decorView.MeasuredWidth, decorView.MeasuredHeight);
+				handler.PlatformViewUnderTest.LayoutParameters = new LinearLayoutCompat.LayoutParams(decorView.MeasuredWidth, decorView.MeasuredHeight);
 
 				FakeActivityRootView = new FakeActivityRootView(ScopedMauiContext.Context);
 				FakeActivityRootView.LayoutParameters = new LinearLayoutCompat.LayoutParams(decorView.MeasuredWidth, decorView.MeasuredHeight);
-				FakeActivityRootView.AddView(rootView);
+				FakeActivityRootView.AddView(handler.PlatformViewUnderTest);
 
 				return FakeActivityRootView;
 			}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -290,6 +290,22 @@ namespace Microsoft.Maui.DeviceTests
 			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 
+		protected Task OnNavigatedToAsync(Page page, TimeSpan? timeOut = null)
+		{
+			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+
+			page.NavigatedTo += NavigatedTo;
+
+			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
+			void NavigatedTo(object sender, NavigatedToEventArgs e)
+			{
+				taskCompletionSource.SetResult(true);
+				page.NavigatedTo -= NavigatedTo;
+			}
+		}
+
+
 		protected Task OnFrameSetToNotEmpty(VisualElement frameworkElement, TimeSpan? timeOut = null)
 		{
 			if (frameworkElement.Frame.Height > 0 &&

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using AView = Android.Views.View;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using static Microsoft.Maui.DeviceTests.HandlerTestBase;
@@ -14,22 +16,35 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 			[nameof(IWindow.Content)] = MapContent
 		};
 
+		public AView PlatformViewUnderTest { get; private set; }
+
 		void UpdateContent()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
-			
-			var rootManager = MauiContext.GetNavigationRootManager();
 
-			var previousRootView = rootManager.RootView;
-			rootManager.Connect(VirtualView.Content);
+			AView platformView;
+			if (VirtualView.Content is not Shell)
+			{
+				var rootManager = MauiContext.GetNavigationRootManager();
+				//var previousRootView = rootManager.RootView;
+				rootManager.Connect(VirtualView.Content);
+				platformView = rootManager.RootView;
+			}
+			else
+			{
+				platformView = VirtualView.Content.ToPlatform(MauiContext);
+			}
+
 
 			// This is used for cases where we are testing swapping out the page set on window
-			if (previousRootView?.Parent is FakeActivityRootView farw)
+			if (PlatformViewUnderTest?.Parent is FakeActivityRootView farw)
 			{
-				previousRootView.RemoveFromParent();
-				rootManager.RootView.LayoutParameters = new LinearLayoutCompat.LayoutParams(500, 500);
-				farw.AddView(rootManager.RootView);
+				PlatformViewUnderTest.RemoveFromParent();
+				platformView.LayoutParameters = new LinearLayoutCompat.LayoutParams(500, 500);
+				farw.AddView(platformView);
 			}
+
+			PlatformViewUnderTest = platformView;
 		}
 
 		public static void MapContent(WindowHandlerStub handler, IWindow window)


### PR DESCRIPTION
### Description of Change

When the WinUI shell handler was combined with the navigation page handler the code that pivoted the window content mapping was incorrectly deleted for Android. 

This does not fix the issue when swapping out the root between multiple NavigationPages

