### PR TITLE
Compress Grid measurements for star rows/columns

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -29,12 +29,9 @@ namespace Microsoft.Maui.Layouts
 
 		public override Size ArrangeChildren(Rect bounds)
 		{
-			if (_gridStructure == null)
-			{
-				_gridStructure = new GridStructure(Grid, bounds.Width, bounds.Height);
-			}
+			_gridStructure ??= new GridStructure(Grid, bounds.Width, bounds.Height);
 
-			_gridStructure.AdjustStarsForArrange(bounds.Size);
+			_gridStructure.DecompressStars(bounds.Size);
 
 			foreach (var view in Grid)
 			{
@@ -70,7 +67,8 @@ namespace Microsoft.Maui.Layouts
 
 			Definition[] _rows { get; }
 			Definition[] _columns { get; }
-			IView[] _childrenToLayOut;
+
+			readonly IView[] _childrenToLayOut;
 			Cell[] _cells { get; }
 
 			readonly Thickness _padding;
@@ -104,12 +102,8 @@ namespace Microsoft.Maui.Layouts
 				_rowDefinitions = grid.RowDefinitions;
 				_columnDefinitions = grid.ColumnDefinitions;
 
-				// Determine whether "*" values make sense in each dimension, given our constraints
-				bool treatStarRowsAsAuto = ShouldTreatStarsAsAuto(_gridHeightConstraint, _explicitGridHeight, _grid.VerticalLayoutAlignment);
-				bool treatStarColumnsAsAuto = ShouldTreatStarsAsAuto(_gridWidthConstraint, _explicitGridWidth, _grid.HorizontalLayoutAlignment);
-
-				_rows = InitializeRows(treatStarRowsAsAuto);
-				_columns = InitializeColumns(treatStarColumnsAsAuto);
+				_rows = InitializeRows();
+				_columns = InitializeColumns();
 
 				// We could work out the _childrenToLayOut array (with the Collapsed items filtered out) with a Linq 1-liner
 				// but doing it the hard way means we don't allocate extra enumerators, especially if we're in the 
@@ -140,22 +134,22 @@ namespace Microsoft.Maui.Layouts
 				MeasureCells();
 			}
 
-			static Definition[] Implied(bool treatStarAsAuto)
+			static Definition[] Implied()
 			{
 				return new Definition[]
 				{
-					new Definition(treatStarAsAuto ? GridLength.Auto : GridLength.Star, treatStarAsAuto)
+					new Definition(GridLength.Star)
 				};
 			}
 
-			Definition[] InitializeRows(bool treatStarAsAuto)
+			Definition[] InitializeRows()
 			{
 				int count = _rowDefinitions.Count;
 
 				if (count == 0)
 				{
 					// Since no rows are specified, we'll create an implied row 0 
-					return Implied(treatStarAsAuto);
+					return Implied();
 				}
 
 				var rows = new Definition[count];
@@ -163,28 +157,20 @@ namespace Microsoft.Maui.Layouts
 				for (int n = 0; n < count; n++)
 				{
 					var definition = _rowDefinitions[n];
-
-					if (definition.Height.GridUnitType == GridUnitType.Star && treatStarAsAuto)
-					{
-						rows[n] = new Definition(GridLength.Auto, treatStarAsAuto);
-					}
-					else
-					{
-						rows[n] = new Definition(definition.Height);
-					}
+					rows[n] = new Definition(definition.Height);
 				}
 
 				return rows;
 			}
 
-			Definition[] InitializeColumns(bool treatStarAsAuto)
+			Definition[] InitializeColumns()
 			{
 				int count = _columnDefinitions.Count;
 
 				if (count == 0)
 				{
 					// Since no columns are specified, we'll create an implied column 0 
-					return Implied(treatStarAsAuto);
+					return Implied();
 				}
 
 				var definitions = new Definition[count];
@@ -192,15 +178,7 @@ namespace Microsoft.Maui.Layouts
 				for (int n = 0; n < count; n++)
 				{
 					var definition = _columnDefinitions[n];
-
-					if (definition.Width.GridUnitType == GridUnitType.Star && treatStarAsAuto)
-					{
-						definitions[n] = new Definition(GridLength.Auto, treatStarAsAuto);
-					}
-					else
-					{
-						definitions[n] = new Definition(definition.Width);
-					}
+					definitions[n] = new Definition(definition.Width);
 				}
 
 				return definitions;
@@ -318,7 +296,7 @@ namespace Microsoft.Maui.Layouts
 				return width;
 			}
 
-			double SumDefinitions(Definition[] definitions, double spacing)
+			static double SumDefinitions(Definition[] definitions, double spacing)
 			{
 				double sum = 0;
 
@@ -344,57 +322,65 @@ namespace Microsoft.Maui.Layouts
 
 			void MeasureCells()
 			{
-				for (int n = 0; n < _cells.Length; n++)
-				{
-					var cell = _cells[n];
-
-					if (cell.ColumnGridLengthType == GridLengthType.Absolute
-						&& cell.RowGridLengthType == GridLengthType.Absolute)
-					{
-						continue;
-					}
-
-					if (cell.IsColumnSpanAuto || cell.IsRowSpanAuto)
-					{
-						var availableWidth = cell.IsColumnSpanAuto ? double.PositiveInfinity : AvailableWidth(cell);
-						var availableHeight = cell.IsRowSpanAuto ? double.PositiveInfinity : AvailableHeight(cell);
-
-						var measure = _childrenToLayOut[cell.ViewIndex].Measure(availableWidth, availableHeight);
-
-						if (cell.IsColumnSpanAuto)
-						{
-							if (cell.ColumnSpan == 1)
-							{
-								_columns[cell.Column].Update(measure.Width);
-							}
-							else
-							{
-								var span = new Span(cell.Column, cell.ColumnSpan, true, measure.Width);
-								TrackSpan(span);
-							}
-						}
-
-						if (cell.IsRowSpanAuto)
-						{
-							if (cell.RowSpan == 1)
-							{
-								_rows[cell.Row].Update(measure.Height);
-							}
-							else
-							{
-								var span = new Span(cell.Row, cell.RowSpan, false, measure.Height);
-								TrackSpan(span);
-							}
-						}
-					}
-				}
-
-				ResolveSpans();
+				// Do the initial pass for all the auto/star stuff
+				MeasureCellsWithUnknowns();
 
 				ResolveStarColumns(_gridWidthConstraint);
 				ResolveStarRows(_gridHeightConstraint);
 
-				EnsureFinalMeasure();
+				// Measure the content for cells where we know the dimensions
+				MeasureKnownCells();
+
+				ResolveSpans();
+
+				// Compress the star values to their minimums for measurement 
+				CompressStarMeasurements();
+			}
+
+			void MeasureCellsWithUnknowns() 
+			{
+				for (int n = 0; n < _cells.Length; n++)
+				{
+					var cell = _cells[n];
+
+					if (cell.IsAbsolute)
+					{
+						// This cell is entirely within rows/columns with absolute sizes; we don't need to measure
+						// it to figure out those sizes
+						continue;
+					}
+
+					var availableWidth = cell.IsColumnSpanAuto ? double.PositiveInfinity : AvailableWidth(cell);
+					var availableHeight = cell.IsRowSpanAuto ? double.PositiveInfinity : AvailableHeight(cell);
+
+					var measure = _childrenToLayOut[cell.ViewIndex].Measure(availableWidth, availableHeight);
+
+					if (cell.IsColumnSpanAuto)
+					{
+						if (cell.ColumnSpan == 1)
+						{
+							_columns[cell.Column].Update(measure.Width);
+						}
+						else
+						{
+							var span = new Span(cell.Column, cell.ColumnSpan, true, measure.Width);
+							TrackSpan(span);
+						}
+					}
+
+					if (cell.IsRowSpanAuto)
+					{
+						if (cell.RowSpan == 1)
+						{
+							_rows[cell.Row].Update(measure.Height);
+						}
+						else
+						{
+							var span = new Span(cell.Row, cell.RowSpan, false, measure.Height);
+							TrackSpan(span);
+						}
+					}
+				}
 			}
 
 			void TrackSpan(Span span)
@@ -428,7 +414,7 @@ namespace Microsoft.Maui.Layouts
 				}
 			}
 
