### PR TITLE
Add AppThemeColor

### DIFF
--- a/src/Controls/samples/Controls.Sample/AppResources.xaml
+++ b/src/Controls/samples/Controls.Sample/AppResources.xaml
@@ -13,7 +13,11 @@
     
     <!-- APP THEME COLORS -->
     <AppThemeColor Light="#5639b0" Dark="#7e2bea" x:Key="AccentColor" />
-    <AppThemeColor Light="#F9F8FF" Dark="#181819" x:Key="BackgroundColor" />
+    <AppThemeColor Light="#AB32FF" Dark="#181819" x:Key="BackgroundColor" />
+    <AppThemeColor Light="#F9F9FF" Dark="#313133" x:Key="BackgroundSecondaryColor" />
+    <AppThemeColor Light="#B0150303" Dark="#FCFCFC" x:Key="TextPrimaryColor" />
+    <AppThemeColor Light="#B01D1D1D" Dark="#F5F5F5" x:Key="TextSecondaryColor" />
+    <AppThemeColor Light="#C8C8C8" Dark="#FEFEFE" x:Key="BorderColor" />
 
     <!-- LIGHT COLORS -->
     <Color x:Key="LightAccentColor">#5639b0</Color>
@@ -33,7 +37,8 @@
 
     <!-- STYLES -->
     <Style x:Key="SearchBorderStyle" TargetType="Frame">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />
+        <!--<Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />-->
+        <Setter Property="BackgroundColor" Value="{AppTheme BackgroundColor}" />
         <Setter Property="HasShadow" Value="True" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="HeightRequest" Value="40" />
@@ -42,8 +47,10 @@
     </Style>
 
     <Style x:Key="GalleryItemContainerStyle" TargetType="Border">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />
-        <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource LightBorderColor}, Dark={StaticResource DarkBorderColor}}" />
+        <!--<Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />-->
+        <Setter Property="BackgroundColor" Value="{AppTheme BackgroundSecondaryColor}" />
+        <!--<Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource LightBorderColor}, Dark={StaticResource DarkBorderColor}}" />-->
+        <Setter Property="Stroke" Value="{AppTheme BorderColor}" />
         <Setter Property="Padding" Value="12" />
         <Setter Property="Margin" Value="0" />
     </Style>
@@ -52,14 +59,16 @@
         <Setter Property="FontSize" Value="Small" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontAttributes" Value="Bold" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightAccentColor}, Dark={StaticResource DarkAccentColor}}" />
+        <!--<Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightAccentColor}, Dark={StaticResource DarkAccentColor}}" />-->
+        <Setter Property="TextColor" Value="{AppTheme AccentColor}" />
         <Setter Property="Margin" Value="0, 0, 0, 6" />
     </Style>
 
     <Style x:Key="GalleryItemDescriptionStyle" TargetType="Label">
         <Setter Property="FontSize" Value="Caption" />
         <Setter Property="FontFamily" Value="Segoe UI" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />
+        <!--<Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />-->
+        <Setter Property="TextColor" Value="{AppTheme TextPrimaryColor}" />
         <Setter Property="LineBreakMode" Value="WordWrap" />
     </Style>
 
@@ -69,19 +78,22 @@
         <Setter Property="HorizontalTextAlignment" Value="Center" />
         <Setter Property="HorizontalOptions" Value="Center" />
         <Setter Property="VerticalOptions" Value="Center" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />
+        <!--<Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />-->
+        <Setter Property="TextColor" Value="{AppTheme TextPrimaryColor}" />
     </Style>
 
     <Style x:Key="Headline" TargetType="Label">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="10" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />
+        <!--<Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />-->
+        <Setter Property="TextColor" Value="{AppTheme TextPrimaryColor}" />
     </Style>
 
     <Style x:Key="Subhead" TargetType="Label">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="9" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />
+        <!--<Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />-->
+        <Setter Property="TextColor" Value="{AppTheme TextPrimaryColor}" />
     </Style>
 
 </ResourceDictionary>

