### PR TITLE
Remove "Multi-platform" from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# .NET Multi-platform App UI (.NET MAUI)
+# .NET App UI (.NET MAUI)
 
 [![Build Status](https://dev.azure.com/xamarin/public/_apis/build/status/MAUI-public?repoName=dotnet%2Fmaui&branchName=main&label=Public)](https://dev.azure.com/xamarin/public/_build/latest?definitionId=57&repoName=dotnet%2Fmaui&branchName=main) [![Build Status](https://devdiv.visualstudio.com/DevDiv/_apis/build/status/MAUI?repoName=dotnet%2Fmaui&branchName=main&label=Private)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=13330&repoName=dotnet%2Fmaui&branchName=main)
 
-[.NET Multi-platform App UI (.NET MAUI)](https://dotnet.microsoft.com/en-us/apps/maui) is a cross-platform framework for creating mobile and desktop apps with C# and XAML. Using .NET MAUI, you can develop apps that can run on Android, iOS, iPadOS, macOS, and Windows from a single shared codebase.
+[.NET App UI (.NET MAUI)](https://dotnet.microsoft.com/en-us/apps/maui) is a cross-platform framework for creating mobile and desktop apps with C# and XAML. Using .NET MAUI, you can develop apps that can run on Android, iOS, iPadOS, macOS, and Windows from a single shared codebase.
 
 ## Getting Started ##
 
@@ -13,7 +13,7 @@
 
 ## Overview
 
-.NET Multi-platform App UI (.NET MAUI) is the evolution of Xamarin.Forms that expands capabilities beyond mobile Android and iOS into desktop apps for Windows and macOS. With .NET MAUI, you can build apps that perform great for any device that runs Windows, macOS, Android, & iOS from a single codebase. Coupled with Visual Studio productivity tools and emulators, .NET and Visual Studio significantly speed up the development process for building apps that target the widest possible set of devices. Use a single development stack that supports the best of breed solutions for all modern workloads with a unified SDK, base class libraries, and toolchain. [Read More](https://docs.microsoft.com/dotnet/maui/what-is-maui)
+.NET App UI (.NET MAUI) is the evolution of Xamarin.Forms that expands capabilities beyond mobile Android and iOS into desktop apps for Windows and macOS. With .NET MAUI, you can build apps that perform great for any device that runs Windows, macOS, Android, & iOS from a single codebase. Coupled with Visual Studio productivity tools and emulators, .NET and Visual Studio significantly speed up the development process for building apps that target the widest possible set of devices. Use a single development stack that supports the best of breed solutions for all modern workloads with a unified SDK, base class libraries, and toolchain. [Read More](https://docs.microsoft.com/dotnet/maui/what-is-maui)
 
 ![.NET MAUI Weather App on all platforms](Assets/maui-weather-hero-sm.png)
 


### PR DESCRIPTION
### Description of Change

Removes "Multi-platform" from the README

### Issues Fixed

This repo's README has the word "Multi-platform" littered all over it which might mislead people into thinking that this library also supports linux given how relevant it is becoming and the commitment microsoft is supposedly putting into its loved community and how every other important "Multi-platform" UI toolkit supports it. To avoid such confusion this Pull-Request removes the word Multi-platform from the README therefore making it more closely reflect the goals of the project.

Additionally the "M" should be removed from the project name to reflect the change in the readme which has the additional benefit of not shadowing [this project](https://mauikit.org/) which is also called MAUI but that actually supports all of the major platforms. I think we can all agree that the name MAUI is a better fit for that project.