### PR TITLE
Fix for #5523 MauiWebView not loading local files on Windows

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -9,6 +9,26 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiWebView : WebView2, IWebViewDelegate
 	{
+		public MauiWebView()
+		{
+			NavigationStarting += (sender, args) =>
+			{
+				// Auto map local virtual app dir host, e.g. if navigating back to local site from a link to an external site
+				if (args?.Uri?.ToLowerInvariant().StartsWith(LocalScheme.TrimEnd('/').ToLowerInvariant()) == true)
+				{
+					CoreWebView2.SetVirtualHostNameToFolderMapping(
+						LocalHostName,
+						ApplicationPath,
+						Web.WebView2.Core.CoreWebView2HostResourceAccessKind.Allow);
+				}
+				// Auto unmap local virtual app dir host if navigating to any other potentially unsafe domain
+				else
+				{
+					CoreWebView2.ClearVirtualHostNameToFolderMapping(LocalHostName);
+				}
+			};
+		}
+
 		WebView2? _internalWebView;
 
 		// Arbitrary local host name for virtual folder mapping

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Platform
 			}";
 
 		// Allow for packaged/unpackaged app support
-		string ApplicationPath = AppInfoUtils.IsPackagedApp
+		string ApplicationPath => AppInfoUtils.IsPackagedApp
 			? Package.Current.InstalledLocation.Path
 			: AppContext.BaseDirectory;
 


### PR DESCRIPTION
### Description of Change

Modified the MauiWebView control on Windows to map the Application AppX install directory to a virtual folder using the WebView2.CoreWebView.SetVirtualHostNameToFolderMapping method.

The existing implementation used the "ms-appx-web:///" URI scheme, which according to these issues is not being implemented in WebView2 for WinUI3.
https://github.com/microsoft/microsoft-ui-xaml/issues/1967
https://github.com/MicrosoftEdge/WebView2Feedback/issues/37

### Issues Fixed

- Maui WebView on Windows won't load local HTML files marked with Build action "MauiAsset". For me, the Maui GA release never loads even a simple HTML file via this method, and I have tested extensively on multiple Windows machines.

Fixes #5523 