### PR TITLE
Ensure Flex items have updated values from FlexLayout children before layout

### DIFF
--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -460,10 +460,9 @@ namespace Microsoft.Maui.Controls
 			item.Height = height < 0 ? float.NaN : (float)height;
 			item.IsVisible = GetIsVisible(view);
 
-			// TODO ezhart The Core layout interfaces don't have the padding property yet; when that's available, we should add a check for it here
-			if (view is FlexLayout && view is Controls.Layout layout)
+			if (view is IPadding viewWithPadding)
 			{
-				var (pleft, ptop, pright, pbottom) = (Thickness)layout.GetValue(Compatibility.Layout.PaddingProperty);
+				var (pleft, ptop, pright, pbottom) = viewWithPadding.Padding;
 				item.PaddingLeft = (float)pleft;
 				item.PaddingTop = (float)ptop;
 				item.PaddingRight = (float)pright;
@@ -558,6 +557,17 @@ namespace Microsoft.Maui.Controls
 			};
 		}
 
+		void EnsureFlexItemPropertiesUpdated() 
+		{
+			for (int n = 0; n < this.Count; n++)
+			{
+				var child = this[n];
+				var flexItem = GetFlexItem(child);
+
+				InitItemProperties(child, flexItem);
+			}
+		}
+
 		/// <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='Layout']/Docs" />
 		public void Layout(double width, double height)
 		{
@@ -569,6 +579,8 @@ namespace Microsoft.Maui.Controls
 			{
 				PrepareMeasureHack();
 			}
+
+			EnsureFlexItemPropertiesUpdated();
 
 			_root.Width = !double.IsPositiveInfinity((width)) ? (float)width : 0;
 			_root.Height = !double.IsPositiveInfinity((height)) ? (float)height : 0;

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -22,6 +22,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			}
 		}
 
+		class TestLabel : Label
+		{
+			protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+			{
+				return new Size(150, 100);
+			}
+		}
+
 		[Test]
 		public void FlexLayoutMeasuresImagesUnconstrained()
 		{
@@ -36,6 +44,41 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			_ = manager.Measure(1000, 1000);
 
 			Assert.True(image.Passed, "Image should be measured unconstrained even if the FlexLayout is constrained.");
+		}
+
+		[Test]
+		public void FlexLayoutRecognizesVisibilityChange()
+		{
+			var root = new Grid();
+			var flexLayout = new FlexLayout() as IFlexLayout;
+			var view = new TestLabel();
+			var view2 = new TestLabel();
+
+			root.Add(flexLayout);
+			flexLayout.Add(view as IView);
+			flexLayout.Add(view2 as IView);
+
+			var manager = new FlexLayoutManager(flexLayout);
+
+			// Measure and arrange the layout while the first view is visible
+			var measure = manager.Measure(1000, 1000);
+			manager.ArrangeChildren(new Rect(Point.Zero, measure));
+			
+			// Keep track of where the second view is arranged
+			var whenVisible = view2.Frame.X;
+
+			// Change the visibility
+			view.IsVisible = false;
+
+			// Measure and arrange againg
+			measure = manager.Measure(1000, 1000);
+			manager.ArrangeChildren(new Rect(Point.Zero, measure));
+
+			var whenInvisible = view2.Frame.X;
+
+			// The location of the second view should have changed
+			// now that the first view is not visible
+			Assert.True(whenInvisible != whenVisible);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Ensures that any flex items associated with a FlexLayout child are up-to-date with layout properties (e.g., IsVisible) before layout.

### Issues Fixed

Fixes #7621