-			void ResolveSpan(Definition[] definitions, int start, int length, double spacing, double requestedSize)
+			static void ResolveSpan(Definition[] definitions, int start, int length, double spacing, double requestedSize)
 			{
 				double currentSize = 0;
 				var end = start + length;
@@ -536,7 +522,7 @@ namespace Microsoft.Maui.Layouts
 
 					foreach (var cell in _cells)
 					{
-						if (cellCheck(cell)) // Check whether this cell should count toward the type of star value were measuring
+						if (cellCheck(cell)) // Check whether this cell should count toward the type of star value we're measuring
 						{
 							// Update the star width if the view in this cell is bigger
 							starSize = Math.Max(starSize, dimension(_childrenToLayOut[cell.ViewIndex].DesiredSize));
@@ -577,11 +563,11 @@ namespace Microsoft.Maui.Layouts
 				ResolveStars(_rows, availableSpace, cellCheck, getDimension);
 			}
 
-			void EnsureFinalMeasure()
+			void MeasureKnownCells()
 			{
 				foreach (var cell in _cells)
 				{
-					if (!cell.NeedsFinalMeasure)
+					if (!cell.NeedsKnownMeasurePass)
 					{
 						continue;
 					}
@@ -604,7 +590,19 @@ namespace Microsoft.Maui.Layouts
 						continue;
 					}
 
-					_childrenToLayOut[cell.ViewIndex].Measure(width, height);
+					var measure = _childrenToLayOut[cell.ViewIndex].Measure(width, height);
+
+					if (cell.IsColumnSpanStar && cell.ColumnSpan > 1)
+					{
+						var span = new Span(cell.Column, cell.ColumnSpan, true, measure.Width);
+						TrackSpan(span);
+					}
+
+					if (cell.IsRowSpanStar && cell.RowSpan > 1)
+					{
+						var span = new Span(cell.Row, cell.RowSpan, false, measure.Height);
+						TrackSpan(span);
+					}
 				}
 			}
 
@@ -684,90 +682,169 @@ namespace Microsoft.Maui.Layouts
 				return available + cellRowsHeight;
 			}
 
-			public void AdjustStarsForArrange(Size targetSize)
+			public void DecompressStars(Size targetSize)
 			{
-				if (_grid.VerticalLayoutAlignment == Primitives.LayoutAlignment.Fill)
+				if (_grid.VerticalLayoutAlignment == LayoutAlignment.Fill || Dimension.IsExplicitSet(_explicitGridHeight))
 				{
 					if (_grid.DesiredSize.Height < targetSize.Height)
 					{
 						// Reset the size on all star rows
-						for (int n = 0; n < _rows.Length; n++)
-						{
-							var definition = _rows[n];
-							if (definition.IsStar)
-							{
-								definition.Size = 0;
-							}
-						}
+						ZeroOutStarSizes(_rows);
 
-						// Reset the size on all "star as auto" rows
-						for (int n = 0; n < _rows.Length; n++)
-						{
-							var definition = _rows[n];
-							if (definition.IsStarAsAuto)
-							{
-								_rows[n] = new Definition(GridLength.Star);
-							}
-						}
-
+						// And compute them for the actual arrangement height
 						ResolveStarRows(targetSize.Height);
 					}
 				}
 
-				if (_grid.HorizontalLayoutAlignment == Primitives.LayoutAlignment.Fill)
+				if (_grid.HorizontalLayoutAlignment == LayoutAlignment.Fill || Dimension.IsExplicitSet(_explicitGridWidth))
 				{
 					if (_grid.DesiredSize.Width < targetSize.Width)
 					{
 						// Reset the size on all star rows
-						for (int n = 0; n < _columns.Length; n++)
-						{
-							var definition = _columns[n];
-							if (definition.IsStar)
-							{
-								definition.Size = 0;
-							}
-						}
+						ZeroOutStarSizes(_columns);
 
-						// Reset the size on all "star as auto" rows
-						for (int n = 0; n < _columns.Length; n++)
-						{
-							var definition = _columns[n];
-							if (definition.IsStarAsAuto)
-							{
-								_columns[n] = new Definition(GridLength.Star);
-							}
-						}
-
+						// And compute them for the actual arrangement width
 						ResolveStarColumns(targetSize.Width);
 					}
 				}
 			}
 
