### PR TITLE
Fix root page swapping

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellContentFragment.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellContentFragment.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 		AToolbar _toolbar;
 		IShellToolbarTracker _toolbarTracker;
 		bool _disposed;
-		IMauiContext MauiContext => _shellContext.Shell.Handler.MauiContext;
 
 		public ShellContentFragment(IShellContext shellContext, ShellContent shellContent)
 		{
@@ -133,7 +132,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			_root = inflater.Inflate(Controls.Resource.Layout.shellcontent, null).JavaCast<CoordinatorLayout>();
 
-			var shellContentMauiContext = MauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
+			var shellContentMauiContext = _shellContext.Shell.Handler.MauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager);
 
 			Maui.IElement parentElement = (_shellContent as Maui.IElement) ?? _page;
 			var shellToolbar = new Toolbar(parentElement);

--- a/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Maui.Controls
 				// Unset styles set by parent NavigationView
 				_navigationView.SetApplicationResource("NavigationViewMinimalHeaderMargin", null);
 				_navigationView.SetApplicationResource("NavigationViewHeaderMargin", null);
+				_navigationView.SetApplicationResource("NavigationViewContentMargin", null);
 
 				return _navigationView;
 			}

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			_mauiNavigationView = platformView;
 			platformView.SetApplicationResource("NavigationViewMinimalHeaderMargin", null);
 			platformView.SetApplicationResource("NavigationViewHeaderMargin", null);
+			platformView.SetApplicationResource("NavigationViewContentMargin", null);
 
 			_mauiNavigationView.Loaded += OnNavigationViewLoaded;
 			return platformView;

