### PR TITLE
Resize star rows/columns _only_ during Arrange, if necessary

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -35,26 +35,6 @@ namespace Microsoft.Maui.Layouts
 
 			_gridStructure.AdjustStarsForArrange(bounds.Size);
 
-			// The problem isn't that we need to measure again
-			// the problem is that the stars are all wrong because the size has changed
-			// So we just need to resize the star stuff based on the new size
-			// 
-
-			// NeedsStarAdjustments is basically "is the bounds size at all different than the measured size?"
-			
-
-			// When we measure stars as auto because of infinity, we need to mark that col/row definition so we know
-			// to adjust it later if the size is no longer infinity
-
-			// Then we need to loop through all star defs and starasauto defs and mark them as not having a size
-			// then run resolve star rows and resolve star columns again 
-
-			// and then we should be good.
-
-			// This should be pretty easy to write unit tests for
-
-			// Once we have that in place and verify that it works for Windows, check to make sure that this is functional for iOS as well (I don't think it used this feature anyway)
-
 			var reverseColumns = Grid.ColumnDefinitions.Count > 1 && !Grid.ShouldArrangeLeftToRight();
 
 			foreach (var view in Grid)

--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -28,10 +28,32 @@ namespace Microsoft.Maui.Layouts
 
 		public override Size ArrangeChildren(Rect bounds)
 		{
-			if (_gridStructure  == null || NeedsRemeasure(bounds, Grid, _gridStructure))
+			if (_gridStructure  == null)
 			{
 				_gridStructure = new GridStructure(Grid, bounds.Width, bounds.Height);
 			}
+
+			_gridStructure.AdjustStarsForArrange(bounds.Size);
+
+			// The problem isn't that we need to measure again
+			// the problem is that the stars are all wrong because the size has changed
+			// So we just need to resize the star stuff based on the new size
+			// 
+
+			// NeedsStarAdjustments is basically "is the bounds size at all different than the measured size?"
+			
+
+			// When we measure stars as auto because of infinity, we need to mark that col/row definition so we know
+			// to adjust it later if the size is no longer infinity
+
+			// Then we need to loop through all star defs and starasauto defs and mark them as not having a size
+			// then run resolve star rows and resolve star columns again 
+
+			// and then we should be good.
+
+			// This should be pretty easy to write unit tests for
+
+			// Once we have that in place and verify that it works for Windows, check to make sure that this is functional for iOS as well (I don't think it used this feature anyway)
 
 			var reverseColumns = Grid.ColumnDefinitions.Count > 1 && !Grid.ShouldArrangeLeftToRight();
 
@@ -56,23 +78,6 @@ namespace Microsoft.Maui.Layouts
 			var actual = new Size(_gridStructure.MeasuredGridWidth(), _gridStructure.MeasuredGridHeight());
 
 			return actual.AdjustForFill(bounds, Grid);
-		}
-
-		static bool NeedsRemeasure(Rect bounds, IGridLayout grid, GridStructure structure) 
-		{
-			if (grid.VerticalLayoutAlignment == Primitives.LayoutAlignment.Fill
-					&& structure.HeightConstraint != bounds.Height)
-			{
-				return true;
-			}
-			
-			if (grid.HorizontalLayoutAlignment == Primitives.LayoutAlignment.Fill
-				&& structure.WidthConstraint != bounds.Width)
-			{
-				return true;
-			}
-
-			return false;
 		}
 
 		class GridStructure
@@ -168,7 +173,7 @@ namespace Microsoft.Maui.Layouts
 			{
 				return new Definition[]
 				{
-					new Definition(treatStarAsAuto ? GridLength.Auto : GridLength.Star)
+					new Definition(treatStarAsAuto ? GridLength.Auto : GridLength.Star, treatStarAsAuto)
 				};
 			}
 
@@ -190,7 +195,7 @@ namespace Microsoft.Maui.Layouts
 
 					if (definition.Height.GridUnitType == GridUnitType.Star && treatStarAsAuto)
 					{
-						rows[n] = new Definition(GridLength.Auto);
+						rows[n] = new Definition(GridLength.Auto, treatStarAsAuto);
 					}
 					else
 					{
@@ -219,7 +224,7 @@ namespace Microsoft.Maui.Layouts
 
 					if (definition.Width.GridUnitType == GridUnitType.Star && treatStarAsAuto)
 					{
-						definitions[n] = new Definition(GridLength.Auto);
+						definitions[n] = new Definition(GridLength.Auto, treatStarAsAuto);
 					}
 					else
 					{
@@ -415,8 +420,8 @@ namespace Microsoft.Maui.Layouts
 
 				ResolveSpans();
 
-				ResolveStarColumns();
-				ResolveStarRows();
+				ResolveStarColumns(_gridWidthConstraint);
+				ResolveStarRows(_gridHeightConstraint);
 
 				EnsureFinalMeasure();
 			}
@@ -583,18 +588,18 @@ namespace Microsoft.Maui.Layouts
 				}
 			}
 
-			void ResolveStarColumns()
+			void ResolveStarColumns(double widthConstraint)
 			{
-				var availableSpace = _gridWidthConstraint - GridWidth();
+				var availableSpace = widthConstraint - GridWidth();
 				static bool cellCheck(Cell cell) => cell.IsColumnSpanStar;
 				static double getDimension(Size size) => size.Width;
 
 				ResolveStars(_columns, availableSpace, cellCheck, getDimension);
 			}
 
