### PR TITLE
[Android] Avoid crash in IsLoaded View extension method (if controls is disposed)

### DIFF
--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -422,8 +422,16 @@ namespace Microsoft.Maui.Platform
 				context.FromPixels((float)rect.Height()));
 		}
 
-		internal static bool IsLoaded(this View frameworkElement) =>
-			frameworkElement.IsAttachedToWindow;
+		internal static bool IsLoaded(this View frameworkElement)
+		{
+			if (frameworkElement == null)
+				return false;
+
+			if (frameworkElement.IsDisposed())
+				return false;
+
+			return frameworkElement.IsAttachedToWindow;
+		}
 
 		internal static IDisposable OnLoaded(this View frameworkElement, Action action)
 		{

--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -197,8 +197,13 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
-		internal static bool IsLoaded(this FrameworkElement frameworkElement) =>
-			frameworkElement.IsLoaded;
+		internal static bool IsLoaded(this FrameworkElement frameworkElement)
+		{
+			if (frameworkElement == null)
+				return false;
+
+			return frameworkElement.IsLoaded;
+		}
 
 		internal static IDisposable OnLoaded(this FrameworkElement frameworkElement, Action action)
 		{

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -453,8 +453,13 @@ namespace Microsoft.Maui.Platform
 		internal static IWindow? GetHostedWindow(this UIView? view)
 			=> GetHostedWindow(view?.Window);
 
-		internal static bool IsLoaded(this UIView uiView) =>
-			uiView.Window != null;
+		internal static bool IsLoaded(this UIView uiView)
+		{
+			if (uiView == null)
+				return false;
+
+			return uiView.Window != null;
+		}
 
 		internal static IDisposable OnLoaded(this UIView uiView, Action action)
 		{


### PR DESCRIPTION
### Description of Change

Avoid crash in IsLoaded View extension method if controls is already disposed.

### Issues Fixed

Fixes #9806