### PR TITLE
Call disconnect on previous handler with Shell

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 {
 	public class ShellFlyoutRecyclerAdapter : RecyclerView.Adapter
 	{
-		readonly IShellContext _shellContext;
+		IShellContext _shellContext;
 		List<AdapterListItem> _listItems;
 		List<List<Element>> _flyoutGroupings;
 		Action<Element> _selectedCallback;
@@ -203,13 +203,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (disposing)
 			{
-				((IShellController)Shell).FlyoutItemsChanged -= OnFlyoutItemsChanged;
-
-				_listItems = null;
-				_selectedCallback = null;
+				Disconnect();
 			}
 
 			base.Dispose(disposing);
+		}
+
+		internal void Disconnect()
+		{
+			if (Shell is IShellController scc)
+				scc.FlyoutItemsChanged -= OnFlyoutItemsChanged;
+
+			_listItems = null;
+			_selectedCallback = null;
+			_shellContext = null;
 		}
 
 		public class AdapterListItem

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRenderer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		#endregion IFlyoutBehaviorObserver
 
 		const uint DefaultScrimColor = 0x99000000;
-		readonly IShellContext _shellContext;
+		IShellContext _shellContext;
 		AView _content;
 		IShellFlyoutContentRenderer _flyoutContent;
 		int _flyoutWidthDefault;
@@ -391,6 +391,31 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
+		internal void Disconnect()
+		{
+			ShellController?.RemoveAppearanceObserver(this);
+
+			if (Shell != null)
+				Shell.PropertyChanged -= OnShellPropertyChanged;
+
+			if (this.IsAlive())
+			{
+				this.DrawerClosed -= OnDrawerClosed;
+				this.DrawerSlide -= OnDrawerSlide;
+				this.DrawerOpened -= OnDrawerOpened;
+				this.DrawerStateChanged -= OnDrawerStateChanged;
+			}
+
+			ShellController?.RemoveFlyoutBehaviorObserver(this);
+
+			if (_flyoutContent is ShellFlyoutTemplatedContentRenderer flyoutTemplatedContentRenderer)
+			{
+				flyoutTemplatedContentRenderer.Disconnect();
+			}
+
+			_shellContext = null;
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)
@@ -400,15 +425,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (disposing)
 			{
-				ShellController.RemoveAppearanceObserver(this);
-				Shell.PropertyChanged -= OnShellPropertyChanged;
-
-				this.DrawerClosed -= OnDrawerClosed;
-				this.DrawerSlide -= OnDrawerSlide;
-				this.DrawerOpened -= OnDrawerOpened;
-				this.DrawerStateChanged -= OnDrawerStateChanged;
-
-				((IShellController)_shellContext.Shell).RemoveFlyoutBehaviorObserver(this);
+				Disconnect();
 
 				RemoveView(_content);
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -199,6 +199,17 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			UpdateContentPadding();
 		}
 
+
+		void DisconnectRecyclerView()
+		{
+			if (_flyoutContentView.IsAlive() &&
+				_flyoutContentView is RecyclerViewContainer rvc &&
+				rvc.GetAdapter() is ShellFlyoutRecyclerAdapter sfra)
+			{
+				sfra.Disconnect();
+			}
+		}
+
 		AView CreateFlyoutContent(ViewGroup rootView)
 		{
 			_rootView = rootView;
@@ -208,6 +219,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				_contentView = null;
 				oldContentView.View = null;
 			}
+
+			DisconnectRecyclerView();
 
 			var content = ((IShellController)ShellContext.Shell).FlyoutContent;
 			if (content == null)
@@ -592,6 +605,26 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		}
 
