### PR TITLE
[ci] Use nuget-msi-convert/job/v3.yml

### DIFF
--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -14,7 +14,7 @@ stages:
           displayName: Sign Phase
           condition: and(succeeded(), eq(variables.signingCondition, true))
 
-      - template: nuget-msi-convert/job/v2.yml@xamarin-templates
+      - template: nuget-msi-convert/job/v3.yml@xamarin-templates
         parameters:
           yamlResourceName: xamarin-templates
           artifactName: nuget


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195

Updates the build to the latest MSI generation template.  The `v3`
template uses the latest changes from arcade which include a large
refactoring and support for workload pack group MSIs.

The generation of workload pack group MSIs is enabled by default.  The
tooling will now generate a single MSI for each workload declared in our
WorkloadManifest.json file.  This should improve MSI based installation
scenarios as it dramatically reduces the number of MSIs that we ship.


### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
