### PR TITLE
[iOS] Fix cell size changed on CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -294,12 +294,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var visibleCells = CollectionView.VisibleCells;
-
+			List<NSIndexPath> paths = new List<NSIndexPath>();
+			
 			for (int n = 0; n < visibleCells.Length; n++)
 			{
+				paths.Add(CollectionView.IndexPathForCell(visibleCells[n]));
 				if (cell == visibleCells[n])
 				{
-					Layout?.InvalidateLayout();
+					CollectionView.ReloadItems(paths.ToArray());
 					return;
 				}
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -177,22 +177,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			(renderer.VirtualView as View).MeasureInvalidated += MeasureInvalidated;
 		}
 
-		protected void Layout(CGSize constraints)
-		{
-			var platformView = PlatformHandler.ToPlatform();
-
-			var width = constraints.Width;
-			var height = constraints.Height;
-
-			PlatformHandler.VirtualView.Measure(width, height);
-
-			platformView.Frame = new CGRect(0, 0, width, height);
-
-			var rectangle = platformView.Frame.ToRectangle();
-			PlatformHandler.VirtualView.Arrange(rectangle);
-			_size = rectangle.Size;
-		}
-
 		void ClearSubviews()
 		{
 			for (int n = ContentView.Subviews.Length - 1; n >= 0; n--)

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -898,9 +898,13 @@ namespace Microsoft.Maui.Controls
 		{
 			base.OnChildAdded(child);
 
+
 			if (child is View view)
 			{
 				ComputeConstraintForView(view);
+
+				if (this is not Microsoft.Maui.ILayout)
+					return;
 				view.MeasureInvalidated += ChildViewMeasureInvalidated;
 			}
 		}
@@ -1223,6 +1227,18 @@ namespace Microsoft.Maui.Controls
 		void ChildViewMeasureInvalidated(object sender, EventArgs e)
 		{
 			var trigger = (e as InvalidationEventArgs)?.Trigger ?? InvalidationTrigger.MeasureChanged;
+
+			//We only this for new Layouts, old layouts already have this invalidation
+			if (sender is View view)
+			{
+				// we can ignore the request if we are either fully constrained or when the size request changes and we were already fully constrainted
+				if ((trigger == InvalidationTrigger.MeasureChanged && view.Constraint == LayoutConstraint.Fixed) ||
+					(trigger == InvalidationTrigger.SizeRequestChanged && view.ComputedConstraint == LayoutConstraint.Fixed))
+				{
+					return;
+				}
+			}
+
 			InvalidateMeasureNonVirtual(trigger);
 		}
 

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -897,16 +897,23 @@ namespace Microsoft.Maui.Controls
 		protected override void OnChildAdded(Element child)
 		{
 			base.OnChildAdded(child);
-			var view = child as View;
-			if (view != null)
+
+			if (child is View view)
+			{
 				ComputeConstraintForView(view);
+				view.MeasureInvalidated += ChildViewMeasureInvalidated;
+			}
 		}
 
 		protected override void OnChildRemoved(Element child, int oldLogicalIndex)
 		{
 			base.OnChildRemoved(child, oldLogicalIndex);
+
 			if (child is View view)
+			{
 				view.ComputedConstraint = LayoutConstraint.None;
+				view.MeasureInvalidated -= ChildViewMeasureInvalidated;
+			}
 		}
 
 		protected void OnChildrenReordered()
@@ -1211,6 +1218,12 @@ namespace Microsoft.Maui.Controls
 			SizeChanged?.Invoke(this, EventArgs.Empty);
 
 			BatchCommit();
+		}
+
+		void ChildViewMeasureInvalidated(object sender, EventArgs e)
+		{
+			var trigger = (e as InvalidationEventArgs)?.Trigger ?? InvalidationTrigger.MeasureChanged;
+			InvalidateMeasureNonVirtual(trigger);
 		}
 
 		public class FocusRequestArgs : EventArgs


### PR DESCRIPTION
### Description of Change

CollectionView Cells need a way to know that the contents of the MAUI view have changed and to update it's layout. We used MeasuredInvalidated for that, but the new layouts weren't bubbling it from the children, this pr allows that to done when a child is added to the VE. 

On iOS the InvalidateLayout wasn0't working to update cell size, but if we reload the visible cells it works fine. 

### Issues Fixed

Fixes #3643 

Use this to test 

```
<Grid>
      <CollectionView ItemsSource="{Binding Items}" BackgroundColor="Pink" >
          <CollectionView.ItemTemplate>
              <DataTemplate>
                  <Grid BackgroundColor="Red" Padding="10">
                      <Label Text="{Binding Name}" BackgroundColor="Yellow" TextColor="Black"/>
                  </Grid>
              </DataTemplate>
          </CollectionView.ItemTemplate>
      </CollectionView>
 </Grid>
 ```
 
 ```
 public MainPage()
{
	InitializeComponent();
	BindingContext = this;
	Device.StartTimer(TimeSpan.FromSeconds(5), () =>
	{
		UpdateStuff();
		return false;
	});
}

ObservableCollection<SomeItem> _items;
public ObservableCollection<SomeItem> Items
{
	get
	{
		if (_items == null)
		{
			_items = new ObservableCollection<SomeItem>(Enumerable.Range(0, 1).Select(c =>
			{
				return new SomeItem() { Name = string.Format("Item {0}", c) };
			}));
		}

		return _items;
	}
}
	
void UpdateStuff()
{
	System.Diagnostics.Debug.WriteLine($"UpdateStuff");
			var bigString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
	foreach (var item in Items)
	{
		item.Name = bigString;
	}
}

public class SomeItem : INotifyPropertyChanged
{
	string name;
	public string Name
	{
		get => name;
		set
		{
			name = value;
			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
		}
	}

	public event PropertyChangedEventHandler PropertyChanged;
}
 ```