### PR TITLE
Correctly layout the WebView

### DIFF
--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Handlers
 		internal const string AssetBaseUrl = "file:///android_asset/";
 
 		WebViewClient? _webViewClient;
-		WebChromeClient? _webChromeClient;
+		MauiWebChromeClient? _webChromeClient;
 
 		bool _firstRun = true;
 		readonly HashSet<string> _loadedCookies = new HashSet<string>();

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.Handlers
 		internal const string AssetBaseUrl = "file:///android_asset/";
 
 		WebViewClient? _webViewClient;
-		MauiWebChromeClient? _webChromeClient;
+		WebChromeClient? _webChromeClient;
 
 		bool _firstRun = true;
 		readonly HashSet<string> _loadedCookies = new HashSet<string>();
@@ -25,7 +25,7 @@ namespace Microsoft.Maui.Handlers
 		{
 			var platformView = new MauiWebView(this, Context!)
 			{
-				LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.WrapContent)
+				LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent)
 			};
 
 			platformView.Settings.JavaScriptEnabled = true;


### PR DESCRIPTION
### Description of Change

Correctly layout the WebView without always expanding to fit page contents.

It appears that Xamarin.Forms also used the parameters in this PR:
https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs#L137

### Issues Fixed

- Fixes #9884
- FIxes #9890


### Workaround

A workaround for now is to catch the native view when it is loaded and set the layout parameters for Android:

```xaml
<WebView Source="https://www.youtube.com/watch?v=LXZfrnBasNU" Loaded="WebView_Loaded" />
```

```cs
private void WebView_Loaded(object sender, EventArgs e)
{
#if ANDROID
    var view = sender as WebView;
    var handler = view.Handler;
    var webview = handler?.PlatformView as Android.Webkit.WebView;
    if (webview is not null)
    {
        webview.LayoutParameters = new(
            Android.Views.ViewGroup.LayoutParams.MatchParent,
            Android.Views.ViewGroup.LayoutParams.MatchParent);

    }
#endif
```