### PR TITLE
[xamlc] add compiled PointTypeConverter

### DIFF
--- a/src/Controls/src/Build.Tasks/CompiledConverters/PointTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/PointTypeConverter.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Microsoft.Maui.Controls.Build.Tasks;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Graphics;
+using Mono.Cecil.Cil;
+
+namespace Microsoft.Maui.Controls.XamlC;
+
+class PointTypeConverter : ICompiledTypeConverter
+{
+	public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
+	{
+		var module = context.Body.Method.Module;
+		do
+		{
+			if (string.IsNullOrEmpty(value))
+				break;
+			if (Point.TryParse(value.Trim(), out var point))
+			{
+				yield return Instruction.Create(OpCodes.Ldc_R8, point.X);
+				yield return Instruction.Create(OpCodes.Ldc_R8, point.Y);
+				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics", "Point"), parameterTypes: new[] {
+					("mscorlib", "System", "Double"),
+					("mscorlib", "System", "Double")}));
+				yield break;
+			}
+		} while (false);
+		throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(Point));
+	}
+}

--- a/src/Controls/src/Build.Tasks/NodeILExtensions.cs
+++ b/src/Controls/src/Build.Tasks/NodeILExtensions.cs
@@ -156,6 +156,7 @@ namespace Microsoft.Maui.Controls.Build.Tasks
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "CornerRadiusTypeConverter")), typeof(CornerRadiusTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "EasingTypeConverter")), typeof(EasingTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "ColorTypeConverter")), typeof(ColorTypeConverter) },
+					{ module.ImportReference(("Microsoft.Maui.Graphics", "Microsoft.Maui.Graphics.Converters", "PointTypeConverter")), typeof(PointTypeConverter) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexJustifyTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexJustify>) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexDirectionTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexDirection>) },
 					{ module.ImportReference(("Microsoft.Maui", "Microsoft.Maui.Converters", "FlexAlignContentTypeConverter")), typeof(EnumTypeConverter<Layouts.FlexAlignContent>) },

--- a/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml
@@ -5,6 +5,7 @@
              xmlns:cmp="clr-namespace:Microsoft.Maui.Controls.Compatibility;assembly=Microsoft.Maui.Controls"
 			 RectangleP="0,1,2,4"
 			 RectangleBP="4,8,16,32"
+			 PointP="1,2"
 			 BackgroundColor="Pink"
 			 List="Foo, Bar">
 	<Label x:Name="label"

--- a/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 		public Rect RectangleP { get; set; }
 
+		public Point PointP { get; set; }
+
 		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
 		public IList<string> List { get; set; }
 
@@ -38,6 +40,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				var p = new CompiledTypeConverter(useCompiledXaml);
 				Assert.AreEqual(new Rect(0, 1, 2, 4), p.RectangleP);
 				Assert.AreEqual(new Rect(4, 8, 16, 32), p.RectangleBP);
+				Assert.AreEqual(new Point(1, 2), p.PointP);
 				Assert.AreEqual(Colors.Pink, p.BackgroundColor);
 				Assert.AreEqual(LayoutOptions.EndAndExpand, p.label.GetValue(View.HorizontalOptionsProperty));
 				var xConstraint = Microsoft.Maui.Controls.Compatibility.RelativeLayout.GetXConstraint(p.label);


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/4293#issuecomment-1171372950

`dotnet new maui` templates previously showed time spent in:

    2.82ms (0.01%) microsoft.maui.graphics!Microsoft.Maui.Graphics.Converters.PointTypeConverter.ConvertFrom(System.ComponentModel.ITypeDes...

Viewing the assembly in ILSpy, before:

    setter94.Value = new PointTypeConverter().ConvertFromInvariantString("10,10");

With these changes, after:

    setter94.Value((object)new Point(10.0, 10.0));

I updated a test for this scenario.
