### PR TITLE
Don't force the TextDirection on Android unless the content direction can't be determined

### DIFF
--- a/src/Core/src/Platform/Android/TextViewExtensions.cs
+++ b/src/Core/src/Platform/Android/TextViewExtensions.cs
@@ -104,11 +104,11 @@ namespace Microsoft.Maui.Platform
 					break;
 				case FlowDirection.RightToLeft:
 					platformView.LayoutDirection = ALayoutDirection.Rtl;
-					platformView.TextDirection = ATextDirection.Rtl;
+					platformView.TextDirection = ATextDirection.FirstStrongRtl;
 					break;
 				case FlowDirection.LeftToRight:
 					platformView.LayoutDirection = ALayoutDirection.Ltr;
-					platformView.TextDirection = ATextDirection.Ltr;
+					platformView.TextDirection = ATextDirection.FirstStrongLtr;
 					break;
 			}
 		}


### PR DESCRIPTION
### Description of Change

Most of the time when folks have an app with mixed RTL/LTR content, they want the text content to maintain the correct direction for the content's language. These changes allow the text content for TextView (and its descendants, including Button) to keep the text direction from the content language when it can be determined; the fallback is the layout direction. 

This makes the default behavior less confusing; if this default behavior isn't what the user wants, it can still be customized by modifying the flow direction mapping.

### Issues Fixed

Fixes #2880