### PR TITLE
Just call Arrange to set the Frame

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -243,7 +243,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					ContentView.Frame =
 							new CGRect(parent.Bounds.X, HeaderTopMargin, parent.Bounds.Width, parent.Bounds.Height - HeaderTopMargin - footerHeight);
 
-					Content?.LayoutToSize(ContentView.Frame.Width, ContentView.Frame.Height - contentViewYOffset);
+					var platformFrame = new CGRect(0, 0, ContentView.Frame.Width, ContentView.Frame.Height - contentViewYOffset);
+					Content?.Arrange(platformFrame.ToRectangle());
 				}
 			}
 			else
@@ -261,8 +262,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				ContentView.Frame =
 						new CGRect(parent.Bounds.X, topMargin + contentViewYOffset, parent.Bounds.Width, parent.Bounds.Height - topMargin - footerHeight - contentViewYOffset);
 
-
-				Content?.LayoutToSize(ContentView.Frame.Width, ContentView.Frame.Height);
+				var platformFrame = new CGRect(0, 0, ContentView.Frame.Width, ContentView.Frame.Height);
+				Content?.Arrange(platformFrame.ToRectangle());
 			}
 
 			if (HeaderView != null && !double.IsNaN(HeaderSize))

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -240,11 +240,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				}
 				else
 				{
-					ContentView.Frame =
-							new CGRect(parent.Bounds.X, HeaderTopMargin, parent.Bounds.Width, parent.Bounds.Height - HeaderTopMargin - footerHeight);
-
-					var platformFrame = new CGRect(0, 0, ContentView.Frame.Width, ContentView.Frame.Height - contentViewYOffset);
-					Content?.Arrange(platformFrame.ToRectangle());
+					var contentFrame = new Rect(parent.Bounds.X, HeaderTopMargin, parent.Bounds.Width, parent.Bounds.Height - HeaderTopMargin - footerHeight);
+					(Content as IView)?.Arrange(contentFrame);
 				}
 			}
 			else
@@ -259,11 +256,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					topMargin = (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
 				}
 
-				ContentView.Frame =
-						new CGRect(parent.Bounds.X, topMargin + contentViewYOffset, parent.Bounds.Width, parent.Bounds.Height - topMargin - footerHeight - contentViewYOffset);
-
-				var platformFrame = new CGRect(0, 0, ContentView.Frame.Width, ContentView.Frame.Height);
-				Content?.Arrange(platformFrame.ToRectangle());
+				var contentFrame = new Rect(parent.Bounds.X, topMargin + contentViewYOffset, parent.Bounds.Width, parent.Bounds.Height - topMargin - footerHeight - contentViewYOffset);
+				(Content as IView)?.Arrange(contentFrame);
 			}
 
 			if (HeaderView != null && !double.IsNaN(HeaderSize))

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -231,6 +231,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				footerHeight = FooterView.Frame.Height;
 
 			var contentViewYOffset = HeaderView?.Frame.Height ?? 0;
+
 			if (ScrollView != null)
 			{
 				if (Content == null)
@@ -255,6 +256,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				{
 					topMargin = (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
 				}
+				else if (OperatingSystem.IsIOSVersionAtLeast(11))
+					contentViewYOffset -= (nfloat)HeaderTopMargin;
 
 				var contentFrame = new Rect(parent.Bounds.X, topMargin + contentViewYOffset, parent.Bounds.Width, parent.Bounds.Height - topMargin - footerHeight - contentViewYOffset);
 				(Content as IView)?.Arrange(contentFrame);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutLayoutManager.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				{
 					topMargin = (float)UIApplication.SharedApplication.GetSafeAreaInsetsForWindow().Top;
 				}
-				else if (OperatingSystem.IsIOSVersionAtLeast(11))
+				else
 					contentViewYOffset -= (nfloat)HeaderTopMargin;
 
 				var contentFrame = new Rect(parent.Bounds.X, topMargin + contentViewYOffset, parent.Bounds.Width, parent.Bounds.Height - topMargin - footerHeight - contentViewYOffset);

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerView.cs
@@ -93,6 +93,10 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		public override void LayoutSubviews()
 		{
 			var platformFrame = new CGRect(0, 0, Width ?? Frame.Width, Height ?? MeasuredHeight);
+
+			if (_view.Handler != null)
+				_view.ToPlatform().Frame = platformFrame;
+
 			_view.Arrange(platformFrame.ToRectangle());
 		}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerView.cs
@@ -92,12 +92,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public override void LayoutSubviews()
 		{
-			var platformFrame = new CGRect(0, 0, Width ?? Frame.Width, Height ?? MeasuredHeight);
-
-			if (_view.Handler != null)
-				_view.ToPlatform().Frame = platformFrame;
-
-			_view.Arrange(platformFrame.ToRectangle());
+			var platformFrame = new Rect(0, 0, Width ?? Frame.Width, Height ?? MeasuredHeight);
+			(_view as IView).Arrange(platformFrame);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/UIContainerView.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_renderer = (IPlatformViewHandler)view.ToHandler(view.FindMauiContext());
 
-			AddSubview(_renderer.PlatformView);
+			AddSubview(view.ToPlatform());
 			ClipsToBounds = true;
 			view.MeasureInvalidated += OnMeasureInvalidated;
 			MeasuredHeight = double.NaN;
@@ -92,7 +92,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		public override void LayoutSubviews()
 		{
-			_view.LayoutToSize(Width ?? Frame.Width, Height ?? MeasuredHeight);
+			var platformFrame = new CGRect(0, 0, Width ?? Frame.Width, Height ?? MeasuredHeight);
+			_view.Arrange(platformFrame.ToRectangle());
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -419,16 +419,6 @@ namespace Microsoft.Maui.Platform
 			return view?.Superview;
 		}
 
-		internal static void LayoutToSize(this IView view, double width, double height)
-		{
-			var platformFrame = new CGRect(0, 0, width, height);
-
-			if (view.Handler is IPlatformViewHandler viewHandler && viewHandler.PlatformView != null)
-				viewHandler.PlatformView.Frame = platformFrame;
-
-			view.Arrange(platformFrame.ToRectangle());
-		}
-
 		internal static Size LayoutToMeasuredSize(this IView view, double width, double height)
 		{
 			var size = view.Measure(width, height);


### PR DESCRIPTION
### Description of Change

The following [PR ](https://github.com/dotnet/maui/pull/7297) added a `SetNeedsLayout` call that will propagate up to the FlyoutHeader container during LayoutSubviews. This causes an infinite loop so this stops the call to `SetNeedsLayout` if the call comes from `LayoutSubviews`

I doubt this is the best fix but it's the fix that gets it back to not crashing. The best fix will come once this issue is fixed https://github.com/dotnet/maui/issues/8568

### Issues Fixed

Fixes #8146

### Testing info

[We have tests for this but we're still figuring out why shell tests don't run on CI .](https://github.com/dotnet/maui/issues/8568)

