### PR TITLE
Fix WinUI Modal to work with lack of root panel

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml
@@ -5,14 +5,13 @@
     x:Class="Maui.Controls.Sample.Pages.ModalPage"    
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base">
     <views:BasePage.Content>
-        <Grid Margin="12" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Grid Margin="12" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
             <Label Grid.Row="0" Text="" x:Name="lblModalPageNumber"></Label>
             <Button Grid.Row="1" Clicked="PushClicked" Text="Push Page" />
             <Button Grid.Row="2" Clicked="PushModalClicked" Text="Push Modal Page" />
             <Button Grid.Row="3" Clicked="PushNavigationModalClicked" Text="Push Modal Navigation Page" />
             <Button Grid.Row="4" Clicked="PushFlyoutPageClicked" Text="Push Modal Flyout Page" />
-            <Button Grid.Row="5" Clicked="PushTransparentModal" Text="Push Transparent Modal Page" />
-            <Button Grid.Row="6" x:Name="PopModal" Clicked="PopModalClicked" Text="Pop Modal Page" />
+            <Button Grid.Row="5" x:Name="PopModal" Clicked="PopModalClicked" Text="Pop Modal Page" />
         </Grid>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml
@@ -5,12 +5,14 @@
     x:Class="Maui.Controls.Sample.Pages.ModalPage"    
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base">
     <views:BasePage.Content>
-        <VerticalStackLayout Margin="12">
-            <Button Clicked="PushClicked" Text="Push Page" />
-            <Button Clicked="PushModalClicked" Text="Push Modal Page" />
-            <Button Clicked="PushNavigationModalClicked" Text="Push Modal Navigation Page" />
-            <Button Clicked="PushFlyoutPageClicked" Text="Push Modal Flyout Page" />
-            <Button x:Name="PushModal" Clicked="PopModalClicked" Text="Pop Modal Page" />
-        </VerticalStackLayout>
+        <Grid Margin="12" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+            <Label Grid.Row="0" Text="" x:Name="lblModalPageNumber"></Label>
+            <Button Grid.Row="1" Clicked="PushClicked" Text="Push Page" />
+            <Button Grid.Row="2" Clicked="PushModalClicked" Text="Push Modal Page" />
+            <Button Grid.Row="3" Clicked="PushNavigationModalClicked" Text="Push Modal Navigation Page" />
+            <Button Grid.Row="4" Clicked="PushFlyoutPageClicked" Text="Push Modal Flyout Page" />
+            <Button Grid.Row="5" Clicked="PushTransparentModal" Text="Push Transparent Modal Page" />
+            <Button Grid.Row="6" x:Name="PushModal" Clicked="PopModalClicked" Text="Pop Modal Page" />
+        </Grid>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml
@@ -12,7 +12,7 @@
             <Button Grid.Row="3" Clicked="PushNavigationModalClicked" Text="Push Modal Navigation Page" />
             <Button Grid.Row="4" Clicked="PushFlyoutPageClicked" Text="Push Modal Flyout Page" />
             <Button Grid.Row="5" Clicked="PushTransparentModal" Text="Push Transparent Modal Page" />
-            <Button Grid.Row="6" x:Name="PushModal" Clicked="PopModalClicked" Text="Pop Modal Page" />
+            <Button Grid.Row="6" x:Name="PopModal" Clicked="PopModalClicked" Text="Pop Modal Page" />
         </Grid>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
