### PR TITLE
Utilize explicit dimensions for star measurements in non-Fill alignments

### DIFF
--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1967,5 +1967,60 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view0, new Rect(0, 0, 100, 20));
 		}
 
+		[Theory, Category(GridStarSizing)]
+		[InlineData(LayoutAlignment.Center)]
+		[InlineData(LayoutAlignment.Start)]
+		[InlineData(LayoutAlignment.End)]
+		[InlineData(LayoutAlignment.Fill)]
+		public void StarRowsShouldFitKnownDimensions(LayoutAlignment verticalAlignment)
+		{
+			var grid = CreateGridLayout(rows: "*");
+			grid.VerticalLayoutAlignment.Returns(verticalAlignment);
+			grid.Height.Returns(100);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			SubstituteChildren(grid, view0);
+
+			var manager = new GridLayoutManager(grid);
+			var gridMeasure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			// Because the Grid has an explicit height, we expect the single Star row
+			// to have that height.
+			Assert.Equal(100, gridMeasure.Height);
+
+			manager.ArrangeChildren(new Rect(Point.Zero, gridMeasure));
+
+			// Because the child has VerticalAlignment.Fill, we expect it to fill up the 100
+			// units in the Star row
+			AssertArranged(view0, new Rect(0, 0, 20, 100));
+		}
+
+		[Theory, Category(GridStarSizing)]
+		[InlineData(LayoutAlignment.Center)]
+		[InlineData(LayoutAlignment.Start)]
+		[InlineData(LayoutAlignment.End)]
+		[InlineData(LayoutAlignment.Fill)]
+		public void StarColumnsShouldFitKnownDimensions(LayoutAlignment horizontalAlignment)
+		{
+			var grid = CreateGridLayout(columns: "*");
+			grid.HorizontalLayoutAlignment.Returns(horizontalAlignment);
+			grid.Width.Returns(100);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			SubstituteChildren(grid, view0);
+
+			var manager = new GridLayoutManager(grid);
+			var gridMeasure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			// Because the Grid has an explicit width, we expect the single Star column
+			// to have that width.
+			Assert.Equal(100, gridMeasure.Width);
+
+			manager.ArrangeChildren(new Rect(Point.Zero, gridMeasure));
+
+			// Because the child has HorizontalAlignment.Fill, we expect it to fill up the 100
+			// units in the Star column
+			AssertArranged(view0, new Rect(0, 0, 100, 20));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Grids with non-Fill LayoutAlignments are treating Star Rows/Columns as Auto even when the Grids have explicit sizes in the applicable dimensions, which is wrong. 

IOW, if the Grid is explicitly marked as being 100 units tall, a single "*" Row should get 100 units, even if the Grid is vertically centered in the Page. These changes make the Grid work as expected in this scenario.

### Issues Fixed

Fixes #7499

