### PR TITLE
Add Obsolete attribute to MessagingCenter

### DIFF
--- a/src/Compatibility/ControlGallery/src/WinUI/WinUIStartup.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/WinUIStartup.cs
@@ -42,11 +42,13 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 	{
 		public static void OnActivated(UI.Xaml.Window window, UI.Xaml.WindowActivatedEventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(window, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
 			MessagingCenter.Subscribe<NativeBindingGalleryPage>(window, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Application.Current.PropertyChanged += OnAppPropertyChanged;
 

--- a/src/Compatibility/ControlGallery/src/WinUI/_57114Renderer.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/_57114Renderer.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 
 		void OnTapped(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Send(this as object, Bugzilla57114._57114NativeGestureFiredMessage);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Compatibility/ControlGallery/src/iOS/AppDelegate.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/AppDelegate.cs
@@ -146,15 +146,23 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 			}
 
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<Bugzilla40911>(this, Bugzilla40911.ReadyToSetUp40911Test, SetUp40911Test);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<Issue5503>(this, Issue5503.ChangeUITableViewAppearanceBgColor, (s) =>
 			{
 				UITableView.Appearance.BackgroundColor = UITableView.Appearance.BackgroundColor == null ? UIColor.Red : null;
 			});
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<NativeBindingGalleryPage>(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return base.FinishedLaunching(uiApplication, launchOptions);
 		}

--- a/src/Compatibility/ControlGallery/src/iOS/PerformanceTrackerRenderer.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/PerformanceTrackerRenderer.cs
@@ -278,7 +278,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 			base.LayoutSubviews();
 
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Instance.Send((IDrawnObservable)this, PerformanceTrackerRenderer.SubviewAddedMessage);
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 			_watcher.SubscribeToDrawn(this);
 		}
@@ -731,7 +733,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 			base.LayoutSubviews();
 
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Instance.Send((IDrawnObservable)this, PerformanceTrackerRenderer.SubviewAddedMessage);
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 			_watcher.SubscribeToDrawn(this);
 		}
@@ -783,7 +787,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 			base.LayoutSubviews();
 
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Instance.Send((IDrawnObservable)this, PerformanceTrackerRenderer.SubviewAddedMessage);
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 			_watcher.SubscribeToDrawn(this);
 		}
@@ -1134,7 +1140,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 			base.LayoutSubviews();
 
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Instance.Send((IDrawnObservable)this, PerformanceTrackerRenderer.SubviewAddedMessage);
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 			_watcher.SubscribeToDrawn(this);
 		}

