### PR TITLE
[VisualDiagnostics] Allow RegisterSourceInfo to update existing targets

### DIFF
--- a/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
+++ b/src/Core/src/VisualDiagnostics/VisualDiagnostics.cs
@@ -19,8 +19,17 @@ namespace Microsoft.Maui
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void RegisterSourceInfo(object target, Uri uri, int lineNumber, int linePosition)
 		{
-			if (target != null && DebuggerHelper.DebuggerIsAttached && !sourceInfos.TryGetValue(target, out _))
+#if !NETSTANDARD2_0
+			if (target != null && DebuggerHelper.DebuggerIsAttached)
+				sourceInfos.AddOrUpdate(target, new SourceInfo(uri, lineNumber, linePosition));
+#else
+			if (target != null && DebuggerHelper.DebuggerIsAttached)
+			{
+				if (sourceInfos.TryGetValue(target, out _))
+					sourceInfos.Remove(target);
 				sourceInfos.Add(target, new SourceInfo(uri, lineNumber, linePosition));
+			}
+#endif
 		}
 
 		/// <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='GetXamlSourceInfo']/Docs" />


### PR DESCRIPTION
UI Tools depends on RegisterSourceInfo to give us the accurate source info for where elements are placed within XAML files. However, there's a slight issue with the current implementation. It checks if a target element has already been registered; if it has, it won't register the other item.

This causes problems for correctly parsing the XAML Tree and affects the Live Visual Tree and XAML Hot Reload. For example, lets say you have a custom control called "CardView." This control is in its own XAML Content View. The current RegisterSourceInfo methods will hit this XAML, hit CardView, and register that Content View page. However, lets say you then use that CardView within your app, in MainPage. When MAUI parses the existing tree and calls RegisterSourceInfo for the elements within MainPage, the CardView implementations will be skipped, because RegisterSourceInfo was _already created_ for it for the original Content View page. This is incorrect, we want the source info for where CardView is implemented _within_ an existing XAML page.

This PR updates the logic for RegisterSourceInfo so it can update an existing target if given one. That should fix our issues with Hot Reloading properties of custom controls.

This should also match what WPF does for its RegisterSourceInfo implementation,

https://github.com/dotnet/wpf/blob/c8742b5c39f72927e8598825291d6cf4e593df10/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Diagnostics/XamlSourceInfoHelper.cs#L97

It's also documented in their code for why this should be the case.
https://github.com/dotnet/wpf/blob/c8742b5c39f72927e8598825291d6cf4e593df10/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Diagnostics/XamlSourceInfoHelper.cs#L120-L131

fixes #8948 


