### PR TITLE
Update Rollback.in.json

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Rollback.in.json
@@ -5,6 +5,8 @@
   "microsoft.net.sdk.macos": "@MicrosoftmacOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
   "microsoft.net.sdk.maui": "@VERSION@/@DotNetMauiManifestVersionBand@",
   "microsoft.net.sdk.tvos": "@MicrosofttvOSSdkPackageVersion@/@DotNetMaciOSManifestVersionBand@",
-  "microsoft.net.workload.mono.toolchain": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
-  "microsoft.net.workload.emscripten": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@"
+  "microsoft.net.workload.mono.toolchain.net6": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
+  "microsoft.net.workload.mono.toolchain.net7": "@MicrosoftNETCoreAppRefPackageVersion@/@DotNetMonoManifestVersionBand@",
+  "microsoft.net.workload.emscripten.net6": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@",
+  "microsoft.net.workload.emscripten.net7": "@MicrosoftNETWorkloadEmscriptenPackageVersion@/@DotNetEmscriptenManifestVersionBand@"
 }


### PR DESCRIPTION
### Description of Change

We now have 2 workloads for mono/emscripten because they are very different with regards to tooling and linkers.

Before:

> Invalid rollback definition. The manifest IDs in rollback definition C:\Users\mattl\Downloads\workloads.json do not match installed manifest IDs (microsoft.net.workload.mono.toolchain, 7.0.0-rc.1.22423.16, 7.0.100) (microsoft.net.workload.emscripten, 7.0.0-rc.1.22423.3, 7.0.100).