### PR TITLE
[android] bring back `$(AndroidLinkResources)` by default

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.targets
+++ b/.nuspec/Microsoft.Maui.Controls.targets
@@ -11,6 +11,7 @@
 		<SkipMicrosoftUIXamlCheckTargetPlatformVersion Condition="'$(SkipMicrosoftUIXamlCheckTargetPlatformVersion)'==''">true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
 		<SkipMicrosoftUIXamlCheckTargetPlatformVersion Condition="'$(SkipMicrosoftUIXamlCheckTargetPlatformVersion)'=='false'"></SkipMicrosoftUIXamlCheckTargetPlatformVersion>
 		<AndroidUseDefaultAotProfile Condition="'$(AndroidEnableProfiledAot)' == 'true' and '$(AndroidUseDefaultAotProfile)' == ''">false</AndroidUseDefaultAotProfile>
+		<AndroidLinkResources Condition=" '$(AndroidLinkResources)' == '' And '$(Configuration)' == 'Release' ">True</AndroidLinkResources>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This reverts commit af8e7ce03fa562b5fc4ecd99b9eb5a912fbcdb19.

Thanks to:

https://github.com/xamarin/xamarin-android/commit/d521ac0280c0ad165570077a860cb1846025010b

`int[]` fields now work in .NET 7, when you enable `$(AndroidLinkResources)`. Our thought is to try this by default in .NET 7 RC 2.

Difference in app size for the .NET Podcast app:

    > apkdiff -f before.apk after.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
    +           8 lib/arm64-v8a/libaot-Microsoft.Maui.Controls.Xaml.dll.so
    -         608 lib/arm64-v8a/libaot-Microsoft.Maui.Controls.Compatibility.dll.so
    -       3,448 lib/arm64-v8a/libaot-Microsoft.Maui.Controls.dll.so
    -       4,424 lib/arm64-v8a/libaot-Microsoft.Maui.dll.so
    -       5,656 lib/arm64-v8a/libaot-Microsoft.NetConf2021.Maui.dll.so
    -     129,617 assemblies/assemblies.blob
    Summary:
    -     129,617 Other entries -1.03% (of 12,605,899)
    +           0 Dalvik executables 0.00% (of 11,756,376)
    -      14,128 Shared libraries -0.10% (of 14,849,096)
    -     131,072 Package size difference -0.64% (of 20,380,049)