--- a/src/Controls/samples/Controls.Sample/AppResources.xaml
+++ b/src/Controls/samples/Controls.Sample/AppResources.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:Maui.Controls.Sample"
@@ -10,6 +10,10 @@
     <!-- COMMON COLORS -->
     <Color x:Key="BlackColor">#150303</Color>
     <Color x:Key="WhiteColor">#F8F8FF</Color>
+    
+    <!-- APP THEME COLORS -->
+    <AppThemeColor Light="#5639b0" Dark="#7e2bea" x:Key="AccentColor" />
+    <AppThemeColor Light="#F9F8FF" Dark="#181819" x:Key="BackgroundColor" />
 
     <!-- LIGHT COLORS -->
     <Color x:Key="LightAccentColor">#5639b0</Color>

--- a/src/Controls/src/Core/AppThemeColor.cs
+++ b/src/Controls/src/Core/AppThemeColor.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.Controls
+{
+	public class AppThemeColor
+	{
+		Color _light;
+		Color _dark;
+		Color _default;
+		bool _isLightSet;
+		bool _isDarkSet;
+		bool _isDefaultSet;
+
+		public Color Light
+		{
+			get => _light;
+			set
+			{
+				_light = value;
+				_isLightSet = true;
+			}
+		}
+
+		public Color Dark
+		{
+			get => _dark;
+			set
+			{
+				_dark = value;
+				_isDarkSet = true;
+			}
+		}
+
+		public Color Default
+		{
+			get => _default;
+			set
+			{
+				_default = value;
+				_isDefaultSet = true;
+			}
+		}
+
+		internal AppThemeBinding GetBinding()
+		{
+			var binding = new AppThemeBinding();
+			if (_isDarkSet)
+				binding.Dark = Dark;
+			if (_isLightSet)
+				binding.Light = Light;
+			if (_isDefaultSet)
+				binding.Default = Default;
+
+			return binding;
+		}
+
+		internal Color GetValue(AppTheme appTheme)
+		{
+			return appTheme switch
+			{
+				AppTheme.Dark => _isDarkSet ? Dark : Default,
+				_ => _isLightSet ? Light : Default,
+			};
+		}
+	}
+}

--- a/src/Controls/src/Core/AppThemeColor.cs
+++ b/src/Controls/src/Core/AppThemeColor.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Maui.ApplicationModel;
-using Microsoft.Maui.Graphics;
+﻿using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {

--- a/src/Controls/src/Core/AppThemeColor.cs
+++ b/src/Controls/src/Core/AppThemeColor.cs
@@ -57,14 +57,5 @@ namespace Microsoft.Maui.Controls
 
 			return binding;
 		}
-
-		internal Color GetValue(AppTheme appTheme)
-		{
-			return appTheme switch
-			{
-				AppTheme.Dark => _isDarkSet ? Dark : Default,
-				_ => _isLightSet ? Light : Default,
-			};
-		}
 	}
 }

--- a/src/Controls/src/Core/AppThemeResource.cs
+++ b/src/Controls/src/Core/AppThemeResource.cs
@@ -1,0 +1,25 @@
+﻿#nullable enable
+namespace Microsoft.Maui.Controls
+{
+	public class AppThemeResource
+	{
+		public object? Light { get; set; }
+
+		public object? Dark { get; set; }
+
+		public object? Default { get; set; }
+
+		internal BindingBase GetBinding()
+		{
+			var binding = new AppThemeBinding();
+			if (Light is not null)
+				binding.Light = Light;
+			if (Dark is not null)
+				binding.Dark = Dark;
+			if (Default is not null)
+				binding.Default = Default;
+
+			return binding;
+		}
+	}
+}

--- a/src/Controls/src/Core/BindableObjectExtensions.cs
+++ b/src/Controls/src/Core/BindableObjectExtensions.cs
@@ -59,5 +59,11 @@ namespace Microsoft.Maui.Controls
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObjectExtensions.xml" path="//Member[@MemberName='SetAppThemeColor']/Docs" />
 		public static void SetAppThemeColor(this BindableObject self, BindableProperty targetProperty, Color light, Color dark) => SetAppTheme(self, targetProperty, light, dark);
