### PR TITLE
Set Window Parent before initialize the child ContentPage

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
@@ -140,8 +140,8 @@ namespace Microsoft.Maui.Controls
 			if (window is NavigableElement ne)
 				ne.NavigationProxy.Inner = NavigationProxy;
 
-			// Once the window has been attached to the application the window
-			// will finish propagating events like `Appearing`.
+			// Once the window has been attached to the application. 
+			// The window will finish propagating events like `Appearing`.
 			//
 			// I could fire this from 'OnParentSet` inside Window but
 			// I'd rather wait until Application is done wiring itself

--- a/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
@@ -132,7 +132,9 @@ namespace Microsoft.Maui.Controls
 
 			if (window is Element windowElement)
 			{
-				windowElement.Parent = this;
+				if (windowElement.Parent != this)
+					windowElement.Parent = this;
+
 				InternalChildren.Add(windowElement);
 				OnChildAdded(windowElement);
 			}

--- a/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
@@ -132,15 +132,22 @@ namespace Microsoft.Maui.Controls
 
 			if (window is Element windowElement)
 			{
-				if (windowElement.Parent != this)
-					windowElement.Parent = this;
-
+				windowElement.Parent = this;
 				InternalChildren.Add(windowElement);
 				OnChildAdded(windowElement);
 			}
 
 			if (window is NavigableElement ne)
 				ne.NavigationProxy.Inner = NavigationProxy;
+
+			// Once the window has been attached to the application the window
+			// will finish propagating events like `Appearing`.
+			//
+			// I could fire this from 'OnParentSet` inside Window but
+			// I'd rather wait until Application is done wiring itself
+			// up to the window before triggering any down stream life cycle
+			// events.
+			window.FinishedAddingWindowToApplication(this);
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -67,6 +67,9 @@ namespace Microsoft.Maui.Controls
 		public Window(Page page)
 			: this()
 		{
+			if (this is Element windowElement)
+				windowElement.Parent = Application.Current;
+
 			Page = page;
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -67,9 +67,6 @@ namespace Microsoft.Maui.Controls
 		public Window(Page page)
 			: this()
 		{
-			if (this is Element windowElement)
-				windowElement.Parent = Application.Current;
-
 			Page = page;
 		}
 
@@ -267,13 +264,19 @@ namespace Microsoft.Maui.Controls
 				{
 					_visualChildren.Add(item);
 					OnChildAdded(item);
-					// TODO once we have better life cycle events on pages 
-					if (item is Page)
+
+					if (Parent != null && item is Page)
 					{
 						SendWindowAppearing();
 					}
 				}
 			}
+		}
+
+		internal void FinishedAddingWindowToApplication(Application application)
+		{
+			if (Parent != null)
+				SendWindowAppearing();
 		}
 
 		void SendWindowAppearing()

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -463,8 +463,10 @@ namespace Microsoft.Maui.Controls
 		{
 			// Only fire appearing if the page has been added to the windows
 			// Visual Hierarchy
+			// The window/application will take care of re-firing this appearing 
+			// if it needs to
 			var window = this.FindParentOfType<Window>();
-			if (window == null)
+			if (window?.Parent == null)
 			{
 				return;
 			}

--- a/src/Controls/tests/Core.UnitTests/FlyoutPageUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlyoutPageUnitTests.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void FlyoutPageAppearingAnDisappearingPropagatesToFlyout()
+		public void FlyoutPageAppearingAndDisappearingPropagatesToFlyout()
 		{
 			int disappearing = 0;
 			int appearing = 0;
@@ -414,7 +414,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Detail = new ContentPage() { Title = "detail" }
 			};
 
-			_ = new Window(flyoutPage);
+			_ = new TestWindow(flyoutPage);
 			flyout.Appearing += (_, __) => appearing++;
 			flyout.Disappearing += (_, __) => disappearing++;
 
@@ -433,7 +433,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void FlyoutPageAppearingAnDisappearingPropagatesToDetail()
+		public void FlyoutPageAppearingAndDisappearingPropagatesToDetail()
 		{
 			int disappearing = 0;
 			int appearing = 0;

--- a/src/Controls/tests/Core.UnitTests/FlyoutPageUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/FlyoutPageUnitTests.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Detail = detail
 			};
 
-			_ = new Window(flyoutPage);
+			_ = new TestWindow(flyoutPage);
 
 			detail.Appearing += (_, __) => appearing++;
 			detail.Disappearing += (_, __) => disappearing++;

--- a/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationPageLifecycleTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			NavigationPage nav = new TestNavigationPage(useMaui, contentPage);
 
 			Assert.IsNull(resultPage);
-			_ = new Window(nav);
+			_ = new TestWindow(nav);
 			Assert.AreEqual(resultPage, contentPage);
 		}
 
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				=> pageAppearing = (ContentPage)sender;
 
 			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
