### PR TITLE
Remove SplitDrawable from Shell code

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -291,13 +291,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				color = Color.FromArgb("#03A9F4").ToPlatform();
 			}
-
-			if (!(decorView.Background is SplitDrawable splitDrawable) ||
-				splitDrawable.Color != color || splitDrawable.TopSize != statusBarHeight || splitDrawable.BottomSize != navigationBarHeight)
-			{
-				var split = new SplitDrawable(color, statusBarHeight, navigationBarHeight);
-				decorView.SetBackground(split);
-			}
 		}
 
 		bool IViewHandler.HasContainer { get => false; set { } }
@@ -371,48 +364,5 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			_disposed = true;
 		}
-
-		class SplitDrawable : Drawable
-		{
-			public int BottomSize { get; }
-			public AColor Color { get; }
-			public int TopSize { get; }
-
-			public SplitDrawable(AColor color, int topSize, int bottomSize)
-			{
-				Color = color;
-				BottomSize = bottomSize;
-				TopSize = topSize;
-			}
-
-			public override int Opacity => (int)Format.Opaque;
-
-			public override void Draw(Canvas canvas)
-			{
-				var bounds = Bounds;
-
-				using (var paint = new Paint())
-				{
-#pragma warning disable CA1416 // https://github.com/xamarin/xamarin-android/issues/6962
-					paint.Color = Color;
-#pragma warning restore CA1416
-
-					canvas.DrawRect(new ARect(0, 0, bounds.Right, TopSize), paint);
-
-					canvas.DrawRect(new ARect(0, bounds.Bottom - BottomSize, bounds.Right, bounds.Bottom), paint);
-
-					paint.Dispose();
-				}
-			}
-
-			public override void SetAlpha(int alpha)
-			{
-			}
-
-			public override void SetColorFilter(ColorFilter colorFilter)
-			{
-			}
-		}
-
 	}
 }

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellRenderer.cs
@@ -85,7 +85,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
-			UpdateStatusBarColor(appearance);
 		}
 
 		#endregion IAppearanceObserver
@@ -267,30 +266,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		int MakeMeasureSpec(int size, MeasureSpecMode mode)
 		{
 			return size + (int)mode;
-		}
-
-		void UpdateStatusBarColor(ShellAppearance appearance)
-		{
-			var activity = AndroidContext.GetActivity();
-			var window = activity?.Window;
-			var decorView = window?.DecorView;
-
-			int statusBarHeight = AndroidContext.GetStatusBarHeight();
-			int navigationBarHeight = AndroidContext.GetNavigationBarHeight();
-
-			// we are using the split drawable here to avoid GPU overdraw.
-			// All it really is is a drawable that only draws under the statusbar/bottom bar to make sure
-			// we dont draw over areas we dont need to. This has very limited benefits considering its
-			// only saving us a flat color fill BUT it helps people not freak out about overdraw.
-			AColor color;
-			if (appearance != null)
-			{
-				color = appearance.BackgroundColor.ToPlatform(Color.FromArgb("#03A9F4"));
-			}
-			else
-			{
-				color = Color.FromArgb("#03A9F4").ToPlatform();
-			}
 		}
 
 		bool IViewHandler.HasContainer { get => false; set { } }

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Maui.DeviceTests
 			return (AView)viewHandler.PlatformView;
 		}
 
-		static Drawable _decorDrawable;
 		Task SetupWindowForTests<THandler>(IWindow window, Func<Task> runTests, IMauiContext mauiContext = null)
 			where THandler : class, IElementHandler
 		{
@@ -46,7 +45,6 @@ namespace Microsoft.Maui.DeviceTests
 			return InvokeOnMainThreadAsync(async () =>
 			{
 				AViewGroup rootView = MauiContext.Context.GetActivity().Window.DecorView as AViewGroup;
-				_decorDrawable ??= rootView.Background;
 				var linearLayoutCompat = new LinearLayoutCompat(MauiContext.Context);
 				var fragmentManager = MauiContext.GetFragmentManager();
 				var viewFragment = new WindowTestFragment(MauiContext, window);
@@ -83,10 +81,6 @@ namespace Microsoft.Maui.DeviceTests
 						await viewFragment.View.OnUnloadedAsync();
 
 					await viewFragment.FinishedDestroying;
-
-					// This is mainly to remove changes to the decor view that shell imposes
-					if (_decorDrawable != rootView.Background)
-						rootView.Background = _decorDrawable;
 
 					// Unset the Support Action bar if the calling code has set the support action bar
 					if (MauiContext.Context.GetActivity() is AppCompatActivity aca)


### PR DESCRIPTION
### Description of Change

The `SplitDrawable` added to the DecorView can lead to some odd behavior with Shell. As you can see from the modified device tests I have to account for its existence otherwise `Android` starts drawing the surface with a really odd schmear effect and everything breaks. I'm currently fixing up the code to allow for the root page on the window to get swapped out and I'd have to account for adding/removing the `SplitDrawable` when the user switches out of shell. 

Given that even the original comment seems to allude to it only being useful in testing scenarios and not actual scenarios. I'm just going to remove it. 

### Issues Fixed
Fixes #5217