+
+		public static void SetAppThemeColor(this BindableObject self, BindableProperty targetProperty, AppThemeColor appThemeColor) =>
+			self.SetBinding(targetProperty, appThemeColor.GetBinding());
+
+		public static void SetAppTheme(this BindableObject self, BindableProperty targetProperty, AppThemeResource resource) =>
+			self.SetBinding(targetProperty, resource.GetBinding());
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.AppThemeColor
+Microsoft.Maui.Controls.AppThemeColor.AppThemeColor() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlyoutPage.OnDisappearing() -> void
@@ -9,6 +11,12 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedCont
 override Microsoft.Maui.Controls.Platform.ControlsAccessibilityDelegate.OnInitializeAccessibilityNodeInfo(Android.Views.View! host, AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat! info) -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+~Microsoft.Maui.Controls.AppThemeColor.Dark.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Default.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void
 ~override Microsoft.Maui.Controls.Handlers.Compatibility.ViewCellRenderer.DisconnectHandler(Android.Views.View platformView) -> void
 *REMOVED*override Microsoft.Maui.Controls.ContentView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.ContentView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.AppThemeResource
+Microsoft.Maui.Controls.AppThemeResource.AppThemeResource() -> void
+Microsoft.Maui.Controls.AppThemeResource.Dark.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Dark.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Default.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Default.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Light.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Light.set -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.AppThemeColor
@@ -26,3 +34,5 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*override Microsoft.Maui.Controls.Platform.ControlsAccessibilityDelegate.OnInitializeAccessibilityNodeInfo(Android.Views.View? host, AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat? info) -> void
 ~override Microsoft.Maui.Controls.Shell.OnHandlerChanging(Microsoft.Maui.Controls.HandlerChangingEventArgs args) -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppTheme(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeResource resource) -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppThemeColor(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeColor appThemeColor) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.AppThemeColor
+Microsoft.Maui.Controls.AppThemeColor.AppThemeColor() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlyoutPage.OnDisappearing() -> void
@@ -14,3 +16,9 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+~Microsoft.Maui.Controls.AppThemeColor.Dark.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Default.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.AppThemeResource
+Microsoft.Maui.Controls.AppThemeResource.AppThemeResource() -> void
+Microsoft.Maui.Controls.AppThemeResource.Dark.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Dark.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Default.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Default.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Light.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Light.set -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.AppThemeColor
@@ -22,3 +30,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppTheme(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeResource resource) -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppThemeColor(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeColor appThemeColor) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.AppThemeColor
+Microsoft.Maui.Controls.AppThemeColor.AppThemeColor() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlyoutPage.OnDisappearing() -> void
@@ -14,3 +16,9 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+~Microsoft.Maui.Controls.AppThemeColor.Dark.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Default.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.AppThemeResource
+Microsoft.Maui.Controls.AppThemeResource.AppThemeResource() -> void
+Microsoft.Maui.Controls.AppThemeResource.Dark.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Dark.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Default.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Default.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Light.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Light.set -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.AppThemeColor
@@ -22,3 +30,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppTheme(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeResource resource) -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppThemeColor(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeColor appThemeColor) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.AppThemeResource
+Microsoft.Maui.Controls.AppThemeResource.AppThemeResource() -> void
+Microsoft.Maui.Controls.AppThemeResource.Dark.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Dark.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Default.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Default.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Light.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Light.set -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.AppThemeColor
@@ -21,3 +29,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppTheme(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeResource resource) -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppThemeColor(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeColor appThemeColor) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.AppThemeColor
+Microsoft.Maui.Controls.AppThemeColor.AppThemeColor() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlyoutPage.OnDisappearing() -> void
@@ -13,3 +15,9 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+~Microsoft.Maui.Controls.AppThemeColor.Dark.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Default.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.AppThemeResource
+Microsoft.Maui.Controls.AppThemeResource.AppThemeResource() -> void
+Microsoft.Maui.Controls.AppThemeResource.Dark.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Dark.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Default.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Default.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Light.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Light.set -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.AppThemeColor
@@ -21,3 +29,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppTheme(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeResource resource) -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppThemeColor(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeColor appThemeColor) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.AppThemeColor
+Microsoft.Maui.Controls.AppThemeColor.AppThemeColor() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlyoutPage.OnDisappearing() -> void
@@ -13,3 +15,9 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+~Microsoft.Maui.Controls.AppThemeColor.Dark.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Default.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.AppThemeResource
+Microsoft.Maui.Controls.AppThemeResource.AppThemeResource() -> void
+Microsoft.Maui.Controls.AppThemeResource.Dark.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Dark.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Default.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Default.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Light.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Light.set -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.AppThemeColor
@@ -21,3 +29,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppTheme(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeResource resource) -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppThemeColor(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeColor appThemeColor) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.AppThemeColor
+Microsoft.Maui.Controls.AppThemeColor.AppThemeColor() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlyoutPage.OnDisappearing() -> void
@@ -13,3 +15,9 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+~Microsoft.Maui.Controls.AppThemeColor.Dark.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Default.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.AppThemeResource
+Microsoft.Maui.Controls.AppThemeResource.AppThemeResource() -> void
+Microsoft.Maui.Controls.AppThemeResource.Dark.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Dark.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Default.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Default.set -> void
+Microsoft.Maui.Controls.AppThemeResource.Light.get -> object?
+Microsoft.Maui.Controls.AppThemeResource.Light.set -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.AppThemeColor
@@ -21,3 +29,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
 ~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
 ~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppTheme(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeResource resource) -> void