--- a/src/Compatibility/ControlGallery/src/iOS/_57114Renderer.cs
+++ b/src/Compatibility/ControlGallery/src/iOS/_57114Renderer.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.iOS
 		public override void TouchesBegan(NSSet touches, UIEvent evt)
 		{
 			base.TouchesBegan(touches, evt);
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Instance.Send(this as object, Bugzilla57114._57114NativeGestureFiredMessage);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Compatibility/Maps/src/Android/MapRenderer.cs
+++ b/src/Compatibility/Maps/src/Android/MapRenderer.cs
@@ -89,7 +89,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.Android
 			{
 				if (Element != null)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 					((ObservableCollection<Pin>)Element.Pins).CollectionChanged -= OnPinCollectionChanged;
 					foreach (Pin pin in Element.Pins)
@@ -149,7 +151,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.Android
 					child.PropertyChanged -= MapElementPropertyChanged;
 				}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (NativeMap != null)
 				{
@@ -165,7 +169,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.Android
 
 			Control.GetMapAsync(this);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<Map, MapSpan>(this, MoveMessageName, OnMoveToRegionMessage, Map);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			((INotifyCollectionChanged)Map.Pins).CollectionChanged += OnPinCollectionChanged;
 			((INotifyCollectionChanged)Map.MapElements).CollectionChanged += OnMapElementCollectionChanged;

--- a/src/Compatibility/Maps/src/iOS/MapRenderer.cs
+++ b/src/Compatibility/Maps/src/iOS/MapRenderer.cs
@@ -66,7 +66,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.MacOS
 				if (Element != null)
 				{
 					var mapModel = (Map)Element;
+#pragma warning disable CS0618 // Type or member is obsolete
 					MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+#pragma warning restore CS0618 // Type or member is obsolete
 					((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnPinCollectionChanged;
 					((ObservableCollection<MapElement>)mapModel.MapElements).CollectionChanged -= OnMapElementCollectionChanged;
 					foreach (Pin pin in mapModel.Pins)
@@ -117,7 +119,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.MacOS
 			{
 				var mapModel = (Map)e.OldElement;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnPinCollectionChanged;
 				foreach (Pin pin in mapModel.Pins)
@@ -161,7 +165,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Maps.MacOS
 #endif
 				}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				MessagingCenter.Subscribe<Map, MapSpan>(this, MoveMessageName, (s, a) => MoveToRegion(a), mapModel);
+#pragma warning restore CS0618 // Type or member is obsolete
 				//if (mapModel.LastMoveToRegion != null)
 				//	MoveToRegion(mapModel.LastMoveToRegion, false);
 

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -52,7 +52,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 				}
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<ExampleTemplateCarousel>(this, "remove", (obj) => Items.Remove(obj.BindingContext as CarouselItem));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Items = new ObservableCollection<CarouselItem>(items);
 			Count = Items.Count - 1;

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/ExampleTemplateCarousel.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CarouselViewGalleries/ExampleTemplateCarousel.xaml.cs
@@ -48,7 +48,9 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.CarouselViewGalleri
 					{
 						this.FadeTo(0.1);
 						this.TranslateTo(X, Y - 1000);
+#pragma warning disable CS0618 // Type or member is obsolete
 						MessagingCenter.Send(this, "remove");
+#pragma warning restore CS0618 // Type or member is obsolete
 					}
 					else
 					{

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ItemsSourceGenerator.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/ItemsSourceGenerator.cs
@@ -54,10 +54,12 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 			layout.Children.Add(button);
 
 			button.Clicked += GenerateItems;
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<ExampleTemplateCarousel>(this, "remove", (obj) =>
 			{
 				(cv.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>).Remove(obj.BindingContext as CollectionViewGalleryTestItem);
 			});
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Content = layout;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/CustomSwipeItemViewGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/CustomSwipeItemViewGallery.xaml.cs
@@ -9,8 +9,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/ResourceSwipeItemsGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/ResourceSwipeItemsGallery.xaml.cs
@@ -13,8 +13,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeBindableLayoutGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeBindableLayoutGallery.xaml.cs
@@ -15,8 +15,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 
@@ -64,17 +68,23 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 
 		void OnFavourite()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Send(this, "favourite");
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void OnDelete()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Send(this, "delete");
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void OnTap()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Send(this, "tap");
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeCarouselViewGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeCarouselViewGallery.xaml.cs
@@ -13,8 +13,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeHorizontalCollectionViewGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeHorizontalCollectionViewGallery.xaml.cs
@@ -13,8 +13,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		async void OnSwipeCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs args)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeListViewGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeListViewGallery.xaml.cs
@@ -13,8 +13,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		async void OnSwipeListViewItemTapped(object sender, ItemTappedEventArgs args)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeVerticalCollectionViewGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeVerticalCollectionViewGallery.xaml.cs
@@ -13,8 +13,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		async void OnSwipeCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs args)

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewGestureRecognizerGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewGestureRecognizerGallery.xaml.cs
@@ -11,9 +11,15 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "tap", sender => { DisplayAlert("SwipeView", "TapGestureRecognizer", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewVisualStatesCollectionGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SwipeViewGalleries/SwipeViewVisualStatesCollectionGallery.xaml.cs
@@ -11,8 +11,12 @@ namespace Maui.Controls.Sample.Pages.SwipeViewGalleries
 			InitializeComponent();
 			BindingContext = new SwipeViewGalleryViewModel();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		async void OnSwipeCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs args)

--- a/src/Controls/src/Core/MessagingCenter.cs
+++ b/src/Controls/src/Core/MessagingCenter.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Maui.Controls
 	}
 
 	/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="Type[@FullName='Microsoft.Maui.Controls.MessagingCenter']/Docs/*" />
+	[Obsolete("We recommend migrating to `CommunityToolkit.MVVM.WeakReferenceMessenger`: https://www.nuget.org/packages/CommunityToolkit.Mvvm")]
 	public class MessagingCenter : IMessagingCenter
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Instance']/Docs/*" />

--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -195,11 +195,12 @@ namespace Microsoft.Maui.Controls
 			var args = new ActionSheetArguments(title, cancel, destruction, buttons);
 
 			args.FlowDirection = flowDirection;
-
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			if (IsPlatformEnabled)
 				MessagingCenter.Send(this, ActionSheetSignalName, args);
 			else
 				_pendingActions.Add(() => MessagingCenter.Send(this, ActionSheetSignalName, args));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return args.Result.Task;
 		}
@@ -235,10 +236,12 @@ namespace Microsoft.Maui.Controls
 			var args = new AlertArguments(title, message, accept, cancel);
 			args.FlowDirection = flowDirection;
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			if (IsPlatformEnabled)
 				MessagingCenter.Send(this, AlertSignalName, args);
 			else
 				_pendingActions.Add(() => MessagingCenter.Send(this, AlertSignalName, args));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return args.Result.Task;
 		}
@@ -248,10 +251,12 @@ namespace Microsoft.Maui.Controls
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			if (IsPlatformEnabled)
 				MessagingCenter.Send(this, PromptSignalName, args);
 			else
 				_pendingActions.Add(() => MessagingCenter.Send(this, PromptSignalName, args));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return args.Result.Task;
 		}
