### PR TITLE
Secondary ButtonMask

### DIFF
--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38978.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Bugzilla38978.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 				Label label = new Label { Text = "Click the image to resize", VerticalOptions = LayoutOptions.Center };
 
 				var tapGestureRecognizer = new TapGestureRecognizer();
-				tapGestureRecognizer.Tapped += (object sender, EventArgs e) =>
+				tapGestureRecognizer.Tapped += (sender, e) =>
 				{
 					if (_image.HeightRequest < 250)
 					{

--- a/src/Compatibility/Core/src/iOS/EventTracker.cs
+++ b/src/Compatibility/Core/src/iOS/EventTracker.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 					return;
 
 				if (weakRecognizer.Target is TapGestureRecognizer tapGestureRecognizer && view != null)
-					tapGestureRecognizer.SendTapped(view);
+					tapGestureRecognizer.SendTapped(view, null);
 			});
 		}
 
@@ -230,7 +230,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 				var tapGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as TapGestureRecognizer;
 				foreach (var item in recognizers)
 					if (item == tapGestureRecognizer && view != null)
-						tapGestureRecognizer.SendTapped(view);
+						tapGestureRecognizer.SendTapped(view, null);
 			});
 		}
 #endif

--- a/src/Compatibility/Core/src/iOS/EventTracker.cs
+++ b/src/Compatibility/Core/src/iOS/EventTracker.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 					return;
 
 				if (weakRecognizer.Target is TapGestureRecognizer tapGestureRecognizer && view != null)
-					tapGestureRecognizer.SendTapped(view, null);
+					tapGestureRecognizer.SendTapped(view);
 			});
 		}
 
@@ -230,7 +230,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 				var tapGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as TapGestureRecognizer;
 				foreach (var item in recognizers)
 					if (item == tapGestureRecognizer && view != null)
-						tapGestureRecognizer.SendTapped(view, null);
+						tapGestureRecognizer.SendTapped(view);
 			});
 		}
 #endif

--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -6,14 +6,12 @@ namespace Maui.Controls.Sample.Pages
 {
 	public class TapGestureGalleryPage : BasePage
 	{
-		Command clickCommand;
 		Command TapCommand;
 		Label changeColorBoxView;
 
 		public TapGestureGalleryPage()
 		{
 			TapCommand = new Command<Color>(HandleTapCommand);
-			clickCommand = new Command<Color>(HandleClickCommand);
 
 			var vertical = new VerticalStackLayout
 			{
@@ -81,51 +79,6 @@ namespace Maui.Controls.Sample.Pages
 				})
 			});
 
-			AddMoreStuff(vertical);
-			Content = vertical;
-		}
-
-		void AddMoreStuff(VerticalStackLayout vertical)
-		{
-			var horizontal = new StackLayout
-			{
-				Orientation = StackOrientation.Horizontal,
-				Spacing = 20,
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center
-			};
-			vertical.Children.Add(horizontal);
-
-			var singleClickLabel = new Label
-			{
-				Text = "Click me!",
-				BackgroundColor = Colors.PaleGreen
-			};
-			var singleClickGesture = new TapGestureRecognizer
-			{
-				Command = clickCommand,
-				CommandParameter = Colors.PaleGreen,
-				NumberOfTapsRequired = 1,
-				Buttons = ButtonsMask.Primary
-			};
-			singleClickLabel.GestureRecognizers.Add(singleClickGesture);
-			horizontal.Children.Add(singleClickLabel);
-
-			var doubleClickLabel = new Label
-			{
-				Text = "Double click me!!",
-				BackgroundColor = Colors.Aqua
-			};
-			var doubleClickGesture = new TapGestureRecognizer
-			{
-				Command = clickCommand,
-				CommandParameter = Colors.Aqua,
-				NumberOfTapsRequired = 2,
-				Buttons = ButtonsMask.Primary
-			};
-			doubleClickLabel.GestureRecognizers.Add(doubleClickGesture);
-			horizontal.Children.Add(doubleClickLabel);
-
 			var tripleClicklabel = new Label
 			{
 				Text = "Triple click me!!!",
@@ -133,7 +86,7 @@ namespace Maui.Controls.Sample.Pages
 			};
 			var tripleClickGesture = new TapGestureRecognizer
 			{
-				Command = clickCommand,
+				Command = TapCommand,
 				CommandParameter = Colors.Olive,
 				NumberOfTapsRequired = 3,
 				Buttons = ButtonsMask.Primary
@@ -148,7 +101,7 @@ namespace Maui.Controls.Sample.Pages
 			};
 			var rigthClickGesture = new TapGestureRecognizer
 			{
-				Command = clickCommand,
+				Command = TapCommand,
 				CommandParameter = Colors.Coral,
 				NumberOfTapsRequired = 1,
 				Buttons = ButtonsMask.Secondary
@@ -156,30 +109,10 @@ namespace Maui.Controls.Sample.Pages
 			rightClickLabel.GestureRecognizers.Add(rigthClickGesture);
 			horizontal.Children.Add(rightClickLabel);
 
-			var doubleRightClickLabel = new Label
-			{
-				Text = "Double right click me¡¡",
-				BackgroundColor = Colors.Gold
-			};
-			var doubleRigthClickGesture = new TapGestureRecognizer
-			{
-				Command = clickCommand,
-				CommandParameter = Colors.Gold,
-				NumberOfTapsRequired = 2,
-				Buttons = ButtonsMask.Secondary
-			};
-
-			doubleRightClickLabel.GestureRecognizers.Add(doubleRigthClickGesture);
-			horizontal.Children.Add(doubleRightClickLabel);
+			Content = vertical;
 		}
 
-		async void HandleTapCommand(Color backgroundColor)
-		{
-			changeColorBoxView.BackgroundColor = backgroundColor;
-			await DisplayAlert("Tapped", "Tap Command Fired", "Close");
-		}
-
-		void HandleClickCommand(Color backgroundColor)
+		void HandleTapCommand(Color backgroundColor)
 		{
 			changeColorBoxView.BackgroundColor = backgroundColor;
 		}

--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -8,6 +8,10 @@ namespace Maui.Controls.Sample.Pages
 	{
 		Command TapCommand;
 		Label changeColorBoxView;
+		Label windowPosition = new Label();
+		Label relativeToToggleButtonPosition = new Label();
+		Label relativeToContainerPosition = new Label();
+		Button toggleButton;
 
 		public TapGestureGalleryPage()
 		{
@@ -19,6 +23,10 @@ namespace Maui.Controls.Sample.Pages
 				HorizontalOptions = LayoutOptions.Center,
 				Spacing = 40
 			};
+
+			vertical.Add(windowPosition);
+			vertical.Add(relativeToToggleButtonPosition);
+			vertical.Add(relativeToContainerPosition);
 
 			var horizontal = new HorizontalStackLayout
 			{
@@ -39,6 +47,7 @@ namespace Maui.Controls.Sample.Pages
 				CommandParameter = Colors.PaleGreen,
 				NumberOfTapsRequired = 1,
 			};
+			singleTapGesture.Tapped += OnTapped;
 			singleTapLabel.GestureRecognizers.Add(singleTapGesture);
 			horizontal.Add(singleTapLabel);
 
@@ -53,6 +62,7 @@ namespace Maui.Controls.Sample.Pages
 				CommandParameter = Colors.Aqua,
 				NumberOfTapsRequired = 2,
 			};
+			doubleTapGesture.Tapped += OnTapped;
 			doubleTapLabel.GestureRecognizers.Add(doubleTapGesture);
 			horizontal.Add(doubleTapLabel);
 
@@ -66,8 +76,7 @@ namespace Maui.Controls.Sample.Pages
 			};
 			vertical.Add(changeColorBoxView);
 
-
-			vertical.Add(new Button()
+			toggleButton = new Button()
 			{
 				Text = "Toggle Single Tap Gesture",
 				Command = new Command(() =>
@@ -77,7 +86,9 @@ namespace Maui.Controls.Sample.Pages
 					else
 						singleTapLabel.GestureRecognizers.Add(singleTapGesture);
 				})
-			});
+			};
+
+			vertical.Add(toggleButton);
 
 			var tripleClicklabel = new Label
 			{
@@ -91,6 +102,7 @@ namespace Maui.Controls.Sample.Pages
 				NumberOfTapsRequired = 3,
 				Buttons = ButtonsMask.Primary
 			};
+			tripleClickGesture.Tapped += OnTapped;
 			tripleClicklabel.GestureRecognizers.Add(tripleClickGesture);
 			horizontal.Children.Add(tripleClicklabel);
 
