### PR TITLE
Add ctors to MauiMKWebView

### DIFF
--- a/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.iOS.cs
@@ -21,14 +21,8 @@ namespace Microsoft.Maui.Handlers
 		internal WebNavigationEvent _lastBackForwardEvent;
 		WKUIDelegate? _delegate;
 
-		protected override WKWebView CreatePlatformView()
-		{
-			var nativeWebView = new MauiWKWebView(RectangleF.Empty, this)
-			{
-				NavigationDelegate = new MauiWebViewNavigationDelegate(this)
-			};
-			return nativeWebView;
-		}
+		protected override WKWebView CreatePlatformView() =>
+			new MauiWKWebView(this);
 
 		internal WebNavigationEvent CurrentNavigationEvent
 		{

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Platform
 		public MauiWKWebView(CGRect frame, WebViewHandler handler, WKWebViewConfiguration configuration)
 			: base(frame, configuration)
 		{
+			_ = handler ?? throw new ArgumentNullException("handler");
 			_handler = new WeakReference<WebViewHandler>(handler);
 
 			BackgroundColor = UIColor.Clear;

--- a/src/Core/src/Platform/iOS/MauiWKWebView.cs
+++ b/src/Core/src/Platform/iOS/MauiWKWebView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Threading.Tasks;
 using CoreGraphics;
 using Foundation;
@@ -14,13 +15,25 @@ namespace Microsoft.Maui.Platform
 		string? _pendingUrl;
 		readonly WebViewHandler _handler;
 
+		public MauiWKWebView(WebViewHandler handler)
+			: this(RectangleF.Empty, handler)
+		{
+		}
+
 		public MauiWKWebView(CGRect frame, WebViewHandler handler)
-			: base(frame, CreateConfiguration())
+			: this(frame, handler, CreateConfiguration())
+		{
+		}
+
+		public MauiWKWebView(CGRect frame, WebViewHandler handler, WKWebViewConfiguration configuration)
+			: base(frame, configuration)
 		{
 			_handler = handler;
 
 			BackgroundColor = UIColor.Clear;
 			AutosizesSubviews = true;
+
+			NavigationDelegate = new MauiWebViewNavigationDelegate(_handler);
 		}
 
 		public string? CurrentUrl =>
@@ -87,7 +100,7 @@ namespace Microsoft.Maui.Platform
 		// The main workaround I've found for ensuring that cookies synchronize 
 		// is to share the Process Pool between all WkWebView instances.
 		// It also has to be shared at the point you call init
-		static WKWebViewConfiguration CreateConfiguration()
+		public static WKWebViewConfiguration CreateConfiguration()
 		{
 			var config = new WKWebViewConfiguration();
 

--- a/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
@@ -13,22 +13,35 @@ namespace Microsoft.Maui.Platform
 	// so we'd like to stick with the older one for now
 	public class MauiWebViewNavigationDelegate : NSObject, IWKNavigationDelegate
 	{
-		readonly WebViewHandler _handler;
+		readonly WeakReference<WebViewHandler> _handler;
 		WebNavigationEvent _lastEvent;
 
 		public MauiWebViewNavigationDelegate(WebViewHandler handler)
 		{
-			_handler = handler ?? throw new ArgumentNullException("handler");
+			_handler = new WeakReference<WebViewHandler>(handler) ?? throw new ArgumentNullException("handler");
+		}
+
+		WebViewHandler? Handler
+		{
+			get
+			{
+				if (_handler.TryGetTarget(out var handler))
+				{
+					return handler;
+				}
+
+				return null;
+			}
 		}
 
 		[Export("webView:didFinishNavigation:")]
 		public void DidFinishNavigation(WKWebView webView, WKNavigation navigation)
 		{
-			if (_handler == null)
+			var handler = Handler;
+			if (handler == null)
 				return;
 
-			if (_handler != null)
-				_handler.PlatformView.UpdateCanGoBackForward(_handler.VirtualView);
+			handler.PlatformView?.UpdateCanGoBackForward(handler.VirtualView);
 
 			if (webView.IsLoading)
 				return;
@@ -38,50 +51,52 @@ namespace Microsoft.Maui.Platform
 			if (url == $"file://{NSBundle.MainBundle.BundlePath}/")
 				return;
 
-			var virtualView = _handler?.VirtualView;
+			var virtualView = handler.VirtualView;
 
 			if (virtualView == null)
 				return;
 
 			virtualView.Navigated(_lastEvent, url, WebNavigationResult.Success);
 
-			_handler?.PlatformView.UpdateCanGoBackForward(virtualView);
+			handler.PlatformView?.UpdateCanGoBackForward(virtualView);
 		}
 
 		[Export("webView:didFailNavigation:withError:")]
 		public void DidFailNavigation(WKWebView webView, WKNavigation navigation, NSError error)
 		{
-			if (_handler == null)
+			var handler = Handler;
+			if (handler == null)
 				return;
 
 			var url = GetCurrentUrl();
 
-			var virtualView = _handler.VirtualView;
+			var virtualView = handler.VirtualView;
 
 			if (virtualView == null)
 				return;
 
 			virtualView.Navigated(_lastEvent, url, WebNavigationResult.Failure);
 
-			_handler.PlatformView?.UpdateCanGoBackForward(virtualView);
+			handler.PlatformView?.UpdateCanGoBackForward(virtualView);
 		}
 
 		[Export("webView:didFailProvisionalNavigation:withError:")]
 		public void DidFailProvisionalNavigation(WKWebView webView, WKNavigation navigation, NSError error)
 		{
-			if (_handler == null)
+			var handler = Handler;
+			if (handler == null)
 				return;
 
 			var url = GetCurrentUrl();
 
-			var virtualView = _handler.VirtualView;
+			var virtualView = handler.VirtualView;
 
 			if (virtualView == null)
 				return;
 
 			virtualView.Navigated(_lastEvent, url, WebNavigationResult.Failure);
 
-			_handler.PlatformView?.UpdateCanGoBackForward(virtualView);
+			handler.PlatformView?.UpdateCanGoBackForward(virtualView);
 
 		}
 
@@ -89,7 +104,8 @@ namespace Microsoft.Maui.Platform
 		[Export("webView:decidePolicyForNavigationAction:decisionHandler:")]
 		public void DecidePolicy(WKWebView webView, WKNavigationAction navigationAction, Action<WKNavigationActionPolicy> decisionHandler)
 		{
-			if (_handler == null)
+			var handler = Handler;
+			if (handler == null)
 				return;
 
 			var navEvent = WebNavigationEvent.NewPage;
@@ -108,7 +124,7 @@ namespace Microsoft.Maui.Platform
 					navEvent = WebNavigationEvent.NewPage;
 					break;
 				case WKNavigationType.BackForward:
-					navEvent = _handler.CurrentNavigationEvent;
+					navEvent = handler.CurrentNavigationEvent;
 					break;
 				case WKNavigationType.Reload:
 					navEvent = WebNavigationEvent.Refresh;
@@ -123,7 +139,7 @@ namespace Microsoft.Maui.Platform
 
 			_lastEvent = navEvent;
 
-			var virtualView = _handler.VirtualView;
+			var virtualView = handler.VirtualView;
 
 			if (virtualView == null)
 				return;
@@ -132,13 +148,13 @@ namespace Microsoft.Maui.Platform
 			var lastUrl = request.Url.ToString();
 
 			bool cancel = virtualView.Navigating(navEvent, lastUrl);
-			_handler.PlatformView?.UpdateCanGoBackForward(virtualView);
+			handler.PlatformView?.UpdateCanGoBackForward(virtualView);
 			decisionHandler(cancel ? WKNavigationActionPolicy.Cancel : WKNavigationActionPolicy.Allow);
 		}
 
 		string GetCurrentUrl()
 		{
-			return _handler.PlatformView?.Url?.AbsoluteUrl?.ToString() ?? string.Empty;
+			return Handler?.PlatformView?.Url?.AbsoluteUrl?.ToString() ?? string.Empty;
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiWebViewNavigationDelegate.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Maui.Platform
 
 		public MauiWebViewNavigationDelegate(WebViewHandler handler)
 		{
-			_handler = new WeakReference<WebViewHandler>(handler) ?? throw new ArgumentNullException("handler");
+			_ = handler ?? throw new ArgumentNullException("handler");
+			_handler = new WeakReference<WebViewHandler>(handler);
 		}
 
 		WebViewHandler? Handler

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -6,6 +6,8 @@ Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler
 Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.MenuFlyoutSeparatorHandler() -> void
 Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.MenuFlyoutSeparatorHandler(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
 Microsoft.Maui.IMenuFlyoutSeparator
+Microsoft.Maui.Platform.MauiWKWebView.MauiWKWebView(CoreGraphics.CGRect frame, Microsoft.Maui.Handlers.WebViewHandler! handler, WebKit.WKWebViewConfiguration! configuration) -> void
+Microsoft.Maui.Platform.MauiWKWebView.MauiWKWebView(Microsoft.Maui.Handlers.WebViewHandler! handler) -> void
 override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
 override Microsoft.Maui.Handlers.BorderHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
@@ -21,6 +23,7 @@ override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.set -> void
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
+static Microsoft.Maui.Platform.MauiWKWebView.CreateConfiguration() -> WebKit.WKWebViewConfiguration!
 static Microsoft.Maui.Platform.ViewExtensions.UpdateBackground(this UIKit.UIView! platformView, Microsoft.Maui.Graphics.Paint? paint, Microsoft.Maui.IButtonStroke? stroke = null) -> void
 virtual Microsoft.Maui.MauiUIApplicationDelegate.ApplicationSignificantTimeChange(UIKit.UIApplication! application) -> void
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.ApplicationSignificantTimeChange

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -6,6 +6,8 @@ Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler
 Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.MenuFlyoutSeparatorHandler() -> void
 Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.MenuFlyoutSeparatorHandler(Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
 Microsoft.Maui.IMenuFlyoutSeparator
+Microsoft.Maui.Platform.MauiWKWebView.MauiWKWebView(CoreGraphics.CGRect frame, Microsoft.Maui.Handlers.WebViewHandler! handler, WebKit.WKWebViewConfiguration! configuration) -> void
+Microsoft.Maui.Platform.MauiWKWebView.MauiWKWebView(Microsoft.Maui.Handlers.WebViewHandler! handler) -> void
 override Microsoft.Maui.Handlers.BorderHandler.ConnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
 override Microsoft.Maui.Handlers.BorderHandler.DisconnectHandler(Microsoft.Maui.Platform.ContentView! platformView) -> void
 override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
@@ -21,6 +23,7 @@ override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.set -> void
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
+static Microsoft.Maui.Platform.MauiWKWebView.CreateConfiguration() -> WebKit.WKWebViewConfiguration!
 static Microsoft.Maui.Platform.ViewExtensions.UpdateBackground(this UIKit.UIView! platformView, Microsoft.Maui.Graphics.Paint? paint, Microsoft.Maui.IButtonStroke? stroke = null) -> void
 virtual Microsoft.Maui.MauiUIApplicationDelegate.ApplicationSignificantTimeChange(UIKit.UIApplication! application) -> void
 Microsoft.Maui.LifecycleEvents.iOSLifecycle.ApplicationSignificantTimeChange


### PR DESCRIPTION
### Description of Change

- add ctors to `MauiMkWebView` so developers can apply their own `WKWebViewConfiguration`
- Make the static creator for `WKWebViewConfiguration` public so users can make use of it to retrieve our `configuration`
- Move all the code for creating `MauiMkWebView` into `MauiMkWebView` so users only have to instantiate `MauiMkWebView` in order for it to work instead of having to figure out what things we are setting. 
- Use WeakReference for all local instances of Handler

### Issues Fixed

Fixes #9429
