### PR TITLE
[Catalyst] Fix brushes in Frame

### DIFF
--- a/src/Compatibility/Core/src/iOS/Renderers/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/iOS/Renderers/FrameRenderer.cs
@@ -133,7 +133,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 		public override void LayoutSubviews()
 		{
 			if (_previousSize != Bounds.Size)
+			{
 				SetNeedsDisplay();
+				this.UpdateBackgroundLayer();
+			}
 
 			base.LayoutSubviews();
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
@@ -17,6 +17,21 @@
                     Text="Only with BackgroundColor" />
             </Frame>
             <Label
+                Text="Background"
+                Style="{StaticResource Headline}"/>
+            <Frame>
+                <Frame.Background>
+                    <LinearGradientBrush EndPoint="1,0">
+                        <GradientStop Color="Yellow" 
+                                      Offset="0.1" />
+                        <GradientStop Color="Green"                                   
+                                      Offset="1.0" />
+                    </LinearGradientBrush>
+                </Frame.Background>
+                <Label 
+                    Text="Background" />
+            </Frame>
+            <Label
                 Text="BorderColor"
                 Style="{StaticResource Headline}"/>
             <Frame      

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -132,7 +132,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public override void LayoutSubviews()
 		{
 			if (_previousSize != Bounds.Size)
+			{
 				SetNeedsDisplay();
+				this.UpdateBackgroundLayer();
+			}
 
 			base.LayoutSubviews();
 		}


### PR DESCRIPTION
### Description of Change

Brushes were not rendering on the Frame in Catalyst. The issue is that we weren't updating the size of the Layer used to draw the gradient when resizing the UIView.

<img width="509" alt="Captura de Pantalla 2022-06-10 a las 12 06 33" src="https://user-images.githubusercontent.com/6755973/173045550-b844ceb5-479f-4e17-96ac-d64cce10c28c.png">

### Issues Fixed

Fixes #7261 
Fixes #8108
Fixes #8402
FIxes #9854