### PR TITLE
[main] Update dependencies from dotnet/installer

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,12 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.1.22374.1" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.1.22407.1" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>53587f98e132f3c5bc6d2a77d779d6872710d53e</Sha>
+      <Sha>8f639696e6d57fb09e03e89c6397d913de1231ed</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22367.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rc.1.22403.8" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>aafa91036e1efd3d4dcb67eeb261cb6d8f774685</Sha>
+      <Sha>26a71c61fbda229f151afb14e274604b4926df5c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="33.0.0-rc.1.125">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
@@ -28,9 +28,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>868666ec926df89ec09e05fca8049075dc53b652</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-rc.1.22362.2" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-rc.1.22368.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>11a9acf5ab6fe5a20f0a7d4326c785bd51e9859c</Sha>
+      <Sha>7b2cd1ee7169143248a7da9fd749caf22affa624</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsAppSDK" Version="0.0.1">
       <Uri>https://dev.azure.com/microsoft/ProjectReunion/_git/ProjectReunionInternal</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,9 +3,9 @@
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
     <MicrosoftMauiPreviousDotNetReleasedVersion>6.0.419</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-rc.1.22374.1</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-rc.1.22407.1</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22367.4</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rc.1.22403.8</MicrosoftNETCoreAppRefPackageVersion>
     <!-- NOTE: should eventually revert back to $(MicrosoftNETCoreAppRefPackageVersion) in .NET 7 -->
     <MicrosoftExtensionsPackageVersion>7.0.0-preview.7.22369.4</MicrosoftExtensionsPackageVersion>
     <MicrosoftExtensionsServicingPackageVersion>7.0.0-preview.7.22369.4</MicrosoftExtensionsServicingPackageVersion>
@@ -20,7 +20,7 @@
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.100-preview.7.20</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->
-    <MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>7.0.0-rc.1.22362.2</MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>7.0.0-rc.1.22368.1</MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- wasdk -->
     <MicrosoftWindowsAppSDKPackageVersion>1.1.3</MicrosoftWindowsAppSDKPackageVersion>

--- a/src/BlazorWebView/src/WindowsForms/WindowsFormsDispatcher.cs
+++ b/src/BlazorWebView/src/WindowsForms/WindowsFormsDispatcher.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WindowsForms
 				else
 				{
 					var asyncResult = _dispatchThreadControl.BeginInvoke(workItem);
-					return await Task<TResult>.Factory.FromAsync(asyncResult, result => (TResult)_dispatchThreadControl.EndInvoke(result));
+					return await Task<TResult>.Factory.FromAsync(asyncResult, result => (TResult)_dispatchThreadControl.EndInvoke(result)!);
 				}
 			}
 			catch (Exception ex)


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:Coherency Updates)
## Coherency Updates

The following updates ensure that dependencies with a *CoherentParentDependency*
attribute were produced in a build used as input to the parent dependency's build.
See [Dependency Description Format](https://github.com/dotnet/arcade/blob/master/Documentation/DependencyDescriptionFormat.md#dependency-description-overview)

[DependencyUpdate]: <> (Begin)

- **Coherency Updates**:
  - **Microsoft.NETCore.App.Ref**: from 7.0.0-rc.1.22367.4 to 7.0.0-rc.1.22403.8 (parent: Microsoft.Dotnet.Sdk.Internal)
  - **Microsoft.NET.Workload.Emscripten.Manifest-7.0.100**: from 7.0.0-rc.1.22362.2 to 7.0.0-rc.1.22368.1 (parent: Microsoft.NETCore.App.Ref)

[DependencyUpdate]: <> (End)

[marker]: <> (End:Coherency Updates)





[marker]: <> (Begin:97ee8954-2ef3-4217-5719-08da2edb85ba)
## From https://github.com/dotnet/installer
- **Subscription**: 97ee8954-2ef3-4217-5719-08da2edb85ba
- **Build**: 20220807.1
- **Date Produced**: August 8, 2022 2:44:04 AM UTC
- **Commit**: 8f639696e6d57fb09e03e89c6397d913de1231ed
- **Branch**: refs/heads/main

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.Dotnet.Sdk.Internal**: [from 7.0.100-rc.1.22374.1 to 7.0.100-rc.1.22407.1][17]
  - **Microsoft.NETCore.App.Ref**: [from 7.0.0-rc.1.22367.4 to 7.0.0-rc.1.22403.8][19]
  - **Microsoft.NET.Workload.Emscripten.Manifest-7.0.100**: [from 7.0.0-rc.1.22362.2 to 7.0.0-rc.1.22368.1][20]

[17]: https://github.com/dotnet/installer/compare/53587f9...8f63969
[18]: https://github.com/dotnet/linker/compare/31a57b5...f09bacf
[19]: https://github.com/dotnet/runtime/compare/aafa910...26a71c6
[20]: https://github.com/dotnet/emsdk/compare/11a9acf...7b2cd1e

[DependencyUpdate]: <> (End)


[marker]: <> (End:97ee8954-2ef3-4217-5719-08da2edb85ba)













