### PR TITLE
[workload] Improve pack name suffix consistency

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -22,6 +22,6 @@
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />
     <ComponentResources Include="maui-windows"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Windows" Description=".NET SDK Workload for building MAUI applications that target Windows." />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Maui.Manifest*.nupkg" Version="@VS_COMPONENT_VERSION@" />
-    <MultiTargetPackNames Include="Microsoft.Maui.Sdk" />
+    <MultiTargetPackNames Include="Microsoft.Maui.Sdk;Microsoft.Maui.Templates" />
   </ItemGroup>
 </Project>

--- a/src/Templates/src/Microsoft.Maui.Templates.csproj
+++ b/src/Templates/src/Microsoft.Maui.Templates.csproj
@@ -31,7 +31,7 @@
   <PropertyGroup>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
     <PackageType>Template</PackageType>
-    <PackageId>Microsoft.Maui.Templates-$(_MauiDotNetVersion)</PackageId>
+    <PackageId>Microsoft.Maui.Templates.net$(_MauiDotNetVersionMajor)</PackageId>
     <Title>.NET MAUI Templates</Title>
     <Authors>Microsoft</Authors>
     <Description>Templates for .NET MAUI.</Description>

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -32,7 +32,7 @@
           "Microsoft.Maui.Extensions",
           "Microsoft.Maui.Graphics",
           "Microsoft.Maui.Resizetizer.Sdk",
-          "Microsoft.Maui.Templates-@MAUI_DOTNET_VERSION@",
+          "Microsoft.Maui.Templates.net6",
           "Microsoft.Maui.Core.Ref.any",
           "Microsoft.Maui.Core.Runtime.any",
           "Microsoft.Maui.Controls.Ref.any",
@@ -298,7 +298,7 @@
       "kind": "sdk",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Templates-@MAUI_DOTNET_VERSION@": {
+    "Microsoft.Maui.Templates.net6": {
       "kind": "template",
       "version": "@VERSION@"
     }


### PR DESCRIPTION
Improve naming consistency across products by renaming the template
pack suffix to .net6 instead of -net6.0.