### PR TITLE
[workload] Trim dot from pack names and alias 

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Current previous .NET SDK major version's stable release of MAUI packages -->
-    <MicrosoftMauiPreviousDotNetReleasedVersion>6.0.514</MicrosoftMauiPreviousDotNetReleasedVersion>
+    <MicrosoftMauiPreviousDotNetReleasedVersion>6.0.526</MicrosoftMauiPreviousDotNetReleasedVersion>
     <!-- dotnet/installer -->
     <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-rc.1.22425.9</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->

--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -22,6 +22,6 @@
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />
     <ComponentResources Include="maui-windows"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Windows" Description=".NET SDK Workload for building MAUI applications that target Windows." />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Maui.Manifest*.nupkg" Version="@VS_COMPONENT_VERSION@" />
-    <MultiTargetPackNames Include="Microsoft.Maui.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.Maui.Sdk;Microsoft.Maui.Templates" />
   </ItemGroup>
 </Project>

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -31,7 +31,7 @@
   <PropertyGroup>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <PackageType>Template</PackageType>
-    <PackageId>Microsoft.Maui.Templates-$(_MauiDotNetVersion)</PackageId>
+    <PackageId>Microsoft.Maui.Templates.net$(_MauiDotNetVersionMajor)</PackageId>
     <Title>.NET MAUI Templates</Title>
     <Authors>Microsoft</Authors>
     <Description>Templates for .NET MAUI.</Description>

--- a/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/Microsoft.NET.Sdk.Maui.csproj
@@ -57,9 +57,9 @@
       <_VersionsToReplace Include="MicrosoftMauiGraphicsWin2DWinUIDesktopPackageVersion" PropertyName="MicrosoftMauiGraphicsVersion" />
       <_VersionsToReplace Include="MAUI_GRAPHICS_VERSION" PropertyName="MicrosoftMauiGraphicsVersion" />
       <_VersionsToReplace Include="VERSION" PropertyName="PackageReferenceVersion" />
-      <_VersionsToReplace Include="MAUI_DOTNET_TFM" PropertyName="_MauiDotNetTfm" />
+      <_VersionsToReplace Include="MAUI_DOTNET_VERSION_MAJOR" PropertyName="_MauiDotNetVersionMajor" />
       <_VersionsToReplace Include="MAUI_DOTNET_VERSION" PropertyName="_MauiDotNetVersion" />
-      <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_TFM" PropertyName="_MauiPreviousDotNetTfm" />
+      <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_VERSION_MAJOR" PropertyName="_MauiPreviousDotNetVersionMajor" />
       <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_VERSION" PropertyName="_MauiPreviousDotNetVersion" />
       <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_VERSION_NO_DOT" PropertyName="_MauiPreviousDotNetVersionNoDot" />
       <_VersionsToReplace Include="MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION" PropertyName="MicrosoftMauiPreviousDotNetReleasedVersion" />

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -27,12 +27,12 @@
       "abstract": true,
       "description": ".NET MAUI SDK Core Packages",
       "packs": [
-          "Microsoft.Maui.Sdk.@MAUI_DOTNET_TFM@",
-          "Microsoft.Maui.Sdk.@MAUI_PREVIOUS_DOTNET_TFM@",
+          "Microsoft.Maui.Sdk.net@MAUI_DOTNET_VERSION_MAJOR@",
+          "Microsoft.Maui.Sdk.net@MAUI_PREVIOUS_DOTNET_VERSION_MAJOR@",
           "Microsoft.Maui.Graphics",
           "Microsoft.Maui.Resizetizer.Sdk",
-          "Microsoft.Maui.Templates-@MAUI_PREVIOUS_DOTNET_VERSION@",
-          "Microsoft.Maui.Templates-@MAUI_DOTNET_VERSION@",
+          "Microsoft.Maui.Templates.net@MAUI_DOTNET_VERSION_MAJOR@",
+          "Microsoft.Maui.Templates.net@MAUI_PREVIOUS_DOTNET_VERSION_MAJOR@",
           "Microsoft.Maui.Core.Ref.any",
           "Microsoft.Maui.Core.Runtime.any",
           "Microsoft.Maui.Controls.Ref.any",
@@ -279,14 +279,14 @@
       "kind": "library",
       "version": "@MAUI_GRAPHICS_VERSION@"
     },
-    "Microsoft.Maui.Sdk.@MAUI_DOTNET_TFM@": {
+    "Microsoft.Maui.Sdk.net@MAUI_DOTNET_VERSION_MAJOR@": {
       "kind": "sdk",
       "version": "@VERSION@",
       "alias-to": {
         "any": "Microsoft.Maui.Sdk"
       }
     },
-    "Microsoft.Maui.Sdk.@MAUI_PREVIOUS_DOTNET_TFM@": {
+    "Microsoft.Maui.Sdk.net@MAUI_PREVIOUS_DOTNET_VERSION_MAJOR@": {
       "kind": "sdk",
       "version": "@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@",
       "alias-to": {
@@ -297,11 +297,11 @@
       "kind": "sdk",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Templates-@MAUI_DOTNET_VERSION@": {
+    "Microsoft.Maui.Templates.net@MAUI_DOTNET_VERSION_MAJOR@": {
       "kind": "template",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Templates-@MAUI_PREVIOUS_DOTNET_VERSION@": {
+    "Microsoft.Maui.Templates.net@MAUI_PREVIOUS_DOTNET_VERSION_MAJOR@": {
       "kind": "template",
       "version": "@MAUI_PREVIOUS_DOTNET_RELEASED_NUGET_VERSION@"
     }

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
@@ -7,11 +7,11 @@
 
   <Import
       Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true') and ($([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@'))) "
-      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk.@MAUI_DOTNET_TFM@"
+      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk.net@MAUI_DOTNET_VERSION_MAJOR@"
   />
   <Import
       Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true') and ($([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_PREVIOUS_DOTNET_VERSION@'))) "
-      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk.@MAUI_PREVIOUS_DOTNET_TFM@"
+      Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk.net@MAUI_PREVIOUS_DOTNET_VERSION_MAJOR@"
   />
 
   <Import


### PR DESCRIPTION
Improve naming consistency across products by renaming SDK and template
pack and alias suffixes to `.net7` instead of `.net7.0`.