### PR TITLE
Fix SpecialFolder.Personal usages

### DIFF
--- a/eng/provisioning/xcode.csx
+++ b/eng/provisioning/xcode.csx
@@ -45,7 +45,7 @@ item.XcodeSelect();
 
 LogInstalledXcodes();
 
-var appleSdkOverride = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Preferences", "Xamarin", "Settings.plist");
+var appleSdkOverride = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Preferences", "Xamarin", "Settings.plist");
 Item("Override Apple SDK Settings")
     .Condition(item => !File.Exists(appleSdkOverride) || GetSettingValue(appleSdkOverride, "AppleSdkRoot") != GetSelectedXcodePath())
     .Action(item =>

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8821.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8821.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 		{
 			var bytes = await DownloadImageAsync(imageUrl);
 
-			string path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+			string path = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 			SecondImageSource = IOPath.Combine(path, "Issue8821.gif");
 			File.WriteAllBytes(SecondImageSource, bytes);
 

--- a/src/Compatibility/ControlGallery/src/Xamarin.Forms.ControlGallery.MacOS/NativeServices.cs
+++ b/src/Compatibility/ControlGallery/src/Xamarin.Forms.ControlGallery.MacOS/NativeServices.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.ControlGallery.MacOS
 	{
 		public void ClearImageCache()
 		{
-			var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			var documents = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 			var cache = IOPath.Combine(documents, ".config", ".isolated-storage", "ImageLoaderCache");
 			foreach (var file in Directory.GetFiles(cache))
 			{


### PR DESCRIPTION
SpecialFolder Personal is the same value as MyDocuments, both of which will be changed on Unix from `~` to `~/Documents` in .NET 8. See https://github.com/dotnet/runtime/pull/68610.

Fixing the usages of SpecialFolder to either be UserProfile or MyDocuments, as appropriate.