### PR TITLE
Fix GridLayoutManager Layout calculation

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -84,11 +84,12 @@ namespace Microsoft.Maui.Layouts
 			{
 				_grid = grid;
 
-				_gridWidthConstraint = widthConstraint;
-				_gridHeightConstraint = heightConstraint;
-
 				_explicitGridHeight = _grid.Height;
 				_explicitGridWidth = _grid.Width;
+
+				_gridWidthConstraint = _explicitGridWidth > -1 ? _explicitGridWidth : widthConstraint;
+				_gridHeightConstraint = _explicitGridHeight > -1 ? _explicitGridHeight : heightConstraint;
+				
 				_gridMaxHeight = _grid.MaximumHeight;
 				_gridMinHeight = _grid.MinimumHeight;
 				_gridMaxWidth = _grid.MaximumWidth;

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1851,6 +1851,23 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(10, measuredSize.Width);
 		}
 
+		[Fact("ArrangeChildren should arranged within measured size")]
+		[Category(GridStarSizing)]
+		public void ArrangeChildrenShouldArrangedWithinMeasuredSize()
+		{
+			var grid = CreateGridLayout(rows: "*");
+			grid.Width.Returns(105);
+			grid.Height.Returns(120);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			SubstituteChildren(grid, view0);
+
+			var measuredSize = MeasureAndArrange(grid, 300, double.PositiveInfinity);
+
+			// we expect that the child will be arranged within measured size
+			AssertArranged(view0, 0, 0, measuredSize.Width, measuredSize.Height);
+		}
+
 		[Theory]
 		[InlineData(LayoutAlignment.Center, true)]
 		[InlineData(LayoutAlignment.Center, false)]


### PR DESCRIPTION
### Description of Change
<!-- Enter description of the fix in this section -->
 Replaced widthConstraint/heightConstraint to explicit width/height, if explicit width/height was valid.

 GridlayoutManager returns the explicit width/height as a measure result if it was valid
 https://github.com/dotnet/maui/blob/3ae0029bf0c0e44b52a6b9beaf9295f763f55966/src/Core/src/Layouts/GridLayoutManager.cs#L289
 https://github.com/dotnet/maui/blob/3ae0029bf0c0e44b52a6b9beaf9295f763f55966/src/Core/src/Layouts/GridLayoutManager.cs#L306

 But, Layout calculation was not affected by explicit width/height. so, `ArrangeChildren` is not working propertly
 It was fixed

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #7681 
