### PR TITLE
[Tizen] Update SkiaGraphicsView.Tizen.cs

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -20,7 +20,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
+    <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/skiasharp-stable-88c09609-signed/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>

--- a/NuGet.config
+++ b/NuGet.config
@@ -20,7 +20,8 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/skiasharp-stable-88c09609-signed/nuget/v3/index.json" />
+    <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
+    <add key="skiasharp-stable-sha-signed" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/skiasharp-stable-88c09609-signed/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,7 +58,7 @@
     -->
     <_SkiaSharpVersion>2.88.2-preview.5</_SkiaSharpVersion>
     <_HarfBuzzSharpVersion>2.8.2.2-preview.5</_HarfBuzzSharpVersion>
-    <_SkiaSharpNativeAssetsVersion>0.0.0-commit.a26ea4ca482ae8a2f0a530874264328885cce2c4.475</_SkiaSharpNativeAssetsVersion>
+    <_SkiaSharpNativeAssetsVersion>0.0.0-commit.88c096095fc1cf61a64b47b7044e9e89e3f6c097.480</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.5.22226.1</MicrosoftTemplateEngineTasksVersion>
     <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.22429.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
     <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.22429.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,8 +56,8 @@
        - Feed URI in the nuget.config
        - Native assets build and sha
     -->
-    <_SkiaSharpVersion>2.88.1</_SkiaSharpVersion>
-    <_HarfBuzzSharpVersion>2.8.2.1</_HarfBuzzSharpVersion>
+    <_SkiaSharpVersion>2.88.2-preview.5</_SkiaSharpVersion>
+    <_HarfBuzzSharpVersion>2.8.2.2-preview.5</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.a26ea4ca482ae8a2f0a530874264328885cce2c4.475</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.5.22226.1</MicrosoftTemplateEngineTasksVersion>
     <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.22429.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,8 +56,8 @@
        - Feed URI in the nuget.config
        - Native assets build and sha
     -->
-    <_SkiaSharpVersion>2.88.2-preview.5</_SkiaSharpVersion>
-    <_HarfBuzzSharpVersion>2.8.2.2-preview.5</_HarfBuzzSharpVersion>
+    <_SkiaSharpVersion>2.88.2</_SkiaSharpVersion>
+    <_HarfBuzzSharpVersion>2.8.2.2</_HarfBuzzSharpVersion>
     <_SkiaSharpNativeAssetsVersion>0.0.0-commit.88c096095fc1cf61a64b47b7044e9e89e3f6c097.480</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.5.22226.1</MicrosoftTemplateEngineTasksVersion>
     <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.22429.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>

