### PR TITLE
fix tests

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -1851,6 +1851,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public void Convert()
 		{
+			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
 			var slider = new Slider();
 			var vm = new MockViewModel { Text = "0.5" };
 			slider.BindingContext = vm;

--- a/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/TypedBindingUnitTests.cs
@@ -1254,6 +1254,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		[Test]
 		public void Convert()
 		{
+			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
 			var slider = new Slider();
 			var vm = new MockViewModel { Text = "0.5" };
 			slider.BindingContext = vm;


### PR DESCRIPTION
### Description of Change

Somehow this version of VSMac doesn't run tests in the InvariantCulture, so the test was failing on the text<->double conversions