### PR TITLE
If the FlyoutBehavior is "Flyout" show toolbar

### DIFF
--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -111,17 +111,20 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
+				var flyoutBehavior = (_shell as IFlyoutView).FlyoutBehavior;
 #if WINDOWS
 				IsVisible = (BackButtonVisible ||
 					!String.IsNullOrEmpty(Title) ||
 					TitleView != null ||
 					_toolbarTracker.ToolbarItems.Count > 0 ||
-					_menuBarTracker.ToolbarItems.Count > 0);
+					_menuBarTracker.ToolbarItems.Count > 0 ||
+					flyoutBehavior == FlyoutBehavior.Flyout);
 #else
 				IsVisible = (BackButtonVisible ||
 					!String.IsNullOrEmpty(Title) ||
 					TitleView != null ||
-					_toolbarTracker.ToolbarItems.Count > 0);
+					_toolbarTracker.ToolbarItems.Count > 0 ||
+					flyoutBehavior == FlyoutBehavior.Flyout);
 #endif
 			}
 

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -226,5 +226,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(Colors.Orange, toolbar.IconColor);
 			Assert.AreEqual(Colors.Pink, toolbar.BarTextColor);
 		}
+
+		[Test]
+		public void ToolBarShouldBeVisibleWithEmptyTitleAndFlyoutBehaviorSetToFlyout()
+		{
+			TestShell testShell = new TestShell()
+			{
+				CurrentItem = new FlyoutItem()
+				{
+					CurrentItem = new ContentPage()
+				}
+			};
+
+			_ = new Window() { Page = testShell };
+			var toolbar = testShell.Toolbar;
+
+			Assert.IsTrue(toolbar.IsVisible);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Shell isn't correctly taking into account the `Flyoutbehavior` value when determining if the Toolbar should be visible. 

This means if the user hasn't specified any `ToolbarItems` or a `Title` but they still want the Hamburger Menu they weren't getting it. This PR fixes that.

