### PR TITLE
[ci] Add support to net7.0 for multi-targeting in VS

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
-    <MicrosoftMauiPreviousDotNetReleasedVersion>6.0.511</MicrosoftMauiPreviousDotNetReleasedVersion>
+    <MicrosoftMauiPreviousDotNetReleasedVersion>6.0.514</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
     <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-rc.1.22424.4</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->

--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -22,5 +22,6 @@
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />
     <ComponentResources Include="maui-windows"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Windows" Description=".NET SDK Workload for building MAUI applications that target Windows." />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Maui.Manifest*.nupkg" Version="@VS_COMPONENT_VERSION@" />
+    <MultiTargetPackNames Include="Microsoft.Maui.Sdk" />
   </ItemGroup>
 </Project>

--- a/eng/pipelines/common/sdk-insertion.yml
+++ b/eng/pipelines/common/sdk-insertion.yml
@@ -49,3 +49,16 @@ jobs:
         inputs:
           artifactName: vsdrop-signed
           downloadPath: $(Build.StagingDirectory)/$(VSDropCommitStatusName)
+  - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+    parameters:
+      githubToken: $(github--pat--vs-mobiletools-engineering-service2)
+      githubContext: $(MultiTargetVSDropCommitStatusName)
+      blobName: $(MultiTargetVSDropCommitStatusName)
+      packagePrefix: maui
+      artifactsPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)
+      yamlResourceName: xamarin-templates
+      downloadSteps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifactName: vsdrop-multitarget-signed
+          downloadPath: $(Build.StagingDirectory)/$(MultiTargetVSDropCommitStatusName)

--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -14,7 +14,7 @@ stages:
           displayName: Sign Phase
           condition: and(succeeded(), eq(variables.signingCondition, true))
 
-      - template: nuget-msi-convert/job/v2.yml@xamarin-templates
+      - template: nuget-msi-convert/job/v3.yml@xamarin-templates
         parameters:
           yamlResourceName: xamarin-templates
           artifactName: nuget

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -57,7 +57,9 @@
       <_VersionsToReplace Include="MicrosoftMauiGraphicsWin2DWinUIDesktopPackageVersion" PropertyName="MicrosoftMauiGraphicsVersion" />
       <_VersionsToReplace Include="MAUI_GRAPHICS_VERSION" PropertyName="MicrosoftMauiGraphicsVersion" />
       <_VersionsToReplace Include="VERSION" PropertyName="PackageReferenceVersion" />
+      <_VersionsToReplace Include="MAUI_DOTNET_TFM" PropertyName="_MauiDotNetTfm" />
       <_VersionsToReplace Include="MAUI_DOTNET_VERSION" PropertyName="_MauiDotNetVersion" />
+      <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_TFM" PropertyName="_MauiPreviousDotNetTfm" />
       <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_VERSION" PropertyName="_MauiPreviousDotNetVersion" />
       <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_VERSION_NO_DOT" PropertyName="_MauiPreviousDotNetVersionNoDot" />
       <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION" PropertyName="MicrosoftMauiPreviousDotNetReleasedVersion" />

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -27,8 +27,8 @@
       "abstract": true,
       "description": ".NET MAUI SDK Core Packages",
       "packs": [
-          "Microsoft.Maui.Sdk",
-          "Microsoft.Maui.Sdk-@MAUI_PREVIOUS_DOTNET_VERSION@",
+          "Microsoft.Maui.Sdk.@MAUI_DOTNET_TFM@",
+          "Microsoft.Maui.Sdk.@MAUI_PREVIOUS_DOTNET_TFM@",
           "Microsoft.Maui.Graphics",
           "Microsoft.Maui.Resizetizer.Sdk",
           "Microsoft.Maui.Templates-@MAUI_PREVIOUS_DOTNET_VERSION@",
@@ -279,11 +279,14 @@
       "kind": "library",
       "version": "@MAUI_GRAPHICS_VERSION@"
     },
-    "Microsoft.Maui.Sdk": {
+    "Microsoft.Maui.Sdk.@MAUI_DOTNET_TFM@": {
       "kind": "sdk",
-      "version": "@VERSION@"
+      "version": "@VERSION@",
+      "alias-to": {
+        "any": "Microsoft.Maui.Sdk"
+      }
     },
-    "Microsoft.Maui.Sdk-@MAUI_PREVIOUS_DOTNET_VERSION@": {
+    "Microsoft.Maui.Sdk.@MAUI_PREVIOUS_DOTNET_TFM@": {
       "kind": "sdk",
       "version": "@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@",
       "alias-to": {

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
@@ -7,11 +7,11 @@
 
   <Import
       Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true') and ($([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@'))) "
-      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk"
+      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk.@MAUI_DOTNET_TFM@"
   />
   <Import
       Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true') and ($([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_PREVIOUS_DOTNET_VERSION@'))) "
-      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk-@MAUI_PREVIOUS_DOTNET_VERSION@"
+      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk.@MAUI_PREVIOUS_DOTNET_TFM@"
   />
 
   <Import


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/180
Context: https://github.com/xamarin/yaml-templates/pull/195
Context: https://github.com/xamarin/yaml-templates/pull/199

Updates the build to use the latest MSI generation template. The v3
template uses the latest changes from arcade which include a large
refactoring, support for multi-targeting, and support for workload pack
group MSIs.

The build will now produce two different VS Drop artifacts.  The MSI and
VSMAN files generated for SDK packs have been split out into a new
`vsdrop-multitarget-signed` artifact, allowing us to include multiple
versions of the SDK packs in VS.

The `Microsoft.Maui.Sdk` pack has been renamed to
`Microsoft.Maui.Sdk.net7` to allow it to be imported by the .NET 8
workload manifest when the time comes.