@@ -478,11 +483,13 @@ namespace Microsoft.Maui.Controls
 
 			if (IsBusy)
 			{
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				if (IsPlatformEnabled)
 					MessagingCenter.Send(this, BusySetSignalName, true);
 				else
 					_pendingActions.Add(() => MessagingCenter.Send(this, BusySetSignalName, true));
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			OnAppearing();
 			Appearing?.Invoke(this, EventArgs.Empty);
@@ -502,8 +509,10 @@ namespace Microsoft.Maui.Controls
 
 			_hasAppeared = false;
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			if (IsBusy)
 				MessagingCenter.Send(this, BusySetSignalName, false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			var pageContainer = this as IPageContainer<Page>;
 			pageContainer?.CurrentPage?.SendDisappearing();
@@ -559,8 +568,9 @@ namespace Microsoft.Maui.Controls
 		{
 			if (!_hasAppeared)
 				return;
-
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			MessagingCenter.Send(this, BusySetSignalName, IsBusy);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void OnToolbarItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -65,10 +65,12 @@ namespace Microsoft.Maui.Controls.Platform
 				Activity = context;
 				MauiContext = mauiContext;
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				MessagingCenter.Subscribe<Page, bool>(Activity, Page.BusySetSignalName, OnPageBusy);
 				MessagingCenter.Subscribe<Page, AlertArguments>(Activity, Page.AlertSignalName, OnAlertRequested);
 				MessagingCenter.Subscribe<Page, PromptArguments>(Activity, Page.PromptSignalName, OnPromptRequested);
 				MessagingCenter.Subscribe<Page, ActionSheetArguments>(Activity, Page.ActionSheetSignalName, OnActionSheetRequested);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			public Activity Activity { get; }
@@ -76,10 +78,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 			public void Dispose()
 			{
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				MessagingCenter.Unsubscribe<Page, bool>(Activity, Page.BusySetSignalName);
 				MessagingCenter.Unsubscribe<Page, AlertArguments>(Activity, Page.AlertSignalName);
 				MessagingCenter.Unsubscribe<Page, PromptArguments>(Activity, Page.PromptSignalName);
 				MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(Activity, Page.ActionSheetSignalName);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			public void ResetBusyCount()

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Tizen.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Tizen.cs
@@ -48,21 +48,23 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			Window = window;
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			MessagingCenter.Subscribe<Page, bool>(Window, Page.BusySetSignalName, OnBusySetRequest);
 			MessagingCenter.Subscribe<Page, AlertArguments>(Window, Page.AlertSignalName, OnAlertRequest);
 			MessagingCenter.Subscribe<Page, ActionSheetArguments>(Window, Page.ActionSheetSignalName, OnActionSheetRequest);
 			MessagingCenter.Subscribe<Page, PromptArguments>(Window, Page.PromptSignalName, OnPromptRequested);
-			_modalStack = modalStack;
 		}
 
 		public NWindow Window { get; }
 
 		public void Dispose()
 		{
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			MessagingCenter.Unsubscribe<Page, AlertArguments>(Window, Page.AlertSignalName);
 			MessagingCenter.Unsubscribe<Page, bool>(Window, Page.BusySetSignalName);
 			MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(Window, Page.ActionSheetSignalName);
 			MessagingCenter.Unsubscribe<Page, PromptArguments>(Window, Page.PromptSignalName);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void OnBusySetRequest(Page sender, bool enabled)

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Tizen.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Tizen.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Maui.Controls.Platform
 			MessagingCenter.Subscribe<Page, AlertArguments>(Window, Page.AlertSignalName, OnAlertRequest);
 			MessagingCenter.Subscribe<Page, ActionSheetArguments>(Window, Page.ActionSheetSignalName, OnActionSheetRequest);
 			MessagingCenter.Subscribe<Page, PromptArguments>(Window, Page.PromptSignalName, OnPromptRequested);
+#pragma warning restore CS0618 // Type or member is obsolete
+			_modalStack = modalStack;
 		}
 
 		public NWindow Window { get; }

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
@@ -46,10 +46,12 @@ namespace Microsoft.Maui.Controls.Platform
 				Window = window;
 				MauiContext = mauiContext;
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				MessagingCenter.Subscribe<Page, bool>(Window, Page.BusySetSignalName, OnPageBusy);
 				MessagingCenter.Subscribe<Page, AlertArguments>(Window, Page.AlertSignalName, OnAlertRequested);
 				MessagingCenter.Subscribe<Page, PromptArguments>(Window, Page.PromptSignalName, OnPromptRequested);
 				MessagingCenter.Subscribe<Page, ActionSheetArguments>(Window, Page.ActionSheetSignalName, OnActionSheetRequested);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			public UI.Xaml.Window Window { get; }
@@ -57,10 +59,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 			public void Dispose()
 			{
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				MessagingCenter.Unsubscribe<Page, bool>(Window, Page.BusySetSignalName);
 				MessagingCenter.Unsubscribe<Page, AlertArguments>(Window, Page.AlertSignalName);
 				MessagingCenter.Unsubscribe<Page, PromptArguments>(Window, Page.PromptSignalName);
 				MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(Window, Page.ActionSheetSignalName);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			void OnPageBusy(Page sender, bool enabled)

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.iOS.cs
@@ -50,10 +50,12 @@ namespace Microsoft.Maui.Controls.Platform
 				VirtualView = virtualView;
 				PlatformView = platformView;
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				MessagingCenter.Subscribe<Page, bool>(PlatformView, Page.BusySetSignalName, OnPageBusy);
 				MessagingCenter.Subscribe<Page, AlertArguments>(PlatformView, Page.AlertSignalName, OnAlertRequested);
 				MessagingCenter.Subscribe<Page, PromptArguments>(PlatformView, Page.PromptSignalName, OnPromptRequested);
 				MessagingCenter.Subscribe<Page, ActionSheetArguments>(PlatformView, Page.ActionSheetSignalName, OnActionSheetRequested);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			public Window VirtualView { get; }
@@ -62,10 +64,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 			public void Dispose()
 			{
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				MessagingCenter.Unsubscribe<Page, bool>(PlatformView, Page.BusySetSignalName);
 				MessagingCenter.Unsubscribe<Page, AlertArguments>(PlatformView, Page.AlertSignalName);
 				MessagingCenter.Unsubscribe<Page, PromptArguments>(PlatformView, Page.PromptSignalName);
 				MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(PlatformView, Page.ActionSheetSignalName);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			void OnPageBusy(IView sender, bool enabled)

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -42,8 +42,11 @@ namespace Microsoft.Maui.Controls.Platform
 				if (_navAnimationInProgress == value)
 					return;
 				_navAnimationInProgress = value;
+
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				if (value)
 					MessagingCenter.Send(this, CloseContextActionsSignalName);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 		}
 

--- a/src/Controls/src/Core/RadioButton.cs
+++ b/src/Controls/src/Core/RadioButton.cs
@@ -392,13 +392,15 @@ namespace Microsoft.Maui.Controls
 			{
 				return;
 			}
-
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			MessagingCenter.Send(this, ValueChangedMessage,
 						new RadioButtonValueChanged(RadioButtonGroup.GetVisualRoot(this)));
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void OnGroupNamePropertyChanged(string oldGroupName, string newGroupName)
 		{
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			if (!string.IsNullOrEmpty(newGroupName))
 			{
 				if (string.IsNullOrEmpty(oldGroupName))
@@ -420,6 +422,7 @@ namespace Microsoft.Maui.Controls
 					MessagingCenter.Unsubscribe<Element, RadioButtonGroupValueChanged>(this, RadioButtonGroup.GroupValueChangedMessage);
 				}
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		bool MatchesScope(RadioButtonScopeMessage message)

--- a/src/Controls/src/Core/RadioButtonGroup.cs
+++ b/src/Controls/src/Core/RadioButtonGroup.cs
@@ -61,8 +61,10 @@ namespace Microsoft.Maui.Controls
 				? GroupByParent(radioButton)
 				: GetVisualRoot(radioButton);
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			MessagingCenter.Send(radioButton, GroupSelectionChangedMessage,
 				new RadioButtonGroupSelectionChanged(scope));
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		internal static Element GroupByParent(RadioButton radioButton)

--- a/src/Controls/src/Core/RadioButtonGroupController.cs
+++ b/src/Controls/src/Core/RadioButtonGroupController.cs
@@ -26,12 +26,14 @@ namespace Microsoft.Maui.Controls
 				UpdateGroupNames(_layout, _groupName);
 			}
 
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 			MessagingCenter.Subscribe<RadioButton, RadioButtonGroupSelectionChanged>(this,
 				RadioButtonGroup.GroupSelectionChangedMessage, HandleRadioButtonGroupSelectionChanged);
 			MessagingCenter.Subscribe<RadioButton, RadioButtonGroupNameChanged>(this, RadioButton.GroupNameChangedMessage,
 				HandleRadioButtonGroupNameChanged);
 			MessagingCenter.Subscribe<RadioButton, RadioButtonValueChanged>(this, RadioButton.ValueChangedMessage,
 				HandleRadioButtonValueChanged);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		bool MatchesScope(RadioButtonScopeMessage message)
@@ -136,8 +138,10 @@ namespace Microsoft.Maui.Controls
 
 			if (radioButtonValue != null)
 			{
+#pragma warning disable CS0618 // TODO: Remove when we internalize/replace MessagingCenter
 				MessagingCenter.Send<Element, RadioButtonGroupValueChanged>(_layout, RadioButtonGroup.GroupValueChangedMessage,
 					new RadioButtonGroupValueChanged(_groupName, RadioButtonGroup.GetVisualRoot(_layout), radioButtonValue));
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 		}
 

--- a/src/Essentials/samples/Samples/Model/PermissionItem.cs
+++ b/src/Essentials/samples/Samples/Model/PermissionItem.cs
@@ -37,7 +37,9 @@ namespace Samples.Model
 				}
 				catch (Exception ex)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					MessagingCenter.Send<PermissionItem, Exception>(this, nameof(PermissionException), ex);
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 			});
 
@@ -51,7 +53,9 @@ namespace Samples.Model
 				}
 				catch (Exception ex)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					MessagingCenter.Send<PermissionItem, Exception>(this, nameof(PermissionException), ex);
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 			});
 
