### PR TITLE
Display orientation should not use window size

### DIFF
--- a/src/Essentials/samples/Samples/Platforms/Android/MainActivity.cs
+++ b/src/Essentials/samples/Samples/Platforms/Android/MainActivity.cs
@@ -8,7 +8,7 @@ using Microsoft.Maui;
 
 namespace Samples.Droid
 {
-	[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+	[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation, ScreenOrientation = ScreenOrientation.FullSensor)]
 	[IntentFilter(
 		new[] { Microsoft.Maui.ApplicationModel.Platform.Intent.ActionAppAction },
 		Categories = new[] { Intent.CategoryDefault })]

--- a/src/Essentials/samples/Samples/View/DeviceInfoPage.xaml
+++ b/src/Essentials/samples/Samples/View/DeviceInfoPage.xaml
@@ -8,10 +8,10 @@
         <viewmodels:DeviceInfoViewModel />
     </views:BasePage.BindingContext>
 
-    <StackLayout>
+    <Grid RowDefinitions="Auto,*">
         <Label Text="Find out about the device with ease." FontAttributes="Bold" Margin="12" />
 
-        <ScrollView>
+        <ScrollView Grid.Row="1">
             <StackLayout Padding="12,0,12,12" Spacing="6">
                 <Label Text="Device Info:" FontAttributes="Bold" Margin="0,6,0,0" />
                 <Label Text="{Binding Model, StringFormat='Model: {0}'}" />
@@ -30,8 +30,11 @@
                 <Label Text="{Binding ScreenMetrics.Orientation, StringFormat='Orientation: {0}'}" />
                 <Label Text="{Binding ScreenMetrics.Rotation, StringFormat='Rotation: {0}'}" />
                 <Label Text="{Binding ScreenMetrics.RefreshRate, StringFormat='Refresh Rate: {0}'}" />
+
+                <Label Text="Top of Device Arrow:" FontAttributes="Bold" Margin="0,6,0,0" />
+                <Label Text="&#x2191;" FontSize="64" HorizontalOptions="Start" Rotation="{Binding Rotation}" />
             </StackLayout>
         </ScrollView>
-    </StackLayout>
+    </Grid>
 
 </views:BasePage>

--- a/src/Essentials/samples/Samples/ViewModel/DeviceInfoViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/DeviceInfoViewModel.cs
@@ -21,11 +21,21 @@ namespace Samples.ViewModel
 		public DeviceIdiom Idiom => DeviceInfo.Idiom;
 
 		public DeviceType DeviceType => DeviceInfo.DeviceType;
+		
+		public double Rotation =>
+			ScreenMetrics.Rotation switch
+			{
+				DisplayRotation.Rotation0 => 0,
+				DisplayRotation.Rotation90 => -90,
+				DisplayRotation.Rotation180 => -180,
+				DisplayRotation.Rotation270 => -270,
+				_ => 0
+			};
 
 		public DisplayInfo ScreenMetrics
 		{
 			get => screenMetrics;
-			set => SetProperty(ref screenMetrics, value);
+			set => SetProperty(ref screenMetrics, value, onChanged: () => OnPropertyChanged(nameof(Rotation)));
 		}
 
 		public override void OnAppearing()

--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
@@ -44,40 +44,6 @@ namespace Microsoft.Maui.Devices
 			}
 		}
 
-		static DisplayRotation CalculateRotation(DisplayOrientations native, DisplayOrientations current)
-		{
-			if (native == DisplayOrientations.Portrait)
-			{
-				switch (current)
-				{
-					case DisplayOrientations.Landscape:
-						return DisplayRotation.Rotation90;
-					case DisplayOrientations.Portrait:
-						return DisplayRotation.Rotation0;
-					case DisplayOrientations.LandscapeFlipped:
-						return DisplayRotation.Rotation270;
-					case DisplayOrientations.PortraitFlipped:
-						return DisplayRotation.Rotation180;
-				}
-			}
-			else if (native == DisplayOrientations.Landscape)
-			{
-				switch (current)
-				{
-					case DisplayOrientations.Landscape:
-						return DisplayRotation.Rotation0;
-					case DisplayOrientations.Portrait:
-						return DisplayRotation.Rotation270;
-					case DisplayOrientations.LandscapeFlipped:
-						return DisplayRotation.Rotation180;
-					case DisplayOrientations.PortraitFlipped:
-						return DisplayRotation.Rotation90;
-				}
-			}
-
-			return DisplayRotation.Unknown;
-		}
-
 		AppWindow? _currentAppWindowListeningTo;
 
 		protected override DisplayInfo GetMainDisplayInfo()
