### PR TITLE
Run the Templates test on implicit and explicit TFMs

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -9,7 +9,7 @@ string MSBuildExe = Argument("msbuild", EnvironmentVariable("MSBUILD_EXE", ""));
 string TestTFM = Argument("testtfm", "");
 Exception pendingException = null;
 
-var NuGetOnlyPackages = new [] {
+var NuGetOnlyPackages = new string[] {
 };
 
 // Tasks for CI

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -290,7 +290,8 @@ Task("dotnet-pack-library-packs")
             CleanDirectories(tempDir);
         }
 
-        // Download("PACKAGE_ID", "VERSION_VARIABLE", "SOURCE_URL");
+        Download("Microsoft.Maui.Graphics", "MicrosoftMauiGraphicsVersion", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json");
+        Download("Microsoft.Maui.Graphics.Win2D.WinUI.Desktop", "MicrosoftMauiGraphicsVersion", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json", "https://api.nuget.org/v3/index.json");
     });
 
 Task("dotnet-pack-docs")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -8,6 +8,9 @@ var vsVersion = GetBuildVariable("VS", "");
 string MSBuildExe = Argument("msbuild", EnvironmentVariable("MSBUILD_EXE", ""));
 Exception pendingException = null;
 
+var NuGetOnlyPackages = new [] {
+};
+
 // Tasks for CI
 
 Task("dotnet")
@@ -82,9 +85,12 @@ Task("dotnet-build")
 Task("dotnet-samples")
     .Does(() =>
     {
+        var tempDir = PrepareSeparateBuildContext("samplesTest", false);
+
         RunMSBuildWithDotNet("./Microsoft.Maui.Samples.slnf", new Dictionary<string, string> {
             ["UseWorkload"] = "true",
             // ["GenerateAppxPackageOnBuild"] = "true",
+            ["RestoreConfigFile"] = tempDir.CombineWithFilePath("NuGet.config").FullPath,
         });
     });
 
@@ -96,15 +102,7 @@ Task("dotnet-templates")
 
         var dn = localDotnet ? dotnetPath : "dotnet";
 
-        var templatesTest = GetTempDirectory().Combine("templatesTest");
-
-        EnsureDirectoryExists(templatesTest);
-        CleanDirectories(templatesTest.FullPath);
-
-        // Create empty Directory.Build.props/targets
-        FileWriteText(templatesTest.CombineWithFilePath("Directory.Build.props"), "<Project/>");
-        FileWriteText(templatesTest.CombineWithFilePath("Directory.Build.targets"), "<Project/>");
-        CopyFileToDirectory(File("./NuGet.config"), templatesTest);
+        var tempDir = PrepareSeparateBuildContext("templatesTest", true);
 
         // See: https://github.com/dotnet/project-system/blob/main/docs/design-time-builds.md
         var designTime = new Dictionary<string, string> {
@@ -120,8 +118,8 @@ Task("dotnet-templates")
             // Properties that ensure we don't use cached packages, and *only* the empty NuGet.config
             { "RestoreNoCache", "true" },
             // { "GenerateAppxPackageOnBuild", "true" },
-            { "RestorePackagesPath", MakeAbsolute(templatesTest.CombineWithFilePath("packages")).FullPath },
-            { "RestoreConfigFile", MakeAbsolute(templatesTest.CombineWithFilePath("nuget.config")).FullPath },
+            { "RestorePackagesPath", tempDir.Combine("packages").FullPath },
+            { "RestoreConfigFile", tempDir.CombineWithFilePath("NuGet.config").FullPath },
 
             // Avoid iOS build warning as error on Windows: There is no available connection to the Mac. Task 'VerifyXcodeVersion' will not be executed
             { "CustomBeforeMicrosoftCSharpTargets", MakeAbsolute(File("./src/Templates/TemplateTestExtraTargets.targets")).FullPath },
@@ -154,7 +152,7 @@ Task("dotnet-templates")
                 var projectName = template.Key.Split(":")[0];
                 var templateName = template.Key.Split(":")[1];
 
-                projectName = $"{templatesTest}/{projectName}_{type}";
+                projectName = $"{tempDir}/{projectName}_{type}";
 
                 // Create
                 StartProcess(dn, $"new {templateName} -o \"{projectName}\"");
@@ -182,7 +180,7 @@ Task("dotnet-templates")
 
         try
         {
-            CleanDirectories(templatesTest.FullPath);
+            CleanDirectories(tempDir.FullPath);
         }
         catch
         {
@@ -284,8 +282,7 @@ Task("dotnet-pack-library-packs")
             CleanDirectories(tempDir);
         }
 
-        Download("Microsoft.Maui.Graphics", "MicrosoftMauiGraphicsVersion", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json");
-        Download("Microsoft.Maui.Graphics.Win2D.WinUI.Desktop", "MicrosoftMauiGraphicsVersion", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json", "https://api.nuget.org/v3/index.json");
+        // Download("PACKAGE_ID", "VERSION_VARIABLE", "SOURCE_URL");
     });
 
 Task("dotnet-pack-docs")
@@ -694,4 +691,35 @@ void RunTestWithLocalDotNet(string csproj)
             ResultsDirectory = GetTestResultsDirectory(),
             ArgumentCustomization = args => args.Append($"-bl:{binlog}")
         });