+		internal void Disconnect()
+		{
+			if (_shellContext?.Shell != null)
+				_shellContext.Shell.PropertyChanged -= OnShellPropertyChanged;
+
+			if (_flyoutHeader != null)
+				_flyoutHeader.MeasureInvalidated -= OnFlyoutHeaderMeasureInvalidated;
+
+			_flyoutHeader = null;
+
+			if (_footerView != null)
+				_footerView.View = null;
+
+			_headerView?.Disconnect();
+			DisconnectRecyclerView();
+
+			if (_contentView != null)
+				_contentView.View = null;
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)
@@ -601,10 +634,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (disposing)
 			{
-				_shellContext.Shell.PropertyChanged -= OnShellPropertyChanged;
-
-				if (_flyoutHeader != null)
-					_flyoutHeader.MeasureInvalidated -= OnFlyoutHeaderMeasureInvalidated;
+				Disconnect();
 
 				if (_appBar != null)
 				{
@@ -627,17 +657,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					_contentView.View = null;
 
 				_flyoutContentView?.Dispose();
-				_headerView.Dispose();
+				_headerView?.Dispose();
 
-				if (_footerView != null)
-					_footerView.View = null;
-
-				_rootView.Dispose();
+				_rootView?.Dispose();
 				_defaultBackgroundColor?.Dispose();
 				_bgImage?.Dispose();
 
 				_contentView = null;
-				_flyoutHeader = null;
 				_rootView = null;
 				_headerView = null;
 				_shellContext = null;
@@ -715,15 +741,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					return;
 
 				_isdisposed = true;
-				if (disposing)
-				{
-					if (View != null)
-						View.PropertyChanged -= OnViewPropertyChanged;
-				}
 
-				View = null;
+				if (disposing)
+					Disconnect();
 
 				base.Dispose(disposing);
+			}
+
+			internal void Disconnect()
+			{
+				if (View != null)
+				{
+					View.PropertyChanged -= OnViewPropertyChanged;
+					View = null;
+				}
 			}
 
 			internal void SetFlyoutHeaderBehavior(FlyoutHeaderBehavior flyoutHeaderBehavior)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentContainer.cs
@@ -29,11 +29,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// Handler and MauiContext
 			// But we want to update the inflater and ChildFragmentManager to match
 			// the handlers new home			
-			if (_page?.Handler?.MauiContext is MauiContext scopedMauiContext)
+			if (_page.Handler?.MauiContext is MauiContext scopedMauiContext)
 			{
-				scopedMauiContext.AddWeakSpecific(ChildFragmentManager);
-				scopedMauiContext.AddWeakSpecific(inflater);
-				mauiContext = scopedMauiContext;
+				// If this page comes to us from a different activity then don't reuse it
+				// disconnect the handler so it can recreate against new MauiContext
+				if (scopedMauiContext.GetActivity() == Context.GetActivity())
+				{
+					scopedMauiContext.AddWeakSpecific(ChildFragmentManager);
+					scopedMauiContext.AddWeakSpecific(inflater);
+					mauiContext = scopedMauiContext;
+				}
+				else
+				{
+					_page.Handler.DisconnectHandler();
+				}
 			}
 
 			mauiContext ??= _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFragmentStateAdapter.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public override Fragment CreateFragment(int position)
 		{
+
 			var shellContent = _items[position];
 			return new ShellFragmentContainer(shellContent, _mauiContext) { Arguments = Bundle.Empty };
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellItemRendererBase.cs
@@ -75,13 +75,20 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			}
 		}
 
-		protected IShellContext ShellContext { get; }
+		protected IShellContext ShellContext { get; private set; }
 
 		protected ShellItem ShellItem { get; private set; }
 
 		protected virtual IShellObservableFragment CreateFragmentForPage(Page page)
 		{
 			return ShellContext.CreateFragmentForPage(page);
+		}
+
+		internal void Disconnect()
+		{
+			ShellSection = null;
+			DisplayedPage = null;
+			ShellContext = null;
 		}
 
 		void Destroy()

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -355,7 +355,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			Element.SizeChanged -= OnElementSizeChanged;
 			((IShellController)Element).RemoveAppearanceObserver(this);
 
-			// This cast is necessary because IShellFlyoutRenderer doesn't implement IDisposable
 			if (_flyoutView is ShellFlyoutRenderer sfr)
 				sfr.Disconnect();
 			else

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		IShellFlyoutRenderer _flyoutView;
 		FrameLayout _frameLayout;
 		IMauiContext _mauiContext;
+		bool _disposed;
 
 		event EventHandler<PropertyChangedEventArgs> _elementPropertyChanged;
 
@@ -345,6 +346,31 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void IElementHandler.DisconnectHandler()
 		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			Element.PropertyChanged -= OnElementPropertyChanged;
