### PR TITLE
Use the new public SkiaSharp

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -21,7 +21,6 @@
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
-    <add key="skiasharp-stable-sha-signed" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/skiasharp-stable-88c09609-signed/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -71,9 +71,9 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3f4da9ced34942d83054e647f3b1d9d7dde281e8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Maui.Graphics" Version="6.0.500">
+    <Dependency Name="Microsoft.Maui.Graphics" Version="6.0.501">
       <Uri>https://github.com/dotnet/Microsoft.Maui.Graphics</Uri>
-      <Sha>1759e742e20189e92f19b409687a14458accbe85</Sha>
+      <Sha>015c4cd2d4ce120e516d75601ef5e80004b141a7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="1.0.0-prerelease.22276.1">
       <Uri>https://github.com/dotnet/xharness</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.22302.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
-    <MicrosoftMauiGraphicsVersion>6.0.500</MicrosoftMauiGraphicsVersion>
+    <MicrosoftMauiGraphicsVersion>6.0.501</MicrosoftMauiGraphicsVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
     <_MicrosoftWebWebView2Version>1.0.1210.39</_MicrosoftWebWebView2Version>
     <!-- GLIDE - the android maven artifact in /src/Core/AndroidNative/maui/build.gradle -->
@@ -53,7 +53,7 @@
     -->
     <_SkiaSharpVersion>2.88.2</_SkiaSharpVersion>
     <_HarfBuzzSharpVersion>2.8.2.2</_HarfBuzzSharpVersion>
-    <_SkiaSharpNativeAssetsVersion>0.0.0-commit.88c096095fc1cf61a64b47b7044e9e89e3f6c097.480</_SkiaSharpNativeAssetsVersion>
+    <_SkiaSharpNativeAssetsVersion>0.0.0-commit.193b587552cb0ed39372a049d7e6c692db98c267.483</_SkiaSharpNativeAssetsVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-preview.5.22226.1</MicrosoftTemplateEngineTasksVersion>
     <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.22276.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
     <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.22276.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>

--- a/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
+++ b/src/SingleProject/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="16.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.7.0" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="SkiaSharp" Version="2.88.1" />
+    <PackageReference Include="SkiaSharp" Version="$(_SkiaSharpVersion)" />
     <PackageReference Include="SkiaSharp.Extended" Version="2.0.0-preview.61" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />


### PR DESCRIPTION
### Description of Change

Now that SkiaSharp is public, use the new version and commit sha.