### PR TITLE
Fix Editor on iOS so it can GC

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.iOS.cs
@@ -14,14 +14,20 @@ namespace Microsoft.Maui.Handlers
 			var platformEditor = new MauiTextView();
 
 #if !MACCATALYST
-			platformEditor.InputAccessoryView = new MauiDoneAccessoryView(() =>
-			{
-				platformEditor.ResignFirstResponder();
-				VirtualView?.Completed();
-			});
+			var accessoryView = new MauiDoneAccessoryView(OnDoneClicked, this);
+			platformEditor.InputAccessoryView = accessoryView;
 #endif
 
 			return platformEditor;
+		}
+
+		static void OnDoneClicked(object sender)
+		{
+			if (sender is EditorHandler handler)
+			{
+				handler.PlatformView.ResignFirstResponder();
+				handler.VirtualView.Completed();
+			}
 		}
 
 		protected override void ConnectHandler(MauiTextView platformView)

--- a/src/Core/src/Platform/iOS/MauiDoneAccessoryView.cs
+++ b/src/Core/src/Platform/iOS/MauiDoneAccessoryView.cs
@@ -1,15 +1,33 @@
 ﻿#if IOS && !MACCATALYST
 using System;
 using CoreGraphics;
-using Foundation;
-using Microsoft.Maui.Devices;
-using Microsoft.Maui.Graphics;
 using UIKit;
 
 namespace Microsoft.Maui.Platform
 {
 	internal class MauiDoneAccessoryView : UIToolbar
 	{
+		WeakReference<object>? _data;
+		Action<object>? _doneClicked;
+
+		public MauiDoneAccessoryView(Action<object> doneClicked, object data) : base(new CGRect(0, 0, UIScreen.MainScreen.Bounds.Width, 44))
+		{
+			BarStyle = UIBarStyle.Default;
+			Translucent = true;
+			_data = new WeakReference<object>(data);
+			_doneClicked = doneClicked;
+			var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);
+			var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, OnClicked);
+
+			SetItems(new[] { spacer, doneButton }, false);
+		}
+
+		void OnClicked(object? sender, EventArgs e)
+		{
+			if (_data?.TryGetTarget(out object? target) == true)
+				_doneClicked?.Invoke(target);
+		}
+
 		public MauiDoneAccessoryView(Action doneClicked) : base(new CGRect(0, 0, UIScreen.MainScreen.Bounds.Width, 44))
 		{
 			BarStyle = UIBarStyle.Default;

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class HandlerTestBase<THandler, TStub> : HandlerTestBase
-		where THandler : IViewHandler, new()
+		where THandler : class, IViewHandler, new()
 		where TStub : StubBase, IView, new()
 	{
 		public static Task<bool> Wait(Func<bool> exitCondition, int timeout = 1000) =>

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.DeviceTests
 	}
 
 	public abstract partial class ImageHandlerTests<TImageHandler, TStub> : HandlerTestBase<TImageHandler, TStub>
-		where TImageHandler : IImageHandler, new()
+		where TImageHandler : class, IImageHandler, new()
 		where TStub : StubBase, IImageStub, new()
 	{
 #if ANDROID

--- a/src/Core/tests/DeviceTests/Handlers/TextInput/TextInputHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/TextInput/TextInputHandlerTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Microsoft.Maui.DeviceTests
 {
 	public abstract partial class TextInputHandlerTests<THandler, TStub> : HandlerTestBase<THandler, TStub>
-		where THandler : IViewHandler, new()
+		where THandler : class, IViewHandler, new()
 		where TStub : StubBase, ITextInputStub, new()
 	{
 		[Theory(DisplayName = "TextChanged Events Fire Correctly")]

--- a/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/EditorStub.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public bool IsTextPredictionEnabled { get; set; } = true;
 
-		public Keyboard Keyboard { get; set; }
+		public Keyboard Keyboard { get; set; } = Keyboard.Default;
 
 		public TextAlignment HorizontalTextAlignment { get; set; }
 


### PR DESCRIPTION
### Description of Change

- Added an ctor for MauiAccessoryView that we can supply a static action to so that we don't cause circular references. I realize there are two ctor's now but I'll slowly move through the rest of the controls that use `MauiAccessoryView` but I figured it'd be better to do that one control at a time
- WinUI seems to leak if you subscribe to any events (at least according to these tests). It's odd though because if you set a breakpoint and then continue the run then those all cleanup? So, the way to test WinUI needs a bit more investigation here.