+			Element.SizeChanged -= OnElementSizeChanged;
+			((IShellController)Element).RemoveAppearanceObserver(this);
+
+			// This cast is necessary because IShellFlyoutRenderer doesn't implement IDisposable
+			if (_flyoutView is ShellFlyoutRenderer sfr)
+				sfr.Disconnect();
+			else
+				(_flyoutView as IDisposable)?.Dispose();
+
+			if (_currentView is ShellItemRendererBase sir)
+				sir.Disconnect();
+			else
+				_currentView.Dispose();
+
+			_currentView = null;
+
+			Element = null;
+
+			_disposed = true;
 		}
 
 		class SplitDrawable : Drawable

--- a/src/Controls/src/Core/HandlerImpl/Shell.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shell.Impl.cs
@@ -28,5 +28,14 @@ namespace Microsoft.Maui.Controls
 			if (propertyName == Shell.FlyoutIsPresentedProperty.PropertyName)
 				Handler?.UpdateValue(nameof(IFlyoutView.IsPresented));
 		}
+
+#if ANDROID
+		protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+		{
+			base.OnHandlerChanging(args);
+			args.OldHandler?.DisconnectHandler();
+		}
+
+#endif
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -11,3 +11,4 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+~override Microsoft.Maui.Controls.Shell.OnHandlerChanging(Microsoft.Maui.Controls.HandlerChangingEventArgs args) -> void

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -17,6 +17,8 @@ using AView = Android.Views.View;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Core.View;
 using static Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedContentRenderer;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -217,6 +219,44 @@ namespace Microsoft.Maui.DeviceTests
 				var appBar = headerPlatformView.GetParentOfType<AppBarLayout>();
 				Assert.Equal(appBar.MeasuredHeight, headerPlatformView.MeasuredHeight);
 			});
+		}
+
+
+		[Fact]
+		public async Task SwappingOutAndroidContextDoesntCrash()
+		{
+			SetupBuilder();
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.Items.Add(new FlyoutItem() { Route = "FlyoutItem1", Items = { new ContentPage() }, Title = "Flyout Item" });
+				shell.Items.Add(new FlyoutItem() { Route = "FlyoutItem2", Items = { new ContentPage() }, Title = "Flyout Item" });
+			});
+
+			var window = new Controls.Window(shell);
+			var mauiContextStub1 = new ContextStub(MauiApp.Services);
+			var activity = mauiContextStub1.GetActivity();
+			mauiContextStub1.Context = new ContextThemeWrapper(activity, Resource.Style.Maui_MainTheme_NoActionBar);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
+			{
+				await OnLoadedAsync(shell.CurrentPage);
+				await OnNavigatedToAsync(shell.CurrentPage);
+				await Task.Delay(100);
+				await shell.GoToAsync("//FlyoutItem2");
+			}, mauiContextStub1);
+
+			var mauiContextStub2 = new ContextStub(MauiApp.Services);
+			mauiContextStub2.Context = new ContextThemeWrapper(activity, Resource.Style.Maui_MainTheme_NoActionBar);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, async (handler) =>
+			{
+				await OnLoadedAsync(shell.CurrentPage);
+				await OnNavigatedToAsync(shell.CurrentPage);
+				await Task.Delay(100);
+				await shell.GoToAsync("//FlyoutItem1");
+				await shell.GoToAsync("//FlyoutItem2");
+			}, mauiContextStub2);
 		}
 
 		protected AView GetFlyoutPlatformView(ShellRenderer shellRenderer)

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -39,9 +39,10 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		static Drawable _decorDrawable;
-		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests)
+		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests, IMauiContext mauiContext = null)
 			where THandler : class, IElementHandler
 		{
+			mauiContext ??= MauiContext;
 			return InvokeOnMainThreadAsync(async () =>
 			{
 				AViewGroup rootView = MauiContext.Context.GetActivity().Window.DecorView as AViewGroup;

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -24,12 +24,13 @@ namespace Microsoft.Maui.DeviceTests
 			== AccessibilityView.Content;
 
 
-		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests)
+		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests, IMauiContext mauiContext = null)
 			where THandler : class, IElementHandler
 		{
+			mauiContext ??= MauiContext;
 			return InvokeOnMainThreadAsync(async () =>
 			{
-				var applicationContext = MauiContext.MakeApplicationScope(UI.Xaml.Application.Current);
+				var applicationContext = mauiContext.MakeApplicationScope(UI.Xaml.Application.Current);
 
 				var appStub = new MauiAppNewWindowStub(window);
 				UI.Xaml.Application.Current.SetApplicationHandler(appStub, applicationContext);

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.DeviceTests
 	public partial class HandlerTestBase : TestBase, IDisposable
 	{
 		bool _isCreated;
-		MauiApp _mauiApp;
+		protected MauiApp MauiApp { get; private set; }
 		IMauiContext _mauiContext;
 
 		// In order to run any page level tests android needs to add itself to the decor view inside a new fragment
@@ -78,16 +78,16 @@ namespace Microsoft.Maui.DeviceTests
 
 			additionalCreationActions?.Invoke(appBuilder);
 
-			_mauiApp = appBuilder.Build();
+			MauiApp = appBuilder.Build();
 
-			_mauiContext = new ContextStub(_mauiApp.Services);
+			_mauiContext = new ContextStub(MauiApp.Services);
 		}
 
 		public void Dispose()
 		{
-			((IDisposable)_mauiApp)?.Dispose();
+			((IDisposable)MauiApp)?.Dispose();
 
-			_mauiApp = null;
+			MauiApp = null;
 			_mauiContext = null;
 		}
 
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		static SemaphoreSlim _takeOverMainContentSempahore = new SemaphoreSlim(1);
-		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action)
+		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action, IMauiContext mauiContext = null)
 			where THandler : class, IElementHandler
 		{
 			return InvokeOnMainThreadAsync(async () =>
@@ -221,7 +221,7 @@ namespace Microsoft.Maui.DeviceTests
 							await action((THandler)cp.Content.Handler);
 						else
 							throw new Exception($"I can't work with {typeof(THandler)}");
-					});
+					}, mauiContext);
 				}
 				finally
 				{

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.iOS.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.iOS.cs
@@ -24,14 +24,15 @@ namespace Microsoft.Maui.DeviceTests
 			return platformView.AccessibilityElementsHidden;
 		}
 
