### PR TITLE
Propagate semantics to CV Item container

### DIFF
--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -129,10 +129,17 @@ namespace Microsoft.Maui.Controls.Platform
 			base.OnContentChanged(oldContent, newContent);
 
 			if (oldContent != null && _visualElement != null)
+			{
 				_visualElement.MeasureInvalidated -= OnViewMeasureInvalidated;
+				_visualElement.PropertyChanged -= OnViewPropertyChanged;
+			}
 
 			if (newContent != null && _visualElement != null)
+			{
 				_visualElement.MeasureInvalidated += OnViewMeasureInvalidated;
+				_visualElement.PropertyChanged += OnViewPropertyChanged;
+				UpdateSemanticProperties(_visualElement);
+			}
 		}
 
 		internal void Realize()
@@ -215,6 +222,44 @@ namespace Microsoft.Maui.Controls.Platform
 		void OnViewMeasureInvalidated(object sender, EventArgs e)
 		{
 			InvalidateMeasure();
+		}
+
+		void OnViewPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (e.IsOneOf(
+				SemanticProperties.HeadingLevelProperty,
+				SemanticProperties.HintProperty,
+				SemanticProperties.DescriptionProperty,
+				AutomationProperties.IsInAccessibleTreeProperty) &&
+				sender is IView view)
+			{
+				UpdateSemanticProperties(view);
+			}
+		}
+
+		void UpdateSemanticProperties(IView view)
+		{
+			// If you don't set the automation properties on the root element
+			// of a list item it just reads out the class type to narrator
+			// https://docs.microsoft.com/en-us/accessibility-tools-docs/items/uwpxaml/listitem_name
+			// Because this is the root element of the ListViewItem we need to propagate
+			// the semantic properties from the root xplat element to this platform element
+			if (view == null)
+				return;
+
+			this.UpdateSemantics(view);
+
+			var semantics = view.Semantics;
+
+			UI.Xaml.Automation.Peers.AccessibilityView defaultAccessibilityView = 
+				UI.Xaml.Automation.Peers.AccessibilityView.Content;
+
+			if (!String.IsNullOrWhiteSpace(semantics?.Description) || !String.IsNullOrWhiteSpace(semantics?.Hint))
+			{
+				defaultAccessibilityView = UI.Xaml.Automation.Peers.AccessibilityView.Raw;
+			}
+
+			this.SetAutomationPropertiesAccessibilityView(_visualElement, defaultAccessibilityView);
 		}
 
 		protected override WSize MeasureOverride(WSize availableSize)


### PR DESCRIPTION
### Description of Change

If you don't set the AutomationProperties on the root element of a templated ListViewItem in WinUI then it just reads out the class type on Narrator. In order to read out something useful the [guidance ](https://docs.microsoft.com/en-us/accessibility-tools-docs/items/uwpxaml/listitem_name) is to set the `AutomationProperties` of the root element. This PR propagates the semantic properties set on the root xplat element to the `ContentControl` that acts as the root container for the WinUI CV.

### Example Usage

```C#
new CollectionView()
{
	ItemsSource = new int[] { 1, 2, 3, 4, 5 },
	ItemTemplate = new DataTemplate(() =>
	{
		var layout = new StackLayout()
		{
			new Button()
			{
				Text = "Whatever"
			}
		};

		SemanticProperties.SetDescription(layout, "Hello there");
		return layout;
	})
};
```


