### PR TITLE
[Windows] Add a root view for a window to manage pages and overlays

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Windows.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -25,7 +26,7 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
 				async (handler) =>
 				{
-					var rootView = handler.PlatformView.Content;
+					var windowRootViewContainer = (WPanel)handler.PlatformView.Content;
 					ContentPage backgroundColorContentPage = new ContentPage();
 
 					if (useColor)
@@ -34,16 +35,19 @@ namespace Microsoft.Maui.DeviceTests
 						backgroundColorContentPage.Background = SolidColorBrush.Purple;
 
 					await navPage.CurrentPage.Navigation.PushModalAsync(backgroundColorContentPage);
-
-					// Root should now be a ContentPanel
-					var rootPanel = (ContentPanel)handler.PlatformView.Content;
-					Assert.Contains(rootView, rootPanel.Children);
+					
 					var modalRootView =
 						backgroundColorContentPage.FindMauiContext().GetNavigationRootManager().RootView;
-					Assert.Contains(modalRootView, rootPanel.Children);
+					var rootPageRootView =
+						navPage.FindMauiContext().GetNavigationRootManager().RootView;
+
+					Assert.Equal(1, windowRootViewContainer.Children.IndexOf(modalRootView));
+					Assert.Equal(0, windowRootViewContainer.Children.IndexOf(rootPageRootView));
 
 					await navPage.CurrentPage.Navigation.PopModalAsync();
-					Assert.Equal(rootView, handler.PlatformView.Content);
+
+					Assert.Equal(0, windowRootViewContainer.Children.IndexOf(rootPageRootView));
+					Assert.DoesNotContain(modalRootView, windowRootViewContainer.Children);
 				});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Platform;
+using Microsoft.Maui.Handlers;
+using WPanel = Microsoft.UI.Xaml.Controls.Panel;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class WindowTests : HandlerTestBase
+	{
+		[Fact(DisplayName = "Swapping Root Page Removes Previous Page from WindowRootViewContainer")]
+		public async Task SwappingRootPageRemovesPreviousPageFromWindowRootViewContainer()
+		{
+			SetupBuilder();
+
+			var mainPage = new Shell() { CurrentItem = new ContentPage() };
+			var swappedInMainPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, async (handler) =>
+			{
+				var windowRootViewContainer = (WPanel)handler.PlatformView.Content;
+				var countBeforePageSwap = windowRootViewContainer.Children.Count;
+
+				var mainPageRootView =
+					mainPage.FindMauiContext().GetNavigationRootManager().RootView;
+
+				(handler.VirtualView as Window).Page = swappedInMainPage;
+				await OnNavigatedToAsync(swappedInMainPage.CurrentPage);
+				await OnFrameSetToNotEmpty(swappedInMainPage.CurrentPage);
+
+				var countAfterPageSwap = windowRootViewContainer.Children.Count;
+				Assert.Equal(countBeforePageSwap, countAfterPageSwap);
+			});
+		}
+
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -4,11 +4,35 @@ using Microsoft.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using WPanel = Microsoft.UI.Xaml.Controls.Panel;
 using Xunit;
+using System.Linq;
+using Microsoft.Maui.Graphics.Win2D;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class WindowTests : HandlerTestBase
 	{
+		[Fact]
+		public async Task AdornerLayerAdded()
+		{
+			SetupBuilder();
+
+			var mainPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, (handler) =>
+			{
+				var windowRootViewContainer = (WPanel)handler.PlatformView.Content;
+				var overlayView =
+					windowRootViewContainer
+						.Children
+						.OfType<W2DGraphicsView>()
+						.SingleOrDefault();
+
+				Assert.NotNull(overlayView);
+				Assert.Equal(overlayView, windowRootViewContainer.Children.Last());
+				return Task.CompletedTask;
+			});
+		}
+
 		[Fact(DisplayName = "Swapping Root Page Removes Previous Page from WindowRootViewContainer")]
 		public async Task SwappingRootPageRemovesPreviousPageFromWindowRootViewContainer()
 		{
@@ -33,6 +57,5 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(countBeforePageSwap, countAfterPageSwap);
 			});
 		}
