### PR TITLE
Fix RadioButton DefaultTemplate

### DIFF
--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -458,18 +458,29 @@ namespace Microsoft.Maui.Controls
 
 		static View BuildDefaultTemplate()
 		{
-			var frame = new Frame
+			var border = new Border
 			{
-				HasShadow = false,
 				Padding = 6
 			};
 
-			BindToTemplatedParent(frame, BackgroundColorProperty, Microsoft.Maui.Controls.Frame.BorderColorProperty, HorizontalOptionsProperty,
+			BindToTemplatedParent(border, BackgroundColorProperty, HorizontalOptionsProperty, VerticalOptionsProperty,
 				MarginProperty, OpacityProperty, RotationProperty, ScaleProperty, ScaleXProperty, ScaleYProperty,
-				TranslationYProperty, TranslationXProperty, VerticalOptionsProperty);
+				TranslationYProperty, TranslationXProperty);
+
+			border.SetBinding(Border.StrokeProperty, new Binding(BorderColorProperty.PropertyName,
+				converter: new BorderColorToBrush(),
+				source: RelativeBindingSource.TemplatedParent));
+
+			border.SetBinding(Border.StrokeShapeProperty, new Binding(CornerRadiusProperty.PropertyName,
+				converter: new CornerRadiusToShape(),
+				source: RelativeBindingSource.TemplatedParent));
+
+			border.SetBinding(Border.StrokeThicknessProperty, new Binding(BorderWidthProperty.PropertyName,
+				source: RelativeBindingSource.TemplatedParent));
 
 			var grid = new Grid
 			{
+				ColumnSpacing = 6,
 				RowSpacing = 0,
 				ColumnDefinitions = new ColumnDefinitionCollection {
 					new ColumnDefinition { Width = GridLength.Auto },
@@ -508,10 +519,9 @@ namespace Microsoft.Maui.Controls
 			var contentPresenter = new ContentPresenter
 			{
 				HorizontalOptions = LayoutOptions.Fill,
-				VerticalOptions = LayoutOptions.Fill
+				VerticalOptions = LayoutOptions.Center
 			};
 
-			contentPresenter.SetBinding(MarginProperty, new Binding("Padding", source: RelativeBindingSource.TemplatedParent));
 			contentPresenter.SetBinding(BackgroundColorProperty, new Binding(BackgroundColorProperty.PropertyName,
 				source: RelativeBindingSource.TemplatedParent));
 
@@ -519,11 +529,11 @@ namespace Microsoft.Maui.Controls
 			grid.Add(checkMark);
 			grid.Add(contentPresenter, 1, 0);
 
-			frame.Content = grid;
+			border.Content = grid;
 
 			INameScope nameScope = new NameScope();
-			NameScope.SetNameScope(frame, nameScope);
-			nameScope.RegisterName(TemplateRootName, frame);
+			NameScope.SetNameScope(border, nameScope);
+			nameScope.RegisterName(TemplateRootName, border);
 			nameScope.RegisterName(UncheckedButton, normalEllipse);
 			nameScope.RegisterName(CheckedIndicator, checkMark);
 			nameScope.RegisterName("ContentPresenter", contentPresenter);
@@ -550,9 +560,9 @@ namespace Microsoft.Maui.Controls
 
 			visualStateGroups.Add(checkedStates);
 
-			VisualStateManager.SetVisualStateGroups(frame, visualStateGroups);
+			VisualStateManager.SetVisualStateGroups(border, visualStateGroups);
 
-			return frame;
+			return border;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='ContentAsString']/Docs" />
@@ -565,6 +575,35 @@ namespace Microsoft.Maui.Controls
 			}
 
 			return content?.ToString();
+		}
+
+		class BorderColorToBrush : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			{
+				return new SolidColorBrush((Graphics.Color)value);
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		class CornerRadiusToShape : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			{
+				return new RoundRectangle
+				{
+					CornerRadius = (int)value,
+				};
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+			{
+				throw new NotImplementedException();
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change
 Update RadioButton DefaultTemplate. 
 I increased the margin between mark and content and the Frame was changed to Border and borderwidth was applied.
|Before| After
|-|-|
|<img width="516" alt="175028973-02cf0c02-3ce0-4da3-bdc3-0814c7988ed2" src="https://user-images.githubusercontent.com/1029155/175430599-ec73f5e1-9171-4e06-88c7-e6271e521d20.png">|<img width="516" alt="175288895-13145e34-8033-440f-aaf2-7830185ec0fb" src="https://user-images.githubusercontent.com/1029155/175430634-2c2929b4-20d6-4818-ac61-e71abde8f1e1.png">|

|Before| After
|-|-|
|<img width="516" alt="175029199-b833dc3e-5dfe-4bfd-bcf0-52a8bebd7bd9" src="https://user-images.githubusercontent.com/1029155/175430871-55f9ef4f-373a-4647-9155-0a14f95c98e9.png">|<img width="516" alt="175288933-c46a9357-dcaa-45f4-8b3e-8203b1f501e3" src="https://user-images.githubusercontent.com/1029155/175430881-257acf80-3c8b-4936-b81d-0fb9d5a8d9ef.png">|

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #8291 
