### PR TITLE
Make CalendarDatePickerExtensions.ToDateFormat internal until .NET 7

### DIFF
--- a/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
@@ -3,9 +3,9 @@ using System.Linq;
 
 namespace Microsoft.Maui.Platform
 {
-	public static class CalendarDatePickerExtensions
+	internal static class CalendarDatePickerExtensions
 	{
-		public static string ToDateFormat(this string dateFormat)
+		internal static string ToDateFormat(this string dateFormat)
 		{
 			// The WinUI CalendarDatePicker DateFormat property use this formatter:
 			// https://docs.microsoft.com/en-us/uwp/api/Windows.Globalization.DateTimeFormatting.DateTimeFormatter?redirectedfrom=MSDN&view=winrt-22621#code-snippet-2

--- a/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 namespace Microsoft.Maui.Platform
 {
+	//TODO make this public on NET7
 	internal static class CalendarDatePickerExtensions
 	{
 		internal static string ToDateFormat(this string dateFormat)

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,5 +1,3 @@
 ﻿#nullable enable
 override Microsoft.Maui.Handlers.EditorHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.EntryHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
-Microsoft.Maui.Platform.CalendarDatePickerExtensions
-static Microsoft.Maui.Platform.CalendarDatePickerExtensions.ToDateFormat(this string! dateFormat) -> string!


### PR DESCRIPTION
### Description of Change

I approved and merged #7991 but realized that it added new APIs to .NET 6 which we can't do. This PR is a follow-up to internalize those APIs for now. Once this is merged up, I'll do a PR for the .NET 7 branch to make them public again.

### Issues Fixed

Fixes #7372
