### PR TITLE
Update readme to include latest release blogpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 ## Current News
 
+* May 23, 2022 - [Introducing .NET MAUI – One Codebase, Many Platforms](https://devblogs.microsoft.com/dotnet/introducing-dotnet-maui-one-codebase-many-platforms/)
 * May 10, 2022 - [.NET MAUI Release Candidate 3](https://devblogs.microsoft.com/dotnet/dotnet-maui-rc-3/)
 * April 26, 2022 - [.NET MAUI Release Candidate 2](https://devblogs.microsoft.com/dotnet/dotnet-maui-rc-2/)
 * April 12, 2022 - [.NET MAUI Release Candidate - Ready for Cross-Platform App Development](https://devblogs.microsoft.com/dotnet/dotnet-maui-rc-1/)


### PR DESCRIPTION
### Description of Change

Added the blogpost: "Introducing .NET MAUI – One Codebase, Many Platforms" (https://devblogs.microsoft.com/dotnet/introducing-dotnet-maui-one-codebase-many-platforms/) to the readme under "Current News".

If this would be better for an official team member to do, please go ahead : ). I just noticed that the readme was slightly out of date and wanted to fix/bring attention to it.

Thank you

### Issues Fixed

N/A
