### PR TITLE
[Windows] Fixes DatePicker format

### DIFF
--- a/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Platform
 				var day = format.Count(x => x == 'd');
 
 				if (day == 3)
-					return "{dayofweek.abbreviated}";
+					return "{day.integer} {dayofweek.abbreviated}";
 				else if (day == 4)
 					return "{dayofweek.full}";
 				else

--- a/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
@@ -84,11 +84,11 @@ namespace Microsoft.Maui.Platform
 				var day = format.Count(x => x == 'd');
 
 				if (day == 3)
-					return "{day dayofweek.abbreviated}";
+					return "{dayofweek.abbreviated}";
 				else if (day == 4)
 					return "{dayofweek.full}";
 				else
-					return "{day.integer}";
+					return $"{{day.integer({day})}}";
 			}
 		}
 
@@ -112,10 +112,10 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				var month = format.Count(x => x == 'M');
+				var month = format.Count(x => string.Equals(new string(new char[] { x }), "M", StringComparison.OrdinalIgnoreCase));
 
 				if (month <= 2)
-					return "{month.integer}";
+					return $"{{month.integer({month})}}";
 				else if (month == 3)
 					return "{month.abbreviated}";
 				else

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.cs
@@ -67,6 +67,26 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.PlatformViewValue);
 		}
 
+		async protected Task ValidatePropertyInitValue<TValue>(
+			IView view,
+			Func<TValue> GetValue,
+			Func<THandler, TValue> GetPlatformValue,
+			TValue expectedValue,
+			TValue expectedPlatformValue)
+		{
+			var values = await GetValueAsync(view, (handler) =>
+			{
+				return new
+				{
+					ViewValue = GetValue(),
+					PlatformViewValue = GetPlatformValue(handler)
+				};
+			});
+
+			Assert.Equal(expectedValue, values.ViewValue);
+			Assert.Equal(expectedPlatformValue, values.PlatformViewValue);
+		}
+
 		async protected Task ValidatePropertyUpdatesValue<TValue>(
 			IView view,
 			string property,

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Windows.cs
@@ -1,13 +1,37 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.UI.Xaml.Controls;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class DatePickerHandlerTests
 	{
+		[Theory(DisplayName = "Format Initializes Correctly")]
+		[InlineData("dd/MM/yyyy", "{day.integer(2)}/{month.integer(2)}/{year.full}")]
+		[InlineData("d/M/yy", "{day.integer}/{month.integer(1)}/{year.abbreviated}")]
+		[InlineData("ddd/MMM/yyyy", "{dayofweek.abbreviated}/{month.abbreviated}/{year.full}")]
+		[InlineData("dddd/MMMM/yyyy", "{dayofweek.full}/{month.full}/{year.full}")]
+		public async Task FormatInitializesCorrectly(string format, string nativeFormat)
+		{
+			var datePicker = new DatePickerStub();
+
+			datePicker.Date = DateTime.Today;
+			datePicker.Format = format;
+
+			await ValidatePropertyInitValue(datePicker, () => datePicker.Format, GetNativeFormat, format, nativeFormat);
+		}
+
 		CalendarDatePicker GetNativeDatePicker(DatePickerHandler datePickerHandler) =>
 			datePickerHandler.PlatformView;
+
+		string GetNativeFormat(DatePickerHandler datePickerHandler)
+		{
+			var plaformDatePicker = GetNativeDatePicker(datePickerHandler);
+			return plaformDatePicker.DateFormat;
+		}
 
 		DateTime GetNativeDate(DatePickerHandler datePickerHandler)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/DatePicker/DatePickerHandlerTests.Windows.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests
 		[Theory(DisplayName = "Format Initializes Correctly")]
 		[InlineData("dd/MM/yyyy", "{day.integer(2)}/{month.integer(2)}/{year.full}")]
 		[InlineData("d/M/yy", "{day.integer}/{month.integer(1)}/{year.abbreviated}")]
-		[InlineData("ddd/MMM/yyyy", "{dayofweek.abbreviated}/{month.abbreviated}/{year.full}")]
+		[InlineData("ddd/MMM/yyyy", "{day.integer} {dayofweek.abbreviated}/{month.abbreviated}/{year.full}")]
 		[InlineData("dddd/MMMM/yyyy", "{dayofweek.full}/{month.full}/{year.full}")]
 		public async Task FormatInitializesCorrectly(string format, string nativeFormat)
 		{


### PR DESCRIPTION
### Description of Change
Fixes DatePicker format on Windows to show days and months using 1 or 2 digits.

Also fixes a related bug to format correctly the abbreviated day 

### Issues Fixed
Fixes #9255

