### PR TITLE
Fix [Android] CollectionView EmptyView SelectionMode=Single on Android

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/RecyclerViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/RecyclerViewExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				case SelectionMode.Single:
 					var selectedItem = selectableItemsView.SelectedItem;
-					adapter.MarkPlatformSelection(selectedItem);
+					adapter?.MarkPlatformSelection(selectedItem);
 					return;
 
 				case SelectionMode.Multiple:
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 					foreach (var item in selectedItems)
 					{
-						adapter.MarkPlatformSelection(item);
+						adapter?.MarkPlatformSelection(item);
 					}
 					return;
 			}

--- a/src/Controls/src/Core/Platform/Android/Extensions/RecyclerViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/RecyclerViewExtensions.cs
@@ -26,12 +26,14 @@ namespace Microsoft.Maui.Controls.Platform
 					return;
 
 				case SelectionMode.Multiple:
-					var selectedItems = selectableItemsView.SelectedItems;
-
-					foreach (var item in selectedItems)
+					if (adapter is not null)
 					{
-						adapter?.MarkPlatformSelection(item);
-					}
+						var selectedItems = selectableItemsView.SelectedItems;
+						foreach (var item in selectedItems)
+						{
+							adapter?.MarkPlatformSelection(item);
+						}
+					}					
 					return;
 			}
 		}

--- a/src/Controls/src/Core/Platform/Android/Extensions/RecyclerViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/RecyclerViewExtensions.cs
@@ -13,7 +13,10 @@ namespace Microsoft.Maui.Controls.Platform
 			var mode = selectableItemsView.SelectionMode;
 			//TODO: on NET7 implement a ISelectableItemsViewAdapter interface on the adapter
 			var adapter = recyclerView.GetAdapter() as ReorderableItemsViewAdapter<ReorderableItemsView, IGroupableItemsViewSource>;
-			adapter?.ClearPlatformSelection();
+			if (adapter == null)
+				return;
+
+			adapter.ClearPlatformSelection();
 
 			switch (mode)
 			{
@@ -22,18 +25,15 @@ namespace Microsoft.Maui.Controls.Platform
 
 				case SelectionMode.Single:
 					var selectedItem = selectableItemsView.SelectedItem;
-					adapter?.MarkPlatformSelection(selectedItem);
+					adapter.MarkPlatformSelection(selectedItem);
 					return;
 
-				case SelectionMode.Multiple:
-					if (adapter is not null)
-					{
+				case SelectionMode.Multiple:					
 						var selectedItems = selectableItemsView.SelectedItems;
 						foreach (var item in selectedItems)
 						{
-							adapter?.MarkPlatformSelection(item);
-						}
-					}					
+							adapter.MarkPlatformSelection(item);
+						}										
 					return;
 			}
 		}


### PR DESCRIPTION
### Description of Change

If an empty view is used in a collection view with a single selection mode and there is no Item in the list on startup the app crashes on Android. Works fine on ios/Windows.

Fixes #9060 


