### PR TITLE
[Android] Fix crash on Picker with null and fix up handler to not use INCC

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Picker/Picker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Picker/Picker.Impl.cs
@@ -13,12 +13,23 @@ namespace Microsoft.Maui.Controls
 		string IItemDelegate<string>.GetItem(int index)
 		{
 			if (index < 0)
-				return "";
+				return string.Empty;
 			if (index < Items?.Count)
-				return Items[index];
+				return GetItem(index);
 			if (index < ItemsSource?.Count)
 				return GetDisplayMember(ItemsSource[index]);
-			return "";
+			return string.Empty;
+		}
+
+		string GetItem(int index)
+		{
+			if (index < Items?.Count)
+			{
+				var item = Items[index];
+				return item == null ? string.Empty : item;
+			}
+
+			return string.Empty;
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Picker/Picker.cs
+++ b/src/Controls/src/Core/HandlerImpl/Picker/Picker.cs
@@ -7,6 +7,7 @@
 #if IOS
 			[PlatformConfiguration.iOSSpecific.Picker.UpdateModeProperty.PropertyName] = MapUpdateMode,
 #endif
+			[nameof(Picker.ItemsSource)] = (handler, _) => handler.UpdateValue(nameof(IPicker.Items))
 		};
 
 		internal static new void RemapForControls()

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -248,8 +248,6 @@ namespace Microsoft.Maui.Controls
 			// If the index has not changed, still need to change the selected item
 			if (newIndex == oldIndex)
 				UpdateSelectedItem(newIndex);
-
-			Handler?.Invoke("Reload");
 		}
 
 		static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
@@ -295,7 +293,10 @@ namespace Microsoft.Maui.Controls
 					ResetItems();
 					break;
 			}
+
+			Handler?.UpdateValue(nameof(IPicker.Items));
 		}
