### PR TITLE
Update Development Notes to the latest

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -60,8 +60,8 @@ Create new .NET MAUI app using your new packs
 ```dotnetcli
 dotnet tool restore
 dotnet cake --pack
-mkdir MauiApp
-cd MauiApp
+mkdir MyMauiApp
+cd MyMauiApp
 ..\bin\dotnet\dotnet new maui
 ..\bin\dotnet\dotnet build -t:Run -f net6.0-android
 ```

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -13,7 +13,7 @@ In most cases, when you have Visual Studio installed with the .NET workloads che
    - [Install the latest Public Preview of Visual Studio](https://docs.microsoft.com/en-us/dotnet/maui/get-started/installation/)
    - [macOS](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)  
 2. If you're on a Windows development machine, install [SDK 20348](https://go.microsoft.com/fwlink/?linkid=2164145)
-3. If you're on a MacOS development machine, install [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos)
+3. If you're on a MacOS development machine, install [PowerShell](https://docs.microsoft.com/powershell/scripting/install/installing-powershell-on-macos)
    
 ### iOS / MacCatalyst
 

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -11,29 +11,92 @@ In most cases, when you have Visual Studio installed with the .NET workloads che
 1. Install the latest .NET 6:  
    <!--- [Win (x64)](https://aka.ms/dotnet/6.0.2xx/daily/dotnet-sdk-win-x64.exe)   -->
    - [Install the latest Public Preview of Visual Studio](https://docs.microsoft.com/en-us/dotnet/maui/get-started/installation/)
-   - [macOS (x64)](https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-x64.pkg)  
-   - [macOS (arm64)](https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-arm64.pkg)
-2. Clear your nuget cache:  
+   - [macOS](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)  
+2. If you're on a Windows development machine, install [SDK 20348](https://go.microsoft.com/fwlink/?linkid=2164145)
+3. If you're on a MacOS development machine, install [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos)
+   
+### iOS / MacCatalyst
+
+iOS and MacCatalyst will require Xcode 13.3 Stable. You can get this [here](https://developer.apple.com/download/more/?name=Xcode).
+
+### Android
+
+Android API-31 (Android 12) is now the default in .NET 6.
+
+## Running
+
+### Compile using a local `bin\dotnet`
+
+This method ensures that the workloads installed by Visual Studio won't get changed. This is usually the best method to use if you want to preserve the global state of your machine. This method will also use the versions that are specific to the branch you are on which is a good way to ensure compatibility.
+
+#### Cake
+
+You can run a `Cake` target to bootstrap .NET 6 in `bin\dotnet` and launch Visual Studio:
+
+```dotnetcli
+dotnet tool restore
+dotnet cake --target=VS
+```
+
+#### Testing branch against your project
+`--sln=<Path to SLN>`
+- This will pack .NET and then open a VS instance using the local pack. This is useful if you want to check to see if the changes in a branch will address your particular issues. Pack only runs the first time so you will need to explicitly add the `--pack` flag if you make changes and need to repack.
+
+```dotnetcli
+dotnet tool restore
+dotnet cake --sln="<download_directory>\MauiApp2\MauiApp2.sln" --target=VS
+```
+
+#### Pack
+`--pack`
+- This creates .NET MAUI packs inside the local dotnet install. This lets you use the CLI commands with the local dotnet to create/deploy with any changes that have been made on that branch (including template changes).
+
+```dotnetcli
+dotnet tool restore
+dotnet cake --target=VS --pack --sln="<download_directory>\MauiApp2\MauiApp2.sln"
+```
+
+Create new .NET MAUI app using your new packs
+```dotnetcli
+dotnet tool restore
+dotnet cake --pack
+mkdir MauiApp
+cd MauiApp
+..\bin\dotnet\dotnet new maui
+..\bin\dotnet\dotnet build -t:Run -f net6.0-android
+```
+
+You can also run commands individually:
+```dotnetcli
+# install local tools required to build (cake, pwsh, etc..)
+dotnet tool restore
+# Provision .NET 6 in bin\dotnet
+dotnet build src\DotNet\DotNet.csproj
+# Builds Maui MSBuild tasks
+.\bin\dotnet\dotnet build Microsoft.Maui.BuildTasks.slnf
+# Builds the rest of Maui
+.\bin\dotnet\dotnet build Microsoft.Maui.sln
+# Launch Visual Studio
+dotnet cake --target=VS
+```
+
+### Compile with globally installed `dotnet`
+
+> You'll probably need to run these commands with elevated privileges:
+
+#### WARNING ####
+
+> This will replace what Visual Studio has installed for your workloads so now your entire machine will be using the workloads you have installed here.
+
+#### main branch
+
+1. Clear your nuget cache:  
    ```
    dotnet nuget locals all --clear
    ```
    > NOTE: this is going to contain the "stable" versions of the packages, so you will have to clear the NuGet cache when this feed changes and when .NET ships. The various `darc-pub-dotnet-*` feeds are temporary and are generated on various builds. These feeds my disappear and be replaced with new ones as new builds come out. Make sure to verify that you are on the latest here and clear the nuget cache if it changes.
-4. If you're on a Windows development machine, install [SDK 20348](https://go.microsoft.com/fwlink/?linkid=2164145)
-5. If you're on a MacOS development machine, install [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos)
-   
 
-### .NET MAUI Workload
-
-> You'll probably need to run these commands with elevated privileges:
-
-Install the .NET MAUI workload using the versions from a particular branch:  
-
-#### main branch
-
-1. First, install .NET SDK 6.0.300
-
-2. Next run the following workload command:
-
+2. 
 Windows:
 
 ```bat
@@ -56,101 +119,28 @@ dotnet workload install maui \
   --source https://api.nuget.org/v3/index.json
 ```
 
-### iOS / MacCatalyst
-
-iOS and MacCatalyst will require Xcode 13.3 Stable. You can get this [here](https://developer.apple.com/download/more/?name=Xcode).
-
-### Android
-
-Android API-31 (Android 12) is now the default in .NET 6.
-
-
-## Running
-
-### Compile with globally installed `dotnet`
-
-This will build and launch Visual Studio using global workloads
+3. This will build and launch Visual Studio using global workloads
 
 ```dotnetcli
 dotnet tool restore
-dotnet cake --target=VS-NET6 --workloads=global
-```
-
-### Compile using a local `bin\dotnet`
-
-#### Windows
-
-You can run a `Cake` target to bootstrap .NET 6 in `bin\dotnet` and launch Visual Studio:
-
-```dotnetcli
-dotnet tool restore
-dotnet cake --target=VS-NET6
-```
-
-You can also run:
-
-```dotnetcli
-dotnet tool restore
-dotnet cake --target=VS
-```
-
-_NOTES:_
-- _If the IDE doesn't show any Android devices try unloading and reloading the `Sample.Droid-net6` project._
-
-You can also run commands individually:
-```dotnetcli
-# install local tools required to build (cake, pwsh, etc..)
-dotnet tool restore
-# Provision .NET 6 in bin\dotnet
-dotnet build src\DotNet\DotNet.csproj
-# Builds Maui MSBuild tasks
-.\bin\dotnet\dotnet build Microsoft.Maui.BuildTasks.sln
-# Builds the rest of Maui
-.\bin\dotnet\dotnet build Microsoft.Maui.sln
-# (Windows-only) to launch Visual Studio
-dotnet cake --target=VS
-```
-
-To build & run .NET 6 sample apps, you will also need to use `.\bin\dotnet\dotnet` or just `dotnet` if you've
-installed the workloads globally: as well as need the `-f` switch to choose the platform:
-
-```dotnetcli
-.\bin\dotnet\dotnet build src\Controls\samples\Controls.Sample\Maui.Controls.Sample.csproj -t:Run -f net6.0-android
-.\bin\dotnet\dotnet build src\Controls\samples\Controls.Sample\Maui.Controls.Sample.csproj -t:Run -f net6.0-ios
+dotnet cake --target=VS --workloads=global
 ```
 
 #### MacOS
 
-> 💡 _VS Mac is not yet supported._
+All of the above cake commands should work fine on `MacOS`.
 
-```bash
-# install local tools required to build (cake, pwsh, etc..)
-dotnet tool restore
+If you aren't using the cake scripts and the `Microsoft.Maui-mac.slnf` isn't working for you try `_omnisharp.sln`
 
-# build MAUI
-dotnet build Microsoft.Maui-mac.slnf
-```
+### Additional Cake Commands
 
-Try out a "single project", you will need the `-f` switch to choose the platform:
-
-```bash
-dotnet build src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj -t:Run -f net6.0-ios
-dotnet build src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj -t:Run -f net6.0-maccatalyst
-dotnet build src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj -t:Run -f net6.0-android
-```
+#### Clean
+`--clean`
+- This will do a recursive delete of all your obj/bin folders. This is helpful if for some reason your repository is in a bad state and you don't want to go as scorched earth as `git clean -xdf`
 
 ### Blazor Desktop
 
 To build and run Blazor Desktop samples, check out the [Blazor Desktop](https://github.com/dotnet/maui/wiki/Blazor-Desktop) wiki topic.
-
-### Win UI 3
-
-To build and run WinUI 3 support, please install the additional components mentioned on the [Getting Started](https://docs.microsoft.com/en-us/dotnet/maui/get-started/installation) page and run:
-
-```dotnetcli
-dotnet tool restore
-dotnet cake --target=VS-WINUI
-```
 
 ### Android
 


### PR DESCRIPTION
### Description of Change
- prioritize local build suggestions over global
- because our main/net6.0 branches are both net6.0 I removed the recommendation to install .net and just tell users to install VS
- AFAIK all of these commands work with VS MAC so I removed anything that was particular to window
- included extra cake commands added for packing and testing solutions