@@ -106,6 +118,7 @@ namespace Maui.Controls.Sample.Pages
 				NumberOfTapsRequired = 1,
 				Buttons = ButtonsMask.Secondary
 			};
+			rigthClickGesture.Tapped += OnTapped;
 			rightClickLabel.GestureRecognizers.Add(rigthClickGesture);
 			horizontal.Children.Add(rightClickLabel);
 
@@ -122,11 +135,23 @@ namespace Maui.Controls.Sample.Pages
 				NumberOfTapsRequired = 1,
 				Buttons = ButtonsMask.Secondary | ButtonsMask.Primary
 			};
+
+			rigthOrLeftClickGesture.Tapped += OnTapped;
 			rightorLeftClickLabel.GestureRecognizers.Add(rigthOrLeftClickGesture);
 			horizontal.Children.Add(rightorLeftClickLabel);
 
 
 			Content = vertical;
+		}
+
+		void OnTapped(object sender, System.EventArgs e)
+		{
+			var args = (TappedEventArgs)e;
+			var view = (View)sender;
+
+			windowPosition.Text = $"Position inside window: {args.GetPosition(null)}";
+			relativeToToggleButtonPosition.Text = $"Position relative to toggle button: {args.GetPosition(toggleButton)}";
+			relativeToContainerPosition.Text = $"Position inside my view: {args.GetPosition(view)}";
 		}
 
 		void HandleTapCommand(Color backgroundColor)

--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -6,12 +6,15 @@ namespace Maui.Controls.Sample.Pages
 {
 	public class TapGestureGalleryPage : BasePage
 	{
+		Command clickCommand;
 		Command TapCommand;
 		Label changeColorBoxView;
 
 		public TapGestureGalleryPage()
 		{
 			TapCommand = new Command<Color>(HandleTapCommand);
+			clickCommand = new Command<Color>(HandleClickCommand);
+
 			var vertical = new VerticalStackLayout
 			{
 				VerticalOptions = LayoutOptions.Center,
@@ -78,13 +81,107 @@ namespace Maui.Controls.Sample.Pages
 				})
 			});
 
+			AddMoreStuff(vertical);
 			Content = vertical;
+		}
+
+		void AddMoreStuff(VerticalStackLayout vertical)
+		{
+			var horizontal = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal,
+				Spacing = 20,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+			vertical.Children.Add(horizontal);
+
+			var singleClickLabel = new Label
+			{
+				Text = "Click me!",
+				BackgroundColor = Colors.PaleGreen
+			};
+			var singleClickGesture = new TapGestureRecognizer
+			{
+				Command = clickCommand,
+				CommandParameter = Colors.PaleGreen,
+				NumberOfTapsRequired = 1,
+				Buttons = ButtonsMask.Primary
+			};
+			singleClickLabel.GestureRecognizers.Add(singleClickGesture);
+			horizontal.Children.Add(singleClickLabel);
+
+			var doubleClickLabel = new Label
+			{
+				Text = "Double click me!!",
+				BackgroundColor = Colors.Aqua
+			};
+			var doubleClickGesture = new TapGestureRecognizer
+			{
+				Command = clickCommand,
+				CommandParameter = Colors.Aqua,
+				NumberOfTapsRequired = 2,
+				Buttons = ButtonsMask.Primary
+			};
+			doubleClickLabel.GestureRecognizers.Add(doubleClickGesture);
+			horizontal.Children.Add(doubleClickLabel);
+
+			var tripleClicklabel = new Label
+			{
+				Text = "Triple click me!!!",
+				BackgroundColor = Colors.Olive
+			};
+			var tripleClickGesture = new TapGestureRecognizer
+			{
+				Command = clickCommand,
+				CommandParameter = Colors.Olive,
+				NumberOfTapsRequired = 3,
+				Buttons = ButtonsMask.Primary
+			};
+			tripleClicklabel.GestureRecognizers.Add(tripleClickGesture);
+			horizontal.Children.Add(tripleClicklabel);
+
+			var rightClickLabel = new Label
+			{
+				Text = "Right click me¡",
+				BackgroundColor = Colors.Coral
+			};
+			var rigthClickGesture = new TapGestureRecognizer
+			{
+				Command = clickCommand,
+				CommandParameter = Colors.Coral,
+				NumberOfTapsRequired = 1,
+				Buttons = ButtonsMask.Secondary
+			};
+			rightClickLabel.GestureRecognizers.Add(rigthClickGesture);
+			horizontal.Children.Add(rightClickLabel);
+
+			var doubleRightClickLabel = new Label
+			{
+				Text = "Double right click me¡¡",
+				BackgroundColor = Colors.Gold
+			};
+			var doubleRigthClickGesture = new TapGestureRecognizer
+			{
+				Command = clickCommand,
+				CommandParameter = Colors.Gold,
+				NumberOfTapsRequired = 2,
+				Buttons = ButtonsMask.Secondary
+			};
+
+			doubleRightClickLabel.GestureRecognizers.Add(doubleRigthClickGesture);
+			horizontal.Children.Add(doubleRightClickLabel);
 		}
 
 		async void HandleTapCommand(Color backgroundColor)
 		{
 			changeColorBoxView.BackgroundColor = backgroundColor;
 			await DisplayAlert("Tapped", "Tap Command Fired", "Close");
+		}
+
+		void HandleClickCommand(Color backgroundColor)
+		{
+			changeColorBoxView.BackgroundColor = backgroundColor;
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -109,6 +109,23 @@ namespace Maui.Controls.Sample.Pages
 			rightClickLabel.GestureRecognizers.Add(rigthClickGesture);
 			horizontal.Children.Add(rightClickLabel);
 
+
+			var rightorLeftClickLabel = new Label
+			{
+				Text = "Right or Left click me¡",
+				BackgroundColor = Colors.Green
+			};
+			var rigthOrLeftClickGesture = new TapGestureRecognizer
+			{
+				Command = TapCommand,
+				CommandParameter = Colors.Green,
+				NumberOfTapsRequired = 1,
+				Buttons = ButtonsMask.Secondary | ButtonsMask.Primary
+			};
+			rightorLeftClickLabel.GestureRecognizers.Add(rigthOrLeftClickGesture);
+			horizontal.Children.Add(rightorLeftClickLabel);
+
+
 			Content = vertical;
 		}
 

--- a/src/Controls/samples/Controls.Sample/ViewModels/GesturesViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/GesturesViewModel.cs
@@ -17,8 +17,8 @@ namespace Maui.Controls.Sample.ViewModels
 				"Pan Gesture."),
 			new SectionModel(typeof(SwipeGestureGalleryPage), "Swipe Gesture",
 				"Swipe Gesture."),
-			new SectionModel(typeof(TapGestureGalleryPage), "Click Gesture",
-				"Click Gesture."),
+			new SectionModel(typeof(TapGestureGalleryPage), "Tap Gesture",
+				"Tap Gesture."),
 		};
 	}
 }

--- a/src/Controls/src/Core/ButtonsMask.cs
+++ b/src/Controls/src/Core/ButtonsMask.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel;
+using System.Windows.Input;
+
+namespace Microsoft.Maui.Controls
+{
+	/// <include file="../../docs/Microsoft.Maui.Controls/ButtonsMask.xml" path="Type[@FullName='Microsoft.Maui.Controls.ButtonsMask']/Docs" />
+	[Flags]
+	public enum ButtonsMask
+	{
+		/// <include file="../../docs/Microsoft.Maui.Controls/ButtonsMask.xml" path="//Member[@MemberName='Primary']/Docs" />
+		Primary = 1 << 0,
+		/// <include file="../../docs/Microsoft.Maui.Controls/ButtonsMask.xml" path="//Member[@MemberName='Secondary']/Docs" />
+		Secondary = 1 << 1
+	}
+}

