### PR TITLE
Fix TemplatedView

### DIFF
--- a/src/Controls/samples/Controls.Sample/Controls/Rate/Rate.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/Rate/Rate.cs
@@ -1,0 +1,293 @@
+﻿using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
+using System.Runtime.CompilerServices;
+using Microsoft.Maui;
+
+namespace Maui.Controls.Sample.Controls
+{
+    public class Rate : TemplatedView
+    {
+        const string ElementPanel = "PART_Panel";
+
+        StackLayout _rateLayout;
+
+        public static readonly BindableProperty IconProperty =
+            BindableProperty.Create(nameof(Icon), typeof(Geometry), typeof(Rate), GetDefaultIcon());
+
+        public Geometry Icon
+        {
+            get => (Geometry)GetValue(IconProperty);
+            set => SetValue(IconProperty, value);
+        }
+
+        static Geometry GetDefaultIcon()
+        {
+            Application.Current.Resources.TryGetValue("StarGeometry", out object resource);
+            PathGeometry pathGeometry = (PathGeometry)resource;
+
+            return pathGeometry;
+        }
+
+        public static readonly BindableProperty ItemSizeProperty =
+            BindableProperty.Create(nameof(ItemSize), typeof(double), typeof(Rate), 30.0d);
+
+        public double ItemSize
+        {
+            get => (double)GetValue(ItemSizeProperty);
+            set => SetValue(ItemSizeProperty, value);
+        }
+
+        public static readonly BindableProperty ItemCountProperty =
+            BindableProperty.Create(nameof(ItemCount), typeof(int), typeof(Rate), 5);
+
+        public int ItemCount
+        {
+            get => (int)GetValue(ItemCountProperty);
+            set => SetValue(ItemCountProperty, value);
+        }
+
+        public static readonly BindableProperty SelectedFillProperty =
+            BindableProperty.Create(nameof(SelectedFill), typeof(Color), typeof(Rate), Color.FromArgb("#F6C602"));
+
+        public Color SelectedFill
+        {
+            get => (Color)GetValue(SelectedFillProperty);
+            set => SetValue(SelectedFillProperty, value);
+        }
+
+        public static readonly BindableProperty UnSelectedFillProperty =
+            BindableProperty.Create(nameof(UnSelectedFill), typeof(Color), typeof(Rate), Colors.Transparent);
+
+        public Color UnSelectedFill
+        {
+            get => (Color)GetValue(UnSelectedFillProperty);
+            set => SetValue(UnSelectedFillProperty, value);
+        }
+
+        public static readonly BindableProperty SelectedStrokeProperty =
+            BindableProperty.Create(nameof(SelectedStroke), typeof(Color), typeof(Rate), Color.FromArgb("#F6C602"));
+
+        public Color SelectedStroke
+        {
+            get => (Color)GetValue(SelectedStrokeProperty);
+            set => SetValue(SelectedStrokeProperty, value);
+        }
+
+        public static readonly BindableProperty UnSelectedStrokeProperty =
+            BindableProperty.Create(nameof(UnSelectedStroke), typeof(Color), typeof(Rate), Colors.Black);
+
+        public Color UnSelectedStroke
+        {
+            get => (Color)GetValue(UnSelectedStrokeProperty);
+            set => SetValue(UnSelectedStrokeProperty, value);
+        }
+
+        public static readonly BindableProperty SelectedStrokeWidthProperty =
+            BindableProperty.Create(nameof(SelectedStrokeWidth), typeof(double), typeof(Rate), 1.0d);
+
+        public double SelectedStrokeWidth
+        {
+            get => (double)GetValue(SelectedStrokeWidthProperty);
+            set => SetValue(SelectedStrokeWidthProperty, value);
+        }
+
+        public static readonly BindableProperty UnSelectedStrokeWidthProperty =
+            BindableProperty.Create(nameof(UnSelectedStrokeWidth), typeof(double), typeof(Rate), 1.0d);
+
+        public double UnSelectedStrokeWidth
+        {
+            get => (double)GetValue(UnSelectedStrokeWidthProperty);
+            set => SetValue(UnSelectedStrokeWidthProperty, value);
+        }
+
+        public static readonly BindableProperty TextProperty =
+            BindableProperty.Create(nameof(Text), typeof(string), typeof(Rate), default(string));
+
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        public static readonly BindableProperty ShowTextProperty =
+            BindableProperty.Create(nameof(ShowText), typeof(bool), typeof(Rate), false);
+
+        public bool ShowText
+        {
+            get => (bool)GetValue(ShowTextProperty);
+            set => SetValue(ShowTextProperty, value);
+        }
+
+        public static readonly BindableProperty IsReadOnlyProperty =
+            BindableProperty.Create(nameof(IsReadOnly), typeof(bool), typeof(Rate), false,
+                propertyChanged: OnIsReadOnlyChanged);
+
+        static void OnIsReadOnlyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            (bindable as Rate)?.UpdateIsReadOnly();
+        }
+
+        public bool IsReadOnly
+        {
+            get => (bool)GetValue(IsReadOnlyProperty);
+            set => SetValue(IsReadOnlyProperty, value);
+        }
+
+        public static readonly BindableProperty ValueProperty =
+            BindableProperty.Create(nameof(Value), typeof(int), typeof(Rate), default(int));
+
+        public int Value
+        {
+            get => (int)GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
+        }
+
+        public event EventHandler<ValueChangedEventArgs> ValueChanged;
+
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            _rateLayout = GetTemplateChild(ElementPanel) as StackLayout;
+
+            UpdateRateItems();
+        }
+
+        protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            base.OnPropertyChanged(propertyName);
+
+            if (propertyName == ValueProperty.PropertyName)
+                UpdateValue();
+            else if (propertyName == IconProperty.PropertyName)
+                UpdateIcon();
+            else if (propertyName == ItemCountProperty.PropertyName)
+                UpdateItemCount();
+            else if (propertyName == ItemSizeProperty.PropertyName)
+                UpdateItemSize();
+            else if (propertyName == SelectedFillProperty.PropertyName)
+                UpdateSelectedFill();
+            else if (propertyName == UnSelectedFillProperty.PropertyName)
+                UpdateUnSelectedFill();
+            else if (propertyName == SelectedStrokeProperty.PropertyName)
+                UpdateSelectedStroke();
+            else if (propertyName == UnSelectedStrokeProperty.PropertyName)
+                UpdateUnSelectedStroke();
+            else if (propertyName == SelectedStrokeWidthProperty.PropertyName)
+                UpdateSelectedStrokeWidth();
+            else if (propertyName == UnSelectedStrokeWidthProperty.PropertyName)
+                UpdateUnSelectedStrokeWidth();
+        }
+
+        void UpdateRateItems()
+        {
+            _rateLayout.Children.Clear();
+
+            for (var i = 1; i <= ItemCount; i++)
+            {
+                var rateItem = new RateItem();
+
+                _rateLayout.Children.Add((IView)rateItem);
+            }
+
+            UpdateIsReadOnly();
+            UpdateIcon();
+            UpdateItemSize();
+            UpdateSelectedFill();
+            UpdateUnSelectedFill();
+            UpdateSelectedStroke();
+            UpdateUnSelectedStroke();
+            UpdateSelectedStrokeWidth();
+            UpdateUnSelectedStrokeWidth();
+        }
+
+        void UpdateIsReadOnly()
+        {
+            if (IsReadOnly)
+            {
+                foreach (var rateItem in _rateLayout.Children)
+                    (rateItem as View)?.GestureRecognizers.Clear();
+            }
+            else
+            {
+                foreach (var rateItem in _rateLayout.Children)
+                {
+                    var tapGestureRecognizer = new TapGestureRecognizer();
+                    tapGestureRecognizer.Tapped += OnTapped;
+                    (rateItem as View)?.GestureRecognizers.Add(tapGestureRecognizer);
+                }
+            }
+        }
+
+        void UpdateIcon()
+        {
+            foreach (var child in _rateLayout.Children)
+                ((RateItem)child).Icon = Icon;
+        }
+
+        void UpdateItemCount()
+        {
+            UpdateRateItems();
+        }
+
+        void UpdateItemSize()
+        {
+            foreach (var child in _rateLayout.Children)
+                ((RateItem)child).ItemSize = ItemSize;
+        }
+
+        void UpdateSelectedFill()
+        {
+            foreach (var child in _rateLayout.Children)
+                ((RateItem)child).SelectedFill = SelectedFill;
+        }
+
+        void UpdateUnSelectedFill()
+        {
+            foreach (var child in _rateLayout.Children)
+                ((RateItem)child).UnSelectedFill = UnSelectedFill;
+        }
+
+        void UpdateSelectedStroke()
+        {
+            foreach (var child in _rateLayout.Children)
+                ((RateItem)child).SelectedFill = SelectedFill;
+        }
+
+        void UpdateUnSelectedStroke()
+        {
+            foreach (var child in _rateLayout.Children)
+                ((RateItem)child).UnSelectedFill = UnSelectedFill;
+        }
+
+        void UpdateSelectedStrokeWidth()
+        {
+            foreach (var child in _rateLayout.Children)
+                ((RateItem)child).SelectedStrokeWidth = SelectedStrokeWidth;
+        }
+
+        void UpdateUnSelectedStrokeWidth()
+        {
+            foreach (var child in _rateLayout.Children)
+                ((RateItem)child).UnSelectedStrokeWidth = UnSelectedStrokeWidth;
+        }
+
+        void UpdateValue()
+        {
+            for (int i = 0; i < ItemCount; i++)
+                ((RateItem)_rateLayout.Children[i]).IsSelected = i < Value;
+
+            ValueChanged?.Invoke(this, new ValueChangedEventArgs(Value));
+        }
+
+        void OnTapped(object sender, EventArgs e)
+        {
+            var star = (IView)sender;
+            var index = _rateLayout.Children.IndexOf(star);
+
+            Value = index + 1;
+        }
+    }
+}

