### PR TITLE
Revert "[net6.0] Update dependencies from xamarin/xamarin-macios"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>04623cdc317c3da5efce46cb16d94befe4833125</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.455">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.454">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>9ed77490baef852ec98513d2b791884b0242715e</Sha>
+      <Sha>4bd34d034c8c5a4e092c8bd3c8868153d94277b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.455">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.454">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>9ed77490baef852ec98513d2b791884b0242715e</Sha>
+      <Sha>4bd34d034c8c5a4e092c8bd3c8868153d94277b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.455">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.454">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>9ed77490baef852ec98513d2b791884b0242715e</Sha>
+      <Sha>4bd34d034c8c5a4e092c8bd3c8868153d94277b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.455">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.454">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>9ed77490baef852ec98513d2b791884b0242715e</Sha>
+      <Sha>4bd34d034c8c5a4e092c8bd3c8868153d94277b4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.9" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,10 +11,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>32.0.468</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftiOSSdkPackageVersion>15.4.455</MicrosoftiOSSdkPackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>15.4.455</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>12.3.455</MicrosoftmacOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>15.4.455</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>15.4.454</MicrosoftiOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>15.4.454</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>12.3.454</MicrosoftmacOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>15.4.454</MicrosofttvOSSdkPackageVersion>
     <!-- Samsung/Tizen.NET -->
     <SamsungTizenSdkPackageVersion>7.0.400-preview.1.0</SamsungTizenSdkPackageVersion>
     <!-- emsdk -->


### PR DESCRIPTION
Reverts dotnet/maui#10018


The underlying iOS branch updated to a new runtime (6.0.10) that we cannot take yet. 

See also: https://github.com/xamarin/xamarin-android/pull/7355