### PR TITLE
Disconnect old handler after setting new handler

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Element/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.Impl.cs
@@ -60,8 +60,7 @@ namespace Microsoft.Maui.Controls
 
 				_handler = newHandler;
 
-				if (newHandler != null)
-					_previousHandler?.DisconnectHandler();
+				_previousHandler?.DisconnectHandler();
 
 				if (_handler?.VirtualView != this)
 					_handler?.SetVirtualView(this);

--- a/src/Controls/src/Core/HandlerImpl/Element/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.Impl.cs
@@ -60,7 +60,11 @@ namespace Microsoft.Maui.Controls
 
 				_handler = newHandler;
 
-				_previousHandler?.DisconnectHandler();
+				// Only call disconnect if the previous handler is still connected to this virtual view.
+				// If a handler is being reused for a different VirtualView then the virtual
+				// view would have already rolled 
+				if (_previousHandler?.VirtualView == this)
+					_previousHandler?.DisconnectHandler();
 
 				if (_handler?.VirtualView != this)
 					_handler?.SetVirtualView(this);

--- a/src/Controls/src/Core/HandlerImpl/Element/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.Impl.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Maui.Controls
 				OnHandlerChangingCore(new HandlerChangingEventArgs(_previousHandler, newHandler));
 
 				_handler = newHandler;
+				_previousHandler?.DisconnectHandler();
 
 				if (_handler?.VirtualView != this)
 					_handler?.SetVirtualView(this);

--- a/src/Controls/src/Core/HandlerImpl/Element/Element.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.Impl.cs
@@ -59,7 +59,9 @@ namespace Microsoft.Maui.Controls
 				OnHandlerChangingCore(new HandlerChangingEventArgs(_previousHandler, newHandler));
 
 				_handler = newHandler;
-				_previousHandler?.DisconnectHandler();
+
+				if (newHandler != null)
+					_previousHandler?.DisconnectHandler();
 
 				if (_handler?.VirtualView != this)
 					_handler?.SetVirtualView(this);

--- a/src/Controls/src/Core/HandlerImpl/Shell.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Shell.Impl.cs
@@ -28,14 +28,5 @@ namespace Microsoft.Maui.Controls
 			if (propertyName == Shell.FlyoutIsPresentedProperty.PropertyName)
 				Handler?.UpdateValue(nameof(IFlyoutView.IsPresented));
 		}
