### PR TITLE
Fix the sample build

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
+++ b/.nuspec/Microsoft.Maui.Controls.MultiTargeting.targets
@@ -69,7 +69,7 @@
     <Compile Remove="bin\**;obj\**" />
     <None Remove="bin\**;obj\**" />
   </ItemGroup>
-  
+
   <PropertyGroup>
     <!-- Windows -->
     <WindowsProjectFolder>Platform\Windows\</WindowsProjectFolder>
@@ -96,38 +96,22 @@
     <DefineConstants>$(DefineConstants);IOS</DefineConstants>
   </PropertyGroup>
 
+  <!-- Mac Catalyst -->
   <PropertyGroup Condition=" '$(_MauiTargetPlatformIsMacCatalyst)' == 'True' ">
     <DefineConstants>$(DefineConstants);MACCATALYST;IOS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Tizen  -->
+  <!-- Tizen -->
   <PropertyGroup Condition=" '$(_MauiTargetPlatformIsTizen)' == 'True' ">
     <DefineConstants>$(DefineConstants);TIZEN</DefineConstants>
   </PropertyGroup>
 
-  <!-- If this becomes part of the product we will remove these but for now it's useful having them all in one place -->
-  <ItemGroup Condition=" '$(_MauiTargetPlatformIsAndroid)' == 'True' ">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
-    <PackageReference Include="Xamarin.Google.Android.Material" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
-    <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />
-    <PackageReference Include="Xamarin.AndroidX.Navigation.Fragment" />
-    <PackageReference Include="Xamarin.AndroidX.Navigation.Runtime" />
-    <PackageReference Include="Xamarin.AndroidX.Navigation.Common" />
-  </ItemGroup>
+  <!-- Windows -->
   <PropertyGroup Condition=" '$(_MauiTargetPlatformIsWindows)' == 'True' ">
     <DefineConstants>WINDOWS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
     <DefineConstants>WINDOWS_UWP;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(_MauiTargetPlatformIsWindows)' == 'True' ">
-    <PackageReference Include="Microsoft.WindowsAppSDK" />
-    <PackageReference Include="Microsoft.Graphics.Win2D" />
-    <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(_MauiTargetPlatformIsTizen)' == 'True' ">
-    <PackageReference Include="Tizen.UIExtensions.ElmSharp" />
-    <PackageReference Include="Microsoft.Maui.Graphics.Skia" />
-  </ItemGroup>
+
 </Project>

--- a/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
+++ b/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\..\..\..\Controls\Maps\src\Controls.Maps.csproj" />
     <ProjectReference Include="..\..\..\..\Controls\src\Core\Controls.Core.csproj" />
     <ProjectReference Include="..\..\..\..\Core\src\Core.csproj" />
-    <ProjectReference Include="..\..\..\Core\src\Compatibility.csproj" />
+    <ProjectReference Include="..\..\..\..\Compatibility\Core\src\Compatibility.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Compatibility/Maps/src/iOS/Compatibility.Maps.iOS.csproj
+++ b/src/Compatibility/Maps/src/iOS/Compatibility.Maps.iOS.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\..\..\Controls\Maps\src\Controls.Maps.csproj" />
     <ProjectReference Include="..\..\..\..\Controls\src\Core\Controls.Core.csproj" />
     <ProjectReference Include="..\..\..\..\Core\src\Core.csproj" />
-    <ProjectReference Include="..\..\..\Core\src\Compatibility.csproj" />
+    <ProjectReference Include="..\..\..\..\Compatibility\Core\src\Compatibility.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Controls/Foldable/src/Controls.Foldable.csproj
+++ b/src/Controls/Foldable/src/Controls.Foldable.csproj
@@ -1,30 +1,27 @@
 ﻿<Project Sdk="Microsoft.Net.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
+    <TargetFrameworks>$(_MauiDotNetTfm);$(MauiPlatforms)</TargetFrameworks>
     <AssemblyName>Microsoft.Maui.Controls.Foldable</AssemblyName>
     <RootNamespace>Microsoft.Maui.Controls.Foldable</RootNamespace>
     <WarningsNotAsErrors>BI1234</WarningsNotAsErrors>
     <IsPackable>false</IsPackable>
+    <!-- TODO: remove this when Foldable is made into a nupkg -->
+    <UseMaui Condition=" '$(UseWorkload)' == 'true' ">true</UseMaui>
   </PropertyGroup>
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
-  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
-    <!-- remove other AndroidX packages from the MultiTargeting -->
-    <PackageReference Remove="*" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Graphics" />
   </ItemGroup>
   <ItemGroup Condition=" '$(UseMaui)' != 'true' ">
-    <ProjectReference Include="..\..\src\Core\Controls.Core.csproj" />
+    <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
     <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(UseMaui)' != 'true' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
     <PackageReference Include="Xamarin.Google.Android.Material" />

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -17,8 +17,24 @@
     <PackageReference Include="Microsoft.Maui.Graphics" />
     <PackageReference Include="System.Numerics.Vectors" Condition="$(TargetFramework.StartsWith('netstandard'))" />
   </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" />
+    <PackageReference Include="Microsoft.Maui.Graphics.Win2D.WinUI.Desktop" />
+  </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
     <PackageReference Include="Xamarin.Android.Glide" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+    <PackageReference Include="Xamarin.Google.Android.Material" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
+    <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />
+    <PackageReference Include="Xamarin.AndroidX.Navigation.Fragment" />
+    <PackageReference Include="Xamarin.AndroidX.Navigation.Runtime" />
+    <PackageReference Include="Xamarin.AndroidX.Navigation.Common" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.Contains('-tizen'))">
+    <PackageReference Include="Tizen.UIExtensions.ElmSharp" />
+    <PackageReference Include="Microsoft.Maui.Graphics.Skia" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Essentials\src\Essentials.csproj" />

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -11,10 +11,6 @@
     <NoWarn>$(NoWarn);CS1591;NU5104;RS0041;RS0026</NoWarn>
   </PropertyGroup>
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
-  <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
-    <!-- remove other AndroidX packages from the MultiTargeting -->
-    <PackageReference Remove="*" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Graphics" />
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />
@@ -33,6 +29,7 @@
   <ItemGroup Condition=" $(TargetFramework.Contains('-windows')) ">
     <Compile Include="**\*.uwp.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <Compile Include="**\*.uwp.*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
     <Compile Include="**\*.android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />


### PR DESCRIPTION
### Description of Change

The sample build is secretly building maui! This is because the sample sln contains the foldable project - which is a library that references all of maui.

This PR marks the Foldable project as a "sample-able" project and excludes the maui project references when building the samples. It also moves all the package references in the "Microsoft.Maui.Controls.MultiTargeting.targets" file into the Core project as this is where it is needed. This makes Essentials no longer depend on things it does not need.
