### PR TITLE
Capture UI context when triggering UI actions

### DIFF
--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.DeviceTests
 			view.LayoutChange += OnLayout;
 
 			var cts = new CancellationTokenSource();
-			cts.Token.Register(() => OnLayout(view));
+			cts.Token.Register(() => OnLayout(view), true);
 			cts.CancelAfter(timeout);
 
 			return tcs.Task;


### PR DESCRIPTION
### Description of Change

Honestly not sure how this worked when I pushed it all that time ago. It started off working, then intermittent fails, then regular fails and now always fails.

It should never have worked.

This PR makes sure to capture the UI context and then use that when working with the UI.