+~static Microsoft.Maui.Controls.BindableObjectExtensions.SetAppThemeColor(this Microsoft.Maui.Controls.BindableObject self, Microsoft.Maui.Controls.BindableProperty targetProperty, Microsoft.Maui.Controls.AppThemeColor appThemeColor) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.AppThemeColor
+Microsoft.Maui.Controls.AppThemeColor.AppThemeColor() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.ContentPresenter.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.FlyoutPage.OnDisappearing() -> void
@@ -13,3 +15,9 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+~Microsoft.Maui.Controls.AppThemeColor.Dark.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Dark.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Default.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Default.set -> void
+~Microsoft.Maui.Controls.AppThemeColor.Light.get -> Microsoft.Maui.Graphics.Color
+~Microsoft.Maui.Controls.AppThemeColor.Light.set -> void

--- a/src/Controls/src/Xaml/MarkupExtensionParser.cs
+++ b/src/Controls/src/Xaml/MarkupExtensionParser.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Maui.Controls.Xaml
 				markupExtension = new OnPlatformExtension();
 			else if (match == "OnIdiom")
 				markupExtension = new OnIdiomExtension();
+			else if (match == "AppTheme")
+				markupExtension = new AppThemeExtension();
 			else if (match == "AppThemeBinding")
 				markupExtension = new AppThemeBindingExtension();
 			else if (match == "DataTemplate")

--- a/src/Controls/src/Xaml/MarkupExtensions/AppThemeExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/AppThemeExtension.cs
@@ -28,10 +28,14 @@ namespace Microsoft.Maui.Controls.Xaml
 			{
 				return color.GetBinding();
 			}
+			else if(resource is AppThemeResource themeResource)
+			{
+				return themeResource.GetBinding();
+			}
 			else
 			{
 				var xmlLineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider xmlLineInfoProvider ? xmlLineInfoProvider.XmlLineInfo : null;
-				throw new XamlParseException($"StaticResource for key {Key} is not an AppThemeColor", xmlLineInfo);
+				throw new XamlParseException($"StaticResource for key {Key} is not an AppThemeColor or AppThemeResource", xmlLineInfo);
 			}
 		}
 

