### PR TITLE
[Shell] Fixes for Shell issues with iOS and Mac

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		internal void UpdateFlowDirection(Shell shell)
 		{
 			_uiSearchBar.UpdateFlowDirection(shell);
-			_numericAccessoryView.UpdateFlowDirection(shell);
+			_numericAccessoryView?.UpdateFlowDirection(shell);
 
 			var uiTextField = _uiSearchBar.FindDescendantView<UITextField>();
 			UpdateSearchBarHorizontalTextAlignment(uiTextField, shell);
@@ -304,7 +304,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// iPhone does not have an enter key on numeric keyboards
 			if (DeviceInfo.Idiom == DeviceIdiom.Phone && (keyboard == Keyboard.Numeric || keyboard == Keyboard.Telephone))
 			{
-				_numericAccessoryView = _numericAccessoryView ?? CreateNumericKeyboardAccessoryView();
+				_numericAccessoryView ??= CreateNumericKeyboardAccessoryView();
 				_uiSearchBar.InputAccessoryView = _numericAccessoryView;
 			}
 			else

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutContentRenderer.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 			}
 
-			imageSource.LoadImage(imageSource.FindMauiContext(), result =>
+			imageSource.LoadImage(imageSource.FindMauiContext(true), result =>
 			{
 				var nativeImage = result?.Value;
 				if (View == null || nativeImage == null)

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellFlyoutContentRenderer.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				return;
 			}
 
-			imageSource.LoadImage(imageSource.FindMauiContext(true), result =>
+			imageSource.LoadImage(_shellContext.Shell.FindMauiContext(), result =>
 			{
 				var nativeImage = result?.Value;
 				if (View == null || nativeImage == null)


### PR DESCRIPTION
### Description of Change

* .jpg files do not contain a context; let's use the Shell context when an image does not have one
* The accessory view of the Search bar was trying to change its flow direction when `null`, that does not seem right

### Issues Fixed

Fixes #7260

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