-			static bool ShouldTreatStarsAsAuto(double constraint, double explicitDimension, LayoutAlignment layoutAlignment)
+			void CompressStarMeasurements()
 			{
-				if (double.IsInfinity(constraint))
+				CompressStarRows();
+				CompressStarColumns();
+			}
+
+			void CompressStarRows()
+			{
+				var copy = ScratchCopy(_rows);
+
+				// Iterate over the cells and inflate the star row sizes in the copy
+				// to the minimum required in order to contain the cells
+
+				for (int n = 0; n < _cells.Length; n++)
 				{
-					// If the constraint is infinite, then "*" doesn't really make any sense; we'll treat the 
-					// measurement as "Auto" instead
-					return true;
+					var cell = _cells[n];
+
+					if (!cell.IsRowSpanStar)
+					{
+						// This cell doesn't span any star rows, nothing to do
+						continue;
+					}
+
+					var start = cell.Row;
+					var end = start + cell.RowSpan;
+
+					var desiredHeight = _childrenToLayOut[cell.ViewIndex].DesiredSize.Height;
+
+					ExpandStarsInSpan(desiredHeight, _rows, copy, start, end);
 				}
 
-				if (layoutAlignment == LayoutAlignment.Fill)
+				UpdateStarSizes(_rows, copy);
+			}
+
+			void CompressStarColumns()
+			{
+				var copy = ScratchCopy(_columns);
+
+				// Iterate over the cells and inflate the star column sizes in the copy
+				// to the minimum required in order to contain the cells
+
+				for (int n = 0; n < _cells.Length; n++)
 				{
-					// If the constraint is not infinite and our Grid is supposed to Fill this dimension, then
-					// we can definitely come up with a meaningful value for "*", so don't treat this as "Auto"
-					return false;
+					var cell = _cells[n];
+
+					if (!cell.IsColumnSpanStar)
+					{
+						// This cell doesn't span any star columns, nothing to do
+						continue;
+					}
+
+					var start = cell.Column;
+					var end = start + cell.ColumnSpan;
+
+					var cellRequiredWidth = _childrenToLayOut[cell.ViewIndex].DesiredSize.Width;
+
+					ExpandStarsInSpan(cellRequiredWidth, _columns, copy, start, end);
 				}
 
-				if (Dimension.IsExplicitSet(explicitDimension))
+				UpdateStarSizes(_columns, copy);
+			}
+
+			static Definition[] ScratchCopy(Definition[] original) 
+			{
+				var copy = new Definition[original.Length];
+				original.CopyTo(copy, 0);
+
+				// zero out the star sizes in the copy
+				ZeroOutStarSizes(copy);
+
+				return copy;
+			}
+
+			static void ExpandStarsInSpan(double spaceNeeded, Definition[] original, Definition[] updated, int start, int end)
+			{
+				// Remove the parts of spaceNeeded which are already covered by explicit and auto columns in the span
+				for (int n = start; n < end; n++)
 				{
-					// If we're not filling the dimension but our size in this dimension is fixed, then we 
-					// can definitely get a meaningful value for "*", so don't treat this as "Auto"
-					return false;
+					if (original[n].IsAbsolute || original[n].IsAuto)
+					{
+						spaceNeeded -= original[n].Size;
+					}
 				}
 
-				// We don't have the info to make "*" meaningful, so treat it as "Auto" instead
-				return true;
+				// Determine how much space the star sizes in the span are already requesting
+				// (because of other overlapping cells)
+
+				double spaceAvailable = 0;
+				int starCount = 0;
+				for (int n = start; n < end; n++)
+				{
+					if (updated[n].IsStar)
+					{
+						starCount += 1;
+						spaceAvailable += updated[n].Size;
+					}
+				}
+
+				// If previous inflations from other cells haven't given us enough room,
+				// distribute the amount of space we still need evenly across the stars in the span
+				if (spaceAvailable < spaceNeeded)
+				{
+					var toAdd = (spaceNeeded - spaceAvailable) / starCount;
+					for (int n = start; n < end; n++)
+					{
+						if (updated[n].IsStar)
+						{
+							updated[n].Update(toAdd);
+						}
+					}
+				}
+			}
+
+			static void ZeroOutStarSizes(Definition[] definitions) 
+			{
+				for (int n = 0; n < definitions.Length; n++)
+				{
+					var definition = definitions[n];
+					if (definition.IsStar)
+					{
+						definition.Size = 0;
+					}
+				}
+			}
+
+			static void UpdateStarSizes(Definition[] original, Definition[] updated) 
+			{
+				for (int n = 0; n < updated.Length; n++)
+				{
+					if (!updated[n].IsStar)
+					{
+						continue;
+					}
+
+					original[n].Size = updated[n].Size;
+				}
 			}
 		}
 
