### PR TITLE
Use correct type for template selector on Shell

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutTemplateSelector.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutTemplateSelector.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		protected override Microsoft.UI.Xaml.DataTemplate SelectTemplateCore(object item)
 		{
-			if (item is MenuFlyoutSeparator)
+			if (item is UI.Xaml.Controls.MenuFlyoutSeparator)
 				return SeperatorTemplate;
 
 			if (item is MenuItem)

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -49,6 +49,53 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task FlyoutWithAsMultipleItemsRendersWithoutCrashing()
+		{
+			SetupBuilder();
+
+			Shell shell = await CreateShellAsync(shell =>
+			{
+				shell.Items.Add(new FlyoutItem()
+				{
+					FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems,
+					Items =
+					{
+						new ShellSection()
+						{
+							FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems,
+							Items =
+							{
+								new ShellContent()
+								{
+									ContentTemplate = new DataTemplate(() => new ContentPage())
+								}
+							}
+						},
+						new ShellSection()
+						{
+							FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems,
+							Items =
+							{
+								new ShellContent()
+								{
+									ContentTemplate = new DataTemplate(() => new ContentPage())
+								}
+							}
+						}
+					}
+				});
+			});
+
+			bool finished = false;
+			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, (_) =>
+			{
+				finished = true;
+			});
+
+			Assert.True(finished);
+		}
+
 		[Fact(DisplayName = "Appearing Fires Before NavigatedTo")]
 		public async Task AppearingFiresBeforeNavigatedTo()
 		{


### PR DESCRIPTION
### Description of Change

MenuFlyoutSeparator [PR ](https://github.com/dotnet/maui/pull/8565) added a type called `MenuFlyoutSeparator` which started to hide the `UI.XAML.MenuFlyoutSeparator` type that we are checking for when running Shell. This was leading to a crash because the wrong template type is being returned