### PR TITLE
Wait to fire nav events until page exists

### DIFF
--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -856,10 +856,9 @@ namespace Microsoft.Maui.Controls
 				SetCurrentItem()
 					.FireAndForget();
 
-			((ShellElementCollection)Items).VisibleItemsChangedInternal += (s, e) =>
+			((ShellElementCollection)Items).VisibleItemsChangedInternal += async (s, e) =>
 			{
-				SetCurrentItem()
-					.FireAndForget();
+				await SetCurrentItem();
 
 				SendStructureChanged();
 				SendFlyoutItemsChanged();

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -156,12 +156,6 @@ namespace Microsoft.Maui.Controls
 			base.OnChildAdded(child);
 			if (child is Page page)
 			{
-				if (IsVisibleContent && page.IsVisible)
-				{
-					SendAppearing();
-					SendPageAppearing(page);
-				}
-
 				page.PropertyChanged += OnPagePropertyChanged;
 				_isPageVisibleChanged?.Invoke(this, EventArgs.Empty);
 			}

--- a/src/Controls/tests/Core.UnitTests/ShellTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTests.cs
@@ -1191,6 +1191,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public async Task GetCurrentPageBetweenSections()
 		{
 			var shell = new Shell();
+			_ = new Window() { Page = shell };
 			var one = new ShellItem { Route = "one" };
 			var two = new ShellItem { Route = "two" };
 
@@ -1225,6 +1226,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void GetCurrentPageOnInit()
 		{
 			var shell = new Shell();
+			_ = new Window() { Page = shell };
 			Page page = null;
 			shell.Navigated += (_, __) =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -101,26 +101,40 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-
-
 		[Fact(DisplayName = "Navigating During Navigated Doesnt ReFire Appearing")]
 		public async Task NavigatingDuringNavigatedDoesntReFireAppearing()
 		{
 			SetupBuilder();
 			var contentPage = new ContentPage();
+			var secondContentPage = new ContentPage();
 			int contentPageAppearingFired = 0;
 			int navigatedToFired = 0;
+
+			int secondContentPageAppearingFired = 0;
+			int secondNavigatedToFired = 0;
+
 			TaskCompletionSource<object> finishedSecondNavigation = new TaskCompletionSource<object>();
 			contentPage.Appearing += (_, _) =>
 			{
 				contentPageAppearingFired++;
 			};
 
+			secondContentPage.Appearing += (_, _) =>
+			{
+				secondContentPageAppearingFired++;
+				Assert.Equal(0, secondNavigatedToFired);
+			};
+
+			secondContentPage.NavigatedTo += (_, _) =>
+			{
+				secondNavigatedToFired++;
+			};
+
 			Shell shell = null;
 			contentPage.NavigatedTo += async (_, _) =>
 			{
 				navigatedToFired++;
-				await shell.Navigation.PushAsync(new ContentPage());
+				await shell.Navigation.PushAsync(secondContentPage);
 				finishedSecondNavigation.SetResult(true);
 			};
 
@@ -144,6 +158,8 @@ namespace Microsoft.Maui.DeviceTests
 
 				Assert.Equal(1, contentPageAppearingFired);
 				Assert.Equal(1, navigatedToFired);
+				Assert.Equal(1, secondContentPageAppearingFired);
+				Assert.Equal(1, secondNavigatedToFired);
 			});
 		}
 


### PR DESCRIPTION
### Description of Change

- When we added window to everything the appearing call on page was setup so it wouldn't fire until a window was attached. When shell is first initializing it fires the appearing/navigation events [too early](https://github.com/dotnet/maui/issues/6193). This PR ensures that the ordering is correct and that the events will refire once shell has been attached to the window. Ideally we will fix #6193 but it's important to at least have this code in place that enforces some lifecycle expectations
- Remove the code that would fire appearing when the ShellContent datatemplate is constructed. The datatemplate might create the ShellContent while navigating away from that content is occurring (if the user does a navigation inside appearing or navigated). This code was old and the appearing process is now all handled higher up.

### Issues Fixed


Fixes #6716
