### PR TITLE
Replace Newtonsoft.Json dependency with System.Text.Json in Resizetizer

### DIFF
--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -2,12 +2,15 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.Maui.Resizetizer
 {
 	internal class AppleIconAssetsGenerator
 	{
+		private JsonSerializerOptions options;
+
 		public AppleIconAssetsGenerator(ResizeImageInfo info, string appIconName, string intermediateOutputPath, DpiPath[] dpis, ILogger logger)
 		{
 			Info = info;
@@ -15,6 +18,7 @@ namespace Microsoft.Maui.Resizetizer
 			IntermediateOutputPath = intermediateOutputPath;
 			AppIconName = appIconName;
 			Dpis = dpis;
+			options = new JsonSerializerOptions { WriteIndented = true };
 		}
 
 		public string AppIconName { get; }
@@ -80,7 +84,7 @@ namespace Microsoft.Maui.Resizetizer
 			};
 
 			//File.WriteAllText(assetContentsFile, infoJsonProp.ToString());
-			File.WriteAllText(appIconSetContentsFile, appIconContentsJson.ToJsonString());
+			File.WriteAllText(appIconSetContentsFile, appIconContentsJson.ToJsonString(options));
 
 			return new List<ResizedImageInfo> {
 				//new ResizedImageInfo { Dpi = new DpiPath("", 1), Filename = assetContentsFile },

--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Maui.Resizetizer
 {
@@ -37,12 +37,16 @@ namespace Microsoft.Maui.Resizetizer
 			var assetContentsFile = Path.Combine(outputAssetsDir, "Contents.json");
 			var appIconSetContentsFile = Path.Combine(outputAppIconSetDir, "Contents.json");
 
-			var infoJsonProp = new JObject(
-				new JProperty("info", new JObject(
-					new JProperty("version", 1),
-					new JProperty("author", "xcode"))));
+			var infoJsonProp = new JsonObject
+			{
+				["info"] = new JsonObject
+				{
+					["version"] = 1,
+					["author"] = "xcode",
+				}
+			};
 
-			var appIconImagesJson = new List<JObject>();
+			var appIconImagesJson = new JsonArray();
 
 			foreach (var dpi in Dpis)
 			{
@@ -52,23 +56,31 @@ namespace Microsoft.Maui.Resizetizer
 					var h = dpi.Size.Value.Height.ToString("0.#", CultureInfo.InvariantCulture);
 					var s = dpi.Scale.ToString("0", CultureInfo.InvariantCulture);
 
-					appIconImagesJson.Add(new JObject(
-						new JProperty("idiom", idiom),
-						new JProperty("size", $"{w}x{h}"),
-						new JProperty("scale", $"{s}x"),
-						new JProperty("filename", AppIconName + dpi.FileSuffix + ".png")));
+					var imageIcon = new JsonObject
+					{
+						["idiom"] = idiom,
+						["size"] = $"{w}x{h}",
+						["scale"] = $"{s}x",
+						["filename"] = AppIconName + dpi.FileSuffix + ".png",
+					};
+
+					appIconImagesJson.Add(imageIcon);
 				}
 			}
 
-			var appIconContentsJson = new JObject(
-				new JProperty("images", appIconImagesJson.ToArray()),
-				new JProperty("properties", new JObject()),
-				new JProperty("info", new JObject(
-					new JProperty("version", 1),
-					new JProperty("author", "xcode"))));
+			var appIconContentsJson = new JsonObject
+			{
+				["images"] = appIconImagesJson,
+				["properties"] = new JsonObject(),
+				["info"] = new JsonObject
+				{
+					["version"] = 1,
+					["author"] = "xcode",
+				},
+			};
 
 			//File.WriteAllText(assetContentsFile, infoJsonProp.ToString());
-			File.WriteAllText(appIconSetContentsFile, appIconContentsJson.ToString());
+			File.WriteAllText(appIconSetContentsFile, appIconContentsJson.ToJsonString());
 
 			return new List<ResizedImageInfo> {
 				//new ResizedImageInfo { Dpi = new DpiPath("", 1), Filename = assetContentsFile },

--- a/src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems
+++ b/src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems
@@ -21,6 +21,7 @@
     <PackageReference Include="System.Memory" Version="4.5.5" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="6.0.5" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
@@ -32,6 +33,7 @@
     <_ResizetizerFiles Include="$(PkgSystem_Memory)\lib\netstandard2.0\System.Memory.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_Buffers)\lib\netstandard2.0\System.Buffers.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" />
+    <_ResizetizerFiles Include="$(PkgMicrosoft_Bcl_AsyncInterfaces)\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_Numerics_Vectors)\lib\netstandard2.0\System.Numerics.Vectors.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_ObjectModel)\lib\netstandard1.3\System.ObjectModel.dll" />

--- a/src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems
+++ b/src/SingleProject/Resizetizer/src/ResizetizerPackages.projitems
@@ -20,7 +20,7 @@
     <PackageReference Include="Fizzler" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.5.5" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="6.0.5" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
@@ -31,6 +31,7 @@
   <ItemGroup>
     <_ResizetizerFiles Include="$(PkgSystem_Memory)\lib\netstandard2.0\System.Memory.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_Buffers)\lib\netstandard2.0\System.Buffers.dll" />
+    <_ResizetizerFiles Include="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_Numerics_Vectors)\lib\netstandard2.0\System.Numerics.Vectors.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll" />
     <_ResizetizerFiles Include="$(PkgSystem_ObjectModel)\lib\netstandard1.3\System.ObjectModel.dll" />
@@ -62,7 +63,6 @@
     <_ResizetizerFiles Include="$(PkgHarfBuzzSharp_NativeAssets_Linux)\runtimes\linux-arm64\native\libHarfBuzzSharp.so" Link="arm64\libHarfBuzzSharp.so" Arch="arm64/" />
     <_ResizetizerFiles Include="$(PkgHarfBuzzSharp_NativeAssets_Linux)\runtimes\linux-musl-x64\native\libHarfBuzzSharp.so" Link="musl-x64\libHarfBuzzSharp.so" Arch="musl-x64/" />
     <_ResizetizerFiles Include="$(PkgHarfBuzzSharp_NativeAssets_Linux)\runtimes\linux-x64\native\libHarfBuzzSharp.so" Link="x64\libHarfBuzzSharp.so" Arch="x64/" />
-    <_ResizetizerFiles Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\Newtonsoft.Json.dll" />
   </ItemGroup>
 
 </Project>

--- a/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
+++ b/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.7.0" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.0-preview.256" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />


### PR DESCRIPTION
Resizetizer uses Newtonsoft.Json to handle creating JSON files for handling Apple Icon assets. We could replace this with System.Text.Json to remove the third party dependency.

Functionally, it should be the same as it was before. Right now, I'm targeting `main` since, IMO, this isn't critical enough to warrant going into a net6 servicing release, but it would be useful for net7.