### PR TITLE
Merge most updates required for net7 to main

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <_MauiTargetPlatformIsWindows Condition="$(_MauiTargetPlatformIdentifier.Contains('windows')) == 'True'">True</_MauiTargetPlatformIsWindows>
     <_MauiTargetPlatformIsTizen Condition="'$(_MauiTargetPlatformIdentifier)' == 'tizen'">True</_MauiTargetPlatformIsTizen>
 
-    <IncludeWindowsTargetFrameworks Condition="($([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full') or ('$(Packing)' == 'true')">true</IncludeWindowsTargetFrameworks>
+    <IncludeWindowsTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
     <IncludeTizenTargetFrameworks Condition="'$(CI)' == 'true' or '$(TF_BUILD)' == 'true' or
              Exists('$(DOTNET_ROOT)\sdk-manifests\$(DotNetVersionBand)\samsung.net.sdk.tizen\WorkloadManifest.json') or
              Exists('$(ProgramFiles)\dotnet\sdk-manifests\$(DotNetVersionBand)\samsung.net.sdk.tizen\WorkloadManifest.json')">true</IncludeTizenTargetFrameworks>
@@ -29,6 +29,7 @@
     <!-- HACK: WinUI seems to have issues without this -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
+    <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
   </PropertyGroup>
 
   <!-- version number information -->

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -165,8 +165,11 @@ Task("dotnet-templates")
 
                 // Enable Tizen
                 ReplaceTextInFiles($"{projectName}/*.csproj",
-                    "<!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->",
-                    "<TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks>");
+                    "<!-- <TargetFrameworks>",
+                    "<TargetFrameworks>");
+                ReplaceTextInFiles($"{projectName}/*.csproj",
+                    "</TargetFrameworks> -->",
+                    "</TargetFrameworks>");
 
                 // Build
                 RunMSBuildWithDotNet(projectName, properties, warningsAsError: true, forceDotNetBuild: forceDotNetBuild);
@@ -464,29 +467,6 @@ bool RunPackTarget()
     return false;
 }
 