@@ -828,12 +905,14 @@ namespace Microsoft.Maui.Layouts
 			public bool IsRowSpanAuto => HasFlag(RowGridLengthType, GridLengthType.Auto);
 			public bool IsColumnSpanStar => HasFlag(ColumnGridLengthType, GridLengthType.Star);
 			public bool IsRowSpanStar => HasFlag(RowGridLengthType, GridLengthType.Star);
+			public bool IsAbsolute => ColumnGridLengthType == GridLengthType.Absolute
+						&& RowGridLengthType == GridLengthType.Absolute;
 
-			// If any part of the Cell's spans are Absolute or Star, then the Cell will need a measure at the final size. 
-			// If the cell is entirely Auto, then it doesn't need another measure call. 
-			public bool NeedsFinalMeasure => ((ColumnGridLengthType | RowGridLengthType) ^ GridLengthType.Auto) > 0;
+			// If any part of the Cell's spans are Absolute or Star, then the Cell will need a measure pass at the known
+			// size once that's been determined (i.e., when the Auto stuff has been worked out)
+			public bool NeedsKnownMeasurePass => ((ColumnGridLengthType | RowGridLengthType) ^ GridLengthType.Auto) > 0;
 
-			bool HasFlag(GridLengthType a, GridLengthType b)
+			static bool HasFlag(GridLengthType a, GridLengthType b)
 			{
 				// Avoiding Enum.HasFlag here for performance reasons; we don't need the type check
 				return (a & b) == b;
@@ -876,11 +955,10 @@ namespace Microsoft.Maui.Layouts
 			public bool IsAuto => _gridLength.IsAuto;
 			public bool IsStar => _gridLength.IsStar;
 			public bool IsAbsolute => _gridLength.IsAbsolute;
-			public bool IsStarAsAuto { get; }
 
 			public GridLength GridLength => _gridLength;
 
-			public Definition(GridLength gridLength, bool treatStarAsAuto = false)
+			public Definition(GridLength gridLength)
 			{
 				if (gridLength.IsAbsolute)
 				{
@@ -888,8 +966,6 @@ namespace Microsoft.Maui.Layouts
 				}
 
 				_gridLength = gridLength;
-
-				IsStarAsAuto = gridLength.IsAuto && treatStarAsAuto;
 			}
 		}
 	}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -129,13 +129,30 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			grid.GetColumnSpan(view).Returns(colSpan);
 		}
 
-		Size MeasureAndArrange(IGridLayout grid, double widthConstraint = double.PositiveInfinity, double heightConstraint = double.PositiveInfinity, double left = 0, double top = 0)
+		static Size MeasureAndArrangeFixed(IGridLayout grid, double widthConstraint, double heightConstraint, double left = 0, double top = 0)
+		{
+			var manager = new GridLayoutManager(grid);
+			var measuredSize = manager.Measure(widthConstraint, heightConstraint);
+
+			var arrangeSize = new Size(widthConstraint, heightConstraint);
+
+			manager.ArrangeChildren(new Rect(new Point(left, top), arrangeSize));
+
+			return measuredSize;
+		}
+
+		static Size MeasureAndArrange(IGridLayout grid, double widthConstraint = double.PositiveInfinity, double heightConstraint = double.PositiveInfinity, double left = 0, double top = 0)
 		{
 			var manager = new GridLayoutManager(grid);
 			var measuredSize = manager.Measure(widthConstraint, heightConstraint);
 			manager.ArrangeChildren(new Rect(new Point(left, top), measuredSize));
 
 			return measuredSize;
+		}
+
+		static Size MeasureAndArrangeAuto(IGridLayout grid) 
+		{
+			return MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity, 0, 0);
 		}
 
 		[Category(GridAutoSizing)]
@@ -154,7 +171,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Set up the row/column values and spans
 			SetLocation(grid, view);
 
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 
 			// No rows/columns were specified, so the implied */* is used; we're measuring with infinity, so
 			// we expect that the view will be arranged at its measured size
@@ -178,7 +195,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, col: 1);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 
 			// Column width is 100, viewSize is less than that, so it should be able to layout out at full size
 			AssertArranged(view0, 0, 0, 100, 10);
@@ -208,7 +225,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view3, row: 1, col: 1);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 
 			// Verify that the views are getting measured at all, and that they're being measured at 
 			// the appropriate sizes
@@ -246,7 +263,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, col: 1);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 
 			// Column width is 100, viewSize is less, so it should be able to layout at full size
 			AssertArranged(view0, 0, 0, 100, viewSize.Height);
@@ -272,7 +289,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 1);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 
 			// Row height is 100, so full view should fit
 			AssertArranged(view0, 0, 0, viewSize.Width, 100);
@@ -290,7 +307,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view);
 			SetLocation(grid, view);
 
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 			AssertArranged(view, 0, 0, 100, 100);
 		}
 
@@ -305,7 +322,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0);
 			SetLocation(grid, view1, row: 1);
 
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 			AssertArranged(view0, 0, 0, 100, 100);
 
 			// With column width 100 and spacing of 10, we expect the second column to start at 110
@@ -405,7 +422,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view);
 			SetLocation(grid, view);
 
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 			AssertArranged(view, 0, 0, 100, 100);
 		}
 
@@ -420,7 +437,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0);
 			SetLocation(grid, view1, col: 1);
 
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 			AssertArranged(view0, 0, 0, 100, 100);
 
 			// With column width 100 and spacing of 10, we expect the second column to start at 110
@@ -519,7 +536,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 			SetLocation(grid, view0, rowSpan: 2);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			AssertArranged(view0, 0, 0, 100, 100);
 			Assert.Equal(100, measuredSize.Width);
@@ -540,7 +557,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, rowSpan: 2);
 			SetLocation(grid, view1, row: 1, col: 1);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(100 + 50, measuredSize.Width);
 			Assert.Equal(100, measuredSize.Height);
@@ -563,7 +580,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 0, col: 1);
 			SetLocation(grid, view2, row: 1, col: 1);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(150, measuredSize.Width);
 			Assert.Equal(50 + 50 + 5, measuredSize.Height);