-		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests)
+		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests, IMauiContext mauiContext = null)
 			where THandler : class, IElementHandler
 		{
+			mauiContext ??= MauiContext;
 			return InvokeOnMainThreadAsync(async () =>
 			{
 				try
 				{
-					_ = window.ToHandler(MauiContext);
+					_ = window.ToHandler(mauiContext);
 					await runTests.Invoke();
 				}
 				finally

--- a/src/Controls/tests/DeviceTests/Stubs/ContextStub.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/ContextStub.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		NavigationRootManager _windowManager;
 #endif
 
+#if ANDROID
+		Android.Content.Context _androidContext;
+#endif
+
 		public ContextStub(IServiceProvider services)
 		{
 			_services = services;
@@ -31,7 +35,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 				return _manager ??= _services.GetRequiredService<IAnimationManager>();
 #if ANDROID
 			if (serviceType == typeof(Android.Content.Context))
-				return MauiProgram.CurrentContext;
+				return _androidContext ?? MauiProgram.CurrentContext;
 
 			if (serviceType == typeof(NavigationRootManager))
 				return _windowManager ??= new NavigationRootManager(this);
@@ -56,8 +60,12 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 			Services.GetRequiredService<IMauiHandlersFactory>();
 
 #if __ANDROID__
-		public Android.Content.Context Context =>
-			Services.GetRequiredService<Android.Content.Context>();
+		public Android.Content.Context Context
+		{
+			get => Services.GetRequiredService<Android.Content.Context>();
+			set => _androidContext = value;
+		}
+			
 #endif
 	}
 }


### PR DESCRIPTION
### Description of Change

When swapping in a new handler for shell call disconnect on the previous handler so that the xplat events don't trigger operations on the old set of handlers. There's a larger issue here where I think we need to call `SetVirtualView(null)` on the previous handler.  Something not quite as involved as calling "Disconnect". 
https://github.com/dotnet/maui/issues/8456

### Testing notes

To test this 
- fire up a shell app
- go into developer settings on android and select the option to always destroy activities

### Issues Fixed

Fixes #7940