--- a/src/Controls/samples/Controls.Sample/Controls/Rate/Rate.xaml
+++ b/src/Controls/samples/Controls.Sample/Controls/Rate/Rate.xaml
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Themes.Rate"
+    xmlns:controls="clr-namespace:Maui.Controls.Sample.Controls">
+ 
+    <Style TargetType="controls:RateItem">
+        <Setter Property="ControlTemplate">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid
+                        x:Name="LayoutRoot"
+                        HeightRequest="{TemplateBinding ItemSize}"
+                        WidthRequest="{TemplateBinding ItemSize}">
+                        <Path
+                            WidthRequest="{Binding Source={x:Reference LayoutRoot}, Path=Width}"
+                            HeightRequest="{Binding Source={x:Reference LayoutRoot}, Path=Height}"
+                            Data="{TemplateBinding Icon}"
+                            Fill="{TemplateBinding UnSelectedFill}"
+                            Stroke="{TemplateBinding UnSelectedStroke}"
+                            StrokeThickness="{TemplateBinding UnSelectedStrokeWidth}"
+                            Aspect="Uniform"/>
+                        <Grid
+                            x:Name="PART_Icon"
+                            IsVisible="{TemplateBinding IsSelected}">
+                            <Path
+                                HorizontalOptions="Start"
+                                WidthRequest="{Binding Source={x:Reference LayoutRoot}, Path=Width}"
+                                HeightRequest="{Binding Source={x:Reference LayoutRoot}, Path=Height}"
+                                Data="{TemplateBinding Icon}"
+                                Fill="{TemplateBinding SelectedFill}"
+                                Stroke="{TemplateBinding SelectedStroke}"
+                                StrokeThickness="{TemplateBinding SelectedStrokeWidth}"
+                                Aspect="Uniform"/>
+                        </Grid>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="controls:Rate">
+        <Setter Property="HorizontalOptions" Value="Start"/>
+        <Setter Property="VerticalOptions" Value="Start"/>
+        <Setter Property="ControlTemplate">
+            <Setter.Value>
+                <ControlTemplate>
+                    <StackLayout>
+                        <StackLayout
+                            x:Name="PART_Panel"
+                            Orientation="Horizontal"
+                            HorizontalOptions="Center"/>
+                        <Label
+                            IsVisible="{TemplateBinding ShowText}"
+                            Text="{TemplateBinding Text}"
+                            HorizontalOptions="Center"/>
+                    </StackLayout>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Controls/samples/Controls.Sample/Controls/Rate/Rate.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/Rate/Rate.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Themes
+{
+    public partial class Rate : ResourceDictionary
+    {
+        public Rate()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Controls/samples/Controls.Sample/Controls/Rate/RateItem.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/Rate/RateItem.cs
@@ -1,0 +1,111 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Controls
+{
+    public class RateItem : TemplatedView
+    {
+        const string ElementIcon = "PART_Icon";
+
+        View _icon;
+
+        public static readonly BindableProperty ItemSizeProperty =
+            BindableProperty.Create(nameof(ItemSize), typeof(double), typeof(RateItem), 30.0d);
+
+        public double ItemSize
+        {
+            get => (double)GetValue(ItemSizeProperty);
+            set => SetValue(ItemSizeProperty, value);
+        }
+
+        public static readonly BindableProperty SelectedFillProperty =
+            BindableProperty.Create(nameof(SelectedFill), typeof(Color), typeof(RateItem), Color.FromArgb("#F6C602"));
+
+        public Color SelectedFill
+        {
+            get => (Color)GetValue(SelectedFillProperty);
+            set => SetValue(SelectedFillProperty, value);
+        }
+
+        public static readonly BindableProperty UnSelectedFillProperty =
+            BindableProperty.Create(nameof(UnSelectedFill), typeof(Color), typeof(RateItem), Colors.Transparent);
+
+        public Color UnSelectedFill
+        {
+            get => (Color)GetValue(UnSelectedFillProperty);
+            set => SetValue(UnSelectedFillProperty, value);
+        }
+
+        public static readonly BindableProperty SelectedStrokeProperty =
+            BindableProperty.Create(nameof(SelectedStroke), typeof(Color), typeof(RateItem), Color.FromArgb("#F6C602"));
+
+        public Color SelectedStroke
+        {
+            get => (Color)GetValue(SelectedStrokeProperty);
+            set => SetValue(SelectedStrokeProperty, value);
+        }
+
+        public static readonly BindableProperty UnSelectedStrokeProperty =
+            BindableProperty.Create(nameof(UnSelectedStroke), typeof(Color), typeof(RateItem), Colors.Black);
+
+        public Color UnSelectedStroke
+        {
+            get => (Color)GetValue(UnSelectedStrokeProperty);
+            set => SetValue(UnSelectedStrokeProperty, value);
+        }
+
+        public static readonly BindableProperty SelectedStrokeWidthProperty =
+            BindableProperty.Create(nameof(SelectedStrokeWidth), typeof(double), typeof(RateItem), 1.0d);
+
+        public double SelectedStrokeWidth
+        {
+            get => (double)GetValue(SelectedStrokeWidthProperty);
+            set => SetValue(SelectedStrokeWidthProperty, value);
+        }
+
+        public static readonly BindableProperty UnSelectedStrokeWidthProperty =
+            BindableProperty.Create(nameof(UnSelectedStrokeWidth), typeof(double), typeof(RateItem), 1.0d);
+
+        public double UnSelectedStrokeWidth
+        {
+            get => (double)GetValue(UnSelectedStrokeWidthProperty);
+            set => SetValue(UnSelectedStrokeWidthProperty, value);
+        }
+
+        public static readonly BindableProperty IconProperty =
+            BindableProperty.Create(nameof(Icon), typeof(Geometry), typeof(RateItem), null);
+
+        public Geometry Icon
+        {
+            get => (Geometry)GetValue(IconProperty);
+            set => SetValue(IconProperty, value);
+        }
+
+        public static readonly BindableProperty IsReadOnlyProperty =
+            BindableProperty.Create(nameof(IsReadOnly), typeof(bool), typeof(RateItem), false);
+
+        public bool IsReadOnly
+        {
+            get => (bool)GetValue(IsReadOnlyProperty);
+            set => SetValue(IsReadOnlyProperty, value);
+        }
+
+        public static readonly BindableProperty IsSelectedProperty =
+            BindableProperty.Create(nameof(IsSelected), typeof(bool), typeof(RateItem), false);
+
+        public bool IsSelected
+        {
+            get => (bool)GetValue(IsSelectedProperty);
+            set => SetValue(IsSelectedProperty, value);
+        }
+
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            _icon = GetTemplateChild(ElementIcon) as View;
+            _icon.WidthRequest = Width;
+        }
+    }
+}

--- a/src/Controls/samples/Controls.Sample/Controls/Rate/ValueChangedEventArgs.cs
+++ b/src/Controls/samples/Controls.Sample/Controls/Rate/ValueChangedEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Maui.Controls.Sample.Controls
+{
+    public class ValueChangedEventArgs : EventArgs
+    {
+        public ValueChangedEventArgs(double value)
+        {
+            Value = value;
+        }
+
+        public double Value { get; set; }
+    }
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/TemplatedViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/TemplatedViewPage.xaml
@@ -35,7 +35,11 @@
                     </StackLayout>
                 </Grid>
             </ControlTemplate>
-            
+           
+            <PathGeometry
+                x:Key="HeartGeometry"
+                Figures="M8.5319849,0C11.560988,7.3866431E-08 14.464015,1.6680007 15.99997,4.5209999 18.139016,0.55099538 22.921994,-1.1230173 27.008008,0.7949839 31.297024,2.8069787 33.185032,8.0069957 31.22604,12.411997 29.27303,16.804 15.998994,30.380001 15.998994,30.380001 15.915985,30.327022 2.7269701,16.804 0.77395964,12.411997 -1.1850933,8.0069957 0.70291448,2.8069787 4.9929701,0.7949839 6.1419612,0.25497467 7.3469826,7.3866431E-08 8.5319849,0z"/>
+
         </ResourceDictionary>
     </views:BasePage.Resources>
     <views:BasePage.Content>
@@ -78,6 +82,22 @@
                 IconBackgroundColor="SlateGray"
                 IconImageSource="dotnet_bot.png"
                 ControlTemplate="{StaticResource CardViewCompressed}" />
+            <Label 
+                Text="A custom control based on a ControlTemplate"
+                FontAttributes="Italic"
+                TextColor="Red"
+                Margin="0,0,0,10" />
+            <controls:Rate    
+                Icon="{StaticResource HeartGeometry}"
+                ItemCount="5"
+                ItemSize="30"
+                Value="3"
+                SelectedFill="Red"
+                SelectedStroke="DarkRed"
+                SelectedStrokeWidth="2"
+                UnSelectedFill="LightGray"
+                UnSelectedStroke="DarkGray"
+                UnSelectedStrokeWidth="0.5"/>
         </StackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/XamlApp.xaml
+++ b/src/Controls/samples/Controls.Sample/XamlApp.xaml
@@ -9,6 +9,7 @@
 
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="AppResources.xaml" />
+                <ResourceDictionary Source="Controls/Rate/Rate.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
         </ResourceDictionary>

--- a/src/Controls/src/Core/ContentView.cs
+++ b/src/Controls/src/Core/ContentView.cs
@@ -42,29 +42,5 @@ namespace Microsoft.Maui.Controls
 				SetInheritedBindingContext(content, BindingContext);
 			}
 		}