@@ -591,7 +608,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, colSpan: 2);
 			SetLocation(grid, view1, row: 1, col: 1);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(100, measuredSize.Width);
 			Assert.Equal(100 + 50, measuredSize.Height);
@@ -615,7 +632,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 1, col: 0);
 			SetLocation(grid, view2, row: 1, col: 1);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(50 + 50 + 5, measuredSize.Width);
 			Assert.Equal(100 + 50, measuredSize.Height);
@@ -642,7 +659,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, rowSpan: 2);
 			SetLocation(grid, view1, row: 0, col: 1);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(30 + 50, measuredSize.Width);
 			Assert.Equal(50, measuredSize.Height);
@@ -663,7 +680,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, colSpan: 2);
 			SetLocation(grid, view1, row: 1, col: 0);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(50, measuredSize.Width);
 			Assert.Equal(30 + 50, measuredSize.Height);
@@ -682,7 +699,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			SetLocation(grid, view0, row: 1, col: 1);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(15 + 85, measuredSize.Width);
 			Assert.Equal(10 + 40, measuredSize.Height);
@@ -702,7 +719,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, row: 0, col: 0, colSpan: 2);
 			SetLocation(grid, view1, row: 0, col: 1, rowSpan: 2);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(60, measuredSize.Width);
 			Assert.Equal(60, measuredSize.Height);
@@ -723,7 +740,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, rowSpan: 2);
 			SetLocation(grid, view1, row: 1, col: 1);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(100 + 50, measuredSize.Width);
 			Assert.Equal(100, measuredSize.Height);
@@ -747,7 +764,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, colSpan: 2);
 			SetLocation(grid, view1, row: 1, col: 1);
 
-			var measuredSize = MeasureAndArrange(grid);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(100, measuredSize.Width);
 			Assert.Equal(100 + 10, measuredSize.Height);
@@ -807,7 +824,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 			SetLocation(grid, view0);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Row height is auto, so it gets the height of the view
 			// Column is *, so it should get the whole width
@@ -827,7 +844,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 			SetLocation(grid, view0);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Row height is auto, so it gets the height of the view
 			// The column is 3*, but it's the only column, so it should get the full width
@@ -853,7 +870,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, col: 1);
 			SetLocation(grid, view2, col: 2);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Row height is auto, so it gets the height of the view
 			// Columns are *,*,*, so each view should be arranged at 1/3 the width
@@ -887,7 +904,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0);
 			SetLocation(grid, view1, col: 1);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Row height is auto, so it gets the height of the view
 			// First column should get 1/3 of the width, second should get 2/3
@@ -939,7 +956,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 			SetLocation(grid, view0);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Column width is auto, so it gets the width of the view
 			// Row is *, so it should get the whole height
@@ -959,7 +976,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 			SetLocation(grid, view0);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Column width is auto, so it gets the width of the view
 			// The row is 3*, but it's the only row, so it should get the full height
@@ -985,7 +1002,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 1);
 			SetLocation(grid, view2, row: 2);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Column width is auto, so it gets the width of the view
 			// Rows are *,*,*, so each view should be arranged at 1/3 the height
@@ -1013,7 +1030,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0);
 			SetLocation(grid, view1, row: 1);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Column width is auto, so it gets the width of the view
 			// First row should get 1/3 of the height, second should get 2/3
@@ -1072,7 +1089,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, col: 1);
 			SetLocation(grid, view2, col: 2);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Row height is auto, so it gets the height of the view
 			// Columns are 3*,100,* 
@@ -1095,7 +1112,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0);
 
 			// Using 300,300 - the implied row/column are GridLength.Star
-			MeasureAndArrange(grid, 300, 300);
+			MeasureAndArrangeFixed(grid, 300, 300);
 
 			// Since it's using GridLength.Star, we expect the view to be arranged at the full size of the grid
 			AssertArranged(view0, 0, 0, 300, 300);
@@ -1218,7 +1235,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Set up the row/column values and spans
 			SetLocation(grid, view);
 
-			var size = MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			var size = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(100, size.Width);
 			Assert.Equal(100, size.Height);
@@ -1289,7 +1306,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 			SetLocation(grid, view0, row, col);
 
-			MeasureAndArrange(grid, 100 * cols, 100 * rows);
+			MeasureAndArrangeFixed(grid, 100 * cols, 100 * rows);
 
 			AssertArranged(view0, 100 * actualCol, 100 * actualRow, 100, 100);
 		}
@@ -1334,7 +1351,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 			SetLocation(grid, view0, row, col, rowSpan, colSpan);
 
-			MeasureAndArrange(grid, 100 * GridSize, 100 * GridSize);
+			MeasureAndArrangeFixed(grid, 100 * GridSize, 100 * GridSize);
 
 			AssertArranged(
 				view0,
@@ -1549,7 +1566,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0);
 			SetLocation(grid, view1);
 
-			MeasureAndArrange(grid, constraintSize, constraintSize);
+			MeasureAndArrangeFixed(grid, constraintSize, constraintSize);
 
 			var expectedRectangle = new Rect(0, 0, expectedSize, expectedSize);
 
@@ -1604,7 +1621,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, col: 1);
 			SetLocation(grid, view2, col: 2);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Row height is auto, so it gets the height of the view
 			var expectedHeight = viewSize.Height;
@@ -1644,7 +1661,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 1);
 			SetLocation(grid, view2, row: 2);
 
-			MeasureAndArrange(grid, screenWidth, screenHeight);
+			MeasureAndArrangeFixed(grid, screenWidth, screenHeight);
 
 			// Column width is auto, so it gets the width of the view
 			var expectedWidth = viewSize.Width;
@@ -1679,12 +1696,14 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, col: 2);
 
 			var manager = new GridLayoutManager(grid);
