### PR TITLE
Resolving TableView/ListView issues

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -497,7 +497,7 @@ void SetDotNetEnvironmentVariables()
     SetEnvironmentVariable("PATH", dotnet, prepend: true);
 
     // Get "full" .binlog in Project System Tools
-    if (HasArgument("debug"))
+    if (HasArgument("dbg"))
         SetEnvironmentVariable("MSBuildDebugEngine", "1");
 }
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/CellRenderer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 					if (Cell != oldCell)
 					{
-						oldCell.Handler.DisconnectHandler();
+						oldCell.Handler?.DisconnectHandler();
 					}
 				}
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
@@ -253,6 +253,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				cellIsBeingReused = true;
 				convertView = layout.GetChildAt(0);
+
+				_layoutsCreated[position] = layout;
 			}
 			else
 			{
@@ -546,6 +548,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			var element = (renderedView as INativeElementView)?.Element;
 			var view = (element as ViewCell)?.View;
+
+			if (renderedView is ViewGroup vg && view?.Handler?.PlatformView is AView aView)
+				vg.RemoveView(aView);
+
 			view?.Handler?.DisconnectHandler();
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
@@ -89,11 +89,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					_listCount = count;
 				}
 
-				//if (_listView.CachingStrategy == ListViewCachingStrategy.RetainElement &&
-				//	_layoutsCreated.Count > _listCount)
-				//{ 
-				//}
-
 				return _listCount;
 			}
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewAdapter.cs
@@ -88,6 +88,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 					_listCount = count;
 				}
+
+				//if (_listView.CachingStrategy == ListViewCachingStrategy.RetainElement &&
+				//	_layoutsCreated.Count > _listCount)
+				//{ 
+				//}
+
 				return _listCount;
 			}
 		}
@@ -267,6 +273,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				else
 				{
 					layout = new ConditionalFocusLayout(_context) { Orientation = Orientation.Vertical };
+
+					if (_layoutsCreated.TryGetValue(position, out ConditionalFocusLayout value))
+						DisposeOfConditionalFocusLayout(value);
+
 					_layoutsCreated[position] = layout;
 				}
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ListViewRenderer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
 	public class ListViewRenderer : ViewRenderer<ListView, AListView>
 	{
-		public static PropertyMapper<ListView, ListViewRenderer> Mapper =	
+		public static PropertyMapper<ListView, ListViewRenderer> Mapper =
 			new PropertyMapper<ListView, ListViewRenderer>(VisualElementRendererMapper);
 
 		public static CommandMapper<ListView, ListViewRenderer> CommandMapper =
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		Container _headerView;
 		Container _footerView;
 		bool _isAttached;
+		bool _reattached;
 		ScrollToRequestedEventArgs _pendingScrollTo;
 
 		SwipeRefreshLayout _refresh;
@@ -61,6 +62,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_isAttached = true;
 			_adapter.IsAttachedToWindow = _isAttached;
 			UpdateIsRefreshing(isInitialValue: true);
+
+			// There might be a better way to go about doing this but from what I can tell 
+			// once you detach and then reattach a ListView the cells become unselectable 
+			// and the Android.ListView in general is left in an odd state.
+			// We didn't have to do this in XF because in XF there's an extra measure call that happens
+			// when the listview is reattached that essentially does the exact same thing.
+			// You can see this by adding back the legacy renderers and setting a breakpoint on the 
+			// adapter.GetView call. In MAUI this never gets called when navigating back vs XF it does
+			if (!_reattached)
+			{
+				_reattached = true;
+			}
+			else
+			{
+				Control?.InvalidateViews();
+			}
 		}
 
 		protected override void OnDetachedFromWindow()
@@ -255,11 +272,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						// that in as the convert view so that GetView doesn't create
 						// an additional ConditionalFocusLayout
 						// We're basically faking re-use to the GetView call
-						AView currentParent = null;
-						if (cell.Handler?.PlatformView is AView aView)
-							currentParent = aView.Parent as AView;
-
-						currentParent ??= _adapter.GetConvertViewForMeasuringInfiniteHeight(i);
+						AView currentParent = _adapter.GetConvertViewForMeasuringInfiniteHeight(i);
 						AView listItem = _adapter.GetView(i, currentParent, Control);
 						int widthSpec;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -198,7 +198,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					_viewCell = cell;
 
 					Performance.Start(reference, "Reuse.SetElement");
-					_viewHandler.SetVirtualView(cell.View);
+
+					if (_viewHandler != cell.View.Handler)
+					{
+						RemoveView(_viewHandler.PlatformView);
+						cell.View.Handler?.DisconnectHandler();
+						_viewHandler.SetVirtualView(cell.View);
+						AddView(_viewHandler.PlatformView);
+
+					}
+
 					Performance.Stop(reference, "Reuse.SetElement");
 
 					Invalidate();

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/ViewCellRenderer.cs
@@ -58,6 +58,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			return c;
 		}
 
