### PR TITLE
[xamlc] fix compiled {OnPlatform}

### DIFF
--- a/src/Controls/src/Xaml/SimplifyOnPlatformVisitor.cs
+++ b/src/Controls/src/Xaml/SimplifyOnPlatformVisitor.cs
@@ -78,6 +78,13 @@ namespace Microsoft.Maui.Controls.Xaml
 				if (parentNode is IElementNode parentEnode)
 					parentEnode.Properties[name] = targetNode;
 			}
+			else if (node.CollectionItems.Count > 0) // syntax like {OnPlatform foo, iOS=bar}
+			{
+				if (!ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name))
+					return;
+				if (parentNode is IElementNode parentEnode)
+					parentEnode.Properties[name] = node.CollectionItems[0];
+			}
 			else //no prop for target and no Default set
 			{
 				if (!ApplyPropertiesVisitor.TryGetPropertyName(node, parentNode, out XmlName name))

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatformOptimization.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatformOptimization.xaml
@@ -3,13 +3,12 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.OnPlatformOptimization">
 	<StackLayout>
-		<Border>
+		<Grid>
 			<Label x:Name="label0"
 				Text="{OnPlatform Android='john', iOS='paul', Default='ringo' }"
 				Padding="{OnPlatform iOS='2,3,4,5'}" />
-		    <Border.StrokeShape>
-			<RoundRectangle CornerRadius="12"/>
-		    </Border.StrokeShape>
-		</Border>
+			<Label x:Name="label1"
+				Text="{OnPlatform foo, iOS=bar }" />
+		</Grid>
 	</StackLayout>
 </ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/OnPlatformOptimization.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/OnPlatformOptimization.xaml.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Maui.Controls.Xaml.UnitTests
 {
-	[XamlCompilation(XamlCompilationOptions.Skip)]
 	public partial class OnPlatformOptimization : ContentPage
 	{
 		public OnPlatformOptimization()
@@ -31,6 +30,18 @@ namespace Microsoft.Maui.Controls.Xaml.UnitTests
 			{
 				MockCompiler.Compile(typeof(OnPlatformOptimization), out var methodDef, targetFramework);
 				Assert.That(!methodDef.Body.Instructions.Any(instr => InstructionIsOnPlatformExtensionCtor(methodDef, instr)), "This Xaml still generates a new OnPlatformExtension()");
+
+				var expected = targetFramework == "net6.0-ios" ? "bar" : "foo";
+				Assert.That(methodDef.Body.Instructions.Any(instr => instr.Operand as string == expected), $"Did not find instruction containing '{expected}'");
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void ValuesAreSet(bool useCompiledXaml)
+			{
+				var p = new OnPlatformOptimization(useCompiledXaml);
+				Assert.AreEqual("ringo", p.label0.Text);
+				Assert.AreEqual("foo", p.label1.Text);
 			}
 
 			bool InstructionIsOnPlatformExtensionCtor(MethodDefinition methodDef, Mono.Cecil.Cil.Instruction instruction)


### PR DESCRIPTION
A customer's project was doing:

    {OnPlatform foo, iOS=bar}

When compiling with `dotnet build -f net6.0-android -c Release`.

The value `foo` was not set!

However, either of these combinations work fine:

    {OnPlatform Default=foo, iOS=bar}
    {OnPlatform Android=foo, iOS=bar}

It appears we are missing the case for the `[ContentProperty]` for the
`{OnPlatform}` markup extension.

I added tests cases for this, and solved the problem by using
`node.CollectionItems[0]` to get the actual value.

I think this is the right approach?

### Issues Fixed

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1584968