-			var width = 100 + colSpacing + 100 + colSpacing + 100;
-			var measure = manager.Measure(width, double.PositiveInfinity);
+			var widthConstraint = 100 + colSpacing + 100 + colSpacing + 100;
+			var measure = manager.Measure(widthConstraint, double.PositiveInfinity);
 
-			Assert.Equal(width, measure.Width);
+			var expectedWidthMeasure = 100 + colSpacing + 0 + colSpacing + 100;
 
-			manager.ArrangeChildren(new Rect(0, 0, measure.Width, measure.Height));
+			Assert.Equal(expectedWidthMeasure, measure.Width);
+
+			manager.ArrangeChildren(new Rect(0, 0, widthConstraint, measure.Height));
 			AssertArranged(view0, new Rect(0, 0, 100, 100));
 			AssertArranged(view1, new Rect(220, 0, 100, 100));
 		}
@@ -1703,12 +1722,14 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view1, row: 2);
 
 			var manager = new GridLayoutManager(grid);
-			var height = 100 + rowSpacing + 100 + rowSpacing + 100;
-			var measure = manager.Measure(double.PositiveInfinity, height);
+			var heightConstraint = 100 + rowSpacing + 100 + rowSpacing + 100;
+			var measure = manager.Measure(double.PositiveInfinity, heightConstraint);
 
-			Assert.Equal(height, measure.Height);
+			var expectedHeightMeasure = 100 + rowSpacing + 0 + rowSpacing + 100;
 
-			manager.ArrangeChildren(new Rect(0, 0, measure.Width, measure.Height));
+			Assert.Equal(expectedHeightMeasure, measure.Height);
+
+			manager.ArrangeChildren(new Rect(0, 0, measure.Width, heightConstraint));
 			AssertArranged(view0, new Rect(0, 0, 100, 100));
 			AssertArranged(view1, new Rect(0, 220, 100, 100));
 		}
@@ -1728,7 +1749,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, col: 1);
 			SetLocation(grid, view1, row: 1, colSpan: 2);
 
-			MeasureAndArrange(grid, 200, 200);
+			MeasureAndArrangeFixed(grid, 200, 200);
 
 			// We expect that column 0 has no width, so view0 will be arranged at 0,0
 			AssertArranged(view0, 0, 0, 200, 10);
@@ -1750,7 +1771,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 
 			// Verify that the view is getting measured at the appropriate height (50)
 			view0.Received().Measure(Arg.Any<double>(), Arg.Is<double>(50));
@@ -1774,7 +1795,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0, row: 1);
 			SetLocation(grid, view1, col: 1, rowSpan: 2);
 
-			MeasureAndArrange(grid, 200, 200);
+			MeasureAndArrangeFixed(grid, 200, 200);
 
 			// We expect that row 0 has no height, so view0 will be arranged at 0,0
 			AssertArranged(view0, 0, 0, 10, 200);
@@ -1796,7 +1817,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SubstituteChildren(grid, view0);
 
 			// Assuming no constraints on space
-			MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			MeasureAndArrangeAuto(grid);
 
 			// Verify that the view is getting measured at the appropriate width (50)
 			view0.Received().Measure(Arg.Is<double>(50), Arg.Any<double>());
@@ -1817,7 +1838,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			SubstituteChildren(grid, view0);
 
-			MeasureAndArrange(grid, 500, 500);
+			MeasureAndArrangeFixed(grid, 500, 500);
 
 			// Verify that the view is getting measured at the appropriate height (infinity)
 			view0.Received().Measure(Arg.Is<double>(500), Arg.Is(double.PositiveInfinity));
@@ -1835,7 +1856,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			SubstituteChildren(grid, view0);
 
-			MeasureAndArrange(grid, 500, 500);
+			MeasureAndArrangeFixed(grid, 500, 500);
 
 			// Verify that the view is getting measured at the appropriate width (infinity)
 			view0.Received().Measure(Arg.Is(double.PositiveInfinity), Arg.Is<double>(500));
@@ -1855,14 +1876,14 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			SubstituteChildren(grid, view0, view1);
 
-			var measuredSize = MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(10, measuredSize.Height);
 		}
 
 		[Fact("Star Column Width is correct when the first child is Collapsed")]
 		[Category(GridStarSizing)]
-		public void StarCoumnWidthCorrectWhenFirstChildCollapsed()
+		public void StarColumnWidthCorrectWhenFirstChildCollapsed()
 		{
 			var grid = CreateGridLayout(columns: "*");
 
@@ -1874,7 +1895,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			SubstituteChildren(grid, view0, view1);
 
-			var measuredSize = MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			var measuredSize = MeasureAndArrangeAuto(grid);
 
 			Assert.Equal(10, measuredSize.Width);
 		}
@@ -1893,6 +1914,8 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var measuredSize = MeasureAndArrange(grid, 300, double.PositiveInfinity);
 
 			// we expect that the child will be arranged within measured size
+			// TODO this test might be improperly named, and also the measuredSize.Width should probably be 300
+
 			AssertArranged(view0, 0, 0, measuredSize.Width, measuredSize.Height);
 		}
 
@@ -1903,11 +1926,13 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		[InlineData(LayoutAlignment.Start, false)]
 		[InlineData(LayoutAlignment.End, true)]
 		[InlineData(LayoutAlignment.End, false)]