+		protected override void DisconnectHandler(AView platformView)
+		{
+			base.DisconnectHandler(platformView);
+			ViewCellContainer c = platformView.GetParentOfType<ViewCellContainer>();
+			c?.DisconnectHandler();
+		}
+
 		internal class ViewCellContainer : ViewGroup, INativeElementView
 		{
 			readonly View _parent;
@@ -69,6 +76,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			GestureDetector _longPressGestureDetector;
 			ListViewRenderer _listViewRenderer;
 			bool _watchForLongPress;
+			AView _currentView;
 
 			ListViewRenderer ListViewRenderer
 			{
@@ -201,11 +209,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 					if (_viewHandler != cell.View.Handler)
 					{
-						RemoveView(_viewHandler.PlatformView);
+						if (cell.View.Handler?.PlatformView is AView oldCellView &&
+							oldCellView.GetParentOfType<ViewCellContainer>() is ViewCellContainer vc)
+						{
+							vc.DisconnectHandler();
+						}
+
+						var oldView = _currentView ?? _viewHandler.PlatformView;
+						if (oldView != null)
+							RemoveView(oldView);
+
 						cell.View.Handler?.DisconnectHandler();
 						_viewHandler.SetVirtualView(cell.View);
 						AddView(_viewHandler.PlatformView);
-
 					}
 
 					Performance.Stop(reference, "Reuse.SetElement");
@@ -217,7 +233,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					return;
 				}
 
-				RemoveView(_viewHandler.PlatformView);
+				RemoveView(_currentView ?? _viewHandler.PlatformView);
 				_viewCell.View.Handler?.DisconnectHandler();
 				_viewCell.View.IsPlatformEnabled = false;
 
@@ -238,6 +254,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			public void UpdateIsEnabled()
 			{
 				Enabled = _parent.IsEnabled && _viewCell.IsEnabled;
+			}
+
+			public void DisconnectHandler()
+			{
+				var oldView = _currentView ?? _viewHandler.PlatformView;
+				if (oldView != null)
+					RemoveView(oldView);
+
+				_viewCell?.View?.Handler?.DisconnectHandler();
+
+			}
+
+			public override void AddView(AView child)
+			{
+				base.AddView(child);
+				_currentView = child;
 			}
 
 			protected override void OnLayout(bool changed, int l, int t, int r, int b)

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Android.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Maui.Controls
 				if (_mauiTextView != null)
 				{
 					_mauiTextView.LayoutChanged -= OnLayoutChanged;
-					_mauiTextView.Dispose();
 					_mauiTextView = null;
 				}
 			}

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Android.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Platform;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Xunit;
+using Android.Views;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.ListView)]
+	public partial class ListViewTests
+	{
+		void ValidatePlatformCells(ListView listView)
+		{
+			var renderer = (ListViewRenderer)listView.Handler;
+
+			var viewCells = renderer
+				.Control
+				.GetChildrenOfType<ViewCellRenderer.ViewCellContainer>()
+				.ToList();
+
+			// This validates that all the cells created/added their correct
+			// number of viewz
+			foreach (var cell in viewCells)
+			{
+				Assert.Equal(1, cell.ChildCount);
+
+				var renderedView = cell.GetChildAt(0) as ViewGroup;
+				Assert.Equal(1, renderedView.ChildCount);
+			}
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.Windows.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.ListView)]
+	public partial class ListViewTests
+	{
+		void ValidatePlatformCells(ListView listView)
+		{
+
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Maui.DeviceTests
 					{
 						View = new VerticalStackLayout()
 						{
-							new Label(),
 							new Label()
 						}
 					};
@@ -62,12 +61,17 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (handler) =>
 			{
 				await Task.Delay(100);
+				ValidatePlatformCells(listView);
 				data.RemoveAt(0);
 				await Task.Delay(100);
+				ValidatePlatformCells(listView);
 				data.Insert(1, "new");
 				data.Insert(2, "record");
 				await Task.Delay(100);
+				ValidatePlatformCells(listView);
 				data.RemoveAt(0);
+				await Task.Delay(100);
+				ValidatePlatformCells(listView);
 			});
 		}
 
@@ -101,8 +105,10 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				listView.ItemsSource = Enumerable.Range(1, 1);
 				await Task.Delay(100);
+				ValidatePlatformCells(listView);
 				listView.ItemsSource = Enumerable.Range(1, 2);
 				await Task.Delay(100);
+				ValidatePlatformCells(listView);
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
@@ -26,6 +27,50 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task RemovingFirstItemOfListViewDoesntCrash()
+		{
+			SetupBuilder();
+			ObservableCollection<string> data = new ObservableCollection<string>()
+			{
+				"cat",
+				"dog",
+				"catdog"
+			};
+
+			var listView = new ListView()
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					return new ViewCell()
+					{
+						View = new VerticalStackLayout()
+						{
+							new Label(),
+							new Label()
+						}
+					};
+				}),
+				ItemsSource = data
+			};
+
+			var layout = new VerticalStackLayout()
+			{
+				listView
+			};
+
+			await CreateHandlerAndAddToWindow<LayoutHandler>(layout, async (handler) =>
+			{
+				await Task.Delay(100);
+				data.RemoveAt(0);
+				await Task.Delay(100);
+				data.Insert(1, "new");
+				data.Insert(2, "record");
+				await Task.Delay(100);
+				data.RemoveAt(0);
+			});
+		}
+
 		[Fact(DisplayName = "ReAssigning ListView in VSL Crashes")]
 		public async Task ReAssigninListViewInVSLCrashes()
 		{
@@ -37,12 +82,12 @@ namespace Microsoft.Maui.DeviceTests
 					return new ViewCell()
 					{
 						View = new VerticalStackLayout()
+						{
+							new Label()
 							{
-								new Label()
-								{
-									Text = "Cat"
-								}
+								Text = "Cat"
 							}
+						}
 					};
 				})
 			};

--- a/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ListView/ListViewTests.iOS.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.ListView)]
+	public partial class ListViewTests
+	{
+		void ValidatePlatformCells(ListView listView)
+		{
+
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

- When re-attaching the ListView/TableView to the visual tree we need to invalidate the views so that the ListView can return to a functional state. This used to happen naturally in XF because in XF when you navigated back to a page it would force a measure which was basically the same thing as calling InvalidateView
- A few more fixes related to using a ListView with infinite height

### Issues Fixed

Fixes #6584
Fixes #7406 
Fixes #6943