### PR TITLE
First load absolute image paths before trying drawables

### DIFF
--- a/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.Android.cs
+++ b/src/Core/src/ImageSources/FileImageSourceService/FileImageSourceService.Android.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Android.Content;
@@ -16,26 +17,29 @@ namespace Microsoft.Maui
 
 			if (!fileImageSource.IsEmpty)
 			{
-				var callback = new ImageLoaderCallback();
+				var file = fileImageSource.File;
 
 				try
 				{
-					var id = imageView.Context?.GetDrawableId(fileImageSource.File) ?? -1;
-					if (id > 0)
+					if (!Path.IsPathRooted(file) || !File.Exists(file))
 					{
-						imageView.SetImageResource(id);
-						return Task.FromResult<IImageSourceServiceResult?>(new ImageSourceServiceLoadResult());
+						var id = imageView.Context?.GetDrawableId(file) ?? -1;
+						if (id > 0)
+						{
+							imageView.SetImageResource(id);
+							return Task.FromResult<IImageSourceServiceResult?>(new ImageSourceServiceLoadResult());
+						}
 					}
-					else
-					{
-						PlatformInterop.LoadImageFromFile(imageView, fileImageSource.File, callback);
-					}
+
+					var callback = new ImageLoaderCallback();
+
+					PlatformInterop.LoadImageFromFile(imageView, file, callback);
 
 					return callback.Result;
 				}
 				catch (Exception ex)
 				{
-					Logger?.LogWarning(ex, "Unable to load image file '{File}'.", fileImageSource.File);
+					Logger?.LogWarning(ex, "Unable to load image file '{File}'.", file);
 					throw;
 				}
 			}
@@ -48,25 +52,30 @@ namespace Microsoft.Maui
 			var fileImageSource = (IFileImageSource)imageSource;
 			if (!fileImageSource.IsEmpty)
 			{
+				var file = fileImageSource.File;
+
 				try
 				{
-					var id = context?.GetDrawableId(fileImageSource.File) ?? -1;
-					if (id > 0)
+					if (!Path.IsPathRooted(file) || !File.Exists(file))
 					{
-						var d = context?.GetDrawable(id);
-						if (d is not null)
-							return Task.FromResult<IImageSourceServiceResult<Drawable>?>(new ImageSourceServiceResult(d));
+						var id = context?.GetDrawableId(file) ?? -1;
+						if (id > 0)
+						{
+							var d = context?.GetDrawable(id);
+							if (d is not null)
+								return Task.FromResult<IImageSourceServiceResult<Drawable>?>(new ImageSourceServiceResult(d));
+						}
 					}
 
-					var drawableCallback = new ImageLoaderResultCallback();
+					var callback = new ImageLoaderResultCallback();
 
-					PlatformInterop.LoadImageFromFile(context, fileImageSource.File, drawableCallback);
+					PlatformInterop.LoadImageFromFile(context, file, callback);
 
-					return drawableCallback.Result;
+					return callback.Result;
 				}
 				catch (Exception ex)
 				{
-					Logger?.LogWarning(ex, "Unable to load image file '{File}'.", fileImageSource.File);
+					Logger?.LogWarning(ex, "Unable to load image file '{File}'.", file);
 					throw;
 				}
 			}

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.Android.cs
@@ -41,6 +41,34 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Theory]
+		[InlineData("#FF0000")]
+		[InlineData("#00FF00")]
+		[InlineData("#000000")]
+		public async Task LoadDrawableAsyncWithFileLoadsFileInsteadOfResource(string colorHex)
+		{
+			var expectedColor = Color.FromArgb(colorHex);
+
+			var service = new FileImageSourceService();
+
+			var filename = BaseImageSourceServiceTests.CreateBitmapFile(100, 100, expectedColor, "blue.png");
+			var imageSource = new FileImageSourceStub(filename);
+
+			var image = new TStub();
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler<TImageHandler>(image);
+
+				await handler.PlatformView.AttachAndRun(async () =>
+				{
+					var result = await service.LoadDrawableAsync(imageSource, handler.PlatformView);
+
+					await handler.PlatformView.AssertColorAtCenter(expectedColor.ToPlatform());
+				});
+			});
+		}
+
 		ImageView GetPlatformImageView(IImageHandler imageHandler) =>
 			imageHandler.PlatformView;
 

--- a/src/Core/tests/DeviceTests/Services/ImageSource/BaseImageSourceServiceTests.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/BaseImageSourceServiceTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.DeviceTests
 			this IImageSourceService service,
 			IImageSource imageSource,
 			CancellationToken cancellationToken = default) =>
