### PR TITLE
[Windows] Fix crash using MainDisplayInfoChanged on page constructor

### DIFF
--- a/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
+++ b/src/Essentials/src/DeviceDisplay/DeviceDisplay.uwp.cs
@@ -145,8 +145,10 @@ namespace Microsoft.Maui.Devices
 				WindowStateManager.Default.ActiveWindowDisplayChanged += OnWindowDisplayChanged;
 				WindowStateManager.Default.ActiveWindowChanged += OnCurrentWindowChanged;
 
-				_currentAppWindowListeningTo = WindowStateManager.Default.GetActiveAppWindow(true)!;
-				_currentAppWindowListeningTo.Changed += OnAppWindowChanged;
+				_currentAppWindowListeningTo = WindowStateManager.Default.GetActiveAppWindow(false)!;
+
+				if (_currentAppWindowListeningTo != null)
+					_currentAppWindowListeningTo.Changed += OnAppWindowChanged;
 			});
 		}
 


### PR DESCRIPTION
### Description of Change

Fix crash using MainDisplayInfoChanged on page constructor on Windows.

To test the changes:
1. Include `DeviceDisplay.MainDisplayInfoChanged += DeviceDisplay_MainDisplayInfoChanged;` in your MainPage constructor.
2. Check that the `DeviceDisplay_MainDisplayInfoChanged` method is invoked (for example, resize the App Window).

### Issues Fixed

Fixes #7809 