### PR TITLE
Add visual state for PointerOver

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
@@ -68,7 +68,7 @@
                 Text=""
                 Placeholder="Type something to enable 2nd Entry" />
             <Label
-                Text="Label with Normal, PointerEntered, and Presed visual states:" 
+                Text="Label with Normal, PointerOver, and Pressed visual states:" 
                 Style="{StaticResource Headline}" />
             <Button 
                 Text="Login"

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
@@ -80,13 +80,13 @@
                             <VisualState x:Name="Normal">
                                 <VisualState.Setters>
                                     <Setter Property="BackgroundColor" Value="LightBlue" />
-                                    <Setter Property="BorderColor" Value="Gray" />
+                                    <Setter Property="BorderColor" Value="LightBlue" />
                                 </VisualState.Setters>
                             </VisualState>
                             <VisualState x:Name="PointerOver">
                                 <VisualState.Setters>
                                     <Setter Property="BackgroundColor" Value="LightBlue" />
-                                    <Setter Property="BorderColor" Value="Gray" />
+                                    <Setter Property="BorderColor" Value="LightBlue" />
                                 </VisualState.Setters>
                             </VisualState>
                             <VisualState x:Name="Pressed">

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
@@ -83,7 +83,7 @@
                                     <Setter Property="BorderColor" Value="Gray" />
                                 </VisualState.Setters>
                             </VisualState>
-                            <VisualState x:Name="PointerEntered">
+                            <VisualState x:Name="PointerOver">
                                 <VisualState.Setters>
                                     <Setter Property="BackgroundColor" Value="LightBlue" />
                                     <Setter Property="BorderColor" Value="Gray" />

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
@@ -68,10 +68,39 @@
                 Text=""
                 Placeholder="Type something to enable 2nd Entry" />
             <Label
-                Text="Label with Normal, PointerOver, and Pressed visual states:" 
+                Text="Button with Normal and PointerOver visual states:" 
                 Style="{StaticResource Headline}" />
             <Button 
-                Text="Login"
+                Text="Hover me to see color change"
+                WidthRequest="300"
+                HorizontalOptions="Center">
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroupList>
+                        <VisualStateGroup x:Name="CommonStates">
+                            <VisualState x:Name="Normal">
+                                <VisualState.Setters>
+                                    <Setter Property="BackgroundColor" Value="LightBlue" />
+                                    <Setter Property="BorderColor" Value="LightBlue" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="PointerOver">
+                                <VisualState.Setters>
+                                    <Setter Property="BackgroundColor" Value="Blue" />
+                                    <Setter Property="BorderColor" Value="LightBlue" />
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateGroupList>
+                </VisualStateManager.VisualStateGroups>
+            </Button>
+            <Label
+                Text="Button with Normal, PointerOver, and Pressed visual states:" 
+                Style="{StaticResource Headline}" />
+            <Label 
+                Text="The Normal and PointerOver states for this button are the same. This demonstrates how the PointerOver state can be used to set the visual state of the button after it has been clicked so that it's no longer Pressed."
+                FontSize="Body"/>
+            <Button 
+                Text="Click me to see color change and revert back"
                 WidthRequest="300"
                 HorizontalOptions="Center">
                 <VisualStateManager.VisualStateGroups>
@@ -99,7 +128,6 @@
                     </VisualStateGroupList>
                 </VisualStateManager.VisualStateGroups>
             </Button>
-
         </StackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
@@ -67,6 +67,27 @@
                 x:Name="entry3"
                 Text=""
                 Placeholder="Type something to enable 2nd Entry" />
+            <Label
+                Text="Label with PointerEntered visual state:" 
+                Style="{StaticResource Headline}" />
+            <Label Text="Hover me">
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor"
+                                            Value="Blue" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="PointerEntered">
+                            <VisualState.Setters>
+                                <Setter Property="TextColor"
+                                            Value="Pink" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateManager.VisualStateGroups>
+            </Label>
         </StackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/UserInterface/VisualStatesPage.xaml