+}
+
+DirectoryPath PrepareSeparateBuildContext(string dirName, bool generateDirectoryProps = false)
+{
+    var dir = GetTempDirectory().Combine(dirName);
+    EnsureDirectoryExists(dir);
+    CleanDirectories(dir.FullPath);
+
+    var nugetOnly = dir.Combine("nuget-only");
+    EnsureDirectoryExists(nugetOnly);
+    CleanDirectories(nugetOnly.FullPath);
+
+    CopyFileToDirectory(File("./NuGet.config"), dir);
+    var config = dir.CombineWithFilePath("NuGet.config");
+
+    foreach (var pattern in NuGetOnlyPackages)
+    {
+        CopyFiles($"./artifacts/{pattern}", nugetOnly, false);
+    }
+
+    // Add a specific folder for nuget-only packages
+    ReplaceTextInFiles(
+        config.FullPath,
+        $"<!-- <add key=\"local\" value=\"artifacts\" /> -->",
+        $"<add key=\"nuget-only\" value=\"{nugetOnly.FullPath}\" />");
+
+    // Create empty Directory.Build.props/targets
+    FileWriteText(dir.CombineWithFilePath("Directory.Build.props"), "<Project/>");
+    FileWriteText(dir.CombineWithFilePath("Directory.Build.targets"), "<Project/>");
+
+    return MakeAbsolute(dir);
 }

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -12,6 +12,8 @@ Exception pendingException = null;
 var NuGetOnlyPackages = new string[] {
 };
 
+throw new Exception($"We got '{TestTFM}'.");
+
 // Tasks for CI
 
 Task("dotnet")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -12,8 +12,6 @@ Exception pendingException = null;
 var NuGetOnlyPackages = new string[] {
 };
 
