### PR TITLE
Add bot rule to manage 's/move-to-vs-feedback' issues

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1962,7 +1962,230 @@
             }
           ]
         }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssuesOnlyResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "s/move-to-vs-feedback"
+                }
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issues",
+            "project_card"
+          ],
+          "taskName": "Ask user to use VS Feedback for VS issues",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "Thanks for the issue report ${issueAuthor}! This issue appears to be a problem with Visual Studio, so we ask that you use the VS feedback tool to report the issue. That way it will get to the routed to the team that owns this experience in VS.\n\nIf you encounter a problem with Visual Studio, we want to know about it so that we can diagnose and fix it. By using the Report a Problem tool, you can collect detailed information about the problem, and send it to Microsoft with just a few button clicks.\n\n1. Go to the [VS feedback tool](https://docs.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2022) to report the issue\n2. Close this bug, and consider adding a link to the VS Feedback issue so that others can follow its activity there.\n\nThis issue will be automatically closed in 3 days if there are no further comments."
+              }
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "scheduled",
+        "capabilityId": "ScheduledSearch",
+        "subCapability": "ScheduledSearch",
+        "version": "1.1",
+        "config": {
+          "frequency": [
+            {
+              "weekDay": 0,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 1,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 2,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 3,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 4,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 5,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            },
+            {
+              "weekDay": 6,
+              "hours": [
+                0,
+                6,
+                12,
+                18
+              ]
+            }
+          ],
+          "searchTerms": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "s/move-to-vs-feedback"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 3
+              }
+            }
+          ],
+          "taskName": "Close 's/move-to-vs-feedback' after 3 days of no activity",
+          "actions": [
+            {
+              "name": "addReply",
+              "parameters": {
+                "comment": "This issue is being closed due to inactivity. If this issue is still affecting you, please follow the steps above to use the VS Feedback Tool to report the issue."
+              }
+            },
+            {
+              "name": "closeIssue",
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "taskType": "trigger",
+        "capabilityId": "IssueResponder",
+        "subCapability": "IssueCommentResponder",
+        "version": "1.0",
+        "config": {
+          "conditions": {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              },
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "created"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "s/move-to-vs-feedback"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "noActivitySince",
+                    "parameters": {
+                      "days": 3
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isCloseAndComment",
+                    "parameters": {}
+                  }
+                ]
+              },
+              {
+                "name": "isActivitySender",
+                "parameters": {
+                  "user": {
+                    "type": "author"
+                  }
+                }
+              },
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "none"
+                }
+              }
+            ]
+          },
+          "eventType": "issue",
+          "eventNames": [
+            "issue_comment"
+          ],
+          "taskName": "For issues labeled with 's/move-to-vs-feedback' mark as 's/needs-attention' if there is activity",
+          "actions": [
+            {
+              "name": "removeLabel",
+              "parameters": {
+                "label": "s/move-to-vs-feedback"
+              }
+            },
+            {
+              "name": "addLabel",
+              "parameters": {
+                "label": "s/needs-attention"
+              }
+            }
+          ]
+        }
       }
     ],
     "userGroups": []
-  }
+}


### PR DESCRIPTION
Workflows being added:
* When the `s/move-to-vs-feedback` label is applied to an open issue, the bot will add this comment to the issue:
   > 
   > Thanks for the issue report ${issueAuthor}! This issue appears to be a problem with Visual Studio, so we ask that you use the VS feedback tool to report the issue. That way it will get to the routed to the team that owns this experience in VS.
   > 
   > If you encounter a problem with Visual Studio, we want to know about it so that we can diagnose and fix it. By using the Report a Problem tool, you can collect detailed information about the problem, and send it to Microsoft with just a few button clicks.
   > 
   > 1. Go to the [VS feedback tool](https://docs.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2022) to report the issue
   > 2. Close this bug, and consider adding a link to the VS Feedback issue so that others can follow its activity there.
   > 
   > This issue will be automatically closed in 3 days if there are no further comments.
* If there is comment activity on the issue within 3 days, the `s/move-to-vs-feedback` label will be removed and the `s/needs-attention` label will be added
* If there is no further activity on the issue, it will be closed after 3 days with a comment saying to use the VS Feedback tool
