### PR TITLE
Fix cleanup up WebView code

### DIFF
--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -52,10 +52,16 @@ namespace Microsoft.Maui.Handlers
 
 		protected override void DisconnectHandler(AWebView platformView)
 		{
+			if (_webViewClient is MauiWebViewClient mauiWebViewClient)
+				mauiWebViewClient.Disconnect();
+
+			_webChromeClient?.Disconnect();
+			platformView.SetWebChromeClient(null);
+
 			platformView.StopLoading();
 
-			_webViewClient?.Dispose();
-			_webChromeClient?.Dispose();
+			_webViewClient = null;
+			_webChromeClient = null;
 
 			base.DisconnectHandler(platformView);
 		}

--- a/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
+++ b/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Maui.Handlers
 
 		protected internal bool NavigatingCanceled(string? url)
 		{
-			if (VirtualView == null || string.IsNullOrWhiteSpace(url))
+			if (VirtualView == null || string.IsNullOrWhiteSpace(url) || _webViewClient == null)
 				return true;
 
 			if (url == AssetBaseUrl)
@@ -146,7 +146,13 @@ namespace Microsoft.Maui.Handlers
 
 			// TODO: Sync Cookies
 			bool cancel = VirtualView.Navigating(CurrentNavigationEvent, url);
+
+			// if the user disconnects from the handler we want to exit
+			if (_webViewClient == null)
+				return true;
+
 			PlatformView?.UpdateCanGoBackForward(VirtualView);
+
 			UrlCanceled = cancel ? null : url;
 
 			return cancel;

--- a/src/Core/src/Platform/Android/MauiWebChromeClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebChromeClient.cs
@@ -11,15 +11,14 @@ namespace Microsoft.Maui.Platform
 {
 	public class MauiWebChromeClient : WebChromeClient
 	{
-		readonly WebViewHandler _handler;
-		Activity _activity;
+		WeakReference<Activity> _activityRef;
 		List<int> _requestCodes;
 
 		public MauiWebChromeClient(WebViewHandler handler)
 		{
-			_handler = handler ?? throw new ArgumentNullException("handler");
+			_ = handler ?? throw new ArgumentNullException("handler");
 
-			SetContext(_handler.Context);
+			SetContext(handler);
 		}
 
 		public override bool OnShowFileChooser(WebView webView, IValueCallback filePathCallback, FileChooserParams fileChooserParams)
@@ -30,7 +29,7 @@ namespace Microsoft.Maui.Platform
 
 		public void UnregisterCallbacks()
 		{
-			if (_requestCodes == null || _requestCodes.Count == 0 || _activity == null)
+			if (_requestCodes == null || _requestCodes.Count == 0 || !_activityRef.TryGetTarget(out Activity activity))
 				return;
 
 			foreach (int requestCode in _requestCodes)
@@ -43,7 +42,7 @@ namespace Microsoft.Maui.Platform
 
 		protected bool ChooseFile(IValueCallback filePathCallback, Intent intent, string title)
 		{
-			if (_activity == null)
+			if (!_activityRef.TryGetTarget(out Activity activity))
 				return false;
 
 			Action<Result, Intent> callback = (resultCode, intentData) =>
@@ -61,7 +60,7 @@ namespace Microsoft.Maui.Platform
 
 			_requestCodes.Add(newRequestCode);
 
-			_activity.StartActivityForResult(Intent.CreateChooser(intent, title), newRequestCode);
+			activity.StartActivityForResult(Intent.CreateChooser(intent, title), newRequestCode);
 
 			return true;
 		}
@@ -69,7 +68,7 @@ namespace Microsoft.Maui.Platform
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
-				Disconnect();
+				UnregisterCallbacks();
 
 			base.Dispose(disposing);
 		}
@@ -77,6 +76,7 @@ namespace Microsoft.Maui.Platform
 		internal void Disconnect()
 		{
 			UnregisterCallbacks();
+			_activityRef = null;
 		}
 
 		protected virtual Object ParseResult(Result resultCode, Intent data)
@@ -84,15 +84,14 @@ namespace Microsoft.Maui.Platform
 			return FileChooserParams.ParseResult((int)resultCode, data);
 		}
 
-		void SetContext(Context thisActivity)
+		void SetContext(WebViewHandler handler)
 		{
-			_activity = thisActivity as Activity;
+			var activity = (handler.Context?.GetActivity()) ?? ApplicationModel.Platform.CurrentActivity;
 
-			if (_activity == null)
-				_activity = ApplicationModel.Platform.CurrentActivity;
+			if (activity == null)
+				handler?.MauiContext?.CreateLogger<WebViewHandler>()?.LogWarning($"Failed to set the activity of the WebChromeClient, can't show pickers on the Webview");
 
-			if (_activity == null)
-				_handler?.MauiContext?.CreateLogger<WebViewHandler>()?.LogWarning($"Failed to set the activity of the WebChromeClient, can't show pickers on the Webview");
+			_activityRef = new WeakReference<Activity>(activity);
 		}
 	}
 }