--- a/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void TestGetGradientStopHashCode()
 		{
 			var gradientStop = new GradientStop();
-			var hashCode = gradientStop.GetHashCode();
-			Assert.NotNull(hashCode);
+			_ = gradientStop.GetHashCode();
+			// This test is just validating that calling `GetHashCode` doesn't throw
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowPageSwapTestCases.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowPageSwapTestCases.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public class WindowPageSwapTestCases : IEnumerable<object[]>
+	{
+		private readonly List<object[]> _data = new()
+		{
+			new object[] { new WindowPageSwapTestCase(typeof(TabbedPage), typeof(Shell), typeof(FlyoutPage)) },
+			new object[] { new WindowPageSwapTestCase(typeof(Shell), typeof(NavigationPage), typeof(FlyoutPage)) },
+			new object[] { new WindowPageSwapTestCase(typeof(NavigationPage), typeof(NavigationPage), typeof(Shell)) },
+		};
+
+		public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+
+	public class WindowPageSwapTestCase : IEqualityComparer<WindowPageSwapTestCase>
+	{
+
+		Type[] _pageCombinations;
+		Page _page;
+		int index = 0;
+
+
+		public WindowPageSwapTestCase(params Type[] pageCombinations)
+		{
+			_pageCombinations = pageCombinations;
+		}
+
+		public bool IsFinished() => index >= _pageCombinations.Length;
+
+		public Page GetNextPageType()
+		{
+			if (IsFinished())
+				return null;
+
+			var result = _pageCombinations[index];
+			index++;
+
+			Page returnValue = null;
+			if (result == typeof(ContentPage))
+				returnValue = _page;
+			else if (result == typeof(FlyoutPage))
+			{
+				_page.Title ??= "Details Page";
+				returnValue = new FlyoutPage()
+				{
+					Detail = _page,
+					Flyout = new ContentPage() { Title = "Flyout" }
+				};
+			}
+			else if (result == typeof(TabbedPage))
+			{
+				returnValue = new TabbedPage()
+				{
+					Children =
+					{
+						_page
+					}
+				};
+			}
+			else if (result == typeof(NavigationPage))
+			{
+				returnValue = new NavigationPage(_page);
+			}
+			else if (result == typeof(Shell))
+			{
+				returnValue = new Shell() { CurrentItem = (_page as ContentPage) };
+			}
+
+			_page = null;
+			return returnValue;
+		}
+
+		public void SetPageContent(Page page)
+		{
+			_page = page;
+		}
+
+		public override string ToString()
+		{
+			String debugName = String.Empty;
+
+			foreach (var type in _pageCombinations)
+			{
+				if (!String.IsNullOrWhiteSpace(debugName))
+					debugName += ", ";
+
+				debugName += $"{type}";
+			}
+
+			return debugName;
+		}
+
+		public bool Equals(WindowPageSwapTestCase x, WindowPageSwapTestCase y)
+		{
+			return Object.ReferenceEquals(x, y);
+		}
+
+		public int GetHashCode([DisallowNull] WindowPageSwapTestCase obj)
+		{
+			return obj.GetHashCode();
+		}
+	}
+
+}

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowPageSwapTestCases.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowPageSwapTestCases.cs
@@ -86,10 +86,18 @@ namespace Microsoft.Maui.DeviceTests
 			var labelToTest = new Label();
 			var contentToTest = new ContentPage()
 			{
-				Content = new VerticalStackLayout()
+				Title = "title",
+				ToolbarItems =
+				{
+					new ToolbarItem()
 					{
-						labelToTest
+						Text = "Item"
 					}
+				},
+				Content = new VerticalStackLayout()
+				{
+					labelToTest
+				}
 			};
 
 			return contentToTest;

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowPageSwapTestCases.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowPageSwapTestCases.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Maui.DeviceTests
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
 
-	public class WindowPageSwapTestCase : IEqualityComparer<WindowPageSwapTestCase>
+	public class WindowPageSwapTestCase
 	{
 
 		Type[] _pageCombinations;
-		Page _page;
+		public ContentPage Page { get; private set; }
 		int index = 0;
 
 
@@ -46,15 +46,16 @@ namespace Microsoft.Maui.DeviceTests
 			var result = _pageCombinations[index];
 			index++;
 
+			Page = CreateNewPage();
 			Page returnValue = null;
 			if (result == typeof(ContentPage))
-				returnValue = _page;
+				returnValue = Page;
 			else if (result == typeof(FlyoutPage))
 			{
-				_page.Title ??= "Details Page";
+				Page.Title ??= "Details Page";
 				returnValue = new FlyoutPage()
 				{
-					Detail = _page,
+					Detail = Page,
 					Flyout = new ContentPage() { Title = "Flyout" }
 				};
 			}
@@ -64,27 +65,36 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					Children =
 					{
-						_page
+						Page
 					}
 				};
 			}
 			else if (result == typeof(NavigationPage))
 			{
-				returnValue = new NavigationPage(_page);
+				returnValue = new NavigationPage(Page);
 			}
 			else if (result == typeof(Shell))
 			{
-				returnValue = new Shell() { CurrentItem = (_page as ContentPage) };
+				returnValue = new Shell() { CurrentItem = (Page as ContentPage) };
 			}
 
-			_page = null;
 			return returnValue;
 		}
 
-		public void SetPageContent(Page page)
+		ContentPage CreateNewPage()
 		{
-			_page = page;
+			var labelToTest = new Label();
+			var contentToTest = new ContentPage()
+			{
+				Content = new VerticalStackLayout()
+					{
+						labelToTest
+					}
+			};
+
+			return contentToTest;
 		}
+
 
 		public override string ToString()
 		{
@@ -99,16 +109,6 @@ namespace Microsoft.Maui.DeviceTests
 			}
 
 			return debugName;
-		}
-
-		public bool Equals(WindowPageSwapTestCase x, WindowPageSwapTestCase y)
-		{
-			return Object.ReferenceEquals(x, y);
-		}
-
-		public int GetHashCode([DisallowNull] WindowPageSwapTestCase obj)
-		{
-			return obj.GetHashCode();
 		}
 	}
 

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -18,11 +18,15 @@ using System;
 using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
 #endif
 
