### PR TITLE
Add release 6.0.536

### DIFF
--- a/docs/ReleaseSchedule.md
+++ b/docs/ReleaseSchedule.md
@@ -9,6 +9,7 @@ For a full list, including release notes, please refer to our [Releases page](ht
 
 | Version | Release Date |
 |---------|--------------|
+| [6.0.536 (Service Release 4.1)](https://github.com/dotnet/maui/releases/tag/6.0.536) | 2022/09/14 |
 | [6.0.486 (Service Release 4)](https://github.com/dotnet/maui/releases/tag/6.0.486) | 2022/08/09 |
 | [6.0.424 (Service Release 3.1)](https://github.com/dotnet/maui/releases/tag/6.0.424) | 2022/08/01 |
 | [6.0.419 (Service Release 3)](https://github.com/dotnet/maui/releases/tag/6.0.419) | 2022/07/20 |


### PR DESCRIPTION
Add release 6.0.536


### Description of Change
Add latest MAUI release in ReleaseSchedule.md file.
<!-- Enter description of the fix in this section -->

### Issues Fixed
N/A
<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->



<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