-			void ResolveStarRows()
+			void ResolveStarRows(double heightConstraint)
 			{
-				var availableSpace = _gridHeightConstraint - GridHeight();
+				var availableSpace = heightConstraint - GridHeight();
 				static bool cellCheck(Cell cell) => cell.IsRowSpanStar;
 				static double getDimension(Size size) => size.Height;
 
@@ -707,6 +712,65 @@ namespace Microsoft.Maui.Layouts
 
 				return available + cellRowsHeight;
 			}
+
+			public void AdjustStarsForArrange(Size targetSize) 
+			{
+				if (_grid.VerticalLayoutAlignment == Primitives.LayoutAlignment.Fill)
+				{
+					if (_grid.DesiredSize.Height < targetSize.Height)
+					{
+						// Reset the size on all star rows
+						for (int n = 0; n < _rows.Length; n++)
+						{
+							var definition = _rows[n];
+							if (definition.IsStar)
+							{
+								definition.Size = 0;
+							}
+						}
+
+						// Reset the size on all "star as auto" rows
+						for (int n = 0; n < _rows.Length; n++)
+						{
+							var definition = _rows[n];
+							if (definition.IsStarAsAuto)
+							{
+								_rows[n] = new Definition(GridLength.Star);
+							}
+						}
+
+						ResolveStarRows(targetSize.Height);
+					}
+				}
+				
+				if (_grid.HorizontalLayoutAlignment == Primitives.LayoutAlignment.Fill)
+				{
+					if (_grid.DesiredSize.Width < targetSize.Width)
+					{
+						// Reset the size on all star rows
+						for (int n = 0; n < _columns.Length; n++)
+						{
+							var definition = _columns[n];
+							if (definition.IsStar)
+							{
+								definition.Size = 0;
+							}
+						}
+
+						// Reset the size on all "star as auto" rows
+						for (int n = 0; n < _columns.Length; n++)
+						{
+							var definition = _columns[n];
+							if (definition.IsStarAsAuto)
+							{
+								_columns[n] = new Definition(GridLength.Star);
+							}
+						}
+
+						ResolveStarColumns(targetSize.Width);
+					}
+				}
+			}
 		}
 
 		// Dictionary key for tracking a Span
@@ -814,10 +878,11 @@ namespace Microsoft.Maui.Layouts
 			public bool IsAuto => _gridLength.IsAuto;
 			public bool IsStar => _gridLength.IsStar;
 			public bool IsAbsolute => _gridLength.IsAbsolute;
+			public bool IsStarAsAuto { get; }
 
 			public GridLength GridLength => _gridLength;
 
-			public Definition(GridLength gridLength)
+			public Definition(GridLength gridLength, bool treatStarAsAuto = false)
 			{
 				if (gridLength.IsAbsolute)
 				{
@@ -825,6 +890,8 @@ namespace Microsoft.Maui.Layouts
 				}
 
 				_gridLength = gridLength;
+
+				IsStarAsAuto = gridLength.IsAuto && treatStarAsAuto;
 			}
 		}
 	}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1897,5 +1897,58 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			Assert.Equal(20, measuredSize.Height);
 		}
+
+		[Fact]
+		public void StarRowsResizeWhenGridExpandsToFill()
+		{
+			var grid = CreateGridLayout(rows: "*");
+			grid.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			SubstituteChildren(grid, view0);
+
+			var manager = new GridLayoutManager(grid);
+
+			// Measuring at infinite height, we expect the Grid's only row (*) to act like an
+			// Auto row and get the height of the view
+			var measuredSize = manager.Measure(20, double.PositiveInfinity);
+			Assert.Equal(20, measuredSize.Height);
+			
+			grid.DesiredSize.Returns(measuredSize);
+
+			// We arrange at a height taller than the Grid's measurement; because the Grid
+			// is set to vertically Fill, we expect it to expand to the arranged height
+			manager.ArrangeChildren(new Rect(0, 0, 20, 100));
+
+			// And we expect the * row to fill up that new height
+			AssertArranged(view0, new Rect(0, 0, 20, 100));
+		}
+
+		[Fact]
+		public void StarColumnsResizeWhenGridExpandsToFill()
+		{
+			var grid = CreateGridLayout(columns: "*");
+			grid.HorizontalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			SubstituteChildren(grid, view0);
+
+			var manager = new GridLayoutManager(grid);
+
+			// Measuring at infinite width, we expect the Grid's only column (*) to act like an
+			// Auto column and get the width of the view
+			var measuredSize = manager.Measure(double.PositiveInfinity, 20);
+			Assert.Equal(20, measuredSize.Width);
+
+			grid.DesiredSize.Returns(measuredSize);
+
+			// We arrange at a width wider than the Grid's measurement; because the Grid
+			// is set to horizontally Fill, we expect it to expand to the arranged width
+			manager.ArrangeChildren(new Rect(0, 0, 100, 20));
+
+			// And we expect the * column to fill up that new width
+			AssertArranged(view0, new Rect(0, 0, 100, 20));
+		}
+
 	}
 }


### PR DESCRIPTION
### Description of Change

To get #7514 working, we added a re-measure for the Grid during Arrange to get the * rows/columns to lay out at the new size. But re-measuring in some circumstances on Windows causes a layout cycle. 

These changes skip the re-measuring and simply expand the * rows/columns as appropriate when the Grid is set to Fill and the Arrange destination exceeds the DesiredSize. 

### Issues Fixed

Fixes #8126