### PR TITLE
Remove validation exceptions Slider min/max values

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
@@ -5,7 +5,8 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="Slider">
     <views:BasePage.Content>
-        <VerticalStackLayout Margin="12">
+        <ScrollView>
+        <VerticalStackLayout Margin="12" Spacing="6">
             <Label Text="Default" Style="{StaticResource Headline}"/>
             <Slider/>
             <Label
@@ -69,5 +70,6 @@
                     Clicked="OnUpdateMaximumButtonClicked" /> 
             </HorizontalStackLayout>
         </VerticalStackLayout>
+        </ScrollView>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/src/Core/Slider.cs
+++ b/src/Controls/src/Core/Slider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Input;
-using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -9,11 +8,7 @@ namespace Microsoft.Maui.Controls
 	public partial class Slider : View, ISliderController, IElementConfiguration<Slider>
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='MinimumProperty']/Docs" />
-		public static readonly BindableProperty MinimumProperty = BindableProperty.Create("Minimum", typeof(double), typeof(Slider), 0d, validateValue: (bindable, value) =>
-		{
-			var slider = (Slider)bindable;
-			return (double)value < slider.Maximum;
-		}, coerceValue: (bindable, value) =>
+		public static readonly BindableProperty MinimumProperty = BindableProperty.Create(nameof(Minimum), typeof(double), typeof(Slider), 0d, coerceValue: (bindable, value) =>
 		{
 			var slider = (Slider)bindable;
 			slider.Value = slider.Value.Clamp((double)value, slider.Maximum);
@@ -21,11 +16,7 @@ namespace Microsoft.Maui.Controls
 		});
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='MaximumProperty']/Docs" />
-		public static readonly BindableProperty MaximumProperty = BindableProperty.Create("Maximum", typeof(double), typeof(Slider), 1d, validateValue: (bindable, value) =>
-		{
-			var slider = (Slider)bindable;
-			return (double)value > slider.Minimum;
-		}, coerceValue: (bindable, value) =>
+		public static readonly BindableProperty MaximumProperty = BindableProperty.Create(nameof(Maximum), typeof(double), typeof(Slider), 1d, coerceValue: (bindable, value) =>
 		{
 			var slider = (Slider)bindable;
 			slider.Value = slider.Value.Clamp(slider.Minimum, (double)value);
@@ -33,7 +24,7 @@ namespace Microsoft.Maui.Controls
 		});
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Slider.xml" path="//Member[@MemberName='ValueProperty']/Docs" />
-		public static readonly BindableProperty ValueProperty = BindableProperty.Create("Value", typeof(double), typeof(Slider), 0d, BindingMode.TwoWay, coerceValue: (bindable, value) =>
+		public static readonly BindableProperty ValueProperty = BindableProperty.Create(nameof(Value), typeof(double), typeof(Slider), 0d, BindingMode.TwoWay, coerceValue: (bindable, value) =>
 		{
 			var slider = (Slider)bindable;
 			return ((double)value).Clamp(slider.Minimum, slider.Maximum);
@@ -73,7 +64,7 @@ namespace Microsoft.Maui.Controls
 		public Slider(double min, double max, double val) : this()
 		{
 			if (min >= max)
-				throw new ArgumentOutOfRangeException("min");
+				throw new ArgumentOutOfRangeException(nameof(min));
 
 			if (max > Minimum)
 			{

--- a/src/Controls/tests/Core.UnitTests/SliderUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SliderUnitTests.cs
@@ -59,14 +59,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void TestInvalidMaxValue()
 		{
 			var slider = new Slider();
-			Assert.Throws<ArgumentException>(() => slider.Maximum = slider.Minimum - 1);
+			Assert.DoesNotThrow(() => slider.Maximum = slider.Minimum - 1);
 		}
 
 		[Test]
 		public void TestInvalidMinValue()
 		{
 			var slider = new Slider();
-			Assert.Throws<ArgumentException>(() => slider.Minimum = slider.Maximum + 1);
+			Assert.DoesNotThrow(() => slider.Minimum = slider.Maximum + 1);
 		}
 
 		[Test]

--- a/src/Core/src/Platform/iOS/SliderExtensions.cs
+++ b/src/Core/src/Platform/iOS/SliderExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Platform
 			if (slider.MaximumTrackColor != null)
 			{
 				if (uiSlider.TraitCollection.UserInterfaceIdiom != UIUserInterfaceIdiom.Mac)
-					uiSlider.MaximumTrackTintColor = slider.MinimumTrackColor.ToPlatform();
+					uiSlider.MaximumTrackTintColor = slider.MaximumTrackColor.ToPlatform();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

This PR removes the validation of the `Slider.Minimum` and `Slider.Maximum`. Effectively this means we remove the requirement to specify `Minimum` and `Maximum` in a certain order in XAML. Users are now responsible for setting the right values. If that doesn't happen (e.g. `Minimum` is bigger than `Maximum`) weird behavior might occur (which will be the platforms behavior), but the app will not crash.

I left the exception for the constructor in place as this is still some kind of safeguard and doesn't stand in the way of what we're trying to fix here.

### Issues Fixed

Fixes #6305
