### PR TITLE
[Windows] Notify changes in Picker ItemsSource

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Picker/Picker.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Picker/Picker.Impl.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Maui.Controls
 			if (index < Items?.Count)
 			{
 				var item = Items[index];
-				return item == null ? string.Empty : item;
+				return item ?? string.Empty;
 			}
 
 			return string.Empty;

--- a/src/Controls/src/Core/Picker.cs
+++ b/src/Controls/src/Core/Picker.cs
@@ -318,6 +318,7 @@ namespace Microsoft.Maui.Controls
 			((LockableObservableListWrapper)Items).InternalClear();
 			foreach (object item in ItemsSource)
 				((LockableObservableListWrapper)Items).InternalAdd(GetDisplayMember(item));
+			Handler?.UpdateValue(nameof(IPicker.Items));
 			UpdateSelectedItem(SelectedIndex);
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Picker/PickerHandlerTests.Windows.cs
@@ -1,16 +1,63 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.UI.Xaml.Controls;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class PickerHandlerTests
 	{
+		[Fact(DisplayName = "ItemsSource Updates Correctly")]
+		public async Task ItemsSourceUpdatesCorrectly()
+		{
+			int selectedIndex = 0;
+
+			var oldItems = new List<string>
+			{
+				"Old Item 1",
+				"Old Item 2",
+				"Old Item 3"
+			};
+
+			var newItems = new List<string>
+			{
+				"New Item 1",
+				"New Item 2",
+				"New Item 3"
+			};
+
+			var picker = new PickerStub()
+			{
+				Title = "Select an Item",
+				ItemsSource = oldItems,
+				SelectedIndex = 1
+			};
+
+			picker.ItemsSource = newItems;
+			picker.SelectedIndex = selectedIndex;
+
+			string expected = picker.ItemsSource[selectedIndex].ToString();
+			var actual = await GetValueAsync(picker, handler => GetNativeText(handler));
+
+			Assert.Equal(expected, actual);
+		}
+
+
 		ComboBox GetNativePicker(PickerHandler pickerHandler) =>
-			pickerHandler.PlatformView; 
-		
+			pickerHandler.PlatformView;
+
 		UI.Xaml.HorizontalAlignment GetNativeHorizontalTextAlignment(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).HorizontalContentAlignment;
 
 		UI.Xaml.VerticalAlignment GetNativeVerticalTextAlignment(PickerHandler pickerHandler) =>
 			GetNativePicker(pickerHandler).VerticalAlignment;
+
+		string GetNativeText(PickerHandler pickerHandler)
+		{
+			var comboBox = GetNativePicker(pickerHandler);
+
+			return comboBox.Items[comboBox.SelectedIndex].ToString();
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/PickerStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/PickerStub.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
 
@@ -12,7 +13,24 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		public IList<string> Items { get; set; } = new List<string>();
 
-		public IList ItemsSource { get; set; }
+		IList _itemsSource;
+
+		public IList ItemsSource
+		{
+			get => _itemsSource;
+			set => SetProperty(ref _itemsSource, value, onChanged: OnItemsSourceChanged);
+		}
+
+		void OnItemsSourceChanged(IList oldValue, IList newValue)
+		{
+			if (ItemsSource == null)
+				return;
+
+			Items.Clear();
+
+			foreach (object item in ItemsSource)
+				Items.Add(item.ToString());
+		}
 
 		public int SelectedIndex { get; set; } = -1;
 


### PR DESCRIPTION
### Description of Change

Notify changes in Picker ItemsSource (without using ObservableCollection). Fix the issue #9239 updating the Picker ItemsSource.

![fix-9239](https://user-images.githubusercontent.com/6755973/185979139-cd1f4fce-6a51-405f-a06a-fa47e0ac9aa8.gif)

### Issues Fixed

Fixes #9239 
Fixes https://github.com/dotnet/maui/issues/9496