### PR TITLE
[Tizen] Update handling IconPressed event of MauiToolbar

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Tizen/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Tizen/ShellView.cs
@@ -219,6 +219,12 @@ namespace Microsoft.Maui.Controls.Platform
 			return new ShellItemTemplateAdaptor(Element!, Element!.Items);
 		}
 
+		void OnIconPressed(object? sender, EventArgs e)
+		{
+			if (!Element!.Toolbar.BackButtonVisible && ((Element!.Toolbar.IsVisible)))
+				IsOpened = true;
+		}
+
 		void UpdetDrawerToggleVisible()
 		{
 			Element!.Toolbar.DrawerToggleVisible = ((Element!.Toolbar.DrawerToggleVisible) && (Element.FlyoutBehavior == FlyoutBehavior.Flyout));
@@ -247,14 +253,6 @@ namespace Microsoft.Maui.Controls.Platform
 
 			_cachedGroups = groups;
 			return false;
-		}
-
-		void OnIconPressed(object? sender, EventArgs e)
-		{
-			if (Element!.Toolbar.BackButtonVisible)
-				MauiContext?.GetPlatformWindow().GetWindow()?.BackButtonClicked();
-			else
-				IsOpened = true;
 		}
 
 		void OnTabItemSelected(object? sender, CollectionViewSelectionChangedEventArgs e)

--- a/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Tizen.cs
+++ b/src/Core/src/Handlers/FlyoutView/FlyoutViewHandler.Tizen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		protected override DrawerView CreatePlatformView()
 		{
-			return DeviceInfo.IsTV ? new TVNavigationDrawer() : new NavigationDrawer();
+			return DeviceInfo.IsTV ? new MauiTVFlyoutView() : new MauiFlyoutView();
 		}
 
 		protected override void ConnectHandler(DrawerView platformView)
@@ -61,25 +61,18 @@ namespace Microsoft.Maui.Handlers
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
 
