### PR TITLE
[xamlc] add compiled BrushTypeConverter

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
@@ -136,7 +136,7 @@
                 <Button
                     Text="Button"
                     HorizontalOptions="Start"
-                    Background="LightGrey"
+                    Background="LightGray"
                     Padding="NaN"/>
                 <Label
                     Text="Padding = 0"
@@ -144,7 +144,7 @@
                 <Button
                     Text="Button"
                     HorizontalOptions="Start"
-                    Background="LightGrey"
+                    Background="LightGray"
                     Padding="0"/>
                 <Label
                     Text="Padding"
@@ -156,7 +156,7 @@
                 <Button
                     Text="Button"
                     HorizontalOptions="Start"
-                    Background="LightGrey"
+                    Background="LightGray"
                     Padding="{Binding Text, Source={Reference paddingEntry}, Converter={StaticResource ThicknessConverter}}"/>
                 <Label
                     Text="LineBreakMode"

--- a/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
@@ -6,9 +6,9 @@ using Mono.Cecil.Cil;
 
 namespace Microsoft.Maui.Controls.XamlC;
 
-class BrushTypeConverter : ColorTypeConverter
+class BrushTypeConverter : ICompiledTypeConverter
 {
-	public override IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
+	public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 	{
 		var module = context.Body.Method.Module;
 
@@ -18,7 +18,8 @@ class BrushTypeConverter : ColorTypeConverter
 
 			if (value.StartsWith("#", StringComparison.Ordinal))
 			{
-				foreach (var instruction in base.ConvertFromString(value, context, node))
+				var colorConverter = new ColorTypeConverter();
+				foreach (var instruction in colorConverter.ConvertFromString(value, context, node))
 					yield return instruction;
 
 				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "SolidColorBrush"), parameterTypes: new[] {

--- a/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
@@ -27,20 +27,15 @@ class BrushTypeConverter : ColorTypeConverter
 				yield break;
 			}
 
-			var parts = value.Split('.');
-			if (parts.Length == 1 || (parts.Length == 2 && parts[0] == "Brush"))
-			{
-				var brush = parts[parts.Length - 1];
-				var propertyGetterReference = module.ImportPropertyGetterReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "Brush"),
-																   brush,
-																   isStatic: true,
-																   caseSensitive: false);
+			var propertyGetterReference = module.ImportPropertyGetterReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "Brush"),
+																				value,
+																				isStatic: true,
+																				caseSensitive: false);
 
-				if (propertyGetterReference != null)
-				{
-					yield return Instruction.Create(OpCodes.Call, propertyGetterReference);
-					yield break;
-				}
+			if (propertyGetterReference != null)
+			{
+				yield return Instruction.Create(OpCodes.Call, propertyGetterReference);
+				yield break;
 			}
 		}
 		throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(Brush));

--- a/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
@@ -45,9 +45,6 @@ class BrushTypeConverter : ICompiledTypeConverter
 			if (parts.Length == 1 || (parts.Length == 2 && parts[0] == "Brush"))
 			{
 				var brush = parts[parts.Length - 1];
-				if (brush == "lightgrey")
-					brush = "lightgray";
-
 				var propertyGetterReference = module.ImportPropertyGetterReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "Brush"),
 																   brush,
 																   isStatic: true,

--- a/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
@@ -2,14 +2,13 @@
 using System.Collections.Generic;
 using Microsoft.Maui.Controls.Build.Tasks;
 using Microsoft.Maui.Controls.Xaml;
-using Microsoft.Maui.Graphics;
 using Mono.Cecil.Cil;
 
 namespace Microsoft.Maui.Controls.XamlC;
 
-class BrushTypeConverter : ICompiledTypeConverter
+class BrushTypeConverter : ColorTypeConverter
 {
-	public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
+	public override IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 	{
 		var module = context.Body.Method.Module;
 
@@ -19,18 +18,8 @@ class BrushTypeConverter : ICompiledTypeConverter
 
 			if (value.StartsWith("#", StringComparison.Ordinal))
 			{
-				var color = Color.FromArgb(value);
-
-				yield return Instruction.Create(OpCodes.Ldc_R4, color.Red);
-				yield return Instruction.Create(OpCodes.Ldc_R4, color.Green);
-				yield return Instruction.Create(OpCodes.Ldc_R4, color.Blue);
-				yield return Instruction.Create(OpCodes.Ldc_R4, color.Alpha);
-
-				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics", "Color"), parameterTypes: new[] {
-						("mscorlib", "System", "Single"),
-						("mscorlib", "System", "Single"),
-						("mscorlib", "System", "Single"),
-						("mscorlib", "System", "Single")}));
+				foreach (var instruction in base.ConvertFromString(value, context, node))
+					yield return instruction;
 
 				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "SolidColorBrush"), parameterTypes: new[] {
 						("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics", "Color")}));

