### PR TITLE
Use the WASDK self-contained by default

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -2,11 +2,11 @@
 
   <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
     <OutputType Condition="'$(OutputType)' == 'Exe'">WinExe</OutputType>
-    <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnableMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">MSIX</WindowsPackageType>
-    <WindowsAppSDKSelfContained Condition=" '$(WindowsAppSDKSelfContained)' == '' and '$(WindowsPackageType)' == 'None' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">true</WindowsAppSDKSelfContained>
-    <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
+    <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' == 'WinExe' ">MSIX</WindowsPackageType>
+    <WindowsAppSDKSelfContained Condition=" '$(WindowsAppSDKSelfContained)' == '' and '$(WindowsPackageType)' == 'None' and '$(OutputType)' == 'WinExe' ">true</WindowsAppSDKSelfContained>
+    <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
     <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
-    <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>
+    <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>
     <_SingleProjectRIDSpecified Condition="'$(RuntimeIdentifier)' != '' or '$(RuntimeIdentifiers)' != ''">true</_SingleProjectRIDSpecified>
   </PropertyGroup>
 

--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -3,6 +3,7 @@
   <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
     <OutputType Condition="'$(OutputType)' == 'Exe'">WinExe</OutputType>
     <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnableMsixTooling)' == 'true' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">MSIX</WindowsPackageType>
+    <WindowsAppSDKSelfContained Condition=" '$(WindowsAppSDKSelfContained)' == '' and '$(WindowsPackageType)' == 'None' and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe') ">true</WindowsAppSDKSelfContained>
     <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'Exe' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
     <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
     <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -69,7 +69,6 @@
 
   <!--
     Workaround for https://github.com/microsoft/WindowsAppSDK/issues/2684
-    This replaces the error check target entirely as it is not needed.
   -->
   <Import Project="src\Workload\Microsoft.Maui.Sdk\Sdk\WinUI.Unpackaged.targets" Condition=" '$(WindowsPackageType)' == 'None' and '$(_MauiTargetPlatformIsWindows)' == 'True' " />
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -67,4 +67,10 @@
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.24" TargetingPackVersion="10.0.18362.24" />
   </ItemGroup>
 
+  <!--
+    Workaround for https://github.com/microsoft/WindowsAppSDK/issues/2684
+    This replaces the error check target entirely as it is not needed.
+  -->
+  <Import Project="src\Workload\Microsoft.Maui.Sdk\Sdk\WinUI.Unpackaged.targets" Condition=" '$(WindowsPackageType)' == 'None' and '$(_MauiTargetPlatformIsWindows)' == 'True' " />
+
 </Project>

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -138,6 +138,12 @@ Task("dotnet-templates")
                 ReplaceTextInFiles($"{dir}/*.csproj", "UseMaui", "UseMauiCore");
                 ReplaceTextInFiles($"{dir}/*.csproj", "SingleProject", "EnablePreviewMsixTooling");
             } },
+            { "mauiunpackaged:maui", dir => {
+                ReplaceTextInFiles($"{dir}/*.csproj", "<UseMaui>true</UseMaui>", "<UseMaui>true</UseMaui><WindowsPackageType>None</WindowsPackageType>");
+            } },
+            { "mauiblazorunpackaged:maui-blazor", dir => {
+                ReplaceTextInFiles($"{dir}/*.csproj", "<UseMaui>true</UseMaui>", "<UseMaui>true</UseMaui><WindowsPackageType>None</WindowsPackageType>");
+            } },
         };
 
         var alsoPack = new [] {

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.Unpackaged.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.Unpackaged.targets
@@ -1,0 +1,39 @@
+<!-- Workarounds for WinUI -->
+<Project>
+
+  <!--
+    Workaround for https://github.com/microsoft/WindowsAppSDK/issues/2684
+    This replaces the error check target entirely as it is not needed.
+  -->
+  <Target Name="WindowsAppSDKSelfContainedVerifyConfiguration">
+  </Target>
+
+  <!--
+    Workaround for https://github.com/microsoft/WindowsAppSDK/issues/2684
+    This adjusts the items if we are still resolving to AnyCPU.
+  -->
+  <Target Name="_MAUIAfter_GetExtractMicrosoftWindowsAppSDKMsixFilesInputs"
+          AfterTargets="GetExtractMicrosoftWindowsAppSDKMsixFilesInputs"
+          Condition="'$(NativePlatform)' == 'AnyCPU'">
+    <PropertyGroup>
+      <NativePlatform>Invalid</NativePlatform>
+      <NativePlatform Condition="'$(Platform)' == 'x86'">x86</NativePlatform>
+      <NativePlatform Condition="'$(Platform)' == 'Win32'">x86</NativePlatform>
+      <NativePlatform Condition="'$(Platform)' == 'x64'">x64</NativePlatform>
+      <NativePlatform Condition="'$(Platform)' == 'arm'">arm</NativePlatform>
+      <NativePlatform Condition="'$(Platform)' == 'arm64'">arm64</NativePlatform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Platform)' == 'AnyCPU'">
+      <NativePlatform>neutral</NativePlatform>
+      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-x86'">x86</NativePlatform>
+      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-x64'">x64</NativePlatform>
+      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-arm'">arm</NativePlatform>
+      <NativePlatform Condition="'$(RuntimeIdentifier)' == 'win10-arm64'">arm64</NativePlatform>
+    </PropertyGroup>
+    <ItemGroup>
+      <MicrosoftWindowsAppSDKMsix Include="$([MSBuild]::NormalizeDirectory('$(MicrosoftWindowsAppSDKPackageDir)','tools\Msix\win10-$(NativePlatform)'))Microsoft.WindowsAppRuntime.?.?.Msix"/>
+      <MicrosoftWindowsAppSDKMsix Include="$([MSBuild]::NormalizeDirectory('$(MicrosoftWindowsAppSDKPackageDir)','tools\Msix\win10-$(NativePlatform)'))Microsoft.WindowsAppRuntime.?.?-*.Msix"/>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.targets
@@ -18,6 +18,9 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    Workaround for https://github.com/microsoft/WindowsAppSDK/issues/2684
+  -->
   <Import Project="WinUI.Unpackaged.targets" Condition=" '$(WindowsPackageType)' == 'None' " />
 
 </Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.targets
@@ -18,4 +18,6 @@
     </ItemGroup>
   </Target>
 
+  <Import Project="WinUI.Unpackaged.targets" Condition=" '$(WindowsPackageType)' == 'None' " />
+
 </Project>


### PR DESCRIPTION
### Description of Change

This PR adds the fully self-contained support for unpackaged Maui apps. In WASDK 1.0, unpackaged support was added, but this involved the developer making sure the various Windows App SDK runtime MSIX files were installed on the end-user's machine. In 1.1, the WinUI team added support for a fully self contained apps with all the required bits in the box.

See more info on the pros and cons of all the options in this table: https://docs.microsoft.com/en-us/windows/apps/package-and-deploy/deploy-overview

For maui apps, the defaults after this PR will be:
 - MSIX apps will not include the runtime bits as this is usually managed by the store and the OS
 - Unpackaged apps will include the runtime bits to make a fully xcopy to production

All these options can still be controlled with:

 - `WindowsPackageType`: `MSIX` or `None` to control packaged and unpackaged respectively
 - `WindowsAppSDKSelfContained`: `true` or `false` to control whether the app includes the WASDK runtime or not


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

 - Part of #3166 

Contains the workarounds for https://github.com/microsoft/WindowsAppSDK/issues/2684