### PR TITLE
Avoid crash with invalid cast using RadioButtonGroup.GroupName with a View

### DIFF
--- a/src/Controls/src/Core/RadioButtonGroup.cs
+++ b/src/Controls/src/Core/RadioButtonGroup.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls
 
 		static readonly BindableProperty RadioButtonGroupControllerProperty =
 			BindableProperty.CreateAttached("RadioButtonGroupController", typeof(RadioButtonGroupController), typeof(Maui.ILayout), default(RadioButtonGroupController),
-			defaultValueCreator: (b) => new RadioButtonGroupController((Maui.ILayout)b),
+			defaultValueCreator: (b) => new RadioButtonGroupController(b as Maui.ILayout),
 			propertyChanged: (b, o, n) => OnControllerChanged(b, (RadioButtonGroupController)o, (RadioButtonGroupController)n));
 
 		static RadioButtonGroupController GetRadioButtonGroupController(BindableObject b)


### PR DESCRIPTION
### Description of Change

Avoid crash with invalid cast using RadioButtonGroup.GroupName with a View. This avoid the casting crash, but I am going to create another issue to  add validation so we get compile time and runtime errors.

The error comes from an unexpected use of the API, but we can protect these cases and/or provide extra information.

### Issues Fixed

Fixes #7347 
