### PR TITLE
[Windows] Align Button VisualStates behavior with other platforms

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
@@ -5,6 +5,46 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     xmlns:local="clr-namespace:Maui.Controls.Sample"
     Title="Button">
+    <views:BasePage.Resources>
+        <ResourceDictionary>
+
+            <Style x:Key="CustomButtonStyle" TargetType="Button">
+                <Setter Property="BackgroundColor" Value="Red"/>
+                <Setter Property="TextColor" Value="White"/>
+                <Setter Property="FontSize" Value="24"/>
+                <Setter Property="Margin" Value="8"/>
+                <Setter Property="CornerRadius" Value="40"/>
+                <Setter Property="HorizontalOptions" Value="Center"/>
+                <Setter Property="WidthRequest" Value="80"/>
+                <Setter Property="HeightRequest" Value="80"/>
+                <Setter
+                    Property="VisualStateManager.VisualStateGroups">
+                    <VisualStateGroupList>
+                        <VisualStateGroup
+                            x:Name="CommonStates">
+                            <VisualState
+                                x:Name="Normal">
+                                <VisualState.Setters>
+                                    <Setter
+                                        Property="Scale"
+                                        Value="1" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            <VisualState
+                                x:Name="Pressed">
+                                <VisualState.Setters>
+                                    <Setter
+                                        Property="Scale"
+                                        Value="0.8" />
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateGroupList>
+                </Setter>
+            </Style>
+
+        </ResourceDictionary>
+    </views:BasePage.Resources>
     <views:BasePage.Content>
         <ScrollView>
             <VerticalStackLayout Margin="12" Spacing="6">
@@ -172,6 +212,12 @@
                     Style="{StaticResource Headline}"/>
                 <local:CustomButton
                     Text="Custom Button" />
+                <Label
+                    Text="Using VisualStates"
+                    Style="{StaticResource Headline}"/>
+                <Button
+                    Text="B" 
+                    Style="{StaticResource CustomButtonStyle}" />
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Windows.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Handlers
 			_pointerPressedHandler = new PointerEventHandler(OnPointerPressed);
 			_pointerReleasedHandler = new PointerEventHandler(OnPointerReleased);
 
+			platformView.AllowFocusOnInteraction = false;
 			platformView.Click += OnClick;
 			platformView.AddHandler(UIElement.PointerPressedEvent, _pointerPressedHandler, true);
 			platformView.AddHandler(UIElement.PointerReleasedEvent, _pointerReleasedHandler, true);


### PR DESCRIPTION
### Description of Change

Align Button VisualStates behavior with other platforms. Currently:

- Windows: Clicking the Button sets the Pressed state and the focus to the control. So, although the state momentarily changes to Normal after the click, it immediately changes to Focused. It's not until we click outside the button that we don't remove the focus and go to the Normal state again.
- Other Platforms: Clicking the Button sets the Pressed state and then changes to Normal.

![fix-visualstates-button](https://user-images.githubusercontent.com/6755973/175944023-ced1f822-ea7a-4f13-be56-fe00e84ccf1b.gif)

In this PR we add changes to still allow to set the Button focus programatically, using the Keyboard etc but not just clicking it.

Should we look for another solution thinking about **a11y**? Maybe change the VisualState to Normal after releasing the pointer?

### Issues Fixed

Fixes #7570
Fixes #8309
Fixes #9715