@@ -68,26 +68,38 @@
                 Text=""
                 Placeholder="Type something to enable 2nd Entry" />
             <Label
-                Text="Label with PointerEntered visual state:" 
+                Text="Label with Normal, PointerEntered, and Presed visual states:" 
                 Style="{StaticResource Headline}" />
-            <Label Text="Hover me">
+            <Button 
+                Text="Login"
+                WidthRequest="300"
+                HorizontalOptions="Center">
                 <VisualStateManager.VisualStateGroups>
-                    <VisualStateGroup x:Name="CommonStates">
-                        <VisualState x:Name="Normal">
-                            <VisualState.Setters>
-                                <Setter Property="TextColor"
-                                            Value="Blue" />
-                            </VisualState.Setters>
-                        </VisualState>
-                        <VisualState x:Name="PointerEntered">
-                            <VisualState.Setters>
-                                <Setter Property="TextColor"
-                                            Value="Pink" />
-                            </VisualState.Setters>
-                        </VisualState>
-                    </VisualStateGroup>
+                    <VisualStateGroupList>
+                        <VisualStateGroup x:Name="CommonStates">
+                            <VisualState x:Name="Normal">
+                                <VisualState.Setters>
+                                    <Setter Property="BackgroundColor" Value="LightBlue" />
+                                    <Setter Property="BorderColor" Value="Gray" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="PointerEntered">
+                                <VisualState.Setters>
+                                    <Setter Property="BackgroundColor" Value="LightBlue" />
+                                    <Setter Property="BorderColor" Value="Gray" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="Pressed">
+                                <VisualState.Setters>
+                                    <Setter Property="BackgroundColor" Value="Blue" />
+                                    <Setter Property="BorderColor" Value="LightBlue" />
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateGroupList>
                 </VisualStateManager.VisualStateGroups>
-            </Label>
+            </Button>
+
         </StackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
@@ -284,8 +284,8 @@ namespace Microsoft.Maui.Controls.Platform
 					var view = _element as View;
 					if (view != null)
 					{
-						if (ElementGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
-							oc.CollectionChanged -= _collectionChangedHandler;
+						if (ElementGestureRecognizers != null)
+							ElementGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
 					}
 				}
 
@@ -296,8 +296,8 @@ namespace Microsoft.Maui.Controls.Platform
 					var view = _element as View;
 					if (view != null)
 					{
-						if (ElementGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
-							oc.CollectionChanged += _collectionChangedHandler;
+						if (ElementGestureRecognizers != null)
+							ElementGestureRecognizers.CollectionChanged += _collectionChangedHandler;
 					}
 				}
 			}
@@ -349,8 +349,8 @@ namespace Microsoft.Maui.Controls.Platform
 				var view = _element as View;
 				if (view != null)
 				{
-					if (ElementGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
-						oc.CollectionChanged -= _collectionChangedHandler;
+					if (ElementGestureRecognizers != null)
+						ElementGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
 				}
 			}
 

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
@@ -68,6 +68,18 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 		}
 