--- a/src/Core/src/Platform/Android/MauiWebChromeClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebChromeClient.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Platform
 
 		public void UnregisterCallbacks()
 		{
-			if (_requestCodes == null || _requestCodes.Count == 0 || !_activityRef.TryGetTarget(out Activity activity))
+			if (_requestCodes == null || _requestCodes.Count == 0 || !_activityRef.TryGetTarget(out Activity _))
 				return;
 
 			foreach (int requestCode in _requestCodes)

--- a/src/Core/src/Platform/Android/MauiWebChromeClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebChromeClient.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Platform
 		WeakReference<Activity> _activityRef;
 		List<int> _requestCodes;
 
-		public MauiWebChromeClient(WebViewHandler handler)
+		public MauiWebChromeClient(IWebViewHandler handler)
 		{
 			_ = handler ?? throw new ArgumentNullException("handler");
 
@@ -84,9 +84,9 @@ namespace Microsoft.Maui.Platform
 			return FileChooserParams.ParseResult((int)resultCode, data);
 		}
 
-		void SetContext(WebViewHandler handler)
+		void SetContext(IWebViewHandler handler)
 		{
-			var activity = (handler.Context?.GetActivity()) ?? ApplicationModel.Platform.CurrentActivity;
+			var activity = (handler?.MauiContext?.Context?.GetActivity()) ?? ApplicationModel.Platform.CurrentActivity;
 
 			if (activity == null)
 				handler?.MauiContext?.CreateLogger<WebViewHandler>()?.LogWarning($"Failed to set the activity of the WebChromeClient, can't show pickers on the Webview");

--- a/src/Core/src/Platform/Android/MauiWebChromeClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebChromeClient.cs
@@ -69,9 +69,14 @@ namespace Microsoft.Maui.Platform
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
-				UnregisterCallbacks();
+				Disconnect();
 
 			base.Dispose(disposing);
+		}
+
+		internal void Disconnect()
+		{
+			UnregisterCallbacks();
 		}
 
 		protected virtual Object ParseResult(Result resultCode, Intent data)

--- a/src/Core/src/Platform/Android/MauiWebViewClient.cs
+++ b/src/Core/src/Platform/Android/MauiWebViewClient.cs
@@ -91,9 +91,14 @@ namespace Microsoft.Maui.Platform
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
-				_handler = null;
+				Disconnect();
 
 			base.Dispose(disposing);
+		}
+
+		internal void Disconnect()
+		{
+			_handler = null;
 		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -122,3 +122,5 @@ static Microsoft.Maui.Handlers.LabelHandler.CommandMapper -> Microsoft.Maui.Comm
 static Microsoft.Maui.Handlers.MenuFlyoutItemHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IMenuFlyoutItem!, Microsoft.Maui.Handlers.IMenuFlyoutItemHandler!>!
 static Microsoft.Maui.Handlers.ProgressBarHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.IProgress!, Microsoft.Maui.Handlers.IProgressBarHandler!>!
 static Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.CommandMapper -> Microsoft.Maui.CommandMapper<Microsoft.Maui.ISwipeItemMenuItem!, Microsoft.Maui.Handlers.ISwipeItemMenuItemHandler!>!
+~Microsoft.Maui.Platform.MauiWebChromeClient.MauiWebChromeClient(Microsoft.Maui.Handlers.IWebViewHandler handler) -> void
+*REMOVED*~Microsoft.Maui.Platform.MauiWebChromeClient.MauiWebChromeClient(Microsoft.Maui.Handlers.WebViewHandler handler) -> void


### PR DESCRIPTION
### Description of Change

Currently our Unit Tests are failing occasionally with a crash on the MauiWebViewClient. This is most likely happening because in disconnect we are disposing of the `MauiWebViewClient` but it's still connected to an active `WebViewClient`. I've updated the code so that the `MauiWebViewClient` is more GC'able and then just disconnect any references to our code so the GC should just take care of the life cycle now. 