### PR TITLE
Don't Propagate Command Mappers when Android View is Disposed of

### DIFF
--- a/src/Core/src/CommandMapper.cs
+++ b/src/Core/src/CommandMapper.cs
@@ -26,6 +26,9 @@ namespace Microsoft.Maui
 
 		private protected virtual void InvokeCore(string key, IElementHandler viewHandler, IElement virtualView, object? args)
 		{
+			if (!viewHandler.CanInvokeMappers())
+				return;
+
 			var action = GetCommand(key);
 			action?.Invoke(viewHandler, virtualView, args);
 		}

--- a/src/Core/src/Handlers/ElementHandlerExtensions.cs
+++ b/src/Core/src/Handlers/ElementHandlerExtensions.cs
@@ -84,5 +84,16 @@ namespace Microsoft.Maui
 			handler?.Invoke(commandName, args);
 			return args.Result;
 		}
+
+		public static bool CanInvokeMappers(this IElementHandler viewHandler)
+		{
+#if ANDROID
+			var platformView = viewHandler?.PlatformView;
+
+			if (platformView is PlatformView androidView && androidView.IsDisposed())
+				return false;
+#endif
+			return true;
+		}
 	}
 }

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui
 
 		protected virtual void UpdatePropertyCore(string key, IElementHandler viewHandler, IElement virtualView)
 		{
-			if (!CanUpdateProperty(viewHandler))
+			if (!viewHandler.CanInvokeMappers())
 				return;
 
 			var action = GetProperty(key);
@@ -121,17 +121,6 @@ namespace Microsoft.Maui
 					foreach (var key in chain.GetKeys())
 						yield return key;
 			}
-		}
-
-		bool CanUpdateProperty(IElementHandler viewHandler)
-		{
-#if ANDROID
-			var platformView = viewHandler?.PlatformView;
-
-			if(platformView is PlatformView androidView && androidView.IsDisposed())
-				return false;
-#endif
-			return true;
 		}
 	}
 


### PR DESCRIPTION
### Description of Change

We already have code inside the property mapper to not propagate when the android view is disposed. We should have the same code inside the CommandMapper. If you run the device tests enough times you'll hit a crash from the command mapper invoking on a disposed unmanaged peer
