### PR TITLE
Update SGen to add "NET6_0_OR_GREATER" instead of NET5

### DIFF
--- a/src/Controls/src/SourceGen/CodeBehindGenerator.cs
+++ b/src/Controls/src/SourceGen/CodeBehindGenerator.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Controls.SourceGen
 			// add MemberNotNull attributes
 			if (namedFields != null)
 			{
-				sb.AppendLine($"#if NET5_0_OR_GREATER");
+				sb.AppendLine($"#if NET6_0_OR_GREATER");
 				foreach ((var fname, _, _) in namedFields)
 				{
 


### PR DESCRIPTION
### Description of Change

Updates a piece of source generated code to check for .NET 6 as opposed to .NET 5 which it is now. 

### Issues Fixed

Fixes #8540