+		ObservableCollection<IGestureRecognizer>? ElementGestureRecognizers
+		{
+			get
+			{
+				if (_handler?.VirtualView is IGestureController gc &&
+					gc.CompositeGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
+					return oc;
+
+				return null;
+			}
+		}
+
 		// TODO MAUI
 		// Do we need to provide a hook for this in the handlers?
 		// For now I just built this ugly matching statement
@@ -272,10 +284,7 @@ namespace Microsoft.Maui.Controls.Platform
 					var view = _element as View;
 					if (view != null)
 					{
-						var oldRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
-						oldRecognizers.CollectionChanged -= _collectionChangedHandler;
-
-						if ((view as IGestureController)?.CompositeGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
+						if (ElementGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
 							oc.CollectionChanged -= _collectionChangedHandler;
 					}
 				}
@@ -287,16 +296,13 @@ namespace Microsoft.Maui.Controls.Platform
 					var view = _element as View;
 					if (view != null)
 					{
-						var newRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
-						newRecognizers.CollectionChanged += _collectionChangedHandler;
-
-						if ((view as IGestureController)?.CompositeGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
+						if (ElementGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
 							oc.CollectionChanged += _collectionChangedHandler;
 					}
 				}
 			}
 		}
-
+		
 		public void Dispose()
 		{
 			Dispose(true);
@@ -343,8 +349,8 @@ namespace Microsoft.Maui.Controls.Platform
 				var view = _element as View;
 				if (view != null)
 				{
-					var oldRecognizers = (ObservableCollection<IGestureRecognizer>)view.GestureRecognizers;
-					oldRecognizers.CollectionChanged -= _collectionChangedHandler;
+					if (ElementGestureRecognizers is ObservableCollection<IGestureRecognizer> oc)
+						oc.CollectionChanged -= _collectionChangedHandler;
 				}
 			}
 
@@ -503,7 +509,7 @@ namespace Microsoft.Maui.Controls.Platform
 			if (view == null)
 				return;
 
-			var pointerGestures = view.GestureRecognizers.GetGesturesFor<PointerGestureRecognizer>();
+			var pointerGestures = ElementGestureRecognizers.GetGesturesFor<PointerGestureRecognizer>();
 			foreach (var recognizer in pointerGestures)
 			{
 				SendPointerEvent.Invoke(view, recognizer);

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -34,6 +34,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
+Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -70,6 +70,7 @@ static Microsoft.Maui.Controls.Toolbar.MapTitle(Microsoft.Maui.Handlers.IToolbar
 static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static Microsoft.Maui.Controls.Window.MapContent(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! view) -> void
@@ -90,6 +91,7 @@ static readonly Microsoft.Maui.Controls.Window.XProperty -> Microsoft.Maui.Contr
 static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -70,7 +70,6 @@ static Microsoft.Maui.Controls.Toolbar.MapTitle(Microsoft.Maui.Handlers.IToolbar
 static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
-override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static Microsoft.Maui.Controls.Window.MapContent(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! view) -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -34,7 +34,6 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
-Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -91,7 +91,7 @@ static readonly Microsoft.Maui.Controls.Window.XProperty -> Microsoft.Maui.Contr
 static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
-~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerOver = "PointerOver" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -63,6 +63,7 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -83,6 +84,7 @@ static readonly Microsoft.Maui.Controls.Window.XProperty -> Microsoft.Maui.Contr
 static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -34,6 +34,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
+Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double
@@ -63,7 +64,6 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -34,7 +34,6 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
-Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -84,7 +84,7 @@ static readonly Microsoft.Maui.Controls.Window.XProperty -> Microsoft.Maui.Contr
 static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
-~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerOver = "PointerOver" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -63,6 +63,7 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -83,6 +84,7 @@ static readonly Microsoft.Maui.Controls.Window.XProperty -> Microsoft.Maui.Contr
 static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -34,6 +34,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
+Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double
@@ -63,7 +64,6 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -34,7 +34,6 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
-Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -84,7 +84,7 @@ static readonly Microsoft.Maui.Controls.Window.XProperty -> Microsoft.Maui.Contr
 static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Controls.BindableProperty!
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
-~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerOver = "PointerOver" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3557,7 +3557,7 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.Focused = "Focused" -> string
 ~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.Normal = "Normal" -> string
 ~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.Selected = "Selected" -> string
-~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerOver = "PointerOver" -> string
 ~Microsoft.Maui.Controls.AbsoluteLayout.GetLayoutBounds(Microsoft.Maui.IView view) -> Microsoft.Maui.Graphics.Rect
 ~Microsoft.Maui.Controls.AbsoluteLayout.GetLayoutFlags(Microsoft.Maui.IView view) -> Microsoft.Maui.Layouts.AbsoluteLayoutFlags
 ~Microsoft.Maui.Controls.AbsoluteLayout.SetLayoutBounds(Microsoft.Maui.IView view, Microsoft.Maui.Graphics.Rect bounds) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -2878,7 +2878,6 @@ Microsoft.Maui.Controls.VisualElement.IsPlatformEnabled.get -> bool
 Microsoft.Maui.Controls.VisualElement.IsPlatformEnabled.set -> void
 Microsoft.Maui.Controls.VisualElement.IsPlatformStateConsistent.get -> bool
 Microsoft.Maui.Controls.VisualElement.IsPlatformStateConsistent.set -> void
-Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.VisualElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.VisualElement.IsVisible.set -> void
 Microsoft.Maui.Controls.VisualElement.Layout(Microsoft.Maui.Graphics.Rect bounds) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3224,6 +3224,7 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 override Microsoft.Maui.Controls.TemplatedView.OnMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.SizeRequest
 override Microsoft.Maui.Controls.TextCell.OnTapped() -> void
 override Microsoft.Maui.Controls.UriImageSource.IsEmpty.get -> bool
+override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 override Microsoft.Maui.Controls.View.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.VisualElement.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.VisualState.GetHashCode() -> int
@@ -3556,6 +3557,7 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.Focused = "Focused" -> string
 ~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.Normal = "Normal" -> string
 ~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.Selected = "Selected" -> string
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
 ~Microsoft.Maui.Controls.AbsoluteLayout.GetLayoutBounds(Microsoft.Maui.IView view) -> Microsoft.Maui.Graphics.Rect
 ~Microsoft.Maui.Controls.AbsoluteLayout.GetLayoutFlags(Microsoft.Maui.IView view) -> Microsoft.Maui.Layouts.AbsoluteLayoutFlags
 ~Microsoft.Maui.Controls.AbsoluteLayout.SetLayoutBounds(Microsoft.Maui.IView view, Microsoft.Maui.Graphics.Rect bounds) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -2878,6 +2878,7 @@ Microsoft.Maui.Controls.VisualElement.IsPlatformEnabled.get -> bool
 Microsoft.Maui.Controls.VisualElement.IsPlatformEnabled.set -> void
 Microsoft.Maui.Controls.VisualElement.IsPlatformStateConsistent.get -> bool
 Microsoft.Maui.Controls.VisualElement.IsPlatformStateConsistent.set -> void
+Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.VisualElement.IsVisible.get -> bool
 Microsoft.Maui.Controls.VisualElement.IsVisible.set -> void
 Microsoft.Maui.Controls.VisualElement.Layout(Microsoft.Maui.Graphics.Rect bounds) -> void
@@ -3224,7 +3225,6 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 override Microsoft.Maui.Controls.TemplatedView.OnMeasure(double widthConstraint, double heightConstraint) -> Microsoft.Maui.SizeRequest
 override Microsoft.Maui.Controls.TextCell.OnTapped() -> void
 override Microsoft.Maui.Controls.UriImageSource.IsEmpty.get -> bool
-override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 override Microsoft.Maui.Controls.View.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.VisualElement.OnBindingContextChanged() -> void
 override Microsoft.Maui.Controls.VisualState.GetHashCode() -> int

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -71,6 +71,7 @@ static Microsoft.Maui.Controls.Toolbar.MapBackButtonEnabled(Microsoft.Maui.Handl
 static Microsoft.Maui.Controls.Toolbar.MapIcon(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapToolbarDynamicOverflowEnabled(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapToolbarPlacement(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -95,6 +96,7 @@ static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Contr
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -71,7 +71,6 @@ static Microsoft.Maui.Controls.Toolbar.MapBackButtonEnabled(Microsoft.Maui.Handl
 static Microsoft.Maui.Controls.Toolbar.MapIcon(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapToolbarDynamicOverflowEnabled(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapToolbarPlacement(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
-override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -37,6 +37,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
+Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -96,7 +96,7 @@ static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Contr
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
-~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerOver = "PointerOver" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -37,7 +37,6 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
-Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -62,6 +62,7 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -82,6 +83,7 @@ static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Contr
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -34,6 +34,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
+Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double
@@ -62,7 +63,6 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -83,7 +83,7 @@ static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Contr
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
-~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerOver = "PointerOver" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -34,7 +34,6 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
-Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -62,6 +62,7 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -82,6 +83,7 @@ static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Contr
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -34,6 +34,7 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
+Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double
@@ -62,7 +63,6 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
-override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -83,7 +83,7 @@ static readonly Microsoft.Maui.Controls.Window.YProperty -> Microsoft.Maui.Contr
 virtual Microsoft.Maui.Controls.PointerEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Controls.Element? relativeTo) -> Microsoft.Maui.Graphics.Point?
 static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Microsoft.Maui.Controls.BindableProperty!
-~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerEntered = "PointerEntered" -> string
+~const Microsoft.Maui.Controls.VisualStateManager.CommonStates.PointerOver = "PointerOver" -> string
 ~Microsoft.Maui.Controls.MenuFlyout.Add(Microsoft.Maui.IMenuElement item) -> void
 ~Microsoft.Maui.Controls.MenuFlyout.Contains(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.CopyTo(Microsoft.Maui.IMenuElement[] array, int arrayIndex) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -34,7 +34,6 @@ Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler<Micro
 Microsoft.Maui.Controls.TappedEventArgs.Buttons.get -> Microsoft.Maui.Controls.ButtonsMask
 Microsoft.Maui.Controls.ToolTipProperties
 Microsoft.Maui.Controls.ToolTipProperties.ToolTipProperties() -> void
-Microsoft.Maui.Controls.VisualElement.IsPointerOver -> bool
 Microsoft.Maui.Controls.Window.Height.get -> double
 Microsoft.Maui.Controls.Window.Height.set -> void
 Microsoft.Maui.Controls.Window.MaximumHeight.get -> double

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Maui.Controls
 			get { return _gestureRecognizers; }
 		}
 
-		bool IsPointerInside = false;
+		bool IsPointerOver = false;
 
 		ObservableCollection<IGestureRecognizer> _compositeGestureRecognizers;
 
@@ -161,12 +161,12 @@ namespace Microsoft.Maui.Controls
 				PointerGestureRecognizer pgr = new PointerGestureRecognizer();
 				pgr.PointerEntered += (s, e) =>
 				{
-					IsPointerInside = true;
+					IsPointerOver = true;
 					ChangeVisualState();
 				};
 				pgr.PointerExited += (s, e) =>
 				{
-					IsPointerInside = false;
+					IsPointerOver = false;
 					ChangeVisualState();
 				};
 
@@ -223,8 +223,8 @@ namespace Microsoft.Maui.Controls
 
 		override protected internal void ChangeVisualState()
 		{
-			if (IsPointerInside)
-				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerEntered);
+			if (IsPointerOver)
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
 			else
 				base.ChangeVisualState();
 		}

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -118,9 +118,6 @@ namespace Microsoft.Maui.Controls
 						List<IElementDefinition> remove = new List<IElementDefinition>();
 						List<IElementDefinition> add = new List<IElementDefinition>();
 
-						var _compositeGestureRecognizers = GestureController.CompositeGestureRecognizers;
-						PointerGestureRecognizer _pointerGestureRecognizerForPointerOverState = _compositeGestureRecognizers[0] as PointerGestureRecognizer;
-
 						foreach (IElementDefinition item in _gestureRecognizers.OfType<IElementDefinition>())
 						{
 							if (!_gestureRecognizers.Contains((IGestureRecognizer)item))
@@ -128,9 +125,9 @@ namespace Microsoft.Maui.Controls
 							item.Parent = this;
 						}
 
-						foreach (IElementDefinition item in _compositeGestureRecognizers.OfType<IElementDefinition>())
+						foreach (IElementDefinition item in GestureController.CompositeGestureRecognizers.OfType<IElementDefinition>())
 						{
-							if (item == _pointerGestureRecognizerForPointerOverState)
+							if (item == _recognizerForPointerOverState)
 								continue;
 
 							if (_gestureRecognizers.Contains((IGestureRecognizer)item))
@@ -154,6 +151,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		bool IsPointerOver = false;
+		PointerGestureRecognizer _recognizerForPointerOverState = new PointerGestureRecognizer();
 
 		ObservableCollection<IGestureRecognizer> _compositeGestureRecognizers;
 
@@ -164,19 +162,19 @@ namespace Microsoft.Maui.Controls
 				if (_compositeGestureRecognizers is not null)
 					return _compositeGestureRecognizers;
 
-				PointerGestureRecognizer pgr = new PointerGestureRecognizer();
-				pgr.PointerEntered += (s, e) =>
+				_recognizerForPointerOverState.PointerEntered += (s, e) =>
 				{
 					IsPointerOver = true;
 					ChangeVisualState();
 				};
-				pgr.PointerExited += (s, e) =>
+
+				_recognizerForPointerOverState.PointerExited += (s, e) =>
 				{
 					IsPointerOver = false;
 					ChangeVisualState();
 				};
 
-				_compositeGestureRecognizers = new ObservableCollection<IGestureRecognizer>() { pgr };
+				_compositeGestureRecognizers = new ObservableCollection<IGestureRecognizer>() { _recognizerForPointerOverState };
 				return _compositeGestureRecognizers;
 			}
 		}

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -166,13 +166,11 @@ namespace Microsoft.Maui.Controls
 				_recognizerForPointerOverState.PointerEntered += (s, e) =>
 				{
 					IsPointerOver = true;
-					ChangeVisualState();
 				};
 
 				_recognizerForPointerOverState.PointerExited += (s, e) =>
 				{
 					IsPointerOver = false;
-					ChangeVisualState();
 				};
 
 				_compositeGestureRecognizers = new ObservableCollection<IGestureRecognizer>() { _recognizerForPointerOverState };

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -78,6 +78,8 @@ namespace Microsoft.Maui.Controls
 
 		readonly ObservableCollection<IGestureRecognizer> _gestureRecognizers = new ObservableCollection<IGestureRecognizer>();
 
+		PointerGestureRecognizer _recognizerForPointerOverState;
+
 		protected internal View()
 		{
 			_gestureRecognizers.CollectionChanged += (sender, args) =>
@@ -150,17 +152,13 @@ namespace Microsoft.Maui.Controls
 			get { return _gestureRecognizers; }
 		}
 
-		bool IsPointerOver = false;
-		PointerGestureRecognizer _recognizerForPointerOverState = new PointerGestureRecognizer();
-
 		ObservableCollection<IGestureRecognizer> _compositeGestureRecognizers;
 
 		IList<IGestureRecognizer> IGestureController.CompositeGestureRecognizers
 		{
 			get
 			{
-				if (_compositeGestureRecognizers is not null)
-					return _compositeGestureRecognizers;
+				_recognizerForPointerOverState ??= new PointerGestureRecognizer();
 
 				_recognizerForPointerOverState.PointerEntered += (s, e) =>
 				{
@@ -223,14 +221,6 @@ namespace Microsoft.Maui.Controls
 				return;
 			if (gesture is PinchGestureRecognizer && _gestureRecognizers.GetGesturesFor<PinchGestureRecognizer>().Count() > 1)
 				throw new InvalidOperationException($"Only one {nameof(PinchGestureRecognizer)} per view is allowed");
-		}
-
-		override protected internal void ChangeVisualState()
-		{
-			if (IsPointerOver)
-				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
-			else
-				base.ChangeVisualState();
 		}
 	}
 }

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -118,6 +118,9 @@ namespace Microsoft.Maui.Controls
 						List<IElementDefinition> remove = new List<IElementDefinition>();
 						List<IElementDefinition> add = new List<IElementDefinition>();
 
+						var _compositeGestureRecognizers = GestureController.CompositeGestureRecognizers;
+						PointerGestureRecognizer _pointerGestureRecognizerForPointerOverState = _compositeGestureRecognizers[0] as PointerGestureRecognizer;
+
 						foreach (IElementDefinition item in _gestureRecognizers.OfType<IElementDefinition>())
 						{
 							if (!_gestureRecognizers.Contains((IGestureRecognizer)item))
@@ -125,8 +128,11 @@ namespace Microsoft.Maui.Controls
 							item.Parent = this;
 						}
 
-						foreach (IElementDefinition item in GestureController.CompositeGestureRecognizers.OfType<IElementDefinition>())
+						foreach (IElementDefinition item in _compositeGestureRecognizers.OfType<IElementDefinition>())
 						{
+							if (item == _pointerGestureRecognizerForPointerOverState)
+								continue;
+
 							if (_gestureRecognizers.Contains((IGestureRecognizer)item))
 								item.Parent = this;
 							else

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -162,13 +162,13 @@ namespace Microsoft.Maui.Controls
 
 				_recognizerForPointerOverState.PointerEntered += (s, e) =>
 				{
-					IsPointerOver = true;
+					_isPointerOver = true;
 					ChangeVisualState();
 				};
 
 				_recognizerForPointerOverState.PointerExited += (s, e) =>
 				{
-					IsPointerOver = false;
+					_isPointerOver = false;
 					ChangeVisualState();
 				};
 

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -165,13 +165,13 @@ namespace Microsoft.Maui.Controls
 
 				_recognizerForPointerOverState.PointerEntered += (s, e) =>
 				{
-					_isPointerOver = true;
+					IsPointerOver = true;
 					ChangeVisualState();
 				};
 
 				_recognizerForPointerOverState.PointerExited += (s, e) =>
 				{
-					_isPointerOver = false;
+					IsPointerOver = false;
 					ChangeVisualState();
 				};
 

--- a/src/Controls/src/Core/View.cs
+++ b/src/Controls/src/Core/View.cs
@@ -158,7 +158,10 @@ namespace Microsoft.Maui.Controls
 		{
 			get
 			{
-				_recognizerForPointerOverState ??= new PointerGestureRecognizer();
+				if (_compositeGestureRecognizers is not null)
+					return _compositeGestureRecognizers;
+
+				_recognizerForPointerOverState = new PointerGestureRecognizer();
 
 				_recognizerForPointerOverState.PointerEntered += (s, e) =>
 				{

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1087,7 +1087,7 @@ namespace Microsoft.Maui.Controls
 
 		internal void ChangeVisualStateInternal() => ChangeVisualState();
 
-		protected internal bool IsPointerOver = false;
+		internal bool IsPointerOver = false;
 
 		protected internal virtual void ChangeVisualState()
 		{

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1087,7 +1087,20 @@ namespace Microsoft.Maui.Controls
 
 		internal void ChangeVisualStateInternal() => ChangeVisualState();
 
-		internal bool IsPointerOver { get; private protected set; }
+		bool _isPointerOver;
+
+		internal bool IsPointerOver
+		{
+			get { return _isPointerOver; }
+			private protected set
+			{
+				if (value == _isPointerOver)
+					return;
+
+				_isPointerOver = value;
+				ChangeVisualState();
+			}
+		}
 
 		protected internal virtual void ChangeVisualState()
 		{

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1087,13 +1087,13 @@ namespace Microsoft.Maui.Controls
 
 		internal void ChangeVisualStateInternal() => ChangeVisualState();
 
-		internal bool _isPointerOver = false;
+		internal bool IsPointerOver { get; private protected set; }
 
 		protected internal virtual void ChangeVisualState()
 		{
 			if (!IsEnabled)
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
-			else if (_isPointerOver)
+			else if (IsPointerOver)
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
 			else if (IsFocused)
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Focused);

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1087,13 +1087,13 @@ namespace Microsoft.Maui.Controls
 
 		internal void ChangeVisualStateInternal() => ChangeVisualState();
 
-		internal bool IsPointerOver = false;
+		internal bool _isPointerOver = false;
 
 		protected internal virtual void ChangeVisualState()
 		{
 			if (!IsEnabled)
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
-			else if (IsPointerOver)
+			else if (_isPointerOver)
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
 			else if (IsFocused)
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Focused);

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1087,10 +1087,14 @@ namespace Microsoft.Maui.Controls
 
 		internal void ChangeVisualStateInternal() => ChangeVisualState();
 
+		protected internal bool IsPointerOver = false;
+
 		protected internal virtual void ChangeVisualState()
 		{
 			if (!IsEnabled)
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
+			else if (IsPointerOver)
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
 			else if (IsFocused)
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Focused);
 			else

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Controls
 			public const string Disabled = "Disabled";
 			public const string Focused = "Focused";
 			public const string Selected = "Selected";
+			public const string PointerEntered = "PointerEntered";
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateManager.xml" path="//Member[@MemberName='VisualStateGroupsProperty']/Docs/*" />

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls
 			public const string Disabled = "Disabled";
 			public const string Focused = "Focused";
 			public const string Selected = "Selected";
-			public const string PointerEntered = "PointerEntered";
+			public const string PointerOver = "PointerOver";
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateManager.xml" path="//Member[@MemberName='VisualStateGroupsProperty']/Docs/*" />

--- a/src/Controls/tests/Core.UnitTests/ViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ViewUnitTests.cs
@@ -662,10 +662,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var gestureRecognizer = new TapGestureRecognizer();
 
 			view.GestureRecognizers.Add(gestureRecognizer);
+			Assert.Equal(2, (view as IGestureController).CompositeGestureRecognizers.Count);
+			
 			view.GestureRecognizers.Clear();
-
-
-			Assert.Equal(0, (view as IGestureController).CompositeGestureRecognizers.Count);
+			Assert.Equal(1, (view as IGestureController).CompositeGestureRecognizers.Count);
 			Assert.Null(gestureRecognizer.Parent);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/ViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ViewUnitTests.cs
@@ -662,16 +662,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var gestureRecognizer = new TapGestureRecognizer();
 
 			view.GestureRecognizers.Add(gestureRecognizer);
-
-#if !ANDROID
-			Assert.Equal(2, (view as IGestureController).CompositeGestureRecognizers.Count);
-#endif          
+			Assert.Equal(2, (view as IGestureController).CompositeGestureRecognizers.Count);       
+			
 			view.GestureRecognizers.Clear();
-#if ANDROID
-			Assert.Equal(0, (view as IGestureController).CompositeGestureRecognizers.Count);
-#else
 			Assert.Equal(1, (view as IGestureController).CompositeGestureRecognizers.Count);
-#endif
 			Assert.Null(gestureRecognizer.Parent);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/ViewUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ViewUnitTests.cs
@@ -662,10 +662,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var gestureRecognizer = new TapGestureRecognizer();
 
 			view.GestureRecognizers.Add(gestureRecognizer);
+
+#if !ANDROID
 			Assert.Equal(2, (view as IGestureController).CompositeGestureRecognizers.Count);
-			
+#endif          
 			view.GestureRecognizers.Clear();
+#if ANDROID
+			Assert.Equal(0, (view as IGestureController).CompositeGestureRecognizers.Count);
+#else
 			Assert.Equal(1, (view as IGestureController).CompositeGestureRecognizers.Count);
+#endif
 			Assert.Null(gestureRecognizer.Parent);
 		}
 


### PR DESCRIPTION
### Description of Change

Introduces new visual state `PointerOver` for when the mouse cursor is hovering over a view.
When both `PointerOver` and `Pressed` states are defined, the `PointerOver` state kicks in when the view is still hovered but not pressed.

Related to #9592
Related to #9861 

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Provides workaround for #7570
Provides workaround for #9715

Related to #9139 