--- a/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
@@ -13,11 +13,8 @@ class BrushTypeConverter : ICompiledTypeConverter
 	{
 		var module = context.Body.Method.Module;
 
-		do
+		if (!string.IsNullOrEmpty (value))
 		{
-			if (string.IsNullOrEmpty(value))
-				break;
-
 			value = value.Trim();
 
 			if (value.StartsWith("#", StringComparison.Ordinal))
@@ -56,8 +53,7 @@ class BrushTypeConverter : ICompiledTypeConverter
 					yield break;
 				}
 			}
-
-		} while (false);
+		}
 		throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(Brush));
 	}
 }

--- a/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/BrushTypeConverter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls.Build.Tasks;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Graphics;
+using Mono.Cecil.Cil;
+
+namespace Microsoft.Maui.Controls.XamlC;
+
+class BrushTypeConverter : ICompiledTypeConverter
+{
+	public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
+	{
+		var module = context.Body.Method.Module;
+
+		do
+		{
+			if (string.IsNullOrEmpty(value))
+				break;
+
+			value = value.Trim();
+
+			if (value.StartsWith("#", StringComparison.Ordinal))
+			{
+				var color = Color.FromArgb(value);
+
+				yield return Instruction.Create(OpCodes.Ldc_R4, color.Red);
+				yield return Instruction.Create(OpCodes.Ldc_R4, color.Green);
+				yield return Instruction.Create(OpCodes.Ldc_R4, color.Blue);
+				yield return Instruction.Create(OpCodes.Ldc_R4, color.Alpha);
+
+				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics", "Color"), parameterTypes: new[] {
+						("mscorlib", "System", "Single"),
+						("mscorlib", "System", "Single"),
+						("mscorlib", "System", "Single"),
+						("mscorlib", "System", "Single")}));
+
+				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "SolidColorBrush"), parameterTypes: new[] {
+						("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics", "Color")}));
+
+				yield break;
+			}
+
+			var parts = value.Split('.');
+			if (parts.Length == 1 || (parts.Length == 2 && parts[0] == "Brush"))
+			{
+				var brush = parts[parts.Length - 1];
+				if (brush == "lightgrey")
+					brush = "lightgray";
+
+				var propertyGetterReference = module.ImportPropertyGetterReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "Brush"),
+																   brush,
+																   isStatic: true,
+																   caseSensitive: false);
+
+				if (propertyGetterReference != null)
+				{
+					yield return Instruction.Create(OpCodes.Call, propertyGetterReference);
+					yield break;
+				}
+			}
+
+		} while (false);
+		throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(Brush));
+	}
+}

--- a/src/Controls/src/Build.Tasks/CompiledConverters/ColorTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/ColorTypeConverter.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.XamlC
 {
 	class ColorTypeConverter : ICompiledTypeConverter
 	{
-		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
+		public virtual IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
 		{
 			var module = context.Body.Method.Module;
 

--- a/src/Controls/src/Build.Tasks/NodeILExtensions.cs
+++ b/src/Controls/src/Build.Tasks/NodeILExtensions.cs
@@ -157,6 +157,8 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "EasingTypeConverter")), typeof(EasingTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "ColorTypeConverter")), typeof(ColorTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "PointTypeConverter")), typeof(PointTypeConverter) },
+					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "RectTypeConverter")), typeof(RectangleTypeConverter) },
+					{ module.ImportReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "BrushTypeConverter")), typeof(XamlC.BrushTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexJustifyTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexJustify>) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexDirectionTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexDirection>) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexAlignContentTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexAlignContent>) },

--- a/src/Controls/src/Build.Tasks/NodeILExtensions.cs
+++ b/src/Controls/src/Build.Tasks/NodeILExtensions.cs
@@ -158,7 +158,6 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "ColorTypeConverter")), typeof(ColorTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "PointTypeConverter")), typeof(PointTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "RectTypeConverter")), typeof(RectangleTypeConverter) },
-					{ module.ImportReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "BrushTypeConverter")), typeof(XamlC.BrushTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexJustifyTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexJustify>) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexDirectionTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexDirection>) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexAlignContentTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexAlignContent>) },

--- a/src/Controls/src/Core/Brush.cs
+++ b/src/Controls/src/Core/Brush.cs
@@ -227,8 +227,6 @@ namespace Microsoft.Maui.Controls
 		static ImmutableBrush lightGray;
 		/// <include file="../../docs/Microsoft.Maui.Controls/Brush.xml" path="//Member[@MemberName='LightGray']/Docs" />
 		public static SolidColorBrush LightGray => lightGray ??= new(Colors.LightGray);
-		/// NOTE: not a public API
-		internal static SolidColorBrush LightGrey => LightGray;
 		static ImmutableBrush lightGreen;
 		/// <include file="../../docs/Microsoft.Maui.Controls/Brush.xml" path="//Member[@MemberName='LightGreen']/Docs" />
 		public static SolidColorBrush LightGreen => lightGreen ??= new(Colors.LightGreen);