-			service.GetDrawableAsync(imageSource, cancellationToken: cancellationToken);
+			service.GetImageSourceAsync(imageSource, cancellationToken: cancellationToken);
 #endif
 	}
 }

--- a/src/Core/tests/DeviceTests/Services/ImageSource/BaseImageSourceServiceTests.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/BaseImageSourceServiceTests.cs
@@ -1,7 +1,27 @@
+using System.Threading.Tasks;
+using System.Threading;
+
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.ImageSource)]
 	public abstract partial class BaseImageSourceServiceTests : TestBase
 	{
+	}
+
+	public static class ImageSourceServiceExtensions
+	{
+#if __ANDROID__
+		public static Task<IImageSourceServiceResult<Android.Graphics.Drawables.Drawable>> GetImageAsync(
+			this IImageSourceService service,
+			IImageSource imageSource,
+			CancellationToken cancellationToken = default) =>
+			service.GetDrawableAsync(imageSource, MauiProgram.DefaultContext, cancellationToken);
+#elif WINDOWS
+		public static Task<IImageSourceServiceResult<UI.Xaml.Media.ImageSource>> GetImageAsync(
+			this IImageSourceService service,
+			IImageSource imageSource,
+			CancellationToken cancellationToken = default) =>
+			service.GetDrawableAsync(imageSource, cancellationToken: cancellationToken);
+#endif
 	}
 }

--- a/src/Core/tests/DeviceTests/Services/ImageSource/FileImageSourceServiceTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/FileImageSourceServiceTests.Android.cs
@@ -1,58 +1,6 @@
-using System;
-using System.Threading.Tasks;
-using Microsoft.Maui.DeviceTests.Stubs;
-using Xunit;
-using Color = Microsoft.Maui.Graphics.Color;
-
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class FileImageSourceServiceTests
 	{
-		[Theory]
-		[InlineData(typeof(FontImageSourceStub))]
-		[InlineData(typeof(StreamImageSourceStub))]
-		[InlineData(typeof(UriImageSourceStub))]
-		public async Task ThrowsForIncorrectTypes(Type type)
-		{
-			var service = new FileImageSourceService();
-
-			var imageSource = (ImageSourceStub)Activator.CreateInstance(type);
-
-			await Assert.ThrowsAsync<InvalidCastException>(() => service.GetDrawableAsync(imageSource, MauiProgram.DefaultContext));
-		}
-
-		[Theory]
-		[InlineData("red.png", "#FF0000")]
-		[InlineData("green.png", "#00FF00")]
-		[InlineData("black.png", "#000000")]
-		public async Task GetDrawableAsyncWithResource(string filename, string colorHex)
-		{
-			var service = new FileImageSourceService();
-
-			var imageSource = new FileImageSourceStub(filename);
-
-			using var result = await service.GetDrawableAsync(imageSource, MauiProgram.DefaultContext);
-
-			var expectedColor = Color.FromArgb(colorHex);
-			result.Value.AssertColorAtCenter(expectedColor.ToPlatform());
-		}
-
-		[Theory]
-		[InlineData("#FF0000")]
-		[InlineData("#00FF00")]
-		[InlineData("#000000")]
-		public async Task GetDrawableAsyncWithFile(string colorHex)
-		{
-			var expectedColor = Color.FromArgb(colorHex);
-
-			var service = new FileImageSourceService();
-
-			var filename = CreateBitmapFile(100, 100, expectedColor);
-			var imageSource = new FileImageSourceStub(filename);
-
-			using var result = await service.GetDrawableAsync(imageSource, MauiProgram.DefaultContext);
-
-			result.Value.AssertColorAtCenter(expectedColor.ToPlatform());
-		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Services/ImageSource/FileImageSourceServiceTests.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/FileImageSourceServiceTests.cs
@@ -1,7 +1,82 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Xunit;
+
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.ImageSource)]
 	public partial class FileImageSourceServiceTests : BaseImageSourceServiceTests
 	{
+#if ANDROID || IOS || MACCATALYST
+		[Theory]
+		[InlineData(typeof(FontImageSourceStub))]
+		[InlineData(typeof(StreamImageSourceStub))]
+		[InlineData(typeof(UriImageSourceStub))]
+		public async Task ThrowsForIncorrectTypes(Type type)
+		{
+			var service = new FileImageSourceService();
+
+			var imageSource = (ImageSourceStub)Activator.CreateInstance(type);
+
+			await Assert.ThrowsAsync<InvalidCastException>(() => service.GetImageAsync(imageSource));
+		}
+
+		[Theory]
+		[InlineData("red.png", "#FF0000")]
+		[InlineData("green.png", "#00FF00")]
+		[InlineData("black.png", "#000000")]
+		public async Task GetImageAsyncWithResource(string filename, string colorHex)
+		{
+			var expectedColor = Color.FromArgb(colorHex);
+
+			var service = new FileImageSourceService();
+
+			var imageSource = new FileImageSourceStub(filename);
+
+			using var result = await service.GetImageAsync(imageSource);
+			var image = result.Value;
+
+			image.AssertColorAtCenter(expectedColor.ToPlatform());
+		}
+
+		[Theory]
+		[InlineData("#FF0000")]
+		[InlineData("#00FF00")]
+		[InlineData("#000000")]
+		public async Task GetImageAsyncWithFile(string colorHex)
+		{
+			var expectedColor = Color.FromArgb(colorHex);
+
+			var service = new FileImageSourceService();
+
+			var filename = CreateBitmapFile(100, 100, expectedColor);
+			var imageSource = new FileImageSourceStub(filename);
+
+			using var result = await service.GetImageAsync(imageSource);
+			var image = result.Value;
+
+			image.AssertColorAtCenter(expectedColor.ToPlatform());
+		}
+
+		[Theory]
+		[InlineData("#FF0000")]
+		[InlineData("#00FF00")]
+		[InlineData("#000000")]
+		public async Task GetImageAsyncWithFileLoadsFileInsteadOfResource(string colorHex)
+		{
+			var expectedColor = Color.FromArgb(colorHex);
+
+			var service = new FileImageSourceService();
+
+			var filename = CreateBitmapFile(100, 100, expectedColor, "blue.png");
+			var imageSource = new FileImageSourceStub(filename);
+
+			using var result = await service.GetImageAsync(imageSource);
+			var image = result.Value;
+
+			image.AssertColorAtCenter(expectedColor.ToPlatform());
+		}
+#endif
 	}
 }

