### PR TITLE
Used platformView property for disconnect

### DIFF
--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Handlers
 			platformView.TextChanged -= OnTextChanged;
 
 			// TODO: NET7 issoto - Remove the casting once we can set the TPlatformView generic type as MauiAppCompatEditText
-			if (_set && PlatformView is MauiAppCompatEditText editText)
+			if (_set && platformView is MauiAppCompatEditText editText)
 				editText.SelectionChanged -= OnSelectionChanged;
 
 			_set = false;

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Maui.Handlers
 			platformView.EditorAction -= OnEditorAction;
 
 			// TODO: NET7 issoto - Remove the casting once we can set the TPlatformView generic type as MauiAppCompatEditText
-			if (_set && PlatformView is MauiAppCompatEditText editText)
+			if (_set && platformView is MauiAppCompatEditText editText)
 				editText.SelectionChanged -= OnSelectionChanged;
 
 			_set = false;


### PR DESCRIPTION
### Description of Change

Platform tests are throwing an NRE from `DisconnectHandler` because `EditorHandler` is using the classes `PlatformView`, inside `DisconnectHandler` vs the parameter.  At the point that `DisconnectHandler` is called the classes `PlatformView` has been set to null.