### PR TITLE
[windows] Release builds use `$(PublishReadyToRun)` by default

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -6,6 +6,7 @@
     <WindowsAppSDKSelfContained Condition=" '$(WindowsAppSDKSelfContained)' == '' and '$(WindowsPackageType)' == 'None' and '$(OutputType)' == 'WinExe' ">true</WindowsAppSDKSelfContained>
     <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
     <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
+    <PublishReadyToRun Condition=" '$(Configuration)' == 'Release' and '$(PublishReadyToRun)' == '' ">true</PublishReadyToRun>
     <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>
     <_SingleProjectRIDSpecified Condition="'$(RuntimeIdentifier)' != '' or '$(RuntimeIdentifiers)' != ''">true</_SingleProjectRIDSpecified>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/core/deploying/ready-to-run
Fixes #9299

One of the biggest wins we see for MAUI startup on Windows is to
enable "Ready to Run", which seems to improve startup by as much as
50% in templates or sample apps with a reasonable increase in app size.

For example, the `dotnet new maui` template built for `win-x64`:

    45375824 PublishReadyToRun-false.msix
    59687908 PublishReadyToRun-true.msix

This setting is already used by the WindowsAppSdk templates via
publish profiles:

    Properties\PublishProfiles\win10-x64.pubxml
    Properties\PublishProfiles\win10-x86.pubxml
    Properties\PublishProfiles\win10-arm64.pubxml

These files are just MSBuild files, but they all contain:

    <PublishReadyToRun>true</PublishReadyToRun>

In .NET MAUI, I think we should just put this as a default in our
MSBuild targets, and customers get it by default for `Release` builds.
You can "opt out" of `PublishReadyToRun` by setting it to `false`.
