### PR TITLE
Modify Controls Methods to use interfaces

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Button/Button.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.Android.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Button
 	{
-		public static void MapText(ButtonHandler handler, Button button)
+		public static void MapText(IButtonHandler handler, Button button)
 		{
 			handler.PlatformView?.UpdateText(button);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Button/Button.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.Standard.cs
@@ -4,8 +4,8 @@
 	public partial class Button
 	{
 		/// <include file="../../../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='MapText']/Docs/*" />
-		public static void MapText(ButtonHandler handler, Button button) { }
+		public static void MapText(IButtonHandler handler, Button button) { }
 
-		public static void MapLineBreakMode(ButtonHandler handler, Button button) { }
+		public static void MapLineBreakMode(IButtonHandler handler, Button button) { }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Button/Button.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.Tizen.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Button
 	{
-		public static void MapText(ButtonHandler handler, Button button)
+		public static void MapText(IButtonHandler handler, Button button)
 		{
 			handler.PlatformView?.UpdateText(button);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Button/Button.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.Windows.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Button
 	{
-		public static void MapImageSource(ButtonHandler handler, Button button)
+		public static void MapImageSource(IButtonHandler handler, Button button)
 		{
 			ButtonHandler.MapImageSource(handler, button);
 			button.Handler?.UpdateValue(nameof(Button.ContentLayout));
 		}
 
-		public static void MapText(ButtonHandler handler, Button button)
+		public static void MapText(IButtonHandler handler, Button button)
 		{
 			var text = TextTransformUtilites.GetTransformedText(button.Text, button.TextTransform);
 			handler.PlatformView?.UpdateText(text);

--- a/src/Controls/src/Core/HandlerImpl/Button/Button.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 		public static IPropertyMapper<IButton, ButtonHandler> ControlsButtonMapper = new PropertyMapper<Button, ButtonHandler>(ButtonHandler.Mapper)
 		{
 			[nameof(ContentLayout)] = MapContentLayout,
-#if __IOS__
+#if IOS
 			[nameof(Padding)] = MapPadding,
 #endif
 #if WINDOWS
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Controls
 		}
 
 		/// <include file="../../../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='MapContentLayout']/Docs/*" />
-		public static void MapContentLayout(ButtonHandler handler, Button button)
+		public static void MapContentLayout(IButtonHandler handler, Button button)
 		{
 			handler.PlatformView.UpdateContentLayout(button);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Button/Button.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.iOS.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Button
 	{
-		private static void MapPadding(ButtonHandler handler, Button button)
+		private static void MapPadding(IButtonHandler handler, Button button)
 		{
 			handler.PlatformView.UpdatePadding(button);
 		}
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 			return result;
 		}
 
-		public static void MapText(ButtonHandler handler, Button button)
+		public static void MapText(IButtonHandler handler, Button button)
 		{
 			handler.PlatformView?.UpdateText(button);
 		}

--- a/src/Controls/src/Core/HandlerImpl/DatePicker/DatePicker.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/DatePicker/DatePicker.iOS.cs
@@ -5,9 +5,10 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class DatePicker
 	{
-		public static void MapUpdateMode(DatePickerHandler handler, DatePicker datePicker)
+		public static void MapUpdateMode(IDatePickerHandler handler, DatePicker datePicker)
 		{
-			handler.UpdateImmediately = datePicker.OnThisPlatform().UpdateMode() == UpdateMode.Immediately;
+			if (handler is DatePickerHandler dph)
+				dph.UpdateImmediately = datePicker.OnThisPlatform().UpdateMode() == UpdateMode.Immediately;
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Editor/Editor.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor/Editor.Android.cs
@@ -2,7 +2,7 @@
 {
 	public partial class Editor
 	{
-		public static void MapText(EditorHandler handler, Editor editor)
+		public static void MapText(IEditorHandler handler, Editor editor)
 		{
 			Platform.EditTextExtensions.UpdateText(handler.PlatformView, editor);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Editor/Editor.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor/Editor.Standard.cs
@@ -2,6 +2,6 @@
 {
 	public partial class Editor
 	{
-		public static void MapText(EditorHandler handler, Editor editor) { }
+		public static void MapText(IEditorHandler handler, Editor editor) { }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Editor/Editor.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor/Editor.Tizen.cs
@@ -2,7 +2,7 @@
 {
 	public partial class Editor
 	{
-		public static void MapText(EditorHandler handler, Editor editor)
+		public static void MapText(IEditorHandler handler, Editor editor)
 		{
 			Platform.TextExtensions.UpdateText(handler.PlatformView, editor);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Editor/Editor.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor/Editor.Windows.cs
@@ -2,12 +2,12 @@
 {
 	public partial class Editor
 	{
-		public static void MapText(EditorHandler handler, Editor editor)
+		public static void MapText(IEditorHandler handler, Editor editor)
 		{
 			Platform.TextBoxExtensions.UpdateText(handler.PlatformView, editor);
 		}
 
-		public static void MapDetectReadingOrderFromContent(EditorHandler handler, Editor editor)
+		public static void MapDetectReadingOrderFromContent(IEditorHandler handler, Editor editor)
 		{
 			Platform.InputViewExtensions.UpdateDetectReadingOrderFromContent(handler.PlatformView, editor);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Editor/Editor.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor/Editor.iOS.cs
@@ -2,7 +2,7 @@
 {
 	public partial class Editor
 	{
-		public static void MapText(EditorHandler handler, Editor editor)
+		public static void MapText(IEditorHandler handler, Editor editor)
 		{
 			Platform.TextExtensions.UpdateText(handler.PlatformView, editor);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Entry/Entry.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry/Entry.Android.cs
@@ -6,12 +6,12 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Entry
 	{
-		public static void MapImeOptions(EntryHandler handler, Entry entry)
+		public static void MapImeOptions(IEntryHandler handler, Entry entry)
 		{
 			Platform.EditTextExtensions.UpdateImeOptions(handler.PlatformView, entry);
 		}
 
-		public static void MapText(EntryHandler handler, Entry entry)
+		public static void MapText(IEntryHandler handler, Entry entry)
 		{
 			Platform.EditTextExtensions.UpdateText(handler.PlatformView, entry);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Entry/Entry.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry/Entry.Standard.cs
@@ -2,6 +2,6 @@
 {
 	public partial class Entry
 	{
-		public static void MapText(EntryHandler handler, Entry entry) { }
+		public static void MapText(IEntryHandler handler, Entry entry) { }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Entry/Entry.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry/Entry.Tizen.cs
@@ -2,7 +2,7 @@
 {
 	public partial class Entry
 	{
-		public static void MapText(EntryHandler handler, Entry entry)
+		public static void MapText(IEntryHandler handler, Entry entry)
 		{
 			Platform.TextExtensions.UpdateText(handler.PlatformView, entry);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Entry/Entry.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry/Entry.Windows.cs
@@ -2,12 +2,12 @@
 {
 	public partial class Entry
 	{
-		public static void MapDetectReadingOrderFromContent(EntryHandler handler, Entry entry)
+		public static void MapDetectReadingOrderFromContent(IEntryHandler handler, Entry entry)
 		{
 			Platform.InputViewExtensions.UpdateDetectReadingOrderFromContent(handler.PlatformView, entry);
 		}
 
-		public static void MapText(EntryHandler handler, Entry entry)
+		public static void MapText(IEntryHandler handler, Entry entry)
 		{
 			Platform.TextBoxExtensions.UpdateText(handler.PlatformView, entry);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Entry/Entry.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry/Entry.iOS.cs
@@ -2,17 +2,17 @@
 {
 	public partial class Entry
 	{
-		public static void MapCursorColor(EntryHandler handler, Entry entry)
+		public static void MapCursorColor(IEntryHandler handler, Entry entry)
 		{
 			Platform.TextExtensions.UpdateCursorColor(handler.PlatformView, entry);
 		}
 
-		public static void MapAdjustsFontSizeToFitWidth(EntryHandler handler, Entry entry)
+		public static void MapAdjustsFontSizeToFitWidth(IEntryHandler handler, Entry entry)
 		{
 			Platform.TextExtensions.UpdateAdjustsFontSizeToFitWidth(handler.PlatformView, entry);
 		}
 
-		public static void MapText(EntryHandler handler, Entry entry)
+		public static void MapText(IEntryHandler handler, Entry entry)
 		{
 			Platform.TextExtensions.UpdateText(handler.PlatformView, entry);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Android.cs
@@ -32,18 +32,18 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		public static void MapTextType(LabelHandler handler, Label label)
+		public static void MapTextType(ILabelHandler handler, Label label)
 		{
 			Platform.TextViewExtensions.UpdateText(handler.PlatformView, label);
 		}
 
-		public static void MapText(LabelHandler handler, Label label)
+		public static void MapText(ILabelHandler handler, Label label)
 		{
 			Platform.TextViewExtensions.UpdateText(handler.PlatformView, label);
 		}
 
 		// TODO: NET7 make this public
-		internal static void MapTextColor(LabelHandler handler, Label label)
+		internal static void MapTextColor(ILabelHandler handler, Label label)
 		{
 			handler.PlatformView?.UpdateTextColor(label);
 
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls
 			Platform.TextViewExtensions.UpdateText(handler.PlatformView, label);
 		}
 
-		public static void MapLineBreakMode(LabelHandler handler, Label label)
+		public static void MapLineBreakMode(ILabelHandler handler, Label label)
 		{
 			handler.PlatformView?.UpdateLineBreakMode(label);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Standard.cs
@@ -6,11 +6,11 @@ namespace Microsoft.Maui.Controls
 	public partial class Label
 	{
 		/// <include file="../../../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='MapTextType']/Docs/*" />
-		public static void MapTextType(LabelHandler handler, Label label) { }
+		public static void MapTextType(ILabelHandler handler, Label label) { }
 		/// <include file="../../../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='MapText']/Docs/*" />
-		public static void MapText(LabelHandler handler, Label label) { }
+		public static void MapText(ILabelHandler handler, Label label) { }
 
-		public static void MapLineBreakMode(LabelHandler handler, Label label) { }
-		public static void MapMaxLines(LabelHandler handler, Label label) { }
+		public static void MapLineBreakMode(ILabelHandler handler, Label label) { }
+		public static void MapMaxLines(ILabelHandler handler, Label label) { }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Tizen.cs
@@ -6,12 +6,12 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Label
 	{
-		public static void MapTextType(LabelHandler handler, Label label)
+		public static void MapTextType(ILabelHandler handler, Label label)
 		{
 			Platform.TextExtensions.UpdateText(handler.PlatformView, label);
 		}
 
-		public static void MapText(LabelHandler handler, Label label)
+		public static void MapText(ILabelHandler handler, Label label)
 		{
 			Platform.TextExtensions.UpdateText(handler.PlatformView, label);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.Windows.cs
@@ -4,13 +4,13 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Label
 	{
-		public static void MapDetectReadingOrderFromContent(LabelHandler handler, Label label) =>
+		public static void MapDetectReadingOrderFromContent(ILabelHandler handler, Label label) =>
 			Platform.TextBlockExtensions.UpdateDetectReadingOrderFromContent(handler.PlatformView, label);
 
-		public static void MapTextType(LabelHandler handler, Label label) =>
+		public static void MapTextType(ILabelHandler handler, Label label) =>
 			Platform.TextBlockExtensions.UpdateText(handler.PlatformView, label);
 
-		public static void MapText(LabelHandler handler, Label label) =>
+		public static void MapText(ILabelHandler handler, Label label) =>
 			Platform.TextBlockExtensions.UpdateText(handler.PlatformView, label);
 
 		public static void MapLineBreakMode(ILabelHandler handler, Label label) =>

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Maui.Controls
 #if ANDROID
 			[nameof(TextColor)] = MapTextColor,
 #endif
-#if __IOS__
+#if IOS
 			[nameof(TextDecorations)] = MapTextDecorations,
 			[nameof(CharacterSpacing)] = MapCharacterSpacing,
 			[nameof(LineHeight)] = MapLineHeight,

--- a/src/Controls/src/Core/HandlerImpl/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.iOS.cs
@@ -5,17 +5,17 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Label
 	{
-		public static void MapTextType(LabelHandler handler, Label label)
+		public static void MapTextType(ILabelHandler handler, Label label)
 		{
 			Platform.LabelExtensions.UpdateText(handler.PlatformView, label);
 		}
 
-		public static void MapText(LabelHandler handler, Label label)
+		public static void MapText(ILabelHandler handler, Label label)
 		{
 			Platform.LabelExtensions.UpdateText(handler.PlatformView, label);
 		}
 
-		public static void MapTextDecorations(LabelHandler handler, Label label)
+		public static void MapTextDecorations(ILabelHandler handler, Label label)
 		{
 			if (label?.HasFormattedTextSpans ?? false)
 				return;
@@ -28,7 +28,7 @@ namespace Microsoft.Maui.Controls
 			LabelHandler.MapTextDecorations(handler, label);
 		}
 
-		public static void MapCharacterSpacing(LabelHandler handler, Label label)
+		public static void MapCharacterSpacing(ILabelHandler handler, Label label)
 		{
 			if (label?.HasFormattedTextSpans ?? false)
 				return;
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls
 			LabelHandler.MapCharacterSpacing(handler, label);
 		}
 
-		public static void MapLineHeight(LabelHandler handler, Label label)
+		public static void MapLineHeight(ILabelHandler handler, Label label)
 		{
 			if (label?.HasFormattedTextSpans ?? false)
 				return;
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls
 			LabelHandler.MapLineHeight(handler, label);
 		}
 
-		public static void MapFont(LabelHandler handler, Label label)
+		public static void MapFont(ILabelHandler handler, Label label)
 		{
 			if (label?.HasFormattedTextSpans ?? false)
 				return;
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.Controls
 			LabelHandler.MapFont(handler, label);
 		}
 
-		public static void MapTextColor(LabelHandler handler, Label label)
+		public static void MapTextColor(ILabelHandler handler, Label label)
 		{
 			if (label?.HasFormattedTextSpans ?? false)
 				return;

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Android.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout)
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
 		{
 			if (handler.PlatformView is LayoutViewGroup layoutViewGroup)
 			{

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Standard.cs
@@ -2,7 +2,7 @@
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout)
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
 		{
 		}
 	}

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Tizen.cs
@@ -2,7 +2,7 @@
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout)
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
 		{
 			if (handler.PlatformView == null)
 				return;

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
@@ -2,7 +2,7 @@
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout)
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
 		{
 			handler.PlatformView?.UpdateInputTransparent(handler, layout);
 			layout.UpdateDescendantInputTransparent();

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.iOS.cs
@@ -2,7 +2,7 @@
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout)
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
 		{
 			handler.PlatformView?.UpdateInputTransparent(handler, layout);
 			layout.UpdateDescendantInputTransparent();

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.iOS.cs
@@ -2,15 +2,15 @@
 {
 	public partial class NavigationPage
 	{
-		public static void MapPrefersLargeTitles(NavigationViewHandler handler, NavigationPage navigationPage)
+		public static void MapPrefersLargeTitles(INavigationViewHandler handler, NavigationPage navigationPage)
 		{
-			if (handler.ViewController is ControlsNavigationController navigationController)
+			if (handler is NavigationViewHandler nvh && nvh.ViewController is ControlsNavigationController navigationController)
 				Platform.NavigationPageExtensions.UpdatePrefersLargeTitles(navigationController, navigationPage);
 		}
 
-		public static void MapIsNavigationBarTranslucent(NavigationViewHandler handler, NavigationPage navigationPage)
+		public static void MapIsNavigationBarTranslucent(INavigationViewHandler handler, NavigationPage navigationPage)
 		{
-			if (handler.ViewController is ControlsNavigationController navigationController)
+			if (handler is NavigationViewHandler nvh && nvh.ViewController is ControlsNavigationController navigationController)
 				Platform.NavigationPageExtensions.UpdateIsNavigationBarTranslucent(navigationController, navigationPage);
 		}
 	}

--- a/src/Controls/src/Core/HandlerImpl/Picker/Picker.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Picker/Picker.iOS.cs
@@ -5,9 +5,10 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Picker
 	{
-		public static void MapUpdateMode(PickerHandler handler, Picker picker)
+		public static void MapUpdateMode(IPickerHandler handler, Picker picker)
 		{
-			handler.UpdateImmediately = picker.OnThisPlatform().UpdateMode() == UpdateMode.Immediately;
+			if (handler is PickerHandler ph)
+				ph.UpdateImmediately = picker.OnThisPlatform().UpdateMode() == UpdateMode.Immediately;
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Android.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class RadioButton
 	{
-		public static void MapContent(RadioButtonHandler handler, RadioButton radioButton)
+		public static void MapContent(IRadioButtonHandler handler, RadioButton radioButton)
 		{
 			if (radioButton.ResolveControlTemplate() != null)
 			{

--- a/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Tizen.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 	{
 		static ControlTemplate s_tizenDefaultTemplate;
 
-		public static void MapContent(RadioButtonHandler handler, RadioButton radioButton)
+		public static void MapContent(IRadioButtonHandler handler, RadioButton radioButton)
 		{
 			if (radioButton.ResolveControlTemplate() == null)
 				radioButton.ControlTemplate = s_tizenDefaultTemplate ?? (s_tizenDefaultTemplate = new ControlTemplate(() => BuildTizenDefaultTemplate()));

--- a/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.Windows.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class RadioButton
 	{
-		public static void MapContent(RadioButtonHandler handler, RadioButton radioButton)
+		public static void MapContent(IRadioButtonHandler handler, RadioButton radioButton)
 		{
 			if (radioButton.ResolveControlTemplate() != null)
 			{

--- a/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/RadioButton/RadioButton.iOS.cs
@@ -2,7 +2,7 @@
 {
 	public partial class RadioButton
 	{
-		public static void MapContent(RadioButtonHandler handler, RadioButton radioButton)
+		public static void MapContent(IRadioButtonHandler handler, RadioButton radioButton)
 		{
 			if (radioButton.ResolveControlTemplate() == null)
 				radioButton.ControlTemplate = DefaultTemplate;

--- a/src/Controls/src/Core/HandlerImpl/RefreshView/RefreshView.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/RefreshView/RefreshView.Windows.cs
@@ -2,7 +2,7 @@
 {
 	public partial class RefreshView
 	{
-		public static void MapRefreshPullDirection(RefreshViewHandler handler, RefreshView refreshView) =>
+		public static void MapRefreshPullDirection(IRefreshViewHandler handler, RefreshView refreshView) =>
 			Platform.RefreshViewExtensions.UpdateRefreshPullDirection(handler.PlatformView, refreshView);
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/ScrollView/ScrollView.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/ScrollView/ScrollView.iOS.cs
@@ -2,7 +2,7 @@
 {
 	public partial class ScrollView
 	{
-		public static void MapShouldDelayContentTouches(ScrollViewHandler handler, ScrollView scrollView)
+		public static void MapShouldDelayContentTouches(IScrollViewHandler handler, ScrollView scrollView)
 		{
 			Platform.ScrollViewExtensions.UpdateShouldDelayContentTouches(handler.PlatformView, scrollView);
 		}

--- a/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Android.cs
@@ -2,7 +2,7 @@
 {
 	public partial class SearchBar
 	{
-		public static void MapText(SearchBarHandler handler, SearchBar searchBar)
+		public static void MapText(ISearchBarHandler handler, SearchBar searchBar)
 		{
 			Platform.SearchViewExtensions.UpdateText(handler.PlatformView, searchBar);
 		}

--- a/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Standard.cs
@@ -2,6 +2,6 @@
 {
 	public partial class SearchBar
 	{
-		public static void MapText(SearchBarHandler handler, SearchBar searchBar) { }
+		public static void MapText(ISearchBarHandler handler, SearchBar searchBar) { }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Tizen.cs
@@ -2,7 +2,7 @@
 {
 	public partial class SearchBar
 	{
-		public static void MapText(SearchBarHandler handler, SearchBar searchBar)
+		public static void MapText(ISearchBarHandler handler, SearchBar searchBar)
 		{
 			Platform.TextExtensions.UpdateText(handler.PlatformView.Entry, searchBar);
 		}

--- a/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.Windows.cs
@@ -2,12 +2,12 @@
 {
 	public partial class SearchBar
 	{
-		public static void MapIsSpellCheckEnabled(SearchBarHandler handler, SearchBar searchBar)
+		public static void MapIsSpellCheckEnabled(ISearchBarHandler handler, SearchBar searchBar)
 		{
 			Platform.AutoSuggestBoxExtensions.UpdateIsSpellCheckEnabled(handler.PlatformView, searchBar);
 		}
 
-		public static void MapText(SearchBarHandler handler, SearchBar searchBar)
+		public static void MapText(ISearchBarHandler handler, SearchBar searchBar)
 		{
 			Platform.AutoSuggestBoxExtensions.UpdateText(handler.PlatformView, searchBar);
 		}

--- a/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/SearchBar/SearchBar.iOS.cs
@@ -2,12 +2,12 @@
 {
 	public partial class SearchBar
 	{
-		public static void MapSearchBarStyle(SearchBarHandler handler, SearchBar searchBar)
+		public static void MapSearchBarStyle(ISearchBarHandler handler, SearchBar searchBar)
 		{
 			Platform.SearchBarExtensions.UpdateSearchBarStyle(handler.PlatformView, searchBar);
 		}
 
-		public static void MapText(SearchBarHandler handler, SearchBar searchBar)
+		public static void MapText(ISearchBarHandler handler, SearchBar searchBar)
 		{
 			Platform.SearchBarExtensions.UpdateText(handler.PlatformView, searchBar);
 		}

--- a/src/Controls/src/Core/HandlerImpl/TimePicker/TimePicker.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/TimePicker/TimePicker.iOS.cs
@@ -5,9 +5,10 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class TimePicker
 	{
-		public static void MapUpdateMode(TimePickerHandler handler, TimePicker timePicker)
+		public static void MapUpdateMode(ITimePickerHandler handler, TimePicker timePicker)
 		{
-			handler.UpdateImmediately = timePicker.OnThisPlatform().UpdateMode() == UpdateMode.Immediately;
+			if (handler is TimePickerHandler tph)
+				tph.UpdateImmediately = timePicker.OnThisPlatform().UpdateMode() == UpdateMode.Immediately;
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
@@ -117,52 +117,52 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		public static void MapBarTextColor(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBarTextColor(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBarTextColor(arg2);
 		}
 
-		public static void MapBarBackground(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBarBackground(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBarBackground(arg2);
 		}
 
-		public static void MapBackButtonTitle(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBackButtonTitle(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBackButton(arg2);
 		}
 
-		public static void MapToolbarItems(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapToolbarItems(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg2.UpdateMenu();
 		}
 
-		public static void MapTitle(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapTitle(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateTitle(arg2);
 		}
 
-		public static void MapIconColor(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapIconColor(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateIconColor(arg2);
 		}
 
-		public static void MapTitleView(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapTitleView(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg2.UpdateTitleView();
 		}
 
-		public static void MapTitleIcon(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapTitleIcon(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateTitleIcon(arg2);
 		}
 
-		public static void MapBackButtonVisible(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBackButtonVisible(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBackButton(arg2);
 		}
 
-		public static void MapIsVisible(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapIsVisible(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateIsVisible(arg2);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Tizen.cs
@@ -10,58 +10,58 @@ namespace Microsoft.Maui.Controls
 		IPlatformViewHandler? _nativeTitleViewHandler;
 		MauiToolbar PlatformView => Handler?.PlatformView as MauiToolbar ?? throw new InvalidOperationException("Native View not set");
 
-		public static void MapBarTextColor(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapBarTextColor(IToolbarHandler handler, Toolbar toolbar)
 		{
 			handler.PlatformView.UpdateBarTextColor(toolbar);
 		}
 
-		public static void MapBarBackgroundColor(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapBarBackgroundColor(IToolbarHandler handler, Toolbar toolbar)
 		{
 			handler.PlatformView.UpdateBarBackgroundColor(toolbar);
 		}
 
-		public static void MapBackButtonTitle(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapBackButtonTitle(IToolbarHandler handler, Toolbar toolbar)
 		{
 			handler.PlatformView.UpdateBackButton(toolbar);
 		}
 
-		public static void MapToolbarItems(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapToolbarItems(IToolbarHandler handler, Toolbar toolbar)
 		{
 			toolbar.UpdateMenu();
 		}
 
-		public static void MapTitle(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapTitle(IToolbarHandler handler, Toolbar toolbar)
 		{
 			handler.PlatformView.UpdateTitle(toolbar);
 		}
 
-		public static void MapTitleView(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapTitleView(IToolbarHandler handler, Toolbar toolbar)
 		{
 			toolbar.UpdateTitleView();
 		}
 
-		public static void MapTitleIcon(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapTitleIcon(IToolbarHandler handler, Toolbar toolbar)
 		{
 			handler.PlatformView.UpdateTitleIcon(toolbar);
 		}
 
-		public static void MapBackButtonVisible(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapBackButtonVisible(IToolbarHandler handler, Toolbar toolbar)
 		{
 			handler.PlatformView.UpdateBackButton(toolbar);
 		}
 
-		public static void MapIsVisible(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapIsVisible(IToolbarHandler handler, Toolbar toolbar)
 		{
 			handler.PlatformView.UpdateIsVisible(toolbar);
 		}
 
-		public static void MapBarBackground(ToolbarHandler handler, Toolbar toolbar)
+		public static void MapBarBackground(IToolbarHandler handler, Toolbar toolbar)
 		{
 			handler.PlatformView.UpdateBarBackgroundColor(toolbar);
 		}
 
 		[MissingMapper]
-		public static void MapIconColor(ToolbarHandler handler, Toolbar toolbar) { }
+		public static void MapIconColor(IToolbarHandler handler, Toolbar toolbar) { }
 
 		void UpdateTitleView()
 		{

--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Windows.cs
@@ -76,65 +76,65 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		public static void MapToolbarPlacement(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapToolbarPlacement(IToolbarHandler arg1, Toolbar arg2)
 		{
 		}
 
-		public static void MapToolbarDynamicOverflowEnabled(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapToolbarDynamicOverflowEnabled(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateToolbarDynamicOverflowEnabled(arg2);
 		}
 
-		public static void MapBarTextColor(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBarTextColor(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBarTextColor(arg2);
 		}
 
-		public static void MapBarBackground(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBarBackground(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBarBackground(arg2);
 		}
 
-		public static void MapBackButtonTitle(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBackButtonTitle(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBackButton(arg2);
 		}
 
-		public static void MapToolbarItems(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapToolbarItems(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg2.UpdateMenu();
 		}
 
-		public static void MapIconColor(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapIconColor(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateIconColor(arg2);
 		}
 
-		public static void MapIcon(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapIcon(IToolbarHandler arg1, Toolbar arg2)
 		{
 		}
 
-		public static void MapTitleView(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapTitleView(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateTitleView(arg2);
 		}
 
-		public static void MapTitleIcon(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapTitleIcon(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateTitleIcon(arg2);
 		}
 
-		public static void MapBackButtonVisible(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBackButtonVisible(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBackButton(arg2);
 		}
 
-		public static void MapBackButtonEnabled(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapBackButtonEnabled(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateBackButton(arg2);
 		}
 
-		public static void MapIsVisible(ToolbarHandler arg1, Toolbar arg2)
+		public static void MapIsVisible(IToolbarHandler arg1, Toolbar arg2)
 		{
 			arg1.PlatformView.UpdateIsVisible(arg2);
 		}

--- a/src/Controls/src/Core/HandlerImpl/WebView/WebView.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/WebView/WebView.Android.cs
@@ -2,17 +2,17 @@
 {
 	public partial class WebView
 	{
-		public static void MapDisplayZoomControls(WebViewHandler handler, WebView webView)
+		public static void MapDisplayZoomControls(IWebViewHandler handler, WebView webView)
 		{
 			Platform.WebViewExtensions.UpdateDisplayZoomControls(handler.PlatformView, webView);
 		}
 
-		public static void MapEnableZoomControls(WebViewHandler handler, WebView webView)
+		public static void MapEnableZoomControls(IWebViewHandler handler, WebView webView)
 		{
 			Platform.WebViewExtensions.UpdateEnableZoomControls(handler.PlatformView, webView);
 		}
 
-		public static void MapMixedContentMode(WebViewHandler handler, WebView webView)
+		public static void MapMixedContentMode(IWebViewHandler handler, WebView webView)
 		{
 			Platform.WebViewExtensions.UpdateMixedContentMode(handler.PlatformView, webView);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Android.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Maui.Controls
 			(Handler?.PlatformView as Activity) ?? throw new InvalidOperationException("Window should have an Activity set.");
 
 		[Obsolete]
-		public static void MapContent(WindowHandler handler, IWindow view)
+		public static void MapContent(IWindowHandler handler, IWindow view)
 		{
 		}
 	}

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -72,6 +72,7 @@ static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.IToo
 static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
+static Microsoft.Maui.Controls.Window.MapContent(Microsoft.Maui.Handlers.IWindowHandler! handler, Microsoft.Maui.IWindow! view) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -148,3 +149,4 @@ static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> 
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Window.MapContent(Microsoft.Maui.Handlers.WindowHandler! handler, Microsoft.Maui.IWindow! view) -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -59,6 +59,7 @@ override Microsoft.Maui.Controls.Platform.Compatibility.ShellFlyoutTemplatedCont
 override Microsoft.Maui.Controls.Platform.ControlsAccessibilityDelegate.OnInitializeAccessibilityNodeInfo(Android.Views.View! host, AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat! info) -> void
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler! handler, Microsoft.Maui.Controls.RadioButton! radioButton) -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -95,8 +96,35 @@ virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Contr
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static readonly Microsoft.Maui.Controls.VisualElement.ZIndexProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*override Microsoft.Maui.Controls.Platform.ControlsAccessibilityDelegate.OnInitializeAccessibilityNodeInfo(Android.Views.View? host, AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat? info) -> void
+~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Entry.MapImeOptions(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
+~static Microsoft.Maui.Controls.Label.MapLineBreakMode(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+~static Microsoft.Maui.Controls.WebView.MapDisplayZoomControls(Microsoft.Maui.Handlers.IWebViewHandler handler, Microsoft.Maui.Controls.WebView webView) -> void
+~static Microsoft.Maui.Controls.WebView.MapEnableZoomControls(Microsoft.Maui.Handlers.IWebViewHandler handler, Microsoft.Maui.Controls.WebView webView) -> void
+~static Microsoft.Maui.Controls.WebView.MapMixedContentMode(Microsoft.Maui.Handlers.IWebViewHandler handler, Microsoft.Maui.Controls.WebView webView) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
+*REMOVED*static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler! handler, Microsoft.Maui.Controls.RadioButton! radioButton) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.WebView.MapDisplayZoomControls(Microsoft.Maui.Handlers.WebViewHandler handler, Microsoft.Maui.Controls.WebView webView) -> void
+*REMOVED*~static Microsoft.Maui.Controls.WebView.MapEnableZoomControls(Microsoft.Maui.Handlers.WebViewHandler handler, Microsoft.Maui.Controls.WebView webView) -> void
+*REMOVED*~static Microsoft.Maui.Controls.WebView.MapMixedContentMode(Microsoft.Maui.Handlers.WebViewHandler handler, Microsoft.Maui.Controls.WebView webView) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.EditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapImeOptions(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapLineBreakMode(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -60,6 +60,16 @@ override Microsoft.Maui.Controls.Platform.ControlsAccessibilityDelegate.OnInitia
 override Microsoft.Maui.Controls.TemplatedView.ArrangeOverride(Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler! handler, Microsoft.Maui.Controls.RadioButton! radioButton) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonTitle(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonVisible(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBarBackground(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBarTextColor(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapIconColor(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapIsVisible(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapTitle(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -128,3 +138,13 @@ static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> 
 *REMOVED*~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
 *REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
 *REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBackButtonTitle(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBackButtonVisible(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBarBackground(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBarTextColor(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapIconColor(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapIsVisible(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapTitle(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -92,8 +92,54 @@ virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Contr
 ~Microsoft.Maui.Controls.MenuFlyout.Remove(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].get -> Microsoft.Maui.IMenuElement
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].set -> void
+~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.DatePicker.MapUpdateMode(Microsoft.Maui.Handlers.IDatePickerHandler handler, Microsoft.Maui.Controls.DatePicker datePicker) -> void
+~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Entry.MapAdjustsFontSizeToFitWidth(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.Entry.MapCursorColor(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
+~static Microsoft.Maui.Controls.Label.MapCharacterSpacing(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapFont(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapLineHeight(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextColor(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextDecorations(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+~static Microsoft.Maui.Controls.NavigationPage.MapIsNavigationBarTranslucent(Microsoft.Maui.Handlers.INavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+~static Microsoft.Maui.Controls.NavigationPage.MapPrefersLargeTitles(Microsoft.Maui.Handlers.INavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+~static Microsoft.Maui.Controls.Picker.MapUpdateMode(Microsoft.Maui.Handlers.IPickerHandler handler, Microsoft.Maui.Controls.Picker picker) -> void
+~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
+~static Microsoft.Maui.Controls.ScrollView.MapShouldDelayContentTouches(Microsoft.Maui.Handlers.IScrollViewHandler handler, Microsoft.Maui.Controls.ScrollView scrollView) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapSearchBarStyle(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+~static Microsoft.Maui.Controls.TimePicker.MapUpdateMode(Microsoft.Maui.Handlers.ITimePickerHandler handler, Microsoft.Maui.Controls.TimePicker timePicker) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
+*REMOVED*~static Microsoft.Maui.Controls.NavigationPage.MapIsNavigationBarTranslucent(Microsoft.Maui.Handlers.NavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+*REMOVED*~static Microsoft.Maui.Controls.NavigationPage.MapPrefersLargeTitles(Microsoft.Maui.Handlers.NavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapCharacterSpacing(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapFont(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapLineHeight(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextColor(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextDecorations(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Picker.MapUpdateMode(Microsoft.Maui.Handlers.PickerHandler handler, Microsoft.Maui.Controls.Picker picker) -> void
+*REMOVED*~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
+*REMOVED*~static Microsoft.Maui.Controls.ScrollView.MapShouldDelayContentTouches(Microsoft.Maui.Handlers.ScrollViewHandler handler, Microsoft.Maui.Controls.ScrollView scrollView) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapSearchBarStyle(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*~static Microsoft.Maui.Controls.TimePicker.MapUpdateMode(Microsoft.Maui.Handlers.TimePickerHandler handler, Microsoft.Maui.Controls.TimePicker timePicker) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.DatePicker.MapUpdateMode(Microsoft.Maui.Handlers.DatePickerHandler handler, Microsoft.Maui.Controls.DatePicker datePicker) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.EditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapAdjustsFontSizeToFitWidth(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapCursorColor(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -92,8 +92,55 @@ virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Contr
 ~Microsoft.Maui.Controls.MenuFlyout.Remove(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].get -> Microsoft.Maui.IMenuElement
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].set -> void
+~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.DatePicker.MapUpdateMode(Microsoft.Maui.Handlers.IDatePickerHandler handler, Microsoft.Maui.Controls.DatePicker datePicker) -> void
+~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Entry.MapAdjustsFontSizeToFitWidth(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.Entry.MapCursorColor(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
+~static Microsoft.Maui.Controls.Label.MapCharacterSpacing(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapFont(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapLineHeight(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextColor(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextDecorations(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+~static Microsoft.Maui.Controls.NavigationPage.MapIsNavigationBarTranslucent(Microsoft.Maui.Handlers.INavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+~static Microsoft.Maui.Controls.NavigationPage.MapPrefersLargeTitles(Microsoft.Maui.Handlers.INavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+~static Microsoft.Maui.Controls.Picker.MapUpdateMode(Microsoft.Maui.Handlers.IPickerHandler handler, Microsoft.Maui.Controls.Picker picker) -> void
+~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
+~static Microsoft.Maui.Controls.ScrollView.MapShouldDelayContentTouches(Microsoft.Maui.Handlers.IScrollViewHandler handler, Microsoft.Maui.Controls.ScrollView scrollView) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapSearchBarStyle(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+~static Microsoft.Maui.Controls.TimePicker.MapUpdateMode(Microsoft.Maui.Handlers.ITimePickerHandler handler, Microsoft.Maui.Controls.TimePicker timePicker) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapAdjustsFontSizeToFitWidth(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapCursorColor(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.DatePicker.MapUpdateMode(Microsoft.Maui.Handlers.DatePickerHandler handler, Microsoft.Maui.Controls.DatePicker datePicker) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.EditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapCharacterSpacing(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapFont(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapLineHeight(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextColor(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextDecorations(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+*REMOVED*~static Microsoft.Maui.Controls.NavigationPage.MapIsNavigationBarTranslucent(Microsoft.Maui.Handlers.NavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+*REMOVED*~static Microsoft.Maui.Controls.NavigationPage.MapPrefersLargeTitles(Microsoft.Maui.Handlers.NavigationViewHandler handler, Microsoft.Maui.Controls.NavigationPage navigationPage) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Picker.MapUpdateMode(Microsoft.Maui.Handlers.PickerHandler handler, Microsoft.Maui.Controls.Picker picker) -> void
+*REMOVED*~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
+*REMOVED*~static Microsoft.Maui.Controls.ScrollView.MapShouldDelayContentTouches(Microsoft.Maui.Handlers.ScrollViewHandler handler, Microsoft.Maui.Controls.ScrollView scrollView) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapSearchBarStyle(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*~static Microsoft.Maui.Controls.TimePicker.MapUpdateMode(Microsoft.Maui.Handlers.TimePickerHandler handler, Microsoft.Maui.Controls.TimePicker timePicker) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3299,17 +3299,6 @@ static Microsoft.Maui.Controls.Shapes.Matrix.operator *(Microsoft.Maui.Controls.
 static Microsoft.Maui.Controls.Shapes.MatrixExtensions.ToMatrix(this System.Numerics.Matrix3x2 matrix3x2) -> Microsoft.Maui.Controls.Shapes.Matrix
 static Microsoft.Maui.Controls.Shapes.MatrixExtensions.ToMatrix3X2(this Microsoft.Maui.Controls.Shapes.Matrix matrix) -> System.Numerics.Matrix3x2
 static Microsoft.Maui.Controls.Toolbar.ControlsToolbarMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.Controls.Toolbar!, Microsoft.Maui.Handlers.ToolbarHandler!>!
-static Microsoft.Maui.Controls.Toolbar.MapBackButtonTitle(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapBackButtonVisible(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapBarBackground(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapBarBackgroundColor(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapBarTextColor(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapIconColor(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapIsVisible(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapTitle(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
-static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.ToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
 static Microsoft.Maui.Controls.ToolTipProperties.GetText(Microsoft.Maui.Controls.BindableObject! bindable) -> object!
 static Microsoft.Maui.Controls.ToolTipProperties.SetText(Microsoft.Maui.Controls.BindableObject! bindable, object! value) -> void
 static Microsoft.Maui.Controls.ViewExtensions.CancelAnimations(this Microsoft.Maui.Controls.VisualElement! view) -> void
@@ -7425,3 +7414,14 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~virtual Microsoft.Maui.Controls.Toolbar.TitleView.get -> Microsoft.Maui.Controls.VisualElement
 ~virtual Microsoft.Maui.Controls.Toolbar.TitleView.set -> void
 ~virtual Microsoft.Maui.Controls.View.GetChildElements(Microsoft.Maui.Graphics.Point point) -> System.Collections.Generic.IList<Microsoft.Maui.Controls.GestureElement>
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonTitle(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonVisible(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBarBackground(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBarBackgroundColor(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBarTextColor(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapIconColor(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapIsVisible(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapTitle(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void
+static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.IToolbarHandler! handler, Microsoft.Maui.Controls.Toolbar! toolbar) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -5618,7 +5618,7 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~static Microsoft.Maui.Controls.Brush.Yellow.get -> Microsoft.Maui.Controls.SolidColorBrush
 ~static Microsoft.Maui.Controls.Brush.YellowGreen.get -> Microsoft.Maui.Controls.SolidColorBrush
 ~static Microsoft.Maui.Controls.Button.ControlsButtonMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IButton, Microsoft.Maui.Handlers.ButtonHandler>
-~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
 ~static Microsoft.Maui.Controls.Button.MapLineBreakMode(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
 ~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
 ~static Microsoft.Maui.Controls.Compatibility.AbsoluteLayout.GetLayoutBounds(Microsoft.Maui.Controls.BindableObject bindable) -> Microsoft.Maui.Graphics.Rect
@@ -5688,14 +5688,14 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~static Microsoft.Maui.Controls.DoubleCollection.implicit operator Microsoft.Maui.Controls.DoubleCollection(double[] d) -> Microsoft.Maui.Controls.DoubleCollection
 ~static Microsoft.Maui.Controls.DoubleCollection.implicit operator Microsoft.Maui.Controls.DoubleCollection(float[] f) -> Microsoft.Maui.Controls.DoubleCollection
 ~static Microsoft.Maui.Controls.Editor.ControlsEditorMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IEditor, Microsoft.Maui.Handlers.EditorHandler>
-~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.EditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
 ~static Microsoft.Maui.Controls.Effect.Resolve(string name) -> Microsoft.Maui.Controls.Effect
 ~static Microsoft.Maui.Controls.EffectiveVisualExtensions.IsDefault(this Microsoft.Maui.Controls.IVisual visual) -> bool
 ~static Microsoft.Maui.Controls.EffectiveVisualExtensions.IsMatchParent(this Microsoft.Maui.Controls.IVisual visual) -> bool
 ~static Microsoft.Maui.Controls.EffectiveVisualExtensions.IsMaterial(this Microsoft.Maui.Controls.IVisual visual) -> bool
 ~static Microsoft.Maui.Controls.Element.ControlsElementMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IElement, Microsoft.Maui.IElementHandler>
 ~static Microsoft.Maui.Controls.Entry.ControlsEntryMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IEntry, Microsoft.Maui.Handlers.EntryHandler>
-~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
 ~static Microsoft.Maui.Controls.FileImageSource.implicit operator Microsoft.Maui.Controls.FileImageSource(string file) -> Microsoft.Maui.Controls.FileImageSource
 ~static Microsoft.Maui.Controls.FileImageSource.implicit operator string(Microsoft.Maui.Controls.FileImageSource file) -> string
 ~static Microsoft.Maui.Controls.FlexLayout.GetAlignSelf(Microsoft.Maui.Controls.BindableObject bindable) -> Microsoft.Maui.Layouts.FlexAlignSelf
@@ -5850,10 +5850,10 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~static Microsoft.Maui.Controls.Label.ControlsLabelMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ILabel, Microsoft.Maui.Handlers.LabelHandler>
 ~static Microsoft.Maui.Controls.Label.MapLineBreakMode(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
 ~static Microsoft.Maui.Controls.Label.MapMaxLines(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
-~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
-~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
 ~static Microsoft.Maui.Controls.Layout.ControlsLayoutMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IView, Microsoft.Maui.IViewHandler>
-~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
 ~static Microsoft.Maui.Controls.MenuItem.GetAccelerator(Microsoft.Maui.Controls.BindableObject bindable) -> Microsoft.Maui.Controls.Accelerator
 ~static Microsoft.Maui.Controls.MenuItem.SetAccelerator(Microsoft.Maui.Controls.BindableObject bindable, Microsoft.Maui.Controls.Accelerator value) -> void
 ~static Microsoft.Maui.Controls.MessagingCenter.Instance.get -> Microsoft.Maui.Controls.IMessagingCenter
@@ -6369,7 +6369,7 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~static Microsoft.Maui.Controls.PointCollection.implicit operator Microsoft.Maui.Controls.PointCollection(Microsoft.Maui.Graphics.Point[] d) -> Microsoft.Maui.Controls.PointCollection
 ~static Microsoft.Maui.Controls.RadioButton.ControlsRadioButtonMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.Controls.RadioButton, Microsoft.Maui.Handlers.RadioButtonHandler>
 ~static Microsoft.Maui.Controls.RadioButton.DefaultTemplate.get -> Microsoft.Maui.Controls.ControlTemplate
-~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
+~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
 ~static Microsoft.Maui.Controls.RadioButtonGroup.GetGroupName(Microsoft.Maui.Controls.BindableObject b) -> string
 ~static Microsoft.Maui.Controls.RadioButtonGroup.GetSelectedValue(Microsoft.Maui.Controls.BindableObject bindableObject) -> object
 ~static Microsoft.Maui.Controls.RadioButtonGroup.SetGroupName(Microsoft.Maui.Controls.BindableObject bindable, string groupName) -> void
@@ -6388,7 +6388,7 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~static Microsoft.Maui.Controls.Routing.UnRegisterRoute(string route) -> void
 ~static Microsoft.Maui.Controls.ScrollView.ControlsScrollViewMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IScrollView, Microsoft.Maui.Handlers.ScrollViewHandler>
 ~static Microsoft.Maui.Controls.SearchBar.ControlsSearchBarMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.ISearchBar, Microsoft.Maui.Handlers.SearchBarHandler>
-~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
 ~static Microsoft.Maui.Controls.SearchHandler.SelectedItemProperty -> Microsoft.Maui.Controls.BindableProperty
 ~static Microsoft.Maui.Controls.SemanticProperties.GetDescription(Microsoft.Maui.Controls.BindableObject bindable) -> string
 ~static Microsoft.Maui.Controls.SemanticProperties.GetHeadingLevel(Microsoft.Maui.Controls.BindableObject bindable) -> Microsoft.Maui.SemanticHeadingLevel

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -5853,7 +5853,7 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
 ~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
 ~static Microsoft.Maui.Controls.Layout.ControlsLayoutMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IView, Microsoft.Maui.IViewHandler>
-~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
 ~static Microsoft.Maui.Controls.MenuItem.GetAccelerator(Microsoft.Maui.Controls.BindableObject bindable) -> Microsoft.Maui.Controls.Accelerator
 ~static Microsoft.Maui.Controls.MenuItem.SetAccelerator(Microsoft.Maui.Controls.BindableObject bindable, Microsoft.Maui.Controls.Accelerator value) -> void
 ~static Microsoft.Maui.Controls.MessagingCenter.Instance.get -> Microsoft.Maui.Controls.IMessagingCenter

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -5631,7 +5631,7 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~static Microsoft.Maui.Controls.Button.ControlsButtonMapper -> Microsoft.Maui.IPropertyMapper<Microsoft.Maui.IButton, Microsoft.Maui.Handlers.ButtonHandler>
 ~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
 ~static Microsoft.Maui.Controls.Button.MapLineBreakMode(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
-~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
 ~static Microsoft.Maui.Controls.Compatibility.AbsoluteLayout.GetLayoutBounds(Microsoft.Maui.Controls.BindableObject bindable) -> Microsoft.Maui.Graphics.Rect
 ~static Microsoft.Maui.Controls.Compatibility.AbsoluteLayout.GetLayoutFlags(Microsoft.Maui.Controls.BindableObject bindable) -> Microsoft.Maui.Layouts.AbsoluteLayoutFlags
 ~static Microsoft.Maui.Controls.Compatibility.AbsoluteLayout.SetLayoutBounds(Microsoft.Maui.Controls.BindableObject bindable, Microsoft.Maui.Graphics.Rect bounds) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -67,6 +67,10 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.Platform.ShellFlyoutItemView.OnContentChanged(object oldContent, object newContent) -> void
 static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler! handler, Microsoft.Maui.Controls.RadioButton! radioButton) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonEnabled(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapIcon(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapToolbarDynamicOverflowEnabled(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapToolbarPlacement(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -135,3 +139,25 @@ static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> 
 *REMOVED*~static Microsoft.Maui.Controls.RefreshView.MapRefreshPullDirection(Microsoft.Maui.Handlers.RefreshViewHandler handler, Microsoft.Maui.Controls.RefreshView refreshView) -> void
 *REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
 *REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonTitle(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBackButtonVisible(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBarBackground(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapBarTextColor(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapIconColor(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapIsVisible(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBackButtonEnabled(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBackButtonTitle(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBackButtonVisible(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBarBackground(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapBarTextColor(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapIcon(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapIconColor(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapIsVisible(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapToolbarDynamicOverflowEnabled(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*static Microsoft.Maui.Controls.Toolbar.MapToolbarPlacement(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -66,6 +66,7 @@ override Microsoft.Maui.Controls.TemplatedView.MeasureOverride(double widthConst
 *REMOVED*override Microsoft.Maui.Controls.RadioButton.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.FlexLayout.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 *REMOVED*override Microsoft.Maui.Controls.Platform.ShellFlyoutItemView.OnContentChanged(object oldContent, object newContent) -> void
+static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.IRadioButtonHandler! handler, Microsoft.Maui.Controls.RadioButton! radioButton) -> void
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerEnteredCommandProperty -> Microsoft.Maui.Controls.BindableProperty!
 static readonly Microsoft.Maui.Controls.PointerGestureRecognizer.PointerExitedCommandParameterProperty -> Microsoft.Maui.Controls.BindableProperty!
@@ -99,8 +100,38 @@ static readonly Microsoft.Maui.Controls.ToolTipProperties.TextProperty -> Micros
 ~Microsoft.Maui.Controls.MenuFlyout.Remove(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].get -> Microsoft.Maui.IMenuElement
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].set -> void
+~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapImageSource(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Editor.MapDetectReadingOrderFromContent(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Entry.MapDetectReadingOrderFromContent(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
+~static Microsoft.Maui.Controls.Label.MapDetectReadingOrderFromContent(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+~static Microsoft.Maui.Controls.RefreshView.MapRefreshPullDirection(Microsoft.Maui.Handlers.IRefreshViewHandler handler, Microsoft.Maui.Controls.RefreshView refreshView) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
+*REMOVED*static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler! handler, Microsoft.Maui.Controls.RadioButton! radioButton) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapDetectReadingOrderFromContent(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapImageSource(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Editor.MapDetectReadingOrderFromContent(Microsoft.Maui.Handlers.EditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.EditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapDetectReadingOrderFromContent(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapIsSpellCheckEnabled(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.RefreshView.MapRefreshPullDirection(Microsoft.Maui.Handlers.RefreshViewHandler handler, Microsoft.Maui.Controls.RefreshView refreshView) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -91,8 +91,30 @@ virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Contr
 ~Microsoft.Maui.Controls.MenuFlyout.Remove(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].get -> Microsoft.Maui.IMenuElement
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].set -> void
+~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapLineBreakMode(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
+~static Microsoft.Maui.Controls.Label.MapLineBreakMode(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapMaxLines(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapLineBreakMode(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.EditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapLineBreakMode(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapMaxLines(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -91,8 +91,31 @@ virtual Microsoft.Maui.Controls.TappedEventArgs.GetPosition(Microsoft.Maui.Contr
 ~Microsoft.Maui.Controls.MenuFlyout.Remove(Microsoft.Maui.IMenuElement item) -> bool
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].get -> Microsoft.Maui.IMenuElement
 ~Microsoft.Maui.Controls.MenuFlyout.this[int index].set -> void
+~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapLineBreakMode(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.IButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.IEditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.IEntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
 ~static Microsoft.Maui.Controls.FlyoutBase.GetContextFlyout(Microsoft.Maui.Controls.BindableObject b) -> Microsoft.Maui.Controls.FlyoutBase
 ~static Microsoft.Maui.Controls.FlyoutBase.SetContextFlyout(Microsoft.Maui.Controls.BindableObject b, Microsoft.Maui.Controls.FlyoutBase value) -> void
+~static Microsoft.Maui.Controls.Label.MapLineBreakMode(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapMaxLines(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.ILabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.ILayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.ISearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
 ~static readonly Microsoft.Maui.Controls.FlyoutBase.ContextFlyoutProperty -> Microsoft.Maui.Controls.BindableProperty
 static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> Microsoft.Maui.Controls.BindableProperty!
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapLineBreakMode(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapText(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Editor.MapText(Microsoft.Maui.Handlers.EditorHandler handler, Microsoft.Maui.Controls.Editor editor) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Entry.MapText(Microsoft.Maui.Handlers.EntryHandler handler, Microsoft.Maui.Controls.Entry entry) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapLineBreakMode(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapMaxLines(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapText(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Label.MapTextType(Microsoft.Maui.Handlers.LabelHandler handler, Microsoft.Maui.Controls.Label label) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
+*REMOVED*~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+*REMOVED*~static Microsoft.Maui.Controls.Button.MapContentLayout(Microsoft.Maui.Handlers.ButtonHandler handler, Microsoft.Maui.Controls.Button button) -> void


### PR DESCRIPTION
### Description of Change

The mapper methods all need to take the interface version of the handler so that the mappers can be used with different handler types that just implement the handler interface. Otherwise you have to do something like [this](https://github.com/PureWeen/ShanedlerSamples/blob/main/ShanedlerSamples/MauiShouldDoBetterMapper.cs) so the mappers won't crash the app when unable to call the methods.
