### PR TITLE
[ci] Add support to net6.0 for multi-targeting in VS

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -22,5 +22,6 @@
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />
     <ComponentResources Include="maui-windows"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Windows" Description=".NET SDK Workload for building MAUI applications that target Windows." />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Maui.Manifest*.nupkg" Version="@VS_COMPONENT_VERSION@" />
+    <MultiTargetPackNames Include="Microsoft.Maui.Sdk" />
   </ItemGroup>
 </Project>

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -50,3 +50,16 @@ jobs:
         inputs:
           artifactName: vsdrop-signed
           downloadPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
+  - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+    parameters:
+      githubToken: $(github--pat--vs-mobiletools-engineering-service2)
+      githubContext: $(MultiTargetVSDropCommitStatusName)
+      blobName: $(MultiTargetVSDropCommitStatusName)
+      packagePrefix: maui
+      artifactsPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)
+      yamlResourceName: xamarin-templates
+      downloadSteps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifactName: vsdrop-multitarget-signed
+          downloadPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)

--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -14,7 +14,7 @@ stages:
           displayName: Sign Phase
           condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/net6.0'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') )))))
 
-      - template: nuget-msi-convert/job/v2.yml@xamarin-templates
+      - template: nuget-msi-convert/job/v3.yml@xamarin-templates
         parameters:
           yamlResourceName: xamarin-templates
           artifactName: nuget
@@ -23,6 +23,7 @@ stages:
           artifactPath: signed
           propsArtifactName: nuget
           signType: Real
+          useDateTimeVersion: false
           preConvertSteps:
             - task: DownloadPipelineArtifact@2
               displayName: Download library-packs nugets

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -28,7 +28,7 @@
       "description": ".NET MAUI SDK Core Packages",
       "packs": [
           "Microsoft.Maui.Dependencies",
-          "Microsoft.Maui.Sdk",
+          "Microsoft.Maui.Sdk.net6",
           "Microsoft.Maui.Extensions",
           "Microsoft.Maui.Graphics",
           "Microsoft.Maui.Resizetizer.Sdk",
@@ -287,9 +287,12 @@
       "kind": "library",
       "version": "@MAUI_GRAPHICS_VERSION@"
     },
-    "Microsoft.Maui.Sdk": {
+    "Microsoft.Maui.Sdk.net6": {
       "kind": "sdk",
-      "version": "@VERSION@"
+      "version": "@VERSION@",
+      "alias-to": {
+        "any": "Microsoft.Maui.Sdk"
+      }
     },
     "Microsoft.Maui.Resizetizer.Sdk": {
       "kind": "sdk",

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.targets
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.targets
@@ -5,7 +5,7 @@
   </ItemGroup>
   <Import
       Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true' "
-      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk"
+      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk.net6"
   />
   <Import
       Condition=" '$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true' "


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195
Context: https://github.com/xamarin/yaml-templates/pull/199

Updates the build to use the latest MSI generation template. The v3
template uses the latest changes from arcade which include a large
refactoring, support for multi-targeting, and support for workload pack
group MSIs.

The build will now produce two different VS Drop artifacts.  The MSI and
VSMAN files generated for SDK packs have been split out into a new
`vsdrop-multitarget-signed` artifact, allowing us to include multiple
versions of the SDK packs in VS.

The `Microsoft.Maui.Sdk` pack has been renamed to
`Microsoft.Maui.Sdk.net6` to match the pack alias that is referenced
in the .NET 7 manifest.