### PR TITLE
Add Grey color overloads

### DIFF
--- a/src/SingleProject/Resizetizer/src/ColorTable.cs
+++ b/src/SingleProject/Resizetizer/src/ColorTable.cs
@@ -15,7 +15,19 @@ namespace Microsoft.Maui.Resizetizer
 		static Dictionary<string, SKColor> GetColors()
 		{
 			var colors = new Dictionary<string, SKColor>(StringComparer.OrdinalIgnoreCase);
+
+			// add from SKColors fields
 			FillWithProperties(colors, typeof(SKColors));
+
+			// add "grey" (with an "e") overloads
+			colors.Add("DarkGrey", colors["DarkGray"]);
+			colors.Add("DarkSlateGrey", colors["DarkSlateGray"]);
+			colors.Add("DimGrey", colors["DimGray"]);
+			colors.Add("Grey", colors["Gray"]);
+			colors.Add("LightGrey", colors["LightGray"]);
+			colors.Add("LightSlateGrey", colors["LightSlateGray"]);
+			colors.Add("SlateGrey", colors["SlateGray"]);
+
 			return colors;
 		}
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/UtilsTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/UtilsTests.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[InlineData("Red", 0xFFFF0000)]
 			[InlineData("Green", 0xFF008000)]
 			[InlineData("Blue", 0xFF0000FF)]
+			[InlineData("Grey", 0xFF808080)]
+			[InlineData("Gray", 0xFF808080)]
+			[InlineData("LightSlateGrey", 0xFF778899)]
+			[InlineData("LightSlateGray", 0xFF778899)]
 			public void ParsesNamedColors(string name, uint argb)
 			{
 				var parsed = Utils.ParseColorString(name);


### PR DESCRIPTION
### Description of Change

Add the various "grey" colors to resizetizer for people coming from forms.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #2170

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