@@ -23,7 +23,7 @@ namespace Maui.Controls.Sample.Pages
 
 		protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
 		{
-			_previousTitle = this.Window.Title;
+			_previousTitle = this.Window?.Title;			
 			base.OnNavigatingFrom(args);
 		}
 

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ModalPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 
@@ -11,17 +12,38 @@ namespace Maui.Controls.Sample.Pages
 	public partial class ModalPage
 	{
 		static int s_instanceCount = 0;
+		string _previousTitle;
 		public ModalPage()
 		{
 			InitializeComponent();
 			BackgroundColor = Colors.Purple;
 			Title = $"Modal Page {s_instanceCount++}";
+			lblModalPageNumber.Text = $"Modal Page {s_instanceCount}";
 		}
+
+		protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
+		{
+			_previousTitle = this.Window.Title;
+			base.OnNavigatingFrom(args);
+		}
+
+		protected override void OnNavigatedTo(NavigatedToEventArgs args)
+		{
+			if (PopModal.IsVisible)
+			{
+				this.Window.Title = "Modal Gallery";
+			}
+			else
+			{
+				this.Window.Title = _previousTitle;
+			}
+		}
+
 
 		protected override void OnAppearing()
 		{
 			base.OnAppearing();
-			PushModal.IsVisible = Navigation.ModalStack.Count > 0;
+			PopModal.IsVisible = Navigation.ModalStack.Count > 0;
 		}
 
 		async void PushNavigationModalClicked(object sender, EventArgs e)
@@ -66,7 +88,7 @@ namespace Maui.Controls.Sample.Pages
 		async void PushFlyoutPageClicked(object sender, EventArgs e)
 		{
 			var modalPage = new ModalPage();
-			Page newMainPage = new NavigationPage(new ModalPage())
+			Page newMainPage = new NavigationPage(modalPage)
 			{
 				BackgroundColor =
 						(BackgroundColor == Colors.Purple) ? Colors.Pink : Colors.Purple,

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ModalTests : HandlerTestBase
+	{
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task PushingPageWithBackgroundStacksAndUnStacksCorrectly(bool useColor)
+		{
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
+				async (handler) =>
+				{
+					var rootView = handler.PlatformView.Content;
+					ContentPage backgroundColorContentPage = new ContentPage();
+
+					if (useColor)
+						backgroundColorContentPage.BackgroundColor = Colors.Purple;
+					else
+						backgroundColorContentPage.Background = SolidColorBrush.Purple;
+
+					await navPage.CurrentPage.Navigation.PushModalAsync(backgroundColorContentPage);
+
+					// Root should now be a ContentPanel
+					var rootPanel = (ContentPanel)handler.PlatformView.Content;
+					Assert.Contains(rootView, rootPanel.Children);
+					var modalRootView =
+						backgroundColorContentPage.FindMauiContext().GetNavigationRootManager().RootView;
+					Assert.Contains(modalRootView, rootPanel.Children);
+
+					await navPage.CurrentPage.Navigation.PopModalAsync();
+					Assert.Equal(rootView, handler.PlatformView.Content);
+				});
+		}
+
+		[Fact]
+		public async Task WindowTitleSetToModalTitleContainer()
+		{
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
+				async (handler) =>
+				{
+					var rootView = handler.PlatformView.Content;
+					ContentPage modalPage = new ContentPage();
+
+					await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(modalPage);
+
+					var customTitleBar = modalPage
+						.FindMauiContext()
+						.GetNavigationRootManager()
+						.AppTitleBarContentControl;
+
+
+					var mauiWindow = (MauiWinUIWindow)handler.PlatformView;
+					Assert.Equal(mauiWindow.MauiCustomTitleBar, customTitleBar);
+					(handler.VirtualView as Window).Title = "Update Title";
+
+					var customTitle = mauiWindow.MauiCustomTitleBar.GetDescendantByName<UI.Xaml.Controls.TextBlock>("AppTitle");
+
+					Assert.Equal("Update Title", customTitle.Text);
+				});
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Devices;
 using Microsoft.Maui.LifecycleEvents;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui
 {
@@ -61,7 +62,7 @@ namespace Microsoft.Maui
 			MauiWinUIApplication.Current.Services?.InvokeLifecycleEvents<WindowsLifecycle.OnVisibilityChanged>(del => del(this, args));
 		}
 
-		#region Native Window
+		#region Platform Window
 
 		IntPtr _hwnd = IntPtr.Zero;
 
@@ -136,6 +137,28 @@ namespace Microsoft.Maui
 				}
 			}
 		}
