### PR TITLE
[Android] Avoid create an unnecessary dialog in DatePickerHandler 

### DIFF
--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Maui.Handlers
 		{
 			// I tested and this is called when an activity is destroyed
 			DeviceDisplay.MainDisplayInfoChanged -= OnMainDisplayInfoChanged;
+			_dialog?.Hide();
+			_dialog = null;
 		}
 
 		void OnViewAttachedToWindow(object? sender = null, View.ViewAttachedToWindowEventArgs? e = null)
@@ -45,13 +47,6 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(MauiDatePicker platformView)
 		{
-			if (_dialog != null)
-			{
-				_dialog.Hide();
-				_dialog.Dispose();
-				_dialog = null;
-			}
-
 			platformView.ViewAttachedToWindow -= OnViewAttachedToWindow;
 			platformView.ViewDetachedFromWindow -= OnViewDetachedFromWindow;
 			OnViewDetachedFromWindow();

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -17,11 +17,6 @@ namespace Microsoft.Maui.Handlers
 				HidePicker = HidePickerDialog
 			};
 
-			var date = VirtualView?.Date;
-
-			if (date != null)
-				_dialog = CreateDatePickerDialog(date.Value.Year, date.Value.Month, date.Value.Day);
-
 			return mauiDatePicker;
 		}
 
@@ -152,7 +147,12 @@ namespace Microsoft.Maui.Handlers
 
 		void HidePickerDialog()
 		{
-			_dialog?.Hide();
+			if (_dialog != null)
+			{
+				_dialog.Hide();
+			}
+
+			_dialog = null;
 		}
 
 		void OnMainDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)

--- a/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
+++ b/src/Core/src/Handlers/DatePicker/DatePickerHandler.Android.cs
@@ -151,8 +151,6 @@ namespace Microsoft.Maui.Handlers
 			{
 				_dialog.Hide();
 			}
-
-			_dialog = null;
 		}
 
 		void OnMainDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)


### PR DESCRIPTION
### Description of Change

Align the Android DatePickerHandler with TimePickerHandler, avoid create an unnecessary dialog creating the PlatformView.

### Issues Fixed

Fixes #8537