### PR TITLE
Use the new layout system in ContentPresenter

### DIFF
--- a/src/Controls/src/Core/ContentPresenter.cs
+++ b/src/Controls/src/Core/ContentPresenter.cs
@@ -99,9 +99,22 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+		{
+			DesiredSize = this.ComputeDesiredSize(widthConstraint, heightConstraint);
+			return DesiredSize;
+		}
+
 		Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 		{
 			return this.MeasureContent(widthConstraint, heightConstraint);
+		}
+
+		protected override Size ArrangeOverride(Rect bounds)
+		{
+			Frame = this.ComputeFrame(bounds);
+			Handler?.PlatformArrange(Frame);
+			return Frame.Size;
 		}
 
 		Size IContentView.CrossPlatformArrange(Rect bounds)

--- a/src/Controls/src/Core/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.ViewCellRenderer.DisconnectHandler(Android.Views.View platformView) -> void

--- a/src/Controls/src/Core/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-android/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void

--- a/src/Controls/src/Core/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.SetNeedsLayout() -> void

--- a/src/Controls/src/Core/PublicAPI/net6.0-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-tizen/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 ﻿#nullable enable
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net6.0-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-tizen/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 ﻿#nullable enable
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.19041/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0-windows10.0.20348/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 ﻿#nullable enable
-override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 ﻿#nullable enable
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 ﻿#nullable enable
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 ﻿#nullable enable
+override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.ContentView.OnApplyTemplate() -> void
 override Microsoft.Maui.Controls.Grid.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size


### PR DESCRIPTION
### Description of Change

We need to call the new layout system with the ContentPresenter because it is still using the compatibility layouts as a base. This same logic is applied to ContentView, ContentPage and TemplatedView (base of ContentView and RadioButton).

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #7805
