### PR TITLE
[xamlc] add compiled ImageSourceConverter

### DIFF
--- a/src/Controls/src/Build.Tasks/CompiledConverters/ImageSourceTypeConverter.cs
+++ b/src/Controls/src/Build.Tasks/CompiledConverters/ImageSourceTypeConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls.Build.Tasks;
+using Microsoft.Maui.Controls.Xaml;
+using Mono.Cecil.Cil;
+
+namespace Microsoft.Maui.Controls.XamlC;
+
+class ImageSourceTypeConverter : ICompiledTypeConverter
+{
+	public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
+	{
+		var module = context.Body.Method.Module;
+		if (!string.IsNullOrEmpty (value))
+		{
+			value = value.Trim();
+
+			if (Uri.TryCreate(value, UriKind.Absolute, out Uri uri) && uri.Scheme != "file")
+			{
+				yield return Instruction.Create(OpCodes.Ldstr, value);
+				yield return Instruction.Create(OpCodes.Ldc_I4_1); // (int)UriKind.Absolute is 1
+				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("System", "System", "Uri"), parameterTypes: new[] {
+																							("mscorlib", "System", "String"),
+																							("System", "System", "UriKind")}));
+				yield return Instruction.Create(OpCodes.Call, module.ImportMethodReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "ImageSource"), "FromUri", parameterTypes: new[] {
+																							("System", "System", "Uri")}, isStatic: true));
+			}
+			else
+			{
+				yield return Instruction.Create(OpCodes.Ldstr, value);
+				yield return Instruction.Create(OpCodes.Call, module.ImportMethodReference(("Microsoft.Maui.Controls", "Microsoft.Maui.Controls", "ImageSource"), "FromFile", parameterTypes: new[] {
+																							("mscorlib", "System", "String")}, isStatic: true));
+			}
+			yield break;
+		}
+		throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(ImageSource));
+	}
+}

--- a/src/Controls/src/Core/ImageSourceConverter.cs
+++ b/src/Controls/src/Core/ImageSourceConverter.cs
@@ -1,10 +1,12 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using Microsoft.Maui.Controls.Xaml;
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/ImageSourceConverter.xml" path="Type[@FullName='Microsoft.Maui.Controls.ImageSourceConverter']/Docs" />
+	[ProvideCompiled("Microsoft.Maui.Controls.XamlC.ImageSourceTypeConverter")]
 	public sealed class ImageSourceConverter : TypeConverter
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/ImageSourceConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs" />

--- a/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml
@@ -9,6 +9,8 @@
 			 BrushByName="Red"
 			 BrushByARGB="#00010203"
 			 BrushByRGB="#010203"
+			 ImageByUrl="https://picsum.photos/200/300"
+			 ImageByName="foo.png"
 			 BackgroundColor="Pink"
 			 List="Foo, Bar">
 	<Label x:Name="label"

--- a/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/CompiledTypeConverter.xaml.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 		public Brush BrushByRGB { get; set; }
 
+		public ImageSource ImageByUrl { get; set; }
+
+		public ImageSource ImageByName { get; set; }
+
 		[System.ComponentModel.TypeConverter(typeof(ListStringTypeConverter))]
 		public IList<string> List { get; set; }
 
@@ -54,6 +58,8 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 				Assert.AreEqual(Brush.Red, p.BrushByName);
 				Assert.AreEqual(new Color(1, 2, 3, 0), ((SolidColorBrush)p.BrushByARGB).Color);
 				Assert.AreEqual(new Color(1, 2, 3), ((SolidColorBrush)p.BrushByRGB).Color);
+				Assert.AreEqual("https://picsum.photos/200/300", ((UriImageSource)p.ImageByUrl).Uri.AbsoluteUri);
+				Assert.AreEqual("foo.png", ((FileImageSource)p.ImageByName).File);
 				Assert.AreEqual(Colors.Pink, p.BackgroundColor);
 				Assert.AreEqual(LayoutOptions.EndAndExpand, p.label.GetValue(View.HorizontalOptionsProperty));
 				var xConstraint = Microsoft.Maui.Controls.Compatibility.RelativeLayout.GetXConstraint(p.label);
@@ -65,6 +71,7 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 
 			[Test]
 			[TestCase(typeof(Microsoft.Maui.Controls.BrushTypeConverter))]
+			[TestCase(typeof(Microsoft.Maui.Controls.ImageSourceConverter))]
 			[TestCase(typeof(Microsoft.Maui.Graphics.Converters.PointTypeConverter))]
 			[TestCase(typeof(Microsoft.Maui.Graphics.Converters.RectTypeConverter))]
 			public void ConvertersAreReplaced(Type converterType)


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/4293#issuecomment-1171372950

`ImageSourceConverter.ConvertFromInvariantString()` was previously
taking up some time in `dotnet trace` output:

    1.17ms (<0.01%) microsoft.maui.controls!Microsoft.Maui.Controls.ImageSourceConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorCon

This is from a single ".NET bot" image in the `dotnet new maui` template.
I suspect this would be even more noticeable in apps with lots of images
setup in XAML.

We can add a "compiled" converter for `ImageSource` to improve this.

Previously we generated:

    compiledTypeConverter.ImageByUrl = (ImageSource)new ImageSourceConverter().ConvertFromInvariantString("https://picsum.photos/200/300");
    compiledTypeConverter.ImageByName = (ImageSource)new ImageSourceConverter().ConvertFromInvariantString("foo.png");

Now we generate:

    compiledTypeConverter.ImageByUrl = ImageSource.FromUri(new Uri("https://picsum.photos/200/300", UriKind.Absolute));
    compiledTypeConverter.ImageByName = ImageSource.FromFile("foo.png");