### PR TITLE
Fix GC issues and cancel button visibility

### DIFF
--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs
@@ -13,10 +13,11 @@ namespace Microsoft.Maui.Handlers
 
 		protected override MauiSearchBar CreatePlatformView()
 		{
-			var searchBar = new MauiSearchBar() { ShowsCancelButton = true, BarStyle = UIBarStyle.Default };
+			var searchBar = new MauiSearchBar() { BarStyle = UIBarStyle.Default };
 
 			_editor = searchBar.GetSearchTextField();
 
+			
 			return searchBar;
 		}
 
@@ -25,15 +26,18 @@ namespace Microsoft.Maui.Handlers
 			platformView.CancelButtonClicked += OnCancelClicked;
 			platformView.SearchButtonClicked += OnSearchButtonClicked;
 			platformView.TextSetOrChanged += OnTextPropertySet;
+			platformView.OnMovedToWindow += OnMovedToWindow;
 			platformView.ShouldChangeTextInRange += ShouldChangeText;
-
-			platformView.OnEditingStarted += OnEditingStarted;
-			platformView.OnEditingStopped += OnEditingEnded;
-
-			if (_editor != null)
-				_editor.EditingChanged += OnEditingChanged;
+			platformView.EditingChanged += OnEditingChanged;
 
 			base.ConnectHandler(platformView);
+		}
+
+		void OnMovedToWindow(object? sender, EventArgs e)
+		{
+			// The cancel button doesn't exist until the control has moved to the window
+			// so we fire this off again so it can set the color
+			UpdateValue(nameof(ISearchBar.CancelButtonColor));
 		}
 
 		protected override void DisconnectHandler(MauiSearchBar platformView)
@@ -42,12 +46,8 @@ namespace Microsoft.Maui.Handlers
 			platformView.SearchButtonClicked -= OnSearchButtonClicked;
 			platformView.TextSetOrChanged -= OnTextPropertySet;
 			platformView.ShouldChangeTextInRange -= ShouldChangeText;
-
-			platformView.OnEditingStarted -= OnEditingStarted;
-			platformView.OnEditingStopped -= OnEditingEnded;
-
-			if (_editor != null)
-				_editor.EditingChanged -= OnEditingChanged;
+			platformView.OnMovedToWindow -= OnMovedToWindow;
+			platformView.EditingChanged -= OnEditingChanged;
 
 			base.DisconnectHandler(platformView);
 		}
@@ -150,46 +150,31 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapCancelButtonColor(ISearchBarHandler handler, ISearchBar searchBar)
 		{
-			if (handler is SearchBarHandler platformHandler)
-			{
-				handler.PlatformView?.UpdateCancelButton(
-					searchBar);
-			}
+			handler.PlatformView?.UpdateCancelButton(searchBar);
 		}
 
 		void OnCancelClicked(object? sender, EventArgs args)
 		{
 			if (VirtualView != null)
 				VirtualView.Text = string.Empty;
-
-			PlatformView?.ResignFirstResponder();
 		}
 
 		void OnSearchButtonClicked(object? sender, EventArgs e)
 		{
 			VirtualView?.SearchButtonPressed();
-			PlatformView?.ResignFirstResponder();
 		}
 
-		void OnTextPropertySet(object? sender, UISearchBarTextChangedEventArgs a) =>
+		void OnTextPropertySet(object? sender, UISearchBarTextChangedEventArgs a)
+		{
 			VirtualView.UpdateText(a.SearchText);
+
+			UpdateCancelButtonVisibility();
+		}
 
 		bool ShouldChangeText(UISearchBar searchBar, NSRange range, string text)
 		{
 			var newLength = searchBar?.Text?.Length + text.Length - range.Length;
 			return newLength <= VirtualView?.MaxLength;
-		}
-
-		void OnEditingEnded(object? sender, EventArgs e)
-		{
-			if (VirtualView != null)
-				VirtualView.IsFocused = false;
-		}
-
-		void OnEditingStarted(object? sender, EventArgs e)
-		{
-			if (VirtualView != null)
-				VirtualView.IsFocused = true;
 		}
 
 		void OnEditingChanged(object? sender, EventArgs e)
@@ -198,6 +183,14 @@ namespace Microsoft.Maui.Handlers
 				return;
 
 			VirtualView.UpdateText(_editor.Text);
+
+			UpdateCancelButtonVisibility();
+		}
+
+		void UpdateCancelButtonVisibility()
+		{
+			if (PlatformView.ShowsCancelButton != VirtualView.ShouldShowCancelButton())
+				UpdateValue(nameof(ISearchBar.CancelButtonColor));
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiDatePickerDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiDatePickerDelegate.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Microsoft.Maui.Platform
 {
-	internal class MauiDatePickerDelegate
+	class MauiDatePickerDelegate
 	{
 		public virtual void DatePickerEditingDidBegin()
 		{

--- a/src/Core/src/Platform/iOS/MauiSearchBar.cs
+++ b/src/Core/src/Platform/iOS/MauiSearchBar.cs
@@ -49,5 +49,30 @@ namespace Microsoft.Maui.Platform
 				}
 			}
 		}
+
+		internal event EventHandler? OnMovedToWindow;
+		internal event EventHandler? EditingChanged;
+
+		public override void WillMoveToWindow(UIWindow? window)
+		{
+			var editor = this.GetSearchTextField();
+
+			base.WillMoveToWindow(window);
+
+			if (editor != null)
+			{
+				editor.EditingChanged -= OnEditingChanged;
+				if (window != null)
+					editor.EditingChanged += OnEditingChanged;
+			}
+
+			if (window != null)
+				OnMovedToWindow?.Invoke(this, EventArgs.Empty);
+		}
+
+		void OnEditingChanged(object? sender, EventArgs e)
+		{
+			EditingChanged?.Invoke(this, EventArgs.Empty);
+		}
 	}
 }