-			_ = new Window(nav);
+			_ = new TestWindow(nav);
 			nav.SendAppearing();
 
 			await nav.PushAsync(pushedPage);
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			ContentPage pageDisappeared = null;
 
 			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
-			_ = new Window(nav);
+			_ = new TestWindow(nav);
 			nav.SendAppearing();
 
 			initialPage.Appearing += (sender, _)
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			ContentPage pageDisappeared = null;
 
 			NavigationPage nav = new TestNavigationPage(useMaui, initialPage);
-			_ = new Window(nav);
+			_ = new TestWindow(nav);
 			nav.SendAppearing();
 
 			initialPage.Appearing += (sender, _)

--- a/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/NavigationUnitTest.cs
@@ -694,7 +694,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var contentPage1 = new ContentPage();
 			var navigationPage = new TestNavigationPage(true, contentPage1);
-			var window = new Window(navigationPage);
+			var window = new TestWindow(navigationPage);
 
 			Assert.IsNotNull(window.Toolbar);
 			Assert.IsNull(contentPage1.Toolbar);
@@ -713,7 +713,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				Flyout = new ContentPage() { Title = "Flyout" }
 			};
 
-			var window = new Window(flyoutPage);
+			var window = new TestWindow(flyoutPage);
 
 			Assert.IsNull(window.Toolbar);
 			Assert.IsNull(contentPage1.Toolbar);
@@ -740,7 +740,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 			};
 
-			var window = new Window(tabbedPage);
+			var window = new TestWindow(tabbedPage);
 
 			Assert.IsNotNull(window.Toolbar);
 			Assert.IsNull(contentPage1.Toolbar);
