### PR TITLE
Measure Images in FlexLayout at full size

### DIFF
--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -471,6 +471,9 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+		// Until we can rewrite the FlexLayout engine to handle measurement properly (without the "in measure mode" hacks)
+		// we need to replace the default implementation of CrossPlatformMeasure.
+		// And we need to disable the public API analyzer briefly, because it doesn't understand hiding.
 #pragma warning disable RS0016 // Add public types and members to the declared API
 		new public Graphics.Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
 #pragma warning restore RS0016 // Add public types and members to the declared API

--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -471,19 +471,46 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		new public Graphics.Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+#pragma warning restore RS0016 // Add public types and members to the declared API
+		{
+			var layoutManager = _layoutManager ??= CreateLayoutManager();
+
+			InMeasureMode = true;
+			var result =  layoutManager.Measure(widthConstraint, heightConstraint);
+			InMeasureMode = false;
+
+			return result;
+		}
+
+		internal bool InMeasureMode { get; set; }
+
 		void AddFlexItem(IView child)
 		{
 			if (_root == null)
 				return;
 			var item = (child as FlexLayout)?._root ?? new Flex.Item();
 			InitItemProperties(child, item);
-			if (!(child is FlexLayout))
-			{ //inner layouts don't get measured
+			if (child is not FlexLayout)
+			{ 
 				item.SelfSizing = (Flex.Item it, ref float w, ref float h) =>
 				{
 					var sizeConstraints = item.GetConstraints();
-					sizeConstraints.Width = (sizeConstraints.Width == 0) ? double.PositiveInfinity : sizeConstraints.Width;
-					sizeConstraints.Height = (sizeConstraints.Height == 0) ? double.PositiveInfinity : sizeConstraints.Height;
+
+					sizeConstraints.Width = (InMeasureMode && sizeConstraints.Width == 0) ? double.PositiveInfinity : sizeConstraints.Width;
+					sizeConstraints.Height = (InMeasureMode && sizeConstraints.Height == 0) ? double.PositiveInfinity : sizeConstraints.Height;
+
+					if (child is Image)
+					{
+						// This is a hack to get FlexLayout to behave like it did in Forms
+						// Forms always did its initial image measure unconstrained, which would return
+						// the intrinsic size of the image (no scaling or aspect ratio adjustments)
+
+						sizeConstraints.Width = double.PositiveInfinity;
+						sizeConstraints.Height = double.PositiveInfinity;
+					}
+
 					var request = child.Measure(sizeConstraints.Width, sizeConstraints.Height);
 					w = (float)request.Width;
 					h = (float)request.Height;
@@ -533,9 +560,21 @@ namespace Microsoft.Maui.Controls
 		{
 			if (_root.Parent != null)   //Layout is only computed at root level
 				return;
+
+			var useMeasureHack = NeedsMeasureHack(width, height);
+			if (useMeasureHack)
+			{
+				PrepareMeasureHack();
+			}
+
 			_root.Width = !double.IsPositiveInfinity((width)) ? (float)width : 0;
 			_root.Height = !double.IsPositiveInfinity((height)) ? (float)height : 0;
 			_root.Layout();
+
+			if (useMeasureHack)
+			{
+				RestoreValues();
+			}
 		}
 
 		protected override void OnParentSet()
@@ -600,25 +639,6 @@ namespace Microsoft.Maui.Controls
 			base.OnClear();
 			ClearLayout();
 			PopulateLayout();
-		}
-
-		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
-		{
-			var useMeasureHack = NeedsMeasureHack(widthConstraint, heightConstraint);
-
-			if (useMeasureHack)
-			{
-				PrepareMeasureHack();
-			}
-
-			var result = base.MeasureOverride(widthConstraint, heightConstraint);
-
-			if (useMeasureHack)
-			{
-				RestoreValues();
-			}
-
-			return result;
 		}
 
 		static bool NeedsMeasureHack(double widthConstraint, double heightConstraint)

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -3048,7 +3048,6 @@ override Microsoft.Maui.Controls.Editor.ArrangeOverride(Microsoft.Maui.Graphics.
 override Microsoft.Maui.Controls.Editor.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.Element.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.FileImageSource.IsEmpty.get -> bool
-override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlexLayout.OnClear() -> void
 override Microsoft.Maui.Controls.FlexLayout.OnParentSet() -> void
 override Microsoft.Maui.Controls.FlyoutPage.LayoutChildren(double x, double y, double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -3046,7 +3046,6 @@ override Microsoft.Maui.Controls.Editor.ArrangeOverride(Microsoft.Maui.Graphics.
 override Microsoft.Maui.Controls.Editor.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.Element.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.FileImageSource.IsEmpty.get -> bool
-override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlexLayout.OnClear() -> void
 override Microsoft.Maui.Controls.FlexLayout.OnParentSet() -> void
 override Microsoft.Maui.Controls.FlyoutPage.LayoutChildren(double x, double y, double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -3046,7 +3046,6 @@ override Microsoft.Maui.Controls.Editor.ArrangeOverride(Microsoft.Maui.Graphics.
 override Microsoft.Maui.Controls.Editor.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.Element.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.FileImageSource.IsEmpty.get -> bool
-override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlexLayout.OnClear() -> void
 override Microsoft.Maui.Controls.FlexLayout.OnParentSet() -> void
 override Microsoft.Maui.Controls.FlyoutPage.LayoutChildren(double x, double y, double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -3011,7 +3011,6 @@ override Microsoft.Maui.Controls.Editor.ArrangeOverride(Microsoft.Maui.Graphics.
 override Microsoft.Maui.Controls.Editor.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.Element.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.FileImageSource.IsEmpty.get -> bool
-override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlexLayout.OnClear() -> void
 override Microsoft.Maui.Controls.FlexLayout.OnParentSet() -> void
 override Microsoft.Maui.Controls.FlyoutPage.LayoutChildren(double x, double y, double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -2977,7 +2977,6 @@ override Microsoft.Maui.Controls.Editor.ArrangeOverride(Microsoft.Maui.Graphics.
 override Microsoft.Maui.Controls.Editor.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.Element.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.FileImageSource.IsEmpty.get -> bool
-override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlexLayout.OnClear() -> void
 override Microsoft.Maui.Controls.FlexLayout.OnParentSet() -> void
 override Microsoft.Maui.Controls.FlyoutPage.LayoutChildren(double x, double y, double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Shipped.txt
@@ -2820,7 +2820,6 @@ override Microsoft.Maui.Controls.Editor.ArrangeOverride(Microsoft.Maui.Graphics.
 override Microsoft.Maui.Controls.Editor.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.Element.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.FileImageSource.IsEmpty.get -> bool
-override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlexLayout.OnClear() -> void
 override Microsoft.Maui.Controls.FlexLayout.OnParentSet() -> void
 override Microsoft.Maui.Controls.FlyoutPage.LayoutChildren(double x, double y, double width, double height) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -2820,7 +2820,6 @@ override Microsoft.Maui.Controls.Editor.ArrangeOverride(Microsoft.Maui.Graphics.
 override Microsoft.Maui.Controls.Editor.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.Element.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.FileImageSource.IsEmpty.get -> bool
-override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlexLayout.OnClear() -> void
 override Microsoft.Maui.Controls.FlexLayout.OnParentSet() -> void
 override Microsoft.Maui.Controls.FlyoutPage.LayoutChildren(double x, double y, double width, double height) -> void

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
+{
+	[TestFixture, Category("Layout")]
+	public class FlexLayoutTests
+	{
+		class TestImage : Image
+		{
+			public bool Passed { get; private set; }
+
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+			{
+				if (double.IsPositiveInfinity(widthConstraint) && double.IsPositiveInfinity(heightConstraint))
+				{
+					Passed = true;
+				}
+
+				return base.MeasureOverride(widthConstraint, heightConstraint);
+			}
+		}
+
+		[Test]
+		public void FlexLayoutMeasuresImagesUnconstrained()
+		{
+			var root = new Grid();
+			var flexLayout = new FlexLayout() as IFlexLayout;
+			var image = new TestImage();
+
+			root.Add(flexLayout);
+			flexLayout.Add(image as IView);
+
+			var manager = new FlexLayoutManager(flexLayout);
+			_ = manager.Measure(1000, 1000);
+
+			Assert.True(image.Passed, "Image should be measured unconstrained even if the FlexLayout is constrained.");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Force FlexLayout image measurement to measure images at full size to preserve legacy behavior.

### Issues Fixed

Fixes #4080
