### PR TITLE
[Windows] Fix Border clipping issue

### DIFF
--- a/src/Core/src/Platform/Windows/ContentPanel.cs
+++ b/src/Core/src/Platform/Windows/ContentPanel.cs
@@ -137,8 +137,8 @@ namespace Microsoft.Maui.Platform
 			if (clipGeometry == null)
 				return;
 
-			double width = Content.ActualWidth;
-			double height = Content.ActualHeight;
+			double width = ActualWidth;
+			double height = ActualHeight;
 
 			if (height <= 0 && width <= 0)
 				return;


### PR DESCRIPTION
### Description of Change

Fix Windows Border clipping issue.

![fix-10027](https://user-images.githubusercontent.com/6755973/189671273-93ec99ec-01a8-4628-8584-056493ac4cee.PNG)

By using the wrong size, in some condition the correct size is not used (or it is zero and no clipping is done). This PR adds changes to use the Container size.

### Issues Fixed

Fixes #10027 