### PR TITLE
[iOS] Fix ActivityIndicator with initial IsRunning value to False

### DIFF
--- a/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.iOS.cs
+++ b/src/Core/src/Handlers/ActivityIndicator/ActivityIndicatorHandler.iOS.cs
@@ -1,4 +1,5 @@
-﻿using CoreGraphics;
+﻿using System;
+using CoreGraphics;
 using ObjCRuntime;
 using UIKit;
 
@@ -6,12 +7,17 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class ActivityIndicatorHandler : ViewHandler<IActivityIndicator, MauiActivityIndicator>
 	{
-		protected override MauiActivityIndicator CreatePlatformView() => new MauiActivityIndicator(CGRect.Empty, VirtualView)
+		protected override MauiActivityIndicator CreatePlatformView()
 		{
-#pragma warning disable CA1416 // TODO: 'UIActivityIndicatorViewStyle.Gray' is unsupported on: 'ios' 13.0 and later
-			ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray
-#pragma warning restore CA1416
-		};
+			MauiActivityIndicator platformView;
+
+			if (OperatingSystem.IsIOSVersionAtLeast(13))
+				platformView = new MauiActivityIndicator(CGRect.Empty, VirtualView) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Medium };
+			else
+				platformView = new MauiActivityIndicator(CGRect.Empty, VirtualView) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray };
+
+			return platformView;
+		}
 
 		public static void MapIsRunning(IActivityIndicatorHandler handler, IActivityIndicator activityIndicator)
 		{

--- a/src/Core/src/Platform/iOS/MauiActivityIndicator.cs
+++ b/src/Core/src/Platform/iOS/MauiActivityIndicator.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Maui.Platform
 		IActivityIndicator? _virtualView;
 
 		public MauiActivityIndicator(CGRect rect, IActivityIndicator? virtualView) : base(rect)
-			=> _virtualView = virtualView;
+		{
+			_virtualView = virtualView;
+		}
 
 		public override void Draw(CGRect rect)
 		{
@@ -17,6 +19,8 @@ namespace Microsoft.Maui.Platform
 
 			if (_virtualView?.IsRunning == true)
 				StartAnimating();
+			else
+				StopAnimating();
 		}
 
 		public override void LayoutSubviews()
@@ -25,11 +29,14 @@ namespace Microsoft.Maui.Platform
 
 			if (_virtualView?.IsRunning == true)
 				StartAnimating();
+			else
+				StopAnimating();
 		}
 
 		protected override void Dispose(bool disposing)
 		{
 			base.Dispose(disposing);
+
 			_virtualView = null;
 		}
 	}


### PR DESCRIPTION
### Description of Change

Fix ActivityIndicator with initial IsRunning value to False on iOS.

<img width="513" alt="Captura de Pantalla 2022-05-30 a las 13 58 48" src="https://user-images.githubusercontent.com/6755973/171006904-0d2f6bf3-ada2-497a-bef1-48f64ba77b1f.png">

To test it can use the .NET MAUI Gallery and navigate to the ActivityIndicator Gallery. Notice how the IsRunning (False) ActivityIndicator is not rendering.

### Issues Fixed

Fixes #6455
