### PR TITLE
VisualTreeElement methods need to use DP vs PX

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Compatibility/VisualElementRendererTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Compatibility/VisualElementRendererTests.cs
@@ -47,9 +47,11 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task CompatibilityRendererWorksWithNoInnerContrlSpecified()
 		{
 			SetupBuilder();
+
 			var renderer = await InvokeOnMainThreadAsync(() => new LegacyComponent().ToPlatform(MauiContext));
 
-			Assert.Equal(renderer, (renderer as IPlatformViewHandler).PlatformView);
+			await InvokeOnMainThreadAsync(() => Assert.Equal(renderer, (renderer as IPlatformViewHandler).PlatformView));
+
 			Assert.NotNull(renderer);
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				AssertionExtensions.AssertWithMessage(
 					() => Assert.Contains(label, window.GetVisualTreeElements(topLeft)),
-					$"Unable to find label using top left coordinate: {topLeft} with label frame of: {labelFrame}");
+					$"Unable to find label using top left coordinate: {topLeft} with label location: {label.GetBoundingBox()}");
 
 				// find label at the bottom right corner
 				var bottomRight = new Graphics.Point(
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.DeviceTests
 
 				AssertionExtensions.AssertWithMessage(
 					() => Assert.Contains(label, window.GetVisualTreeElements(bottomRight)),
-					$"Unable to find label using bottom right coordinate: {bottomRight} with label frame of: {labelFrame}");
+					$"Unable to find label using bottom right coordinate: {bottomRight} with label location: {label.GetBoundingBox()}");
 
 				// Ensure that the point directly outside the bounds of the label doesn't
 				// return the label

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
@@ -1,0 +1,86 @@
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+#if ANDROID || IOS
+using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
+#endif
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.VisualElementTree)]
+#if ANDROID || IOS
+	[Collection(HandlerTestBase.RunInNewWindowCollection)]
+#endif
+	public partial class VisualElementTreeTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
+					handlers.AddHandler<Layout, LayoutHandler>();
+					handlers.AddHandler<Image, ImageHandler>();
+					handlers.AddHandler<Label, LabelHandler>();
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Toolbar, ToolbarHandler>();
+					handlers.AddHandler<MenuBar, MenuBarHandler>();
+					handlers.AddHandler<MenuBarItem, MenuBarItemHandler>();
+					handlers.AddHandler<MenuFlyoutItem, MenuFlyoutItemHandler>();
+					handlers.AddHandler<MenuFlyoutSubItem, MenuFlyoutSubItemHandler>();
+#if WINDOWS
+					handlers.AddHandler<ShellItem, ShellItemHandler>();
+					handlers.AddHandler<ShellSection, ShellSectionHandler>();
+					handlers.AddHandler<ShellContent, ShellContentHandler>();
+#endif
+				});
+			});
+		}
+
+		[Fact]
+		public async Task GetVisualTreeElements()
+		{
+			SetupBuilder();
+			var label = new Label() { Text = "Find Me" };
+			var page = new ContentPage() { Title = "Title Page" };
+			page.Content = new VerticalStackLayout()
+			{
+				label
+			};
+
+			var shell = await InvokeOnMainThreadAsync(() =>
+				new Shell() { CurrentItem = new FlyoutItem() { Items = { page } } }
+			);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, async handler =>
+			{
+				await OnFrameSetToNotEmpty(label);
+				var locationOnScreen = label.GetLocationOnScreen().Value;
+				var labelFrame = label.Frame;
+				var window = shell.Window;
+
+				// Find label at the top left corner
+				Assert.Contains(label, window.GetVisualTreeElements(locationOnScreen.X, locationOnScreen.Y));
+
+				// find label at the bottom right corner
+				Assert.Contains(label, window.GetVisualTreeElements(
+						locationOnScreen.X + labelFrame.Width - 0.1,
+						locationOnScreen.Y + labelFrame.Height - 0.1
+					));
+
+				// Ensure that the point directly outside the bounds of the label doesn't
+				// return the label
+				Assert.DoesNotContain(label, window.GetVisualTreeElements(
+						locationOnScreen.X + labelFrame.Width + 0.1,
+						locationOnScreen.Y + labelFrame.Height + 0.1
+					));
+
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Maui.DeviceTests
 				var window = rootPage.Window;
 
 				// Find label at the top left corner
-				var topLeft = new Graphics.Point(locationOnScreen.X, locationOnScreen.Y);
+				var topLeft = new Graphics.Point(locationOnScreen.X + 1, locationOnScreen.Y + 1);
 
 				AssertionExtensions.AssertWithMessage(
 					() => Assert.Contains(label, window.GetVisualTreeElements(topLeft)),

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
@@ -66,13 +66,20 @@ namespace Microsoft.Maui.DeviceTests
 				var window = rootPage.Window;
 
 				// Find label at the top left corner
-				Assert.Contains(label, window.GetVisualTreeElements(locationOnScreen.X + 0.1, locationOnScreen.Y + 0.1));
+				var topLeft = new Graphics.Point(locationOnScreen.X, locationOnScreen.Y);
+
+				AssertionExtensions.AssertWithMessage(
+					() => Assert.Contains(label, window.GetVisualTreeElements(topLeft)),
+					$"Unable to find label using top left coordinate: {topLeft} with label frame of: {labelFrame}");
 
 				// find label at the bottom right corner
-				Assert.Contains(label, window.GetVisualTreeElements(
-						locationOnScreen.X + labelFrame.Width - 1,
-						locationOnScreen.Y + labelFrame.Height - 1
-					));
+				var bottomRight = new Graphics.Point(
+					locationOnScreen.X + labelFrame.Width - 1,
+					locationOnScreen.Y + labelFrame.Height - 1);
+
+				AssertionExtensions.AssertWithMessage(
+					() => Assert.Contains(label, window.GetVisualTreeElements(bottomRight)),
+					$"Unable to find label using bottom right coordinate: {bottomRight} with label frame of: {labelFrame}");
 
 				// Ensure that the point directly outside the bounds of the label doesn't
 				// return the label

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
@@ -24,7 +24,11 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
+#if IOS
+					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(Controls.Handlers.Compatibility.NavigationRenderer));
+#else
 					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+#endif
 					handlers.AddHandler<Layout, LayoutHandler>();
 					handlers.AddHandler<Image, ImageHandler>();
 					handlers.AddHandler<Label, LabelHandler>();

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
@@ -65,19 +65,19 @@ namespace Microsoft.Maui.DeviceTests
 				var window = shell.Window;
 
 				// Find label at the top left corner
-				Assert.Contains(label, window.GetVisualTreeElements(locationOnScreen.X, locationOnScreen.Y));
+				Assert.Contains(label, window.GetVisualTreeElements(locationOnScreen.X + 0.1, locationOnScreen.Y + 0.1));
 
 				// find label at the bottom right corner
 				Assert.Contains(label, window.GetVisualTreeElements(
-						locationOnScreen.X + labelFrame.Width - 0.2,
-						locationOnScreen.Y + labelFrame.Height - 0.2
+						locationOnScreen.X + labelFrame.Width - 1,
+						locationOnScreen.Y + labelFrame.Height - 1
 					));
 
 				// Ensure that the point directly outside the bounds of the label doesn't
 				// return the label
 				Assert.DoesNotContain(label, window.GetVisualTreeElements(
-						locationOnScreen.X + labelFrame.Width + 0.2,
-						locationOnScreen.Y + labelFrame.Height + 0.2
+						locationOnScreen.X + labelFrame.Width + 1,
+						locationOnScreen.Y + labelFrame.Height + 1
 					));
 
 			});

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
@@ -69,15 +69,15 @@ namespace Microsoft.Maui.DeviceTests
 
 				// find label at the bottom right corner
 				Assert.Contains(label, window.GetVisualTreeElements(
-						locationOnScreen.X + labelFrame.Width - 0.1,
-						locationOnScreen.Y + labelFrame.Height - 0.1
+						locationOnScreen.X + labelFrame.Width - 0.2,
+						locationOnScreen.Y + labelFrame.Height - 0.2
 					));
 
 				// Ensure that the point directly outside the bounds of the label doesn't
 				// return the label
 				Assert.DoesNotContain(label, window.GetVisualTreeElements(
-						locationOnScreen.X + labelFrame.Width + 0.1,
-						locationOnScreen.Y + labelFrame.Height + 0.1
+						locationOnScreen.X + labelFrame.Width + 0.2,
+						locationOnScreen.Y + labelFrame.Height + 0.2
 					));
 
 			});

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTreeTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
+					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
 					handlers.AddHandler<Layout, LayoutHandler>();
 					handlers.AddHandler<Image, ImageHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