-
-#if ANDROID
-		protected override void OnHandlerChanging(HandlerChangingEventArgs args)
-		{
-			base.OnHandlerChanging(args);
-			args.OldHandler?.DisconnectHandler();
-		}
-
-#endif
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -17,4 +17,3 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*override Microsoft.Maui.Controls.Platform.ControlsAccessibilityDelegate.OnInitializeAccessibilityNodeInfo(Android.Views.View? host, AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat? info) -> void
-~override Microsoft.Maui.Controls.Shell.OnHandlerChanging(Microsoft.Maui.Controls.HandlerChangingEventArgs args) -> void

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
 using Xunit;
 using Xunit.Sdk;
 

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 	public class HandlerLifeCycleTests : BaseTestFixture
 	{
-		[Test]
+		[Fact]
 		public void SettingHandlerToNullDisconnectsHandlerFromVirtualView()
 		{
 			var mauiApp1 = MauiApp.CreateBuilder()
@@ -25,10 +25,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			MauiContext mauiContext1 = new MauiContext(mauiApp1.Services);
 			var handler1 = button.ToHandler(mauiContext1);
 			button.Handler = null;
-			Assert.AreNotEqual(button, handler1.VirtualView);
+			Assert.NotEqual(button, handler1.VirtualView);
 		}
 
-		[Test]
+		[Fact]
 		public void SettingNewHandlerDisconnectsOldHandler()
 		{
 			var mauiApp1 = MauiApp.CreateBuilder()
@@ -51,7 +51,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			List<HandlerChangingEventArgs> changingArgs = new List<HandlerChangingEventArgs>();
 			button.HandlerChanging += (s, a) =>
 			{
-				Assert.AreEqual(handler1, a.OldHandler);
+				Assert.Equal(handler1, a.OldHandler);
 				Assert.NotNull(a.NewHandler);
 
 				changingArgs.Add(a);
@@ -59,9 +59,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var handler2 = button.ToHandler(mauiContext2);
 
-			Assert.AreNotEqual(button, handler1.VirtualView);
-			Assert.AreEqual(button, handler2.VirtualView);
-			Assert.AreEqual(1, changingArgs.Count);
+			Assert.NotEqual(button, handler1.VirtualView);
+			Assert.Equal(button, handler2.VirtualView);
+			Assert.Single(changingArgs);
 		}
 
 		[Fact]

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -12,6 +12,42 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 	public class HandlerLifeCycleTests : BaseTestFixture
 	{
+		[Test]
+		public void SettingNewHandlerDisconnectsOldHandler()
+		{
+			var mauiApp1 = MauiApp.CreateBuilder()
+				.UseMauiApp<ApplicationStub>()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<LifeCycleButton, HandlerStub>())
+				.Build();
+
+			LifeCycleButton button = new LifeCycleButton();
+
+			MauiContext mauiContext1 = new MauiContext(mauiApp1.Services);
+			var handler1 = button.ToHandler(mauiContext1);
+
+			var mauiApp2 = MauiApp.CreateBuilder()
+				.UseMauiApp<ApplicationStub>()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<LifeCycleButton, HandlerStub>())
+				.Build();
+
+			MauiContext mauiContext2 = new MauiContext(mauiApp2.Services);
+
+			List<HandlerChangingEventArgs> changingArgs = new List<HandlerChangingEventArgs>();
+			button.HandlerChanging += (s, a) =>
+			{
+				Assert.AreEqual(handler1, a.OldHandler);
+				Assert.NotNull(a.NewHandler);
+
+				changingArgs.Add(a);
+			};
+
+			var handler2 = button.ToHandler(mauiContext2);
+
+			Assert.AreNotEqual(button, handler1.VirtualView);
+			Assert.AreEqual(button, handler2.VirtualView);
+			Assert.AreEqual(1, changingArgs.Count);
+		}
+
 		[Fact]
 		public void ChangingAndChangedBothFireInitially()
 		{

--- a/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HandlerLifeCycleTests.cs
@@ -13,6 +13,22 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class HandlerLifeCycleTests : BaseTestFixture
 	{
 		[Test]
+		public void SettingHandlerToNullDisconnectsHandlerFromVirtualView()
+		{
+			var mauiApp1 = MauiApp.CreateBuilder()
+				.UseMauiApp<ApplicationStub>()
+				.ConfigureMauiHandlers(handlers => handlers.AddHandler<LifeCycleButton, HandlerStub>())
+				.Build();
+
+			LifeCycleButton button = new LifeCycleButton();
+
+			MauiContext mauiContext1 = new MauiContext(mauiApp1.Services);
+			var handler1 = button.ToHandler(mauiContext1);
+			button.Handler = null;
+			Assert.AreNotEqual(button, handler1.VirtualView);
+		}
+
+		[Test]
 		public void SettingNewHandlerDisconnectsOldHandler()
 		{
 			var mauiApp1 = MauiApp.CreateBuilder()

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
@@ -62,8 +62,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var newStack = CurrentNavigationRequest.NavigationStack.ToList();
 			CurrentNavigationRequest = null;
-			(VirtualView as IStackNavigation)
-				.NavigationFinished(newStack);
+
+			if (VirtualView is IStackNavigation sn)
+				sn.NavigationFinished(newStack);
 		}
 
 		async void RequestNavigation(NavigationRequest navigationRequest)

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestNavigationPage.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var newStack = CurrentNavigationRequest.NavigationStack.ToList();
 			CurrentNavigationRequest = null;
 
-			if (VirtualView is IStackNavigation sn)
+			if ((this as IElementHandler).VirtualView is IStackNavigation sn)
 				sn.NavigationFinished(newStack);
 		}
 

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -43,8 +43,6 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			var oldVirtualView = VirtualView;
-			if (oldVirtualView?.Handler != null)
-				oldVirtualView.Handler = null;
 
 			bool setupPlatformView = oldVirtualView == null;
 
@@ -53,6 +51,13 @@ namespace Microsoft.Maui.Handlers
 
 			if (VirtualView.Handler != this)
 				VirtualView.Handler = this;
+
+			// We set the previous virtual view to null after setting it on the incoming virtual view.
+			// This makes it easier for the incoming virtual view to have influence
+			// on how the exchange of handlers happens.
+			// We will just set the handler to null ourselves as a last restore cleanup
+			if (oldVirtualView?.Handler != null)
+				oldVirtualView.Handler = null;
 
 			if (setupPlatformView)
 			{

--- a/src/Core/src/Handlers/Element/ElementHandler.cs
+++ b/src/Core/src/Handlers/Element/ElementHandler.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Handlers
 			// We set the previous virtual view to null after setting it on the incoming virtual view.
 			// This makes it easier for the incoming virtual view to have influence
 			// on how the exchange of handlers happens.
-			// We will just set the handler to null ourselves as a last restore cleanup
+			// We will just set the handler to null ourselves as a last resort cleanup
 			if (oldVirtualView?.Handler != null)
 				oldVirtualView.Handler = null;
 


### PR DESCRIPTION
### Description of Change

- When a handler is set to null on a virtual view call "disconnecthandler" on the previous handler
- When a new handler is being set on a VirtualView call "Disconnecthandler" on the previous handler. This is primarily useful on Android where various scenarios will cause the "Activity" to recreate which means we have to recreate everything. So, as the everything passes through we need to make sure to "Disconnect" from the previous handlers. 

### Issues Fixed

Fixes #8456 