-
-		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
-		{
-			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-			return DesiredSize;
-		}
-
-		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
-		{
-			return this.MeasureContent(widthConstraint, heightConstraint);
-		}
-
-		protected override Size ArrangeOverride(Rect bounds)
-		{
-			Frame = this.ComputeFrame(bounds);
-			Handler?.PlatformArrange(Frame);
-			return Frame.Size;
-		}
-
-		Size IContentView.CrossPlatformArrange(Rect bounds)
-		{
-			this.ArrangeContent(bounds);
-			return bounds.Size;
-		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/ContentView/ContentView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentView/ContentView.Impl.cs
@@ -3,6 +3,7 @@
 	public partial class ContentView : IContentView
 	{
 		object IContentView.Content => Content;
+
 		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? Content;
 
 		protected override void OnApplyTemplate()

--- a/src/Controls/src/Core/HandlerImpl/ContentView/ContentView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/ContentView/ContentView.Impl.cs
@@ -5,11 +5,5 @@
 		object IContentView.Content => Content;
 
 		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? Content;
-
-		protected override void OnApplyTemplate()
-		{
-			base.OnApplyTemplate();
-			Handler?.UpdateValue(nameof(Content));
-		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Impl.cs
@@ -12,30 +12,6 @@ namespace Microsoft.Maui.Controls
 		object IContentView.Content => ContentAsString();
 #endif
 
-		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
-		{
-			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
-			return DesiredSize;
-		}
-
-		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
-		{
-			return this.MeasureContent(widthConstraint, heightConstraint);
-		}
-
-		protected override Size ArrangeOverride(Rect bounds)
-		{
-			Frame = this.ComputeFrame(bounds);
-			Handler?.PlatformArrange(Frame);
-			return Frame.Size;
-		}
-
-		Size IContentView.CrossPlatformArrange(Rect bounds)
-		{
-			this.ArrangeContent(bounds);
-			return bounds.Size;
-		}
-
 		IView IContentView.PresentedContent => ((this as IControlTemplated).TemplateRoot as IView) ?? (Content as IView);
 
 		double IButtonStroke.StrokeThickness => (double)GetValue(BorderWidthProperty);

--- a/src/Controls/src/Core/HandlerImpl/TemplatedView/TemplatedView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/TemplatedView/TemplatedView.Impl.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Maui.Controls
 		IView? IContentView.PresentedContent =>
 			(this as IControlTemplated).TemplateRoot as IView;
 
+		partial void OnApplyTemplateImpl()
+		{
+			Handler?.UpdateValue(nameof(IContentView.Content));
+		}
+
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);

--- a/src/Controls/src/Core/HandlerImpl/TemplatedView/TemplatedView.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/TemplatedView/TemplatedView.Impl.cs
@@ -1,0 +1,38 @@
+﻿#nullable enable
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+
+namespace Microsoft.Maui.Controls
+{
+	public partial class TemplatedView : IContentView
+	{
+		object? IContentView.Content => null;
+
+		IView? IContentView.PresentedContent =>
+			(this as IControlTemplated).TemplateRoot as IView;
+
+		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+		{
+			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
+			return DesiredSize;
+		}
+
+		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+		{
+			return this.MeasureContent(widthConstraint, heightConstraint);
+		}
+
+		protected override Size ArrangeOverride(Rect bounds)
+		{
+			Frame = this.ComputeFrame(bounds);
+			Handler?.PlatformArrange(Frame);
+			return Frame.Size;
+		}
+
+		Size IContentView.CrossPlatformArrange(Rect bounds)
+		{
+			this.ArrangeContent(bounds);
+			return bounds.Size;
+		}
+	}
+}

--- a/src/Controls/src/Core/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.ViewCellRenderer.DisconnectHandler(Android.Views.View platformView) -> void
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -2,3 +2,9 @@
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -2,3 +2,9 @@
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-tizen/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-tizen/PublicAPI.Unshipped.txt
@@ -1,3 +1,9 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,3 +1,9 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -1,3 +1,9 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,9 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,9 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,9 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/TemplatedView.cs
+++ b/src/Controls/src/Core/TemplatedView.cs
@@ -87,7 +87,10 @@ namespace Microsoft.Maui.Controls
 
 		protected virtual void OnApplyTemplate()
 		{
+			OnApplyTemplateImpl();
 		}
+
+		partial void OnApplyTemplateImpl();
 
 		protected override void OnChildRemoved(Element child, int oldLogicalIndex)
 		{

--- a/src/Controls/tests/Core.UnitTests/HostBuilderHandlerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HostBuilderHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -22,7 +23,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var handler = handlers.GetHandler(typeof(Button));
 
 			Assert.NotNull(handler);
-			Assert.AreEqual(handler.GetType(), typeof(ButtonHandler));
+			Assert.AreEqual(typeof(ButtonHandler), handler.GetType());
 		}
 
 		[Test]
@@ -40,7 +41,33 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var specificHandler = handlers.GetHandler(typeof(Button));
 
 			Assert.NotNull(specificHandler);
-			Assert.AreEqual(specificHandler.GetType(), typeof(ButtonHandlerStub));
+			Assert.AreEqual(typeof(ButtonHandlerStub), specificHandler.GetType());
+		}
+
+		[Test]
+		[TestCase(typeof(Label), typeof(LabelHandler))]
+		[TestCase(typeof(Button), typeof(ButtonHandler))]
+		[TestCase(typeof(ContentPage), typeof(PageHandler))]
+		[TestCase(typeof(Page), typeof(PageHandler))]
+		[TestCase(typeof(TemplatedView), typeof(ContentViewHandler))]
+		[TestCase(typeof(ContentView), typeof(ContentViewHandler))]
+		[TestCase(typeof(MyTestCustomTemplatedView), typeof(ContentViewHandler))]
+		public void VariousControlsGetCorrectHandler(Type viewType, Type handlerType)
+		{
+			var mauiApp = MauiApp.CreateBuilder()
+				.UseMauiApp<ApplicationStub>()
+				.Build();
+
+			var handlers = mauiApp.Services.GetRequiredService<IMauiHandlersFactory>();
+
+			var specificHandler = handlers.GetHandler(viewType);
+
+			Assert.NotNull(specificHandler);
+			Assert.AreEqual(handlerType, specificHandler.GetType());
+		}
+
+		class MyTestCustomTemplatedView : TemplatedView
+		{
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/TemplatedViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TemplatedViewUnitTests.cs
@@ -57,6 +57,28 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
+		public void GetTemplatedViewTemplateChildShouldWork()
+		{
+			var xaml =
+				@"<ContentView
+					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					x:Class=""Microsoft.Maui.Controls.Core.UnitTests.MyTestTemplatedView"">
+					<TemplatedView.ControlTemplate>
+						<ControlTemplate>
+							<Label x:Name=""label0""/>
+						</ControlTemplate>
+					</TemplatedView.ControlTemplate>
+				</ContentView>";
+
+			var contentView = new MyTestTemplatedView();
+			contentView.LoadFromXaml(xaml);
+
+			IList<Element> internalChildren = contentView.InternalChildren;
+			Assert.AreEqual(internalChildren[0], contentView.TemplateChildObtained);
+		}
+
+		[Test]
 		public void GetContentPageTemplateChildShouldWork()
 		{
 			var xaml = @"<ContentPage
@@ -93,6 +115,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var contentView = new MyTestContentView();
 			contentView.LoadFromXaml(xaml);
+			Assert.IsTrue(contentView.WasOnApplyTemplateCalled);
+		}
+
+		[Test]
+		public void OnTemplatedViewApplyTemplateShouldBeCalled()
+		{
+			var xaml =
+				@"<ContentView
+					xmlns=""http://schemas.microsoft.com/dotnet/2021/maui""
+					xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+					x:Class=""Microsoft.Maui.Controls.Core.UnitTests.MyTestTemplatedView"">
+					<ContentView.ControlTemplate>
+						<ControlTemplate>
+							<Label x:Name=""label0""/>
+						</ControlTemplate>
+					</ContentView.ControlTemplate>
+				</ContentView>";
+
+			var contentView = new MyTestTemplatedView();
+			contentView.LoadFromXaml(xaml);
+
 			Assert.IsTrue(contentView.WasOnApplyTemplateCalled);
 		}
 
@@ -147,6 +190,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assume.That(label.Text, Is.EqualTo("Foo"));
 			cv.ControlTemplate = template1;
 			Assert.That(label.Text, Is.EqualTo("Foo"));
+		}
+	}
+
+	class MyTestTemplatedView : TemplatedView
+	{
+		public bool WasOnApplyTemplateCalled { get; private set; }
+
+		public Element TemplateChildObtained { get; private set; }
+
+		protected override void OnApplyTemplate()
+		{
+			WasOnApplyTemplateCalled = true;
+			TemplateChildObtained = (Element)GetTemplateChild("label0");
 		}
 	}
 

