### PR TITLE
[release/6.0.5xx-sr5] Update dependencies from xamarin/xamarin-macios

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>d6224ca6b1032ffebc8fe2b496f93a511b0674a6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.453">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.454">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>90e1202867823397a93684f28a53097d194a22ea</Sha>
+      <Sha>4bd34d034c8c5a4e092c8bd3c8868153d94277b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.453">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.454">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>90e1202867823397a93684f28a53097d194a22ea</Sha>
+      <Sha>4bd34d034c8c5a4e092c8bd3c8868153d94277b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.453">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.454">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>90e1202867823397a93684f28a53097d194a22ea</Sha>
+      <Sha>4bd34d034c8c5a4e092c8bd3c8868153d94277b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.453">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.454">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>90e1202867823397a93684f28a53097d194a22ea</Sha>
+      <Sha>4bd34d034c8c5a4e092c8bd3c8868153d94277b4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.9" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,10 +11,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>32.0.465</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftiOSSdkPackageVersion>15.4.453</MicrosoftiOSSdkPackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>15.4.453</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>12.3.453</MicrosoftmacOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>15.4.453</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>15.4.454</MicrosoftiOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>15.4.454</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>12.3.454</MicrosoftmacOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>15.4.454</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.400-preview.1.0</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:0b7b65e6-5d73-49c6-b8c1-08da91234a73)
## From https://github.com/xamarin/xamarin-macios
- **Subscription**: 0b7b65e6-5d73-49c6-b8c1-08da91234a73
- **Commit**: 4bd34d034c8c5a4e092c8bd3c8868153d94277b4
- **Branch**: refs/heads/release/6.0.4xx

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.iOS.Sdk**: [from 15.4.453 to 15.4.454][12]
  - **Microsoft.MacCatalyst.Sdk**: [from 15.4.453 to 15.4.454][12]
  - **Microsoft.macOS.Sdk**: [from 12.3.453 to 12.3.454][12]
  - **Microsoft.tvOS.Sdk**: [from 15.4.453 to 15.4.454][12]

[12]: https://github.com/xamarin/xamarin-macios/compare/90e1202867823397a93684f28a53097d194a22ea...4bd34d034c8c5a4e092c8bd3c8868153d94277b4

[DependencyUpdate]: <> (End)


[marker]: <> (End:0b7b65e6-5d73-49c6-b8c1-08da91234a73)























