### PR TITLE
[Blazor] Account for Maui multi-rid builds

### DIFF
--- a/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
+++ b/src/BlazorWebView/src/Maui/build/Microsoft.AspNetCore.Components.WebView.Maui.targets
@@ -119,4 +119,13 @@
     </ItemGroup>
   </Target>
 
+  <!-- Microsoft.Android.Sdk.AssemblyResolution.targets _ResolveAssemblies triggers a nested build to
+       resolve publish files in a Maui specific way and that breaks elements depending on the '$(IntermediateOutputPath)'.
+       This target detects we are running inside one of such builds and adjust the relevant paths. -->
+  <Target Name="_AdjustStaticWebAssetPathBaseWhenBuildingWithRid" BeforeTargets="ResolveStaticWebAssetsConfiguration" Condition="'$(_OuterIntermediateOutputPath)' != ''">
+    <PropertyGroup>
+      <_StaticWebAssetsManifestBase>$(_OuterIntermediateOutputPath)</_StaticWebAssetsManifestBase>
+    </PropertyGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
Microsoft.Android.Sdk.AssemblyResolution.targets _ResolveAssemblies triggers a nested build to resolve publish files in a Maui specific way and that breaks elements depending on the '$(IntermediateOutputPath)'. 

This target detects we are running inside one of such builds and adjust the relevant paths.