### PR TITLE
Don't add space around collapsed children when measuring stack layouts

### DIFF
--- a/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/HorizontalStackLayoutManager.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Layouts
 
 			double measuredWidth = 0;
 			double measuredHeight = 0;
+			int spacingCount = 0;
 
 			for (int n = 0; n < Stack.Count; n++)
 			{
@@ -26,12 +27,13 @@ namespace Microsoft.Maui.Layouts
 					continue;
 				}
 
+				spacingCount += 1;
 				var measure = child.Measure(double.PositiveInfinity, heightConstraint - padding.VerticalThickness);
 				measuredWidth += measure.Width;
 				measuredHeight = Math.Max(measuredHeight, measure.Height);
 			}
 
-			measuredWidth += MeasureSpacing(Stack.Spacing, Stack.Count);
+			measuredWidth += MeasureSpacing(Stack.Spacing, spacingCount);
 			measuredWidth += padding.HorizontalThickness;
 			measuredHeight += padding.VerticalThickness;
 

--- a/src/Core/src/Layouts/VerticalStackLayoutManager.cs
+++ b/src/Core/src/Layouts/VerticalStackLayoutManager.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Maui.Layouts
 			double measuredHeight = 0;
 			double measuredWidth = 0;
 			double childWidthConstraint = widthConstraint - padding.HorizontalThickness;
+			int spacingCount = 0;
 
 			for (int n = 0; n < Stack.Count; n++)
 			{
@@ -26,12 +27,13 @@ namespace Microsoft.Maui.Layouts
 					continue;
 				}
 
+				spacingCount += 1;
 				var measure = child.Measure(childWidthConstraint, double.PositiveInfinity);
 				measuredHeight += measure.Height;
 				measuredWidth = Math.Max(measuredWidth, measure.Width);
 			}
 
-			measuredHeight += MeasureSpacing(Stack.Spacing, Stack.Count);
+			measuredHeight += MeasureSpacing(Stack.Spacing, spacingCount);
 			measuredHeight += padding.VerticalThickness;
 			measuredWidth += padding.HorizontalThickness;
 

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -372,6 +372,30 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(100 + 100 + 10, measure.Height);
 		}
 
+		[Category(GridSpacing, GridAutoSizing)]
+		[Fact(DisplayName = "Auto rows with collapsed views should not incur additional row spacing")]
+		public void RowSpacingForAutoRowsWithCollapsedViews()
+		{
+			var grid = CreateGridLayout(rows: "100, auto, 100", rowSpacing: 10);
+			var view0 = CreateTestView(new Size(100, 100));
+			var view1 = CreateTestView(new Size(100, 100));
+			var view2 = CreateTestView(new Size(100, 100));
+
+			SubstituteChildren(grid, view0, view2);
+			SetLocation(grid, view0);
+			SetLocation(grid, view1, row: 1);
+			SetLocation(grid, view2, row: 2);
+
+			view1.Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new GridLayoutManager(grid);
+			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			// Because the auto row has no content, we expect it to have height zero
+			// and we expect that it won't add more row spacing 
+			Assert.Equal(100 + 100 + 10, measure.Height);
+		}
+
 		[Category(GridSpacing)]
 		[Fact(DisplayName = "Column spacing shouldn't affect a single-column grid")]
 		public void SingleColumnIgnoresColumnSpacing()
@@ -453,6 +477,30 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0, view2);
 			SetLocation(grid, view0);
 			SetLocation(grid, view2, col: 2);
+
+			var manager = new GridLayoutManager(grid);
+			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			// Because the auto column has no content, we expect it to have width zero
+			// and we expect that it won't add more column spacing 
+			Assert.Equal(100 + 100 + 10, measure.Width);
+		}
+
+		[Category(GridSpacing, GridAutoSizing)]
+		[Fact(DisplayName = "Auto columns with collapsed views should not incur additional column spacing")]
+		public void AutoColumnsWithCollapsedViews()
+		{
+			var grid = CreateGridLayout(columns: "100, auto, 100", colSpacing: 10);
+			var view0 = CreateTestView(new Size(100, 100));
+			var view1 = CreateTestView(new Size(100, 100));
+			var view2 = CreateTestView(new Size(100, 100));
+
+			SubstituteChildren(grid, view0, view2);
+			SetLocation(grid, view0);
+			SetLocation(grid, view1, col: 1);
+			SetLocation(grid, view2, col: 2);
+
+			view1.Visibility.Returns(Visibility.Collapsed);
 
 			var manager = new GridLayoutManager(grid);
 			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);

--- a/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
@@ -427,5 +427,87 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			view.Received().Measure(Arg.Is(expectedMeasureConstraint.Width), Arg.Is(expectedMeasureConstraint.Height));
 		}
