### PR TITLE
Better handle disappearing content with ViewPager2

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
@@ -27,11 +27,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		{
 			_mauiContext = mauiContext;
 			_shellSection = shellSection;
-			SectionController.ItemsCollectionChanged += OnItemsCollectionChanged;
 			_items = SectionController.GetItems();
 		}
 
-		protected virtual void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		public void OnItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			_items = SectionController.GetItems();
 			var removeList = new List<long>();
@@ -42,8 +41,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			foreach (var remove in removeList)
 				_createdShellContent.Remove(remove);
-
-			NotifyDataSetChanged();
 		}
 
 		public int CountOverride { get; set; }
@@ -70,6 +67,14 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public override bool ContainsItem(long itemId)
 		{
+			if (_createdShellContent.TryGetValue(itemId, out var shellContent) &&
+				!_items.Contains(shellContent))
+			{
+				// This means a data set change was triggered but the INCC change hasn't
+				// propagated from our xplat code to here yet
+				_createdShellContent.Remove(itemId);
+			}
+
 			return _createdShellContent.ContainsKey(itemId);
 		}
 
@@ -82,7 +87,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (disposing)
 			{
-				SectionController.ItemsCollectionChanged -= OnItemsCollectionChanged;
 				_shellSection = null;
 
 				_items = null;

--- a/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Page.Impl.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../docs/Microsoft.Maui.Controls/Page.xml" path="Type[@FullName='Microsoft.Maui.Controls.Page']/Docs" />
 	public partial class Page : IView, ITitledElement, IToolbarElement
 	{
+		internal bool HasNavigatedTo { get; private set; }
+
 		Paint IView.Background
 		{
 			get
@@ -40,6 +42,7 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendNavigatedTo(NavigatedToEventArgs args)
 		{
+			HasNavigatedTo = true;
 			NavigatedTo?.Invoke(this, args);
 			OnNavigatedTo(args);
 		}
@@ -52,6 +55,7 @@ namespace Microsoft.Maui.Controls
 
 		internal void SendNavigatedFrom(NavigatedFromEventArgs args)
 		{
+			HasNavigatedTo = false;
 			NavigatedFrom?.Invoke(this, args);
 			OnNavigatedFrom(args);
 		}

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -209,6 +209,11 @@ namespace Microsoft.Maui.Controls
 
 		public static implicit operator ShellContent(TemplatedPage page)
 		{
+			if (page.Parent != null)
+			{
+				return (ShellContent)page.Parent;
+			}
+
 			var shellContent = new ShellContent();
 
 			var pageRoute = Routing.GetRoute(page);

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -72,6 +72,34 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 
 		[Test]
+		public void SettingCurrentItemOnShellViaContentPage()
+		{
+			var page1 = new ContentPage();
+			var page2 = new ContentPage();
+			var shell = new TestShell()
+			{
+				Items =
+				{
+					new TabBar()
+					{
+						Items =
+						{
+							new ShellContent() { Content = page1 },
+							new ShellContent() { Content = page2 },
+						}
+					}
+				}
+			};
+
+			shell.CurrentItem = page2;
+			Assert.AreEqual(1, shell.Items.Count);
+			Assert.AreEqual(2, shell.Items[0].Items.Count);
+			Assert.AreEqual(1, shell.Items[0].Items[0].Items.Count);
+			Assert.AreEqual(1, shell.Items[0].Items[1].Items.Count);
+			Assert.AreEqual(shell.CurrentItem.CurrentItem, shell.Items[0].Items[1]);
+		}
+
+		[Test]
 		public void SetCurrentItemAddsToShellCollection()
 		{
 			var shell = new Shell();

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -190,6 +190,45 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+
+
+		[Fact(DisplayName = "Correctly Adjust to Making Currently Visible Shell Page Invisible")]
+		public async Task CorrectlyAdjustToMakingCurrentlyVisibleShellPageInvisible()
+		{
+			SetupBuilder();
+
+			var page1 = new ContentPage();
+			var page2 = new ContentPage();
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				var tabBar = new TabBar()
+				{
+					Items =
+					{
+						new ShellContent(){ Content = page1 },
+						new ShellContent(){ Content = page2 },
+					}
+				};
+
+				shell.Items.Add(tabBar);
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await OnNavigatedToAsync(page1);
+				shell.CurrentItem = page2;
+				await OnNavigatedToAsync(page2);
+				page2.IsVisible = false;
+				await OnNavigatedToAsync(page1);
+				Assert.Equal(shell.CurrentPage, page1);
+				page2.IsVisible = true;
+				shell.CurrentItem = page2;
+				await OnNavigatedToAsync(page2);
+				Assert.Equal(shell.CurrentPage, page2);
+			});
+		}
+
 		[Fact(DisplayName = "Empty Shell")]
 		public async Task DetailsViewUpdates()
 		{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -290,21 +290,25 @@ namespace Microsoft.Maui.DeviceTests
 			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 
-		protected Task OnNavigatedToAsync(Page page, TimeSpan? timeOut = null)
+		protected async Task OnNavigatedToAsync(Page page, TimeSpan? timeOut = null)
 		{
+			await OnLoadedAsync(page, timeOut);
+
+			if (page.HasNavigatedTo)
+				return;
+
 			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
 			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
 
 			page.NavigatedTo += NavigatedTo;
 
-			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
+			await taskCompletionSource.Task.WaitAsync(timeOut.Value);
 			void NavigatedTo(object sender, NavigatedToEventArgs e)
 			{
 				taskCompletionSource.SetResult(true);
 				page.NavigatedTo -= NavigatedTo;
 			}
 		}
-
 
 		protected Task OnFrameSetToNotEmpty(VisualElement frameworkElement, TimeSpan? timeOut = null)
 		{


### PR DESCRIPTION
### Description of Change

- When all items associated with a ViewPager2 vanish from the adapter, Android will still fires an OnPageSelected call with index zero so we need to just ignore when that happens. The `OnPageSelected` call was added [here](https://github.com/dotnet/maui/pull/5113)
- Workaround https://stackoverflow.com/questions/43221847/cannot-call-this-method-while-recyclerview-is-computing-a-layout-or-scrolling-wh

### Issues Fixed

Fixes #7417
