### PR TITLE
Create AssemblyInfo.cs for .NET MAUI Project Template

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Properties/AssemblyInfo.cs
+++ b/src/Templates/src/templates/maui-mobile/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: XamlCompilation(XamlCompilationOptions.Compile)]


### PR DESCRIPTION
This PR adds a file names AssemblyInfo.cs to the Properties folder.  The AssemblyInfo.cs file has a single, simple responsibility; enable XAML Compile by default.

### Description of Change

This brings the .NET MAUI project template up to the same XamlC standard that Xamarin.Forms used.  This was/is a known headache for developers who are not aware about the topic.

If you're not familiar with XamlC (XAML Compilation), this assembly attribute allows developers to use externally defined XAML components without requiring them to define an x:Name or create a dummy instance in C#. 

Without those precautions, an exception will be thrown at runtime stating that there is an unknown type.

### Example

For example, if a developer has a library with a control named "MyButton". The developer references that library and attempts to use MyButton in XAML like this:

```
<ContentPage xmlns:myControls="MyControlsLibrary">
    <myControls:MyButton Content="Click Me" />
</ContentPage>
```

You would expect it to work... but it will not. There's a runtime exception stating that MyButton is an unknown type.

The solution is to choose one of the following options

### Solutions

#### Option 1- Enable XamlC (using a class level or assembly level attribute)**

This is the most reliable and dev-friendly option because we can do it in the default template without dev-user intervention. We also provide the developer with some other advantages of XamlC by default!

We _could_ add it to the MauiProgram.cs file like this:

```csharp
[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
namespace MauiApp._1;

public static class MauiProgram
{
    ...
}
```

However, that's not best practice. The standard for this is to have an AssemblyInfo.cs file in the Properties folder. This lets the developer know it is an assembly wide attribute.

![image](https://user-images.githubusercontent.com/3520532/184189693-6e710a9c-dd0d-403a-91cc-2f6d872011e8.png)

#### Option 2 - Give every control in all the XAML places, an `x:Name` property value**

This is unreasonable and easily forgettable.


#### Option 3 - Create a dummy instance of that component in somewhere in the project's C#**

This is also clumsy and unreasonable to ask the dev-user to do this.  


## Conclusion

The most reliable and dev-friendly option is to just enable XamlC at the assembly level so that the custom components will work in every XAML file.

That is why in this Pull Request, I have made the small change to the default project template `maui-mobile`, which contains **Option 1** implemented in an `AssemblyInfo.cs` file.

