### PR TITLE
Use the SDK band in the rollback files

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -38,6 +38,11 @@
       <_VersionsToReplace Include="MicrosoftmacOSSdkPackageVersion" />
       <_VersionsToReplace Include="MicrosofttvOSSdkPackageVersion" />
       <_VersionsToReplace Include="MicrosoftNETWorkloadEmscriptenPackageVersion" />
+      <_VersionsToReplace Include="DotNetMauiManifestVersionBand" />
+      <_VersionsToReplace Include="DotNetMonoManifestVersionBand" />
+      <_VersionsToReplace Include="DotNetEmscriptenManifestVersionBand" />
+      <_VersionsToReplace Include="DotNetAndroidManifestVersionBand" />
+      <_VersionsToReplace Include="DotNetMaciOSManifestVersionBand" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreAuthorizationPackageVersion" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsAnalyzersPackageVersion" />
       <_VersionsToReplace Include="MicrosoftAspNetCoreComponentsFormsPackageVersion" />

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
@@ -1,10 +1,10 @@
 {
-  "microsoft.net.sdk.android": "@MicrosoftAndroidSdkWindowsPackageVersion@",
-  "microsoft.net.sdk.ios": "@MicrosoftiOSSdkPackageVersion@",
-  "microsoft.net.sdk.maccatalyst": "@MicrosoftMacCatalystSdkPackageVersion@",
-  "microsoft.net.sdk.macos": "@MicrosoftmacOSSdkPackageVersion@",
-  "microsoft.net.sdk.maui": "@VERSION@",
-  "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@",
-  "microsoft.net.workload.mono.toolchain": "@MicrosoftNETCoreAppRefPackageVersion@",
-  "microsoft.net.workload.emscripten": "@MicrosoftNETWorkloadEmscriptenPackageVersion@"
+  "microsoft.net.sdk.android": "@MicrosoftAndroidSdkWindowsPackageVersion@/@DotNetAndroidManifestVersionBand@",
+  "microsoft.net.sdk.ios": "@MicrosoftiOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
+  "microsoft.net.sdk.maccatalyst": "@MicrosoftMacCatalystSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
+  "microsoft.net.sdk.macos": "@MicrosoftmacOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
+  "microsoft.net.sdk.maui": "@VERSION@/@DotNetMauiManifestVersionBand@",
+  "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
+  "microsoft.net.workload.mono.toolchain": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
+  "microsoft.net.workload.emscripten": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@"
 }


### PR DESCRIPTION
### Description of Change

Using the rollback as is does not work due to mixed SDK bands. This should work without a rollback file as the SDK is smart enough to look, but when using the rollback, it assumes everything is provided.

