### PR TITLE
Remove Assert Not Null check on HashCode test

### DIFF
--- a/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void TestGetGradientStopHashCode()
 		{
 			var gradientStop = new GradientStop();
-			var hashCode = gradientStop.GetHashCode();
-			Assert.NotNull(hashCode);
+			_ = gradientStop.GetHashCode();
+			// This test is just validating that calling `GetHashCode` doesn't throw
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The original test in net6.0 wasn't completely valid and xUnit is doing a better job at letting us know. The original PR was just meant to validate that calling `GetHashCode` wouldn't throw an exception so I don't think we need to validate anything here. The test running to completion is the only interesting thing being tested