--- a/src/Controls/src/Core/ClickGestureRecognizer.cs
+++ b/src/Controls/src/Core/ClickGestureRecognizer.cs
@@ -4,16 +4,6 @@ using System.Windows.Input;
 
 namespace Microsoft.Maui.Controls
 {
-	/// <include file="../../docs/Microsoft.Maui.Controls/ButtonsMask.xml" path="Type[@FullName='Microsoft.Maui.Controls.ButtonsMask']/Docs" />
-	[Flags]
-	public enum ButtonsMask
-	{
-		/// <include file="../../docs/Microsoft.Maui.Controls/ButtonsMask.xml" path="//Member[@MemberName='Primary']/Docs" />
-		Primary = 1 << 0,
-		/// <include file="../../docs/Microsoft.Maui.Controls/ButtonsMask.xml" path="//Member[@MemberName='Secondary']/Docs" />
-		Secondary = 1 << 1
-	}
-
 	/// <include file="../../docs/Microsoft.Maui.Controls/ClickGestureRecognizer.xml" path="Type[@FullName='Microsoft.Maui.Controls.ClickGestureRecognizer']/Docs" />
 	public sealed class ClickGestureRecognizer : GestureRecognizer
 	{

--- a/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
+++ b/src/Controls/src/Core/Platform/Android/InnerGestureListener.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Controls.Platform
 		Func<bool> _scrollCompleteDelegate;
 		Func<float, float, int, bool> _scrollDelegate;
 		Func<int, bool> _scrollStartedDelegate;
-		Func<int, Point, bool> _tapDelegate;
+		Func<int, MotionEvent, bool> _tapDelegate;
 		Func<int, IEnumerable<TapGestureRecognizer>> _tapGestureRecognizers;
 
 		public InnerGestureListener(
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (HasDoubleTapHandler())
 			{
-				return _tapDelegate(2, new Point(e.GetX(), e.GetY()));
+				return _tapDelegate(2, e);
 			}
 
 			if (HasSingleTapHandler())
@@ -82,7 +82,7 @@ namespace Microsoft.Maui.Controls.Platform
 				// If we're registering double taps and we don't actually have a double-tap handler,
 				// but we _do_ have a single-tap handler, then we're really just seeing two singles in a row
 				// Fire off the delegate for the second single-tap (OnSingleTapUp already did the first one)
-				return _tapDelegate(1, new Point(e.GetX(), e.GetY()));
+				return _tapDelegate(1, e);
 			}
 
 			return false;
@@ -149,7 +149,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			// A single tap has occurred and there's no handler for double tap to worry about,
 			// so we can go ahead and run the delegate
-			return _tapDelegate(1, new Point(e.GetX(), e.GetY()));
+			return _tapDelegate(1, e);
 		}
 
 		bool GestureDetector.IOnDoubleTapListener.OnSingleTapConfirmed(MotionEvent e)
@@ -166,7 +166,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			// Since there was a double-tap handler, we had to wait for OnSingleTapConfirmed;
 			// Now that we're sure it's a single tap, we can run the delegate
-			return _tapDelegate(1, new Point(e.GetX(), e.GetY()));
+			return _tapDelegate(1, e);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Controls/src/Core/Platform/Android/PanGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/PanGestureHandler.cs
@@ -6,11 +6,23 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal class PanGestureHandler
 	{
-		readonly Func<double, double> _pixelTranslation;
-
-		public PanGestureHandler(Func<View> getView, Func<double, double> pixelTranslation)
+		Func<double, double> PixelTranslation
 		{
-			_pixelTranslation = pixelTranslation;
+			get
+			{
+				return (input) =>
+				{
+					var context = GetView()?.Handler?.MauiContext?.Context;
+					if (context == null)
+						return 0;
+
+					return context.FromPixels(input);
+				};
+			}
+		}
+
+		public PanGestureHandler(Func<View> getView)
+		{
 			GetView = getView;
 		}
 
@@ -27,7 +39,7 @@ namespace Microsoft.Maui.Controls.Platform
 			foreach (PanGestureRecognizer panGesture in
 				view.GestureRecognizers.GetGesturesFor<PanGestureRecognizer>(g => g.TouchPoints == pointerCount))
 			{
-				((IPanGestureController)panGesture).SendPan(view, _pixelTranslation(x), _pixelTranslation(y), PanGestureRecognizer.CurrentId.Value);
+				((IPanGestureController)panGesture).SendPan(view, PixelTranslation(x), PixelTranslation(y), PanGestureRecognizer.CurrentId.Value);
 				result = true;
 			}
 

--- a/src/Controls/src/Core/Platform/Android/SwipeGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/SwipeGestureHandler.cs
@@ -6,11 +6,23 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal class SwipeGestureHandler
 	{
-		readonly Func<double, double> _pixelTranslation;
-
-		public SwipeGestureHandler(Func<View> getView, Func<double, double> pixelTranslation)
+		Func<double, double> PixelTranslation
 		{
-			_pixelTranslation = pixelTranslation;
+			get
+			{
+				return (input) =>
+				{
+					var context = GetView()?.Handler?.MauiContext?.Context;
+					if (context == null)
+						return 0;
+
+					return context.FromPixels(input);
+				};
+			}
+		}
+
+		public SwipeGestureHandler(Func<View> getView)
+		{
 			GetView = getView;
 		}
 
@@ -27,7 +39,7 @@ namespace Microsoft.Maui.Controls.Platform
 			foreach (SwipeGestureRecognizer swipeGesture in
 					 view.GestureRecognizers.GetGesturesFor<SwipeGestureRecognizer>())
 			{
-				((ISwipeGestureController)swipeGesture).SendSwipe(view, _pixelTranslation(x), _pixelTranslation(y));
+				((ISwipeGestureController)swipeGesture).SendSwipe(view, PixelTranslation(x), PixelTranslation(y));
 				result = true;
 			}
 

--- a/src/Controls/src/Core/Platform/Android/TapGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/TapGestureHandler.cs
@@ -53,6 +53,9 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(recognizer => recognizer.NumberOfTapsRequired == count))
 				{
+					if (!CheckButtonMask(recognizer, e))
+						continue;
+
 					recognizer.SendTapped(view, CalculatePosition);
 					captured = true;
 				}
@@ -64,11 +67,28 @@ namespace Microsoft.Maui.Controls.Platform
 			IEnumerable<TapGestureRecognizer> gestureRecognizers = TapGestureRecognizers(count);
 			foreach (var gestureRecognizer in gestureRecognizers)
 			{
+				if (!CheckButtonMask(gestureRecognizer, e))
+					continue;
+
 				gestureRecognizer.SendTapped(view, CalculatePosition);
 				captured = true;
 			}
 
 			return captured;
+
+			bool CheckButtonMask(TapGestureRecognizer tapGestureRecognizer, MotionEvent? motionEvent)
+			{
+				if (tapGestureRecognizer.Buttons == ButtonsMask.Secondary)
+				{
+					var buttonState = motionEvent?.ButtonState ?? MotionEventButtonState.Primary;
+
+					return
+						buttonState == MotionEventButtonState.Secondary ||
+						buttonState == MotionEventButtonState.StylusSecondary;
+				}
+
+				return (tapGestureRecognizer.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary;
+			}
 
 			Point? CalculatePosition(IElement? element)
 			{

--- a/src/Controls/src/Core/Platform/Android/TapGestureHandler.cs
+++ b/src/Controls/src/Core/Platform/Android/TapGestureHandler.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,14 +10,14 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal class TapGestureHandler
 	{
-		public TapGestureHandler(Func<View> getView, Func<IList<GestureElement>> getChildElements)
+		public TapGestureHandler(Func<View?> getView, Func<IList<GestureElement>> getChildElements)
 		{
 			GetView = getView;
 			GetChildElements = getChildElements;
 		}
 
 		Func<IList<GestureElement>> GetChildElements { get; }
-		Func<View> GetView { get; }
+		Func<View?> GetView { get; }
 
 		public void OnSingleClick()
 		{
@@ -28,7 +30,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public bool OnTap(int count, Point point)
 		{
-			View view = GetView();
+			var view = GetView();
 
 			if (view == null)
 				return false;
@@ -38,11 +40,13 @@ namespace Microsoft.Maui.Controls.Platform
 			var children = view.GetChildElements(point);
 
 			if (children != null)
+			{
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(recognizer => recognizer.NumberOfTapsRequired == count))
 				{
-					recognizer.SendTapped(view);
+					recognizer.SendTapped(view, CalculatePosition);
 					captured = true;
 				}
+			}
 
 			if (captured)
 				return captured;
@@ -50,11 +54,17 @@ namespace Microsoft.Maui.Controls.Platform
 			IEnumerable<TapGestureRecognizer> gestureRecognizers = TapGestureRecognizers(count);
 			foreach (var gestureRecognizer in gestureRecognizers)
 			{
-				gestureRecognizer.SendTapped(view);
+				gestureRecognizer.SendTapped(view, CalculatePosition);
 				captured = true;
 			}
 
 			return captured;
+
+			Point? CalculatePosition(IElement? element)
+			{
+				// TODO Shane will fill this in for iteration 2
+				return null;
+			}
 		}
 
 		public bool HasAnyGestures()
@@ -66,7 +76,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public IEnumerable<TapGestureRecognizer> TapGestureRecognizers(int count)
 		{
-			View view = GetView();
+			var view = GetView();
 			if (view == null)
 				return Enumerable.Empty<TapGestureRecognizer>();
 

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Android.cs
@@ -119,8 +119,8 @@ namespace Microsoft.Maui.Controls.Platform
 
 					return new List<GestureElement>();
 				}),
-				new PanGestureHandler(() => View, context.FromPixels),
-				new SwipeGestureHandler(() => View, context.FromPixels),
+				new PanGestureHandler(() => View),
+				new SwipeGestureHandler(() => View),
 				InitializeDragAndDropHandler()
 			);
 

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Android.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Android.cs
@@ -172,6 +172,20 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				platformView.Touch += OnPlatformViewTouched;
 			}
+
+			if (View is not Microsoft.Maui.IButton)
+			{
+				platformView.KeyPress += PlatformView_KeyPress;
+				platformView.Click += PlatformView_Click;
+			}
+		}
+
+		private void PlatformView_Click(object? sender, EventArgs e)
+		{
+		}
+
+		private void PlatformView_KeyPress(object? sender, AView.KeyEventArgs e)
+		{
 		}
 
 		void OnPlatformViewTouched(object? sender, AView.TouchEventArgs e)

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
@@ -120,17 +120,15 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 
 			var view = Element as View;
-			var gestures =
-				view?
-					.GestureRecognizers?
-					.OfType<TRecognizer>();
+			var gestures = view?.GestureRecognizers;
 
 			if (gestures == null)
 				return;
 
 			foreach (var gesture in gestures)
 			{
-				func(gesture);
+				if (gesture is TRecognizer recognizer)
+					func(recognizer);
 			}
 		}
 
