### PR TITLE
Convert more Android controls to AppCompat counterparts

### DIFF
--- a/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/PickerRenderer.cs
@@ -7,7 +7,7 @@ using Android.Content;
 using Android.Text;
 using Android.Text.Style;
 using Android.Util;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Controls.Platform;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 			AutoPackage = false;
 		}
 
-		protected abstract EditText EditText { get; }
+		protected abstract AppCompatEditText EditText { get; }
 
 		protected override void Dispose(bool disposing)
 		{
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 	}
 
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
-	public class PickerRenderer : PickerRendererBase<EditText>
+	public class PickerRenderer : PickerRendererBase<AppCompatEditText>
 	{
 		TextColorSwitcher _textColorSwitcher;
 		TextColorSwitcher _hintColorSwitcher;
@@ -202,12 +202,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.AppCompat
 		{
 		}
 
-		protected override EditText CreateNativeControl()
+		protected override AppCompatEditText CreateNativeControl()
 		{
 			return new PickerEditText(Context);
 		}
 
-		protected override EditText EditText => Control;
+		protected override AppCompatEditText EditText => Control;
 
 		[PortHandler]
 		protected override void UpdateTitleColor()

--- a/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/EditorRenderer.cs
@@ -7,7 +7,7 @@ using Android.Text.Method;
 using Android.Util;
 using Android.Views;
 using Android.Views.InputMethods;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using Java.Lang;
 using Microsoft.Maui.Controls.Platform;
 
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			};
 		}
 
-		protected override EditText EditText => Control;
+		protected override AppCompatEditText EditText => Control;
 
 		[PortHandler]
 		protected override void UpdatePlaceholderColor()
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		where TControl : global::Android.Views.View
 	{
 		bool _disposed;
-		protected abstract EditText EditText { get; }
+		protected abstract AppCompatEditText EditText { get; }
 
 		public EditorRendererBase(Context context) : base(context)
 		{

--- a/src/Compatibility/Core/src/Android/Renderers/FormsEditText.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormsEditText.cs
@@ -2,7 +2,7 @@ using System;
 using System.ComponentModel;
 using Android.Content;
 using Android.Views;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Graphics.Drawable;
 using Microsoft.Maui.Controls.Platform;
 using ARect = Android.Graphics.Rect;
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		}
 	}
 
