### PR TITLE
Pass the correct parameter value to the method

### DIFF
--- a/src/Essentials/src/Preferences/Preferences.uwp.cs
+++ b/src/Essentials/src/Preferences/Preferences.uwp.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Storage
 			_preferences.Set<T>(key, value, sharedName);
 
 		public T Get<T>(string key, T defaultValue, string sharedName) =>
-			_preferences.Get<T>(key, default, sharedName);
+			_preferences.Get<T>(key, defaultValue, sharedName);
 	}
 
 	class PackagedPreferencesImplementation : IPreferences

--- a/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
@@ -112,6 +112,78 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		}
 
 		[Theory]
+		[InlineData(null, true)]
+		[InlineData(sharedNameTestData, true)]
+		[InlineData(null, false)]
+		[InlineData(sharedNameTestData, false)]
+		public void Remove_Get_Bool(string sharedName, bool defaultValue)
+		{
+			Preferences.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, 5)]
+		[InlineData(sharedNameTestData, 5)]
+		[InlineData(null, 0)]
+		[InlineData(sharedNameTestData, 0)]
+		public void Remove_Get_Double(string sharedName, double defaultValue)
+		{
+			Preferences.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, 5)]
+		[InlineData(sharedNameTestData, 5)]
+		[InlineData(null, 0)]
+		[InlineData(sharedNameTestData, 0)]
+		public void Remove_Get_Float(string sharedName, float defaultValue)
+		{
+			Preferences.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, 5)]
+		[InlineData(sharedNameTestData, 5)]
+		[InlineData(null, 0)]
+		[InlineData(sharedNameTestData, 0)]
+		public void Remove_Get_Int(string sharedName, int defaultValue)
+		{
+			Preferences.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, 5)]
+		[InlineData(sharedNameTestData, 5)]
+		[InlineData(null, 0)]
+		[InlineData(sharedNameTestData, 0)]
+		public void Remove_Get_Long(string sharedName, long defaultValue)
+		{
+			Preferences.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, "text")]
+		[InlineData(sharedNameTestData, "text")]
+		[InlineData(null, null)]
+		[InlineData(sharedNameTestData, null)]
+		public void Remove_Get_String(string sharedName, string defaultValue)
+		{
+			Preferences.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
 		[InlineData(null)]
 		[InlineData(sharedNameTestData)]
 		public void Clear(string sharedName)


### PR DESCRIPTION
### Description of Change

In the effort to improve unpackaged support (https://github.com/dotnet/maui/pull/8536), I inadvertently broke Preferences on Windows because of a typo: `default` instead of `defaultValue`. This got through because our tests were correct, but coincidentally used the same value for `defaultValue` that was also `default`.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #9338
<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