@@ -313,7 +311,6 @@ namespace Microsoft.Maui.Controls.Platform
 				_container.DragOver -= HandleDragOver;
 				_container.Drop -= HandleDrop;
 				_container.Tapped -= OnTap;
-				_container.DoubleTapped -= OnDoubleTap;
 				_container.ManipulationDelta -= OnManipulationDelta;
 				_container.ManipulationStarted -= OnManipulationStarted;
 				_container.ManipulationCompleted -= OnManipulationCompleted;
@@ -421,33 +418,6 @@ namespace Microsoft.Maui.Controls.Platform
 			UpdatingGestureRecognizers();
 		}
 
-		void OnDoubleTap(object sender, DoubleTappedRoutedEventArgs e)
-		{
-			var view = Element as View;
-			if (view == null)
-				return;
-
-			var tapPosition = e.GetPosition(Control);
-			var children = (view as IGestureController)?.GetChildElements(new Point(tapPosition.X, tapPosition.Y));
-
-			if (children != null)
-				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2))
-				{
-					recognizer.SendTapped(view);
-					e.Handled = true;
-				}
-
-			if (e.Handled)
-				return;
-
-			IEnumerable<TapGestureRecognizer> doubleTapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2);
-			foreach (TapGestureRecognizer recognizer in doubleTapGestures)
-			{
-				recognizer.SendTapped(view);
-				e.Handled = true;
-			}
-		}
-
 		void OnManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
 		{
 			SwipeComplete(true);
@@ -511,30 +481,56 @@ namespace Microsoft.Maui.Controls.Platform
 			PanComplete(true);
 		}
 
-		void OnTap(object sender, TappedRoutedEventArgs e)
+		void OnTap(object sender, RoutedEventArgs e)
 		{
 			var view = Element as View;
 			if (view == null)
 				return;
 
 			var tapPosition = e.GetPosition(Control);
-			var children = (view as IGestureController)?.GetChildElements(new Point(tapPosition.X, tapPosition.Y));
 
-			if (children != null)
-				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1))
-				{
-					recognizer.SendTapped(view);
-					e.Handled = true;
-				}
+			var children =
+				(view as IGestureController)?.GetChildElements(new Point(tapPosition.X, tapPosition.Y))?.
+				GetChildGesturesFor<TapGestureRecognizer>(ValidateGesture);
 
-			if (e.Handled)
+			if (ProgessGestureRecognizers(children))
 				return;
 
-			IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1);
-			foreach (var recognizer in tapGestures)
+			IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(ValidateGesture);
+			ProgessGestureRecognizers(tapGestures);
+
+			bool ProgessGestureRecognizers(IEnumerable<TapGestureRecognizer>? tapGestures)
 			{
-				recognizer.SendTapped(view);
-				e.Handled = true;
+				bool handled = false;
+				if (tapGestures == null)
+					return handled;
+
+				foreach (var recognizer in tapGestures)
+				{
+					recognizer.SendTapped(view);
+					e.SetHandled(true);
+					handled = true;
+				}
+
+				return handled;
+			}
+
+			bool ValidateGesture(TapGestureRecognizer g)
+			{
+				if (e is RightTappedRoutedEventArgs &&
+					(g.Buttons & ButtonsMask.Secondary) == ButtonsMask.Secondary)
+				{
+					// Currently we only support single right clicks on WinUI
+					return g.NumberOfTapsRequired == 1;
+				}
+
+				if ((g.Buttons & ButtonsMask.Primary) != ButtonsMask.Primary)
+					return false;
+
+				if (e is DoubleTappedRoutedEventArgs)
+					return g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2;
+
+				return g.NumberOfTapsRequired == 1;
 			}
 		}
 
@@ -649,6 +645,7 @@ namespace Microsoft.Maui.Controls.Platform
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1).Any() == true)
 			{
 				_container.Tapped += OnTap;
+				_container.RightTapped += OnTap;
 			}
 			else
 			{
@@ -661,7 +658,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2).Any()
 				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2).Any() == true)
 			{
-				_container.DoubleTapped += OnDoubleTap;
+				_container.DoubleTapped += OnTap;
 			}
 			else
 			{

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
@@ -496,13 +496,13 @@ namespace Microsoft.Maui.Controls.Platform
 				(view as IGestureController)?.GetChildElements(new Point(tapPosition.Value.X, tapPosition.Value.Y))?.
 				GetChildGesturesFor<TapGestureRecognizer>(ValidateGesture);
 
-			if (ProgessGestureRecognizers(children))
+			if (ProcessGestureRecognizers(children))
 				return;
 
 			IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(ValidateGesture);
-			ProgessGestureRecognizers(tapGestures);
+			ProcessGestureRecognizers(tapGestures);
 
-			bool ProgessGestureRecognizers(IEnumerable<TapGestureRecognizer>? tapGestures)
+			bool ProcessGestureRecognizers(IEnumerable<TapGestureRecognizer>? tapGestures)
 			{
 				bool handled = false;
 				if (tapGestures == null)

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
@@ -486,11 +486,14 @@ namespace Microsoft.Maui.Controls.Platform
 			var view = Element as View;
 			if (view == null)
 				return;
+						
+			var tapPosition = e.GetPositionRelativeToPlatformElement(Control);
 
-			var tapPosition = e.GetPosition(Control);
+			if (tapPosition == null)
+				return;
 
 			var children =
-				(view as IGestureController)?.GetChildElements(new Point(tapPosition.X, tapPosition.Y))?.
+				(view as IGestureController)?.GetChildElements(new Point(tapPosition.Value.X, tapPosition.Value.Y))?.
 				GetChildGesturesFor<TapGestureRecognizer>(ValidateGesture);
 
 			if (ProgessGestureRecognizers(children))
@@ -507,7 +510,15 @@ namespace Microsoft.Maui.Controls.Platform
 
 				foreach (var recognizer in tapGestures)
 				{
-					recognizer.SendTapped(view);
+					recognizer.SendTapped(view, (relativeTo) =>
+					{
+						var result = e.GetPositionRelativeToElement(relativeTo);
+						if (result == null)
+							return null;
+
+						return new Point(result.Value.X, result.Value.Y);
+					});
+
 					e.SetHandled(true);
 					handled = true;
 				}
@@ -706,6 +717,5 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			doubleTappedRoutedEventArgs.Handled = true;
 		}
-
 	}
 }

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -111,7 +111,8 @@ namespace Microsoft.Maui.Controls.Platform
 			WeakReference weakEventTracker,
 			WeakReference weakRecognizer,
 			CGPoint originPoint,
