### PR TITLE
[Android] Fix clear button not working on Entry 

### DIFF
--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.Handlers
 		void OnTouch(object? sender, TouchEventArgs e) =>
 			e.Handled =
 				VirtualView?.ClearButtonVisibility == ClearButtonVisibility.WhileEditing &&
-				PlatformView.HandleClearButtonTouched(VirtualView.FlowDirection, e, GetClearButtonDrawable);
+				PlatformView.HandleClearButtonTouched(VirtualView.GetEffectiveFlowDirection(), e, GetClearButtonDrawable);
 
 		void OnEditorAction(object? sender, EditorActionEventArgs e)
 		{

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Maui.Handlers
 	public partial class EntryHandler : ViewHandler<IEntry, AppCompatEditText>
 	{
 		Drawable? _clearButtonDrawable;
+		bool _clearButtonVisible;
 		bool _set;
 
 		protected override AppCompatEditText CreatePlatformView()
@@ -127,20 +128,31 @@ namespace Microsoft.Maui.Handlers
 				handler.PlatformView?.UpdateClearButtonVisibility(entry, platformHandler.GetClearButtonDrawable);
 		}
 
-		void OnTextChanged(object? sender, TextChangedEventArgs e) =>
-			VirtualView?.UpdateText(e);
+		void OnTextChanged(object? sender, TextChangedEventArgs e)
+		{
+			if (VirtualView == null)
+			{
+				return;
+			}
 
-		// This will eliminate additional native property setting if not required.
+			VirtualView.UpdateText(e);
+			MapClearButtonVisibility(this, VirtualView);
+		}
+
 		void OnFocusedChange(object? sender, FocusChangeEventArgs e)
 		{
-			if (VirtualView?.ClearButtonVisibility == ClearButtonVisibility.WhileEditing)
-				UpdateValue(nameof(IEntry.ClearButtonVisibility));
+			if (VirtualView == null)
+			{
+				return;
+			}
+
+			MapClearButtonVisibility(this, VirtualView);
 		}
 
 		// Check whether the touched position inbounds with clear button.
 		void OnTouch(object? sender, TouchEventArgs e) =>
 			e.Handled =
-				VirtualView?.ClearButtonVisibility == ClearButtonVisibility.WhileEditing &&
+				_clearButtonVisible && VirtualView != null &&
 				PlatformView.HandleClearButtonTouched(VirtualView.GetEffectiveFlowDirection(), e, GetClearButtonDrawable);
 
 		void OnEditorAction(object? sender, EditorActionEventArgs e)
@@ -165,6 +177,38 @@ namespace Microsoft.Maui.Handlers
 
 			if (VirtualView.SelectionLength != selectedTextLength)
 				VirtualView.SelectionLength = selectedTextLength;
+		}
+
+		internal void ShowClearButton()
+		{
+			if (_clearButtonVisible)
+			{
+				return;
+			}
+
+			var drawable = GetClearButtonDrawable();
+
+			if (VirtualView.GetEffectiveFlowDirection() == FlowDirection.RightToLeft)
+			{
+				PlatformView.SetCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null);
+			}
+			else
+			{
+				PlatformView.SetCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null);
+			}
+
+			_clearButtonVisible = true;
+		}
+
+		internal void HideClearButton()
+		{
+			if (!_clearButtonVisible)
+			{
+				return;
+			}
+
+			PlatformView.SetCompoundDrawablesWithIntrinsicBounds(null, null, null, null);
+			_clearButtonVisible = false;
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Maui.Platform
 	{
 		public static void UpdateText(this EditText editText, IEntry entry)
 		{
+			var previousTextLength = editText.Length();
+
 			// Setting the text causes the cursor to reset to position zero
 			// Therefore if:
 			// User Types => VirtualView Updated => Triggers Native Update
@@ -171,30 +173,16 @@ namespace Microsoft.Maui.Platform
 			editText.SetCursorVisible(isReadOnly);
 		}
 
+		// TODO: NET7 hartez - Remove this, nothing uses it
 		public static void UpdateClearButtonVisibility(this EditText editText, IEntry entry, Drawable? clearButtonDrawable) =>
 			UpdateClearButtonVisibility(editText, entry, () => clearButtonDrawable);
 
+		// TODO: NET7 hartez - Remove the getClearButtonDrawable parameter, nothing uses it
 		public static void UpdateClearButtonVisibility(this EditText editText, IEntry entry, Func<Drawable?>? getClearButtonDrawable)
 		{
-			// Places clear button drawable at the end or start of the EditText based on FlowDirection.
-			void ShowClearButton()
+			if (entry?.Handler is not EntryHandler entryHandler)
 			{
-				var drawable = getClearButtonDrawable?.Invoke();
-
-				if (entry.GetEffectiveFlowDirection() == FlowDirection.RightToLeft)
-				{
-					editText.SetCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null);
-				}
-				else
-				{
-					editText.SetCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null);
-				}
-			}
-
-			// Hides clear button drawable from the control.
-			void HideClearButton()
-			{
-				editText.SetCompoundDrawablesWithIntrinsicBounds(null, null, null, null);
+				return;
 			}
 
 			bool isFocused = editText.IsFocused;
@@ -206,11 +194,11 @@ namespace Microsoft.Maui.Platform
 
 			if (shouldDisplayClearButton)
 			{
-				ShowClearButton();
+				entryHandler.ShowClearButton();
 			}
 			else
 			{
-				HideClearButton();
+				entryHandler.HideClearButton();
 			}
 		}
 

--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Maui.Platform
 			if (motionEvent.Action != MotionEventActions.Up)
 				return false;
 
-			var x = motionEvent.GetX();
+			var x = motionEvent.RawX;
 			var y = motionEvent.GetY();
 
 			if ((flowDirection != FlowDirection.LeftToRight


### PR DESCRIPTION
### Description of Change

Fix clear button not working on Entry. The FlowDirection used when checking if the tapped point is inside the Clear button Rect was not correct. This PR adds changes to correct the issue.

![fix-7963](https://user-images.githubusercontent.com/6755973/173374583-e4622eb2-2f6f-45c7-9508-18a7e1d161db.gif)
 
Can use the .NET MAUI Gallery and the Entry samples to verify the changes.

### Issues Fixed

Fixes #7963 
