### PR TITLE
[Tizen] Update default Shell Flyout behavior

### DIFF
--- a/src/Controls/src/Core/Platform/Tizen/Shell/ShellView.cs
+++ b/src/Controls/src/Core/Platform/Tizen/Shell/ShellView.cs
@@ -99,7 +99,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 		protected virtual INavigationDrawer CreateNavigationDrawer()
 		{
-			return new NavigationDrawer(PlatformParent);
+			return new NavigationDrawer(PlatformParent)
+			{
+				IsOpen = false
+			};
 		}
 
 		protected virtual ITNavigationView CreateNavigationView()


### PR DESCRIPTION
### Description of Change

The default Shell Flyout behavior was open in Tizen. Therefore, when `Shell.FlyoutBehavior=Disabled` or `Shell.FlyoutIsPresented = false`, the Flyout shows at first app launch and closes immediately.
This PR updates this default Shell Flyout behavior to not show when it is not supposed to be seen.

### Screenshots

current
<img src="https://user-images.githubusercontent.com/14328614/174252717-18edb077-88c7-475a-9bd1-f2f7a028ed35.gif" width=200 />

updated
<img src="https://user-images.githubusercontent.com/14328614/174252973-b6f23cf8-b8bf-49cf-9563-3ace0baa0470.gif" width=200 />
