### PR TITLE
Bump AspNet.Security.OAuth.Apple to 6.0.10

### DIFF
--- a/src/Essentials/samples/Sample.Server.WebAuthenticator/Essentials.Sample.Server.WebAuthenticator.csproj
+++ b/src/Essentials/samples/Sample.Server.WebAuthenticator/Essentials.Sample.Server.WebAuthenticator.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.Apple" Version="6.0.4" />
+    <PackageReference Include="AspNet.Security.OAuth.Apple" Version="6.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" />


### PR DESCRIPTION
### Description of Change

Bump AspNet.Security.OAuth.Apple to 6.0.10 in the WebAuthenticator sample to resolve https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/security/advisories/GHSA-3893-h8qg-6h5f.
