### PR TITLE
Fix DatePicker on Android so that it can GC

### DIFF
--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Android.App;
-using Android.Content.Res;
-using Android.Graphics.Drawables;
+using Android.Views;
 using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Handlers
@@ -31,7 +30,22 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiDatePicker platformView)
 		{
 			base.ConnectHandler(platformView);
+			//platformView.ViewAttachedToWindow += OnViewAttachedToWindow;
+			//platformView.ViewDetachedFromWindow += OnViewDetachedFromWindow;
 
+			//if (platformView.IsAttachedToWindow)
+			//	DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
+		}
+
+		void OnViewDetachedFromWindow(object? sender, View.ViewDetachedFromWindowEventArgs e)
+		{
+			// I tested and this is called when an activity is destroyed
+			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
+		}
+
+		void OnViewAttachedToWindow(object? sender, View.ViewAttachedToWindowEventArgs e)
+		{
+			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
 			DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
 		}
 
@@ -44,6 +58,8 @@ namespace Microsoft.Maui.Handlers
 				_dialog = null;
 			}
 
+			platformView.ViewAttachedToWindow -= OnViewAttachedToWindow;
+			platformView.ViewDetachedFromWindow -= OnViewDetachedFromWindow;
 			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
 
 			base.DisconnectHandler(platformView);

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -34,16 +34,16 @@ namespace Microsoft.Maui.Handlers
 			platformView.ViewDetachedFromWindow += OnViewDetachedFromWindow;
 
 			if (platformView.IsAttachedToWindow)
-				DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
+				OnViewAttachedToWindow();
 		}
 
-		void OnViewDetachedFromWindow(object? sender, View.ViewDetachedFromWindowEventArgs e)
+		void OnViewDetachedFromWindow(object? sender = null, View.ViewDetachedFromWindowEventArgs? e = null)
 		{
 			// I tested and this is called when an activity is destroyed
 			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
 		}
 
-		void OnViewAttachedToWindow(object? sender, View.ViewAttachedToWindowEventArgs e)
+		void OnViewAttachedToWindow(object? sender = null, View.ViewAttachedToWindowEventArgs? e = null)
 		{
 			DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
 		}
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Handlers
 
 			platformView.ViewAttachedToWindow -= OnViewAttachedToWindow;
 			platformView.ViewDetachedFromWindow -= OnViewDetachedFromWindow;
-			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
+			OnViewDetachedFromWindow();
 
 			base.DisconnectHandler(platformView);
 		}

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Maui.Handlers
 		protected override void ConnectHandler(MauiDatePicker platformView)
 		{
 			base.ConnectHandler(platformView);
-			//platformView.ViewAttachedToWindow += OnViewAttachedToWindow;
-			//platformView.ViewDetachedFromWindow += OnViewDetachedFromWindow;
+			platformView.ViewAttachedToWindow += OnViewAttachedToWindow;
+			platformView.ViewDetachedFromWindow += OnViewDetachedFromWindow;
 
-			//if (platformView.IsAttachedToWindow)
-			//	DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
+			if (platformView.IsAttachedToWindow)
+				DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
 		}
 
 		void OnViewDetachedFromWindow(object? sender, View.ViewDetachedFromWindowEventArgs e)
@@ -45,7 +45,6 @@ namespace Microsoft.Maui.Handlers
 
 		void OnViewAttachedToWindow(object? sender, View.ViewAttachedToWindowEventArgs e)
 		{
-			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
 			DeviceDisplay.MainDisplayInfoChanged += OnMainDisplayInfoChanged;
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBase.cs
@@ -88,6 +88,15 @@ namespace Microsoft.Maui.DeviceTests
 			return handler;
 		}
 
