### PR TITLE
Update xharness / show emulator for local runs

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.22276.1",
+      "version": "1.0.0-prerelease.22358.1",
       "commands": [
         "xharness"
       ]

--- a/eng/devices/android.cake
+++ b/eng/devices/android.cake
@@ -46,7 +46,10 @@ Information("Build Configuration: {0}", CONFIGURATION);
 
 var avdSettings = new AndroidAvdManagerToolSettings { SdkRoot = ANDROID_SDK_ROOT };
 var adbSettings = new AdbToolSettings { SdkRoot = ANDROID_SDK_ROOT };
-var emuSettings = new AndroidEmulatorToolSettings { SdkRoot = ANDROID_SDK_ROOT, ArgumentCustomization = args => args.Append("-no-window") };
+var emuSettings = new AndroidEmulatorToolSettings { SdkRoot = ANDROID_SDK_ROOT };
+
+if (IsCIBuild())
+	emuSettings.ArgumentCustomization = args => args.Append("-no-window");
 
 AndroidEmulatorProcess emulatorProcess = null;
 


### PR DESCRIPTION
### Description of Change

- Update to latest version of xharness cli.
- When running locally show the android emulator. This is useful when running locally so you can verify the emulator has started and tests are running.
