### PR TITLE
Make Date/Time Pickers on Android only pop up when tapped/clicked/enter key hit

### DIFF
--- a/src/Core/src/Platform/Android/MauiDatePicker.cs
+++ b/src/Core/src/Platform/Android/MauiDatePicker.cs
@@ -39,22 +39,12 @@ namespace Microsoft.Maui.Platform
 			ShowPicker?.Invoke();
 		}
 
-		protected override void OnFocusChanged(bool gainFocus, [GeneratedEnum] FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect)
-		{
-			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
-
-			if (gainFocus)
-			{
-				if (Clickable)
-					CallOnClick();
-			}
-		}
-
 		void Initialize()
 		{
 			DrawableCompat.Wrap(Background);
 
 			Focusable = true;
+			FocusableInTouchMode = false;
 			Clickable = true;
 			InputType = InputTypes.Null;
 

--- a/src/Core/src/Platform/Android/MauiTimePicker.cs
+++ b/src/Core/src/Platform/Android/MauiTimePicker.cs
@@ -39,22 +39,12 @@ namespace Microsoft.Maui.Platform
 			ShowPicker?.Invoke();
 		}
 
-		protected override void OnFocusChanged(bool gainFocus, [GeneratedEnum] FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect)
-		{
-			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
-
-			if (gainFocus)
-			{
-				if (Clickable)
-					CallOnClick();
-			}
-		}
-
 		void Initialize()
 		{
 			DrawableCompat.Wrap(Background);
 
 			Focusable = true;
+			FocusableInTouchMode = false;
 			Clickable = true;
 			InputType = InputTypes.Null;
 

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -2126,7 +2126,6 @@ override Microsoft.Maui.Platform.LocalizedDigitsKeyListener.FilterFormatted(Java
 override Microsoft.Maui.Platform.LocalizedDigitsKeyListener.GetAcceptedChars() -> char[]!
 override Microsoft.Maui.Platform.LocalizedDigitsKeyListener.InputType.get -> Android.Text.InputTypes
 override Microsoft.Maui.Platform.MauiAccessibilityDelegateCompat.OnInitializeAccessibilityNodeInfo(Android.Views.View? host, AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat? info) -> void
-override Microsoft.Maui.Platform.MauiDatePicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void
 override Microsoft.Maui.Platform.MauiMaterialButton.OnLayout(bool changed, int left, int top, int right, int bottom) -> void
 override Microsoft.Maui.Platform.MauiPicker.Dispose(bool disposing) -> void
 override Microsoft.Maui.Platform.MauiPicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void
@@ -2140,7 +2139,6 @@ override Microsoft.Maui.Platform.MauiSwipeView.OnAttachedToWindow() -> void
 override Microsoft.Maui.Platform.MauiSwipeView.OnInterceptTouchEvent(Android.Views.MotionEvent? e) -> bool
 override Microsoft.Maui.Platform.MauiSwipeView.OnTouchEvent(Android.Views.MotionEvent? e) -> bool
 override Microsoft.Maui.Platform.MauiTextView.OnLayout(bool changed, int l, int t, int r, int b) -> void
-override Microsoft.Maui.Platform.MauiTimePicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void
 override Microsoft.Maui.Platform.MauiWebChromeClient.Dispose(bool disposing) -> void
 override Microsoft.Maui.Platform.MauiWebViewClient.Dispose(bool disposing) -> void
 override Microsoft.Maui.Platform.MauiWebViewClient.OnPageFinished(Android.Webkit.WebView? view, string? url) -> void

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ override Microsoft.Maui.Handlers.EditorHandler.SetVirtualView(Microsoft.Maui.IVi
 override Microsoft.Maui.Handlers.EntryHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.MauiAppCompatActivity.OnDestroy() -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED* override Microsoft.Maui.Platform.MauiDatePicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void
+*REMOVED* override Microsoft.Maui.Platform.MauiTimePicker.OnFocusChanged(bool gainFocus, Android.Views.FocusSearchDirection direction, Android.Graphics.Rect? previouslyFocusedRect) -> void


### PR DESCRIPTION
### Description of Change

Removes auto-open on focus from Date/Time Pickers, sets `FocusableInTouchMode` to `false` so that they open on the first tap. 

### Issues Fixed

- Single pickers on pages auto-opening when the page is navigated to
