### PR TITLE
Reducing the maps API space

### DIFF
--- a/src/Core/maps/src/Handlers/Map/IMapHandler.cs
+++ b/src/Core/maps/src/Handlers/Map/IMapHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Gms.Maps.MapView;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
-using PlatformView = ElmSharp.EvasObject;
+using PlatformView = Tizen.NUI.BaseComponents.View;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Maps.Handlers
 		new IMap VirtualView { get; }
 		new PlatformView PlatformView { get; }
 #if MONOANDROID
-		GoogleMap? Map { get; set; }
+		GoogleMap? Map { get; }
 #endif
 		void UpdateMapElement(IMapElement element);
 	}

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Maps.Handlers
 		List<APolygon>? _polygons;
 		List<ACircle>? _circles;
 
-		public GoogleMap? Map { get; set; }
+		public GoogleMap? Map { get; private set; }
 
 		static Bundle? s_bundle;
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Tizen.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using Microsoft.Maui.Handlers;
+using NView = Tizen.NUI.BaseComponents.View;
 
 namespace Microsoft.Maui.Maps.Handlers
 {
-	public partial class MapHandler : ViewHandler<IMap, ElmSharp.EvasObject>
+	public partial class MapHandler : ViewHandler<IMap, NView>
 	{
 
-		protected override ElmSharp.EvasObject CreatePlatformView() => throw new NotImplementedException();
+		protected override NView CreatePlatformView() => throw new NotImplementedException();
 
 		public static void MapMapType(IMapHandler handler, IMap map) => throw new NotImplementedException();
 

--- a/src/Core/maps/src/Handlers/Map/MapHandler.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = Android.Gms.Maps.MapView;
 #elif WINDOWS
 using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
 #elif TIZEN
-using PlatformView = ElmSharp.EvasObject;
+using PlatformView = Tizen.NUI.BaseComponents.View;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/maps/src/Handlers/MapElement/IMapElementHandler.cs
+++ b/src/Core/maps/src/Handlers/MapElement/IMapElementHandler.cs
@@ -8,7 +8,7 @@ using PlatformView = Java.Lang.Object;
 #elif WINDOWS
 using PlatformView = System.Object;
 #elif TIZEN
-using PlatformView = ElmSharp.EvasObject;
+using PlatformView = System.Object;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/maps/src/Handlers/MapElement/MapElementHandler.Tizen.cs
+++ b/src/Core/maps/src/Handlers/MapElement/MapElementHandler.Tizen.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.Maui.Handlers;
 namespace Microsoft.Maui.Maps.Handlers
 {
-	public partial class MapElementHandler : ElementHandler<IMapElement, ElmSharp.EvasObject>
+	public partial class MapElementHandler : ElementHandler<IMapElement, object>
 	{
-		protected override ElmSharp.EvasObject CreatePlatformElement() => throw new System.NotImplementedException();
+		protected override object CreatePlatformElement() => throw new System.NotImplementedException();
 		public static void MapStroke(IMapElementHandler handler, IMapElement mapElement) => throw new System.NotImplementedException();
 		public static void MapStrokeThickness(IMapElementHandler handler, IMapElement mapElement) => throw new System.NotImplementedException();
 		public static void MapFill(IMapElementHandler handler, IMapElement mapElement) => throw new System.NotImplementedException();

--- a/src/Core/maps/src/Handlers/MapElement/MapElementHandler.cs
+++ b/src/Core/maps/src/Handlers/MapElement/MapElementHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = Java.Lang.Object;
 #elif WINDOWS
 using PlatformView = System.Object;
 #elif TIZEN
-using PlatformView = ElmSharp.EvasObject;
+using PlatformView = System.Object;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/maps/src/Handlers/MapPin/IMapPinHandler.cs
+++ b/src/Core/maps/src/Handlers/MapPin/IMapPinHandler.cs
@@ -6,7 +6,7 @@ using PlatformView = Android.Gms.Maps.Model.MarkerOptions;
 #elif WINDOWS
 using PlatformView = System.Object;
 #elif TIZEN
-using PlatformView = ElmSharp.EvasObject;
+using PlatformView = System.Object;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Tizen.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.Tizen.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.Maui.Handlers;
 namespace Microsoft.Maui.Maps.Handlers
 {
-	public partial class MapPinHandler : ElementHandler<IMapPin, ElmSharp.EvasObject>
+	public partial class MapPinHandler : ElementHandler<IMapPin, object>
 	{
-		protected override ElmSharp.EvasObject CreatePlatformElement() => throw new System.NotImplementedException();
+		protected override object CreatePlatformElement() => throw new System.NotImplementedException();
 		public static void MapLocation(IMapPinHandler handler, IMapPin mapPin) { }
 
 		public static void MapLabel(IMapPinHandler handler, IMapPin mapPin) { }

--- a/src/Core/maps/src/Handlers/MapPin/MapPinHandler.cs
+++ b/src/Core/maps/src/Handlers/MapPin/MapPinHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = Android.Gms.Maps.Model.MarkerOptions;
 #elif WINDOWS
 using PlatformView = System.Object;
 #elif TIZEN
-using PlatformView = ElmSharp.EvasObject;
+using PlatformView = System.Object;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0 && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -11,7 +11,6 @@ Microsoft.Maui.Maps.Handlers.IMapElementHandler.PlatformView.get -> Java.Lang.Ob
 Microsoft.Maui.Maps.Handlers.IMapElementHandler.VirtualView.get -> Microsoft.Maui.Maps.IMapElement!
 Microsoft.Maui.Maps.Handlers.IMapHandler
 Microsoft.Maui.Maps.Handlers.IMapHandler.Map.get -> Android.Gms.Maps.GoogleMap?
-Microsoft.Maui.Maps.Handlers.IMapHandler.Map.set -> void
 Microsoft.Maui.Maps.Handlers.IMapHandler.PlatformView.get -> Android.Gms.Maps.MapView!
 Microsoft.Maui.Maps.Handlers.IMapHandler.UpdateMapElement(Microsoft.Maui.Maps.IMapElement! element) -> void
 Microsoft.Maui.Maps.Handlers.IMapHandler.VirtualView.get -> Microsoft.Maui.Maps.IMap!
@@ -33,7 +32,6 @@ Microsoft.Maui.Maps.Handlers.MapHandler.GetNativePolygon(Microsoft.Maui.Maps.IGe
 Microsoft.Maui.Maps.Handlers.MapHandler.GetNativePolyline(Microsoft.Maui.Maps.IGeoPathMapElement! polyline) -> Android.Gms.Maps.Model.Polyline?
 Microsoft.Maui.Maps.Handlers.MapHandler.GetPinForMarker(Android.Gms.Maps.Model.Marker! marker) -> Microsoft.Maui.Maps.IMapPin?
 Microsoft.Maui.Maps.Handlers.MapHandler.Map.get -> Android.Gms.Maps.GoogleMap?
-Microsoft.Maui.Maps.Handlers.MapHandler.Map.set -> void
 Microsoft.Maui.Maps.Handlers.MapHandler.MapHandler() -> void
 Microsoft.Maui.Maps.Handlers.MapHandler.MapHandler(Microsoft.Maui.IPropertyMapper? mapper = null, Microsoft.Maui.CommandMapper? commandMapper = null) -> void
 Microsoft.Maui.Maps.Handlers.MapHandler.UpdateMapElement(Microsoft.Maui.Maps.IMapElement! element) -> void

--- a/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/maps/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -8,14 +8,14 @@ Microsoft.Maui.Maps.Distance.Meters.get -> double
 Microsoft.Maui.Maps.Distance.Miles.get -> double
 Microsoft.Maui.Maps.GeographyUtils
 Microsoft.Maui.Maps.Handlers.IMapElementHandler
-Microsoft.Maui.Maps.Handlers.IMapElementHandler.PlatformView.get -> ElmSharp.EvasObject!
+Microsoft.Maui.Maps.Handlers.IMapElementHandler.PlatformView.get -> object!
 Microsoft.Maui.Maps.Handlers.IMapElementHandler.VirtualView.get -> Microsoft.Maui.Maps.IMapElement!
 Microsoft.Maui.Maps.Handlers.IMapHandler
-Microsoft.Maui.Maps.Handlers.IMapHandler.PlatformView.get -> ElmSharp.EvasObject!
+Microsoft.Maui.Maps.Handlers.IMapHandler.PlatformView.get -> Tizen.NUI.BaseComponents.View!
 Microsoft.Maui.Maps.Handlers.IMapHandler.UpdateMapElement(Microsoft.Maui.Maps.IMapElement! element) -> void
 Microsoft.Maui.Maps.Handlers.IMapHandler.VirtualView.get -> Microsoft.Maui.Maps.IMap!
 Microsoft.Maui.Maps.Handlers.IMapPinHandler
-Microsoft.Maui.Maps.Handlers.IMapPinHandler.PlatformView.get -> ElmSharp.EvasObject!
+Microsoft.Maui.Maps.Handlers.IMapPinHandler.PlatformView.get -> object!
 Microsoft.Maui.Maps.Handlers.IMapPinHandler.VirtualView.get -> Microsoft.Maui.Maps.IMapPin!
 Microsoft.Maui.Maps.Handlers.MapElementHandler
 Microsoft.Maui.Maps.Handlers.MapElementHandler.MapElementHandler() -> void
@@ -43,9 +43,9 @@ Microsoft.Maui.Maps.IMap
 Microsoft.Maui.Maps.IMap.Clicked(Microsoft.Maui.Devices.Sensors.Location! position) -> void
 Microsoft.Maui.Maps.IMap.Elements.get -> System.Collections.Generic.IList<Microsoft.Maui.Maps.IMapElement!>!
 Microsoft.Maui.Maps.IMap.IsScrollEnabled.get -> bool
+Microsoft.Maui.Maps.IMap.IsShowingUser.get -> bool
 Microsoft.Maui.Maps.IMap.IsTrafficEnabled.get -> bool
 Microsoft.Maui.Maps.IMap.IsZoomEnabled.get -> bool
-Microsoft.Maui.Maps.IMap.IsShowingUser.get -> bool
 Microsoft.Maui.Maps.IMap.MapType.get -> Microsoft.Maui.Maps.MapType
 Microsoft.Maui.Maps.IMap.MoveToRegion(Microsoft.Maui.Maps.MapSpan! region) -> void
 Microsoft.Maui.Maps.IMap.Pins.get -> System.Collections.Generic.IList<Microsoft.Maui.Maps.IMapPin!>!
@@ -76,9 +76,9 @@ Microsoft.Maui.Maps.MapType.Satellite = 1 -> Microsoft.Maui.Maps.MapType
 Microsoft.Maui.Maps.MapType.Street = 0 -> Microsoft.Maui.Maps.MapType
 override Microsoft.Maui.Maps.Distance.Equals(object? obj) -> bool
 override Microsoft.Maui.Maps.Distance.GetHashCode() -> int
-override Microsoft.Maui.Maps.Handlers.MapElementHandler.CreatePlatformElement() -> ElmSharp.EvasObject!
-override Microsoft.Maui.Maps.Handlers.MapHandler.CreatePlatformView() -> ElmSharp.EvasObject!
-override Microsoft.Maui.Maps.Handlers.MapPinHandler.CreatePlatformElement() -> ElmSharp.EvasObject!
+override Microsoft.Maui.Maps.Handlers.MapElementHandler.CreatePlatformElement() -> object!
+override Microsoft.Maui.Maps.Handlers.MapHandler.CreatePlatformView() -> Tizen.NUI.BaseComponents.View!
+override Microsoft.Maui.Maps.Handlers.MapPinHandler.CreatePlatformElement() -> object!
 override Microsoft.Maui.Maps.MapSpan.Equals(object? obj) -> bool
 override Microsoft.Maui.Maps.MapSpan.GetHashCode() -> int
 override Microsoft.Maui.Maps.MapSpan.ToString() -> string!
@@ -98,9 +98,9 @@ static Microsoft.Maui.Maps.Handlers.MapElementHandler.MapStrokeThickness(Microso
 static Microsoft.Maui.Maps.Handlers.MapHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.Maps.IMap!, Microsoft.Maui.Maps.Handlers.IMapHandler!>!
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapElements(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsScrollEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
+static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsShowingUser(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsTrafficEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsZoomEnabled(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
-static Microsoft.Maui.Maps.Handlers.MapHandler.MapIsShowingUser(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapMapType(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.MapMoveToRegion(Microsoft.Maui.Maps.Handlers.IMapHandler! handler, Microsoft.Maui.Maps.IMap! map, object? arg) -> void
 static Microsoft.Maui.Maps.Handlers.MapHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.Maps.IMap!, Microsoft.Maui.Maps.Handlers.IMapHandler!>!


### PR DESCRIPTION
### Description of Change

This PR is to make the public `GoogleMap? IMapHandler.Map { get; }` not be settable from outside the handler.

The other part is to make the base type for the map elements be plain C# objects so that Tizen does not have to use views as that is probably not supported - just like we use plain objects in all the other platforms.