--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -103,9 +103,12 @@ namespace Microsoft.Maui.Platform
 			uiSearchBar.UserInteractionEnabled = !(searchBar.IsReadOnly || searchBar.InputTransparent);
 		}
 
+		internal static bool ShouldShowCancelButton(this ISearchBar searchBar) =>
+			!string.IsNullOrEmpty(searchBar.Text);
+
 		public static void UpdateCancelButton(this UISearchBar uiSearchBar, ISearchBar searchBar)
 		{
-			uiSearchBar.ShowsCancelButton = !string.IsNullOrEmpty(uiSearchBar.Text);
+			uiSearchBar.ShowsCancelButton = searchBar.ShouldShowCancelButton();
 
 			// We can't cache the cancel button reference because iOS drops it when it's not displayed
 			// and creates a brand new one when necessary, so we have to look for it each time

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -21,6 +21,7 @@ override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.get -> bool
 override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.set -> void
 *REMOVED*override Microsoft.Maui.Handlers.LabelHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
+override Microsoft.Maui.Platform.MauiSearchBar.WillMoveToWindow(UIKit.UIWindow? window) -> void
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
 static Microsoft.Maui.Platform.MauiWKWebView.CreateConfiguration() -> WebKit.WKWebViewConfiguration!

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -21,6 +21,7 @@ override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.get -> bool
 override Microsoft.Maui.Platform.LayoutView.UserInteractionEnabled.set -> void
 *REMOVED*override Microsoft.Maui.Handlers.LabelHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect rect) -> void
 *REMOVED*override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
+override Microsoft.Maui.Platform.MauiSearchBar.WillMoveToWindow(UIKit.UIWindow? window) -> void
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
 static Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IMenuFlyoutSeparator!, Microsoft.Maui.Handlers.IMenuFlyoutSeparatorHandler!>!
 static Microsoft.Maui.Platform.MauiWKWebView.CreateConfiguration() -> WebKit.WKWebViewConfiguration!

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -11,6 +11,27 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SearchBarHandlerTests
 	{
+		[Fact]
+		public async Task ShouldShowCancelButtonToggles()
+		{
+			var searchBarStub = new SearchBarStub();
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var searchBar = CreateHandler(searchBarStub).PlatformView;
+
+				Assert.False(searchBar.ShowsCancelButton);
+
+				searchBarStub.Text = "additional text";
+				searchBarStub.Handler.UpdateValue(nameof(ISearchBar.Text));
+				Assert.True(searchBar.ShowsCancelButton);
+
+				searchBarStub.Text = "";
+				searchBarStub.Handler.UpdateValue(nameof(ISearchBar.Text));
+				Assert.False(searchBar.ShowsCancelButton);
+			});
+		}
+
 		[Fact(DisplayName = "Horizontal TextAlignment Updates Correctly")]
 		public async Task HorizontalTextAlignmentInitializesCorrectly()
 		{

--- a/src/Core/tests/DeviceTests/Memory/MemoryTestTypes.cs
+++ b/src/Core/tests/DeviceTests/Memory/MemoryTestTypes.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Maui.Handlers.Memory
 		{
 			yield return new object[] { (typeof(DatePickerStub), typeof(DatePickerHandler)) };
 			yield return new object[] { (typeof(EditorStub), typeof(EditorHandler)) };
+			yield return new object[] { (typeof(SearchBarStub), typeof(SearchBarHandler)) };
 		}
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Core/tests/DeviceTests/Memory/MemoryTests.cs
+++ b/src/Core/tests/DeviceTests/Memory/MemoryTests.cs
@@ -38,8 +38,11 @@ namespace Microsoft.Maui.Handlers.Memory
 		[ClassData(typeof(MemoryTestTypes))]
 		public async Task Allocate((Type ViewType, Type HandlerType) data)
 		{
+
+#if ANDROID
 			if (!OperatingSystem.IsAndroidVersionAtLeast(30))
 				return;
+#endif
 
 			var handler = await InvokeOnMainThreadAsync(() => CreateHandler((IElement)Activator.CreateInstance(data.ViewType), data.HandlerType));
 			WeakReference weakHandler = new WeakReference(handler);
@@ -56,8 +59,11 @@ namespace Microsoft.Maui.Handlers.Memory
 		[ClassData(typeof(MemoryTestTypes))]
 		public async Task CheckAllocation((Type ViewType, Type HandlerType) data)
 		{
+
+#if ANDROID
 			if (!OperatingSystem.IsAndroidVersionAtLeast(30))
 				return;
+#endif
 
 			// This is mainly relevant when running inside the visual runner as a single test
 			if (!_fixture.HasType(data.HandlerType))


### PR DESCRIPTION
### Description of Change

- the cancel button visibility is set inside the `UpdateCancelButton` call which is currently only called once. This PR calls it any time the text changes so that the `cancelbutton` can toggle correctly
- Fixup the event handlers so they are GC safe
- remove any code that modifies the responder or the focus

### Issues Fixed

https://github.com/dotnet/maui/issues/8754