-			int uiTapGestureRecognizerNumberOfTapsRequired)
+			int uiTapGestureRecognizerNumberOfTapsRequired, 
+			UITapGestureRecognizer? uITapGestureRecognizer = null)
 		{
 			var recognizer = weakRecognizer.Target as IGestureRecognizer;
 			var eventTracker = weakEventTracker.Target as GestureManager;
@@ -125,7 +126,7 @@ namespace Microsoft.Maui.Controls.Platform
 					return;
 
 				if (view != null)
-					tapGestureRecognizer.SendTapped(view);
+					tapGestureRecognizer.SendTapped(view, CalculatePosition);
 			}
 			else if (recognizer is ChildGestureRecognizer childGestureRecognizer)
 			{
@@ -139,7 +140,13 @@ namespace Microsoft.Maui.Controls.Platform
 				var childTapGestureRecognizer = childGestureRecognizer.GestureRecognizer as TapGestureRecognizer;
 				foreach (var item in recognizers)
 					if (item == childTapGestureRecognizer && view != null)
-						childTapGestureRecognizer.SendTapped(view);
+						childTapGestureRecognizer.SendTapped(view, CalculatePosition);
+			}
+
+			Point? CalculatePosition(IElement? element)
+			{
+				// TODO Shane will fill this in for iteration 2
+				return null;
 			}
 		}
 
@@ -325,7 +332,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				var eventTracker = weakEventTracker.Target as GestureManager;
 				var originPoint = sender.LocationInView(eventTracker?._handler?.PlatformView);
-				ProcessRecognizerHandlerTap(weakEventTracker, weakRecognizer, originPoint, (int)sender.NumberOfTapsRequired);
+				ProcessRecognizerHandlerTap(weakEventTracker, weakRecognizer, originPoint, (int)sender.NumberOfTapsRequired, sender);
 			});
 
 			var result = new UITapGestureRecognizer(action)

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -145,8 +145,25 @@ namespace Microsoft.Maui.Controls.Platform
 
 			Point? CalculatePosition(IElement? element)
 			{
-				// TODO Shane will fill this in for iteration 2
-				return null;
+				var recognizer = weakRecognizer.Target as IGestureRecognizer;
+
+				if (recognizer == null)
+					return null;
+
+				if (uITapGestureRecognizer == null)
+					return null;
+
+				CGPoint? result = null;
+				if (element == null)
+					result = uITapGestureRecognizer.LocationInView(null);
+				else if(element.Handler?.PlatformView is UIView view)
+					result = uITapGestureRecognizer.LocationInView(view);
+
+				if (result == null)
+					return null;
+
+				return new Point(result.Value.X, result.Value.Y);
+
 			}
 		}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (_platformView != null && OperatingSystem.IsIOSVersionAtLeast(11))
 			{
-				foreach(IUIInteraction interaction in _interactions)
+				foreach (IUIInteraction interaction in _interactions)
 				{
 					_platformView.RemoveInteraction(interaction);
 				}
@@ -509,6 +509,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				_platformView.AccessibilityTraits |= UIAccessibilityTrait.Button;
 				_addedFlags |= UIAccessibilityTrait.Button;
+
 				if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsTvOSVersionAtLeast(13))
 				{
 					_defaultAccessibilityRespondsToUserInteraction = _platformView.AccessibilityRespondsToUserInteraction;
@@ -525,7 +526,7 @@ namespace Microsoft.Maui.Controls.Platform
 				if (_gestureRecognizers.ContainsKey(recognizer))
 					continue;
 
-				if(TryGetTapGestureRecognizer(recognizer, out TapGestureRecognizer? tapGestureRecognizer) &&
+				if (TryGetTapGestureRecognizer(recognizer, out TapGestureRecognizer? tapGestureRecognizer) &&
 					tapGestureRecognizer != null)
 				{
 					tapGestureRecognizer.PropertyChanged += OnTapGestureRecognizerPropertyChanged;

--- a/src/Controls/src/Core/Platform/SemanticExtensions.cs
+++ b/src/Controls/src/Core/Platform/SemanticExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.Platform
 				//Accessibility can't handle Tap Recognizers with > 1 tap
 				if (gesture is TapGestureRecognizer tgr && tgr.NumberOfTapsRequired == 1)
 				{
-					return true;
+					return (tgr.Buttons & ButtonsMask.Primary) == ButtonsMask.Primary;
 				}
 			}
 			return false;

--- a/src/Controls/src/Core/Platform/Windows/VisualElementTracker.cs
+++ b/src/Controls/src/Core/Platform/Windows/VisualElementTracker.cs
@@ -25,7 +25,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui.Controls.Platform
 {
-	// TODO MAUI: can we convert this over to using IView
+	[Obsolete]
 	public class VisualElementTracker<TElement, TPlatformElement> : IDisposable where TElement : VisualElement where TPlatformElement : FrameworkElement
 	{
 		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
@@ -504,7 +504,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (children != null)
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2))
 				{
-					recognizer.SendTapped(view);
+					recognizer.SendTapped(view, null);
 					e.Handled = true;
 				}
 
@@ -514,7 +514,7 @@ namespace Microsoft.Maui.Controls.Platform
 			IEnumerable<TapGestureRecognizer> doubleTapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2);
 			foreach (TapGestureRecognizer recognizer in doubleTapGestures)
 			{
-				recognizer.SendTapped(view);
+				recognizer.SendTapped(view, null);
 				e.Handled = true;
 			}
 		}
@@ -599,7 +599,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (children != null)
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1))
 				{
-					recognizer.SendTapped(view);
+					recognizer.SendTapped(view, null);
 					e.Handled = true;
 				}
 
@@ -609,7 +609,7 @@ namespace Microsoft.Maui.Controls.Platform
 			IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1);
 			foreach (var recognizer in tapGestures)
 			{
-				recognizer.SendTapped(view);
+				recognizer.SendTapped(view, null);
 				e.Handled = true;
 			}
 		}

--- a/src/Controls/src/Core/Platform/Windows/VisualElementTracker.cs
+++ b/src/Controls/src/Core/Platform/Windows/VisualElementTracker.cs
@@ -25,7 +25,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Maui.Controls.Platform
 {
-	[Obsolete]
+	[Obsolete("VisualElementTracker is obsolete as of .NET 7. This behavior has been built into ViewHandler and is included by default on anything that inherits from `Microsoft.Maui.Controls.View`. If something is missing for you please log an issue. In the mean time, you can try using Microsoft.Maui.Controls.Compatibility.Platform.UWP.VisualElementTracker")]
 	public class VisualElementTracker<TElement, TPlatformElement> : IDisposable where TElement : VisualElement where TPlatformElement : FrameworkElement
 	{
 		readonly NotifyCollectionChangedEventHandler _collectionChangedHandler;
@@ -504,7 +504,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (children != null)
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2))
 				{
-					recognizer.SendTapped(view, null);
+					recognizer.SendTapped(view);
 					e.Handled = true;
 				}
 
@@ -514,7 +514,7 @@ namespace Microsoft.Maui.Controls.Platform
 			IEnumerable<TapGestureRecognizer> doubleTapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2);
 			foreach (TapGestureRecognizer recognizer in doubleTapGestures)
 			{
-				recognizer.SendTapped(view, null);
+				recognizer.SendTapped(view);
 				e.Handled = true;
 			}
 		}
@@ -599,7 +599,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (children != null)
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1))
 				{
-					recognizer.SendTapped(view, null);
+					recognizer.SendTapped(view);
 					e.Handled = true;
 				}
 
@@ -609,7 +609,7 @@ namespace Microsoft.Maui.Controls.Platform
 			IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1);
 			foreach (var recognizer in tapGestures)
 			{
-				recognizer.SendTapped(view, null);
+				recognizer.SendTapped(view);
 				e.Handled = true;
 			}
 		}

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -2702,7 +2702,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.get -> int
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.set -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.TapGestureRecognizer() -> void
-Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.TappedEventArgs
 Microsoft.Maui.Controls.TargetIdiom
 Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
@@ -5215,10 +5215,10 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TableView.Root.get -> Microsoft.Maui.Controls.TableRoot
 ~Microsoft.Maui.Controls.TableView.Root.set -> void
 ~Microsoft.Maui.Controls.TableView.TableView(Microsoft.Maui.Controls.TableRoot root) -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand?
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object?
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
 Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
 Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
@@ -7570,9 +7570,9 @@ static readonly Microsoft.Maui.Controls.AdaptiveTrigger.MinWindowWidthProperty -
 ~static readonly Microsoft.Maui.Controls.TableSectionBase.TitleProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.HasUnevenRowsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.RowHeightProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.TemplatedPage.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TextCell.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -5219,8 +5219,8 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
