### PR TITLE
Merge compiler warning fix from main/net7.0

### DIFF
--- a/src/Compatibility/Core/src/Android/ResourceManager.cs
+++ b/src/Compatibility/Core/src/Android/ResourceManager.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 
 		static Assembly _assembly;
 		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Resource.designer.cs is in the root application assembly, which should be preserved.")]
+		[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "Resource.designer.cs may be linked away, so don't worry if there are missing things.")]
 		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
 		static Type FindType(string name, string altName)
 		{


### PR DESCRIPTION
### Description of Change

This is a new warning in the new compiler that will appear in cross-compiling. Might as well fix it now.