### PR TITLE
Fix set the Font to Microsoft.Maui.Graphics.Skia

### DIFF
--- a/src/Graphics/src/Graphics.Skia/SkiaCanvasState.cs
+++ b/src/Graphics/src/Graphics.Skia/SkiaCanvasState.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Maui.Graphics.Skia
 		{
 			set
 			{
-				if (_font != value && (_font != null && !_font.Equals(value)))
+				if (!ReferenceEquals(_font, value) && (_font is null || !_font.Equals(value)))
 				{
 					_font = value;
 					_typefaceInvalid = true;


### PR DESCRIPTION
### Description of Change

When the `_font` is null that it will never set the value to the `_font` field.

It always return false when the `_font` is null:

```
_font != value && _font != null
```

This bug is a cause of https://github.com/dotnet/Microsoft.Maui.Graphics/issues/473 . We can not set any Font name to SkiaCanvas and the default Font do not support Chinese text.

The origin PR: https://github.com/dotnet/Microsoft.Maui.Graphics/pull/474

### Issues Fixed



Fixes #https://github.com/dotnet/Microsoft.Maui.Graphics/issues/473

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