-		public void StarColumnsAreAutoWhenGridAlignmentIsNotFill(LayoutAlignment alignment, bool impliedColumn)
+		[InlineData(LayoutAlignment.Fill, true)]
+		[InlineData(LayoutAlignment.Fill, false)]
+		public void GridMeasuresStarColumnToChildWidth(LayoutAlignment alignment, bool impliedColumn) 
 		{
-			string columns = impliedColumn ? null : "*";
+			string layoutData = impliedColumn ? null : "*";
 
-			var grid = CreateGridLayout(columns: columns);
+			var grid = CreateGridLayout(columns: layoutData);
 
 			grid.HorizontalLayoutAlignment.Returns(alignment);
 
@@ -1915,9 +1940,32 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			SubstituteChildren(grid, view0);
 
-			var measuredSize = MeasureAndArrange(grid, 100, 100);
+			var manager = new GridLayoutManager(grid);
+			var measuredSize = manager.Measure(100, 100);
 
 			Assert.Equal(20, measuredSize.Width);
+		}
+
+		[Theory]
+		[InlineData(true, 100)]
+		[InlineData(false, 100)]
+		[InlineData(true, 15)]
+		[InlineData(false, 15)]
+		public void FillGridArrangesStarColumnToWidthConstraint(bool implied, double constraint) 
+		{
+			string layoutData = implied ? null : "*";
+
+			var grid = CreateGridLayout(columns: layoutData);
+
+			grid.HorizontalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var view0 = CreateTestView(new Size(20, 20));
+
+			SubstituteChildren(grid, view0);
+
+			MeasureAndArrangeFixed(grid, constraint, 100);
+
+			AssertArranged(view0, new Rect(0, 0, constraint, 100));
 		}
 
 		[Theory]
@@ -1927,20 +1975,99 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		[InlineData(LayoutAlignment.Start, false)]
 		[InlineData(LayoutAlignment.End, true)]
 		[InlineData(LayoutAlignment.End, false)]
-		public void StarRowsAreAutoWhenGridAlignmentIsNotFill(LayoutAlignment alignment, bool impliedRow)
+		public void NonFillGridArrangesStarColumnToChildWidth(LayoutAlignment alignment, bool implied)
 		{
-			string rows = impliedRow ? null : "*";
+			string layoutData = implied ? null : "*";
 
-			var grid = CreateGridLayout(rows: rows);
+			var grid = CreateGridLayout(columns: layoutData);
+
+			grid.HorizontalLayoutAlignment.Returns(alignment);
+
+			var view0 = CreateTestView(new Size(20, 20));
+
+			SubstituteChildren(grid, view0);
+
+			var measure = MeasureAndArrangeFixed(grid, 100, 100);
+
+			Assert.Equal(20, measure.Height);
+			Assert.Equal(20, measure.Width);
+
+			AssertArranged(view0, new Rect(0, 0, 20, 100));
+		}
+
+		[Theory]
+		[InlineData(LayoutAlignment.Center, true)]
+		[InlineData(LayoutAlignment.Center, false)]
+		[InlineData(LayoutAlignment.Start, true)]
+		[InlineData(LayoutAlignment.Start, false)]
+		[InlineData(LayoutAlignment.End, true)]
+		[InlineData(LayoutAlignment.End, false)]
+		[InlineData(LayoutAlignment.Fill, true)]
+		[InlineData(LayoutAlignment.Fill, false)]
+		public void GridMeasuresStarRowToChildHeight(LayoutAlignment alignment, bool implied)
+		{
+			string layoutData = implied ? null : "*";
+
+			var grid = CreateGridLayout(rows: layoutData);
+
 			grid.VerticalLayoutAlignment.Returns(alignment);
 
 			var view0 = CreateTestView(new Size(20, 20));
 
 			SubstituteChildren(grid, view0);
 
-			var measuredSize = MeasureAndArrange(grid, 100, 100);
+			var manager = new GridLayoutManager(grid);
+			var measuredSize = manager.Measure(100, 100);
 
 			Assert.Equal(20, measuredSize.Height);
+		}
+
+		[Theory]
+		[InlineData(true, 100)]
+		[InlineData(false, 100)]
+		[InlineData(true, 15)]
+		[InlineData(false, 15)]
+		public void FillGridArrangesStarRowToHeightConstraint(bool implied, double constraint)
+		{
+			string layoutData = implied ? null : "*";
+
+			var grid = CreateGridLayout(rows: layoutData);
+
+			grid.VerticalLayoutAlignment.Returns(LayoutAlignment.Fill);
+
+			var view0 = CreateTestView(new Size(20, 20));
+
+			SubstituteChildren(grid, view0);
+
+			MeasureAndArrangeFixed(grid, 100, constraint);
+
+			AssertArranged(view0, new Rect(0, 0, 100, constraint));
+		}
+
+		[Theory]
+		[InlineData(LayoutAlignment.Center, true)]
+		[InlineData(LayoutAlignment.Center, false)]
+		[InlineData(LayoutAlignment.Start, true)]
+		[InlineData(LayoutAlignment.Start, false)]
+		[InlineData(LayoutAlignment.End, true)]
+		[InlineData(LayoutAlignment.End, false)]
+		public void NonFillGridArrangesStarRowToChildHeight(LayoutAlignment alignment, bool impliedRow)
+		{
+			string layoutData = impliedRow ? null : "*";
+
+			var grid = CreateGridLayout(rows: layoutData);
+			grid.VerticalLayoutAlignment.Returns(alignment);
+
+			var view0 = CreateTestView(new Size(20, 20));
+
+			SubstituteChildren(grid, view0);
+
+			var measure = MeasureAndArrangeFixed(grid, 100, 100);
+
+			Assert.Equal(20, measure.Height);
+			Assert.Equal(20, measure.Width);
+
+			AssertArranged(view0, new Rect(0, 0, 100, 20));
 		}
 
 		[Fact]
@@ -2000,7 +2127,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		[InlineData(LayoutAlignment.Start)]
 		[InlineData(LayoutAlignment.End)]
 		[InlineData(LayoutAlignment.Fill)]