--- a/src/Core/src/Platform/Tizen/GraphicsViewExtensions.cs
+++ b/src/Core/src/Platform/Tizen/GraphicsViewExtensions.cs
@@ -1,10 +1,10 @@
-﻿using NUISkiaGraphicsView = Tizen.UIExtensions.NUI.GraphicsView.SkiaGraphicsView;
+﻿using Microsoft.Maui.Graphics.Skia.Views;
 
 namespace Microsoft.Maui.Platform
 {
 	public static class GraphicsViewExtensions
 	{
-		public static void UpdateDrawable(this NUISkiaGraphicsView platformGraphicsView, IGraphicsView graphicsView)
+		public static void UpdateDrawable(this SkiaGraphicsView platformGraphicsView, IGraphicsView graphicsView)
 		{
 			platformGraphicsView.Drawable = graphicsView.Drawable;
 		}

--- a/src/Core/src/Platform/Tizen/PlatformTouchGraphicsView.cs
+++ b/src/Core/src/Platform/Tizen/PlatformTouchGraphicsView.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Graphics.Platform;
-using Tizen.UIExtensions.NUI;
-using Tizen.UIExtensions.NUI.GraphicsView;
+using Microsoft.Maui.Graphics.Skia.Views;
 using PointStateType = Tizen.NUI.PointStateType;
 
 namespace Microsoft.Maui.Platform

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -2641,7 +2641,7 @@ static Microsoft.Maui.Platform.FlyoutViewExtensions.UpdateFlyoutBehavior(this Ti
 static Microsoft.Maui.Platform.FlyoutViewExtensions.UpdateFlyoutWidth(this Tizen.UIExtensions.NUI.DrawerView! platformDrawerView, Microsoft.Maui.IFlyoutView! flyoutView) -> void
 static Microsoft.Maui.Platform.FlyoutViewExtensions.UpdateIsGestureEnabled(this Tizen.UIExtensions.NUI.DrawerView! platformDrawerView, Microsoft.Maui.IFlyoutView! flyoutView) -> void
 static Microsoft.Maui.Platform.FlyoutViewExtensions.UpdateIsPresented(this Tizen.UIExtensions.NUI.DrawerView! platformDrawerView, Microsoft.Maui.IFlyoutView! flyoutView) -> void
-static Microsoft.Maui.Platform.GraphicsViewExtensions.UpdateDrawable(this Tizen.UIExtensions.NUI.GraphicsView.SkiaGraphicsView! platformGraphicsView, Microsoft.Maui.IGraphicsView! graphicsView) -> void
+static Microsoft.Maui.Platform.GraphicsViewExtensions.UpdateDrawable(this Microsoft.Maui.Graphics.Skia.Views.SkiaGraphicsView! platformGraphicsView, Microsoft.Maui.IGraphicsView! graphicsView) -> void
 static Microsoft.Maui.Platform.ImageExtensions.Clear(this Tizen.UIExtensions.NUI.Image! platformImage) -> void
 static Microsoft.Maui.Platform.ImageExtensions.UpdateAspect(this Tizen.UIExtensions.NUI.Image! platformImage, Microsoft.Maui.IImage! image) -> void
 static Microsoft.Maui.Platform.ImageExtensions.UpdateIsAnimationPlaying(this Tizen.UIExtensions.NUI.Image! platformImage, Microsoft.Maui.IImageSourcePart! image) -> void

--- a/src/Graphics/samples/GraphicsTester.Skia.Tizen/Main.cs
+++ b/src/Graphics/samples/GraphicsTester.Skia.Tizen/Main.cs
@@ -1,80 +1,112 @@
 using System;
-using ElmSharp;
 using Tizen.Applications;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
 using GraphicsTester.Scenarios;
 using Microsoft.Maui.Graphics.Skia.Views;
 
 namespace GraphicsTester.Skia.Tizen
 {
-	class Program : CoreUIApplication
+	class Program : NUIApplication
 	{
+		SimpleViewStack _stack;
+
 		protected override void OnCreate()
 		{
 			base.OnCreate();
-			CreateTesterView();
+			FocusManager.Instance.EnableDefaultAlgorithm(true);
+			Initialize();
+			_stack.Push(CreateTesterView());
 		}
 
-		private void CreateTesterView()
+		private void Initialize()
 		{
-			Window window = new Window("GraphicsTester")
-			{
-				AvailableRotations = DisplayRotation.Degree_0 | DisplayRotation.Degree_180 | DisplayRotation.Degree_270 | DisplayRotation.Degree_90
-			};
-			window.Show();
-			window.BackButtonPressed += (s, e) =>
-			{
-				EcoreMainloop.Quit();
-			};
+			View.SetDefaultGrabTouchAfterLeave(true);
+			Window.Instance.KeyEvent += OnKeyEvent;
 
-			Conformant conformant = new Conformant(window);
-			conformant.Show();
-
-			Naviframe navi = new Naviframe(window)
+			_stack = new SimpleViewStack
 			{
-				PreserveContentOnPop = true,
-				DefaultBackButtonEnabled = true
-			};
-			navi.Show();
-
-			GenList list = new GenList(window)
-			{
-				AlignmentX = -1,
-				AlignmentY = -1,
-				WeightX = 1,
-				WeightY = 1
-			};
-			GenItemClass defaultClass = new GenItemClass("default")
-			{
-				GetTextHandler = (data, part) =>
-				{
-					var scenario = data as AbstractScenario;
-					return scenario == null ? "" : scenario.GetType().Name;
-				}
-			};
-			foreach (var scenario in ScenarioList.Scenarios)
-			{
-				list.Append(defaultClass, scenario);
-			}
-
-			SkiaGraphicsView graphicsView = new SkiaGraphicsView(window)
-			{
-				AlignmentX = -1,
-				AlignmentY = -1,
-				WeightX = 1,
-				WeightY = 1,
 				BackgroundColor = Color.White
 			};
-			graphicsView.Show();
+			Window.Instance.GetDefaultLayer().Add(_stack);
 
-			list.ItemSelected += (s, e) =>
+			Window.Instance.AddAvailableOrientation(Window.WindowOrientation.Landscape);
+			Window.Instance.AddAvailableOrientation(Window.WindowOrientation.LandscapeInverse);
+			Window.Instance.AddAvailableOrientation(Window.WindowOrientation.Portrait);
+			Window.Instance.AddAvailableOrientation(Window.WindowOrientation.PortraitInverse);
+		}
+
+		private View CreateTesterView()
+		{
+			var layout = new View
 			{
-				var scenario = ScenarioList.Scenarios[e.Item.Index - 1];
-				graphicsView.Drawable = scenario;
-				navi.Push(graphicsView, scenario.GetType().Name);
+				HeightResizePolicy = ResizePolicyType.FillToParent,
+				WidthResizePolicy = ResizePolicyType.FillToParent,
+				Layout = new LinearLayout
+				{
+					LinearOrientation = LinearLayout.Orientation.Vertical,
+				}
 			};
-			list.Show();
-			navi.Push(list, "GraphicsTester.Skia.Tizen");
-			conformant.SetContent(navi);
+
+			EventHandler<ClickedEventArgs> clicked = (object sender, ClickedEventArgs args) =>
+			{
+				var scenario = ((sender as View).BindingContext as AbstractScenario);
+				var graphicsView = new SkiaGraphicsView
+				{
+					Drawable = scenario
+				};
+				_stack.Push(graphicsView);
+			};
+
+
+			var collectionview = new ScrollableBase
+			{
+				Layout = new LinearLayout
+				{
+					LinearOrientation = LinearLayout.Orientation.Vertical
+				}
+			};
+
+			foreach (var scenario in ScenarioList.Scenarios)
+			{
+				var itemView = new DefaultLinearItem();
+
+				itemView.Focusable = true;
+				itemView.BindingContext = scenario;
+				itemView.Clicked += clicked;
+
+				var label = new TextLabel
+				{
+					VerticalAlignment = VerticalAlignment.Center,
+					WidthSpecification = LayoutParamPolicies.MatchParent,
+					HeightSpecification = LayoutParamPolicies.MatchParent,
+				};
+
+				label.PixelSize = 30;
+				label.Text = scenario.ToString();
+
+				itemView.Add(label);
+				collectionview.Add(itemView);
+			}
+			layout.Add(collectionview);
+
+			return layout;
+		}
+
+		private void OnKeyEvent(object sender, Window.KeyEventArgs e)
+		{
+			if (e.Key.State == Key.StateType.Down && (e.Key.KeyPressedName == "XF86Back" || e.Key.KeyPressedName == "Escape"))
+			{
+				if (_stack.Stack.Count > 1)
+				{
+					_stack.Pop();
+				}
+				else
+				{
+					Exit();
+				}
+			}
 		}
 
 		static void Main(string[] args)

--- a/src/Graphics/samples/GraphicsTester.Skia.Tizen/SimpleViewStack.cs
+++ b/src/Graphics/samples/GraphicsTester.Skia.Tizen/SimpleViewStack.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Linq;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+
+namespace GraphicsTester.Skia.Tizen
+{
+	public class SimpleViewStack : View
+	{
+		View _lastTop;
+
+		public SimpleViewStack()
+		{
+			Layout = new AbsoluteLayout();
+			WidthSpecification = LayoutParamPolicies.MatchParent;
+			HeightSpecification = LayoutParamPolicies.MatchParent;
+			InternalStack = new List<View>();
+		}
+
+		List<View> InternalStack { get; set; }
+
+		public IReadOnlyList<View> Stack => InternalStack;
+
+		public void Push(View view)
+		{
+			view.WidthSpecification = LayoutParamPolicies.MatchParent;
+			view.HeightSpecification = LayoutParamPolicies.MatchParent;
+
+			InternalStack.Add(view);
+			Add(view);
+			UpdateTopView();
+		}
+
+		public void Pop()
+		{
+			if (_lastTop != null)
+			{
+				var tobeRemoved = _lastTop;
+				InternalStack.Remove(tobeRemoved);
+				Remove(tobeRemoved);
+				UpdateTopView();
+				// if Pop was called by removed page,
+				// Unrealize cause deletation of NativeCallback, it could be a cause of crash
+				tobeRemoved.Dispose();
+			}
+		}
+
+		public void PopToRoot()
+		{
+			while (InternalStack.Count > 1)
+			{
+				Pop();
+			}
+		}
+
+		public void Insert(View before, View view)
+		{
+			view.Hide();
+			var idx = InternalStack.IndexOf(before);
+			InternalStack.Insert(idx, view);
+			Add(view);
+			UpdateTopView();
+		}
+
+		private void UpdateTopView()
+		{
+			if (_lastTop != InternalStack.LastOrDefault())
+			{
+				_lastTop?.Hide();
+				_lastTop = InternalStack.LastOrDefault();
+				_lastTop.Show();
+			}
+		}
+	}
+}

--- a/src/Graphics/src/Graphics.Skia/Views/SkiaGraphicsView.Tizen.cs
+++ b/src/Graphics/src/Graphics.Skia/Views/SkiaGraphicsView.Tizen.cs
@@ -1,7 +1,8 @@
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Graphics.Skia;
-using SkiaSharp.Views.Tizen;
-using ElmSharp;
+using SkiaSharp.Views.Tizen.NUI;
+using Tizen.NUI;
+using SKPaintSurfaceEventArgs = SkiaSharp.Views.Tizen.SKPaintSurfaceEventArgs;
 
 namespace Microsoft.Maui.Graphics.Skia.Views
 {
@@ -11,7 +12,7 @@ namespace Microsoft.Maui.Graphics.Skia.Views
 		private SkiaCanvas _canvas;
 		private ScalingCanvas _scalingCanvas;
 
-		public SkiaGraphicsView(EvasObject parent, IDrawable drawable = null) : base(parent)
+		public SkiaGraphicsView(IDrawable drawable = null) : base()
 		{
 			_canvas = new SkiaCanvas();
 			_scalingCanvas = new ScalingCanvas(_canvas);
@@ -32,14 +33,13 @@ namespace Microsoft.Maui.Graphics.Skia.Views
 
 		protected virtual void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
 		{
-			if (_drawable == null)
-				return;
+			if (_drawable == null) return;
 
 			var skiaCanvas = e.Surface.Canvas;
 			skiaCanvas.Clear();
 
 			_canvas.Canvas = skiaCanvas;
-			_drawable.Draw(_scalingCanvas, new RectF(0, 0, GetSurfaceSize().Width, GetSurfaceSize().Height));
+			_drawable.Draw(_scalingCanvas, new RectF(0, 0, e.Info.Width , e.Info.Height));
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

This PR is to change the tizen backend implementation of SkiaGraphicsView from EFL (legacy Tizen UI FW) to NUI (brand new Tizen .NET UI FW). Please refer to #9620 and SkiaSharp's ([#2225](https://github.com/mono/SkiaSharp/pull/2225)) related to this together.

~> Keep this PR as a draft until a new version of SkiaSharp packages is released.~

<img src="https://user-images.githubusercontent.com/1029134/187797083-f3c5622b-c0ca-4f6e-878d-2a93c428d7ec.png" width=300/>


