### PR TITLE
Fix Titlebar visibility when backbutton is present

### DIFF
--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -113,8 +113,7 @@ namespace Microsoft.Maui.Controls
 			{
 				var flyoutBehavior = (_shell as IFlyoutView).FlyoutBehavior;
 #if WINDOWS
-				IsVisible = (BackButtonVisible ||
-					!String.IsNullOrEmpty(Title) ||
+				IsVisible = (!String.IsNullOrEmpty(Title) ||
 					TitleView != null ||
 					_toolbarTracker.ToolbarItems.Count > 0 ||
 					_menuBarTracker.ToolbarItems.Count > 0 ||

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -437,5 +437,25 @@ namespace Microsoft.Maui.DeviceTests
 				return Task.CompletedTask;
 			});
 		}
+
+
+		// this is only relevant on windows where the title/backbutton aren't in the same
+		// area
+		[Fact(DisplayName = "Shell Toolbar not visible when only back button is present")]
+		public async Task ShellToolbarNotVisibleWhenOnlyBackButtonIsPresent()
+		{
+			SetupBuilder();
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.CurrentItem = new ContentPage();
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await shell.Navigation.PushAsync(new ContentPage());
+				Assert.False(IsNavigationBarVisible(handler));
+			});
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

On windows don't display the titlebar if only the backbutton is present. The backbutton isn't part of the toolbar

### Issues Fixed


Fixes #7198
