### PR TITLE
[Android] Fix crash opening Shell app via notification tray

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -578,7 +578,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		void OnToolbarPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (_toolbar != null && ShellContext.Shell.CurrentPage == Page)
+			if (_toolbar != null && ShellContext?.Shell?.CurrentPage == Page)
 			{
 				ApplyToolbarChanges((Toolbar)sender, (Toolbar)_toolbar);
 				UpdateToolbarIconAccessibilityText(_platformToolbar, ShellContext.Shell);


### PR DESCRIPTION
### Description of Change

Fix crash opening Shell app via notification tray.

![fix-9090](https://user-images.githubusercontent.com/6755973/188572264-d3682447-a3bf-41e9-aa59-d5c5a362aebb.gif)

### Issues Fixed

Fixes #9090
