### PR TITLE
Pin SDK to stable 6.0.400

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
     "Microsoft.Build.NoTargets": "3.3.0"
   },
   "sdk": {
-    "version": "6.0.302",
+    "version": "6.0.400",
     "allowPrerelease": true,
     "rollForward": "latestMinor"
   }


### PR DESCRIPTION
### Description of Change

Now that 6.0.400 is stable let's pin to it. 