### PR TITLE
[Essentials] Fixes IPreferences DateTime handling

### DIFF
--- a/src/Essentials/src/Preferences/Preferences.android.cs
+++ b/src/Essentials/src/Preferences/Preferences.android.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Maui.Storage
 
 		public void Set<T>(string key, T value, string sharedName)
 		{
+			Preferences.CheckIsSupportedType<T>();
+
 			lock (locker)
 			{
 				using (var sharedPreferences = GetSharedPreferences(sharedName))
@@ -78,6 +80,9 @@ namespace Microsoft.Maui.Storage
 								break;
 							case float f:
 								editor.PutFloat(key, f);
+								break;
+							case DateTime dt:
+								editor.PutLong(key, dt.ToBinary());
 								break;
 						}
 					}
@@ -133,6 +138,10 @@ namespace Microsoft.Maui.Storage
 							case string s:
 								// the case when the string is not null
 								value = sharedPreferences.GetString(key, s);
+								break;
+							case DateTime dt:
+								var encondedValue = sharedPreferences.GetLong(key, dt.ToBinary());
+								value = DateTime.FromBinary(encondedValue);
 								break;
 						}
 					}

--- a/src/Essentials/src/Preferences/Preferences.android.cs
+++ b/src/Essentials/src/Preferences/Preferences.android.cs
@@ -140,8 +140,8 @@ namespace Microsoft.Maui.Storage
 								value = sharedPreferences.GetString(key, s);
 								break;
 							case DateTime dt:
-								var encondedValue = sharedPreferences.GetLong(key, dt.ToBinary());
-								value = DateTime.FromBinary(encondedValue);
+								var encodedValue = sharedPreferences.GetLong(key, dt.ToBinary());
+								value = DateTime.FromBinary(encodedValue);
 								break;
 						}
 					}

--- a/src/Essentials/src/Preferences/Preferences.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/Preferences/Preferences.ios.tvos.watchos.macos.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Maui.Storage
 
 		public void Set<T>(string key, T value, string sharedName)
 		{
+			Preferences.CheckIsSupportedType<T>();
+
 			lock (locker)
 			{
 				using (var userDefaults = GetUserDefaults(sharedName))
@@ -78,6 +80,10 @@ namespace Microsoft.Maui.Storage
 							break;
 						case float f:
 							userDefaults.SetFloat(f, key);
+							break;
+						case DateTime dt:
+							var dtString = Convert.ToString(dt.ToBinary(), CultureInfo.InvariantCulture);
+							userDefaults.SetString(dtString, key);
 							break;
 					}
 				}
@@ -112,6 +118,11 @@ namespace Microsoft.Maui.Storage
 							break;
 						case float f:
 							value = userDefaults.FloatForKey(key);
+							break;
+						case DateTime dt:
+							var savedDateTime = userDefaults.StringForKey(key);
+							var dtLong = Convert.ToInt64(savedDateTime, CultureInfo.InvariantCulture);
+							value = DateTime.FromBinary(dtLong);
 							break;
 						case string s:
 							// the case when the string is not null

--- a/src/Essentials/src/Preferences/Preferences.ios.tvos.watchos.macos.cs
+++ b/src/Essentials/src/Preferences/Preferences.ios.tvos.watchos.macos.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Maui.Storage
 							userDefaults.SetFloat(f, key);
 							break;
 						case DateTime dt:
-							var dtString = Convert.ToString(dt.ToBinary(), CultureInfo.InvariantCulture);
-							userDefaults.SetString(dtString, key);
+							var encodedDateTime = Convert.ToString(dt.ToBinary(), CultureInfo.InvariantCulture);
+							userDefaults.SetString(encodedDateTime, key);
 							break;
 					}
 				}
@@ -121,8 +121,8 @@ namespace Microsoft.Maui.Storage
 							break;
 						case DateTime dt:
 							var savedDateTime = userDefaults.StringForKey(key);