--- a/src/Controls/src/Xaml/MarkupExtensions/AppThemeExtension.cs
+++ b/src/Controls/src/Xaml/MarkupExtensions/AppThemeExtension.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.Maui.Controls.Xaml
+{
+	[ContentProperty(nameof(Key))]
+	public sealed class AppThemeExtension : IMarkupExtension<BindingBase>
+	{
+		public string Key { get; set; }
+
+		public BindingBase ProvideValue(IServiceProvider serviceProvider)
+		{
+			if (serviceProvider is null)
+				throw new ArgumentNullException(nameof(serviceProvider));
+			if (Key is null)
+				throw new XamlParseException("you must specify a key in {AppThemeColor}", serviceProvider);
+			if (serviceProvider.GetService(typeof(IProvideValueTarget)) is not IProvideParentValues valueProvider)
+				throw new ArgumentException(null, nameof(serviceProvider));
+
+			if (!TryGetResource(Key, valueProvider.ParentObjects, out var resource, out var resourceDictionary)
+				&& !TryGetApplicationLevelResource(Key, out resource, out resourceDictionary))
+			{
+				var xmlLineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider xmlLineInfoProvider ? xmlLineInfoProvider.XmlLineInfo : null;
+				throw new XamlParseException($"StaticResource not found for key {Key}", xmlLineInfo);
+			}
+			else if(resource is AppThemeColor color)
+			{
+				return color.GetBinding();
+			}
+			else
+			{
+				var xmlLineInfo = serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider xmlLineInfoProvider ? xmlLineInfoProvider.XmlLineInfo : null;
+				throw new XamlParseException($"StaticResource for key {Key} is not an AppThemeColor", xmlLineInfo);
+			}
+		}
+
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) =>
+			ProvideValue(serviceProvider);
+
+		static bool TryGetResource(string key, IEnumerable<object> parentObjects, out object resource, out ResourceDictionary resourceDictionary)
+		{
+			resource = null;
+			resourceDictionary = null;
+
+			foreach (var p in parentObjects)
+			{
+				var resDict = p is IResourcesProvider irp && irp.IsResourcesCreated ? irp.Resources : p as ResourceDictionary;
+				if (resDict == null)
+					continue;
+				if (resDict.TryGetValueAndSource(key, out resource, out resourceDictionary))
+					return true;
+			}
+			return false;
+		}
+
+		static bool TryGetApplicationLevelResource(string key, out object resource, out ResourceDictionary resourceDictionary)
+		{
+			resource = null;
+			resourceDictionary = null;
+			// TODO: Remove reference to Application.Current
+			return Application.Current != null
+				&& ((IResourcesProvider)Application.Current).IsResourcesCreated
+				&& Application.Current.Resources.TryGetValueAndSource(key, out resource, out resourceDictionary);
+		}
+	}
+}

--- a/src/Controls/src/Xaml/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Xaml.AppThemeExtension
+Microsoft.Maui.Controls.Xaml.AppThemeExtension.AppThemeExtension() -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.get -> string
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.set -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.ProvideValue(System.IServiceProvider serviceProvider) -> Microsoft.Maui.Controls.BindingBase

--- a/src/Controls/src/Xaml/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Xaml.AppThemeExtension
+Microsoft.Maui.Controls.Xaml.AppThemeExtension.AppThemeExtension() -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.get -> string
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.set -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.ProvideValue(System.IServiceProvider serviceProvider) -> Microsoft.Maui.Controls.BindingBase

--- a/src/Controls/src/Xaml/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Xaml.AppThemeExtension
+Microsoft.Maui.Controls.Xaml.AppThemeExtension.AppThemeExtension() -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.get -> string
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.set -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.ProvideValue(System.IServiceProvider serviceProvider) -> Microsoft.Maui.Controls.BindingBase

--- a/src/Controls/src/Xaml/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Xaml.AppThemeExtension
+Microsoft.Maui.Controls.Xaml.AppThemeExtension.AppThemeExtension() -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.get -> string
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.set -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.ProvideValue(System.IServiceProvider serviceProvider) -> Microsoft.Maui.Controls.BindingBase

--- a/src/Controls/src/Xaml/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Xaml.AppThemeExtension
+Microsoft.Maui.Controls.Xaml.AppThemeExtension.AppThemeExtension() -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.get -> string
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.set -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.ProvideValue(System.IServiceProvider serviceProvider) -> Microsoft.Maui.Controls.BindingBase

--- a/src/Controls/src/Xaml/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Xaml.AppThemeExtension
+Microsoft.Maui.Controls.Xaml.AppThemeExtension.AppThemeExtension() -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.get -> string
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.set -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.ProvideValue(System.IServiceProvider serviceProvider) -> Microsoft.Maui.Controls.BindingBase

--- a/src/Controls/src/Xaml/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Xaml/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Xaml.AppThemeExtension
+Microsoft.Maui.Controls.Xaml.AppThemeExtension.AppThemeExtension() -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.get -> string
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.Key.set -> void
+~Microsoft.Maui.Controls.Xaml.AppThemeExtension.ProvideValue(System.IServiceProvider serviceProvider) -> Microsoft.Maui.Controls.BindingBase