--- a/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.Android.cs
@@ -1,0 +1,15 @@
+﻿using Android.Views;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class TemplatedViewTests
+	{
+		static int GetChildCount(ContentViewHandler contentViewHandler) =>
+			contentViewHandler.PlatformView.ChildCount;
+
+		static View GetChild(ContentViewHandler contentViewHandler, int index = 0) =>
+			contentViewHandler.PlatformView.GetChildAt(index);
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.Windows.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class TemplatedViewTests
+	{
+		static int GetChildCount(ContentViewHandler contentViewHandler) =>
+			contentViewHandler.PlatformView.Children.Count;
+
+		static UIElement GetChild(ContentViewHandler contentViewHandler, int index = 0) =>
+			contentViewHandler.PlatformView.Children[index];
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.TemplatedView)]
+	public partial class TemplatedViewTests : HandlerTestBase
+	{
+		public TemplatedViewTests()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<IContentView, ContentViewHandler>();
+					handlers.AddHandler<Grid, LayoutHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+				});
+			});
+		}
+
+		[Fact]
+		public async Task ControlTemplateInitializesCorrectly()
+		{
+			var content = new Label { Text = "Content 1" };
+			var templatedView = new TemplatedView
+			{
+				ControlTemplate = new ControlTemplate(() => content)
+			};
+
+			var handler = await CreateHandlerAsync<ContentViewHandler>(templatedView);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.Equal(1, GetChildCount(handler));
+				Assert.Equal(content.Handler.PlatformView, GetChild(handler));
+			});
+		}
+
+		[Fact]
+		public async Task ControlTemplateCanBeReplacedCorrectly()
+		{
+			var content1 = new Label { Text = "Content 1" };
+			var controlTemplate1 = new ControlTemplate(() => content1);
+
+			var content2 = new Label { Text = "Content 2" };
+			var controlTemplate2 = new ControlTemplate(() => content2);
+
+			var templatedView = new TemplatedView { ControlTemplate = controlTemplate1 };
+
+			var handler = await CreateHandlerAsync<ContentViewHandler>(templatedView);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				Assert.Equal(1, GetChildCount(handler));
+				Assert.Equal(content1.Handler.PlatformView, GetChild(handler));
+
+				templatedView.ControlTemplate = controlTemplate2;
+
+				Assert.Equal(1, GetChildCount(handler));
+				Assert.Equal(content2.Handler.PlatformView, GetChild(handler));
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TemplatedView/TemplatedViewTests.iOS.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Maui.Handlers;
+using UIKit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class TemplatedViewTests
+	{
+		static int GetChildCount(ContentViewHandler contentViewHandler) =>
+			contentViewHandler.PlatformView.Subviews.Length;
+
+		static UIView GetChild(ContentViewHandler contentViewHandler, int index = 0) =>
+			contentViewHandler.PlatformView.Subviews[index];
+	}
+}

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -20,6 +20,7 @@
 		public const string SearchBar = "SearchBar";
 		public const string Shell = "Shell";
 		public const string TabbedPage = "TabbedPage";
+		public const string TemplatedView = "TemplatedView";
 		public const string VisualElement = "VisualElement";
 		public const string Window = "Window";
 	}


### PR DESCRIPTION
### Description of Change

Implement `IContentView` on `TemplatedView` in order to make it usable again.

Basically this PR moves the various Measure and Arrange methods into the shared base TemplatedView. Not only does this share the code but also makes TemplatedView work again.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #7325
