### PR TITLE
Obsolete OpenGLView

### DIFF
--- a/src/Compatibility/ControlGallery/src/WinUI/RegistrarValidationService.cs
+++ b/src/Compatibility/ControlGallery/src/WinUI/RegistrarValidationService.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.Controls.Compatibility.Platform.UWP;
 [assembly: Dependency(typeof(RegistrarValidationService))]
 namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.WinUI
 {
+	[System.Obsolete]
 	public class RegistrarValidationService : IRegistrarValidationService
 	{
 		public bool Validate(VisualElement element, out string message)

--- a/src/Compatibility/Core/src/Android/Renderers/OpenGLViewRenderer.cs
+++ b/src/Compatibility/Core/src/Android/Renderers/OpenGLViewRenderer.cs
@@ -10,10 +10,8 @@ using Object = Java.Lang.Object;
 
 namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 {
-	//public class OpenGLViewRenderer : ViewRenderer<OpenGLView, GLSurfaceView>
-#pragma warning disable CS0618 // Type or member is obsolete
+	[Obsolete]	
 	internal class OpenGLViewRenderer : ViewRenderer<OpenGLView, GLSurfaceView>
-#pragma warning restore CS0618 // Type or member is obsolete
 	{
 		bool _disposed;
 

--- a/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
+++ b/src/Compatibility/Core/src/AppHostBuilderExtensions.cs
@@ -77,9 +77,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 
 #if !WINDOWS
 #if !(MACCATALYST || MACOS)
+#pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable CS0612 // Type or member is obsolete
 					handlers.TryAddCompatibilityRenderer(typeof(OpenGLView), typeof(OpenGLViewRenderer));
 #pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 #else
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Controls/src/Core/OpenGLView.cs
+++ b/src/Controls/src/Core/OpenGLView.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/OpenGLView.xml" path="Type[@FullName='Microsoft.Maui.Controls.OpenGLView']/Docs" />
+	[Obsolete("OpenGLView is obsolete as of .NET 7. To enable this view you will need to call `builder.UseMauiCompatibility` but it is currently untested and unsupported.")]
 	public sealed class OpenGLView : View, IOpenGlViewController, IElementConfiguration<OpenGLView>
 	{
 		#region Statics


### PR DESCRIPTION
### Description of Change

The `OpenGLViewRenderer`'s were not ported to .NET MAUI and we currently don't have a plan to.  They are still available via  `build.UseMauiCompatibility` but they are currently not tested and are unsupported