### PR TITLE
[Maps] Fix initial property set when Map is not ready yet

### DIFF
--- a/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
+++ b/src/Core/maps/src/Handlers/Map/MapHandler.Android.cs
@@ -330,6 +330,7 @@ namespace Microsoft.Maui.Maps.Handlers
 			map.MarkerClick += OnMarkerClick;
 			map.InfoWindowClick += OnInfoWindowClick;
 			map.MapClick += OnMapClick;
+			InitialUpdate();
 		}
 
 		internal void UpdateVisibleRegion(LatLng pos)
@@ -351,6 +352,14 @@ namespace Microsoft.Maui.Maps.Handlers
 
 		void MapViewLayoutChange(object? sender, Android.Views.View.LayoutChangeEventArgs e)
 		{
+			InitialUpdate();
+		}
+
+		void InitialUpdate()
+		{
+			if (Map == null)
+				return;
+
 			if (_init && _lastMoveToRegion != null)
 			{
 				MoveToRegion(_lastMoveToRegion, false);
@@ -361,10 +370,7 @@ namespace Microsoft.Maui.Maps.Handlers
 				_init = false;
 			}
 
-			if (Map != null)
-			{
-				UpdateVisibleRegion(Map.CameraPosition.Target);
-			}
+			UpdateVisibleRegion(Map.CameraPosition.Target);
 		}
 
 		void MoveToRegion(MapSpan span, bool animate)


### PR DESCRIPTION
### Description of Change

On Android the initialization of the Map is async and we need to wait for it to be ready to add/update related features. Code was before relaying only on LayoutChange, but we should do it after the map is ready.

### Issues Fixed

Fixes issues with Maps on Android when used on a NavigationPage

For testing please visit the MapGalleries on the Samples project