### PR TITLE
[ios] Set block to null when cancelled

### DIFF
--- a/src/Core/src/Dispatching/Dispatcher.iOS.cs
+++ b/src/Core/src/Dispatching/Dispatcher.iOS.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Maui.Dispatching
 			IsRunning = false;
 
 			_dispatchBlock?.Cancel();
+			_dispatchBlock = null;
 		}
 
 		void OnTimerTick()
@@ -79,7 +80,7 @@ namespace Microsoft.Maui.Dispatching
 
 			Tick?.Invoke(this, EventArgs.Empty);
 
-			if (IsRepeating)
+			if (IsRepeating && _dispatchBlock is not null)
 				_dispatchQueue.DispatchAfter(new DispatchTime(DispatchTime.Now, Interval), _dispatchBlock);
 		}
 	}


### PR DESCRIPTION
### Description of Change

In newer versions of iOS, this is a non-nullable parameter, so it needs the check. But, we also should not be hanging onto a cancelled block.

### Issues Fixed

None.