+
+		[Fact]
+		public void CollapsedItemsDoNotIncurSpacingInMiddle()
+		{
+			var viewWidth = 5;
+			var viewHeight = 7;
+			var spacing = 10;
+
+			var stack = SetUpVisibilityTestStack(viewWidth, viewHeight, spacing);
+			stack.Spacing.Returns(spacing);
+
+			stack[1].Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new HorizontalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var expectedWidth = viewWidth + spacing + viewWidth;
+
+			Assert.Equal(expectedWidth, measuredSize.Width);
+		}
+
+		[Fact]
+		public void CollapsedItemsDoNotIncurSpacingAtEnd()
+		{
+			var viewWidth = 5;
+			var viewHeight = 7;
+			var spacing = 10;
+
+			var stack = SetUpVisibilityTestStack(viewWidth, viewHeight, spacing);
+			stack.Spacing.Returns(spacing);
+
+			stack[2].Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new HorizontalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var expectedWidth = viewWidth + spacing + viewWidth;
+
+			Assert.Equal(expectedWidth, measuredSize.Width);
+		}
+
+		[Fact]
+		public void CollapsedItemsDoNotIncurSpacingAtStart()
+		{
+			var viewWidth = 5;
+			var viewHeight = 7;
+			var spacing = 10;
+
+			var stack = SetUpVisibilityTestStack(viewWidth, viewHeight, spacing);
+			stack.Spacing.Returns(spacing);
+
+			stack[0].Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new HorizontalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var expectedWidth = viewWidth + spacing + viewWidth;
+
+			Assert.Equal(expectedWidth, measuredSize.Width);
+		}
+
+		[Fact]
+		public void LayoutWithAllCollapsedItemsHasNoSpacing()
+		{
+			var viewWidth = 5;
+			var viewHeight = 7;
+			var spacing = 10;
+
+			var stack = SetUpVisibilityTestStack(viewWidth, viewHeight, spacing);
+			stack.Spacing.Returns(spacing);
+
+			stack[0].Visibility.Returns(Visibility.Collapsed);
+			stack[1].Visibility.Returns(Visibility.Collapsed);
+			stack[2].Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new HorizontalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var expectedWidth = 0;
+
+			Assert.Equal(expectedWidth, measuredSize.Width);
+		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/StackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/StackLayoutManagerTests.cs
@@ -68,5 +68,17 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			return stack;
 		}
+
+		protected IStackLayout SetUpVisibilityTestStack(double viewWidth, double viewHeight, double spacing)
+		{
+			var startView = CreateTestView(new Size(viewWidth, viewHeight));
+			var middleView = CreateTestView(new Size(viewWidth, viewHeight));
+			var endView = CreateTestView(new Size(viewWidth, viewHeight));
+
+			var stack = CreateTestLayout(new List<IView> { startView, middleView, endView });
+			stack.Spacing.Returns(spacing);
+
+			return stack;
+		}
 	}
 }

--- a/src/Core/tests/UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
@@ -361,5 +361,87 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			view.Received().Measure(Arg.Is(expectedMeasureConstraint.Width), Arg.Is(expectedMeasureConstraint.Height));
 		}
+
+		[Fact]
+		public void CollapsedItemsDoNotIncurSpacingInMiddle() 
+		{
+			var viewWidth = 7;
+			var viewHeight = 5;
+			var spacing = 10;
+
+			var stack = SetUpVisibilityTestStack(viewWidth, viewHeight, spacing);
+			stack.Spacing.Returns(spacing);
+			
+			stack[1].Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new VerticalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var expectedHeight = viewHeight + spacing + viewHeight;
+
+			Assert.Equal(expectedHeight, measuredSize.Height);
+		}
+
+		[Fact]
+		public void CollapsedItemsDoNotIncurSpacingAtEnd()
+		{
+			var viewWidth = 7;
+			var viewHeight = 5;
+			var spacing = 10;
+
+			var stack = SetUpVisibilityTestStack(viewWidth, viewHeight, spacing);
+			stack.Spacing.Returns(spacing);
+
+			stack[2].Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new VerticalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var expectedHeight = viewHeight + spacing + viewHeight;
+
+			Assert.Equal(expectedHeight, measuredSize.Height);
+		}
+
+		[Fact]
+		public void CollapsedItemsDoNotIncurSpacingAtStart()
+		{
+			var viewWidth = 7;
+			var viewHeight = 5;
+			var spacing = 10;
+
+			var stack = SetUpVisibilityTestStack(viewWidth, viewHeight, spacing);
+			stack.Spacing.Returns(spacing);
+
+			stack[0].Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new VerticalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var expectedHeight = viewHeight + spacing + viewHeight;
+
+			Assert.Equal(expectedHeight, measuredSize.Height);
+		}
+
+		[Fact]
+		public void LayoutWithAllCollapsedItemsHasNoSpacing()
+		{
+			var viewWidth = 7;
+			var viewHeight = 5;
+			var spacing = 10;
+
+			var stack = SetUpVisibilityTestStack(viewWidth, viewHeight, spacing);
+			stack.Spacing.Returns(spacing);
+
+			stack[0].Visibility.Returns(Visibility.Collapsed);
+			stack[1].Visibility.Returns(Visibility.Collapsed);
+			stack[2].Visibility.Returns(Visibility.Collapsed);
+
+			var manager = new VerticalStackLayoutManager(stack);
+			var measuredSize = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			var expectedHeight = 0;
+
+			Assert.Equal(expectedHeight, measuredSize.Height);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Skips collapsed children when adding spacing during measurement of stack layouts.

### Issues Fixed

Fixes #9586