### PR TITLE
Add default `Name=blazorWebView` to MAUI MainPage.xaml

### DIFF
--- a/src/Templates/src/templates/maui-blazor/MainPage.xaml
+++ b/src/Templates/src/templates/maui-blazor/MainPage.xaml
@@ -5,7 +5,7 @@
              x:Class="MauiApp._1.MainPage"
              BackgroundColor="{DynamicResource PageBackgroundColor}">
 
-    <BlazorWebView HostPage="wwwroot/index.html">
+    <BlazorWebView x:Name="blazorWebView" HostPage="wwwroot/index.html">
         <BlazorWebView.RootComponents>
             <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
         </BlazorWebView.RootComponents>


### PR DESCRIPTION
Any harm in having this there by default?

Currently our instructions are a bit ambiguous around this area: https://docs.microsoft.com/aspnet/core/blazor/hybrid/routing?view=aspnetcore-6.0#net-maui
