### PR TITLE
[android] fix MauiSplashScreen on Android 12+

### DIFF
--- a/src/Core/src/Platform/Android/Resources/values/styles.xml
+++ b/src/Core/src/Platform/Android/Resources/values/styles.xml
@@ -29,6 +29,12 @@
     <style name="Maui.SplashTheme" parent="Maui.MainTheme.NoActionBar">
         <item name="maui_splash">true</item>
         <item name="android:windowBackground">@drawable/maui_splash</item>
+        <!--
+          Android 12+ specific settings
+          See: https://developer.android.com/guide/topics/ui/splash-screen#set-theme
+        -->
+        <item name="android:windowSplashScreenBackground">@color/maui_splash_color</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/maui_splash</item>
     </style>
 
     <!-- Themes for Xamarin.Forms backwards compatibility -->


### PR DESCRIPTION
Fixes #7404
Context: https://developer.android.com/guide/topics/ui/splash-screen#set-theme

Reviewing a lot of the feedback around splash screens, I tried:

1. Rename `splash.svg` to `splash2.svg`
2. Change the .NET splash logo from white to blank.

I found these changes worked fine on Android < 12, but I did not see
my changes on Android 12+!

This was more troubling when I changed the `MauiSplashScreen` `Color`
to white:

![image](https://user-images.githubusercontent.com/840039/176271400-0c42c96a-b276-42e6-9abf-2d3810d1b201.png)

After some review, it looks like we need to define:

    <item name="android:windowSplashScreenBackground">@color/maui_splash_color</item>
    <item name="android:windowSplashScreenAnimatedIcon">@drawable/maui_splash</item>

With these changes in place, the splash screen is working for me in
Android 12+, I tested a new project and changed the color of the .NET logo:

![image](https://user-images.githubusercontent.com/840039/176271451-75412e18-69d2-4505-9fec-976c5807c9ba.png)

I believe we implemented `MauiSplashScreen` while Android 12 was still
in beta, so we just didn't notice this behavior. We also were sharing
the same `.svg` file for the app icon and splash screen previously,
which may have confused or hidden this issue.