### PR TITLE
Stop copying content stream in .NET MAUI Blazor Windows

### DIFF
--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -83,15 +83,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers)
 				&& statusCode != 404)
 			{
-				// NOTE: This is stream copying is to work around a hanging bug in WinRT with managed streams.
-				// See issue https://github.com/microsoft/CsWinRT/issues/670
-				var memStream = new MemoryStream();
-				content.CopyTo(memStream);
-				var ms = new InMemoryRandomAccessStream();
-				await ms.WriteAsync(memStream.GetWindowsRuntimeBuffer());
-
 				var headerString = GetHeaderString(headers);
-				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(ms, statusCode, statusMessage, headerString);
+				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content.AsRandomAccessStream(), statusCode, statusMessage, headerString);
 			}
 			else if (new Uri(requestUri) is Uri uri && AppOriginUri.IsBaseOf(uri))
 			{


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/9206

https://github.com/microsoft/CsWinRT/issues/670 and https://task.ms/31565319 have been marked as resolved. This PR removes the existing logic which copies the content into a memory stream, and replaces it with a call to `AsRandomAccessStream()` (`IRandomAccessStream` is still required per the `CoreWebView2` API).

I tried out CSS hot reload with this change and things are working as expected. Not sure if there's a particular behavior/technique we can use to verify the validity of this change. Spoke with @Eilon regarding this, and per his recollection things were immediately hanging, and that's why this change was necessitated.

I _believe_ this will also end up fixing https://github.com/dotnet/maui/issues/9197, however that's a bit tougher to validate as the issue only repros on a new `maui-blazor` app, and not the sample app in the MAUI repo which we use to test the actual changes. Will have to do a quick validation after this merges to see if that's fixed as well. 