-throw new Exception($"We got '{TestTFM}'.");
-
 // Tasks for CI
 
 Task("dotnet")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -130,7 +130,6 @@ Task("dotnet-templates")
         };
 
         var templates = new Dictionary<string, Action<DirectoryPath>> {
-            { "classlib:classlib", null },
             { "maui:maui", null },
             { "mauiblazor:maui-blazor", null },
             { "mauilib:mauilib", null },

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -7,6 +7,9 @@ var localDotnet = GetBuildVariable("workloads", "local") == "local";
 var vsVersion = GetBuildVariable("VS", "");
 string MSBuildExe = Argument("msbuild", EnvironmentVariable("MSBUILD_EXE", ""));
 string TestTFM = Argument("testtfm", "");
+if (TestTFM == "default")
+    TestTFM = "";
+
 Exception pendingException = null;
 
 var NuGetOnlyPackages = new string[] {

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -309,7 +309,7 @@ stages:
                   env:
                     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                     PRIVATE_BUILD: $(PrivateBuild)
-                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="""${{ TestTFM.tfm }}""" --verbosity=diagnostic
+                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="\""${{ TestTFM.tfm }}"\"" --verbosity=diagnostic
                   displayName: 'Build .NET MAUI Templates'
                 - task: PublishBuildArtifacts@1
                   condition: always()

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -153,7 +153,7 @@ stages:
                     UninstallMono: false
                     UninstallXamarinMac: false
                     CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
-              - pwsh: ./build.ps1 --target=dotnet-build  --testtfm="\""${{ parameters.THEBIGTEST }}"\"" --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+              - pwsh: ./build.ps1 --target=dotnet-build  --testtfm=""${{ parameters.THEBIGTEST }}"" --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET Maui'
               - template: common/provision.yml
                 parameters:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -309,7 +309,7 @@ stages:
                   env:
                     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                     PRIVATE_BUILD: $(PrivateBuild)
-                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="${{ TestTFM.tfm }}" --verbosity=diagnostic
+                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm=""${{ TestTFM.tfm }}"" --verbosity=diagnostic
                   displayName: 'Build .NET MAUI Templates'
                 - task: PublishBuildArtifacts@1
                   condition: always()

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -153,7 +153,7 @@ stages:
                     UninstallMono: false
                     UninstallXamarinMac: false
                     CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
-              - pwsh: ./build.ps1 --target=dotnet-build  --testtfm=""${{ parameters.THEBIGTEST }}"" --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+              - pwsh: ./build.ps1 --target=dotnet-build  --testtfm=""""${{ parameters.THEBIGTEST }}"""" --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET Maui'
               - template: common/provision.yml
                 parameters:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -309,7 +309,7 @@ stages:
                   env:
                     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                     PRIVATE_BUILD: $(PrivateBuild)
-                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="\"${{ TestTFM.tfm }}\"" --verbosity=diagnostic
+                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="`"${{ TestTFM.tfm }}`"" --verbosity=diagnostic
                   displayName: 'Build .NET MAUI Templates'
                 - task: PublishBuildArtifacts@1
                   condition: always()

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -104,6 +104,9 @@ parameters:
         tfm: ''
       - name: net6
         tfm: net6.0
+  - name: THEBIGTEST
+    type: string
+    default: ''
 
 resources:
   repositories:
@@ -150,6 +153,8 @@ stages:
                     UninstallMono: false
                     UninstallXamarinMac: false
                     CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
+              - pwsh: ./build.ps1 --target=dotnet-build  --testtfm="\""${{ parameters.THEBIGTEST }}"\"" --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+                displayName: 'Build .NET Maui'
               - template: common/provision.yml
                 parameters:
                   platform: ${{ BuildPlatform.name }}
@@ -161,7 +166,7 @@ stages:
                 env:
                   DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                   PRIVATE_BUILD: $(PrivateBuild)
-              - pwsh: ./build.ps1 --target=dotnet-build --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+              - pwsh: ./build.ps1 --target=dotnet-build  --testtfm="\""${{ parameters.THEBIGTEST }}"\"" --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET Maui'
               - pwsh: ./build.ps1 --target=dotnet-test --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Run Unit Tests'

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -101,7 +101,7 @@ parameters:
     type: object
     default:
       - name: default
-        tfm: ''
+        tfm: ' '
       - name: net6
         tfm: net6.0
 
@@ -309,7 +309,7 @@ stages:
                   env:
                     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                     PRIVATE_BUILD: $(PrivateBuild)
-                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm=""""${{ TestTFM.tfm }}"""" --verbosity=diagnostic
+                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="\"${{ TestTFM.tfm }}\"" --verbosity=diagnostic
                   displayName: 'Build .NET MAUI Templates'
                 - task: PublishBuildArtifacts@1
                   condition: always()

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -97,6 +97,13 @@ parameters:
         bootsiOS: $(iOS.Pkg)
         bootsMacCatalyst: $(MacCatalyst.Pkg)
         artifact: nuget-macos
+  - name: TestTargetFrameworks
+    type: object
+    default:
+      - name: default
+        tfm: ''
+      - name: net6
+        tfm: net6.0
 
 resources:
   repositories:
@@ -258,56 +265,57 @@ stages:
     jobs:
       - ${{ each BuildPlatform in parameters.BuildPlatforms }}:
         - ${{ each BuildConfiguration in parameters.BuildConfigurations }}:
-          - job: build_net6_${{ BuildPlatform.name }}_${{ BuildConfiguration }}
-            workspace:
-              clean: all
-            displayName: ${{ BuildPlatform.name }} (${{ BuildConfiguration }})
-            timeoutInMinutes: 120
-            condition: or(
-              ${{ parameters.BuildEverything }},
-              ne(variables['Build.Reason'], 'PullRequest'),
-              eq('${{ BuildConfiguration }}', 'Release'))
-            pool:
-              name: ${{ BuildPlatform.poolName }}
-              vmImage: ${{ BuildPlatform.vmImage }}
-              demands:
-                - macOS.Name -equals Monterey
-                - macOS.Architecture -equals x64
-                - Agent.HasDevices -equals False
-                - Agent.IsPaired -equals False
-            steps:
-              - ${{ if eq(BuildPlatform.name, 'macOS') }}:
-                - template: agent-cleanser/v1.yml@xamarin-templates
+          - ${{ each TestTFM in parameters.TestTargetFrameworks }}:
+            - job: build_${{ TestTFM.name }}_${{ BuildPlatform.name }}_${{ BuildConfiguration }}
+              workspace:
+                clean: all
+              displayName: ${{ BuildPlatform.name }} ${{ TestTFM.tfm }} (${{ BuildConfiguration }})
+              timeoutInMinutes: 120
+              condition: or(
+                ${{ parameters.BuildEverything }},
+                ne(variables['Build.Reason'], 'PullRequest'),
+                eq('${{ BuildConfiguration }}', 'Release'))
+              pool:
+                name: ${{ BuildPlatform.poolName }}
+                vmImage: ${{ BuildPlatform.vmImage }}
+                demands:
+                  - macOS.Name -equals Monterey
+                  - macOS.Architecture -equals x64
+                  - Agent.HasDevices -equals False
+                  - Agent.IsPaired -equals False
+              steps:
+                - ${{ if eq(BuildPlatform.name, 'macOS') }}:
+                  - template: agent-cleanser/v1.yml@xamarin-templates
+                    parameters:
+                      UninstallMono: false
+                      UninstallXamarinMac: false
+                      CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
+                - template: common/provision.yml
                   parameters:
-                    UninstallMono: false
-                    UninstallXamarinMac: false
-                    CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
-              - template: common/provision.yml
-                parameters:
-                  platform: ${{ BuildPlatform.name }}
-                  poolName: ${{ BuildPlatform.poolName }}
-                  provisionatorChannel: ${{ parameters.provisionatorChannel }}
-              - task: DownloadBuildArtifacts@0
-                displayName: 'Download Packages'
-                inputs:
-                  artifactName: nuget
-                  itemPattern: '**/*.nupkg'
-                  downloadPath: $(System.DefaultWorkingDirectory)/artifacts
-              - pwsh: Move-Item -Path artifacts\nuget\*.nupkg -Destination artifacts -Force
-                displayName: Move the downloaded artifacts
-              - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                displayName: 'Install .NET (Local Workloads)'
-                retryCountOnTaskFailure: 3
-                env:
-                  DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-                  PRIVATE_BUILD: $(PrivateBuild)
-              - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                displayName: 'Build .NET MAUI Templates'
-              - task: PublishBuildArtifacts@1
-                condition: always()
-                displayName: publish artifacts
-                inputs:
-                  ArtifactName: ${{ BuildPlatform.artifact }}
+                    platform: ${{ BuildPlatform.name }}
+                    poolName: ${{ BuildPlatform.poolName }}
+                    provisionatorChannel: ${{ parameters.provisionatorChannel }}
+                - task: DownloadBuildArtifacts@0
+                  displayName: 'Download Packages'
+                  inputs:
+                    artifactName: nuget
+                    itemPattern: '**/*.nupkg'
+                    downloadPath: $(System.DefaultWorkingDirectory)/artifacts
+                - pwsh: Move-Item -Path artifacts\nuget\*.nupkg -Destination artifacts -Force
+                  displayName: Move the downloaded artifacts
+                - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+                  displayName: 'Install .NET (Local Workloads)'
+                  retryCountOnTaskFailure: 3
+                  env:
+                    DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+                    PRIVATE_BUILD: $(PrivateBuild)
+                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="${{ TestTFM.tfm }}" --verbosity=diagnostic
+                  displayName: 'Build .NET MAUI Templates'
+                - task: PublishBuildArtifacts@1
+                  condition: always()
+                  displayName: publish artifacts
+                  inputs:
+                    ArtifactName: ${{ BuildPlatform.artifact }}
 
   - template: common/security-compliance.yml
 

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -104,9 +104,6 @@ parameters:
         tfm: ''
       - name: net6
         tfm: net6.0
-  - name: THEBIGTEST
-    type: string
-    default: ''
 
 resources:
   repositories:
@@ -153,8 +150,6 @@ stages:
                     UninstallMono: false
                     UninstallXamarinMac: false
                     CleanseAgentToolsDotNet: true           # Cleanse all .NET versions under the agent tools directory and use only those provisioned by the pipeline
-              - pwsh: ./build.ps1 --target=dotnet-build  --testtfm=""""${{ parameters.THEBIGTEST }}"""" --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
-                displayName: 'Build .NET Maui'
               - template: common/provision.yml
                 parameters:
                   platform: ${{ BuildPlatform.name }}
@@ -166,7 +161,7 @@ stages:
                 env:
                   DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                   PRIVATE_BUILD: $(PrivateBuild)
-              - pwsh: ./build.ps1 --target=dotnet-build  --testtfm="\""${{ parameters.THEBIGTEST }}"\"" --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
+              - pwsh: ./build.ps1 --target=dotnet-build --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Build .NET Maui'
               - pwsh: ./build.ps1 --target=dotnet-test --configuration="${{ BuildConfiguration }}" --verbosity=diagnostic
                 displayName: 'Run Unit Tests'
@@ -314,7 +309,7 @@ stages:
                   env:
                     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                     PRIVATE_BUILD: $(PrivateBuild)
-                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="\""${{ TestTFM.tfm }}"\"" --verbosity=diagnostic
+                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm=""""${{ TestTFM.tfm }}"""" --verbosity=diagnostic
                   displayName: 'Build .NET MAUI Templates'
                 - task: PublishBuildArtifacts@1
                   condition: always()

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -101,7 +101,7 @@ parameters:
     type: object
     default:
       - name: default
-        tfm: ' '
+        tfm: default
       - name: net6
         tfm: net6.0
 
@@ -309,7 +309,7 @@ stages:
                   env:
                     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                     PRIVATE_BUILD: $(PrivateBuild)
-                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="`"${{ TestTFM.tfm }}`"" --verbosity=diagnostic
+                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="${{ TestTFM.tfm }}" --verbosity=diagnostic
                   displayName: 'Build .NET MAUI Templates'
                 - task: PublishBuildArtifacts@1
                   condition: always()

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -102,8 +102,6 @@ parameters:
     default:
       - name: default
         tfm: default
-      - name: net6
-        tfm: net6.0
 
 resources:
   repositories:

--- a/eng/pipelines/handlers.yml
+++ b/eng/pipelines/handlers.yml
@@ -309,7 +309,7 @@ stages:
                   env:
                     DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
                     PRIVATE_BUILD: $(PrivateBuild)
-                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm=""${{ TestTFM.tfm }}"" --verbosity=diagnostic
+                - pwsh: ./build.ps1 --target=dotnet-templates --configuration="${{ BuildConfiguration }}" --testtfm="""${{ TestTFM.tfm }}""" --verbosity=diagnostic
                   displayName: 'Build .NET MAUI Templates'
                 - task: PublishBuildArtifacts@1
                   condition: always()


### PR DESCRIPTION
### Description of Change

Make the templates get created with and without the `--framework` option when doing `dotnet new` so we can make sure that also works.

This is also the testing part for #8203

Just indented the templates stage, so this is without the ws changes: https://github.com/dotnet/maui/pull/8237/files?w=1