### PR TITLE
[C] default Binding ctor bind to SelfPath

### DIFF
--- a/src/Controls/src/Core/Binding.cs
+++ b/src/Controls/src/Core/Binding.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Controls
 			else
 			{
 				object bindingContext = src ?? Context ?? context;
-				if (_expression == null && bindingContext != null)
+				if (_expression == null)
 					_expression = new BindingExpression(this, SelfPath);
 				_expression.Apply(bindingContext, bindObj, targetProperty);
 			}

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -2210,7 +2210,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		//https://github.com/xamarin/Microsoft.Maui.Controls/issues/3467
+		//https://github.com/xamarin/Xamarin.Forms/issues/3467
 		public void TargetNullValueIgnoredWhenBindingIsResolved()
 		{
 			var bindable = new MockBindable();
@@ -2233,7 +2233,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		//https://github.com/xamarin/Microsoft.Maui.Controls/issues/3994
+		//https://github.com/xamarin/Xamarin.Forms/issues/3994
 		public void INPCOnBindingWithSource()
 		{
 			var page = new ContentPage { Title = "Foo" };
@@ -2249,7 +2249,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		//https://github.com/xamarin/Microsoft.Maui.Controls/issues/10405
+		//https://github.com/xamarin/Xamarin.Forms/issues/10405
 		public void TypeConversionExceptionIsCaughtAndLogged()
 		{
 			var label = new Label();
@@ -2257,6 +2257,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.DoesNotThrow(() => label.BindingContext = new { color = "" });
 			Assert.That(MockApplication.MockLogger.Messages.Count, Is.EqualTo(1), "No error logged");
+		}
+
+		[Test]
+		//https://github.com/dotnet/maui/issues/7977
+		public void NullRefWithDefaultCtor()
+		{
+			var label = new Label();
+			label.SetBinding(Label.TextColorProperty, new Binding());
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

I traced this issue back to 2014, when we introduced default Biding ctor
for XAML purposes. From code, Binding was never meant to be used
Path-less, but here we are...

### Issues Fixed

- fix #7977
