### PR TITLE
Convert Android Hit Test values to Units

### DIFF
--- a/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
@@ -91,7 +91,10 @@ namespace Microsoft.Maui
 			if (e.Event.Action != MotionEventActions.Down && e.Event.ButtonState != MotionEventButtonState.Primary)
 				return;
 
-			var point = new Point(e.Event.RawX, e.Event.RawY);
+			var x = this._nativeLayer?.Context.FromPixels(e.Event.RawX) ?? 0;
+			var y = this._nativeLayer?.Context.FromPixels(e.Event.RawY) ?? 0;
+
+			var point = new Point(x, y);
 
 			e.Handled = false;
 			if (DisableUITouchEventPassthrough)


### PR DESCRIPTION
When we converted the Visual Diagnostics API to Units (https://github.com/dotnet/maui/pull/7904) we didn't update the Hit Testing layer to take it into account. It was still using pixels, meaning that it was always off when doing in-app element selection.

This PR fixes it so it can be consistent.