@@ -65,7 +69,9 @@ namespace Samples.Model
 				}
 				catch (Exception ex)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
 					MessagingCenter.Send<PermissionItem, Exception>(this, nameof(PermissionException), ex);
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 			});
 	}

--- a/src/Essentials/samples/Samples/View/PermissionsPage.xaml.cs
+++ b/src/Essentials/samples/Samples/View/PermissionsPage.xaml.cs
@@ -22,15 +22,19 @@ namespace Samples.View
 		{
 			base.OnAppearing();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Subscribe<PermissionItem, Exception>(this, nameof(PermissionException), async (p, ex) =>
 				await DisplayAlert("Permission Error", ex.Message, "OK"));
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		protected override void OnDisappearing()
 		{
 			base.OnDisappearing();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			MessagingCenter.Unsubscribe<PermissionItem, Exception>(this, nameof(PermissionException));
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -206,9 +206,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		void ILogger.Log(string message)
 		{
-#pragma warning disable CS0618 // Type or member is obsolete
 			Log?.LogMessage(message);
-#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -206,7 +206,9 @@ namespace Microsoft.Maui.Resizetizer
 
 		void ILogger.Log(string message)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			Log?.LogMessage(message);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

First step in deprecating `MessagingCenter`. There are already multiple issues/discussions ongoing (see below) about what we should do here. But I think we all agree that `MessagingCenter` does not really have a place in a UI framework. I think we should take this earliest opportunity to deprecate it and recommend our users an alternative.

As a next step, which is probably .NET 8, at the very least we can internalize the APIs. That way we can still leverage it ourselves. Ideally I think we would want to not rely on a messenger at all or switch to a different, more performant messenger. We are considering the one in the CommunityToolkit.MVVM, but that means taking a dependency on a MVVM framework which is probably not desirable.

There are currently no plans to separate the messenger from CommunityToolkit.MVVM into a seperate package.

Also see:
* https://github.com/dotnet/maui/discussions/3797
* https://github.com/dotnet/maui/pull/3880

### Issues Fixed

N/A