+
+		UI.Xaml.UIElement? _customTitleBar;
+		internal UI.Xaml.UIElement? MauiCustomTitleBar
+		{
+			get => _customTitleBar;
+			set
+			{
+				_customTitleBar = value;
+				SetTitleBar(_customTitleBar);
+				UpdateTitleOnCustomTitleBar();
+			}
+		}
+
+		internal void UpdateTitleOnCustomTitleBar()
+		{
+			if (_customTitleBar is UI.Xaml.FrameworkElement fe &&
+				fe.GetDescendantByName<TextBlock>("AppTitle") is TextBlock tb)
+			{
+				tb.Text = Title;
+			}
+		}
+
 
 		[DllImport("shell32.dll", CharSet = CharSet.Auto)]
 		static extern IntPtr ExtractAssociatedIcon(IntPtr hInst, string iconPath, ref IntPtr index);

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Maui.Platform
 	{
 		Window _platformWindow;
 		WindowRootView _rootView;
-		bool _firstConnect;
-		bool _disconnected;
+		bool _disconnected = true;
+		bool _isActiveRootManager;
 
 		public NavigationRootManager(Window platformWindow)
 		{
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Platform
 				.BackButtonClicked();
 		}
 
+		internal ContentControl? AppTitleBarContentControl => _rootView.AppTitleBarContentControl;
 		internal FrameworkElement? AppTitleBar => _rootView.AppTitleBar;
 		internal MauiToolbar? Toolbar => _rootView.Toolbar;
 
@@ -55,9 +56,7 @@ namespace Microsoft.Maui.Platform
 
 		public virtual void Connect(UIElement platformView)
 		{
-			bool firstConnect = _firstConnect;
-
-			if (!firstConnect)
+			if (_rootView.Content != null)
 			{
 				// We need to make sure to clear out the root view content 
 				// before creating the new view.
@@ -65,8 +64,6 @@ namespace Microsoft.Maui.Platform
 				// It might have code in the handler that retrieves this class.
 				_rootView.Content = null;
 			}
-
-			_firstConnect = false;
 
 			NavigationView rootNavigationView;
 			if (platformView is NavigationView nv)
@@ -91,15 +88,8 @@ namespace Microsoft.Maui.Platform
 
 			if (_disconnected)
 			{
+				_isActiveRootManager = true;
 				_platformWindow.Activated += OnWindowActivated;
-			}
-
-			if (firstConnect)
-			{
-				if (_rootView.AppTitleBarContentControl != null && _platformWindow.ExtendsContentIntoTitleBar)
-					UpdateAppTitleBar(true);
-
-				SetWindowTitle(_platformWindow.GetWindow()?.Title);
 			}
 
 			_disconnected = false;
@@ -120,7 +110,9 @@ namespace Microsoft.Maui.Platform
 				if (isActive)
 				{
 					_rootView.Visibility = UI.Xaml.Visibility.Visible;
-					_platformWindow.SetTitleBar(_rootView.AppTitleBarContentControl);
+					SetTitleBar(_rootView.AppTitleBarContentControl);
+
+					SetWindowTitle(_platformWindow.GetWindow()?.Title);
 				}
 				else
 				{
@@ -129,8 +121,27 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				_platformWindow.SetTitleBar(null);
+				SetTitleBar(null);
 			}
+
+			if (!_isActiveRootManager && isActive)
+			{
+				_platformWindow.Activated += OnWindowActivated;
+			}
+			else if (!isActive)
+			{
+				_platformWindow.Activated -= OnWindowActivated;
+			}
+
+			_isActiveRootManager = isActive;
+		}
+
+		void SetTitleBar(UIElement? titleBar)
+		{
+			if (_platformWindow is MauiWinUIWindow mauiWindow)
+				mauiWindow.MauiCustomTitleBar = titleBar;
+			else
+				_platformWindow.SetTitleBar(titleBar);
 		}
 
 		internal void SetWindowTitle(string? title)
@@ -150,6 +161,11 @@ namespace Microsoft.Maui.Platform
 
 		void OnWindowActivated(object sender, WindowActivatedEventArgs e)
 		{
+			if (!_isActiveRootManager)
+			{
+				_platformWindow.Activated -= OnWindowActivated;
+			}
+
 			if (_rootView.AppTitle == null)
 				return;
 

--- a/src/Core/src/Platform/Windows/RootPanel.cs
+++ b/src/Core/src/Platform/Windows/RootPanel.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+using System;
+using Microsoft.Maui.Graphics;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.Maui.Platform
+{
+	[Obsolete("Use Microsoft.Maui.Platform.ContentPanel")]
+	public class RootPanel : Panel
+	{
+		internal Func<double, double, Size>? CrossPlatformMeasure { get; set; }
+		internal Func<Rect, Size>? CrossPlatformArrange { get; set; }
+
+		protected override global::Windows.Foundation.Size MeasureOverride(global::Windows.Foundation.Size availableSize)
+		{
+			var width = availableSize.Width;
+			var height = availableSize.Height;
+
+			if (double.IsInfinity(width))
+			{
+				width = XamlRoot.Size.Width;
+			}
+
+			if (double.IsInfinity(height))
+			{
+				height = XamlRoot.Size.Height;
+			}
+
+			var size = new global::Windows.Foundation.Size(width, height);
+
+			// Measure the children (should only be one, the Page)
+			foreach (var child in Children)
+			{
+				child.Measure(size);
+			}
+
+			return size;
+		}
+
+		protected override global::Windows.Foundation.Size ArrangeOverride(global::Windows.Foundation.Size finalSize)
+		{
+			foreach (var child in Children)
+			{
+				child.Arrange(new global::Windows.Foundation.Rect(new global::Windows.Foundation.Point(0, 0), finalSize));
+			}
+
+			return finalSize;
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/WindowExtensions.cs
+++ b/src/Core/src/Platform/Windows/WindowExtensions.cs
@@ -13,11 +13,8 @@ namespace Microsoft.Maui.Platform
 		{
 			platformWindow.Title = window.Title;
 
-			var rootManager = window.Handler?.MauiContext?.GetNavigationRootManager();
-			if (rootManager != null)
-			{
-				rootManager.SetWindowTitle(window.Title);
-			}
+			if (platformWindow is MauiWinUIWindow mauiWindow)
+				mauiWindow.UpdateTitleOnCustomTitleBar();
 		}
 
 		public static IWindow? GetWindow(this UI.Xaml.Window platformWindow)


### PR DESCRIPTION
### Description of Change

- Fix Modal on WinUI so that it can deal with the fact that everything isn't nested inside a panel. The behavior of setting your ContentPage to transparent in order to show the view underneath is still [broken](https://github.com/dotnet/maui/issues/7450). This PR is primarily about fixing the fact that modal is completely broken and then we will restore the behavior of having a transparent overlay in a separate PR.
- Add the RootPanel type back in order to maintain ABI compatibility
- Fix `IWindow.Title` so that it will propagate to the currently active custom title

### Issues Fixed

Fixes #7307