+#if IOS || MACCATALYST
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+#endif
+
 namespace Microsoft.Maui.DeviceTests
 {
 
 	[Category(TestCategory.Window)]
-#if ANDROID
+#if ANDROID || IOS || MACCATALYST
 	[Collection(HandlerTestBase.RunInNewWindowCollection)]
 #endif
 	public partial class WindowTests : HandlerTestBase
@@ -39,9 +43,17 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<Label, LabelHandler>();
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Toolbar, ToolbarHandler>();
+
+#if ANDROID || WINDOWS
 					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#else
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+					handlers.AddHandler(typeof(FlyoutPage), typeof(PhoneFlyoutPageRenderer));
+#endif
+
 #if WINDOWS
 					handlers.AddHandler<ShellItem, ShellItemHandler>();
 					handlers.AddHandler<ShellSection, ShellSectionHandler>();

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -56,48 +56,28 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task MainPageSwapTests(WindowPageSwapTestCase swapOrder)
 		{
 			SetupBuilder();
-			var contentPage = CreateNewPage();
-			swapOrder.SetPageContent(contentPage);
 
 			var firstRootPage = swapOrder.GetNextPageType();
 			var window = new Window(firstRootPage);
 
 			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async (handler) =>
 			{
-				await OnLoadedAsync(contentPage.Content);
+				await OnLoadedAsync(swapOrder.Page);
 				if (!swapOrder.IsFinished())
 				{
-					contentPage = CreateNewPage();
-					swapOrder.SetPageContent(contentPage);
 					var nextRootPage = swapOrder.GetNextPageType();
 					window.Page = nextRootPage;
+
 					try
 					{
-						await OnLoadedAsync(contentPage.Content);
+						await OnLoadedAsync(swapOrder.Page);
 					}
 					catch (Exception exc)
 					{
 						throw new Exception($"Failed to swap to {nextRootPage}", exc);
 					}
-
-					//await Task.Delay(1000);
 				}
 			});
-
-
-			ContentPage CreateNewPage()
-			{
-				var labelToTest = new Label();
-				var contentToTest = new ContentPage()
-				{
-					Content = new VerticalStackLayout()
-					{
-						labelToTest
-					}
-				};
-
-				return contentToTest;
-			}
 		}
 
 #if !IOS && !MACCATALYST

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<WindowHandlerStub>(window, async (handler) =>
 			{
 				await OnLoadedAsync(swapOrder.Page);
-				if (!swapOrder.IsFinished())
+				while (!swapOrder.IsFinished())
 				{
 					var nextRootPage = swapOrder.GetNextPageType();
 					window.Page = nextRootPage;

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -199,12 +199,10 @@ namespace Microsoft.Maui.DeviceTests
 				ScopedMauiContext = _mauiContext.MakeScoped(layoutInflater: inflater, fragmentManager: ChildFragmentManager, registerNewNavigationRoot: true);
 				var handler = (WindowHandlerStub)_window.ToHandler(ScopedMauiContext);
 
-				var decorView = RequireActivity().Window.DecorView;
-				handler.PlatformViewUnderTest.LayoutParameters = new FitWindowsFrameLayout.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent);
-
 				FakeActivityRootView = new FakeActivityRootView(ScopedMauiContext.Context);
 				FakeActivityRootView.LayoutParameters = new LinearLayoutCompat.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent);
 				FakeActivityRootView.AddView(handler.PlatformViewUnderTest);
+				handler.PlatformViewUnderTest.LayoutParameters = new FitWindowsFrameLayout.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent);
 
 				return FakeActivityRootView;
 			}

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -88,6 +88,11 @@ namespace Microsoft.Maui.DeviceTests
 			return (navigationRootManager.RootView as WindowRootView).NavigationViewControl;
 		}
 
+		protected WindowRootView GetWindowRootView(IElementHandler handler)
+		{
+			return handler.MauiContext.GetNavigationRootManager().RootView as WindowRootView;
+		}
+
 		protected MauiNavigationView GetMauiNavigationView(IMauiContext mauiContext)
 		{
 			return GetMauiNavigationView(mauiContext.GetNavigationRootManager());

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.Android.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 			// This is used for cases where we are testing swapping out the page set on window
 			if (PlatformViewUnderTest?.Parent is FakeActivityRootView farw)
 			{
-				var decorView = MauiContext.Context.GetActivity().Window.DecorView;
 				PlatformViewUnderTest.RemoveFromParent();
-				platformView.LayoutParameters = new LinearLayoutCompat.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent);
+
 				farw.AddView(platformView);
+				platformView.LayoutParameters = new FitWindowsFrameLayout.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent);
 			}
 
 			PlatformViewUnderTest = platformView;

