### PR TITLE
Add AppThemeBinding fallbacks for theme

### DIFF
--- a/src/Controls/src/Core/AppThemeBinding.cs
+++ b/src/Controls/src/Core/AppThemeBinding.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.Maui.ApplicationModel;
-using Microsoft.Maui.Devices;
 
 namespace Microsoft.Maui.Controls
 {
@@ -8,8 +7,6 @@ namespace Microsoft.Maui.Controls
 	{
 		WeakReference<BindableObject> _weakTarget;
 		BindableProperty _targetProperty;
-
-		public AppThemeBinding() => Application.Current.RequestedThemeChanged += (o, e) => ApplyCore(true);
 
 		internal override BindingBase Clone() => new AppThemeBinding
 		{
@@ -32,6 +29,9 @@ namespace Microsoft.Maui.Controls
 			_targetProperty = targetProperty;
 			base.Apply(context, bindObj, targetProperty, fromBindingContextChanged);
 			ApplyCore();
+
+			if (Application.Current != null)
+				Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
 		}
 
 		internal override void Unapply(bool fromBindingContextChanged = false)
@@ -39,7 +39,13 @@ namespace Microsoft.Maui.Controls
 			base.Unapply(fromBindingContextChanged);
 			_weakTarget = null;
 			_targetProperty = null;
+
+			if (Application.Current != null)
+				Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
 		}
+
+		void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
+			=> ApplyCore(true);
 
 		void ApplyCore(bool dispatch = false)
 		{
@@ -82,10 +88,31 @@ namespace Microsoft.Maui.Controls
 		public object Default { get; set; }
 
 		object GetValue()
-			=> Application.Current.RequestedTheme switch
+		{
+			Application app;
+
+			if (_weakTarget?.TryGetTarget(out var target) == true &&
+				target is VisualElement ve &&
+				ve?.Window?.Parent is Application a)
+			{
+				app = a;
+			}
+			else
+			{
+				app = Application.Current;
+			}
+
+			AppTheme appTheme;
+			if (app == null)
+				appTheme = AppInfo.RequestedTheme;
+			else
+				appTheme = app.RequestedTheme;
+
+			return appTheme switch
 			{
 				AppTheme.Dark => _isDarkSet ? Dark : Default,
 				_ => _isLightSet ? Light : Default,
 			};
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/AppThemeTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AppThemeTests.cs
@@ -195,5 +195,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			SetAppTheme(AppTheme.Dark);
 			Assert.AreEqual(Colors.Pink, shell.FlyoutBackgroundColor);
 		}
+
+		[Test]
+		public void NullApplicationCurrentFallsBackToEssentials()
+		{
+			var label = new Label
+			{
+				Text = "Green on Light, Red on Dark"
+			};
+
+			label.SetAppThemeColor(Label.TextColorProperty, Colors.Green, Colors.Red);
+
+			Application.Current = null;
+
+			Assert.AreEqual(Colors.Green, label.TextColor);
+
+			SetAppTheme(AppTheme.Dark);
+
+			Assert.AreEqual(Colors.Red, label.TextColor);
+		}
 	}
 }

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/iOS/MauiTestApplicationDelegate.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/iOS/MauiTestApplicationDelegate.cs
@@ -81,6 +81,21 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 
 		public override bool WillFinishLaunching(UIApplication application, NSDictionary launchOptions)
 		{
+			Runtime.MarshalManagedException += (object sender, MarshalManagedExceptionEventArgs args) =>
+			{
+				Console.WriteLine("Marshaling managed exception");
+				Console.WriteLine("    Exception: {0}", args.Exception);
+				Console.WriteLine("    Mode: {0}", args.ExceptionMode);
+
+			};
+
+			Runtime.MarshalObjectiveCException += (object sender, MarshalObjectiveCExceptionEventArgs args) =>
+			{
+				Console.WriteLine("Marshaling Objective-C exception");
+				Console.WriteLine("    Exception: {0}", args.Exception);
+				Console.WriteLine("    Mode: {0}", args.ExceptionMode);
+			};
+
 			var mauiApp = CreateMauiApp();
 			Services = mauiApp.Services;
 


### PR DESCRIPTION
### Description of Change

Currently any device tests that use `AppThemeBinding` will crash when running via the headless runner because of how `Application.Current` works. 
- Add fall backs into `AppThemeBinding` if Application.Current is null
- try to use the targets window over Application.Current
- If all else fails just ask essentials

I started to go the route of just removing `Application.Current` but that's a little bit tricky because the initial `Apply` code always runs before the xaml element has a window that it can use to arrive at the application.  I was looking at going the [`AdaptiveTrigger`](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/AdaptiveTrigger.cs#L61) approach but everything inside `AppThemeBinding` holds a weak reference to the target, so once you start adding events then you no longer have a weak reference.  So, I went the minimal "let's make this not crash our tests so we can at least get our full testing back in order and make this perfect [later](https://github.com/dotnet/maui/issues/8713)" route.