@@ -91,13 +57,8 @@ namespace Microsoft.Maui.Devices
 			if (mi == null)
 				return new DisplayInfo();
 
-			DEVMODE vDevMode = new DEVMODE();
+			var vDevMode = new DEVMODE();
 			EnumDisplaySettings(mi.Value.DeviceNameToLPTStr(), -1, ref vDevMode);
-
-			var rotation = CalculateRotation(vDevMode, appWindow);
-			var perpendicular =
-				rotation == DisplayRotation.Rotation90 ||
-				rotation == DisplayRotation.Rotation270;
 
 			var w = vDevMode.dmPelsWidth;
 			var h = vDevMode.dmPelsHeight;
@@ -108,13 +69,18 @@ namespace Microsoft.Maui.Devices
 			else
 				dpi = 1.0;
 
-			var orientation = GetWindowOrientationWin32(appWindow) == DisplayOrientations.Landscape
+			var displayOrientation = GetDisplayOrientation(vDevMode);
+			var rotation = CalculateRotation(displayOrientation);
+
+			var orientation = displayOrientation == DisplayOrientations.Landscape || displayOrientation == DisplayOrientations.LandscapeFlipped
 				? DisplayOrientation.Landscape
 				: DisplayOrientation.Portrait;
 
+			var perpendicular = orientation == DisplayOrientation.Portrait;
+
 			return new DisplayInfo(
-				width: perpendicular ? h : w,
-				height: perpendicular ? w : h,
+				width: w,
+				height: h,
 				density: dpi,
 				orientation: orientation,
 				rotation: rotation,
@@ -179,42 +145,25 @@ namespace Microsoft.Maui.Devices
 		void OnAppWindowChanged(AppWindow sender, AppWindowChangedEventArgs args) =>
 			OnMainDisplayInfoChanged();
 
-		static DisplayRotation CalculateRotation(DEVMODE devMode, AppWindow appWindow)
-		{
-			DisplayOrientations native = DisplayOrientations.Portrait;
-			switch (devMode.dmDisplayOrientation)
+		static DisplayRotation CalculateRotation(DisplayOrientations orientation) =>
+			orientation switch
 			{
-				case 0:
-					native = DisplayOrientations.Landscape;
-					break;
-				case 1:
-					native = DisplayOrientations.Portrait;
-					break;
-				case 2:
-					native = DisplayOrientations.LandscapeFlipped;
-					break;
-				case 3:
-					native = DisplayOrientations.PortraitFlipped;
-					break;
-			}
+				DisplayOrientations.Landscape => DisplayRotation.Rotation0,
+				DisplayOrientations.Portrait => DisplayRotation.Rotation270,
+				DisplayOrientations.LandscapeFlipped => DisplayRotation.Rotation180,
+				DisplayOrientations.PortraitFlipped => DisplayRotation.Rotation90,
+				_ => DisplayRotation.Rotation0,
+			};
 
-			var current = GetWindowOrientationWin32(appWindow);
-			return CalculateRotation(native, current);
-		}
-
-		// https://github.com/marb2000/DesktopWindow/blob/abb21b797767bb24da09c066514117d5f1aabd75/WindowExtensions/DesktopWindow.cs#L407
-		static DisplayOrientations GetWindowOrientationWin32(AppWindow appWindow)
-		{
-			DisplayOrientations orientationEnum;
-			int theScreenWidth = appWindow.Size.Width;
-			int theScreenHeight = appWindow.Size.Height;
-			if (theScreenWidth > theScreenHeight)
-				orientationEnum = DisplayOrientations.Landscape;
-			else
-				orientationEnum = DisplayOrientations.Portrait;
-
-			return orientationEnum;
-		}
+		static DisplayOrientations GetDisplayOrientation(DEVMODE devMode) =>
+			devMode.dmDisplayOrientation switch
+			{
+				0 => DisplayOrientations.Landscape,
+				1 => DisplayOrientations.Portrait,
+				2 => DisplayOrientations.LandscapeFlipped,
+				3 => DisplayOrientations.PortraitFlipped,
+				_ => DisplayOrientations.Landscape,
+			};
 
 		[DllImport("User32", CharSet = CharSet.Unicode)]
 		static extern int GetDpiForWindow(IntPtr hwnd);


### PR DESCRIPTION
### Description of Change

This PR corrects an issue where the device display orientation is basically a check of the window bounds instead of the display bounds and the OS reported orientation.