### PR TITLE
[Windows] Fix wrong Frame sizing 

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
@@ -5,37 +5,109 @@
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="Frame">
     <views:BasePage.Content>
-        <VerticalStackLayout
-            Margin="12">
-            <Label
-                Text="Default"
-                Style="{StaticResource Headline}"/>
-            <Frame      
-                BackgroundColor="LightGray"
-                HasShadow="False">
-                <Label 
-                    Text="Only with BackgroundColor" />
-            </Frame>
-            <Label
-                Text="BorderColor"
-                Style="{StaticResource Headline}"/>
-            <Frame      
-                BackgroundColor="LightGray"
-                BorderColor="Red"
-                HasShadow="False">
-                <Label 
-                    Text="Using BorderColor" />
-            </Frame>
-            <Label
-                Text="Shadow"
-                Style="{StaticResource Headline}"/>
-            <Frame      
-                BackgroundColor="LightGray"
-                BorderColor="Red"
-                HasShadow="True">
-                <Label 
-                    Text="Has Shadow" />
-            </Frame>
-        </VerticalStackLayout>
+        <ScrollView>
+            <VerticalStackLayout
+                Margin="12">
+                <Label
+                    Text="Default"
+                    Style="{StaticResource Headline}"/>
+                <Frame      
+                    BackgroundColor="LightGray"
+                    HasShadow="False">
+                    <Label 
+                        Text="Only with BackgroundColor" />
+                </Frame>
+                <Label
+                    Text="Background"
+                    Style="{StaticResource Headline}"/>
+                <Frame      
+                    HasShadow="False">
+                    <Frame.Background>
+                        <LinearGradientBrush EndPoint="1,0">
+                            <GradientStop Color="Yellow"  
+                                          Offset="0.1" />
+                            <GradientStop Color="Green"
+                                          Offset="1.0" />
+                        </LinearGradientBrush>
+                    </Frame.Background>
+                    <Label 
+                        Text="Background" />
+                </Frame>
+                <Label
+                    Text="BorderColor"
+                    Style="{StaticResource Headline}"/>
+                <Frame      
+                    BackgroundColor="LightGray"
+                    BorderColor="Red"
+                    HasShadow="False">
+                    <Label 
+                        Text="Using BorderColor" />
+                </Frame>
+                <Label
+                    Text="Background and Border"
+                    Style="{StaticResource Headline}"/>
+                <Frame      
+                    BorderColor="Red"
+                    HasShadow="False">
+                    <Frame.Background>
+                        <LinearGradientBrush EndPoint="1,0">
+                            <GradientStop Color="Yellow"  
+                                          Offset="0.1" />
+                            <GradientStop Color="Green"
+                                          Offset="1.0" />
+                        </LinearGradientBrush>
+                    </Frame.Background>
+                    <Label 
+                        Text="Background and Border" />
+                </Frame>
+                <Label
+                    Text="Shadow"
+                    Style="{StaticResource Headline}"/>
+                <Frame      
+                    BackgroundColor="LightGray"
+                    BorderColor="Red"
+                    HasShadow="True">
+                    <Label 
+                        Text="Has Shadow" />
+                </Frame>
+                <Label
+                    Text="CornerRadius"
+                    Style="{StaticResource Headline}"/>
+                <Frame      
+                    BackgroundColor="LightGray"
+                    BorderColor="Red"
+                    HasShadow="True"
+                    CornerRadius="48">
+                    <Label 
+                        Text="CornerRadius" />
+                </Frame>
+                <Label
+                    Text="IsClippedToBounds"
+                    Style="{StaticResource Headline}"/>
+                <Frame      
+                    HeightRequest="100"
+                    BackgroundColor="LightGray"
+                    BorderColor="Red"
+                    HasShadow="True"
+                    Padding="0"
+                    CornerRadius="48"
+                    IsClippedToBounds="True">
+                    <Image
+                        Aspect="AspectFill"
+                        Source="oasis.jpg" />
+                </Frame>
+                <Label
+                    Text="Without Padding"
+                    Style="{StaticResource Headline}"/>
+                <Frame      
+                    BackgroundColor="LightGray"
+                    BorderColor="Red"
+                    HasShadow="False"
+                    Padding="0">
+                    <Label 
+                        Text="Without Padding" />
+                </Frame>
+            </VerticalStackLayout>
+        </ScrollView>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		protected override global::Windows.Foundation.Size ArrangeOverride(global::Windows.Foundation.Size finalSize)
 		{
 			Control.Arrange(new WRect(0, 0, finalSize.Width, finalSize.Height));
+
 			if (Element is IContentView cv)
 				cv.CrossPlatformArrange(new Rect(0, 0, finalSize.Width, finalSize.Height));
 
@@ -90,7 +91,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			var size = base.MeasureOverride(availableSize);
 
-			if (Element is IContentView cv)
+			var invalidateCrossPlatformMeasure = Element.HeightRequest > 0 || Element.WidthRequest > 0;
+
+			if (invalidateCrossPlatformMeasure && Element is IContentView cv)
 				size = cv.CrossPlatformMeasure(availableSize.Width, availableSize.Height).ToPlatform();
 
 			return size;


### PR DESCRIPTION
### Description of Change

Fix wrong Frame sizing on Windows.

![image](https://user-images.githubusercontent.com/6755973/189895438-acaa2d02-2fe0-4d62-8ce5-3b2bb8f69312.png)

Before
![image](https://user-images.githubusercontent.com/6755973/189895578-af052cca-689c-451d-a19d-949f714feea0.png)

After
![fix-9099](https://user-images.githubusercontent.com/6755973/189895406-4008c051-15e9-4bd1-9578-2bce1eb3fe3c.PNG)

To test the changes:
1. Launch the .NET MAUI Gallery on Windows.
2. Navigate to the Frame Gallery and compare the results with the attached screenshots.

### Issues Fixed

Fixes #9099
Fixes #7154
Fixes the Frame issues from https://github.com/dotnet/maui/issues/8438