### PR TITLE
[iOS] Fix updating Border Background using VisualStateManager

### DIFF
--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateBackground(this ContentView platformView, IBorderStroke border)
 		{
-			bool hasBorder = border.Shape != null && border.Stroke != null;
+			bool hasShape = border.Shape != null;
 
-			if (hasBorder)
+			if (hasShape)
 			{
 				platformView.UpdateMauiCALayer(border);
 			}


### PR DESCRIPTION
### Description of Change

Fix updating Border Background using VisualStateManager. Update the Border background even if the stroke is not assigned.

![fix-9444](https://user-images.githubusercontent.com/6755973/185662769-ff9e4129-648a-4ecd-85f3-e6da14feb943.gif)

### Issues Fixed

Fixes #9444 
Fixes #9542