### PR TITLE
Make sure cursor doesn't go out of bounds when setting Entry/Editor text

### DIFF
--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -32,15 +32,15 @@ namespace Microsoft.Maui.Controls.Platform
 				isPasswordEnabled ? TextTransform.None : inputView.TextTransform
 				);
 
-			// Re-calculate the cursor offset position if the text was modified by a Converter.
-			// but if the text is being set by code, let's just move the cursor to the end.
-			var cursorOffset = newText.Length - oldText.Length;
-			int cursorPosition = editText.IsFocused ? editText.GetCursorPosition(cursorOffset) : newText.Length;
-
 			if (oldText != newText)
 				editText.Text = newText;
 
-			editText.SetSelection(cursorPosition, cursorPosition);
+			// Re-calculate the cursor offset position if the text was modified by a Converter.
+			// but if the text is being set by code, let's just move the cursor to the end.
+			var cursorOffset = newText.Length - oldText.Length;
+			int cursorPosition = editText.IsFocused ? editText.GetCursorPosition(cursorOffset) : editText.Text.Length;
+
+			editText.SetSelection(cursorPosition);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Some minor changes to make sure that we don't set the cursor on an `Entry` and `Editor` to an out of bounds value on Android.

This was fixed also on Xamarin.Forms: https://github.com/xamarin/Xamarin.Forms/pull/12764

### Issues Fixed

Fixes #9418