+
+		protected IPlatformViewHandler CreateHandler(IElement view, Type handlerType)
+		{
+			var handler = (IPlatformViewHandler)Activator.CreateInstance(handlerType);
+			InitializeViewHandler(view, handler, MauiContext);
+			return handler;
+
+		}
+
 		public void Dispose()
 		{
 			((IDisposable)_mauiApp).Dispose();

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -24,9 +24,7 @@ namespace Microsoft.Maui.DeviceTests
 			Type[] testedTypes = new[]
 			{
 				typeof(EditorHandler),
-#if IOS
 				typeof(DatePickerHandler)
-#endif
 			};
 
 			if (!testedTypes.Any(t => t.IsAssignableTo(typeof(THandler))))

--- a/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/HandlerTestBaseOfT.Tests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
@@ -12,56 +11,6 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public abstract partial class HandlerTestBase<THandler, TStub>
 	{
-
-		// This way of testing leaks currently doesn't seem to work on WinAppSDK
-		// If you set a break point and the app breaks then the test passes?!?
-		// Not sure if you can test this type of thing with WinAppSDK or not
-#if !WINDOWS
-		[Fact(DisplayName = "Handlers Deallocate When No Longer Referenced")]
-		public async Task HandlersDeallocateWhenNoLongerReferenced()
-		{
-			// Once this includes all handlers we can delete this
-			Type[] testedTypes = new[]
-			{
-				typeof(EditorHandler),
-				typeof(DatePickerHandler)
-			};
-
-			if (!testedTypes.Any(t => t.IsAssignableTo(typeof(THandler))))
-				return;
-
-			var handler = await CreateHandlerAsync(new TStub()) as IPlatformViewHandler;
-
-			WeakReference<THandler> weakHandler = new WeakReference<THandler>((THandler)handler);
-			WeakReference<TStub> weakView = new WeakReference<TStub>((TStub)handler.VirtualView);
-
-			handler = null;
-
-			await AssertionExtensions.Wait(() =>
-			{
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-
-				if (weakHandler.TryGetTarget(out THandler _) ||
-					weakView.TryGetTarget(out TStub _))
-				{
-					return false;
-				}
-
-				return true;
-
-			}, 1500);
-
-			if (weakHandler.TryGetTarget(out THandler _))
-				Assert.True(false, $"{typeof(THandler)} failed to collect");
-
-			if (weakView.TryGetTarget(out TStub _))
-				Assert.True(false, $"{typeof(TStub)} failed to collect");
-		}
-#endif
-
 		[Fact(DisplayName = "Automation Id is set correctly")]
 		public async Task SetAutomationId()
 		{

--- a/src/Core/tests/DeviceTests/Memory/MemoryTestFixture.cs
+++ b/src/Core/tests/DeviceTests/Memory/MemoryTestFixture.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+
+
+namespace Microsoft.Maui.Handlers.Memory
+{
+	public class MemoryTestFixture : IDisposable
+	{
+		Dictionary<Type, (WeakReference handler, WeakReference view)> _handlers
+			= new Dictionary<Type, (WeakReference handler, WeakReference view)>();
+
+		public MemoryTestFixture()
+		{
+		}
+
+		public void AddReferences(Type handlerType, (WeakReference handler, WeakReference view) value) =>
+			_handlers.Add(handlerType, value);
+
+		public bool HasType(Type handlerType) => _handlers.ContainsKey(handlerType);
+
+		public bool DoReferencesStillExist(Type handlerType)
+		{
+			WeakReference weakHandler;
+			WeakReference weakView;
+			(weakHandler, weakView) = _handlers[handlerType];
+
+
+			if (weakHandler.Target != null ||
+				weakHandler.IsAlive ||
+				weakView.Target != null ||
+				weakView.IsAlive)
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		public void Dispose()
+		{
+			_handlers.Clear();
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Memory/MemoryTestOrdering.cs
+++ b/src/Core/tests/DeviceTests/Memory/MemoryTestOrdering.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+
+namespace Microsoft.Maui.Handlers.Memory
+{
+	public class MemoryTestOrdering : ITestCaseOrderer
+	{
+		public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+				where TTestCase : ITestCase
+		{
+			var result = testCases.ToList();
+
+
+			if (result.Count > 2)
+				throw new InvalidOperationException("Add new test to sort if you want it to run");
+
+			return new List<TTestCase>()
+			{
+				result.First(x=> x.TestMethod.Method.Name == nameof(MemoryTests.Allocate)),
+				result.First(x=> x.TestMethod.Method.Name == nameof(MemoryTests.CheckAllocation)),
+			};
+		}
+	}
+}

--- a/src/Core/tests/DeviceTests/Memory/MemoryTestTypes.cs
+++ b/src/Core/tests/DeviceTests/Memory/MemoryTestTypes.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Maui.DeviceTests.Stubs;
+
+
+namespace Microsoft.Maui.Handlers.Memory
+{
+	public class MemoryTestTypes : IEnumerable<object[]>
+	{
+		public IEnumerator<object[]> GetEnumerator()
+		{
+			yield return new object[] { (typeof(DatePickerStub), typeof(DatePickerHandler)) };
+			yield return new object[] { (typeof(EditorStub), typeof(EditorHandler)) };
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}

--- a/src/Core/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Core/tests/DeviceTests/Memory/MemoryTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Media;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+
+namespace Microsoft.Maui.Handlers.Memory
+{
+	/// <summary>
+	/// Trying to allocate and then rely on the GC to collect within the same test was a bit unreliable when running
+	/// tests from the xHarness CLI.
+	/// For example, if you call Thread.Sleep it will block the entire test run from moving forward whereas locally
+	/// it's able to still run in parallel. So, I broke the allocate and check allocate into two steps
+	/// which seems to make Android and WinUI happier. Low APIs on Android still have issues running via xHarness
+	/// which is why we only currently run these on API 30+
+	/// </summary>
+	[TestCaseOrderer("Microsoft.Maui.Handlers.Memory.MemoryTestOrdering", "Microsoft.Maui.Core.DeviceTests")]
+	public class MemoryTests : HandlerTestBase, IClassFixture<MemoryTestFixture>
+	{
+		MemoryTestFixture _fixture;
+		public MemoryTests(MemoryTestFixture fixture)
+		{
+			_fixture = fixture;
+		}
+
+		[Theory]
+		[ClassData(typeof(MemoryTestTypes))]
+		public async Task Allocate((Type ViewType, Type HandlerType) data)
+		{
+			if (!OperatingSystem.IsAndroidVersionAtLeast(30))
+				return;
+
+			var handler = await InvokeOnMainThreadAsync(() => CreateHandler((IElement)Activator.CreateInstance(data.ViewType), data.HandlerType));
+			WeakReference weakHandler = new WeakReference(handler);
+			_fixture.AddReferences(data.HandlerType, (weakHandler, new WeakReference(handler.VirtualView)));
+			handler = null;
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		[Theory]
+		[ClassData(typeof(MemoryTestTypes))]
+		public async Task CheckAllocation((Type ViewType, Type HandlerType) data)
+		{
+			if (!OperatingSystem.IsAndroidVersionAtLeast(30))
+				return;
+
+			// This is mainly relevant when running inside the visual runner as a single test
+			if (!_fixture.HasType(data.HandlerType))
+				await Allocate(data);
+
+			await AssertionExtensions.Wait(() =>
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+
+				if (_fixture.DoReferencesStillExist(data.HandlerType))
+				{
+					return false;
+				}
+
+				return true;
+
+			}, 5000);
+
+			if (_fixture.DoReferencesStillExist(data.HandlerType))
+			{
+				Assert.True(false, $"{data.HandlerType} failed to collect.");
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Only subscribe to the display changed when control is connected to the window. Once it's removed from the window unsubscribe otherwise the handler will leak

Moved the allocation tests out to a separate collection of tests that's able to run as two parts. I found that if you leave the frame of the test and then check the allocation later the GC will have more opportunity to collect. This was needed to get the tests working on API 30 and WinUI. 