### PR TITLE
Propagate semantic properties from FlyoutItem

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -268,8 +268,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					_shell.RemoveLogicalChild(View);
 					if (_element != null && _element is BaseShellItem)
 					{
-						// TODO MAUI I don't think this is relevant
-						//_element.ClearValue(AppCompat.Platform.RendererProperty);
 						_element.PropertyChanged -= OnElementPropertyChanged;
 					}
 
@@ -281,10 +279,13 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 					if (_element != null)
 					{
 						_shell.AddLogicalChild(View);
-						AutomationPropertiesProvider.AccessibilitySettingsChanged(_itemView, value);
-						//_element.SetValue(AppCompat.Platform.RendererProperty, _itemView);
 						_element.PropertyChanged += OnElementPropertyChanged;
 						UpdateVisualState();
+
+						if (value is VisualElement ve)
+						{
+							SemanticProperties.SetDescription(ve, "Hello there");
+						}
 					}
 				}
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutRecyclerAdapter.cs
@@ -281,11 +281,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 						_shell.AddLogicalChild(View);
 						_element.PropertyChanged += OnElementPropertyChanged;
 						UpdateVisualState();
-
-						if (value is VisualElement ve)
-						{
-							SemanticProperties.SetDescription(ve, "Hello there");
-						}
 					}
 				}
 			}

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Maui.Graphics;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -21,18 +16,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 		View _content;
 		object _previousDataContext;
-		FrameworkElement FrameworkElement { get; set; }
 		Shell _shell;
 		ShellView ShellView => _shell.Handler?.PlatformView as ShellView;
 
 		public ShellFlyoutItemView()
 		{
 			this.DataContextChanged += OnDataContextChanged;
-		}
-
-		protected override void OnContentChanged(object oldContent, object newContent)
-		{
-			base.OnContentChanged(oldContent, newContent);
 		}
 
 		public bool IsSelected
@@ -70,14 +59,12 @@ namespace Microsoft.Maui.Controls.Platform
 			if (dataTemplate != null)
 			{
 				_content = (View)dataTemplate.CreateContent();
-				_content.BindingContext = bo;
 				_shell.AddLogicalChild(_content);
+				BindableObject.SetInheritedBindingContext(_content, bo);
 
-				var renderer = _content.ToPlatform(_shell.Handler.MauiContext);
+				var platformView = _content.ToPlatform(_shell.Handler.MauiContext);
 
-				Content = renderer;
-				FrameworkElement = renderer;
-
+				Content = platformView;
 				UpdateVisualState();
 			}
 		}

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -59,8 +59,8 @@ namespace Microsoft.Maui.Controls.Platform
 			if (dataTemplate != null)
 			{
 				_content = (View)dataTemplate.CreateContent();
+				_content.BindingContext = bo;
 				_shell.AddLogicalChild(_content);
-				BindableObject.SetInheritedBindingContext(_content, bo);
 
 				var platformView = _content.ToPlatform(_shell.Handler.MauiContext);
 

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFooterView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFooterView.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Controls.Platform
 			SizeChanged += OnShellFooterViewSizeChanged;
 			HorizontalContentAlignment = HorizontalAlignment.Stretch;
 			VerticalContentAlignment = VerticalAlignment.Stretch;
+			IsTabStop = false;			
 		}
 
 		void OnShellFooterViewSizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellHeaderView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellHeaderView.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Controls.Platform
 			SizeChanged += OnShellHeaderViewSizeChanged;
 			HorizontalContentAlignment = HorizontalAlignment.Stretch;
 			VerticalContentAlignment = VerticalAlignment.Stretch;
+			IsTabStop = false;
 		}
 
 		void OnShellHeaderViewSizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellNavigationViewItem.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellNavigationViewItem.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	public class ShellNavigationViewItem : NavigationViewItem
+	{
+		protected override AutomationPeer OnCreateAutomationPeer()
+		{
+			return new ShellNavigationViewItemAutomationPeer(this);
+		}
+	}
+
+	public class ShellNavigationViewItemAutomationPeer : NavigationViewItemAutomationPeer
+	{
+		readonly ShellNavigationViewItem _owner;
+
+		public ShellNavigationViewItemAutomationPeer(ShellNavigationViewItem owner) : base(owner)
+		{
+			_owner = owner;
+		}
+
+		protected override AutomationPeer GetLabeledByCore()
+		{
+			if (_owner.Content is ShellFlyoutItemView sf && sf.Content is FrameworkElement fe)
+				return FrameworkElementAutomationPeer.FromElement(fe);
+
+			return null;
+		}
+	}
+}

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellNavigationViewItem.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellNavigationViewItem.cs
@@ -31,5 +31,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 			return null;
 		}