+
 		void AddItems(NotifyCollectionChangedEventArgs e)
 		{
 			int index = e.NewStartingIndex < 0 ? Items.Count : e.NewStartingIndex;

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -478,9 +478,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void TestNullItemDisplayBinding()
+		public void NullItemReturnsEmptyStringFromInterface()
 		{
-			var obj = new PickerTestsContextFixture(null, "John Doe");
 			var picker = new Picker
 			{
 				ItemsSource = new ObservableCollection<object>

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -476,5 +476,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(-1, picker.SelectedIndex);
 			Assert.AreEqual(null, picker.SelectedItem);
 		}
+
+		[Test]
+		public void TestNullItemDisplayBinding()
+		{
+			var obj = new PickerTestsContextFixture(null, "John Doe");
+			var picker = new Picker
+			{
+				ItemsSource = new ObservableCollection<object>
+				{
+					(string)null, "John Doe"
+				}
+			};
+
+			var thing = (picker as IPicker).GetItem(0);
+			Assert.IsNotNull(thing);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -224,6 +224,23 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
+		public void TestNullItemDisplayBinding()
+		{
+			var obj = new PickerTestsContextFixture(null, "John Doe");
+			var picker = new Picker
+			{
+				ItemDisplayBinding = new Binding("DisplayName"),
+				ItemsSource = new ObservableCollection<object>
+				{
+					obj
+				}
+			};
+
+			var thing = (picker as IPicker).GetItem(0);
+			Assert.IsNull(thing);
+		}
+
+		[Test]
 		public void TestItemsSourceCollectionChangedAppend()
 		{
 			var items = new ObservableCollection<object>

--- a/src/Controls/tests/Core.UnitTests/PickerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PickerTests.cs
@@ -224,23 +224,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void TestNullItemDisplayBinding()
-		{
-			var obj = new PickerTestsContextFixture(null, "John Doe");
-			var picker = new Picker
-			{
-				ItemDisplayBinding = new Binding("DisplayName"),
-				ItemsSource = new ObservableCollection<object>
-				{
-					obj
-				}
-			};
-
-			var thing = (picker as IPicker).GetItem(0);
-			Assert.IsNull(thing);
-		}
-
-		[Test]
 		public void TestItemsSourceCollectionChangedAppend()
 		{
 			var items = new ObservableCollection<object>

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Android.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Xunit;
+using Microsoft.Maui.Platform;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Picker)]
+	public partial class PickerTests : HandlerTestBase
+	{
+		protected Task<string> GetPlatformControlText(MauiPicker platformView)
+		{
+			return InvokeOnMainThreadAsync(() => platformView.Text);
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Windows.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Xunit;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class PickerTests : HandlerTestBase
+	{
+		protected Task<string> GetPlatformControlText(ComboBox platformView)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				return platformView.SelectedItem?.ToString();
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.Windows.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Xunit;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Maui.Platform;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -15,6 +16,15 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
+				// these will only work if you've attached the combobox to a window
+				var textBlock =
+					platformView
+						.GetDescendantByName<UI.Xaml.Controls.ContentPresenter>("ContentPresenter")
+						?.GetFirstDescendant<TextBlock>();
+
+				if (textBlock != null)
+					return textBlock.Text;
+
 				return platformView.SelectedItem?.ToString();
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Picker)]
+	public partial class PickerTests : HandlerTestBase
+	{
+		[Fact]
+		public async Task ItemsUpdateWithCollectionChanges()
+		{
+			var items = new ObservableCollection<string>()
+			{
+				"1",
+				"2"
+			};
+
+			Picker picker = new Picker()
+			{
+				ItemsSource = items,
+				SelectedIndex = 0
+			};
+
+			var handler = await CreateHandlerAsync<PickerHandler>(picker);
+
+			Assert.Equal("1", await GetPlatformControlText(handler.PlatformView));
+			await InvokeOnMainThreadAsync(() => items.Remove("1"));
+			Assert.Equal("2", await GetPlatformControlText(handler.PlatformView));
+		}
+
+		[Fact]
+		public async Task ItemsUpdateWithNewItemSource()
+		{
+			var newItems = new List<string>()
+			{
+				"1"
+			};
+
+			Picker picker = new Picker()
+			{
+				ItemsSource = new List<string> { "2" },
+				SelectedIndex = 0
+			};
+
+			var handler = await CreateHandlerAsync<PickerHandler>(picker);
+			Assert.Equal("2", await GetPlatformControlText(handler.PlatformView));
+			await InvokeOnMainThreadAsync(() => picker.ItemsSource = newItems);
+			Assert.NotEqual("2", await GetPlatformControlText(handler.PlatformView));
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Picker/PickerTests.iOS.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Xunit;
+using Microsoft.Maui.Platform;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class PickerTests : HandlerTestBase
+	{
+		protected Task<string> GetPlatformControlText(MauiPicker platformView)
+		{
+			return InvokeOnMainThreadAsync(() => platformView.Text);
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -19,6 +19,7 @@
 		public const string Modal = "Modal";
 		public const string NavigationPage = "NavigationPage";
 		public const string Page = "Page";
+		public const string Picker = "Picker";
 		public const string ScrollView = "ScrollView";
 		public const string SearchBar = "SearchBar";
 		public const string Shell = "Shell";

--- a/src/Core/src/Core/Extensions/IPickerExtension.cs
+++ b/src/Core/src/Core/Extensions/IPickerExtension.cs
@@ -6,9 +6,9 @@ namespace Microsoft.Maui
 	public static class IPickerExtension
 	{
 		public static string[] GetItemsAsArray(this IPicker picker)
-			=> Enumerable.Range(0, picker.GetCount()).Select(i => picker.GetItem(i)).ToArray();
+			=> Enumerable.Range(0, picker.GetCount()).Select(picker.GetItem).ToArray();
 
 		public static List<string> GetItemsAsList(this IPicker picker)
-			=> Enumerable.Range(0, picker.GetCount()).Select(i => picker.GetItem(i)).ToList();
+			=> Enumerable.Range(0, picker.GetCount()).Select(picker.GetItem).ToList();
 	}
 }

--- a/src/Core/src/Core/Extensions/IPickerExtension.cs
+++ b/src/Core/src/Core/Extensions/IPickerExtension.cs
@@ -6,9 +6,21 @@ namespace Microsoft.Maui
 	public static class IPickerExtension
 	{
 		public static string[] GetItemsAsArray(this IPicker picker)
-			=> Enumerable.Range(0, picker.GetCount()).Select(picker.GetItem).ToArray();
+		{
+			var returnValue = new string[picker.GetCount()];
+			for (int i = 0; i < returnValue.Length; i++)
+				returnValue[i] = picker.GetItem(i);
+
+			return returnValue;
+		}
 
 		public static List<string> GetItemsAsList(this IPicker picker)
-			=> Enumerable.Range(0, picker.GetCount()).Select(picker.GetItem).ToList();
+		{
+			var returnValue = new List<string>(picker.GetCount());
+			for (int i = 0; i < returnValue.Count; i++)
+				returnValue[i] = picker.GetItem(i);
+
+			return returnValue;
+		}
 	}
 }

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -125,6 +125,13 @@ namespace Microsoft.Maui.Handlers
 
 					string[] items = VirtualView.GetItemsAsArray();
 
+					for (var i = 0; i < items.Length; i++)
+					{
+						var item = items[i];
+						if (item == null)
+							items[i] = String.Empty;
+					}
+
 					builder.SetItems(items, (s, e) =>
 					{
 						var selectedIndex = e.Which;

--- a/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Android.cs
@@ -21,9 +21,6 @@ namespace Microsoft.Maui.Handlers
 			platformView.FocusChange += OnFocusChange;
 			platformView.Click += OnClick;
 
-			if (VirtualView.Items is INotifyCollectionChanged notifyCollection)
-				notifyCollection.CollectionChanged += OnRowsCollectionChanged;
-
 			base.ConnectHandler(platformView);
 		}
 
@@ -31,9 +28,6 @@ namespace Microsoft.Maui.Handlers
 		{
 			platformView.FocusChange -= OnFocusChange;
 			platformView.Click -= OnClick;
-
-			if (VirtualView.Items is INotifyCollectionChanged notifyCollection)
-				notifyCollection.CollectionChanged -= OnRowsCollectionChanged;
 
 			base.DisconnectHandler(platformView);
 		}
@@ -44,7 +38,10 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateBackground(picker);
 		}
 
+		// Uncomment me on NET7 [Obsolete]
 		public static void MapReload(IPickerHandler handler, IPicker picker, object? args) => Reload(handler);
+
+		internal static void MapItems(IPickerHandler handler, IPicker picker) => Reload(handler);
 
 		public static void MapTitle(IPickerHandler handler, IPicker picker)
 		{
@@ -147,7 +144,6 @@ namespace Microsoft.Maui.Handlers
 
 				_dialog.DismissEvent += (sender, args) =>
 				{
-					_dialog?.Dispose();
 					_dialog = null;
 				};
 
@@ -155,16 +151,8 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		void OnRowsCollectionChanged(object? sender, EventArgs e)
-		{
-			Reload(this);
-		}
-
 		static void Reload(IPickerHandler handler)
 		{
-			if (handler.VirtualView == null || handler.PlatformView == null)
-				return;
-
 			handler.PlatformView.UpdatePicker(handler.VirtualView);
 		}
 	}

--- a/src/Core/src/Handlers/Picker/PickerHandler.Standard.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Standard.cs
@@ -6,7 +6,10 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override object CreatePlatformView() => throw new NotImplementedException();
 
+		// Uncomment me on NET7 [Obsolete]
 		public static void MapReload(IPickerHandler handler, IPicker picker, object? args) { }
+		internal static void MapItems(IPickerHandler handler, IPicker picker) { }
+
 		public static void MapTitle(IPickerHandler handler, IPicker view) { }
 		public static void MapTitleColor(IPickerHandler handler, IPicker view) { }
 		public static void MapSelectedIndex(IPickerHandler handler, IPicker view) { }

--- a/src/Core/src/Handlers/Picker/PickerHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Tizen.cs
@@ -66,7 +66,10 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView.UpdatePicker(handler.VirtualView);
 		}
 
+		// Uncomment me on NET7 [Obsolete]
 		public static void MapReload(IPickerHandler handler, IPicker picker, object? args) => Reload(handler);
+
+		internal static void MapItems(IPickerHandler handler, IPicker picker) => Reload(handler);
 
 		public static void MapTitleColor(IPickerHandler handler, IPicker picker)
 		{

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -118,11 +118,6 @@ namespace Microsoft.Maui.Handlers
 			PlatformView.MinWidth = 0;
 		}
 
-		void OnRowsCollectionChanged(object? sender, EventArgs e)
-		{
-			Reload(this);
-		}
-
 		static void OnMauiComboBoxDropDownOpened(object? sender, object e)
 		{
 			ComboBox? comboBox = sender as ComboBox;

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Microsoft.UI.Xaml.Controls;
 using WSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.SelectionChangedEventArgs;
@@ -11,40 +12,52 @@ namespace Microsoft.Maui.Handlers
 		protected override ComboBox CreatePlatformView()
 		{
 			var platformPicker = new ComboBox();
-
-			if (VirtualView != null)
-				platformPicker.ItemsSource = new ItemDelegateList<string>(VirtualView);
-
-			platformPicker.DropDownOpened += OnMauiComboBoxDropDownOpened;
-			platformPicker.SelectionChanged += OnMauiComboBoxSelectionChanged;
-
 			return platformPicker;
 		}
 
 		protected override void ConnectHandler(ComboBox platformView)
 		{
-			platformView.SelectionChanged += OnControlSelectionChanged;
-
-			if (VirtualView.Items is INotifyCollectionChanged notifyCollection)
-				notifyCollection.CollectionChanged += OnRowsCollectionChanged;
+			PlatformView.SelectionChanged += OnControlSelectionChanged;
+			platformView.DropDownOpened += OnMauiComboBoxDropDownOpened;
 		}
 
 		protected override void DisconnectHandler(ComboBox platformView)
 		{
 			platformView.SelectionChanged -= OnControlSelectionChanged;
+			platformView.DropDownOpened -= OnMauiComboBoxDropDownOpened;
+		}
 
-			if (VirtualView.Items is INotifyCollectionChanged notifyCollection)
-				notifyCollection.CollectionChanged -= OnRowsCollectionChanged;
+		// Updating ItemSource Resets the SelectedIndex.
+		// Which propagates that change to the virtualview
+		// We don't want the virtual views selected index to change
+		// when updating the itmmsource.
+		// The ItemSource should probably be reworked to just be an OC that's
+		// kept in sync
+		internal bool UpdatingItemSource { get; set; }
+
+		internal void SetUpdatingItemSource(bool updatingItemSource)
+		{
+			UpdatingItemSource = updatingItemSource;
+
+			if (!updatingItemSource)
+				UpdateValue(nameof(IPicker.SelectedIndex));
 		}
 
 		static void Reload(IPickerHandler handler)
 		{
-			if (handler.VirtualView == null || handler.PlatformView == null)
-				return;
-			handler.PlatformView.ItemsSource = new ItemDelegateList<string>(handler.VirtualView!);
+			if (handler is PickerHandler ph1)
+				ph1.SetUpdatingItemSource(true);
+
+			handler.PlatformView.ItemsSource = new ItemDelegateList<string>(handler.VirtualView);
+
+			if (handler is PickerHandler ph2)
+				ph2.SetUpdatingItemSource(false);
 		}
 
+		// Uncomment me on NET7 [Obsolete]
 		public static void MapReload(IPickerHandler handler, IPicker picker, object? args) => Reload(handler);
+
+		internal static void MapItems(IPickerHandler handler, IPicker picker) => Reload(handler);
 
 		public static void MapTitle(IPickerHandler handler, IPicker picker)
 		{
@@ -99,8 +112,13 @@ namespace Microsoft.Maui.Handlers
 
 		void OnControlSelectionChanged(object? sender, WSelectionChangedEventArgs e)
 		{
-			if (VirtualView != null && PlatformView != null)
+			if (PlatformView == null)
+				return;
+
+			if (VirtualView != null && !UpdatingItemSource)
 				VirtualView.SelectedIndex = PlatformView.SelectedIndex;
+
+			PlatformView.MinWidth = 0;
 		}
 
 		void OnRowsCollectionChanged(object? sender, EventArgs e)
@@ -114,14 +132,6 @@ namespace Microsoft.Maui.Handlers
 			if (comboBox == null)
 				return;
 			comboBox.MinWidth = comboBox.ActualWidth;
-		}
-
-		static void OnMauiComboBoxSelectionChanged(object? sender, SelectionChangedEventArgs e)
-		{
-			ComboBox? comboBox = sender as ComboBox;
-			if (comboBox == null)
-				return;
-			comboBox.MinWidth = 0;
 		}
 	}
 }

--- a/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.Windows.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void ConnectHandler(ComboBox platformView)
 		{
-			PlatformView.SelectionChanged += OnControlSelectionChanged;
+			platformView.SelectionChanged += OnControlSelectionChanged;
 			platformView.DropDownOpened += OnMauiComboBoxDropDownOpened;
 		}
 
@@ -94,10 +94,7 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapTextColor(IPickerHandler handler, IPicker picker)
 		{
-			if (handler is PickerHandler platformHandler)
-			{
-				platformHandler.PlatformView?.UpdateTextColor(picker);
-			}
+			handler.PlatformView.UpdateTextColor(picker);
 		}
 
 		public static void MapHorizontalTextAlignment(IPickerHandler handler, IPicker picker)

--- a/src/Core/src/Handlers/Picker/PickerHandler.cs
+++ b/src/Core/src/Handlers/Picker/PickerHandler.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IPicker.Title)] = MapTitle,
 			[nameof(IPicker.TitleColor)] = MapTitleColor,
 			[nameof(ITextAlignment.HorizontalTextAlignment)] = MapHorizontalTextAlignment,
-			[nameof(ITextAlignment.VerticalTextAlignment)] = MapVerticalTextAlignment
+			[nameof(ITextAlignment.VerticalTextAlignment)] = MapVerticalTextAlignment,
+			[nameof(IPicker.Items)] = MapItems,
 		};
 
 		public static CommandMapper<IPicker, IPickerHandler> CommandMapper = new(ViewCommandMapper)
 		{
-			["Reload"] = MapReload
 		};
 
 		static PickerHandler()

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -1937,7 +1937,6 @@ override Microsoft.Maui.Handlers.PageHandler.DisconnectHandler(Microsoft.Maui.Pl
 override Microsoft.Maui.Handlers.PickerHandler.ConnectHandler(Microsoft.Maui.Platform.MauiPicker! platformView) -> void
 override Microsoft.Maui.Handlers.PickerHandler.CreatePlatformView() -> Microsoft.Maui.Platform.MauiPicker!
 override Microsoft.Maui.Handlers.PickerHandler.DisconnectHandler(Microsoft.Maui.Platform.MauiPicker! platformView) -> void
-override Microsoft.Maui.Handlers.PickerSource.Dispose(bool disposing) -> void
 override Microsoft.Maui.Handlers.PickerSource.GetComponentCount(UIKit.UIPickerView! picker) -> nint
 override Microsoft.Maui.Handlers.PickerSource.GetRowsInComponent(UIKit.UIPickerView! pickerView, nint component) -> nint
 override Microsoft.Maui.Handlers.PickerSource.GetTitle(UIKit.UIPickerView! picker, nint row, nint component) -> string!

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -12,3 +12,4 @@ override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.get -> bool
 override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.set -> void
 override Microsoft.Maui.Platform.MauiTextField.SelectedTextRange.get -> UIKit.UITextRange?
 override Microsoft.Maui.Platform.MauiTextField.SelectedTextRange.set -> void
+*REMOVED* override Microsoft.Maui.Handlers.PickerSource.Dispose(bool disposing) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -1936,7 +1936,6 @@ override Microsoft.Maui.Handlers.PageHandler.DisconnectHandler(Microsoft.Maui.Pl
 override Microsoft.Maui.Handlers.PickerHandler.ConnectHandler(Microsoft.Maui.Platform.MauiPicker! platformView) -> void
 override Microsoft.Maui.Handlers.PickerHandler.CreatePlatformView() -> Microsoft.Maui.Platform.MauiPicker!
 override Microsoft.Maui.Handlers.PickerHandler.DisconnectHandler(Microsoft.Maui.Platform.MauiPicker! platformView) -> void
-override Microsoft.Maui.Handlers.PickerSource.Dispose(bool disposing) -> void
 override Microsoft.Maui.Handlers.PickerSource.GetComponentCount(UIKit.UIPickerView! picker) -> nint
 override Microsoft.Maui.Handlers.PickerSource.GetRowsInComponent(UIKit.UIPickerView! pickerView, nint component) -> nint
 override Microsoft.Maui.Handlers.PickerSource.GetTitle(UIKit.UIPickerView! picker, nint row, nint component) -> string!

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -12,3 +12,4 @@ override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.get -> bool
 override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.set -> void
 override Microsoft.Maui.Platform.MauiTextField.SelectedTextRange.get -> UIKit.UITextRange?
 override Microsoft.Maui.Platform.MauiTextField.SelectedTextRange.set -> void
+*REMOVED* override Microsoft.Maui.Handlers.PickerSource.Dispose(bool disposing) -> void


### PR DESCRIPTION
### Description of Change

- Fix crash on Android Picker with null ItemDisplayBinding.
- Removed INCC subscriptions inside handlers because these will cause memory leaks. The INCC changes should propagate from the VirtualView via a call to MapItems not inside the handler.
- https://github.com/dotnet/maui/issues/8845

![fix-8377](https://user-images.githubusercontent.com/6755973/176418346-8618409d-d4fd-4cda-b039-e0287d0f51db.gif)

### Issues Fixed

Fixes #8377 