-
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Maui.DeviceTests
 				var contentPage = new ContentPage()
 				{
 					ToolbarItems =
-				{
-					toolbarItem
-				}
+					{
+						toolbarItem
+					}
 				};
 
 				var shell = new Shell() { CurrentItem = contentPage };

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -36,11 +36,18 @@ namespace Microsoft.Maui.Handlers
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
 			var windowManager = handler.MauiContext.GetNavigationRootManager();
+			var previousRootView = windowManager.RootView;
+
 			windowManager.Disconnect();
 			windowManager.Connect(handler.VirtualView.Content.ToPlatform(handler.MauiContext));
 
 			if (handler.PlatformView.Content is WindowRootViewContainer container)
+			{
+				if (previousRootView != null && previousRootView != windowManager.RootView)
+					container.RemovePage(previousRootView);
+
 				container.AddPage(windowManager.RootView);
+			}
 
 			if (window.VisualDiagnosticsOverlay != null)
 				window.VisualDiagnosticsOverlay.Initialize();

--- a/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Windows.cs
@@ -5,14 +5,25 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class WindowHandler : ElementHandler<IWindow, UI.Xaml.Window>
 	{
+		protected override void ConnectHandler(UI.Xaml.Window platformView)
+		{
+			base.ConnectHandler(platformView);
+
+			if (platformView.Content is null)
+				platformView.Content = new WindowRootViewContainer();
+		}
+
 		protected override void DisconnectHandler(UI.Xaml.Window platformView)
 		{
 			MauiContext
 				?.GetNavigationRootManager()
 				?.Disconnect();
 
-			if (platformView.Dispatcher != null)
+			if (platformView.Content is WindowRootViewContainer container)
+			{
+				container.Children.Clear();
 				platformView.Content = null;
+			}
 
 			base.DisconnectHandler(platformView);
 		}
@@ -23,11 +34,13 @@ namespace Microsoft.Maui.Handlers
 		public static void MapContent(IWindowHandler handler, IWindow window)
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
 			var windowManager = handler.MauiContext.GetNavigationRootManager();
 			windowManager.Disconnect();
 			windowManager.Connect(handler.VirtualView.Content.ToPlatform(handler.MauiContext));
 
-			handler.PlatformView.Content = windowManager.RootView;
+			if (handler.PlatformView.Content is WindowRootViewContainer container)
+				container.AddPage(windowManager.RootView);
 
 			if (window.VisualDiagnosticsOverlay != null)
 				window.VisualDiagnosticsOverlay.Initialize();

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -1,0 +1,65 @@
+using System;
+using Microsoft.Maui.Graphics.Win2D;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation;
+
+namespace Microsoft.Maui.Platform
+{
+	internal class WindowRootViewContainer : Panel
+	{
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			var width = availableSize.Width;
+			var height = availableSize.Height;
+
+			if (double.IsInfinity(width))
+				width = XamlRoot.Size.Width;
+
+			if (double.IsInfinity(height))
+				height = XamlRoot.Size.Height;
+
+			var size = new Size(width, height);
+
+			// measure the children to fit the container exactly
+			foreach (var child in Children)
+			{
+				child.Measure(size);
+			}
+
+			return size;
+		}
+
+		protected override Size ArrangeOverride(Size finalSize)
+		{
+			foreach (var child in Children)
+			{
+				child.Arrange(new Rect(new Point(0, 0), finalSize));
+			}
+
+			return finalSize;
+		}
+
+		internal void AddPage(FrameworkElement pageView)
+		{
+			if (!Children.Contains(pageView))
+				Children.Add(pageView);
+		}
+
+		internal void RemovePage(FrameworkElement pageView)
+		{
+			Children.Remove(pageView);
+		}
+
+		internal void AddOverlay(FrameworkElement overlayView)
+		{
+			if (!Children.Contains(overlayView))
+				Children.Add(overlayView);
+		}
+
+		internal void RemoveOverlay(FrameworkElement overlayView)
+		{
+			Children.Remove(overlayView);
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
+++ b/src/Core/src/Platform/Windows/WindowRootViewContainer.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Platform
 {
 	internal class WindowRootViewContainer : Panel
 	{
+		FrameworkElement? _topPage;
 		protected override Size MeasureOverride(Size availableSize)
 		{
 			var width = availableSize.Width;
@@ -43,12 +44,28 @@ namespace Microsoft.Maui.Platform
 		internal void AddPage(FrameworkElement pageView)
 		{
 			if (!Children.Contains(pageView))
-				Children.Add(pageView);
+			{
+				int indexOFTopPage = 0;
+				if (_topPage != null)
+					indexOFTopPage = Children.IndexOf(_topPage) + 1;
+
+				Children.Insert(indexOFTopPage, pageView);
+				_topPage = pageView;
+			}
 		}
 
 		internal void RemovePage(FrameworkElement pageView)
 		{
+			int indexOFTopPage = -1;
+			if (_topPage != null)
+				indexOFTopPage = Children.IndexOf(_topPage) - 1;
+
 			Children.Remove(pageView);
+
+			if (indexOFTopPage >= 0)
+				_topPage = (FrameworkElement)Children[indexOFTopPage];
+			else
+				_topPage = null;
 		}
 
 		internal void AddOverlay(FrameworkElement overlayView)

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 ﻿#nullable enable
-*REMOVED*override Microsoft.Maui.Handlers.WindowHandler.ConnectHandler(Microsoft.UI.Xaml.Window! platformView) -> void

--- a/src/Core/src/WindowOverlay/WindowOverlay.Windows.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Windows.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui
 	{
 		W2DGraphicsView? _graphicsView;
 		Frame? _frame;
-		Panel? _panel;
+		WindowRootViewContainer? _panel;
 		FrameworkElement? _platformElement;
 
 		/// <inheritdoc/>
@@ -26,11 +26,15 @@ namespace Microsoft.Maui
 			_platformElement = Window.Content.ToPlatform();
 			if (_platformElement == null)
 				return false;
+
 			var handler = Window.Handler as WindowHandler;
 			if (handler?.PlatformView is not Window _window)
 				return false;
 
-			_panel = _window.Content as Panel;
+			_panel = _window.Content as WindowRootViewContainer;
+			if (_panel is null)
+				return false;
+
 			// Capture when the frame is navigating.
 			// When it is, we will clear existing adorners.
 			if (_platformElement is Frame frame)
@@ -52,7 +56,7 @@ namespace Microsoft.Maui
 			_graphicsView.IsHitTestVisible = false;
 			_graphicsView.Visibility = UI.Xaml.Visibility.Collapsed;
 
-			_panel?.Children.Add(_graphicsView);
+			_panel.AddOverlay(_graphicsView);
 
 			IsPlatformViewInitialized = true;
 			return IsPlatformViewInitialized;
@@ -77,8 +81,6 @@ namespace Microsoft.Maui
 		{
 			if (_frame != null)
 				_frame.Navigating -= FrameNavigating;
-			if (_panel != null)
-				_panel.Children.Remove(_graphicsView);
 			if (_platformElement != null)
 			{
 				_platformElement.Tapped -= ViewTapped;
@@ -88,8 +90,10 @@ namespace Microsoft.Maui
 			{
 				_graphicsView.Tapped -= ViewTapped;
 				_graphicsView.PointerMoved -= PointerMoved;
+				if (_panel != null)
+					_panel.RemoveOverlay(_graphicsView);
+				_graphicsView = null;
 			}
-			_graphicsView = null;
 			IsPlatformViewInitialized = false;
 		}
 


### PR DESCRIPTION
### Description of Change

Over the last set of commits, we tried to improve performance and reduce the view nesting and layout churn. Inadvertently we removed a root view that appeared to not be used. https://github.com/dotnet/maui/pull/7172 This is a result of code not actually using the type and was just casting to Panel or some other base type.

This PR adds the view back, but also adds it back in a more useful way. Most notable the page managers use the type directly to add pages and the overly managers use it to add overlays. Instead of everyone grabbing the view and putting their bits in, we should use the new api so that overlays correctly are added to the top and pages underneath.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #8096
