### PR TITLE
[Android] Fix crash when opening a `TabbedPage` from a `ContentPage` that is referenced in `Shell`

### DIFF
--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 				_tabLayoutFragment = new ViewFragment(TabLayout);
 				var layoutContent = rootManager.RootView.FindViewById(Resource.Id.navigationlayout_content);
-				if (layoutContent.LayoutParameters is ViewGroup.MarginLayoutParams cl)
+				if (layoutContent?.LayoutParameters is ViewGroup.MarginLayoutParams cl)
 				{
 					cl.BottomMargin = 0;
 				}


### PR DESCRIPTION
### Description of Change

Starting from MAUI 6.0.408 there's an NRE here when trying to open a `TabbedPage` from a `ContentPage` that is referenced in `Shell`.

https://github.com/dotnet/maui/blob/ea8e7d233236a2efc94de477292bcbf0af170ce3/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs#L240

![image](https://user-images.githubusercontent.com/6609929/179097818-f25e110a-a2f3-452f-bd0f-2882ac6904b7.png)

This will fix it (not sure if `TabbedPage` would start working, don't know how to test that).

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Related to #7615

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
