### PR TITLE
Exclude `global.json` from iOS Bundle Resources

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -11,6 +11,10 @@
     <Content Remove="**\*.razor" />
     <RazorComponent Include="**\*.razor" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Content Update="@(Content)" Condition="'@(Content->FileName)' == 'global' and '@(Content->Extension)' == '.json'" PublishFolderType="None" />
+  </ItemGroup>
 
   <PropertyGroup>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
@@ -67,8 +71,6 @@
       <!-- Add Scoped CSS files in the app to the list of hidden items -->
       <_TemporaryHiddenContent Include="Pages\**\*.razor.css" />
       <_TemporaryHiddenContent Include="Shared\**\*.razor.css" />
-      <!-- Add global.json to the list of hidden items -->
-      <_TemporaryHiddenContent Include="global.json" />
       <!-- Temporarily remove the items -->
       <Content Remove="@(_TemporaryHiddenContent)" />
     </ItemGroup>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -12,8 +12,9 @@
     <RazorComponent Include="**\*.razor" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
   
+  <!-- Ensure global.json isn't published with the app. -->
   <ItemGroup>
-    <Content Update="@(Content)" Condition="'@(Content->FileName)' == 'global' and '@(Content->Extension)' == '.json'" PublishFolderType="None" />
+    <Content Update="global.json" PublishFolderType="None" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -67,6 +67,8 @@
       <!-- Add Scoped CSS files in the app to the list of hidden items -->
       <_TemporaryHiddenContent Include="Pages\**\*.razor.css" />
       <_TemporaryHiddenContent Include="Shared\**\*.razor.css" />
+      <!-- Add global.json to the list of hidden items -->
+      <_TemporaryHiddenContent Include="global.json" />
       <!-- Temporarily remove the items -->
       <Content Remove="@(_TemporaryHiddenContent)" />
     </ItemGroup>


### PR DESCRIPTION
We were including the `global.json` as part of the iOS (and Mac Catalyst) bundle resources, which was leading to a build failure. Added it to the BlazorWebView targets filtering logic being used to filter out scoped css files.

Before:
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/14852843/178832068-8091ad56-1299-4227-98ed-4882fd0d7d95.png">


After:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/14852843/178831915-b3ae9e1e-4c97-4bf8-9c42-535f8c01ee87.png">

Note this was an issue specific to iOS and MacCatalyst. Windows/Android scenarios were not impacted.

Fixes: https://github.com/dotnet/aspnetcore/issues/41397