### PR TITLE
Fix typo "SpaceAroun" in FlexEnumDesignTypeConverters

### DIFF
--- a/src/Controls/src/Core.Design/FlexEnumDesignTypeConverters.cs
+++ b/src/Controls/src/Core.Design/FlexEnumDesignTypeConverters.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Maui.Controls.Design
 				"Start",
 				"End",
 				"SpaceBetween",
-				"SpaceAroun",
+				"SpaceAround",
 				"SpaceEvenly",
 		};
 	}


### PR DESCRIPTION
### Description of Change

There was a typo in the `FlexEnumDesignTypeConverters` which suggests the wrong value to people through IntelliSense. Luckily, the actual API seems to be named correctly, hence this should not be a breaking change.

### Issues Fixed

Fixes #8966