+
+		protected override IList<AutomationPeer> GetChildrenCore()
+		{
+			return null;
+		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Windows/Styles/ShellStyles.xaml
+++ b/src/Controls/src/Core/Platform/Windows/Styles/ShellStyles.xaml
@@ -7,22 +7,19 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:primitiveContract7Present="using:Microsoft.UI.Xaml.Controls.Primitives?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:xf="using:Microsoft.Maui.Controls.Platform">
+    xmlns:maui="using:Microsoft.Maui.Controls.Platform">
     <x:Double x:Key="NavigationViewItemOnLeftMinHeight">0</x:Double>
     <DataTemplate x:Key="ShellFlyoutBaseShellItemTemplate">
-        <winui:NavigationViewItem x:Name="navItem" AutomationProperties.AutomationId="{Binding AutomationId}">
-            <xf:ShellFlyoutItemView IsSelected="{Binding IsSelected, ElementName=navItem, Mode=TwoWay}"></xf:ShellFlyoutItemView>
-        </winui:NavigationViewItem>
+        <maui:ShellNavigationViewItem  x:Name="navItem">
+            <maui:ShellFlyoutItemView IsTabStop="false" IsSelected="{Binding IsSelected, ElementName=navItem, Mode=TwoWay}"></maui:ShellFlyoutItemView>
+        </maui:ShellNavigationViewItem>
     </DataTemplate>
     <DataTemplate x:Key="ShellFlyoutMenuItemTemplate">
-        <winui:NavigationViewItem x:Name="navItem" AutomationProperties.AutomationId="{Binding AutomationId}">
-            <xf:ShellFlyoutItemView IsSelected="{Binding IsSelected, ElementName=navItem, Mode=TwoWay}"></xf:ShellFlyoutItemView>
-        </winui:NavigationViewItem>
+        <maui:ShellNavigationViewItem x:Name="navItem">
+            <maui:ShellFlyoutItemView IsTabStop="false" IsSelected="{Binding IsSelected, ElementName=navItem, Mode=TwoWay}"></maui:ShellFlyoutItemView>
+        </maui:ShellNavigationViewItem>
     </DataTemplate>
     <DataTemplate x:Key="ShellFlyoutSeperatorTemplate">
         <winui:NavigationViewItemSeparator />
-    </DataTemplate>
-    <DataTemplate x:Key="ShellSectionMenuItemTemplate">
-        <winui:NavigationViewItem Content="{Binding Title}"/>
     </DataTemplate>
 </ResourceDictionary>

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -5228,7 +5228,6 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.EntryCellTextBox.OnKeyUp(Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ListViewGroupStyleSelector.SelectGroupStyleCore(object group, uint level) -> Microsoft.UI.Xaml.Controls.GroupStyle
 ~override Microsoft.Maui.Controls.Platform.ItemContentControl.OnContentChanged(object oldContent, object newContent) -> void
-~override Microsoft.Maui.Controls.Platform.ShellFlyoutItemView.OnContentChanged(object oldContent, object newContent) -> void
 ~override Microsoft.Maui.Controls.Platform.ShellFlyoutTemplateSelector.SelectTemplateCore(object item) -> Microsoft.UI.Xaml.DataTemplate
 ~override Microsoft.Maui.Controls.Platform.ShellFlyoutTemplateSelector.SelectTemplateCore(object item, Microsoft.UI.Xaml.DependencyObject container) -> Microsoft.UI.Xaml.DataTemplate
 ~override Microsoft.Maui.Controls.ReferenceTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+Microsoft.Maui.Controls.Platform.ShellNavigationViewItem
+Microsoft.Maui.Controls.Platform.ShellNavigationViewItem.ShellNavigationViewItem() -> void
+Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -12,4 +15,8 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Controls.Platform.ShellFlyoutItemView.OnContentChanged(object oldContent, object newContent) -> void
+~Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer.ShellNavigationViewItemAutomationPeer(Microsoft.Maui.Controls.Platform.ShellNavigationViewItem owner) -> void
+~override Microsoft.Maui.Controls.Platform.ShellNavigationViewItem.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer
+~override Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer.GetLabeledByCore() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -18,5 +18,6 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.Platform.ShellFlyoutItemView.OnContentChanged(object oldContent, object newContent) -> void
 ~Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer.ShellNavigationViewItemAutomationPeer(Microsoft.Maui.Controls.Platform.ShellNavigationViewItem owner) -> void
 ~override Microsoft.Maui.Controls.Platform.ShellNavigationViewItem.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer
+~override Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer.GetChildrenCore() -> System.Collections.Generic.IList<Microsoft.UI.Xaml.Automation.Peers.AutomationPeer>
 ~override Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer.GetLabeledByCore() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/SemanticProperties.cs
+++ b/src/Controls/src/Core/SemanticProperties.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Microsoft.Maui.Controls
 {
@@ -38,7 +39,9 @@ namespace Microsoft.Maui.Controls
 
 		static void UpdateSemanticsProperty(BindableObject bindable, Action<Semantics> action)
 		{
-			action.Invoke(((VisualElement)bindable).SetupSemantics());
+			if (bindable is VisualElement ve)
+				action.Invoke(ve.SetupSemantics());
+
 			if (bindable is IView fe)
 				fe.Handler?.UpdateValue(nameof(IView.Semantics));
 		}
@@ -71,6 +74,49 @@ namespace Microsoft.Maui.Controls
 		public static void SetHeadingLevel(BindableObject bindable, SemanticHeadingLevel value)
 		{
 			bindable.SetValue(HeadingLevelProperty, value);
+		}
+
+		static BindableProperty[] _semanticPropertiesToWatch = new[]
+		{
+			SemanticProperties.DescriptionProperty,
+			SemanticProperties.HintProperty,
+			SemanticProperties.HeadingLevelProperty,
+			AutomationProperties.NameProperty,
+			AutomationProperties.LabeledByProperty,
+			AutomationProperties.HelpTextProperty,
+			AutomationProperties.IsInAccessibleTreeProperty,
+		};
+
+		// https://github.com/dotnet/maui/issues/9156
+		// this is currently required because you can't bind to an attached property
+		internal static ActionDisposable FakeBindSemanticProperties(BindableObject source, BindableObject dest)
+		{
+			foreach (var bp in _semanticPropertiesToWatch)
+			{
+				CopyProperty(bp, source, dest);
+			}
+
+			source.PropertyChanged += PropagateSemanticProperties;
+
+			// The BindingContext on the template might get changed if the
+			// platform is recycling the views so we need to detach the grid
+			// from watching the FlyoutItem that it's associated with
+			return new ActionDisposable(() => source.PropertyChanged -= PropagateSemanticProperties);
+
+			void PropagateSemanticProperties(Object sender, PropertyChangedEventArgs args)
+			{
+				foreach (var bp in _semanticPropertiesToWatch)
+				{
+					if (args.Is(bp))
+						CopyProperty(bp, source, dest);
+				}
+			}
+
+			void CopyProperty(BindableProperty bp, BindableObject source, BindableObject dest)
+			{
+				if (source.IsSet(bp))
+					dest.SetValue(bp, source.GetValue(bp));
+			}
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/SemanticPropertyUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SemanticPropertyUnitTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	[TestFixture]
+	public class SemanticPropertyUnitTests : BaseTestFixture
+	{
+		[Test]
+		public void FakeBindSemanticProperties_PropertiesPropagate()
+		{
+			Grid source = new Grid();
+			Button dest = new Button();
+			SemanticProperties.FakeBindSemanticProperties(source, dest);
+			SemanticProperties.SetDescription(source, "test");
+
+			var destDescription = SemanticProperties.GetDescription(dest);
+			Assert.AreEqual("test", destDescription);
+		}
+
+		[Test]
+		public void FakeBindSemanticProperties_PropertiesStopPropagating()
+		{
+			Grid source = new Grid();
+			Button dest = new Button();
+			var disconnect = SemanticProperties.FakeBindSemanticProperties(source, dest);
+			SemanticProperties.SetDescription(source, "test");
+			disconnect.Dispose();
+
+			SemanticProperties.SetDescription(source, "second");
+			var destDescription = SemanticProperties.GetDescription(dest);
+			Assert.AreEqual("test", destDescription);
+		}
+
+		[Test]
+		public void FlyoutItemTitlePropagatesToTemplatesSemanticProperties()
+		{
+			Shell shell = new Shell();
+			FlyoutItem flyoutItem = new FlyoutItem() { Title = "title" };
+			shell.Items.Add(flyoutItem);
+
+			var content = (shell as IShellController).GetFlyoutItemDataTemplate(flyoutItem).CreateContent() as BindableObject;
+			content.BindingContext = flyoutItem;
+
+			var destDescription = SemanticProperties.GetDescription(content);
+			Assert.AreEqual("title", destDescription);
+
+			flyoutItem.Title = "new title";
+			destDescription = SemanticProperties.GetDescription(content);
+			Assert.AreEqual("new title", destDescription);
+		}
+
+		[Test]
+		public void FlyoutItemSemanticPropertiesPropagateOverTitle()
+		{
+			Shell shell = new Shell();
+			FlyoutItem flyoutItem = new FlyoutItem() { Title = "title" };
+			SemanticProperties.SetDescription(flyoutItem, "semantic title");
+
+			shell.Items.Add(flyoutItem);
+
+			var content = (shell as IShellController).GetFlyoutItemDataTemplate(flyoutItem).CreateContent() as BindableObject;
+			content.BindingContext = flyoutItem;
+
+			var destDescription = SemanticProperties.GetDescription(content);
+			Assert.AreEqual("semantic title", destDescription);
+
+			flyoutItem.Title = "new title";
+			destDescription = SemanticProperties.GetDescription(content);
+			Assert.AreEqual("semantic title", destDescription);
+		}
+	}
+}

--- a/src/Controls/tests/Core.UnitTests/SemanticPropertyUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SemanticPropertyUnitTests.cs
@@ -3,14 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using NUnit.Framework;
+using Xunit;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
-	[TestFixture]
 	public class SemanticPropertyUnitTests : BaseTestFixture
 	{
-		[Test]
+		[Fact]
 		public void FakeBindSemanticProperties_PropertiesPropagate()
 		{
 			Grid source = new Grid();
@@ -19,10 +18,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			SemanticProperties.SetDescription(source, "test");
 
 			var destDescription = SemanticProperties.GetDescription(dest);
-			Assert.AreEqual("test", destDescription);
+			Assert.Equal("test", destDescription);
 		}
 
-		[Test]
+		[Fact]
 		public void FakeBindSemanticProperties_PropertiesStopPropagating()
 		{
 			Grid source = new Grid();
@@ -33,10 +32,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			SemanticProperties.SetDescription(source, "second");
 			var destDescription = SemanticProperties.GetDescription(dest);
-			Assert.AreEqual("test", destDescription);
+			Assert.Equal("test", destDescription);
 		}
 
-		[Test]
+		[Fact]
 		public void FlyoutItemTitlePropagatesToTemplatesSemanticProperties()
 		{
 			Shell shell = new Shell();
@@ -47,14 +46,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			content.BindingContext = flyoutItem;
 
 			var destDescription = SemanticProperties.GetDescription(content);
-			Assert.AreEqual("title", destDescription);
+			Assert.Equal("title", destDescription);
 
 			flyoutItem.Title = "new title";
 			destDescription = SemanticProperties.GetDescription(content);
-			Assert.AreEqual("new title", destDescription);
+			Assert.Equal("new title", destDescription);
 		}
 
-		[Test]
+		[Fact]
 		public void FlyoutItemSemanticPropertiesPropagateOverTitle()
 		{
 			Shell shell = new Shell();
@@ -67,11 +66,11 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			content.BindingContext = flyoutItem;
 
 			var destDescription = SemanticProperties.GetDescription(content);
-			Assert.AreEqual("semantic title", destDescription);
+			Assert.Equal("semantic title", destDescription);
 
 			flyoutItem.Title = "new title";
 			destDescription = SemanticProperties.GetDescription(content);
-			Assert.AreEqual("semantic title", destDescription);
+			Assert.Equal("semantic title", destDescription);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

- Propagate any `SemanticProperties` set to the templated `Grid` created inside the FlyoutItems. 
- Fix a few spots on WinUI where it would Tab to empty content. I've disabled the TabStop for the templated content controls used to render the flyoutitems and the flyout footer. This way it now tabs directly to the actual content. By default the Navigation items on the WinUI NavigationView can be navigated via arrow keys not by tab. 
  -  One thing to note here is that navigating via tab/arrow keys is broken on WinUI if you do it with a debugger [attached](https://github.com/microsoft/microsoft-ui-xaml/issues/2521#issuecomment-655209746). So, after you've launched your code stop the debugger and then re-launch the app to test

### Issues Fixed
Fixes #9066