@@ -53,16 +54,16 @@ namespace Microsoft.Maui.DeviceTests
 				label
 			};
 
-			var shell = await InvokeOnMainThreadAsync(() =>
-				new Shell() { CurrentItem = new FlyoutItem() { Items = { page } } }
+			var rootPage = await InvokeOnMainThreadAsync(() =>
+				new NavigationPage(page)
 			);
 
-			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, async handler =>
+			await CreateHandlerAndAddToWindow<IWindowHandler>(rootPage, async handler =>
 			{
 				await OnFrameSetToNotEmpty(label);
 				var locationOnScreen = label.GetLocationOnScreen().Value;
 				var labelFrame = label.Frame;
-				var window = shell.Window;
+				var window = rootPage.Window;
 
 				// Find label at the top left corner
 				Assert.Contains(label, window.GetVisualTreeElements(locationOnScreen.X + 0.1, locationOnScreen.Y + 0.1));

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -210,14 +210,9 @@ namespace Microsoft.Maui.DeviceTests
 							content = pc.CurrentPage;
 
 						await OnLoadedAsync(content as VisualElement);
-
-						if (content is Page page)
-							await OnNavigatedToAsync(page);
 #if WINDOWS
-
 						await Task.Delay(10);
 #endif
-
 						if (typeof(THandler).IsAssignableFrom(window.Handler.GetType()))
 							await action((THandler)window.Handler);
 						else if (typeof(THandler).IsAssignableFrom(window.Content.Handler.GetType()))

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -324,8 +324,7 @@ namespace Microsoft.Maui.DeviceTests
 			await taskCompletionSource.Task.WaitAsync(timeOut.Value);
 
 			// Wait for the layout to propagate to the platform
-			if (frameworkElement.GetBoundingBox().Equals(new Rect()))
-				await Task.Delay(10);
+			await Task.Delay(1000);
 
 			void OnBatchCommitted(object sender, Controls.Internals.EventArg<VisualElement> e)
 			{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -324,8 +324,9 @@ namespace Microsoft.Maui.DeviceTests
 			await taskCompletionSource.Task.WaitAsync(timeOut.Value);
 
 			// Wait for the layout to propagate to the platform
-			if (frameworkElement.GetBoundingBox().Equals(new Rect()))
-				await Task.Delay(10);
+			await AssertionExtensions.Wait(
+				() => !frameworkElement.GetBoundingBox().Size.Equals(Size.Zero)
+			);
 
 			void OnBatchCommitted(object sender, Controls.Internals.EventArg<VisualElement> e)
 			{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -324,7 +324,8 @@ namespace Microsoft.Maui.DeviceTests
 			await taskCompletionSource.Task.WaitAsync(timeOut.Value);
 
 			// Wait for the layout to propagate to the platform
-			await Task.Delay(1000);
+			if (frameworkElement.GetBoundingBox().Equals(new Rect()))
+				await Task.Delay(10);
 
 			void OnBatchCommitted(object sender, Controls.Internals.EventArg<VisualElement> e)
 			{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -11,6 +11,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
+using Microsoft.Maui.Platform;
 using Microsoft.Maui.TestUtils.DeviceTests.Runners;
 
 namespace Microsoft.Maui.DeviceTests
@@ -209,6 +210,9 @@ namespace Microsoft.Maui.DeviceTests
 							content = pc.CurrentPage;
 
 						await OnLoadedAsync(content as VisualElement);
+
+						if (content is Page page)
+							await OnNavigatedToAsync(page);
 #if WINDOWS
 
 						await Task.Delay(10);
@@ -310,19 +314,23 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
-		protected Task OnFrameSetToNotEmpty(VisualElement frameworkElement, TimeSpan? timeOut = null)
+		protected async Task OnFrameSetToNotEmpty(VisualElement frameworkElement, TimeSpan? timeOut = null)
 		{
 			if (frameworkElement.Frame.Height > 0 &&
 				frameworkElement.Frame.Width > 0)
 			{
-				return Task.CompletedTask;
+				return;
 			}
 
 			timeOut = timeOut ?? TimeSpan.FromSeconds(2);
 			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
 			frameworkElement.BatchCommitted += OnBatchCommitted;
 
-			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
+			await taskCompletionSource.Task.WaitAsync(timeOut.Value);
+
+			// Wait for the layout to propagate to the platform
+			if (frameworkElement.GetBoundingBox().Equals(new Rect()))
+				await Task.Delay(10);
 
 			void OnBatchCommitted(object sender, Controls.Internals.EventArg<VisualElement> e)
 			{

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -24,6 +24,7 @@
 		public const string TabbedPage = "TabbedPage";
 		public const string TemplatedView = "TemplatedView";
 		public const string VisualElement = "VisualElement";
+		public const string VisualElementTree = "VisualElementTree";
 		public const string Window = "Window";
 	}
 }

--- a/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
+++ b/src/Core/src/Core/Extensions/VisualTreeElementExtensions.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Maui
 			{
 				if (visualElement is IView view)
 				{
-					Rect bounds = view.GetPlatformViewBounds();
+					Rect bounds = view.GetBoundingBox();
 					if (intersectElementBounds(bounds))
 						elements.Add(visualElement);
 				}

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Platform
 						platformView.Background = drawable;
 				}
 			}
-			else if(platformView is LayoutViewGroup)
+			else if (platformView is LayoutViewGroup)
 			{
 				platformView.Background = null;
 			}
@@ -408,12 +408,18 @@ namespace Microsoft.Maui.Platform
 
 		internal static Graphics.Rect GetBoundingBox(this View? platformView)
 		{
-			if (platformView == null)
+			if (platformView?.Context == null)
 				return new Rect();
 
+			var context = platformView.Context;
 			var rect = new Android.Graphics.Rect();
 			platformView.GetGlobalVisibleRect(rect);
-			return new Rect(rect.ExactCenterX() - (rect.Width() / 2), rect.ExactCenterY() - (rect.Height() / 2), (float)rect.Width(), (float)rect.Height());
+
+			return new Rect(
+				context.FromPixels(rect.ExactCenterX() - (rect.Width() / 2)),
+				context.FromPixels(rect.ExactCenterY() - (rect.Height() / 2)),
+				context.FromPixels((float)rect.Width()),
+				context.FromPixels((float)rect.Height()));
 		}
 
 		internal static bool IsLoaded(this View frameworkElement) =>

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -388,6 +388,17 @@ namespace Microsoft.Maui.Platform
 		internal static Matrix4x4 GetViewTransform(this UIView view)
 			=> view.Layer.GetViewTransform();
 
+		internal static Point GetLocationOnScreen(this UIView view) =>
+			view.GetPlatformViewBounds().Location;
+
+		internal static Point? GetLocationOnScreen(this IElement element)
+		{
+			if (element.Handler?.MauiContext == null)
+				return null;
+
+			return (element.ToPlatform())?.GetLocationOnScreen();
+		}
+
 		internal static Graphics.Rect GetBoundingBox(this IView view)
 			=> view.ToPlatform().GetBoundingBox();
 

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Android.cs
@@ -301,10 +301,10 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		protected Maui.Graphics.Rect GetPlatformViewBounds(IViewHandler viewHandler) =>
-			((View)viewHandler.PlatformView).GetPlatformViewBounds();
+			viewHandler.VirtualView.ToPlatform().GetPlatformViewBounds();
 
 		protected Maui.Graphics.Rect GetBoundingBox(IViewHandler viewHandler) =>
-			((View)viewHandler.PlatformView).GetBoundingBox();
+			viewHandler.VirtualView.ToPlatform().GetBoundingBox();
 
 		protected Matrix4x4 GetViewTransform(IViewHandler viewHandler) =>
 			((View)viewHandler.PlatformView).GetViewTransform();

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -190,8 +190,20 @@ namespace Microsoft.Maui.DeviceTests
 			var nativeBoundingBox = await GetValueAsync(view, handler => GetBoundingBox(handler));
 			Assert.NotEqual(nativeBoundingBox, new Graphics.Rect());
 
-			if (!CloseEnough(size, nativeBoundingBox.Size.Height) || !CloseEnough(size, nativeBoundingBox.Size.Width))
-				Assert.Equal(new Size(size, size), nativeBoundingBox.Size);
+
+			// Currently there's an issue with label/progress where they don't set the frame size to
+			// the explicit Width and Height values set
+			// https://github.com/dotnet/maui/issues/7935
+			if (view is ILabel || view is IProgress)
+			{
+				if (!CloseEnough(size, nativeBoundingBox.Size.Width))
+					Assert.Equal(new Size(size, size), nativeBoundingBox.Size);
+			}
+			else
+			{
+				if (!CloseEnough(size, nativeBoundingBox.Size.Height) || !CloseEnough(size, nativeBoundingBox.Size.Width))
+					Assert.Equal(new Size(size, size), nativeBoundingBox.Size);
+			}
 
 			bool CloseEnough(double value1, double value2)
 			{

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			bool CloseEnough(double value1, double value2)
 			{
-				return System.Math.Abs(value2 - value1) < 0.1;
+				return System.Math.Abs(value2 - value1) < 0.2;
 			}
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -189,6 +189,14 @@ namespace Microsoft.Maui.DeviceTests
 
 			var nativeBoundingBox = await GetValueAsync(view, handler => GetBoundingBox(handler));
 			Assert.NotEqual(nativeBoundingBox, new Graphics.Rect());
+
+			if (!CloseEnough(size, nativeBoundingBox.Size.Height) || !CloseEnough(size, nativeBoundingBox.Size.Width))
+				Assert.Equal(new Size(size, size), nativeBoundingBox.Size);
+
+			bool CloseEnough(double value1, double value2)
+			{
+				return System.Math.Abs(value2 - value1) < 0.1;
+			}
 		}
 
 

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Windows.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected Task<Maui.Graphics.Rect> GetPlatformViewBounds(IViewHandler viewHandler)
 		{
-			var fe = (FrameworkElement)viewHandler.PlatformView;
+			var fe = viewHandler.VirtualView.ToPlatform();
 			return fe.AttachAndRun(() => fe.GetPlatformViewBounds());
 		}
 
@@ -147,7 +147,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected Task<Maui.Graphics.Rect> GetBoundingBox(IViewHandler viewHandler)
 		{
-			var fe = (FrameworkElement)viewHandler.PlatformView;
+			var fe = viewHandler.VirtualView.ToPlatform();
 			return fe.AttachAndRun(() => fe.GetBoundingBox());
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.iOS.cs
@@ -173,10 +173,10 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		protected Maui.Graphics.Rect GetPlatformViewBounds(IViewHandler viewHandler) =>
-			((UIView)viewHandler.PlatformView).GetPlatformViewBounds();
+			viewHandler.VirtualView.ToPlatform().GetPlatformViewBounds();
 
 		protected Maui.Graphics.Rect GetBoundingBox(IViewHandler viewHandler) =>
-			((UIView)viewHandler.PlatformView).GetBoundingBox();
+			viewHandler.VirtualView.ToPlatform().GetBoundingBox();
 
 		protected System.Numerics.Matrix4x4 GetViewTransform(IViewHandler viewHandler) =>
 			((UIView)viewHandler.PlatformView).GetViewTransform();

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
@@ -28,6 +29,18 @@ namespace Microsoft.Maui.DeviceTests
 
 			if (!hasFlag)
 				throw new ContainsException(flag, self);
+		}
+
+		public static void AssertWithMessage(Action assertion, string message)
+		{
+			try
+			{
+				assertion();
+			}
+			catch (Exception e)
+			{
+				Assert.True(false, $"Message: {message} Failure: {e}");
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

- Fix GetBoundingBox so that it returns a DP rect opposed to a PX rect
- Fix the code for calculating if a point is inside a rectangle so that it uses a Rect with DP values since the point that's passed in is using DP. 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #4704
