### PR TITLE
Make CalendarDatePickerExtensions public

### DIFF
--- a/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
@@ -3,10 +3,9 @@ using System.Linq;
 
 namespace Microsoft.Maui.Platform
 {
-	//TODO make this public on NET7
-	internal static class CalendarDatePickerExtensions
+	public static class CalendarDatePickerExtensions
 	{
-		internal static string ToDateFormat(this string dateFormat)
+		public static string ToDateFormat(this string dateFormat)
 		{
 			// The WinUI CalendarDatePicker DateFormat property use this formatter:
 			// https://docs.microsoft.com/en-us/uwp/api/Windows.Globalization.DateTimeFormatting.DateTimeFormatter?redirectedfrom=MSDN&view=winrt-22621#code-snippet-2

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -12,3 +12,5 @@ static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.CommandMapper -> Micro
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
 override Microsoft.Maui.Handlers.EditorHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.EntryHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
+Microsoft.Maui.Platform.CalendarDatePickerExtensions
+static Microsoft.Maui.Platform.CalendarDatePickerExtensions.ToDateFormat(this string! dateFormat) -> string!


### PR DESCRIPTION
### Description of Change

Not sure if we can still do this/want to do this for net7, else this will move to net8.
This API was merged for net6 but we were adding public APIs which we can't do. So made them internal for net6 to still make this funtionality work, now making the API public again for net7

### Issues Fixed

Fixes #8931