### PR TITLE
[Build] Don't download library packs we don't have

### DIFF
--- a/eng/pipelines/common/pack.yml
+++ b/eng/pipelines/common/pack.yml
@@ -3,7 +3,6 @@ parameters:
   poolName: ''
   provisionatorChannel: latest
   artifact: 'nuget'
-  libraryPacksArtifact: 'library-packs'
 
 steps:
   - ${{ if eq(parameters.platform, 'macOS') }}:
@@ -42,7 +41,6 @@ steps:
         artifacts/**/*.zip
         artifacts/vs-workload.props
         eng/automation/SignList.xml
-        !artifacts/library-packs/**
         !artifacts/docs-packs/**
       TargetFolder: $(build.artifactstagingdirectory)
       flattenFolders: true
@@ -68,18 +66,11 @@ steps:
     displayName: publish artifacts
     inputs:
       ArtifactName: ${{ parameters.artifact }}
-  # library-packs
-  - task: PublishBuildArtifacts@1
-    condition: always()
-    displayName: publish library packs artifacts
-    inputs:
-      PathToPublish: artifacts/library-packs
-      ArtifactName: ${{ parameters.libraryPacksArtifact }}
   # xml-docs
   - ${{ if eq(parameters.platform, 'Windows') }}:
     - task: PublishBuildArtifacts@1
       condition: always()
-      displayName: publish library packs artifacts
+      displayName: publish docks artifacts
       inputs:
         PathToPublish: artifacts/docs-packs
         ArtifactName: xml-docs

--- a/eng/pipelines/common/pack.yml
+++ b/eng/pipelines/common/pack.yml
@@ -70,7 +70,7 @@ steps:
   - ${{ if eq(parameters.platform, 'Windows') }}:
     - task: PublishBuildArtifacts@1
       condition: always()
-      displayName: publish docks artifacts
+      displayName: publish docs artifacts
       inputs:
         PathToPublish: artifacts/docs-packs
         ArtifactName: xml-docs

--- a/eng/pipelines/common/sign.yml
+++ b/eng/pipelines/common/sign.yml
@@ -23,11 +23,4 @@ stages:
           artifactPath: signed
           propsArtifactName: nuget
           signType: Real
-          useDateTimeVersion: false
-          preConvertSteps:
-            - task: DownloadPipelineArtifact@2
-              displayName: Download library-packs nugets
-              continueOnError: true
-              inputs:
-                artifactName: library-packs
-                downloadPath: $(Build.StagingDirectory)\nugets\signed
+          useDateTimeVersion: falses


### PR DESCRIPTION
### Description of Change

We removed Maui.Graphics so we don't need to do this on main and net7 branches 

### Issues Fixed

Failed step on maui-release pipeline