-~Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object
-~Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object parameter) -> void
+Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
+Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.set -> void
 ~Microsoft.Maui.Controls.TemplateBinding.ConverterParameter.get -> object

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -11,8 +11,8 @@ Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Microsoft.Maui.Controls.TappedEventArgs!>?
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
-Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -26,6 +26,7 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void
@@ -46,4 +47,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
+*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -9,6 +9,10 @@ Microsoft.Maui.Controls.MenuFlyout.IsReadOnly.get -> bool
 Microsoft.Maui.Controls.MenuFlyout.RemoveAt(int index) -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -42,3 +46,4 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -2699,7 +2699,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.get -> int
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.set -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.TapGestureRecognizer() -> void
-Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.TappedEventArgs
 Microsoft.Maui.Controls.TargetIdiom
 Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
@@ -5169,10 +5169,10 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TableView.Root.get -> Microsoft.Maui.Controls.TableRoot
 ~Microsoft.Maui.Controls.TableView.Root.set -> void
 ~Microsoft.Maui.Controls.TableView.TableView(Microsoft.Maui.Controls.TableRoot root) -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand?
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object?
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
 Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
 Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
@@ -7606,9 +7606,9 @@ static readonly Microsoft.Maui.Controls.AdaptiveTrigger.MinWindowWidthProperty -
 ~static readonly Microsoft.Maui.Controls.TableSectionBase.TitleProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.HasUnevenRowsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.RowHeightProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.TemplatedPage.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TextCell.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -5173,8 +5173,8 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
-~Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object
-~Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object parameter) -> void
+Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
+Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.set -> void
 ~Microsoft.Maui.Controls.TemplateBinding.ConverterParameter.get -> object

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -9,6 +9,10 @@ Microsoft.Maui.Controls.MenuFlyout.IsReadOnly.get -> bool
 Microsoft.Maui.Controls.MenuFlyout.RemoveAt(int index) -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -39,3 +43,4 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -11,8 +11,8 @@ Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Microsoft.Maui.Controls.TappedEventArgs!>?
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
-Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -31,6 +31,7 @@ static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void
@@ -43,4 +44,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
+*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -2699,7 +2699,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.get -> int
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.set -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.TapGestureRecognizer() -> void
-Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.TappedEventArgs
 Microsoft.Maui.Controls.TargetIdiom
 Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
@@ -5169,10 +5169,10 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TableView.Root.get -> Microsoft.Maui.Controls.TableRoot
 ~Microsoft.Maui.Controls.TableView.Root.set -> void
 ~Microsoft.Maui.Controls.TableView.TableView(Microsoft.Maui.Controls.TableRoot root) -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand?
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object?
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
 Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
 Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
@@ -7606,9 +7606,9 @@ static readonly Microsoft.Maui.Controls.AdaptiveTrigger.MinWindowWidthProperty -
 ~static readonly Microsoft.Maui.Controls.TableSectionBase.TitleProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.HasUnevenRowsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.RowHeightProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.TemplatedPage.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TextCell.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -5173,8 +5173,8 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
-~Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object
-~Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object parameter) -> void
+Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
+Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.set -> void
 ~Microsoft.Maui.Controls.TemplateBinding.ConverterParameter.get -> object

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -9,6 +9,10 @@ Microsoft.Maui.Controls.MenuFlyout.IsReadOnly.get -> bool
 Microsoft.Maui.Controls.MenuFlyout.RemoveAt(int index) -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -39,3 +43,4 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -11,8 +11,8 @@ Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Microsoft.Maui.Controls.TappedEventArgs!>?
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
-Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -31,6 +31,7 @@ static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void
@@ -43,4 +44,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
+*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -4905,8 +4905,8 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
-~Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object
-~Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object parameter) -> void
+Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
+Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.set -> void
 ~Microsoft.Maui.Controls.TemplateBinding.ConverterParameter.get -> object

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -4901,10 +4901,10 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TableView.Root.get -> Microsoft.Maui.Controls.TableRoot
 ~Microsoft.Maui.Controls.TableView.Root.set -> void
 ~Microsoft.Maui.Controls.TableView.TableView(Microsoft.Maui.Controls.TableRoot root) -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand?
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object?
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
 Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
 Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
@@ -7194,9 +7194,9 @@ static readonly Microsoft.Maui.Controls.AdaptiveTrigger.MinWindowWidthProperty -
 ~static readonly Microsoft.Maui.Controls.TableSectionBase.TitleProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.HasUnevenRowsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.RowHeightProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.TemplatedPage.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TextCell.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -44,4 +44,4 @@ virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Contr
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
-*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
+*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -9,6 +9,10 @@ Microsoft.Maui.Controls.MenuFlyout.IsReadOnly.get -> bool
 Microsoft.Maui.Controls.MenuFlyout.RemoveAt(int index) -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -38,3 +42,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty
+

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -11,8 +11,8 @@ Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Microsoft.Maui.Controls.TappedEventArgs!>?
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
-Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -30,6 +30,7 @@ static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void
@@ -42,5 +43,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty
-
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
+*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -2631,7 +2631,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.get -> int
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.set -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.TapGestureRecognizer() -> void
-Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.TappedEventArgs
 Microsoft.Maui.Controls.TargetIdiom
 Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
@@ -4894,10 +4894,10 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TableView.Root.get -> Microsoft.Maui.Controls.TableRoot
 ~Microsoft.Maui.Controls.TableView.Root.set -> void
 ~Microsoft.Maui.Controls.TableView.TableView(Microsoft.Maui.Controls.TableRoot root) -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand?
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object?
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
 Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
 Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
@@ -7238,9 +7238,9 @@ static readonly Microsoft.Maui.Controls.AdaptiveTrigger.MinWindowWidthProperty -
 ~static readonly Microsoft.Maui.Controls.TableSectionBase.TitleProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.HasUnevenRowsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.RowHeightProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.TemplatedPage.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TextCell.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -4898,8 +4898,8 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
-~Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object
-~Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object parameter) -> void
+Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
+Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.set -> void
 ~Microsoft.Maui.Controls.TemplateBinding.ConverterParameter.get -> object

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -14,8 +14,8 @@ Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Microsoft.Maui.Controls.TappedEventArgs!>?
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
-Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -30,6 +30,7 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.Platform.ShellFlyoutItemView.OnContentChanged(object oldContent, object newContent) -> void
+virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer.ShellNavigationViewItemAutomationPeer(Microsoft.Maui.Controls.Platform.ShellNavigationViewItem owner) -> void
 ~override Microsoft.Maui.Controls.Platform.ShellNavigationViewItem.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer
 ~override Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer.GetChildrenCore() -> System.Collections.Generic.IList<Microsoft.UI.Xaml.Automation.Peers.AutomationPeer>
@@ -50,4 +51,5 @@ static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Micros
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
+*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -12,6 +12,10 @@ Microsoft.Maui.Controls.Platform.ShellNavigationViewItem.ShellNavigationViewItem
 Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -46,3 +50,4 @@ static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Micros
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Shipped.txt
@@ -4578,8 +4578,8 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
-~Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object
-~Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object parameter) -> void
+Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
+Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.set -> void
 ~Microsoft.Maui.Controls.TemplateBinding.ConverterParameter.get -> object

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Shipped.txt
@@ -2474,7 +2474,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.get -> int
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.set -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.TapGestureRecognizer() -> void
-Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.TappedEventArgs
 Microsoft.Maui.Controls.TargetIdiom
 Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
@@ -4574,10 +4574,10 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TableView.Root.get -> Microsoft.Maui.Controls.TableRoot
 ~Microsoft.Maui.Controls.TableView.Root.set -> void
 ~Microsoft.Maui.Controls.TableView.TableView(Microsoft.Maui.Controls.TableRoot root) -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand?
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object?
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
 Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
 Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
@@ -6806,9 +6806,9 @@ static readonly Microsoft.Maui.Controls.AdaptiveTrigger.MinWindowWidthProperty -
 ~static readonly Microsoft.Maui.Controls.TableSectionBase.TitleProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.HasUnevenRowsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.RowHeightProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.TemplatedPage.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TextCell.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -11,8 +11,8 @@ Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Microsoft.Maui.Controls.TappedEventArgs!>?
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
-Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -30,6 +30,7 @@ static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void
@@ -42,4 +43,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
+*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -9,6 +9,10 @@ Microsoft.Maui.Controls.MenuFlyout.IsReadOnly.get -> bool
 Microsoft.Maui.Controls.MenuFlyout.RemoveAt(int index) -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -38,3 +42,4 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -4578,8 +4578,8 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
 ~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
-~Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object
-~Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object parameter) -> void
+Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
+Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.set -> void
 ~Microsoft.Maui.Controls.TemplateBinding.ConverterParameter.get -> object

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -2474,7 +2474,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.get -> int
 Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired.set -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.TapGestureRecognizer() -> void
-Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.TappedEventArgs
 Microsoft.Maui.Controls.TargetIdiom
 Microsoft.Maui.Controls.TargetIdiom.Desktop = 3 -> Microsoft.Maui.Controls.TargetIdiom
@@ -4574,10 +4574,10 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~Microsoft.Maui.Controls.TableView.Root.get -> Microsoft.Maui.Controls.TableRoot
 ~Microsoft.Maui.Controls.TableView.Root.set -> void
 ~Microsoft.Maui.Controls.TableView.TableView(Microsoft.Maui.Controls.TableRoot root) -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand
-~Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object
-~Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.get -> System.Windows.Input.ICommand?
+Microsoft.Maui.Controls.TapGestureRecognizer.Command.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.get -> object?
+Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameter.set -> void
 Microsoft.Maui.Controls.TappedEventArgs.Parameter.get -> object?
 Microsoft.Maui.Controls.TappedEventArgs.TappedEventArgs(object? parameter) -> void
 ~Microsoft.Maui.Controls.TemplateBinding.Converter.get -> Microsoft.Maui.Controls.IValueConverter
@@ -6806,9 +6806,9 @@ static readonly Microsoft.Maui.Controls.AdaptiveTrigger.MinWindowWidthProperty -
 ~static readonly Microsoft.Maui.Controls.TableSectionBase.TitleProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.HasUnevenRowsProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TableView.RowHeightProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.CommandProperty -> Microsoft.Maui.Controls.BindableProperty!
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequiredProperty -> Microsoft.Maui.Controls.BindableProperty!
 ~static readonly Microsoft.Maui.Controls.TemplatedPage.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TemplatedView.ControlTemplateProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static readonly Microsoft.Maui.Controls.TextCell.CommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -11,8 +11,8 @@ Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Microsoft.Maui.Controls.TappedEventArgs!>?
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
-Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -30,6 +30,7 @@ static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
+virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void
@@ -42,4 +43,5 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
-~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty
+static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
+*REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -9,6 +9,10 @@ Microsoft.Maui.Controls.MenuFlyout.IsReadOnly.get -> bool
 Microsoft.Maui.Controls.MenuFlyout.RemoveAt(int index) -> void
 Microsoft.Maui.Controls.MenuFlyoutSeparator
 Microsoft.Maui.Controls.MenuFlyoutSeparator.MenuFlyoutSeparator() -> void
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TapGestureRecognizer.Buttons.set -> void
+Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
+Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
 override Microsoft.Maui.Controls.ContentPresenter.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
@@ -38,3 +42,4 @@ static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsof
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
+~static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty

--- a/src/Controls/src/Core/Span.cs
+++ b/src/Controls/src/Core/Span.cs
@@ -183,7 +183,6 @@ namespace Microsoft.Maui.Controls
 		{
 			switch (gesture)
 			{
-				case ClickGestureRecognizer click:
 				case TapGestureRecognizer tap:
 				case null:
 					break;

--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -1,6 +1,8 @@
+#nullable enable
+
 using System;
-using System.ComponentModel;
 using System.Windows.Input;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
@@ -11,7 +13,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(TapGestureRecognizer), null);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='CommandParameterProperty']/Docs" />
-		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create("CommandParameter", typeof(object), typeof(TapGestureRecognizer), null);
+		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(TapGestureRecognizer), null);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='NumberOfTapsRequiredProperty']/Docs" />
 		public static readonly BindableProperty NumberOfTapsRequiredProperty = BindableProperty.Create("NumberOfTapsRequired", typeof(int), typeof(TapGestureRecognizer), 1);
@@ -24,14 +26,14 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='Command']/Docs" />
-		public ICommand Command
+		public ICommand? Command
 		{
-			get { return (ICommand)GetValue(CommandProperty); }
+			get { return (ICommand?)GetValue(CommandProperty); }
 			set { SetValue(CommandProperty, value); }
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='CommandParameter']/Docs" />
-		public object CommandParameter
+		public object? CommandParameter
 		{
 			get { return GetValue(CommandParameterProperty); }
 			set { SetValue(CommandParameterProperty, value); }
@@ -50,17 +52,16 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(ButtonsProperty, value); }
 		}
 
-		public event EventHandler Tapped;
+		public event EventHandler<TappedEventArgs>? Tapped;
 
-		internal void SendTapped(View sender, object platformArgs = null)
+		internal void SendTapped(View sender, Func<IElement?, Point?>? getPosition)
 		{
-			ICommand cmd = Command;
+			var cmd = Command;
 			if (cmd != null && cmd.CanExecute(CommandParameter))
 				cmd.Execute(CommandParameter);
 
-			EventHandler handler = Tapped;
-			if (handler != null)
-				handler(sender, new TappedEventArgs(CommandParameter, platformArgs));
+			Tapped?.Invoke(sender, new TappedEventArgs(CommandParameter, getPosition));
 		}
+
 	}
 }

--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls
 
 		public event EventHandler<TappedEventArgs>? Tapped;
 
-		internal void SendTapped(View sender, Func<IElement?, Point?>? getPosition)
+		internal void SendTapped(View sender, Func<IElement?, Point?>? getPosition = null)
 		{
 			var cmd = Command;
 			if (cmd != null && cmd.CanExecute(CommandParameter))

--- a/src/Controls/src/Core/TapGestureRecognizer.cs
+++ b/src/Controls/src/Core/TapGestureRecognizer.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='NumberOfTapsRequiredProperty']/Docs" />
 		public static readonly BindableProperty NumberOfTapsRequiredProperty = BindableProperty.Create("NumberOfTapsRequired", typeof(int), typeof(TapGestureRecognizer), 1);
 
+		public static readonly BindableProperty ButtonsProperty = BindableProperty.Create(nameof(Buttons), typeof(ButtonsMask), typeof(TapGestureRecognizer), ButtonsMask.Primary);
+
 		/// <include file="../../docs/Microsoft.Maui.Controls/TapGestureRecognizer.xml" path="//Member[@MemberName='.ctor'][1]/Docs" />
 		public TapGestureRecognizer()
 		{
@@ -42,9 +44,15 @@ namespace Microsoft.Maui.Controls
 			set { SetValue(NumberOfTapsRequiredProperty, value); }
 		}
 
+		public ButtonsMask Buttons
+		{
+			get { return (ButtonsMask)GetValue(ButtonsProperty); }
+			set { SetValue(ButtonsProperty, value); }
+		}
+
 		public event EventHandler Tapped;
 
-		internal void SendTapped(View sender)
+		internal void SendTapped(View sender, object platformArgs = null)
 		{
 			ICommand cmd = Command;
 			if (cmd != null && cmd.CanExecute(CommandParameter))
@@ -52,7 +60,7 @@ namespace Microsoft.Maui.Controls
 
 			EventHandler handler = Tapped;
 			if (handler != null)
-				handler(sender, new TappedEventArgs(CommandParameter));
+				handler(sender, new TappedEventArgs(CommandParameter, platformArgs));
 		}
 	}
 }

--- a/src/Controls/src/Core/TappedEventArgs.cs
+++ b/src/Controls/src/Core/TappedEventArgs.cs
@@ -2,27 +2,23 @@
 
 using System;
 using Microsoft.Maui.Graphics;
-#if WINDOWS
-using PlatformArgs = Microsoft.UI.Xaml.RoutedEventArgs;
-#else
-using PlatformArgs = System.Object;
-#endif
 
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/TappedEventArgs.xml" path="Type[@FullName='Microsoft.Maui.Controls.TappedEventArgs']/Docs" />
 	public class TappedEventArgs : EventArgs
 	{
+		Func<IElement?, Point?>? _getPosition;
+
 		/// <include file="../../docs/Microsoft.Maui.Controls/TappedEventArgs.xml" path="//Member[@MemberName='.ctor']/Docs" />
 		public TappedEventArgs(object? parameter)
 		{
 			Parameter = parameter;
 		}
 
-		internal TappedEventArgs(object? parameter, object platformArgs) : this(parameter)
+		internal TappedEventArgs(object? parameter, Func<IElement?, Point?>? getPosition) : this(parameter)
 		{
-			if (platformArgs is PlatformArgs args)
-				PlatformArgs = args;
+			_getPosition = getPosition;
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/TappedEventArgs.xml" path="//Member[@MemberName='Parameter']/Docs" />
@@ -30,28 +26,7 @@ namespace Microsoft.Maui.Controls
 
 		public ButtonsMask Buttons { get; private set; }
 
-		internal PlatformArgs? PlatformArgs { get; set; }
-
-		public Point? GetPosition(Element? relativeTo)
-		{
-#if WINDOWS
-			if (PlatformArgs == null)
-				return null;
-
-			if (relativeTo == null)
-			{
-				var position = PlatformArgs.GetPosition(null);
-				return new Point(position.X, position.Y);
-			}
-
-			if (relativeTo.ToPlatform() is UI.Xaml.UIElement uiElement)
-			{
-				var position = PlatformArgs.GetPosition(uiElement);
-				return new Point(position.X, position.Y);
-			}
-#endif
-
-			return null;
-		}
+		public virtual Point? GetPosition(Element? relativeTo) =>
+			_getPosition?.Invoke(relativeTo);
 	}
 }

