### PR TITLE
[build] Version .NET VS manifest file

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TargetName>Microsoft.NET.Sdk.Maui.Workload</TargetName>
+    <TargetName>Microsoft.NET.Sdk.Maui.Workload.@VSMAN_VERSION@</TargetName>
     <ManifestBuildVersion>@VS_COMPONENT_VERSION@</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -85,7 +85,7 @@
     <ItemGroup>
       <_WorkloadPropsReplacements Include="@PACK_VERSION_LONG@"     NewValue="$(PackageReferenceVersion)" />
       <_WorkloadPropsReplacements Include="@VS_COMPONENT_VERSION@"  NewValue="$(VSComponentVersion)" />
-      <_WorkloadPropsReplacements Include="@VSMAN_VERSION@"         NewValue="7.0" /> <!-- TODO: Replace with $(_MauiDotNetVersion) -->
+      <_WorkloadPropsReplacements Include="@VSMAN_VERSION@"         NewValue="net7.0" /> <!-- TODO: Replace with $(_MauiDotNetTfm) -->
     </ItemGroup>
     <ReplaceText
         Input="$(MauiRootDirectory)eng/automation/vs-workload.template.props"

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -81,9 +81,18 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_GenerateVSWorkloadProps" AfterTargets="Build" Inputs="$(MSBuildProjectFile);$(MauiRootDirectory)eng/automation/vs-workload.template.props" Outputs="$(PackageOutputPath)/vs-workload.temp.props;$(PackageOutputPath)/vs-workload.props">
-    <ReplaceText Input="$(MauiRootDirectory)eng/automation/vs-workload.template.props" Output="$(PackageOutputPath)/vs-workload.temp.props" OldValue="@PACK_VERSION_LONG@" NewValue="$(PackageReferenceVersion)" />
-    <ReplaceText Input="$(PackageOutputPath)/vs-workload.temp.props" Output="$(PackageOutputPath)/vs-workload.props" OldValue="@VS_COMPONENT_VERSION@" NewValue="$(VSComponentVersion)" />
+  <Target Name="_GenerateVSWorkloadProps" AfterTargets="Build" Inputs="$(MSBuildProjectFile);$(MauiRootDirectory)eng/automation/vs-workload.template.props" Outputs="$(PackageOutputPath)/vs-workload.props">
+    <ItemGroup>
+      <_WorkloadPropsReplacements Include="@PACK_VERSION_LONG@"     NewValue="$(PackageReferenceVersion)" />
+      <_WorkloadPropsReplacements Include="@VS_COMPONENT_VERSION@"  NewValue="$(VSComponentVersion)" />
+      <_WorkloadPropsReplacements Include="@VSMAN_VERSION@"         NewValue="7.0" /> <!-- TODO: Replace with $(_MauiDotNetVersion) -->
+    </ItemGroup>
+    <ReplaceText
+        Input="$(MauiRootDirectory)eng/automation/vs-workload.template.props"
+        Output="$(PackageOutputPath)/vs-workload.props"
+        OldValue="%(_WorkloadPropsReplacements.Identity)"
+        NewValue="%(_WorkloadPropsReplacements.NewValue)"
+    />
     <ItemGroup>
       <FileWrites Include="$(PackageOutputPath)/vs-workload.props" />
     </ItemGroup>


### PR DESCRIPTION
As part of supporting .NET 6 projects with our .NET 7 workload, we will
want to be able to insert both .NET 6 and .NET 7 workload packs into VS.

Historically, we have replaced the [VS manifest file][0] every time we
update our workload.  For .NET 7 we will likely want two VS manifests
side by side, one which contains our .NET 6 packs and one for .NET 7.

Add a version to the .NET VS manifest file to support this potential
side by side scenario.

[0]: https://devdiv.visualstudio.com/DevDiv/_git/VS?path=/.corext/Configs/dotnet-workloads-components.json&version=GBmain&line=10&lineEnd=11&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
