### PR TITLE
Fix crash setting zero or negative values in Border size

### DIFF
--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Platform
 
 			_borderPath?.Arrange(new global::Windows.Foundation.Rect(0, 0, finalSize.Width, finalSize.Height));
 
-			return new global::Windows.Foundation.Size(actual.Width, actual.Height);
+			return new global::Windows.Foundation.Size(Math.Max(0, actual.Width), Math.Max(0, actual.Height));
 		}
 
 		public ContentPanel()


### PR DESCRIPTION
### Description of Change

Fix crash setting zero or negative values in **Border** size.

### Issues Fixed

Fixes #7655 