--- a/src/Controls/src/Core/TappedEventArgs.cs
+++ b/src/Controls/src/Core/TappedEventArgs.cs
@@ -1,4 +1,12 @@
+#nullable enable
+
 using System;
+using Microsoft.Maui.Graphics;
+#if WINDOWS
+using PlatformArgs = Microsoft.UI.Xaml.RoutedEventArgs;
+#else
+using PlatformArgs = System.Object;
+#endif
 
 namespace Microsoft.Maui.Controls
 {
@@ -6,12 +14,44 @@ namespace Microsoft.Maui.Controls
 	public class TappedEventArgs : EventArgs
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/TappedEventArgs.xml" path="//Member[@MemberName='.ctor']/Docs" />
-		public TappedEventArgs(object parameter)
+		public TappedEventArgs(object? parameter)
 		{
 			Parameter = parameter;
 		}
 
+		internal TappedEventArgs(object? parameter, object platformArgs) : this(parameter)
+		{
+			if (platformArgs is PlatformArgs args)
+				PlatformArgs = args;
+		}
+
 		/// <include file="../../docs/Microsoft.Maui.Controls/TappedEventArgs.xml" path="//Member[@MemberName='Parameter']/Docs" />
-		public object Parameter { get; private set; }
+		public object? Parameter { get; private set; }
+
+		public ButtonsMask Buttons { get; private set; }
+
+		internal PlatformArgs? PlatformArgs { get; set; }
+
+		public Point? GetPosition(Element? relativeTo)
+		{
+#if WINDOWS
+			if (PlatformArgs == null)
+				return null;
+
+			if (relativeTo == null)
+			{
+				var position = PlatformArgs.GetPosition(null);
+				return new Point(position.X, position.Y);
+			}
+
+			if (relativeTo.ToPlatform() is UI.Xaml.UIElement uiElement)
+			{
+				var position = PlatformArgs.GetPosition(uiElement);
+				return new Point(position.X, position.Y);
+			}
+#endif
+
+			return null;
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/GestureTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/GestureTests.iOS.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Handlers;
@@ -27,5 +28,59 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(handler.PlatformView.UserInteractionEnabled);
 			});
 		}
+
+#if MACCATALYST
+		[Fact]
+		public async Task InteractionsAreRemovedWhenGestureIsRemoved()
+		{
+			var label = new Label();
+			label.GestureRecognizers.Add(new TapGestureRecognizer() { Buttons = ButtonsMask.Secondary });
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<LabelHandler>(label);
+
+				var interactions =
+					handler.PlatformView.Interactions.OfType<GestureManager.FakeRightClickContextMenuInteraction>()
+						.ToList();
+
+				Assert.Single(interactions);
+
+				label.GestureRecognizers.RemoveAt(0);
+
+				interactions =
+					handler.PlatformView.Interactions.OfType<GestureManager.FakeRightClickContextMenuInteraction>()
+						.ToList();
+
+				Assert.Empty(interactions);
+			});
+		}
+
+		[Fact]
+		public async Task InteractionsAreRemovedWhenGestureButtonMaskChanged()
+		{
+			var label = new Label();
+			label.GestureRecognizers.Add(new TapGestureRecognizer() { Buttons = ButtonsMask.Secondary });
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<LabelHandler>(label);
+
+				var interactions =
+					handler.PlatformView.Interactions.OfType<GestureManager.FakeRightClickContextMenuInteraction>()
+						.ToList();
+
+				Assert.Single(interactions);
+
+				(label.GestureRecognizers[0] as TapGestureRecognizer).Buttons = ButtonsMask.Primary;
+
+				interactions =
+					handler.PlatformView.Interactions.OfType<GestureManager.FakeRightClickContextMenuInteraction>()
+						.ToList();
+
+				Assert.Empty(interactions);
+			});
+		}
+#endif
 	}
 }

--- a/src/Core/src/Platform/Windows/RoutedEventArgsExtensions.cs
+++ b/src/Core/src/Platform/Windows/RoutedEventArgsExtensions.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Maui.Platform
 {
 	internal static class RoutedEventArgsExtensions
 	{
-
 		public static void SetHandled(this RoutedEventArgs e, bool value)
 		{
 			if (e is RightTappedRoutedEventArgs rt)
@@ -19,7 +18,18 @@ namespace Microsoft.Maui.Platform
 				dt.Handled = value;
 		}
 
-		public static WPoint GetPosition(this RoutedEventArgs e, UIElement? relativeTo)
+		public static WPoint? GetPositionRelativeToElement(this RoutedEventArgs e, IElement? relativeTo)
+		{
+			if (relativeTo == null)
+				return GetPositionRelativeToPlatformElement(e, null);
+
+			if (relativeTo?.Handler?.PlatformView is UIElement element)
+				return GetPositionRelativeToPlatformElement(e, element);
+
+			return null;
+		}
+
+		public static WPoint? GetPositionRelativeToPlatformElement(this RoutedEventArgs e, UIElement? relativeTo)
 		{
 			if (e is RightTappedRoutedEventArgs rt)
 				return rt.GetPosition(relativeTo);
@@ -28,7 +38,7 @@ namespace Microsoft.Maui.Platform
 			else if (e is DoubleTappedRoutedEventArgs dt)
 				return dt.GetPosition(relativeTo);
 
-			throw new InvalidOperationException();
+			return null;
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/RoutedEventArgsExtensions.cs
+++ b/src/Core/src/Platform/Windows/RoutedEventArgsExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml;
+using WPoint = Windows.Foundation.Point;
+namespace Microsoft.Maui.Platform
+{
+	internal static class RoutedEventArgsExtensions
+	{
+
+		public static void SetHandled(this RoutedEventArgs e, bool value)
+		{
+			if (e is RightTappedRoutedEventArgs rt)
+				rt.Handled = value;
+			else if (e is TappedRoutedEventArgs t)
+				t.Handled = value;
+			else if (e is DoubleTappedRoutedEventArgs dt)
+				dt.Handled = value;
+		}
+
+		public static WPoint GetPosition(this RoutedEventArgs e, UIElement? relativeTo)
+		{
+			if (e is RightTappedRoutedEventArgs rt)
+				return rt.GetPosition(relativeTo);
+			else if (e is TappedRoutedEventArgs t)
+				return t.GetPosition(relativeTo);
+			else if (e is DoubleTappedRoutedEventArgs dt)
+				return dt.GetPosition(relativeTo);
+
+			throw new InvalidOperationException();
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

This adds `ButtonMask` to `TapGestureRecognizer` which allows users to indicate if they want `secondary` and/or `primary` to trigger the gesture. 

- Secondary currently won't work with "NumberOfTapsRequired"
- Remove `ClickGestureRecognizer`. This wasn't hooked up to anything in .NET MAUI so we're not removing any behavior by deleting this recognizer. It seems a bit excessive and confusing to have a separate recognizer here. Once we get to a point where a user will need to determinate the type of device triggering a `Tap` we can just add an `enum` or [similar](https://docs.microsoft.com/en-us/uwp/api/windows.devices.input.pointerdevicetype?view=winrt-22621).

### Status

- Currently works only for WinUI.  Feel free to review and merge this PR in it current state so the APIs can get in for NET 7.0
 
### API Changes

#### Maui.Controls

```C#
namespace Microsoft.Maui.Controls
{
	public sealed class TapGestureRecognizer : GestureRecognizer
	{
		public static readonly BindableProperty ButtonsProperty = BindableProperty.Create(nameof(Buttons), typeof(ButtonsMask), typeof(TapGestureRecognizer), ButtonsMask.Primary);
```

```C# 
namespace Microsoft.Maui.Controls
{	
        public class TappedEventArgs : EventArgs
	{
		// Allow users to request the location of the tap relative to any view 
		 public Point? GetPosition(Element? relativeTo);

		public ButtonsMask Buttons { get; private set; }

		// This was just EventHandler? Tapped.
		public event EventHandler<TappedEventArgs>? Tapped;
```


### Issues Fixed


Fixes #9140
