### PR TITLE
[SingleProject] Fix SplashScreen behavior on Tizen

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -398,8 +398,15 @@
         </ItemGroup>
 
         <!-- Tizen -->
+        <TizenSplashUpdater
+            Condition="'$(_ResizetizerIsTizenApp)' == 'True'"
+            IntermediateOutputPath="$(_MauiIntermediateSplashScreen)"
+            MauiSplashScreen="@(MauiSplashScreen)" />
+
         <ItemGroup Condition="'$(_ResizetizerIsTizenApp)' == 'True'">
             <MauiImage Include="@(MauiSplashScreen)" />
+            <_MauiSplashScreens Include="$(_MauiIntermediateSplashScreen)splash\*" />
+            <TizenTpkUserIncludeFiles Include="@(_MauiSplashScreens)" TizenTpkSubDir="shared\res\splash" />
         </ItemGroup>
 
         <!-- Stamp file for Outputs -->
@@ -527,12 +534,6 @@
             InputsFile="$(_ResizetizerInputsFile)"
             Images="@(MauiImage->Distinct())">
         </ResizetizeImages>
-
-        <!-- Tizen - Move splash images to a specific location -->
-        <TizenSplashUpdater
-            Condition="'$(_ResizetizerIsTizenApp)' == 'True' And '@(MauiSplashScreen)' != ''"
-            IntermediateOutputPath="$(_MauiIntermediateImages)"
-            MauiSplashScreen="@(MauiSplashScreen)" />
 
         <ItemGroup>
             <!-- Get Images that were generated -->

--- a/src/SingleProject/Resizetizer/src/TizenSplashUpdater.cs
+++ b/src/SingleProject/Resizetizer/src/TizenSplashUpdater.cs
@@ -26,22 +26,24 @@ namespace Microsoft.Maui.Resizetizer
 		public override bool Execute()
 		{
 			var orientations = new List<string>() { "portrait", "landscape" };
-			var splashInfo = MauiSplashScreen?.Length > 0 ? ResizeImageInfo.Parse(MauiSplashScreen[0]) : null;
+			var splashInfo = ResizeImageInfo.Parse(MauiSplashScreen[0]);
 			var image = splashInfo.OutputName + ".png";
-			var sharedResFullPath = Path.GetFullPath(Path.Combine(IntermediateOutputPath, "shared/res/"));
-			var splashFullPath = Path.Combine(sharedResFullPath, splashDirectoryName);
+			var splashFullPath = Path.Combine(IntermediateOutputPath, splashDirectoryName);
 
 			if (Directory.Exists(splashFullPath))
 				Directory.Delete(splashFullPath, true);
 			Directory.CreateDirectory(splashFullPath);
 
+			var appTool = new SkiaSharpAppIconTools(splashInfo, Logger);
+
 			splashDpiMap.Clear();
 			foreach (var dpi in DpiPath.Tizen.SplashScreen)
 			{
-				var imageOutputPath = Path.GetFullPath(Path.Combine(IntermediateOutputPath, dpi.Path));
-				var imageFullPath = Path.Combine(imageOutputPath, image);
+				var destination = Resizer.GetFileDestination(splashInfo, dpi, IntermediateOutputPath);
+				destination = Path.ChangeExtension(destination, ".png");
+				appTool.Resize(dpi, destination);
 
-				if (File.Exists(imageFullPath))
+				if (File.Exists(destination))
 				{
 					var resolution = dpi.Path.Split('-')[1].ToLower();
 					foreach (var orientation in orientations)
@@ -52,23 +54,8 @@ namespace Microsoft.Maui.Resizetizer
 							splashDpiMap.Remove((resolution, orientation));
 						}
 						splashDpiMap.Add((resolution, orientation), $"{splashDirectoryName}/{newImage}");
-						UpdateColorAndMoveFile(splashInfo, GetScreenSize(resolution, orientation), imageFullPath, Path.Combine(splashFullPath, newImage));
+						UpdateColorAndMoveFile(splashInfo, GetScreenSize(resolution, orientation), destination, Path.Combine(splashFullPath, newImage));
 					}
-				}
-				else
-				{
-					Log.LogWarning($"Unable to find splash image at {imageFullPath}.");
-					return false;
-				}
-			}
-
-			foreach (var dpi in DpiPath.Tizen.Image)
-			{
-				var imageOutputPath = Path.GetFullPath(Path.Combine(IntermediateOutputPath, dpi.Path));
-				var imageFullPath = Path.Combine(imageOutputPath, image);
-				if (File.Exists(imageFullPath))
-				{
-					File.Delete(imageFullPath);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change

- Update the behavior of `MauiSplashScreen` on Tizen
    - Separate and improve resize logic generating splash asset.
    - Add splash asset as `MauiImage` so this can also be used as image source in the application.
    - Package the generated splash assets directly from intermediate obj location.

### Screenshots
<image src="https://user-images.githubusercontent.com/14328614/180348909-984c2180-437b-4cb9-86ad-be863a5d4932.gif" height=400 />  <image src="https://user-images.githubusercontent.com/14328614/180349035-97057451-42bc-44d8-be16-245e1173dbca.gif" height=400 />

