### PR TITLE
Blazor Hybrid CSS Hot Reload Fixes

### DIFF
--- a/Microsoft.Maui.sln
+++ b/Microsoft.Maui.sln
@@ -196,6 +196,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiBlazorWebView.DeviceTes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SharedSource", "SharedSource", "{4F2926C8-43AB-4328-A735-D9EAD699F81D}"
 	ProjectSection(SolutionItems) = preProject
+		src\BlazorWebView\src\SharedSource\AutoCloseOnReadCompleteStream.cs = src\BlazorWebView\src\SharedSource\AutoCloseOnReadCompleteStream.cs
 		src\BlazorWebView\src\SharedSource\QueryStringHelper.cs = src\BlazorWebView\src\SharedSource\QueryStringHelper.cs
 		src\BlazorWebView\src\SharedSource\UrlLoadingEventArgs.cs = src\BlazorWebView\src\SharedSource\UrlLoadingEventArgs.cs
 		src\BlazorWebView\src\SharedSource\UrlLoadingStrategy.cs = src\BlazorWebView\src\SharedSource\UrlLoadingStrategy.cs

--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -83,15 +83,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 			if (TryGetResponseContent(requestUri, allowFallbackOnHostPage, out var statusCode, out var statusMessage, out var content, out var headers)
 				&& statusCode != 404)
 			{
-				// NOTE: This is stream copying is to work around a hanging bug in WinRT with managed streams.
-				// See issue https://github.com/microsoft/CsWinRT/issues/670
-				var memStream = new MemoryStream();
-				content.CopyTo(memStream);
-				var ms = new InMemoryRandomAccessStream();
-				await ms.WriteAsync(memStream.GetWindowsRuntimeBuffer());
-
 				var headerString = GetHeaderString(headers);
-				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(ms, statusCode, statusMessage, headerString);
+				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content.AsRandomAccessStream(), statusCode, statusMessage, headerString);
 			}
 			else if (new Uri(requestUri) is Uri uri && AppOriginUri.IsBaseOf(uri))
 			{

--- a/src/BlazorWebView/src/SharedSource/AutoCloseOnReadCompleteStream.cs
+++ b/src/BlazorWebView/src/SharedSource/AutoCloseOnReadCompleteStream.cs
@@ -23,12 +23,15 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 		public override long Position { get => _baseStream.Position; set => _baseStream.Position = value; }
 
-		public override void Flush() => _baseStream?.Flush();
+		public override void Flush() => _baseStream.Flush();
 
 		public override int Read(byte[] buffer, int offset, int count)
 		{
 			var bytesRead = _baseStream.Read(buffer, offset, count);
 
+			// Stream.Read only returns 0 when it has reached the end of stream
+			// and no further bytes are expected. Otherwise it blocks until
+			// one or more (and at most count) bytes can be read.
 			if (bytesRead == 0)
 			{
 				_baseStream.Close();
@@ -41,7 +44,7 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 
 		public override void SetLength(long value) => _baseStream.SetLength(value);
 
-		public override void Write(byte[] buffer, int offset, int count) => _baseStream?.Write(buffer, offset, count);
+		public override void Write(byte[] buffer, int offset, int count) => _baseStream.Write(buffer, offset, count);
 	}
 }
 

--- a/src/BlazorWebView/src/SharedSource/AutoCloseOnReadCompleteStream.cs
+++ b/src/BlazorWebView/src/SharedSource/AutoCloseOnReadCompleteStream.cs
@@ -1,0 +1,48 @@
+﻿#if WEBVIEW2_WINFORMS || WEBVIEW2_WPF
+
+using System.IO;
+
+namespace Microsoft.AspNetCore.Components.WebView.WebView2
+{
+	internal class AutoCloseOnReadCompleteStream : Stream
+	{
+		private readonly Stream _baseStream;
+
+		public AutoCloseOnReadCompleteStream(Stream baseStream)
+		{
+			_baseStream = baseStream;
+		}
+
+		public override bool CanRead => _baseStream.CanRead;
+
+		public override bool CanSeek => _baseStream.CanSeek;
+
+		public override bool CanWrite => _baseStream.CanWrite;
+
+		public override long Length => _baseStream.Length;
+
+		public override long Position { get => _baseStream.Position; set => _baseStream.Position = value; }
+
+		public override void Flush() => _baseStream?.Flush();
+
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			var bytesRead = _baseStream.Read(buffer, offset, count);
+
+			if (bytesRead == 0)
+			{
+				_baseStream.Close();
+			}
+
+			return bytesRead;
+		}
+
+		public override long Seek(long offset, SeekOrigin origin) => _baseStream.Seek(offset, origin);
+
+		public override void SetLength(long value) => _baseStream.SetLength(value);
+
+		public override void Write(byte[] buffer, int offset, int count) => _baseStream?.Write(buffer, offset, count);
+	}
+}
+
+#endif

--- a/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
+++ b/src/BlazorWebView/src/SharedSource/StaticContentHotReloadManager.cs
@@ -67,6 +67,7 @@ namespace Microsoft.AspNetCore.Components.WebView
 				if (_updatedContent.TryGetValue((assemblyName, relativePath), out var values))
 				{
 					responseStatusCode = 200;
+					responseContent.Close();
 					responseContent = new MemoryStream(values.Content);
 					if (!string.IsNullOrEmpty(values.ContentType))
 					{

--- a/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
+++ b/src/BlazorWebView/src/SharedSource/WebView2WebViewManager.cs
@@ -304,7 +304,10 @@ namespace Microsoft.AspNetCore.Components.WebView.WebView2
 				StaticContentHotReloadManager.TryReplaceResponseContent(_contentRootRelativeToAppRoot, requestUri, ref statusCode, ref content, headers);
 
 				var headerString = GetHeaderString(headers);
-				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(content, statusCode, statusMessage, headerString);
+
+				var autoCloseStream = new AutoCloseOnReadCompleteStream(content);
+
+				eventArgs.Response = _coreWebView2Environment!.CreateWebResourceResponse(autoCloseStream, statusCode, statusMessage, headerString);
 			}
 #elif WEBVIEW2_MAUI
 			// No-op here because all the work is done in the derived WinUIWebViewManager


### PR DESCRIPTION
Adds [AutoCloseOnReadCompleteStream](https://github.com/dotnet/maui/commit/8dd13168f91933db0938cb36ac5c9fe3bdcd420e) to close out the content stream upon read completion.

Fixes https://github.com/dotnet/maui/issues/7479

---

If the stream content is supplemented by the static hot reload manager, ensures the initial stream is closed out.

Fixes https://github.com/dotnet/maui/issues/9197