--- a/src/Core/tests/DeviceTests/Services/ImageSource/FileImageSourceServiceTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Services/ImageSource/FileImageSourceServiceTests.iOS.cs
@@ -1,64 +1,6 @@
-using System;
-using System.Threading.Tasks;
-using Microsoft.Maui.DeviceTests.Stubs;
-using Microsoft.Maui.Graphics;
-using ObjCRuntime;
-using UIKit;
-using Xunit;
-
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class FileImageSourceServiceTests
 	{
-		[Theory]
-		[InlineData(typeof(FontImageSourceStub))]
-		[InlineData(typeof(StreamImageSourceStub))]
-		[InlineData(typeof(UriImageSourceStub))]
-		public async Task ThrowsForIncorrectTypes(Type type)
-		{
-			var service = new FileImageSourceService();
-
-			var imageSource = (ImageSourceStub)Activator.CreateInstance(type);
-
-			await Assert.ThrowsAsync<InvalidCastException>(() => service.GetImageAsync(imageSource));
-		}
-
-		[Theory]
-		[InlineData("red.png", "#FF0000")]
-		[InlineData("green.png", "#00FF00")]
-		[InlineData("black.png", "#000000")]
-		public async Task GetImageAsyncWithResource(string filename, string colorHex)
-		{
-			var service = new FileImageSourceService();
-
-			var imageSource = new FileImageSourceStub(filename);
-
-			using var result = await service.GetImageAsync(imageSource);
-
-			var uiimage = Assert.IsType<UIImage>(result.Value);
-
-			var expectedColor = Color.FromArgb(colorHex);
-			uiimage.AssertColorAtCenter(expectedColor.ToPlatform());
-		}
-
-		[Theory]
-		[InlineData("#FF0000")]
-		[InlineData("#00FF00")]
-		[InlineData("#000000")]
-		public async Task GetImageAsyncWithFile(string colorHex)
-		{
-			var expectedColor = Color.FromArgb(colorHex);
-
-			var service = new FileImageSourceService();
-
-			var filename = CreateBitmapFile(100, 100, expectedColor);
-			var imageSource = new FileImageSourceStub(filename);
-
-			using var drawable = await service.GetImageAsync(imageSource);
-
-			var uiimage = Assert.IsType<UIImage>(drawable.Value);
-
-			uiimage.AssertColorAtCenter(expectedColor.ToPlatform());
-		}
 	}
 }


### PR DESCRIPTION
### Description of Change

First load absolute image paths before trying drawable IDs. If there is no full path, then the drawables are probably correct. But, if there is a full path, always try that first as there may be a matching drawable with the same name.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #9883

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
