### PR TITLE
[Tizen] Fill ScrollView when content is smaller than viewport

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Tizen.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Tizen.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		EContainer? _scrollCanvas;
 
-		Box? Canvas => (Box?)_scrollCanvas;
+		LayoutCanvas? Canvas => (LayoutCanvas?)_scrollCanvas;
 
 		protected override ScrollView CreatePlatformView()
 		{
@@ -22,12 +22,14 @@ namespace Microsoft.Maui.Handlers
 				WeightX = 1,
 				WeightY = 1
 			};
-			_scrollCanvas = new Box(scrollView)
+			_scrollCanvas = new LayoutCanvas(scrollView, VirtualView)
 			{
 				AlignmentX = -1,
 				AlignmentY = -1,
 				WeightX = 1,
-				WeightY = 1
+				WeightY = 1,
+				CrossPlatformArrange = VirtualView.CrossPlatformArrange,
+				CrossPlatformMeasure = VirtualView.CrossPlatformMeasure
 			};
 			scrollView.SetContent(_scrollCanvas);
 			return scrollView;


### PR DESCRIPTION
### Description of Change

This PR is Tizen modification according to the change of #7514.

### How to reproduce
1. Run the `ControlGallery`
2. Check the MainPage's contents

#### Before
Nothing is rendered inside ScorllView in MainPage.
<img src="https://user-images.githubusercontent.com/1029134/195014870-18b70d7c-0dcf-4dbb-982c-f93ea9f5515a.png" width="300"/>

#### After 
Works fine as expected.
<img src="https://user-images.githubusercontent.com/1029134/195014903-be2c452c-0d4f-4544-a4f6-6e5ccbb36d9a.png" width="300"/>
