### PR TITLE
[iOS] Correctly return the value from Focus method

### DIFF
--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void Focus(this UIView platformView, FocusRequest request)
 		{
-			platformView.BecomeFirstResponder();
+			request.IsFocused = platformView.BecomeFirstResponder();
 		}
 
 		public static void Unfocus(this UIView platformView, IView view)


### PR DESCRIPTION
### Description of Change

Correctly return the value from Focus method on iOS/Catalyst. I am reviewing https://github.com/dotnet/maui/issues/6786 and although this PR does not fix this issue, it avoid always return false when invoking the Focus method even if the focus is set correctly.
