### PR TITLE
[Windows] Fix default corner radius on Button

### DIFF
--- a/src/Core/src/Platform/Windows/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Windows/ButtonExtensions.cs
@@ -50,10 +50,10 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCornerRadius(this Button platformButton, IButtonStroke buttonStroke)
 		{
-			var radius = buttonStroke.CornerRadius;
+			var radius = buttonStroke.CornerRadius > -1 ? buttonStroke.CornerRadius : 0;
 
 			if (radius >= 0)
-				platformButton.Resources.SetValueForAllKey(CornerRadiusResourceKeys, WinUIHelpers.CreateCornerRadius(buttonStroke.CornerRadius));
+				platformButton.Resources.SetValueForAllKey(CornerRadiusResourceKeys, WinUIHelpers.CreateCornerRadius(radius));
 			else
 				platformButton.Resources.RemoveKeys(CornerRadiusResourceKeys);
 


### PR DESCRIPTION
### Description of Change

 Fix default corner radius on Windows Button.

By default, on Windows the Button used CornerRadius not like it does on Android or iOS. This PR adds changes to match behavior across platforms. The default CornerRadius value is -1; and we was just not setting the CornerRadius value with the default value and using the default native Button CornerRadius value.

Android
![image](https://user-images.githubusercontent.com/6755973/185346298-2257d747-3604-4199-99fb-d7756b0d50ca.png)

Windows
![image](https://user-images.githubusercontent.com/6755973/185348434-b5430bc8-637b-4b2d-b153-67188db3cd16.png)

The issue describes another issue which is a small inner space in the button when using Stroke and CornerRadius. This PR does not add a fix to that problem because after testing directly in WinUI, the problem is there too.

[TestButtonWinUI.zip](https://github.com/dotnet/maui/files/9371793/TestButtonWinUI.zip)

![image](https://user-images.githubusercontent.com/6755973/185346508-ac225d12-be2e-4d66-a520-4b342d334884.png)
![image](https://user-images.githubusercontent.com/6755973/185346698-e5b93e57-7ae9-48d2-8c62-8b5c9a7e1ef0.png)

Tried a hack that could fix the issue but will increase the hierarchy tree. I think is better to notify and expect a fix on WinUI.

### Issues Fixed

Fixes #7128 