--- a/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Stubs/WindowHandlerStub.iOS.cs
@@ -53,19 +53,15 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 			if (view is Shell)
 			{
+				var pvc = platformView?.RootViewController?.PresentedViewController;
 				// This means shell never got to the point of being preesented
-				if (platformView
-					?.RootViewController
-					?.PresentedViewController == null)
+				if (pvc == null)
 				{
 					finishedClosing?.Invoke();
 					return;
 				}
 
-				platformView
-					.RootViewController
-					.PresentedViewController
-					.DismissViewController(false,
+				pvc.DismissViewController(false,
 					() =>
 					{
 						finishedClosing.Invoke();

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Android.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Android.cs
@@ -17,49 +17,58 @@ namespace Microsoft.Maui.Handlers
 
 			var view = li.Inflate(Resource.Layout.fragment_backstack, null).JavaCast<FragmentContainerView>();
 			_ = view ?? throw new InvalidOperationException($"Resource.Layout.navigationlayout view not found");
-
 			return view;
-		}
-
-		public override Graphics.Size GetDesiredSize(double widthConstraint, double heightConstraint)
-		{
-			return base.GetDesiredSize(widthConstraint, heightConstraint);
-		}
-
-		public override void PlatformArrange(Graphics.Rect frame)
-		{
-			base.PlatformArrange(frame);
 		}
 
 		StackNavigationManager CreateNavigationManager()
 		{
 			_ = MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
 			return _stackNavigationManager ??= new StackNavigationManager(MauiContext);
 		}
 
 		protected override void ConnectHandler(View platformView)
 		{
 			base.ConnectHandler(platformView);
+
 			_stackNavigationManager?.Connect(VirtualView);
+
+			platformView.ViewAttachedToWindow += OnViewAttachedToWindow;
+			platformView.ViewDetachedFromWindow += OnViewDetachedFromWindow;
+		}
+
+		void OnViewDetachedFromWindow(object? sender, View.ViewDetachedFromWindowEventArgs e)
+		{
+			PlatformView.LayoutChange -= OnLayoutChanged;
+		}
+
+		void OnViewAttachedToWindow(object? sender, View.ViewAttachedToWindowEventArgs e)
+		{
 			PlatformView.LayoutChange += OnLayoutChanged;
 		}
 
-		void OnLayoutChanged(object? sender, View.LayoutChangeEventArgs e)
-		{
+		void OnLayoutChanged(object? sender, View.LayoutChangeEventArgs e) =>
 			VirtualView.Arrange(e);
+
+		void RequestNavigation(NavigationRequest ea)
+		{
+			_stackNavigationManager?.RequestNavigation(ea);
 		}
 
 		private protected override void OnDisconnectHandler(View platformView)
 		{
+			platformView.ViewAttachedToWindow -= OnViewAttachedToWindow;
+			platformView.ViewDetachedFromWindow -= OnViewDetachedFromWindow;
+			platformView.LayoutChange -= OnLayoutChanged;
+
 			_stackNavigationManager?.Disconnect();
 			base.OnDisconnectHandler(platformView);
-			platformView.LayoutChange -= OnLayoutChanged;
 		}
 
 		public static void RequestNavigation(INavigationViewHandler arg1, IStackNavigation arg2, object? arg3)
 		{
 			if (arg1 is NavigationViewHandler platformHandler && arg3 is NavigationRequest ea)
-				platformHandler._stackNavigationManager?.RequestNavigation(ea);
+				platformHandler.RequestNavigation(ea);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Window/WindowHandler.Android.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Android.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Maui.Handlers
 
 			var rootView = CreateRootViewFromContent(handler, window);
 			handler.PlatformView.SetContentView(rootView);
-			if (window.VisualDiagnosticsOverlay != null && rootView is ViewGroup group)
-				window.VisualDiagnosticsOverlay.Initialize();
 		}
 
 		public static void MapToolbar(IWindowHandler handler, IWindow view)
@@ -31,9 +29,32 @@ namespace Microsoft.Maui.Handlers
 				request.SetResult(handler.PlatformView.GetDisplayDensity());
 		}
 
+		NavigationRootManager? _rootManager;
+		private protected override void OnConnectHandler(object platformView)
+		{
+			base.OnConnectHandler(platformView);
+
+			_rootManager = MauiContext!.GetNavigationRootManager();
+			_rootManager.RootViewChanged += OnRootViewChanged;
+		}
+
+		private protected override void OnDisconnectHandler(object platformView)
+		{
+			base.OnDisconnectHandler(platformView);
+			if (_rootManager != null)
+				_rootManager.RootViewChanged += OnRootViewChanged;
+		}
+
+		void OnRootViewChanged(object? sender, EventArgs e)
+		{
+			if (VirtualView.VisualDiagnosticsOverlay != null && _rootManager?.RootView is ViewGroup)
+				VirtualView.VisualDiagnosticsOverlay.Initialize();
+		}
+
 		internal static View? CreateRootViewFromContent(IWindowHandler handler, IWindow window)
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
+
 			var rootManager = handler.MauiContext.GetNavigationRootManager();
 			rootManager.Connect(window.Content);
 			return rootManager.RootView;

--- a/src/Core/src/Platform/Android/Navigation/ViewFragment.cs
+++ b/src/Core/src/Platform/Android/Navigation/ViewFragment.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Maui.Platform
 	{
 		readonly View _aView;
 
+		/// <summary>
+		/// Do not pass an inflated view into this fragment. This fragment should only be used for very simple views that won't have any
+		/// internal need to use ChildSupportFragmentManager or LayoutInflater.
+		/// </summary>
+		/// <param name="aView"></param>
 		public ViewFragment(View aView)
 		{
 			_aView = aView;

--- a/src/Core/src/Platform/Windows/MauiNavigationView.cs
+++ b/src/Core/src/Platform/Windows/MauiNavigationView.cs
@@ -93,7 +93,6 @@ namespace Microsoft.Maui.Platform
 			PaneHeaderContentBorderRow = (RowDefinition)GetTemplateChild("PaneHeaderContentBorderRow");
 
 			UpdateNavigationBackButtonSize();
-			UpdateNavigationViewContentMargin();
 			UpdateNavigationViewBackButtonMargin();
 			UpdateNavigationViewButtonHolderGridMargin();
 			OnApplyTemplateCore();
@@ -224,29 +223,6 @@ namespace Microsoft.Maui.Platform
 		{
 			if (ButtonHolderGrid != null)
 				ButtonHolderGrid.Margin = NavigationViewButtonHolderGridMargin;
-		}
-		#endregion
-
-		#region NavigationViewContentMargin
-		internal static readonly DependencyProperty NavigationViewContentMarginProperty
-			= DependencyProperty.Register(nameof(NavigationViewContentMargin), typeof(WThickness), typeof(MauiNavigationView),
-				new PropertyMetadata(new WThickness(), OnNavigationViewContentMarginChanged));
-
-		internal WThickness NavigationViewContentMargin
-		{
-			get => (WThickness)GetValue(NavigationViewContentMarginProperty);
-			set => SetValue(NavigationViewContentMarginProperty, value);
-		}
-
-		static void OnNavigationViewContentMarginChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-		{
-			((MauiNavigationView)d).UpdateNavigationViewContentMargin();
-		}
-
-		void UpdateNavigationViewContentMargin()
-		{
-			if (ContentGrid != null)
-				ContentGrid.Margin = NavigationViewContentMargin;
 		}
 		#endregion
 

--- a/src/Core/src/Platform/Windows/RootNavigationView.cs
+++ b/src/Core/src/Platform/Windows/RootNavigationView.cs
@@ -221,7 +221,6 @@ namespace Microsoft.Maui.Platform
 			};
 
 			UpdateToolbarPlacement();
-			UpdateContentGridMargin();
 
 			if (Toolbar != null)
 			{
@@ -234,14 +233,6 @@ namespace Microsoft.Maui.Platform
 		void PaneContentTopPaddingChanged(DependencyObject sender, DependencyProperty dp)
 		{
 			UpdatePaneContentGridMargin();
-		}
-
-		void UpdateContentGridMargin()
-		{
-			if (PaneDisplayMode == NavigationViewPaneDisplayMode.Top)
-				NavigationViewContentMargin = new WThickness(0, 0, 0, 0);
-			else
-				NavigationViewContentMargin = new WThickness(0, AppBarTitleHeight, 0, 0);
 		}
 
 		internal void UpdateAppTitleBar(double appTitleBarHeight)
@@ -297,7 +288,6 @@ namespace Microsoft.Maui.Platform
 
 			UpdatePaneContentGridMargin();
 			UpdateToolbarPlacement();
-			UpdateContentGridMargin();
 		}
 
 		// This updates the amount of space between the top of the window

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Platform
 				new PropertyMetadata(null, OnAppTitleBarTemplateChanged));
 
 		double _appTitleBarHeight;
+		bool _useCustomAppTitleBar;
 		internal event EventHandler? OnAppTitleBarChanged;
 		internal event EventHandler? OnApplyTemplateFinished;
 		internal event EventHandler? ContentChanged;
@@ -101,6 +102,8 @@ namespace Microsoft.Maui.Platform
 
 		internal void UpdateAppTitleBar(Graphics.Rect captionButtonRect, bool useCustomAppTitleBar)
 		{
+			_useCustomAppTitleBar = useCustomAppTitleBar;
+
 			if (AppTitleBarContentControl != null)
 			{
 				AppTitleBarContentControl.MinHeight = captionButtonRect.Height;
@@ -242,7 +245,7 @@ namespace Microsoft.Maui.Platform
 
 				if (_appTitleBarHeight > 0)
 				{
-					NavigationViewControl.UpdateAppTitleBar(_appTitleBarHeight);
+					NavigationViewControl.UpdateAppTitleBar(_appTitleBarHeight, _useCustomAppTitleBar);
 				}
 			}
 

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.Platform
 		{
 		}
 
+		internal double AppTitleBarActualHeight => AppTitleBarContentControl?.ActualHeight ?? 0;
 		internal ContentControl? AppTitleBarContentControl { get; private set; }
 		internal FrameworkElement? AppTitleBarContainer { get; private set; }
 
@@ -173,19 +174,27 @@ namespace Microsoft.Maui.Platform
 			else
 				LoadAppTitleBarControls();
 
-			AppTitleBarContentControl.SizeChanged += (_, __) =>
-			{
-				if (_appTitleBarHeight != AppTitleBarContentControl.ActualHeight)
-				{
-					_appTitleBarHeight = AppTitleBarContentControl.ActualHeight;
-					NavigationViewControl?.UpdateAppTitleBar(_appTitleBarHeight);
-				}
-			};
+			AppTitleBarContentControl.SizeChanged += (_, __) => UpdateAppTitleBarHeight();
 
 			void OnAppTitleBarContentControlLoaded(object sender, RoutedEventArgs e)
 			{
 				LoadAppTitleBarControls();
 				AppTitleBarContentControl.Loaded -= OnAppTitleBarContentControlLoaded;
+			}
+		}
+
+		void UpdateAppTitleBarHeight()
+		{
+			if (AppTitleBarContentControl == null)
+				return;
+
+			if (_appTitleBarHeight != AppTitleBarContentControl.ActualHeight)
+			{
+				_appTitleBarHeight = AppTitleBarContentControl.ActualHeight;
+				NavigationViewControl?.UpdateAppTitleBar(_appTitleBarHeight);
+
+				this.SetApplicationResource("NavigationViewContentMargin", new WThickness(0, _appTitleBarHeight, 0, 0));
+				this.RefreshThemeResources();
 			}
 		}
 
@@ -241,7 +250,6 @@ namespace Microsoft.Maui.Platform
 					NavigationViewControl.UnregisterPropertyChangedCallback(MauiNavigationView.NavigationBackButtonWidthProperty, backButtonWidthToken);
 					NavigationViewControl = null;
 				});
-
 
 				if (_appTitleBarHeight > 0)
 				{

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -108,3 +108,5 @@ Microsoft.Maui.ScrollToRequest.ScrollToRequest(double HorizontalOffset, double V
 *REMOVED*static Microsoft.Maui.IViewExtensions.GetEffectiveFlowDirection(this Microsoft.Maui.IView! view) -> Microsoft.Maui.FlowDirection
 *REMOVED*Microsoft.Maui.IViewExtensions
 *REMOVED*static Microsoft.Maui.Layouts.LayoutExtensions.ShouldArrangeLeftToRight(this Microsoft.Maui.IView! view) -> bool
+*REMOVED*override Microsoft.Maui.Handlers.NavigationViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+*REMOVED*override Microsoft.Maui.Handlers.NavigationViewHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void

--- a/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
@@ -22,7 +22,11 @@ namespace Microsoft.Maui
 			if (Window == null)
 				return false;
 
+			if (Window?.Content?.Handler == null)
+				return false;
+
 			var platformWindow = Window?.Content?.ToPlatform();
+
 			if (platformWindow == null)
 				return false;
 

--- a/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
@@ -19,9 +19,6 @@ namespace Microsoft.Maui
 			if (IsPlatformViewInitialized)
 				return true;
 
-			if (Window == null)
-				return false;
-
 			if (Window?.Content?.Handler == null)
 				return false;
 
@@ -33,6 +30,7 @@ namespace Microsoft.Maui
 			var handler = Window?.Handler as WindowHandler;
 			if (handler?.MauiContext == null)
 				return false;
+
 			var rootManager = handler.MauiContext.GetNavigationRootManager();
 			if (rootManager == null)
 				return false;

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestCaseViewModel.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestCaseViewModel.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.XHarness.TestRunners.Common;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -30,7 +32,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 
 		public string AssemblyFileName { get; }
 
-		public string DisplayName => TestCase.DisplayName;
+		public string DisplayName => TestResult?.TestResultMessage?.Test?.DisplayName ?? TestCase.DisplayName;
 
 		public string? Message
 		{
@@ -70,26 +72,42 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 			private set => Set(ref _testResult, value);
 		}
 
+		// TestCases with strongly typed class data for some reason don't get split into different
+		// test cases by the TheoryDiscoverer.
+		// I've worked around it here for now so that a failed result won't get hidden when using the visual runner
+		Dictionary<string, TestResultViewModel> _testResults = new Dictionary<string, TestResultViewModel>();
+
 		internal void UpdateTestState(TestResultViewModel message)
 		{
+			_testResults[message.TestResultMessage!.Test.DisplayName] = message;
 			TestResult = message;
 
-			Output = message.TestResultMessage?.Output ?? string.Empty;
+			// For now we just want to surface any failing tests up to the visual runner
+			foreach (var result in _testResults)
+			{
+				if (result.Value.TestResultMessage is ITestFailed)
+				{
+					TestResult = result.Value;
+					break;
+				}
+			}
 
-			if (message.TestResultMessage is ITestPassed)
+			Output = TestResult.Output;
+
+			if (TestResult.TestResultMessage is ITestPassed)
 			{
 				Result = TestState.Passed;
 				Message = $"✔ Success! {TestResult.Duration.TotalMilliseconds} ms";
 				RunStatus = RunStatus.Ok;
 			}
-			else if (message.TestResultMessage is ITestFailed failedMessage)
+			else if (TestResult.TestResultMessage is ITestFailed failedMessage)
 			{
 				Result = TestState.Failed;
 				Message = $"⛔ {ExceptionUtility.CombineMessages(failedMessage)}";
 				StackTrace = ExceptionUtility.CombineStackTraces(failedMessage);
 				RunStatus = RunStatus.Failed;
 			}
-			else if (message.TestResultMessage is ITestSkipped skipped)
+			else if (TestResult.TestResultMessage is ITestSkipped skipped)
 			{
 				Result = TestState.Skipped;
 				Message = $"⚠ {skipped.Reason}";


### PR DESCRIPTION
### Description of Change

The root fragment used for displaying content wasn't correctly setting up a new scoped maui context for the `LayoutInflater` and `ChildSupportManager`. This was causing the navigation fragments to get added to the `Activity`'s `FragmentManager`. This would lead to the NavHost surviving root page swaps. 

### Issues Fixed
Fixes #7275
Fixes #7153
Fixes #9459
Fixes #9941
