### PR TITLE
[Android] Fix issue clipping ImageButton

### DIFF
--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.Android.cs
@@ -43,6 +43,12 @@ namespace Microsoft.Maui.Handlers
 			base.ConnectHandler(platformView);
 		}
 
+		// TODO: NET7 make this public
+		internal static void MapBackground(IImageButtonHandler handler, IImageButton imageButton)
+		{
+			(handler.PlatformView as ShapeableImageView)?.UpdateBackground(imageButton);
+		}
+
 		public static void MapStrokeColor(IImageButtonHandler handler, IButtonStroke buttonStroke)
 		{
 			(handler.PlatformView as ShapeableImageView)?.UpdateStrokeColor(buttonStroke);

--- a/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
+++ b/src/Core/src/Handlers/ImageButton/ImageButtonHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IButtonStroke.StrokeColor)] = MapStrokeColor,
 			[nameof(IButtonStroke.CornerRadius)] = MapCornerRadius,
 			[nameof(IImageButton.Padding)] = MapPadding,
-#if WINDOWS
+#if ANDROID || WINDOWS
 			[nameof(IImageButton.Background)] = MapBackground,
 #endif
 		};

--- a/src/Core/src/Platform/Android/ImageButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ImageButtonExtensions.cs
@@ -6,6 +6,14 @@ namespace Microsoft.Maui.Platform
 {
 	public static class ImageButtonExtensions
 	{
+		// TODO: NET7 should this be public?
+		internal static void UpdateBackground(this ShapeableImageView platformButton, IImageButton imageButton)
+		{
+			Paint? paint = imageButton.Background;
+
+			platformButton.Background = paint?.ToDrawable(platformButton.Context);
+		}
+
 		public static void UpdateStrokeColor(this ShapeableImageView platformButton, IButtonStroke buttonStroke)
 		{
 			if (buttonStroke.StrokeColor is Color stroke)

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.Android.cs
@@ -1,17 +1,27 @@
 using System;
 using System.Threading.Tasks;
-using Android.Graphics.Drawables;
-using Android.Widget;
-using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Handlers;
-using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ImageButtonHandlerTests
 	{
+		[Fact(DisplayName = "Clip ImageButton with Background works Correctly")]
+		public async Task ClipImageButtonWithBackgroundWorks()
+		{
+			Color expected = Colors.Yellow;
+
+			var brush = new LinearGradientPaintStub(Colors.Blue, expected);
+
+			var imageButton = new ImageButtonStub
+			{
+				Background = brush,
+				Clip = new EllipseShapeStub()
+			};
+
+			await ValidateHasColor(imageButton, expected);
+		}
+
 		Google.Android.Material.ImageView.ShapeableImageView GetPlatformImageButton(ImageButtonHandler buttonHandler) =>
 			buttonHandler.PlatformView;
 
@@ -32,6 +42,16 @@ namespace Microsoft.Maui.DeviceTests
 				shapeableImageView.ContentPaddingTop,
 				shapeableImageView.ContentPaddingRight,
 				shapeableImageView.ContentPaddingBottom);
+		}
+
+		Task ValidateHasColor(IImageButton imageButton, Color color, Action action = null)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				var platformImageButton = GetPlatformImageButton(CreateHandler(imageButton));
+				action?.Invoke();
+				platformImageButton.AssertContainsColor(color);
+			});
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ImageButton/ImageButtonHandlerTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.DeviceTests
 			var clicked = false;
 
 			var button = new ImageButtonStub();
+
 			button.Clicked += delegate
 			{
 				clicked = true;

--- a/src/Core/tests/DeviceTests/Stubs/LinearGradientPaintStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LinearGradientPaintStub.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public class LinearGradientPaintStub : LinearGradientPaint
+	{
+		public LinearGradientPaintStub(Color startColor, Color endColor)
+		{
+			StartColor = startColor;
+			EndColor = endColor;
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

An earlier PR fixed the positioning of the EllipseGeometry so the Clip renders correctly, but does not apply to the background. This PR adds changes to include the background when Clipping.

Before
![Screenshot_1654252278](https://user-images.githubusercontent.com/6755973/171839674-1e4f3638-1383-4221-af53-bb8cad3fa3aa.png)

After
![Screenshot_1654252198](https://user-images.githubusercontent.com/6755973/171839670-554af52d-307f-40d4-8843-d04f463c125a.png)

### Issues Fixed

Fixes #5948 