-							var dtLong = Convert.ToInt64(savedDateTime, CultureInfo.InvariantCulture);
-							value = DateTime.FromBinary(dtLong);
+							var encodedDateTime = Convert.ToInt64(savedDateTime, CultureInfo.InvariantCulture);
+							value = DateTime.FromBinary(encodedDateTime);
 							break;
 						case string s:
 							// the case when the string is not null

--- a/src/Essentials/src/Preferences/Preferences.shared.cs
+++ b/src/Essentials/src/Preferences/Preferences.shared.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Maui.Storage
 			var type = typeof(T);
 			if (!SupportedTypes.Contains(type))
 			{
-				throw new ArgumentException($"{type} is not supported");
+				throw new NotSupportedException($"Preferences using '{type}' type is not supported");
 			}
 		}
 	}

--- a/src/Essentials/src/Preferences/Preferences.shared.cs
+++ b/src/Essentials/src/Preferences/Preferences.shared.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Microsoft.Maui.Storage
 {
@@ -162,11 +163,11 @@ namespace Microsoft.Maui.Storage
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Get'][9]/Docs" />
 		public static DateTime Get(string key, DateTime defaultValue, string? sharedName) =>
-			DateTime.FromBinary(Current.Get<long>(key, defaultValue.ToBinary(), sharedName));
+			Current.Get<DateTime>(key, defaultValue, sharedName);
 
 		/// <include file="../../docs/Microsoft.Maui.Essentials/Preferences.xml" path="//Member[@MemberName='Set'][9]/Docs" />
 		public static void Set(string key, DateTime value, string? sharedName) =>
-			Current.Set<long>(key, value.ToBinary(), sharedName);
+			Current.Set<DateTime>(key, value, sharedName);
 
 		static IPreferences Current => Storage.Preferences.Default;
 
@@ -180,5 +181,25 @@ namespace Microsoft.Maui.Storage
 
 		internal static void SetDefault(IPreferences? implementation) =>
 			defaultImplementation = implementation;
+
+		internal static Type[] SupportedTypes = new Type[]
+		{
+			typeof(string),
+			typeof(int),
+			typeof(bool),
+			typeof(long),
+			typeof(double),
+			typeof(float),
+			typeof(DateTime),
+		};
+
+		internal static void CheckIsSupportedType<T>()
+		{
+			var type = typeof(T);
+			if (!SupportedTypes.Contains(type))
+			{
+				throw new ArgumentException($"{type} is not supported");
+			}
+		}
 	}
 }

--- a/src/Essentials/src/Preferences/Preferences.tizen.cs
+++ b/src/Essentials/src/Preferences/Preferences.tizen.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Maui.Storage
 							value = Preference.Get<T>(fullKey);
 							break;
 						case DateTime dt:
-							var longValue = Preference.Get<long>(fullKey);
-							value = DateTime.FromBinary(longValue);
+							var encodedValue = Preference.Get<long>(fullKey);
+							value = DateTime.FromBinary(encodedValue);
 						default:
 							// the case when the string is null
 							if (typeof(T) == typeof(string))

--- a/src/Essentials/src/Preferences/Preferences.tizen.cs
+++ b/src/Essentials/src/Preferences/Preferences.tizen.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Maui.Storage
 						case DateTime dt:
 							var encodedValue = Preference.Get<long>(fullKey);
 							value = (T)(object)DateTime.FromBinary(encodedValue);
+							break;
 						default:
 							// the case when the string is null
 							if (typeof(T) == typeof(string))

--- a/src/Essentials/src/Preferences/Preferences.tizen.cs
+++ b/src/Essentials/src/Preferences/Preferences.tizen.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Storage
 							break;
 						case DateTime dt:
 							var encodedValue = Preference.Get<long>(fullKey);
-							value = DateTime.FromBinary(encodedValue);
+							value = (T)(object)DateTime.FromBinary(encodedValue);
 						default:
 							// the case when the string is null
 							if (typeof(T) == typeof(string))