--- a/src/Controls/tests/Core.UnitTests/AppThemeTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AppThemeTests.cs
@@ -214,5 +214,93 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.AreEqual(Colors.Red, label.TextColor);
 		}
+
+		[Test]
+		public void AppThemeColorUsesCorrectColorForTheme()
+		{
+			var color = new AppThemeColor
+			{
+				Light = Colors.Green,
+				Dark = Colors.Red
+			};
+			var label = new Label
+			{
+				Text = "Green on Light, Red on Dark"
+			};
+			label.SetAppThemeColor(Label.TextColorProperty, color);
+
+			Application.Current = null;
+
+			Assert.AreEqual(Colors.Green, label.TextColor);
+
+			SetAppTheme(AppTheme.Dark);
+
+			Assert.AreEqual(Colors.Red, label.TextColor);
+		}
+
+		[Test]
+		public void AppThemeColorUsesDefaultColorWhenDarkColorNotSet()
+		{
+			var color = new AppThemeColor
+			{
+				Light = Colors.Green,
+				Default = Colors.Blue
+			};
+			var label = new Label
+			{
+				Text = "Green on Light, Red on Dark"
+			};
+			label.SetAppThemeColor(Label.TextColorProperty, color);
+
+			Application.Current = null;
+
+			Assert.AreEqual(Colors.Green, label.TextColor);
+
+			SetAppTheme(AppTheme.Dark);
+
+			Assert.AreEqual(Colors.Blue, label.TextColor);
+		}
+
+		[Test]
+		public void AppThemeColorUsesDefaultColorWhenLightColorNotSet()
+		{
+			var color = new AppThemeColor
+			{
+				Default = Colors.Blue,
+				Dark = Colors.Red
+			};
+			var label = new Label
+			{
+				Text = "Green on Light, Red on Dark"
+			};
+			label.SetAppThemeColor(Label.TextColorProperty, color);
+
+			Application.Current = null;
+
+			Assert.AreEqual(Colors.Blue, label.TextColor);
+
+			SetAppTheme(AppTheme.Dark);
+
+			Assert.AreEqual(Colors.Red, label.TextColor);
+		}
+
+		[Test]
+		public void AppThemeResourceUpdatesLabelText()
+		{
+			var label = new Label();
+			var resource = new AppThemeResource
+			{
+				Light = "Light Theme",
+				Dark = "Dark Theme"
+			};
+			label.SetAppTheme(Label.TextProperty, resource);
+
+			Application.Current = null;
+			Assert.AreEqual("Light Theme", label.Text);
+
+			SetAppTheme(AppTheme.Dark);
+
+			Assert.AreEqual("Dark Theme", label.Text);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

This adds an AppThemeColor that can be used to drastically simplify creating a color palette and reduce the verbosity needed when creating an AppThemeBinding. **NOTE** This does make a minor deviation from the original proposal as XamlC was thinking the expected type was `AppThemeColorExtension` instead of `AppThemeColor` when declaring the AppThemeColor.

```xml
<!-- APP THEME COLORS -->
<AppThemeColor Light="#B0150303" Dark="#FCFCFC" x:Key="TextPrimaryColor" />

<Style x:Key="Headline" TargetType="Label">
    <Setter Property="FontFamily" Value="Segoe UI" />
    <Setter Property="FontSize" Value="10" />
    <!--<Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightTextPrimaryColor}, Dark={StaticResource DarkTextPrimaryColor}}" />-->
    <Setter Property="TextColor" Value="{AppTheme TextPrimaryColor}" />
</Style>
```

Also added in this PR is `AppThemeResource` which is meant to be a generic version of the `AppThemeColor` that could be use more broadly for things like an Image Source which may need to change based on Light/Dark mode:

```xml
<ResourceDictionary>
  <AppThemeResource Light="MyLightLogo.png" Dark="MyDarkLogo.png" x:Key="MyLogo" />
</ResourceDictionary>

<Image Source="{AppTheme MyLogo}" />
```

### Issues Fixed

Fixes #2597

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