+			ViewHandler.MapToolbar(handler, flyoutView);
+
 			if (handler.VirtualView is not IToolbarElement toolbarElement)
 				return;
 
 			if (toolbarElement.Toolbar?.ToPlatform(handler.MauiContext) is MauiToolbar platformToolbar)
 			{
-				var toolbarContainer = handler.PlatformView.Content is IToolbarContainer container ?
-					container : handler.MauiContext.GetToolbarContainer();
-
 				platformToolbar.IconPressed += (s, e) =>
 				{
-					if (!toolbarElement.Toolbar.BackButtonVisible)
-					{
-						if (handler.PlatformView.IsOpened)
-							_ = handler.PlatformView.CloseAsync(true);
-						else
-							_ = handler.PlatformView.OpenAsync(true);
-					}
+					if (!toolbarElement.Toolbar.BackButtonVisible && (toolbarElement.Toolbar.IsVisible))
+						_ = handler.PlatformView.OpenAsync(true);
 				};
-				toolbarContainer?.SetToolbar(platformToolbar);
 			}
 		}
 

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Tizen.cs
@@ -1,12 +1,39 @@
-﻿namespace Microsoft.Maui.Handlers
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Handlers
 {
 	public partial class ToolbarHandler : ElementHandler<IToolbar, MauiToolbar>
 	{
 		protected override MauiToolbar CreatePlatformElement() => new();
 
-		public static void MapTitle(IToolbarHandler arg1, IToolbar arg2)
+		protected override void ConnectHandler(MauiToolbar platformView)
 		{
-			arg1.PlatformView.UpdateTitle(arg2);
+			platformView.IconPressed += OnIconPressed;
+			base.ConnectHandler(platformView);
+		}
+
+		protected override void DisconnectHandler(MauiToolbar platformView)
+		{
+			platformView.IconPressed -= OnIconPressed;
+			base.DisconnectHandler(platformView);
+		}
+
+		public static void MapTitle(IToolbarHandler handler, IToolbar toolbar)
+		{
+			handler.PlatformView.UpdateTitle(toolbar);
+		}
+
+		async void OnIconPressed(object? sender, EventArgs args)
+		{
+			if (VirtualView.BackButtonVisible && VirtualView.IsVisible)
+			{
+				// Delays invoking the BackButtonClicked
+				// so the other attached events can be invoked before the pop behavior is done on a FlyoutPage.
+				await Task.Delay(100);
+
+				MauiContext?.GetPlatformWindow().GetWindow()?.BackButtonClicked();
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/Tizen/MauiFlyoutView.cs
+++ b/src/Core/src/Platform/Tizen/MauiFlyoutView.cs
@@ -1,0 +1,15 @@
+﻿using Tizen.UIExtensions.NUI;
+
+namespace Microsoft.Maui.Platform
+{
+	public class MauiFlyoutView : NavigationDrawer, IToolbarContainer
+	{
+		void IToolbarContainer.SetToolbar(MauiToolbar toolbar)
+		{
+			if (Content is IToolbarContainer container)
+			{
+				container.SetToolbar(toolbar);
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/Tizen/MauiTVFlyoutView.cs
+++ b/src/Core/src/Platform/Tizen/MauiTVFlyoutView.cs
@@ -1,0 +1,15 @@
+﻿using Tizen.UIExtensions.NUI;
+
+namespace Microsoft.Maui.Platform
+{
+	public class MauiTVFlyoutView : TVNavigationDrawer, IToolbarContainer
+	{
+		void IToolbarContainer.SetToolbar(MauiToolbar toolbar)
+		{
+			if (Content is IToolbarContainer container)
+			{
+				container.SetToolbar(toolbar);
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/Tizen/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Tizen/StackNavigationManager.cs
@@ -54,10 +54,6 @@ namespace Microsoft.Maui.Platform
 			_toolbar = toolbar;
 			Add(toolbar);
 			(toolbar.Layout as NLayoutGroup)?.ChangeLayoutSiblingOrder(0);
-			_toolbar.IconPressed += (s, e) =>
-			{
-				MauiContext?.GetPlatformWindow().GetWindow()?.BackButtonClicked();
-			};
 		}
 
 		public virtual void Connect(IView navigationView)

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -2358,7 +2358,6 @@ static Microsoft.Maui.Handlers.TimePickerHandler.MapTextColor(Microsoft.Maui.Han
 static Microsoft.Maui.Handlers.TimePickerHandler.MapTime(Microsoft.Maui.Handlers.ITimePickerHandler! handler, Microsoft.Maui.ITimePicker! timePicker) -> void
 static Microsoft.Maui.Handlers.ToolbarHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IToolbar!, Microsoft.Maui.Handlers.IToolbarHandler!>!
 static Microsoft.Maui.Handlers.ToolbarHandler.Mapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IToolbar!, Microsoft.Maui.Handlers.IToolbarHandler!>!
-static Microsoft.Maui.Handlers.ToolbarHandler.MapTitle(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.IToolbar! arg2) -> void
 static Microsoft.Maui.Handlers.ViewHandler.MapAnchorX(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.IView! view) -> void
 static Microsoft.Maui.Handlers.ViewHandler.MapAnchorY(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.IView! view) -> void
 static Microsoft.Maui.Handlers.ViewHandler.MapAutomationId(Microsoft.Maui.IViewHandler! handler, Microsoft.Maui.IView! view) -> void

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
 ﻿#nullable enable
+Microsoft.Maui.Platform.MauiFlyoutView
+Microsoft.Maui.Platform.MauiFlyoutView.MauiFlyoutView() -> void
 Microsoft.Maui.Platform.MauiPicker
 Microsoft.Maui.Platform.MauiPicker.MauiPicker() -> void
+Microsoft.Maui.Platform.MauiTVFlyoutView
+Microsoft.Maui.Platform.MauiTVFlyoutView.MauiTVFlyoutView() -> void
+override Microsoft.Maui.Handlers.ToolbarHandler.ConnectHandler(Microsoft.Maui.Platform.MauiToolbar! platformView) -> void
+override Microsoft.Maui.Handlers.ToolbarHandler.DisconnectHandler(Microsoft.Maui.Platform.MauiToolbar! platformView) -> void
 override Microsoft.Maui.Platform.MauiPicker.OnEnabled(bool enabled) -> void
 override Microsoft.Maui.Platform.MauiStepper.OnEnabled(bool enabled) -> void
+static Microsoft.Maui.Handlers.ToolbarHandler.MapTitle(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.IToolbar! toolbar) -> void


### PR DESCRIPTION
### Description of Change

This PR is to improve the event handling when a user click the toggle/back button of  the `Toolbar` on `Tizen`.
 - the event that triggers `BackButtonPressed` will be handled in `MauiToolbarHandler.Tizen`.
 - the event that opens the drawer will be handled in each handlers in charge of the drawer control.

Screenshot
- FlyoutPage
  <img width=300 src="https://user-images.githubusercontent.com/20968023/187363232-708f6cc4-e96b-49ff-b68b-24b162b6e2a7.gif"/>
- Shell
  <img width=300 src="https://user-images.githubusercontent.com/20968023/187363269-2e0c501f-e5c2-4445-948e-6e701441fffb.gif"/>



