### PR TITLE
Call UpdateEmptyView when switching adapters

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewStringGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/EmptyViewGalleries/EmptyViewStringGallery.xaml.cs
@@ -16,6 +16,17 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.EmptyViewGalleries
 
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
 
+			SearchBar.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(SearchBar.Text))
+				{
+					if (string.IsNullOrEmpty(SearchBar.Text))
+					{
+						_demoFilteredItemSource.FilterItems(SearchBar.Text);
+					}
+				}
+			};
+
 			SearchBar.SearchCommand = new Command(() => _demoFilteredItemSource.FilterItems(SearchBar.Text));
 		}
 	}

--- a/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/MauiRecyclerView.cs
@@ -544,6 +544,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 				// TODO hartez 2018/10/24 17:34:36 If this works, cache this layout manager as _emptyLayoutManager	
 				SetLayoutManager(new LinearLayoutManager(Context));
+				UpdateEmptyView();
 			}
 			else if (!showEmptyView && currentAdapter != ItemsViewAdapter)
 			{


### PR DESCRIPTION
### Description of Change

Adds an extra call to `UpdateEmptyView` whenever we switch to the `EmptyViewAdapter` on Android. This makes sure that the `EmptyView` actually shows up all the time.

The root cause is that `EmptyViewAdapter._emptyItemViewType` isn't incremented otherwise and somehow that causes the view not to show.

Additionally there is a change that allows the "string empty view" search to be reset so I could test if the string option still worked as intended.

### Issues Fixed

Fixes #7076
