### PR TITLE
[layout] avoid IView[] creation in LayoutExtensions

### DIFF
--- a/src/Core/src/Handlers/Layout/LayoutExtensions.cs
+++ b/src/Core/src/Handlers/Layout/LayoutExtensions.cs
@@ -1,59 +1,23 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Maui.Handlers
 {
 	internal static class LayoutExtensions
 	{
-		record ViewAndIndex(IView View, int Index);
-
-		class ZIndexComparer : IComparer<ViewAndIndex>
-		{
-			public int Compare(ViewAndIndex? x, ViewAndIndex? y)
-			{
-				if (x == null || y == null)
-				{
-					return 0;
-				}
-
-				var zIndexCompare = x.View.ZIndex.CompareTo(y.View.ZIndex);
-
-				if (zIndexCompare == 0)
-				{
-					return x.Index.CompareTo(y.Index);
-				}
-
-				return zIndexCompare;
-			}
-		}
-
-		static ZIndexComparer s_comparer = new();
-
-		public static IView[] OrderByZIndex(this ILayout layout)
-		{
-			var count = layout.Count;
-			var indexedViews = new ViewAndIndex[count];
-
-			for (int n = 0; n < count; n++)
-			{
-				indexedViews[n] = new ViewAndIndex(layout[n], n);
-			}
-
-			Array.Sort(indexedViews, s_comparer);
-
-			var ordered = new IView[count];
-
-			for (int n = 0; n < count; n++)
-			{
-				ordered[n] = indexedViews[n].View;
-			}
-
-			return ordered;
-		}
+		public static IOrderedEnumerable<IView> OrderByZIndex(this ILayout layout) => layout.OrderBy(v => v.ZIndex);
 
 		public static int GetLayoutHandlerIndex(this ILayout layout, IView view)
 		{
-			return layout.OrderByZIndex().IndexOf(view);
+			switch (layout.Count)
+			{
+				case 0:
+					return -1;
+				case 1:
+					return view == layout[0] ? 0 : -1;
+				default:
+					return layout.OrderByZIndex().IndexOf(view);
+			}
 		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/ZIndexTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Primitives;
@@ -209,7 +210,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			layout.Add(view0);
 			layout.Add(view1);
 
-			var zordered = layout.OrderByZIndex();
+			var zordered = layout.OrderByZIndex().ToArray();
 			Assert.Equal(view1, zordered[0]);
 			Assert.Equal(view0, zordered[1]);
 		}
@@ -228,7 +229,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			layout.Add(view2);
 			layout.Add(view3);
 
-			var zordered = layout.OrderByZIndex();
+			var zordered = layout.OrderByZIndex().ToArray();
 			Assert.Equal(view0, zordered[0]);
 			Assert.Equal(view1, zordered[1]);
 			Assert.Equal(view2, zordered[2]);
@@ -237,7 +238,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Fake an update
 			view3.ZIndex.Returns(5);
 
-			zordered = layout.OrderByZIndex();
+			zordered = layout.OrderByZIndex().ToArray();
 			Assert.Equal(view0, zordered[0]);
 			Assert.Equal(view1, zordered[1]);
 			Assert.Equal(view2, zordered[2]);
@@ -267,7 +268,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			for (int i = 0; i < iterations; i++)
 			{
-				var zordered = layout.OrderByZIndex();
+				var zordered = layout.OrderByZIndex().ToArray();
 
 				for (int n = 0; n < zordered.Length; n++)
 				{


### PR DESCRIPTION
Context: https://github.com/unoplatform/performance/tree/master/src/dopes/DopeTestMaui

Reviewing `dotnet trace` output of the "dopes" test sample, 7% of CPU
time is spent in `LayoutExtensions.OrderByZIndex()`:

![image](https://user-images.githubusercontent.com/840039/175125295-92d3268d-230b-475a-89d1-564d089d6af9.png)

    3.42s (16%)  microsoft.maui!Microsoft.Maui.Handlers.LayoutHandler.Add(Microsoft.Maui.IView)
    1.52s (7.3%) microsoft.maui!Microsoft.Maui.Handlers.LayoutExtensions.GetLayoutHandlerIndex(Microsoft.Maui.ILayout,Microsoft.Maui.IVie...
    1.50s (7.2%) microsoft.maui!Microsoft.Maui.Handlers.LayoutExtensions.OrderByZIndex(Microsoft.Maui.ILayout)

Reviewing the code in `OrderByZIndex()`:

* Makes a `record ViewAndIndex(IView View, int Index)`
  for each child
* Makes a `ViewAndIndex[]` the size of the number of children
* Call `Array.Sort()`
* Makes a `IView[]` the size of the number of children
* Iterating twice over the arrays in the process

Then if you look at the `GetLayoutHandlerIndex()` method, it does all
the same work to create an `IView[]`, get the index, then throws the
array away.

I removed the above code and used a System.Linq `OrderBy()` with
faster paths for 0 or 1 children. I also made an `internal`
`EnumerateByZIndex()` method for use by `foreach` loops. This avoids
creating arrays in those cases. The `ZIndexTests` still pass for me,
which proves out `OrderBy()`'s stable sort:

https://docs.microsoft.com/dotnet/api/system.linq.enumerable.orderby

After this change, the % time spent in these methods went down:

      1.84s (13%)    microsoft.maui!Microsoft.Maui.Handlers.LayoutHandler.Add(Microsoft.Maui.IView)
    352.24ms (2.50%) microsoft.maui!Microsoft.Maui.Handlers.LayoutExtensions.GetLayoutHandlerIndex(Microsoft.Maui.ILayout,Microsoft.Maui.IVie...
    181.27ms (1.30%) microsoft.maui!Microsoft.Maui.Handlers.LayoutExtensions.<>c.<EnumerateByZIndex>b__0_0(Microsoft.Maui.IView)
      2.78ms (0.02%) microsoft.maui!Microsoft.Maui.Handlers.LayoutExtensions.EnumerateByZIndex(Microsoft.Maui.ILayout)

This kind of goes against the guidance "avoid System.Linq".
But `OrderBy()` generally seems to be fine?

## Results ##

A `Release` build on a Pixel 5 device, I was getting:

    Before:
    103.04 Dopes/s
    After:
    230.87 Dopes/s

I suspect that was a lot of `IView[]`'s before!

![image](https://user-images.githubusercontent.com/840039/175125098-3fb7a81e-920d-4f59-b42a-073ff8fb2e5f.png)