### PR TITLE
Add Maui project capability for development

### DIFF
--- a/src/Maui.InTree.props
+++ b/src/Maui.InTree.props
@@ -1,7 +1,4 @@
 <Project>
-  <ItemGroup>
-	<ProjectCapability Include="Maui" />
-  </ItemGroup>
   <Import Project="$(_MauiBuildTasksLocation)AutoImport.InTree.props"/>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.props"/>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.props"/>

--- a/src/Maui.InTree.props
+++ b/src/Maui.InTree.props
@@ -1,4 +1,7 @@
 <Project>
+  <ItemGroup>
+	<ProjectCapability Include="Maui" />
+  </ItemGroup>
   <Import Project="$(_MauiBuildTasksLocation)AutoImport.InTree.props"/>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.props"/>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.props"/>

--- a/src/Maui.InTree.targets
+++ b/src/Maui.InTree.targets
@@ -1,6 +1,6 @@
 <Project>
-  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'>
-	<ProjectCapability Include="Maui" />
+  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+		<ProjectCapability Include="Maui" />
   </ItemGroup>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />

--- a/src/Maui.InTree.targets
+++ b/src/Maui.InTree.targets
@@ -1,4 +1,7 @@
 <Project>
+  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'>
+	<ProjectCapability Include="Maui" />
+  </ItemGroup>
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Core.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   <Import Project="$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll')" />


### PR DESCRIPTION
### Description of Change

With 17.4 the deployment targets will only list devices if the IDE sees that the project has the MAUI capability set. This capability is set via "UseMaui". Because we don't set `UseMaui` inside our development environment the capability isn't getting set