-		public void StarRowsShouldFitKnownDimensions(LayoutAlignment verticalAlignment)
+		public void StarRowsShouldFitExplicitDimensions(LayoutAlignment verticalAlignment)
 		{
 			var grid = CreateGridLayout(rows: "*");
 			grid.VerticalLayoutAlignment.Returns(verticalAlignment);
@@ -2012,8 +2139,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new GridLayoutManager(grid);
 			var gridMeasure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
 
-			// Because the Grid has an explicit height, we expect the single Star row
-			// to have that height.
+			// Because the Grid has an explicit height, we expect the measurement to have that height
 			Assert.Equal(100, gridMeasure.Height);
 
 			manager.ArrangeChildren(new Rect(Point.Zero, gridMeasure));
@@ -2028,7 +2154,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		[InlineData(LayoutAlignment.Start)]
 		[InlineData(LayoutAlignment.End)]
 		[InlineData(LayoutAlignment.Fill)]
-		public void StarColumnsShouldFitKnownDimensions(LayoutAlignment horizontalAlignment)
+		public void StarColumnsShouldFitExplicitDimensions(LayoutAlignment horizontalAlignment)
 		{
 			var grid = CreateGridLayout(columns: "*");
 			grid.HorizontalLayoutAlignment.Returns(horizontalAlignment);
@@ -2040,8 +2166,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			var manager = new GridLayoutManager(grid);
 			var gridMeasure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
 
-			// Because the Grid has an explicit width, we expect the single Star column
-			// to have that width.
+			// Because the Grid has an explicit width, we expect the measurement to have that width.
 			Assert.Equal(100, gridMeasure.Width);
 
 			manager.ArrangeChildren(new Rect(Point.Zero, gridMeasure));
@@ -2049,6 +2174,111 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			// Because the child has HorizontalAlignment.Fill, we expect it to fill up the 100
 			// units in the Star column
 			AssertArranged(view0, new Rect(0, 0, 100, 20));
+		}
+
+		[Fact]
+		[Category(GridStarSizing)]
+		public void StarColumnsHaveChildWidthsWhenGridCentered()
+		{
+			var grid = CreateGridLayout(columns: "*,*");
+			grid.HorizontalLayoutAlignment.Returns(LayoutAlignment.Center);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			var view1 = CreateTestView(new Size(10, 10));
+
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view1, col: 1);
+
+			_ = MeasureAndArrange(grid, 200, 200);
+
+			AssertArranged(view0, new Rect(0, 0, 20, 20));
+			AssertArranged(view1, new Rect(20, 0, 10, 20));
+		}
+
+		[Fact]
+		[Category(GridStarSizing, GridSpan)]
+		public void MeasureStarAndExplicitColumnSpan()
+		{
+			var grid = CreateGridLayout(columns: "40,*");
+			grid.HorizontalLayoutAlignment.Returns(LayoutAlignment.Center);
+
+			var view0 = CreateTestView(new Size(100, 20));
+			view0.Width.Returns(100);
+
+			SubstituteChildren(grid, view0);
+			SetLocation(grid, view0, col: 0, colSpan: 2);
+
+			var measure = MeasureAndArrange(grid, 200, 200);
+
+			Assert.Equal(100, measure.Width);
+
+			AssertArranged(view0, new Rect(0, 0, 100, 20));
+		}
+
+		[Fact]
+		[Category(GridStarSizing, GridSpan)]
+		public void MeasureAutoAndExplicitColumnSpan()
+		{
+			var grid = CreateGridLayout(columns: "40,auto");
+			grid.HorizontalLayoutAlignment.Returns(LayoutAlignment.Center);
+
+			var view0 = CreateTestView(new Size(100, 20));
+			view0.Width.Returns(100);
+
+			SubstituteChildren(grid, view0);
+			SetLocation(grid, view0, col: 0, colSpan: 2);
+
+			var measure = MeasureAndArrange(grid, 200, 200);
+
+			Assert.Equal(100, measure.Width);
+
+			AssertArranged(view0, new Rect(0, 0, 100, 20));
+		}
+
+		[Fact]
+		[Category(GridStarSizing, GridSpan)]
+		public void MeasureStarAndExplicitRowSpan()
+		{
+			var grid = CreateGridLayout(rows: "40,*");
+			grid.VerticalLayoutAlignment.Returns(LayoutAlignment.Center);
+
+			var view0 = CreateTestView(new Size(20, 100));
+			view0.Height.Returns(100);
+
+			SubstituteChildren(grid, view0);
+			SetLocation(grid, view0, row: 0, rowSpan: 2);
+
+			var measure = MeasureAndArrange(grid, 200, 200);
+
+			Assert.Equal(100, measure.Height);
+
+			AssertArranged(view0, new Rect(0, 0, 20, 100));
+		}
+
+		[Fact]
+		[Category(GridStarSizing)]
+		public void ChildInStarRowWithInfiniteSpaceIsMeasuredWithInfinity()
+		{
+			var grid = CreateGridLayout(rows: "*");
+			var view0 = CreateTestView(new Size(20, 100));
+			SubstituteChildren(grid, view0);
+
+			_ = MeasureAndArrange(grid, 200, double.PositiveInfinity);
+
+			view0.Received().Measure(Arg.Any<double>(), Arg.Is(double.PositiveInfinity));
+		}
+
+		[Fact]
+		[Category(GridStarSizing)]
+		public void ChildInStarColumnWithInfiniteSpaceIsMeasuredWithInfinity()
+		{
+			var grid = CreateGridLayout(columns: "*");
+			var view0 = CreateTestView(new Size(100, 20));
+			SubstituteChildren(grid, view0);
+
+			_ = MeasureAndArrange(grid, double.PositiveInfinity, 200);
+
+			view0.Received().Measure(Arg.Is(double.PositiveInfinity), Arg.Any<double>());
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Grid measurements are returning the fully expanded values for star rows/columns when measuring a Grid with Fill alignment, rather than returning the minimum viable measurement values.

These changes modify the Grid measurement to return the smallest value which satisfies the constraints on measure.

### Issues Fixed

Fixes #7531
