### PR TITLE
Add the Microsoft.Maui.Dispatching using

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.props
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.props
@@ -14,6 +14,7 @@
     <Using Include="Microsoft.Maui.Controls" Sdk="Maui" />
     <Using Include="Microsoft.Maui.Controls.Hosting" Sdk="Maui" />
     <Using Include="Microsoft.Maui.Controls.Xaml" Sdk="Maui" />
+    <Using Include="Microsoft.Maui.Dispatching" Sdk="Maui" />
     <Using Include="Microsoft.Maui.Hosting" Sdk="Maui" />
     <Using Include="Microsoft.Maui.Graphics" Sdk="Maui" />
     <Using Include="Microsoft.Maui.Accessibility" Sdk="Maui" />


### PR DESCRIPTION
### Description of Change

This using has all the extension methods for `IDispatcher`, such as creating/starting timers and a bunch of other useful things. It also has the `IDispatcher` type. Instead of requiring the using in the file for every time you need to use the dispatcher, we can include it.