--- a/src/Essentials/src/Preferences/Preferences.tizen.cs
+++ b/src/Essentials/src/Preferences/Preferences.tizen.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Tizen.Applications;
 
@@ -46,11 +47,17 @@ namespace Microsoft.Maui.Storage
 
 		public void Set<T>(string key, T value, string sharedName)
 		{
+			Preferences.CheckIsSupportedType<T>();
+
 			lock (locker)
 			{
 				var fullKey = GetFullKey(key, sharedName);
 				if (value == null)
 					Preference.Remove(fullKey);
+				else if (value is DateTime dt)
+				{
+					Preference.Set(fullKey, dt.ToBinary());
+				}
 				else
 					Preference.Set(fullKey, value);
 			}
@@ -74,6 +81,9 @@ namespace Microsoft.Maui.Storage
 						case string s:
 							value = Preference.Get<T>(fullKey);
 							break;
+						case DateTime dt:
+							var longValue = Preference.Get<long>(fullKey);
+							value = DateTime.FromBinary(longValue);
 						default:
 							// the case when the string is null
 							if (typeof(T) == typeof(string))

--- a/src/Essentials/src/Preferences/Preferences.uwp.cs
+++ b/src/Essentials/src/Preferences/Preferences.uwp.cs
@@ -86,9 +86,7 @@ namespace Microsoft.Maui.Storage
 
 				if (value is DateTime dt)
 				{
-					// UWP does not support DateTime directly
-					// https://docs.microsoft.com/en-us/windows/apps/design/app-settings/store-and-retrieve-app-data
-					appDataContainer.Values[key] = new DateTimeOffset(dt);
+					appDataContainer.Values[key] = dt.ToBinary();
 				}
 				else
 				{
@@ -107,9 +105,9 @@ namespace Microsoft.Maui.Storage
 					var tempValue = appDataContainer.Values[key];
 					if (tempValue != null)
 					{
-						if (tempValue is DateTimeOffset dto)
+						if (defaultValue is DateTime dt)
 						{
-							return (T)(object)dto.DateTime;
+							return (T)(object)DateTime.FromBinary((long)tempValue);
 						}
 						else
 						{

--- a/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 
 		static DateTime testDateTime = new DateTime(2018, 05, 07);
 
+		#region Static method tests
 		[Theory]
 		[InlineData("datetime1", null)]
 		[InlineData("datetime1", sharedNameTestData)]
@@ -236,9 +237,236 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.Equal(kind, get.Kind);
 		}
 
+		#endregion
+
+		#region Non-static method tests
+
 		[Fact]
 		public void FailsWithUnsupportedType() =>
 			Assert.Throws<NotSupportedException>(() => Preferences.Default.Set("anything", new int[] { 1 }));
 
+		[Theory]
+		[InlineData("datetime1", null)]
+		[InlineData("datetime1", sharedNameTestData)]
+		public void Set_Get_DateTime_NonStatic(string key, string sharedName)
+		{
+			Preferences.Default.Set(key, testDateTime, sharedName);
+
+			Assert.Equal(testDateTime, Preferences.Default.Get(key, DateTime.MinValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData("string1", "TEST", null)]
+		[InlineData("string1", "TEST", sharedNameTestData)]
+		public void Set_Get_String_NonStatic(string key, string value, string sharedName)
+		{
+			Preferences.Default.Set(key, value, sharedName);
+
+			Assert.Equal(value, Preferences.Default.Get<string>(key, null, sharedName));
+		}
+
+		[Theory]
+		[InlineData("string1", "TEST", null)]
+		[InlineData("string1", "TEST", sharedNameTestData)]
+		public void Set_Set_Null_Get_String_NonStatic(string key, string value, string sharedName)
+		{
+			Preferences.Default.Set(key, value, sharedName);
+			Preferences.Default.Set<string>(key, null, sharedName);
+
+			Assert.Null(Preferences.Default.Get<string>(key, null, sharedName));
+		}
+
+		[Theory]
+		[InlineData("int1", int.MaxValue - 1, null)]
+		[InlineData("sint1", int.MinValue + 1, null)]
+		[InlineData("int1", int.MaxValue - 1, sharedNameTestData)]
+		[InlineData("sint1", int.MinValue + 1, sharedNameTestData)]
+		public void Set_Get_Int_NonStatic(string key, int value, string sharedName)
+		{
+			Preferences.Default.Set(key, value, sharedName);
+			Assert.Equal(value, Preferences.Default.Get(key, 0, sharedName));
+		}
+
+		[Theory]
+		[InlineData("long1", long.MaxValue - 1, null)]
+		[InlineData("slong1", long.MinValue + 1, null)]
+		[InlineData("long1", long.MaxValue - 1, sharedNameTestData)]
+		[InlineData("slong1", long.MinValue + 1, sharedNameTestData)]
+		public void Set_Get_Long_NonStatic(string key, long value, string sharedName)
+		{
+			Preferences.Default.Set(key, value, sharedName);
+			Assert.Equal(value, Preferences.Default.Get(key, 0L, sharedName));
+		}
+
+		[Theory]
+		[InlineData("float1", float.MaxValue - 1, null)]
+		[InlineData("sfloat1", float.MinValue + 1, null)]
+		[InlineData("float1", float.MaxValue - 1, sharedNameTestData)]
+		[InlineData("sfloat1", float.MinValue + 1, sharedNameTestData)]
+		public void Set_Get_Float_NonStatic(string key, float value, string sharedName)
+		{
+			Preferences.Default.Set(key, value, sharedName);
+			Assert.Equal(value, Preferences.Default.Get(key, 0f, sharedName));
+		}
+
+		[Theory]
+		[InlineData("double1", double.MaxValue - 1, null)]
+		[InlineData("sdouble1", double.MinValue + 1, null)]
+		[InlineData("double1", double.MaxValue - 1, sharedNameTestData)]
+		[InlineData("sdouble1", double.MinValue + 1, sharedNameTestData)]
+		public void Set_Get_Double_NonStatic(string key, double value, string sharedName)
+		{
+			Preferences.Default.Set(key, value, sharedName);
+			Assert.Equal(value, Preferences.Default.Get(key, 0d, sharedName));
+		}
+
+		[Theory]
+		[InlineData("bool1", true, null)]
+		[InlineData("bool1", true, sharedNameTestData)]
+		public void Set_Get_Bool_NonStatic(string key, bool value, string sharedName)
+		{
+			Preferences.Default.Set(key, value, sharedName);
+			Assert.Equal(value, Preferences.Default.Get(key, false, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData(sharedNameTestData)]
+		public void Remove_NonStatic(string sharedName)
+		{
+			Preferences.Default.Set("RemoveKey1", "value", sharedName);
+
+			Assert.Equal("value", Preferences.Default.Get<string>("RemoveKey1", null, sharedName));
+
+			Preferences.Default.Remove("RemoveKey1", sharedName);
+
+			Assert.Null(Preferences.Default.Get<string>("RemoveKey1", null, sharedName));
+		}
+		
+		[Theory]
+		[InlineData(null, true)]
+		[InlineData(sharedNameTestData, true)]
+		[InlineData(null, false)]
+		[InlineData(sharedNameTestData, false)]
+		public void Remove_Get_Bool_NonStatic(string sharedName, bool defaultValue)
+		{
+			Preferences.Default.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Default.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, 5)]
+		[InlineData(sharedNameTestData, 5)]
+		[InlineData(null, 0)]
+		[InlineData(sharedNameTestData, 0)]
+		public void Remove_Get_Double_NonStatic(string sharedName, double defaultValue)
+		{
+			Preferences.Default.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Default.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, 5)]
+		[InlineData(sharedNameTestData, 5)]
+		[InlineData(null, 0)]
+		[InlineData(sharedNameTestData, 0)]
+		public void Remove_Get_Float_NonStatic(string sharedName, float defaultValue)
+		{
+			Preferences.Default.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Default.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, 5)]
+		[InlineData(sharedNameTestData, 5)]
+		[InlineData(null, 0)]
+		[InlineData(sharedNameTestData, 0)]
+		public void Remove_Get_Int_NonStatic(string sharedName, int defaultValue)
+		{
+			Preferences.Default.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Default.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, 5)]
+		[InlineData(sharedNameTestData, 5)]
+		[InlineData(null, 0)]
+		[InlineData(sharedNameTestData, 0)]
+		public void Remove_Get_Long_NonStatic(string sharedName, long defaultValue)
+		{
+			Preferences.Default.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Default.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, "text")]
+		[InlineData(sharedNameTestData, "text")]
+		[InlineData(null, null)]
+		[InlineData(sharedNameTestData, null)]
+		public void Remove_Get_String_NonStatic(string sharedName, string defaultValue)
+		{
+			Preferences.Default.Remove("RemoveGetKey1", sharedName);
+
+			Assert.Equal(defaultValue, Preferences.Default.Get("RemoveGetKey1", defaultValue, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData(sharedNameTestData)]
+		public void Clear_NonStatic(string sharedName)
+		{
+			Preferences.Default.Set("ClearKey1", "value", sharedName);
+			Preferences.Default.Set("ClearKey2", 2, sharedName);
+
+			Assert.Equal(2, Preferences.Default.Get("ClearKey2", 0, sharedName));
+
+			Preferences.Default.Clear(sharedName);
+
+			Assert.NotEqual("value", Preferences.Default.Get<string>("ClearKey1", null, sharedName));
+			Assert.NotEqual(2, Preferences.Default.Get("ClearKey2", 0, sharedName));
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData(sharedNameTestData)]
+		public void Does_ContainsKey_NonStatic(string sharedName)
+		{
+			Preferences.Default.Set("DoesContainsKey1", "One", sharedName);
+
+			Assert.True(Preferences.Default.ContainsKey("DoesContainsKey1", sharedName));
+		}
+
+		[Theory]
+		[InlineData(null)]
+		[InlineData(sharedNameTestData)]
+		public void Not_ContainsKey_NonStatic(string sharedName)
+		{
+			Preferences.Default.Remove("NotContainsKey1", sharedName);
+
+			Assert.False(Preferences.Default.ContainsKey("NotContainsKey1", sharedName));
+		}
+
+		[Theory]
+		[InlineData(null, DateTimeKind.Utc)]
+		[InlineData(sharedNameTestData, DateTimeKind.Utc)]
+		[InlineData(null, DateTimeKind.Local)]
+		[InlineData(sharedNameTestData, DateTimeKind.Local)]
+		public void DateTimePreservesKind_NonStatic(string sharedName, DateTimeKind kind)
+		{
+			var date = new DateTime(2018, 05, 07, 8, 30, 0, kind);
+
+			Preferences.Default.Set("datetime_utc", date, sharedName);
+
+			var get = Preferences.Default.Get("datetime_utc", DateTime.MinValue, sharedName);
+
+			Assert.Equal(date, get);
+			Assert.Equal(kind, get.Kind);
+		}
+		#endregion
 	}
 }

--- a/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Preferences_Tests.cs
@@ -235,5 +235,10 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 			Assert.Equal(date, get);
 			Assert.Equal(kind, get.Kind);
 		}
+
+		[Fact]
+		public void FailsWithUnsupportedType() =>
+			Assert.Throws<NotSupportedException>(() => Preferences.Default.Set("anything", new int[] { 1 }));
+
 	}
 }


### PR DESCRIPTION
### Description of Change
Fixes Preferences native implementations for `DateTime` handling. It was working using the static Set/Get methods but it did not work when using the `IPreferences` interface

Adds type check for unsupported types.

### Issues Fixed
Fixes #8853

Tested on Windows, iOS and Android. No tested on a Tizen device, but it should work fine.
