### PR TITLE
Update Package.appxmanifest to have PhonePublisherId

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -81,6 +81,11 @@
       "HostIdentifier": {
         "type": "bind",
         "binding": "HostIdentifier"
+      },
+      "PhoneProductId": {
+        "type": "generated",
+        "generator": "guid",
+        "replaces": "$guid9$"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-blazor/Platforms/Windows/Package.appxmanifest
@@ -2,10 +2,13 @@
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
   <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
+
+  <mp:PhoneIdentity PhoneProductId="$guid9$" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
     <DisplayName>$placeholder$</DisplayName>

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -85,6 +85,11 @@
       "HostIdentifier": {
         "type": "bind",
         "binding": "HostIdentifier"
+      },
+      "PhonePublisherId": {
+        "type": "generated",
+        "generator": "guid",
+        "replaces": "$guid9$"
       }
     },
     "defaultName": "MauiApp1"

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -86,7 +86,7 @@
         "type": "bind",
         "binding": "HostIdentifier"
       },
-      "PhonePublisherId": {
+      "PhoneProductId": {
         "type": "generated",
         "generator": "guid",
         "replaces": "$guid9$"

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
@@ -2,10 +2,13 @@
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="1.0.0.0" />
+
+  <mp:PhoneIdentity PhoneProductId="$guid9$" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
     <DisplayName>$placeholder$</DisplayName>

--- a/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
+++ b/src/Templates/src/templates/maui-mobile/Platforms/Windows/Package.appxmanifest
@@ -6,7 +6,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="1.0.0.0" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="$guid9$" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 


### PR DESCRIPTION
### Description of Change

Adding PhonePublisherId to the Package.appxmanifest file to allow publishing to the Windows Store as this is required
Start Version at 1.0.0.0 instead of 0.0.0.0

This brings the template to the same defaults as the UWP templates

### Issues Fixed

[Bug 1564079](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1564079): [MAUI Publish] Error list shows 3 errors when publishing MAUI applications to the Microsoft Store

[Bug 1558236](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1558236): Maui Publish dialog version starts at 0.0.0.0 instead of 1.0.0.0