--- a/src/Controls/src/Core/Brush.cs
+++ b/src/Controls/src/Core/Brush.cs
@@ -227,6 +227,8 @@ namespace Microsoft.Maui.Controls
 		static ImmutableBrush lightGray;
 		/// <include file="../../docs/Microsoft.Maui.Controls/Brush.xml" path="//Member[@MemberName='LightGray']/Docs" />
 		public static SolidColorBrush LightGray => lightGray ??= new(Colors.LightGray);
+		/// NOTE: not a public API
+		internal static SolidColorBrush LightGrey => LightGray;
 		static ImmutableBrush lightGreen;
 		/// <include file="../../docs/Microsoft.Maui.Controls/Brush.xml" path="//Member[@MemberName='LightGreen']/Docs" />
 		public static SolidColorBrush LightGreen => lightGreen ??= new(Colors.LightGreen);

--- a/src/Controls/src/Core/BrushTypeConverter.cs
+++ b/src/Controls/src/Core/BrushTypeConverter.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using Microsoft.Maui.Controls.Xaml;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Converters;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/BrushTypeConverter.xml" path="Type[@FullName='Microsoft.Maui.Controls.BrushTypeConverter']/Docs" />
+	[ProvideCompiled("Microsoft.Maui.Controls.XamlC.BrushTypeConverter")]
 	public class BrushTypeConverter : TypeConverter
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/BrushTypeConverter.xml" path="//Member[@MemberName='LinearGradient']/Docs" />

--- a/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml
@@ -6,6 +6,9 @@
 			 RectangleP="0,1,2,4"
 			 RectangleBP="4,8,16,32"
 			 PointP="1,2"
+			 BrushByName="Red"
+			 BrushByARGB="#00010203"
+			 BrushByRGB="#010203"
 			 BackgroundColor="Pink"
 			 List="Foo, Bar">
 	<Label x:Name="label"

--- a/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml.cs
@@ -19,6 +19,12 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 		public Point PointP { get; set; }
 
+		public Brush BrushByName { get; set; }
+
+		public Brush BrushByARGB { get; set; }
+
+		public Brush BrushByRGB { get; set; }
+
 		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
 		public IList<string> List { get; set; }
 
@@ -41,6 +47,9 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				Assert.AreEqual(new Rect(0, 1, 2, 4), p.RectangleP);
 				Assert.AreEqual(new Rect(4, 8, 16, 32), p.RectangleBP);
 				Assert.AreEqual(new Point(1, 2), p.PointP);
+				Assert.AreEqual(Brush.Red, p.BrushByName);
+				Assert.AreEqual(new Color(1, 2, 3, 0), ((SolidColorBrush)p.BrushByARGB).Color);
+				Assert.AreEqual(new Color(1, 2, 3), ((SolidColorBrush)p.BrushByRGB).Color);
 				Assert.AreEqual(Colors.Pink, p.BackgroundColor);
 				Assert.AreEqual(LayoutOptions.EndAndExpand, p.label.GetValue(View.HorizontalOptionsProperty));
 				var xConstraint = Microsoft.Maui.Controls.Compatibility.RelativeLayout.GetXConstraint(p.label);


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/4293#issuecomment-1171372950

A decent amount of time is spent in `InitializeComponent()` creating
`Brush` objects:

    16.42ms microsoft.maui.controls!Microsoft.Maui.Controls.BrushTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,object)

I added a new `BrushTypeConverter` class and hooked it up in XamlC. I
added some test cases in our existing `CompiledTypeConverterAreInvoked`
test.

The C# code in ILSpy, previously looked like:

    compiledTypeConverter.RectangleP = (Rect)new RectTypeConverter().ConvertFromInvariantString("0,1,2,4");
    compiledTypeConverter.SetValue(RectangleBPProperty, new RectTypeConverter().ConvertFromInvariantString("4,8,16,32"));
    compiledTypeConverter.BrushByName = (Brush)new BrushTypeConverter().ConvertFromInvariantString("Red");
    compiledTypeConverter.BrushByARGB = (Brush)new BrushTypeConverter().ConvertFromInvariantString("#00010203");
    compiledTypeConverter.BrushByRGB = (Brush)new BrushTypeConverter().ConvertFromInvariantString("#010203");

`RectTypeConverter` is missing the same treatment? I added an entry in
`KnownCompiledTypeConverters`, that seems like it was just missing?

After my changes, the resulting C# in ILSpy:

    compiledTypeConverter.RectangleP = new Rect(0.0, 1.0, 2.0, 4.0);
    compiledTypeConverter.SetValue(RectangleBPProperty, new Rect(4.0, 8.0, 16.0, 32.0));
    compiledTypeConverter.BrushByName = Brush.Red;
    compiledTypeConverter.BrushByARGB = new SolidColorBrush(new Color(0.003921569f, 0.007843138f, 1f / 85f, 0f));
    compiledTypeConverter.BrushByRGB = new SolidColorBrush(new Color(0.003921569f, 0.007843138f, 1f / 85f, 1f));