### PR TITLE
Android NamedSize.Header changed from 96 to 14

### DIFF
--- a/src/Controls/src/Core/Compatibility/Android/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/Android/FontNamedSizeService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					case NamedSize.Caption:
 						return 12;
 					case NamedSize.Header:
-						return 96;
+						return 14;
 					case NamedSize.Subtitle:
 						return 16;
 					case NamedSize.Title:
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				case NamedSize.Caption:
 					return 12;
 				case NamedSize.Header:
-					return 96;
+					return 14;
 				case NamedSize.Subtitle:
 					return 16;
 				case NamedSize.Title:


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

This used to be a [bug](https://github.com/xamarin/Xamarin.Forms/issues/11194) in Xamarin.Forms  when running on Android that the font size for `NamedSize.Header` font was 96, this was later [dropped to 14](https://github.com/xamarin/Xamarin.Forms/pull/12983).

MAUI is using 96. This PR brings it back down to 14 to match incoming Xamarin.Forms users.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #7428 
