### PR TITLE
Return VER for PlatformView

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/ViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/ViewRenderer.cs
@@ -20,8 +20,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		TPlatformView? _platformView;
 		AViewGroup? _container;
 
-		public TPlatformView? Control => ((IElementHandler)this).PlatformView as TPlatformView ?? _platformView;
-		object? IElementHandler.PlatformView => _platformView;
+		public TPlatformView? Control
+		{
+			get
+			{
+				var value = ((IElementHandler)this).PlatformView as TPlatformView;
+				if (value != this && value != null)
+					return value;
+
+				return _platformView;
+			}
+		}
+
+		object? IElementHandler.PlatformView => (_platformView as object) ?? this;
 
 		public ViewRenderer(Context context) : this(context, VisualElementRendererMapper, VisualElementRendererCommandMapper)
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/VisualElementRenderer.cs
@@ -12,7 +12,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	public abstract partial class VisualElementRenderer<TElement> : AViewGroup, IPlatformViewHandler
 		where TElement : Element, IView
 	{
-		object? IElementHandler.PlatformView => ChildCount > 0 ? GetChildAt(0) : null;
+		object? IElementHandler.PlatformView
+		{
+			get => ChildCount > 0 ? GetChildAt(0) : this;
+		}
 
 		static partial void ProcessAutoPackage(Maui.IElement element)
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/VisualElementRenderer.cs
@@ -213,7 +213,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		IMauiContext? IElementHandler.MauiContext => _mauiContext;
 
-		PlatformView? IPlatformViewHandler.PlatformView => (Element?.Handler as IElementHandler)?.PlatformView as PlatformView;
+		PlatformView? IPlatformViewHandler.PlatformView
+		{
+			get => ((Element?.Handler)?.PlatformView as PlatformView) ?? this;
+		}
 
 		PlatformView? IPlatformViewHandler.ContainerView => this;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/VisualElementRenderer.cs
@@ -18,8 +18,22 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		TPlatformElement? _nativeView;
 		public FrameworkElement ContainerElement => this;
 
-		public TPlatformElement? Control => ((IElementHandler)this).PlatformView as TPlatformElement ?? _nativeView;
-		object? IElementHandler.PlatformView => _nativeView;
+		public TPlatformElement? Control
+		{
+			get
+			{
+				var value = ((IElementHandler)this).PlatformView as TPlatformElement;
+				if (value != this && value != null)
+					return value;
+
+				return _nativeView;
+			}
+		}
+
+		object? IElementHandler.PlatformView
+		{
+			get => (_nativeView as object) ?? this;
+		}
 
 		public UIElement? GeTPlatformElement() => Control;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/ViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/ViewRenderer.cs
@@ -1,8 +1,5 @@
 ﻿#nullable enable
-using System;
 using CoreGraphics;
-using Microsoft.Maui.Graphics;
-using ObjCRuntime;
 using UIKit;
 using PlatformView = UIKit.UIView;
 
@@ -21,8 +18,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		TPlatformView? _nativeView;
 
-		public TPlatformView? Control => ((IElementHandler)this).PlatformView as TPlatformView ?? _nativeView;
-		object? IElementHandler.PlatformView => _nativeView;
+		public TPlatformView? Control
+		{
+			get
+			{
+				var value = ((IElementHandler)this).PlatformView as TPlatformView;
+				if (value != this && value != null)
+					return value;
+
+				return _nativeView;
+			}
+		}
+
+		object? IElementHandler.PlatformView => (_nativeView as object) ?? this;
 
 		public ViewRenderer() : this(VisualElementRendererMapper, VisualElementRendererCommandMapper)
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/VisualElementRenderer.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	public abstract partial class VisualElementRenderer<TElement> : UIView, IPlatformViewHandler, IElementHandler
 		where TElement : Element, IView
 	{
-		object? IElementHandler.PlatformView => Subviews.Length > 0 ? Subviews[0] : null;
+		object? IElementHandler.PlatformView => Subviews.Length > 0 ? Subviews[0] : this;
 
 		public virtual UIViewController? ViewController => null;
 

--- a/src/Controls/tests/DeviceTests/Elements/Compatibility/VisualElementRendererTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Compatibility/VisualElementRendererTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Compatibility)]
+	public partial class VisualElementRendererTests : HandlerTestBase
+	{
+		class LegacyComponent : View
+		{
+
+		}
+
+#if WINDOWS
+		class LegacyComponentRenderer : ViewRenderer<View, UI.Xaml.FrameworkElement>
+#else
+		class LegacyComponentRenderer : VisualElementRenderer<LegacyComponent>
+#endif
+		{
+#if ANDROID
+			public LegacyComponentRenderer(Android.Content.Context context) : base(context)
+			{
+				
+			}
+#endif
+		}
+
+
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<LegacyComponent, LegacyComponentRenderer>();
+				});
+			});
+		}
+
+		[Fact]
+		public async Task CompatibilityRendererWorksWithNoInnerContrlSpecified()
+		{
+			SetupBuilder();
+			var renderer = await InvokeOnMainThreadAsync(() => new LegacyComponent().ToPlatform(MauiContext));
+
+			Assert.Equal(renderer, (renderer as IPlatformViewHandler).PlatformView);
+			Assert.NotNull(renderer);
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Frame)]
+	public partial class FrameTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Frame, FrameRenderer>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+		}
+
+		[Fact(DisplayName = "Basic Frame Test")]
+		public async Task BasicFrameTest()
+		{
+			SetupBuilder();
+
+			var frame = new Frame()
+			{
+				HeightRequest = 300,
+				WidthRequest = 300,
+				Content = new Label()
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					Text = "Hello Frame"
+				}
+			};
+
+			var labelFrame =
+				await InvokeOnMainThreadAsync(() =>
+					frame.ToHandler(MauiContext).PlatformView.AttachAndRun(async () =>
+					{
+						frame.Measure(300, 300);
+						frame.Arrange(new Graphics.Rect(0, 0, 300, 300));
+
+						// This means the label has been added to the platforms visual tree
+						await OnLoadedAsync(frame.Content);
+						await OnFrameSetToNotEmpty(frame.Content);
+
+						return frame.Content.Frame;
+
+					})
+				);
+
+
+			// validate label is centered in the frame
+			Assert.True(Math.Abs(((300 - labelFrame.Width) / 2) - labelFrame.X) < 1);
+			Assert.True(Math.Abs(((300 - labelFrame.Height) / 2) - labelFrame.Y) < 1);
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -46,11 +46,9 @@ namespace Microsoft.Maui.DeviceTests
 				await InvokeOnMainThreadAsync(() =>
 					frame.ToHandler(MauiContext).PlatformView.AttachAndRun(async () =>
 					{
-						frame.Measure(300, 300);
-						frame.Arrange(new Graphics.Rect(0, 0, 300, 300));
+						(frame as IView).Measure(300, 300);
+						(frame as IView).Arrange(new Graphics.Rect(0, 0, 300, 300));
 
-						// This means the label has been added to the platforms visual tree
-						await OnLoadedAsync(frame.Content);
 						await OnFrameSetToNotEmpty(frame.Content);
 
 						return frame.Content.Frame;

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -4,11 +4,13 @@
 	{
 		public const string Behavior = "Behavior";
 		public const string Button = "Button";
+		public const string Compatibility = "Compatibility";
 		public const string ContentView = "ContentView";
 		public const string Dispatcher = "Dispatcher";
 		public const string Editor = "Editor";
 		public const string Element = "Element";
 		public const string Entry = "Entry";
+		public const string Frame = "Frame";
 		public const string FlyoutPage = "FlyoutPage";
 		public const string Gesture = "Gesture";
 		public const string Label = "Label";


### PR DESCRIPTION
### Description of Change

- If the VisualElementRenderer doesn't set an internal control then just return the VER for the IElementHandler.PlatformView call

I didn't realize that in XF the VisualElementRenderer could work with no internal control specified so I was just returning null for `IElementHandler.PlatformView` if the renderer never sets the control. Having a `null`  `PLatformView` makes the `ToPlatform` call grumpy. This PR fixes scenarios where you might have a VER that looks like [this](https://github.com/davidortinau/CustomRendererSample/blob/main/XamarinCustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer.Android/Renderers/PressableViewRenderer.cs)