-	public class FormsEditTextBase : EditText, IDescendantFocusToggler
+	public class FormsEditTextBase : AppCompatEditText, IDescendantFocusToggler
 	{
 		DescendantFocusToggler _descendantFocusToggler;
 

--- a/src/Compatibility/Core/src/Android/Renderers/FormsTextView.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/FormsTextView.cs
@@ -2,11 +2,11 @@ using System;
 using Android.Content;
 using Android.Runtime;
 using Android.Util;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
-	public class FormsTextView : TextView
+	public class FormsTextView : AppCompatTextView
 	{
 		public FormsTextView(Context context) : base(context)
 		{

--- a/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
@@ -8,6 +8,7 @@ using Android.Text.Method;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Controls.Platform;
 using Color = Microsoft.Maui.Graphics.Color;
 using Size = Microsoft.Maui.Graphics.Size;
@@ -17,7 +18,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 	[System.Obsolete(Compatibility.Hosting.MauiAppBuilderExtensions.UseMapperInstead)]
 	public class SearchBarRenderer : ViewRenderer<SearchBar, SearchView>, SearchView.IOnQueryTextListener
 	{
-		EditText _editText;
+		AppCompatAutoCompleteTextView _editText;
 		InputTypes _inputType;
 		TextColorSwitcher _textColorSwitcher;
 		TextColorSwitcher _hintColorSwitcher;
@@ -90,7 +91,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 				searchView.SetIconifiedByDefault(false);
 				searchView.Iconified = false;
 				SetNativeControl(searchView);
-				_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
+				_editText = _editText ?? Control.GetChildrenOfType<AppCompatAutoCompleteTextView>().FirstOrDefault();
 
 				if (_editText != null)
 				{
@@ -174,7 +175,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateHorizontalTextAlignment()
 		{
-			_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
+			_editText = _editText ?? Control.GetChildrenOfType<AppCompatAutoCompleteTextView>().FirstOrDefault();
 
 			if (_editText == null)
 				return;
@@ -185,7 +186,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateVerticalTextAlignment()
 		{
-			_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
+			_editText = _editText ?? Control.GetChildrenOfType<AppCompatAutoCompleteTextView>().FirstOrDefault();
 
 			if (_editText == null)
 				return;
@@ -237,7 +238,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateFont()
 		{
-			_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
+			_editText = _editText ?? Control.GetChildrenOfType<AppCompatAutoCompleteTextView>().FirstOrDefault();
 
 			if (_editText == null)
 				return;
@@ -270,7 +271,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdateCharacterSpacing()
 		{
-			_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
+			_editText = _editText ?? Control.GetChildrenOfType<AppCompatAutoCompleteTextView>().FirstOrDefault();
 
 			if (_editText != null)
 			{
@@ -285,7 +286,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		void UpdateMaxLength()
 		{
-			_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
+			_editText = _editText ?? Control.GetChildrenOfType<AppCompatAutoCompleteTextView>().FirstOrDefault();
 
 			var currentFilters = new List<IInputFilter>(_editText?.GetFilters() ?? new IInputFilter[0]);
 
@@ -329,7 +330,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 			if (keyboard == Keyboard.Numeric)
 			{
-				_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
+				_editText = _editText ?? Control.GetChildrenOfType<AppCompatAutoCompleteTextView>().FirstOrDefault();
 				if (_editText != null)
 					_editText.KeyListener = GetDigitsKeyListener(_inputType);
 			}

--- a/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		[PortHandler]
 		void UpdatePlaceholder()
 		{
-			Control.SetQueryHint(Element.Placeholder);
+			Control.QueryHint = Element.Placeholder;
 		}
 
 		[PortHandler]

--- a/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
@@ -12,6 +12,7 @@ using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Controls.Platform;
 using Color = Microsoft.Maui.Graphics.Color;
 using Size = Microsoft.Maui.Graphics.Size;
+using SearchView = AndroidX.AppCompat.Widget.SearchView;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {

--- a/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/SearchBarRenderer.cs
@@ -220,10 +220,10 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 			{
 				ClearFocus(control);
 				// removes cursor in SearchView
-				control.SetInputType(InputTypes.Null);
+				control.InputType = (int)InputTypes.Null;
 			}
 			else
-				control.SetInputType(_inputType);
+				control.InputType = (int)_inputType;
 
 			if (_editText != null)
 			{
@@ -327,7 +327,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 					}
 				}
 			}
-			Control.SetInputType(_inputType);
+
+			Control.InputType = (int)_inputType;
 
 			if (keyboard == Keyboard.Numeric)
 			{

--- a/src/Compatibility/Core/tests/Android/PlatformTestFixture.cs
+++ b/src/Compatibility/Core/tests/Android/PlatformTestFixture.cs
@@ -13,7 +13,7 @@ using Microsoft.Maui.Graphics;
 using NUnit.Framework;
 using AColor = Android.Graphics.Color;
 using AProgressBar = Android.Widget.ProgressBar;
-using ASearchView = Android.Widget.SearchView;
+using ASearchView = AndroidX.AppCompat.Widget.SearchView;
 using AView = Android.Views.View;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/BaseCellView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/BaseCellView.cs
@@ -3,6 +3,7 @@ using Android.Content;
 using Android.Text;
 using Android.Views;
 using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Widget;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Compatibility;
@@ -18,9 +19,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		readonly Color _androidDefaultTextColor;
 		Cell _cell;
-		readonly TextView _detailText;
+		readonly AppCompatTextView _detailText;
 		readonly ImageView _imageView;
-		readonly TextView _mainText;
+		readonly AppCompatTextView _mainText;
 		Color _defaultDetailColor;
 		Color _defaultMainTextColor;
 		Color _detailTextColor;
@@ -52,7 +53,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			var textLayout = new LinearLayout(context) { Orientation = Orientation.Vertical };
 
-			_mainText = new TextView(context);
+			_mainText = new AppCompatTextView(context);
 			_mainText.SetSingleLine(true);
 			_mainText.Ellipsize = TextUtils.TruncateAt.End;
 			_mainText.SetPadding((int)context.ToPixels(15), padding, padding, padding);
@@ -61,7 +62,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			using (var lp = new LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent))
 				textLayout.AddView(_mainText, lp);
 
-			_detailText = new TextView(context);
+			_detailText = new AppCompatTextView(context);
 			_detailText.SetSingleLine(true);
 			_detailText.Ellipsize = TextUtils.TruncateAt.End;
 			_detailText.SetPadding((int)context.ToPixels(15), padding, padding, padding);

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellEditText.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellEditText.cs
@@ -1,12 +1,12 @@
 using System;
 using Android.Content;
 using Android.Views;
-using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using ARect = Android.Graphics.Rect;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
-	public sealed class EntryCellEditText : EditText
+	public sealed class EntryCellEditText : AppCompatEditText
 	{
 		SoftInput _startingMode;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellView.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/EntryCellView.cs
@@ -4,6 +4,7 @@ using Android.Text;
 using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using AndroidX.Core.Widget;
 using Java.Lang;
 using Microsoft.Maui.Controls.Compatibility;
@@ -17,7 +18,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public const double DefaultMinHeight = 55;
 
 		readonly Cell _cell;
-		readonly TextView _label;
+		readonly AppCompatTextView _label;
 
 		Color _labelTextColor;
 		string _labelTextText;
@@ -32,7 +33,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var padding = (int)context.ToPixels(8);
 			SetPadding((int)context.ToPixels(15), padding, padding, padding);
 
-			_label = new TextView(context);
+			_label = new AppCompatTextView(context);
 			TextViewCompat.SetTextAppearance(_label, global::Android.Resource.Style.TextAppearanceSmall);
 
 			var layoutParams = new LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent) { Gravity = GravityFlags.CenterVertical };

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/TextCellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Android/TextCellRenderer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Android.Content;
 using Android.Views;
 using Microsoft.Maui.Controls.Internals;

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Android.cs
@@ -7,6 +7,7 @@ using Android.Content;
 using Android.Text;
 using Android.Views;
 using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Controls.Internals;
 using AButton = Android.Widget.Button;
 using AppCompatActivity = AndroidX.AppCompat.App.AppCompatActivity;
@@ -255,7 +256,7 @@ namespace Microsoft.Maui.Controls.Platform
 				alertDialog.SetMessage(arguments.Message);
 
 				var frameLayout = new FrameLayout(Activity);
-				var editText = new EditText(Activity) { Hint = arguments.Placeholder, Text = arguments.InitialValue };
+				var editText = new AppCompatEditText(Activity) { Hint = arguments.Placeholder, Text = arguments.InitialValue };
 				var layoutParams = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent)
 				{
 					LeftMargin = (int)(22 * Activity.Resources.DisplayMetrics.Density),


### PR DESCRIPTION
### Description of Change

Ports the fixes mentioned in #9323 to .NET MAUI.
This changes some public APIs! But we need to have this in order to be able to keep publishing Android apps to the Play Store.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #9323
