### PR TITLE
Add adorner layer to CoordinatorLayout

### DIFF
--- a/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
+++ b/src/Core/src/WindowOverlay/WindowOverlay.Android.cs
@@ -39,6 +39,10 @@ namespace Microsoft.Maui
 
 			_nativeActivity = activity;
 			_nativeLayer = rootManager.RootView as ViewGroup;
+			_nativeLayer = _nativeLayer?.GetFirstChildOfType<CoordinatorLayout>() ?? _nativeLayer;
+
+			if (_nativeLayer is ContainerView containerView)
+				_nativeLayer = containerView.MainView as ViewGroup;
 
 			if (_nativeLayer?.Context == null)
 				return false;


### PR DESCRIPTION
### Description of Change
`Maui.Core` wraps the content created by the `Window.Content` with a `ContainerView` which may or may not be currently useful. Because of how Shell is structured `Window.Content` is the root view of the entire app which means the `ToContainerView` call wraps all of `Shell`. With a non shell app `Window.Content` will just be whatever the user specified (navigationpage, contentpage, etc..) and then `NavigationRootManager` wraps that with a `CoordinatorLayout` which is what the VD layer uses.  The adorner layer wants to add itself to the `CoordinatorLayout` for the application so inside the `VisualDiagnostics` code we need to make sure to locate the `CoordinatorLayout` and add the `PlatformGraphicsView` to that .

### Testing

Verify that when using the Live Visual Tree and Shell that elements inside the app will highlight

### Issues Fixed
Fixes #8866
Fixed #9646
