### PR TITLE
[Android] Fix crash using a Name in a GradientStop

### DIFF
--- a/src/Controls/src/Core/GradientStop.cs
+++ b/src/Controls/src/Core/GradientStop.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/GradientStop.xml" path="//Member[@MemberName='GetHashCode']/Docs" />
 		public override int GetHashCode()
 		{
-			return -1234567890 + Color.GetHashCode();
+			return -1234567890 + (Color?.GetHashCode() ?? 0);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
@@ -87,5 +87,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.AreSame(parent, parent.Background.Parent);
 			Assert.AreSame(context, parent.Background.BindingContext);
 		}
+
+		[Test]
+		public void TestGetGradientStopHashCode()
+		{
+			var gradientStop = new GradientStop();
+			var hashCode = gradientStop.GetHashCode();
+			Assert.NotNull(hashCode);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Fix crash using a Name in a GradientStop.

### Issues Fixed

Fixes #9841 