### PR TITLE
Force DisableFastUpToDateCheck=false for MAUI repo build

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,6 +8,10 @@
   <Import Project="eng\Microsoft.Extensions.targets" />
 
   <PropertyGroup>
+      <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)eng\Maui.Tizen.Workarounds.targets</AfterMicrosoftNETSdkTargets>
+  </PropertyGroup>
+
+  <PropertyGroup>
      <!-- Allows for MAUI Xaml Hot Reload Samples to run without checks  -->
     <IgnoreMauiXamlHotReloadCompatibilityCheck>True</IgnoreMauiXamlHotReloadCompatibilityCheck>
   </PropertyGroup>

--- a/eng/Maui.Tizen.Workarounds.targets
+++ b/eng/Maui.Tizen.Workarounds.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+      <DisableFastUpToDateCheck>false</DisableFastUpToDateCheck>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This setting DisableFastUpToDateCheck is set to true as part of the Tizen tasks and in some cases causes the MAUI solution to build more slowly. This forces the value to false.

Here's the analysis I did on what it improves (and doesn't):

| branch | main | this pr |
|---|---|---|
| Change Controls.Sample MauiProgram.cs | 20-28sec | 35-40sec |
| Change Controls Core Button.cs | 17-19sec | 39-54sec |

Conclusion:
* There's a significant improvement in build time when the only thing that changes is the sample app. However, in my experience that's not a frequent type of change.
* There's a small slowdown in build time when the change is in a core MAUI project

I'm not sure quite how to interpret these results, but I'm curious if others can reproduce the slowdown in changing Button.cs when we have this PR's change.

My next step: Dive into the MSBuild logs and see exactly where the perf differences are.