### PR TITLE
Revert "Fix Shadow rendering on iOS Border (#8464)"

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Image/ImageTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+using Microsoft.Maui.Graphics;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Image)]
+	public partial class ImageTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler<Image, ImageHandler>();
+				});
+			});
+		}
+
+		[Fact]
+		public async Task ImageWithUndefinedSizeAndWithBackgroundSetRenders()
+		{
+			SetupBuilder();
+			var layout = new VerticalStackLayout();
+
+			var image = new Image
+			{
+				Background = Colors.Black,
+				Source = "red.png",
+			};
+
+			layout.Add(image);
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler<LayoutHandler>(layout);
+				await image.Wait();
+				await handler.ToPlatform().AssertContainsColor(Colors.Red);
+			});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Extensions.cs
+++ b/src/Controls/tests/DeviceTests/Extensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public static class Extensions
+	{
+		public static Task Wait(this Image image, int timeout = 1000) =>
+			AssertionExtensions.Wait(() => !image.IsLoading, timeout);
+	}
+}
+

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -7,7 +7,6 @@
 		public const string CheckBox = "CheckBox";
 		public const string Compatibility = "Compatibility";
 		public const string ContentView = "ContentView";
-		public const string MenuFlyout = nameof(MenuFlyout);
 		public const string Dispatcher = "Dispatcher";
 		public const string Editor = "Editor";
 		public const string Element = "Element";
@@ -15,9 +14,11 @@
 		public const string Frame = "Frame";
 		public const string FlyoutPage = "FlyoutPage";
 		public const string Gesture = "Gesture";
+		public const string Image = "Image";
 		public const string Label = "Label";
 		public const string Layout = "Layout";
 		public const string ListView = "ListView";
+		public const string MenuFlyout = nameof(MenuFlyout);
 		public const string Modal = "Modal";
 		public const string NavigationPage = "NavigationPage";
 		public const string Page = "Page";

--- a/src/Core/src/Handlers/View/ViewHandler.iOS.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.iOS.cs
@@ -55,14 +55,7 @@ namespace Microsoft.Maui.Handlers
 		static partial void MappingFrame(IViewHandler handler, IView view)
 		{
 			UpdateTransformation(handler, view);
-
-			var platformView = handler.ToPlatform();
-
-			if (platformView != null)
-			{
-				platformView.UpdateBackgroundLayerFrame();
-				platformView.UpdateShadowLayerFrame();
-			}
+			handler.ToPlatform().UpdateBackgroundLayerFrame();
 		}
 
 		public static void MapTranslationX(IViewHandler handler, IView view)

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -277,27 +277,6 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		// TODO: NET7 make this public for net7.0
-		internal static void UpdateShadowLayerFrame(this UIView view)
-		{
-			if (view == null || view.Frame.IsEmpty)
-				return;
-
-			var layer = view.Layer;
-
-			if (layer == null || layer.Sublayers == null || layer.Sublayers.Length == 0)
-				return;
-
-			foreach (var sublayer in layer.Sublayers)
-			{
-				if (sublayer.Opacity > 0) // If the layer has shadow, invalidate the Size
-				{
-					sublayer.Frame = view.Bounds;
-					break;
-				}
-			}
-		}
-
 		public static void InvalidateMeasure(this UIView platformView, IView view)
 		{
 			platformView.SetNeedsLayout();


### PR DESCRIPTION
### Description of Change

This reverts commit 3ff7c992edf00b4e0dbc191f27b8ed882eabc1b9.
https://github.com/dotnet/maui/pull/8464

The images page on the iOS gallery currently doesn't load any images 