### PR TITLE
Hide non visible shell parts from VO

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			else if (behavior == FlyoutBehavior.Disabled)
 				IsOpen = false;
 			LayoutSidebar(false);
+			UpdateFlyoutAccessibility();
 		}
 
 		#endregion IFlyoutBehaviorObserver
@@ -155,7 +156,41 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				_isOpen = value;
 				Shell.SetValueFromRenderer(Shell.FlyoutIsPresentedProperty, value);
+				UpdateFlyoutAccessibility();
 			}
+		}
+
+		void UpdateFlyoutAccessibility()
+		{
+			bool flyoutElementsHidden = false;
+			bool detailsElementsHidden = false;
+
+			switch (_flyoutBehavior)
+			{
+				case FlyoutBehavior.Flyout:
+					flyoutElementsHidden = !IsOpen;
+					detailsElementsHidden = IsOpen;
+
+					break;
+
+				case FlyoutBehavior.Locked:
+					flyoutElementsHidden = false;
+					detailsElementsHidden = false;
+
+					break;
+
+				case FlyoutBehavior.Disabled:
+					flyoutElementsHidden = false;
+					detailsElementsHidden = true;
+
+					break;
+			}
+
+			if (Flyout?.ViewController?.View != null)
+				Flyout.ViewController.View.AccessibilityElementsHidden = flyoutElementsHidden;
+
+			if (Detail.View != null)
+				Detail.View.AccessibilityElementsHidden = detailsElementsHidden;
 		}
 
 		UIPanGestureRecognizer PanGestureRecognizer { get; set; }
@@ -194,6 +229,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			((IShellController)Shell).AddFlyoutBehaviorObserver(this);
 			UpdateFlowDirection();
+			UpdateFlyoutAccessibility();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -422,6 +458,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 						UpdateTapoffView();
 						_flyoutAnimation = null;
+
+						UIAccessibility.PostNotification(UIAccessibilityPostNotification.ScreenChanged, null);
 					}
 				});
 
@@ -437,6 +475,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				{
 					TapoffView.Layer.Opacity = IsOpen ? 1 : 0;
 				}
+
+				UIAccessibility.PostNotification(UIAccessibilityPostNotification.ScreenChanged, null);
 			}
 
 			void UpdateTapoffView()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (Flyout?.ViewController?.View != null)
 				Flyout.ViewController.View.AccessibilityElementsHidden = flyoutElementsHidden;
 
-			if (Detail.View != null)
+			if (Detail?.View != null)
 				Detail.View.AccessibilityElementsHidden = detailsElementsHidden;
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutRenderer.cs
@@ -180,8 +180,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					break;
 
 				case FlyoutBehavior.Disabled:
-					flyoutElementsHidden = false;
-					detailsElementsHidden = true;
+					flyoutElementsHidden = true;
+					detailsElementsHidden = false;
 
 					break;
 			}


### PR DESCRIPTION
### Description of Change

Currently on iOS if you have a shell app the UICollectionView inside the flyout is always reachable even if it's off the screen. 

- When the flyout is closed set all the children to inaccessible
- When the flyout is open set the details view to inaccessible
- for a locked flyout keep everything accessible
- for a disabled flyout just set the details view to accessible.

I also added code to fire a 
`UIAccessibility.PostNotification(UIAccessibilityPostNotification.ScreenChanged, null);`

Notification once the flyout has finished opening or closing so that something on the screen will gain focus. Without this code nothing is focused after the flyout changes positions.