-string FindMSBuild()
-{
-    if (!string.IsNullOrWhiteSpace(MSBuildExe))
-        return MSBuildExe;
-
-    if (IsRunningOnWindows())
-    {
-        var vsInstallation = VSWhereLatest(new VSWhereLatestSettings { Requires = "Microsoft.Component.MSBuild", IncludePrerelease = true });
-        if (vsInstallation != null)
-        {
-            var path = vsInstallation.CombineWithFilePath(@"MSBuild\Current\Bin\MSBuild.exe");
-            if (FileExists(path))
-                return path.FullPath;
-
-            path = vsInstallation.CombineWithFilePath(@"MSBuild\15.0\Bin\MSBuild.exe");
-            if (FileExists(path))
-                return path.FullPath;
-        }
-    }
-    return "msbuild";
-}
-
-
 Dictionary<string, string> GetDotNetEnvironmentVariables()
 {
     Dictionary<string, string> envVariables = new Dictionary<string, string>();
@@ -596,83 +576,45 @@ void RunMSBuildWithDotNet(
     if(localDotnet)
         SetDotNetEnvironmentVariables();
 
-    // If we're not on Windows, use ./bin/dotnet/dotnet
-    if (useDotNetBuild)
+    var msbuildSettings = new DotNetCoreMSBuildSettings()
+        .SetConfiguration(configuration)
+        .SetMaxCpuCount(0)
+        .WithTarget(target)
+        .EnableBinaryLogger(binlog);
+
+    if (warningsAsError)
     {
-        var msbuildSettings = new DotNetCoreMSBuildSettings()
-            .SetConfiguration(configuration)
-            .SetMaxCpuCount(0)
-            .WithTarget(target)
-            .EnableBinaryLogger(binlog);
-
-        if (warningsAsError)
-        {
-            msbuildSettings.TreatAllWarningsAs(MSBuildTreatAllWarningsAs.Error);
-        }
-
-        if (properties != null)
-        {
-            foreach (var property in properties)
-            {
-                msbuildSettings.WithProperty(property.Key, property.Value);
-            }
-        }
-
-        var dotnetBuildSettings = new DotNetCoreBuildSettings
-        {
-            MSBuildSettings = msbuildSettings,
-        };
-
-        dotnetBuildSettings.ArgumentCustomization = args =>
-        {
-            if (!restore)
-                args.Append("--no-restore");
-
-            if (!string.IsNullOrEmpty(targetFramework))
-                args.Append($"-f {targetFramework}");
-
-            return args;
-        };
-
-        if (localDotnet)
-            dotnetBuildSettings.ToolPath = dotnetPath;
-
-        DotNetCoreBuild(sln, dotnetBuildSettings);
+        msbuildSettings.TreatAllWarningsAs(MSBuildTreatAllWarningsAs.Error);
     }
-    else
-    {
-        // Otherwise we need to run MSBuild for WinUI support
-        var msbuild = FindMSBuild();
-        Information("Using MSBuild: {0}", msbuild);
-        var msbuildSettings = new MSBuildSettings { ToolPath = msbuild }
-            .SetConfiguration(configuration)
-            .SetMaxCpuCount(0)
-            .WithTarget(target)
-            .EnableBinaryLogger(binlog);
 
-        if (warningsAsError)
+    if (properties != null)
+    {
+        foreach (var property in properties)
         {
-            msbuildSettings.WarningsAsError = true;
+            msbuildSettings.WithProperty(property.Key, property.Value);
         }
-        if (restore)
-        {
-            msbuildSettings.WithRestore();
-        }
+    }
+
+    var dotnetBuildSettings = new DotNetCoreBuildSettings
+    {
+        MSBuildSettings = msbuildSettings,
+    };
+
+    dotnetBuildSettings.ArgumentCustomization = args =>
+    {
+        if (!restore)
+            args.Append("--no-restore");
+
         if (!string.IsNullOrEmpty(targetFramework))
-        {
-            msbuildSettings.WithProperty("TargetFramework", targetFramework);
-        }
+            args.Append($"-f {targetFramework}");
 
-        if (properties != null)
-        {
-            foreach (var property in properties)
-            {
-                msbuildSettings.WithProperty(property.Key, property.Value);
-            }
-        }
+        return args;
+    };
 
-        MSBuild(sln, msbuildSettings);
-    }
+    if (localDotnet)
+        dotnetBuildSettings.ToolPath = dotnetPath;
+
+    DotNetCoreBuild(sln, dotnetBuildSettings);
 }
 
 void RunTestWithLocalDotNet(string csproj)

--- a/eng/package.ps1
+++ b/eng/package.ps1
@@ -9,8 +9,11 @@ Write-Host "MSBUILD_EXE: $env:MSBUILD_EXE"
 
 $artifacts = Join-Path $PSScriptRoot ../artifacts
 $logsDirectory = Join-Path $artifacts logs
-$sln = Join-Path $PSScriptRoot ../Microsoft.Maui.Packages.slnf
-$slnMac = Join-Path $PSScriptRoot ../Microsoft.Maui.Packages-mac.slnf
+if ($IsWindows) {
+    $sln = Join-Path $PSScriptRoot ../Microsoft.Maui.Packages.slnf
+} else {
+    $sln = Join-Path $PSScriptRoot ../Microsoft.Maui.Packages-mac.slnf
+}
 
 # Full path to dotnet folder
 $dotnet = Join-Path $PSScriptRoot ../bin/dotnet/
@@ -23,104 +26,26 @@ if (Test-Path -Path $dotnet) {
 
 $dotnet = (Get-Item $dotnet).FullName
 
-if ($IsWindows)
+$oldPATH=$env:PATH
+$oldDOTNET_ROOT=$env:DOTNET_ROOT
+try
 {
-    if (-not $msbuild)
-    {
-        $msbuild = $env:MSBUILD_EXE
-    }
+    # Put our local dotnet on $PATH
+    $env:PATH=($dotnet + [IO.Path]::PathSeparator + $env:PATH)
+    $dotnet_tool = Join-Path $dotnet dotnet
 
-    if (-not $msbuild)
-    {
-        # If MSBuild path isn't specified, use the standard location of 'vswhere' to determine an appropriate MSBuild to use.
-        # Learn more about VSWhere here: https://github.com/microsoft/vswhere/wiki/Find-MSBuild
-        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+    # This tells .NET to use the bootstrapped runtime
+    $env:DOTNET_ROOT=$dotnet
 
-        if (-not $msbuild)
-        {
-            throw 'Could not locate MSBuild automatically. Set the $msbuild parameter of this script to provide a location.'
-        }
-        Write-Host "Found MSBuild at ${msbuild}"
-    }
-
-    # NOTE: I've not found a better way to do this
-    # see: https://github.com/PowerShell/PowerShell/issues/3316
-    $oldDOTNET_INSTALL_DIR=$env:DOTNET_INSTALL_DIR
-    $oldDOTNET_ROOT=$env:DOTNET_ROOT
-    $oldDOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR
-    $oldDOTNET_MULTILEVEL_LOOKUP=$env:DOTNET_MULTILEVEL_LOOKUP
-    $oldMSBuildEnableWorkloadResolver=$env:MSBuildEnableWorkloadResolver
-    $oldPATH=$env:PATH
-    try
-    {
-        $env:DOTNET_INSTALL_DIR=$dotnet
-
-        # This tells .NET to use the bootstrapped runtime
-        $env:DOTNET_ROOT=$dotnet
-
-        # This tells MSBuild to load the SDK from the directory of the bootstrapped SDK
-        $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$env:DOTNET_ROOT
-
-        # This tells .NET not to go looking for .NET in other places
-        $env:DOTNET_MULTILEVEL_LOOKUP=0
-
-        # This enables workload support inside the IDE
-        $env:MSBuildEnableWorkloadResolver=$true
-
-        # Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
-        $env:PATH=($dotnet + [IO.Path]::PathSeparator + $env:PATH)
-
-        # Have to build the solution first so the xbf files are there for pack
-        & $msbuild $sln `
-            /p:configuration=$configuration `
-            /p:SymbolPackageFormat=snupkg `
-            /restore `
-            /t:Build `
-            /p:Packing=true `
-            /bl:"$logsDirectory/maui-build-$configuration.binlog"
-        if (!$?) { throw "Build .NET MAUI failed." }
-
-        & $msbuild $sln `
-            /p:configuration=$configuration `
-            /p:SymbolPackageFormat=snupkg `
-            /t:Pack `
-            /p:Packing=true `
-            /bl:"$logsDirectory/maui-pack-$configuration.binlog"
-        if (!$?) { throw "Pack .NET MAUI failed." }
-    }
-    finally
-    {
-        $env:DOTNET_INSTALL_DIR = $oldDOTNET_INSTALL_DIR
-        $env:DOTNET_ROOT=$oldDOTNET_ROOT
-        $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$oldDOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR
-        $env:DOTNET_MULTILEVEL_LOOKUP=$oldDOTNET_MULTILEVEL_LOOKUP
-        $env:MSBuildEnableWorkloadResolver=$oldMSBuildEnableWorkloadResolver
-        $env:PATH=$oldPATH
-    }
+    # Build with ./bin/dotnet/dotnet
+    & $dotnet_tool pack $sln `
+        -c:$configuration `
+        -p:SymbolPackageFormat=snupkg `
+        -bl:$logsDirectory/maui-pack-$configuration.binlog
+    if (!$?) { throw "Pack failed." }
 }
-else
+finally
 {
-    $oldPATH=$env:PATH
-    $oldDOTNET_ROOT=$env:DOTNET_ROOT
-    try
-    {
-        # Put our local dotnet on $PATH
-        $env:PATH=($dotnet + [IO.Path]::PathSeparator + $env:PATH)
-        $dotnet_tool = Join-Path $dotnet dotnet
-
-        # This tells .NET to use the bootstrapped runtime
-        $env:DOTNET_ROOT=$dotnet
-
-        # Build with ./bin/dotnet/dotnet
-        & $dotnet_tool pack $slnMac `
-            -c:$configuration `
-            -p:SymbolPackageFormat=snupkg `
-            -bl:$logsDirectory/maui-pack-$configuration.binlog
-        if (!$?) { throw "Pack failed." }
-    }
-    finally
-    {
-        $env:PATH=$oldPATH
-        $env:DOTNET_ROOT=$oldDOTNET_ROOT
-    }
+    $env:PATH=$oldPATH
+    $env:DOTNET_ROOT=$oldDOTNET_ROOT
 }

--- a/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/iOS/IOSWebViewManager.cs
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					var uri = _currentUri;
 					_currentUri = null;
 					_currentNavigation = null;
-					var request = new NSUrlRequest(uri);
+					var request = new NSUrlRequest(uri!);
 					webView.LoadRequest(request);
 				}
 			}

--- a/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
+++ b/src/BlazorWebView/src/WindowsForms/BlazorWebView.cs
@@ -286,9 +286,9 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 			// Everything below is overridden to protect the control collection as read-only.
 			public override bool IsReadOnly => true;
 
-			public override void Add(Control value) => throw new NotSupportedException();
+			public override void Add(Control? value) => throw new NotSupportedException();
 			public override void Clear() => throw new NotSupportedException();
-			public override void Remove(Control value) => throw new NotSupportedException();
+			public override void Remove(Control? value) => throw new NotSupportedException();
 			public override void SetChildIndex(Control child, int newIndex) => throw new NotSupportedException();
 		}
 	}

--- a/src/Compatibility/Core/src/Android/ResourceManager.cs
+++ b/src/Compatibility/Core/src/Android/ResourceManager.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		static Assembly _assembly;
 		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Resource.designer.cs is in the root application assembly, which should be preserved.")]
+		[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "Resource.designer.cs may be linked away, so don't worry if there are missing things.")]
 		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
 		static Type FindType(string name, string altName)
 		{

--- a/src/Compatibility/Core/src/Tizen/Extensions/PageExtensions.cs
+++ b/src/Compatibility/Core/src/Tizen/Extensions/PageExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using ElmSharp;
 
 namespace Microsoft.Maui.Controls.Compatibility
@@ -42,7 +43,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 			return Microsoft.Maui.Controls.Compatibility.PageExtensions.CreateEvasObject(page, parent, hasAlpha);
 		}
 
-		public static void UpdateFocusTreePolicy<T>(this MultiPage<T> multiPage) where T : Page
+		public static void UpdateFocusTreePolicy<[DynamicallyAccessedMembers(BindableProperty.DeclaringTypeMembers)] T>(this MultiPage<T> multiPage) where T : Page
 		{
 			foreach (var pageItem in multiPage.Children)
 			{

--- a/src/Compatibility/Core/src/Tizen/Renderers/RefreshViewRenderer.cs
+++ b/src/Compatibility/Core/src/Tizen/Renderers/RefreshViewRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Maui.Layouts;
@@ -281,11 +282,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Tizen
 			return false;
 		}
 
+		//TODO: the following method is not trimming safe
+		[UnconditionalSuppressMessage("Trimming", "IL2026")]
+		[UnconditionalSuppressMessage("Trimming", "IL2075")]
+		[UnconditionalSuppressMessage("Trimming", "IL2091")]
 		int GetScrollYOnGenList(IntPtr handle)
 		{
-#pragma warning disable IL2026
 			var interop = typeof(EvasObject).Assembly.GetType("Interop");
-#pragma warning disable IL2026
 			var elementary = interop?.GetNestedType("Elementary", BindingFlags.NonPublic | BindingFlags.Static) ?? null;
 
 			if (elementary != null)

--- a/src/Controls/src/Core.Design/Controls.Core.Design.csproj
+++ b/src/Controls/src/Core.Design/Controls.Core.Design.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Microsoft.Maui.Controls.DesignTools</AssemblyName>
 		<EnableDefaultCompileItems>False</EnableDefaultCompileItems>
 		<IsPackable>False</IsPackable>
-		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' And '$(MSBuildRuntimeType)' == 'Full'">True</_MauiDesignDllBuild>
+		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' ">True</_MauiDesignDllBuild>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(_MauiDesignDllBuild)' == 'True' ">
 		<Reference Include="System.Xaml" />

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Microsoft.Maui.Controls</AssemblyName>
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>
-    <_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' And '$(MSBuildRuntimeType)' == 'Full'">True</_MauiDesignDllBuild>
+    <_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' ">True</_MauiDesignDllBuild>
     <GitInfoReportImportance>high</GitInfoReportImportance>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027;RS0022</NoWarn>

--- a/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/FormattedStringExtensions.cs
@@ -154,7 +154,11 @@ namespace Microsoft.Maui.Controls.Platform
 			int count = 0;
 			IList<int> totalLineHeights = new List<int>();
 
-			for (int i = 0; i < spannableString.Length(); i = next)
+#pragma warning disable CA1416
+			var strlen = spannableString.Length();
+#pragma warning restore CA1416
+
+			for (int i = 0; i < strlen; i = next)
 			{
 				var type = Java.Lang.Class.FromType(typeof(Java.Lang.Object));
 
@@ -166,7 +170,7 @@ namespace Microsoft.Maui.Controls.Platform
 					continue;
 
 				// Find the next span
-				next = spannableString.NextSpanTransition(i, spannableString.Length(), type);
+				next = spannableString.NextSpanTransition(i, strlen, type);
 
 				// Get all spans in the range - Android can have overlapping spans				
 				var spans = spannableString.GetSpans(i, next, type);

--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="Type[@FullName='Microsoft.Maui.Controls.ResourceDictionary']/Docs" />
 	public class ResourceDictionary : IResourceDictionary, IDictionary<string, object>
 	{
+		const string GetResourcePathUriScheme = "maui://";
 		static ConditionalWeakTable<Type, ResourceDictionary> s_instances = new ConditionalWeakTable<Type, ResourceDictionary>();
 		readonly Dictionary<string, object> _innerDictionary = new Dictionary<string, object>();
 		ResourceDictionary _mergedInstance;
@@ -383,10 +384,11 @@ namespace Microsoft.Maui.Controls
 
 			internal static string GetResourcePath(Uri uri, string rootTargetPath)
 			{
-				//need a fake scheme so it's not seen as file:// uri, and the forward slashes are valid on all plats
+				// GetResourcePathUriScheme is a fake scheme so it's not seen as file:// uri,
+				// and the forward slashes are valid on all plats
 				var resourceUri = uri.OriginalString.StartsWith("/", StringComparison.Ordinal)
-									 ? new Uri($"pack://{uri.OriginalString}", UriKind.Absolute)
-									 : new Uri($"pack:///{rootTargetPath}/../{uri.OriginalString}", UriKind.Absolute);
+									 ? new Uri($"{GetResourcePathUriScheme}{uri.OriginalString}", UriKind.Absolute)
+									 : new Uri($"{GetResourcePathUriScheme}/{rootTargetPath}/../{uri.OriginalString}", UriKind.Absolute);
 
 				//drop the leading '/'
 				return resourceUri.AbsolutePath.Substring(1);

--- a/src/Controls/src/Xaml.Design/Controls.Xaml.Design.csproj
+++ b/src/Controls/src/Xaml.Design/Controls.Xaml.Design.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Microsoft.Maui.Controls.Xaml.DesignTools</AssemblyName>
 		<EnableDefaultCompileItems>False</EnableDefaultCompileItems>
 		<IsPackable>False</IsPackable>
-		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' And '$(MSBuildRuntimeType)' == 'Full'">True</_MauiDesignDllBuild>
+		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' ">True</_MauiDesignDllBuild>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(_MauiDesignDllBuild)' == 'True' ">
 		<Reference Include="System.Xaml" />

--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>Microsoft.Maui.Controls.Xaml</AssemblyName>
 		<RootNamespace>Microsoft.Maui.Controls.Xaml</RootNamespace>
 		<IsPackable>false</IsPackable>
-		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' And '$(MSBuildRuntimeType)' == 'Full'">True</_MauiDesignDllBuild>
+		<_MauiDesignDllBuild Condition=" '$(OS)' != 'Unix' ">True</_MauiDesignDllBuild>
 		<NoWarn>$(NoWarn);CA2200;CS1591;RS0041</NoWarn>
 		<PackageId>Microsoft.Maui.Controls.Xaml</PackageId>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Controls/tests/Core.UnitTests/ImageButtonUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageButtonUnitTest.cs
@@ -200,6 +200,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsTrue(image.IsLoading);
 
 			image.Source = null;
+			mockImageRenderer.CompletionSource.Task.Wait();
 			Assert.IsFalse(image.IsLoading);
 			Assert.IsTrue(cancelled);
 
@@ -240,6 +241,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			public ImageButton Element { get; set; }
 
+			public TaskCompletionSource<bool> CompletionSource { get; private set; } = new TaskCompletionSource<bool>();
+
 			public async void Load()
 			{
 				if (initialLoad && Element.Source != null)
@@ -257,6 +260,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					finally
 					{
 						Element.SetIsLoading(false);
+						CompletionSource.SetResult(true);
 					}
 				}
 			}

--- a/src/Controls/tests/Core.UnitTests/ImageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageTests.cs
@@ -200,6 +200,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.IsTrue(image.IsLoading);
 
 			image.Source = null;
+			mockImageRenderer.CompletionSource.Task.Wait();
 			Assert.IsFalse(image.IsLoading);
 			Assert.IsTrue(cancelled);
 
@@ -239,6 +240,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			public Image Element { get; set; }
 
+			public TaskCompletionSource<bool> CompletionSource { get; private set; } = new TaskCompletionSource<bool>();
+
 			public async void Load()
 			{
 				if (initialLoad && Element.Source != null)
@@ -257,6 +260,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 					finally
 					{
 						controller.SetIsLoading(false);
+						CompletionSource.SetResult(true);
 					}
 				}
 			}

--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Maui.Handlers
 
 				var safeHostUri = new Uri($"{uri.Scheme}://{uri.Authority}", UriKind.Absolute);
 				var safeRelativeUri = new Uri($"{uri.PathAndQuery}{uri.Fragment}", UriKind.Relative);
-				NSUrlRequest request = new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri));
+				NSUrlRequest request = new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri)!);
 
 				if (HasCookiesToLoad(url) && !(OperatingSystem.IsIOSVersionAtLeast(11) || OperatingSystem.IsTvOSVersionAtLeast(11)))
 					return;

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Maui.Platform
 			var uri = new Uri(url ?? string.Empty);
 			var safeHostUri = new Uri($"{uri.Scheme}://{uri.Authority}", UriKind.Absolute);
 			var safeRelativeUri = new Uri($"{uri.PathAndQuery}{uri.Fragment}", UriKind.Relative);
-			NSUrlRequest request = new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri));
+			NSUrlRequest request = new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri)!);
 
 			LoadRequest(request);
 		}


### PR DESCRIPTION
### Description of Change

Taking all the code and csproj changes from net7 and merging into main.

This is because main is where they should have gone, and it makes merging from main into net7 easier and less conflict-y.

It also switches the main build from MSBuild to dotnet build - making life much easier!