### PR TITLE
Return unknown if not on UI Thread for WinUI

### DIFF
--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Maui.ApplicationModel
 		public void ShowSettingsUI() =>
 			global::Windows.System.Launcher.LaunchUriAsync(new global::System.Uri("ms-settings:appsfeatures-app")).WatchForError();
 
-		public AppTheme RequestedTheme =>
-			Application.Current.RequestedTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light;
+		public AppTheme RequestedTheme => MainThread.IsMainThread ?
+			(Application.Current.RequestedTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light) : AppTheme.Unspecified;
 
 		public AppPackagingModel PackagingModel => AppInfoUtils.IsPackagedApp
 			? AppPackagingModel.Packaged

--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -11,6 +11,13 @@ namespace Microsoft.Maui.ApplicationModel
 {
 	class AppInfoImplementation : IAppInfo
 	{
+		ApplicationTheme? _applicationTheme;
+		public AppInfoImplementation()
+		{
+			if (MainThread.IsMainThread)
+				_applicationTheme = Application.Current.RequestedTheme;
+		}
+
 		public string PackageName => Package.Current.Id.Name;
 
 		public string Name => Package.Current.DisplayName;
@@ -32,14 +39,19 @@ namespace Microsoft.Maui.ApplicationModel
 		public void ShowSettingsUI() =>
 			global::Windows.System.Launcher.LaunchUriAsync(new global::System.Uri("ms-settings:appsfeatures-app")).WatchForError();
 
+		internal void ThemeChanged() =>
+			_applicationTheme = Application.Current.RequestedTheme;
+
 		public AppTheme RequestedTheme
 		{
 			get
 			{
-				if (!MainThread.IsMainThread)
-					throw new InvalidOperationException("RequestedTheme must be called from the UI Thread");
+				if (MainThread.IsMainThread)
+					_applicationTheme = Application.Current.RequestedTheme;
+				else if (_applicationTheme == null)
+					return AppTheme.Unspecified;
 
-				return Application.Current.RequestedTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light;
+				return _applicationTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light;
 			}
 		}
 

--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.ApplicationModel
 		ApplicationTheme? _applicationTheme;
 		public AppInfoImplementation()
 		{
-			if (MainThread.IsMainThread)
+			if (MainThread.IsMainThread && Application.Current != null)
 				_applicationTheme = Application.Current.RequestedTheme;
 		}
 
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			get
 			{
-				if (MainThread.IsMainThread)
+				if (MainThread.IsMainThread && Application.Current != null)
 					_applicationTheme = Application.Current.RequestedTheme;
 				else if (_applicationTheme == null)
 					return AppTheme.Unspecified;

--- a/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.uwp.cs
@@ -32,8 +32,16 @@ namespace Microsoft.Maui.ApplicationModel
 		public void ShowSettingsUI() =>
 			global::Windows.System.Launcher.LaunchUriAsync(new global::System.Uri("ms-settings:appsfeatures-app")).WatchForError();
 
-		public AppTheme RequestedTheme => MainThread.IsMainThread ?
-			(Application.Current.RequestedTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light) : AppTheme.Unspecified;
+		public AppTheme RequestedTheme
+		{
+			get
+			{
+				if (!MainThread.IsMainThread)
+					throw new InvalidOperationException("RequestedTheme must be called from the UI Thread");
+
+				return Application.Current.RequestedTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light;
+			}
+		}
 
 		public AppPackagingModel PackagingModel => AppInfoUtils.IsPackagedApp
 			? AppPackagingModel.Packaged

--- a/src/Essentials/src/Platform/WindowStateManager.uwp.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.uwp.cs
@@ -75,6 +75,8 @@ namespace Microsoft.Maui.ApplicationModel
 	{
 		const uint DISPLAY_CHANGED = 126;
 		const uint DPI_CHANGED = 736;
+		const int WM_SETTINGCHANGE = 0x001A;
+		const int WM_THEMECHANGE = 0x031A;
 
 		Window? _activeWindow;
 
@@ -106,6 +108,10 @@ namespace Microsoft.Maui.ApplicationModel
 		// Hopefully there will be a more public API for this down the road so we can just use that directly from Essentials
 		public void OnWindowMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
 		{
+			// TODO NET7 expose a theme changed event property?
+			if ((msg == WM_SETTINGCHANGE || msg == WM_THEMECHANGE) && AppInfo.Current is AppInfoImplementation ai)
+				ai.ThemeChanged();
+
 			if (ActiveWindowDisplayChanged == null)
 				return;
 


### PR DESCRIPTION
### Description of Change

If you call `WinUI.Application.Current.RequestedTheme` off the UI thread WinUI crashes with

<img width="373" alt="image" src="https://user-images.githubusercontent.com/5375137/176052199-c148dee2-2017-4b9a-8fb1-96a08ed3b938.png">

`AppThemeBindings` call into `Application.Current.RequestedTheme` so if anyone uses `AppThemeBinding` off thread then WinUI crashes

This PR stores the requested theme to a local variable so it's retrievable off the main thread. It also listens for changes to the theme and then updates that value.

#### TODO

If @mattleibow is happy then create a new spec for essentials to add a theme changed event to the public API