@@ -752,7 +752,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public async Task TabBarSetsOnModalPageWhenWindowAlsoHasNavigationPage()
 		{
-			var window = new Window(new TestNavigationPage(true, new ContentPage()));
+			var window = new TestWindow(new TestNavigationPage(true, new ContentPage()));
 			var contentPage1 = new ContentPage();
 			var navigationPage = new TestNavigationPage(true, contentPage1);
 			await window.Navigation.PushModalAsync(navigationPage);
@@ -765,7 +765,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public async Task TabBarSetsOnModalPageForSingleNavigationPage()
 		{
-			var window = new Window(new ContentPage());
+			var window = new TestWindow(new ContentPage());
 			var contentPage1 = new ContentPage();
 			var navigationPage = new TestNavigationPage(true, contentPage1);
 			await window.Navigation.PushModalAsync(navigationPage);
@@ -778,7 +778,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public async Task TabBarSetsOnFlyoutPageInsideModalPage()
 		{
-			var window = new Window(new ContentPage());
+			var window = new TestWindow(new ContentPage());
 			var contentPage1 = new ContentPage();
 			var navigationPage = new TestNavigationPage(true, contentPage1);
 			var flyoutPage = new FlyoutPage()
@@ -799,7 +799,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public async Task TabBarSetsOnModalPageWithFlyoutPageNestedInTabbedPage()
 		{
 			// ModalPage => TabbedPage => FlyoutPage => NavigationPage
-			var window = new Window(new ContentPage());
+			var window = new TestWindow(new ContentPage());
 			var contentPage1 = new ContentPage();
 			var navigationPage = new TestNavigationPage(true, contentPage1);
 			var flyoutPage = new FlyoutPage()

--- a/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageLifeCycleTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		{
 			var previousPage = new LCPage();
 			var lcPage = new LCPage();
-			var window = new Window(previousPage);
+			var window = new TestWindow(previousPage);
 
 			await window.Navigation.PushModalAsync(lcPage);
 
@@ -141,7 +141,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var firstPage = new LCPage();
 			var poppedPage = new LCPage();
 
-			var window = new Window(firstPage);
+			var window = new TestWindow(firstPage);
 			await window.Navigation.PushModalAsync(poppedPage);
 			await window.Navigation.PopModalAsync();
 
@@ -161,7 +161,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var firstModalPage = new LCPage();
 			var secondModalPage = new LCPage();
 
-			var window = new Window(firstPage);
+			var window = new TestWindow(firstPage);
 			await window.Navigation.PushModalAsync(firstModalPage);
 			await window.Navigation.PushModalAsync(secondModalPage);
 
@@ -188,7 +188,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var firstModalPage = new LCPage();
 			var secondModalPage = new LCPage();
 
-			var window = new Window(firstPage);
+			var window = new TestWindow(firstPage);
 			await window.Navigation.PushModalAsync(firstModalPage);
 
 			firstModalPage.ClearNavigationArgs();

--- a/src/Controls/tests/Core.UnitTests/PageTests.cs
+++ b/src/Controls/tests/Core.UnitTests/PageTests.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.That(sent, Is.False, "Busy message sent while not visible");
 
-			_ = new Window(page);
+			_ = new TestWindow(page);
 
 			Assert.That(sent, Is.True, "Busy message not sent when visible");
 		}
@@ -344,7 +344,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void BusySentWhenBusyPageDisappears()
 		{
 			var page = new ContentPage { IsBusy = true };
-			_ = new Window(page);
+			_ = new TestWindow(page);
 			((IPageController)page).SendAppearing();
 
 			var sent = false;
@@ -366,7 +366,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			MessagingCenter.Subscribe<Page, bool>(this, Page.BusySetSignalName, (p, b) => sent = true);
 
 			var page = new ContentPage();
-			_ = new Window(page);
+			_ = new TestWindow(page);
 			((IPageController)page).SendAppearing();
 
 			Assert.That(sent, Is.False, "Busy message sent appearing while not busy");
@@ -465,7 +465,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			bool sent = false;
 			page.Appearing += (sender, args) => sent = true;
 
-			_ = new Window(page);
+			_ = new TestWindow(page);
 
 			Assert.True(sent);
 		}
@@ -474,7 +474,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void SendDisappearing()
 		{
 			var page = new ContentPage();
-			_ = new Window(page);
+			_ = new TestWindow(page);
 
 			((IPageController)page).SendAppearing();
 
@@ -494,7 +494,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			int countAppearing = 0;
 			page.Appearing += (sender, args) => countAppearing++;
 
-			_ = new Window(page);
+			_ = new TestWindow(page);
 			((IPageController)page).SendAppearing();
 
 			Assert.That(countAppearing, Is.EqualTo(1));
@@ -524,7 +524,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 			navPage.Appearing += (sender, e) => sentNav = true;
 
-			_ = new Window(navPage);
+			_ = new TestWindow(navPage);
 
 			Assert.True(sentNav);
 			Assert.True(sent);
@@ -537,7 +537,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var page = new ContentPage();
 
 			var navPage = new NavigationPage(page);
-			_ = new Window(navPage);
+			_ = new TestWindow(navPage);
 			((IPageController)navPage).SendAppearing();
 
 			bool sentNav = false;

--- a/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellTestBase.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			public TestShell()
 			{
-				_ = new Window() { Page = this };
+				_ = new TestWindow() { Page = this };
 				Routing.RegisterRoute(nameof(TestPage1), typeof(TestPage1));
 				Routing.RegisterRoute(nameof(TestPage2), typeof(TestPage2));
 				Routing.RegisterRoute(nameof(TestPage3), typeof(TestPage3));

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestApp.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestApp.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class TestApp : Application
+	{
+		ContentPage _withPage;
+		TestWindow _window;
+
+		public TestApp() : base(false)
+		{
+
+		}
+
+		public TestApp(TestWindow window) : base(false)
+		{
+			_window = window;
+		}
+
+		public TestWindow CreateWindow() =>
+			(TestWindow)(this as IApplication).CreateWindow(null);
+
+		protected override Window CreateWindow(IActivationState activationState)
+		{
+			return _window ?? new TestWindow(_withPage ?? new ContentPage());
+		}
+
+		public TestWindow CreateWindow(ContentPage withPage)
+		{
+			_withPage = withPage;
+			return (TestWindow)(this as IApplication).CreateWindow(null);
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestWindow.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestWindow.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class TestWindow : Window
+	{
+		public TestWindow()
+		{
+
+		}
+
+		public TestWindow(Page page) : base(page)
+		{
+		}
+
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			base.OnPropertyChanged(propertyName);
+			if (propertyName == PageProperty.PropertyName &&
+				Parent == null)
+			{
+				var app = new TestApp(this);
+				_ = (app as IApplication).CreateWindow(null);
+			}
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public void ToolbarExistsForNavigationPage()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var startingPage = new NavigationPage(new ContentPage());
 			window.Page = startingPage;
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public async Task TitleAndTitleViewAreMutuallyExclusive()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var contentPage = new ContentPage() { Title = "Test Title" };
 			var navigationPage = new NavigationPage(contentPage);
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public async Task InsertPageBeforeRootPageShowsBackButton()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var startingPage = new TestNavigationPage(true, new ContentPage());
 			window.Page = startingPage;
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public async Task RemoveRootPageHidesBackButton()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var startingPage = new TestNavigationPage(true, new ContentPage());
 			window.Page = startingPage;
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public void BackButtonNotVisibleForInitialPage()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var startingPage = new NavigationPage(new ContentPage());
 			window.Page = startingPage;
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public void NestedNavigation_AppliesFromMostInnerNavigationPage()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var visibleInnerNavigationPage = new NavigationPage(new ContentPage()) { Title = "visibleInnerNavigationPage" };
 			var nonVisibleNavigationPage = new NavigationPage(new ContentPage()) { Title = "nonVisibleNavigationPage" };
@@ -130,7 +130,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public void NestedNavigation_ChangingToTabWithNoNavigationPage()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var innerNavigationPage =
 				new NavigationPage(new ContentPage() { Content = new Label() }) { Title = "innerNavigationPage" };
@@ -166,7 +166,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public void NestedNavigation_NestedNavigationPage()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var innerNavigationPage =
 				new NavigationPage(new ContentPage() { Content = new Label() }) { Title = "innerNavigationPage" };
@@ -202,7 +202,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public async Task NestedNavigation_BackButtonVisibleIfAnyoneHasPages()
 		{
-			var window = new Window();
+			var window = new TestWindow();
 			IToolbarElement toolbarElement = window;
 			var innerNavigationPage =
 				new NavigationPage(new ContentPage() { Content = new Label() }) { Title = "innerNavigationPage" };

--- a/src/Controls/tests/Core.UnitTests/ToolbarTrackerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ToolbarTrackerTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				}
 			};
 
-			var window = new Window()
+			var window = new TestWindow()
 			{
 				Page = page
 			};

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -265,6 +265,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
+		public void WindowParentIsNotNull()
+		{
+			var app = new TestApp();
+			var window = app.CreateWindow();
+
+			Assert.NotNull(window.Parent);
+		}
+		
 		public void DeActivatedFiresDisappearingEvent()
 		{
 			int disappear = 0;

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -350,30 +350,5 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreEqual(app.NavigationProxy, window.NavigationProxy.Inner);
 			Assert.AreEqual(window.NavigationProxy, page.NavigationProxy.Inner);
 		}
-
-		public class TestApp : Application
-		{
-			ContentPage _withPage;
-			public TestWindow CreateWindow() =>
-				(TestWindow)(this as IApplication).CreateWindow(null);
-
-			protected override Window CreateWindow(IActivationState activationState)
-			{
-				return new TestWindow(_withPage ?? new ContentPage());
-			}
-
-			public TestWindow CreateWindow(ContentPage withPage)
-			{
-				_withPage = withPage;
-				return (TestWindow)(this as IApplication).CreateWindow(null);
-			}
-		}
-
-		public class TestWindow : Window
-		{
-			public TestWindow(Page page) : base(page)
-			{
-			}
-		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -265,14 +265,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Test]
-		public void WindowParentIsNotNull()
+		public void ApplicationIsSetOnWindowBeforeAppearingIsCalledOnPage()
 		{
-			var app = new TestApp();
-			var window = app.CreateWindow();
+			bool passed = false;
+			ContentPage cp = new ContentPage();
+			cp.Appearing += (_, _) =>
+			{
+				var findApplication = cp?.Parent?.Parent as IApplication;
+				Assert.NotNull(findApplication);
+				passed = true;
+			};
 
-			Assert.NotNull(window.Parent);
+			_ = new TestApp().CreateWindow(cp);
+
+			Assert.IsTrue(passed);
 		}
-		
+
 		public void DeActivatedFiresDisappearingEvent()
 		{
 			int disappear = 0;
@@ -345,12 +353,19 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 		public class TestApp : Application
 		{
+			ContentPage _withPage;
 			public TestWindow CreateWindow() =>
 				(TestWindow)(this as IApplication).CreateWindow(null);
 
 			protected override Window CreateWindow(IActivationState activationState)
 			{
-				return new TestWindow(new ContentPage());
+				return new TestWindow(_withPage ?? new ContentPage());
+			}
+
+			public TestWindow CreateWindow(ContentPage withPage)
+			{
+				_withPage = withPage;
+				return (TestWindow)(this as IApplication).CreateWindow(null);
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			int appear = 0;
 
 			var cp = new ContentPage();
-			IWindow window = new Window(cp);
+			IWindow window = new TestWindow(cp);
 			window.Activated();
 
 			cp.Appearing += (_, __) => appear++;
@@ -327,7 +327,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var cp = new ContentPage();
 			cp.Disappearing += (_, __) => disappear++;
 
-			Window window = new Window(cp);
+			Window window = new TestWindow(cp);
 			(window as IWindow).Activated();
 			Assert.AreEqual(0, disappear);
 			window.Page = new ContentPage();

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -57,6 +57,12 @@ namespace Microsoft.Maui.DeviceTests
 			int contentPageAppearingFired = 0;
 			int navigatedToFired = 0;
 			int shellNavigatedToFired = 0;
+			
+			// If you fail these from the events then
+			// an exception is raised in the middle of the platform
+			// doing platform things which often leads to a crash
+			bool navigatedPartPassed = false;
+			bool navigatedToPartPassed = false;
 
 			contentPage.Appearing += (_, _) =>
 			{
@@ -68,15 +74,15 @@ namespace Microsoft.Maui.DeviceTests
 			contentPage.NavigatedTo += (_, _) =>
 			{
 				navigatedToFired++;
-				Assert.Equal(1, contentPageAppearingFired);
+				navigatedToPartPassed = (contentPageAppearingFired == 1);
 			};
 
 			Shell shell = await CreateShellAsync(shell =>
 			{
 				shell.Navigated += (_, _) =>
 				{
-					Assert.Equal(1, contentPageAppearingFired);
 					shellNavigatedToFired++;
+					navigatedPartPassed = (contentPageAppearingFired == 1);
 
 				};
 
@@ -95,10 +101,13 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, async (handler) =>
 			{
 				await OnFrameSetToNotEmpty(contentPage);
-				Assert.Equal(1, contentPageAppearingFired);
-				Assert.Equal(1, shellNavigatedToFired);
-				Assert.Equal(1, navigatedToFired);
 			});
+
+			Assert.True(navigatedPartPassed, "Appearing fired too many times before Navigated fired");
+			Assert.True(navigatedToPartPassed, "Appearing fired too many times before NavigatedTo fired");
+			Assert.Equal(1, contentPageAppearingFired);
+			Assert.Equal(1, shellNavigatedToFired);
+			Assert.Equal(1, navigatedToFired);
 		}
 
 		[Fact(DisplayName = "Navigating During Navigated Doesnt ReFire Appearing")]

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			appBuilder.Services.AddSingleton<IDispatcherProvider>(svc => TestDispatcher.Provider);
 			appBuilder.Services.AddScoped<IDispatcher>(svc => TestDispatcher.Current);
-			appBuilder.Services.TryAddSingleton<IApplication>((_) => new Application());
+			appBuilder.Services.TryAddSingleton<IApplication>((_) => new ApplicationStub());
 
 			additionalCreationActions?.Invoke(appBuilder);
 
@@ -196,9 +196,13 @@ namespace Microsoft.Maui.DeviceTests
 		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Func<THandler, Task> action, IMauiContext mauiContext = null)
 			where THandler : class, IElementHandler
 		{
+			mauiContext ??= MauiContext;
+
 			return InvokeOnMainThreadAsync(async () =>
 			{
 				IWindow window = null;
+
+				var application = mauiContext.Services.GetService<IApplication>();
 
 				if (view is IWindow w)
 				{
@@ -211,6 +215,14 @@ namespace Microsoft.Maui.DeviceTests
 				else
 				{
 					window = new Controls.Window(new ContentPage() { Content = (View)view });
+				}
+
+				if (application is ApplicationStub appStub)
+				{
+					appStub.SetWindow((Window)window);
+
+					// Trigger the work flow of creating a window
+					_ = application.CreateWindow(null);
 				}
 
 				try

--- a/src/Controls/tests/DeviceTests/Stubs/ApplicationStub.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/ApplicationStub.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public class ApplicationStub : Application
+	{
+		Window _window;
+
+		public ApplicationStub()
+		{
+		}
+
+		public void SetWindow(Window window) => _window = window;
+
+		protected override Window CreateWindow(IActivationState activationState)
+		{
+			return _window;
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Stubs/ApplicationStub.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/ApplicationStub.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 	{
 		Window _window;
 
-		public ApplicationStub()
+		public ApplicationStub() : base(false)
 		{
 		}
 


### PR DESCRIPTION
### Description of Change
Delay firing `appearing` on pages until the whole visual tree from app => page is setup.  The reason this worked on shell is that shell delays creating pages until the platform asks for it so by that point the parent hierarchy will have been established. 

### Issues Fixed

Fixes #8635 
