### PR TITLE
Fix Semantic Property Propagation and CV TabStop

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.Impl.cs
@@ -172,13 +172,27 @@ namespace Microsoft.Maui.Controls
 
 		Semantics IView.Semantics
 		{
-			get => _semantics;
+			get
+			{
+				UpdateSemantics();
+				return _semantics;
+			}
 		}
 
-		// We don't want to initialize Semantics until someone explicitly 
-		// wants to modify some aspect of the semantics class
-		internal Semantics SetupSemantics() =>
+		void UpdateSemantics()
+		{
+			if (!this.IsSet(SemanticProperties.HintProperty) &&
+				!this.IsSet(SemanticProperties.DescriptionProperty) &&
+				!this.IsSet(SemanticProperties.HeadingLevelProperty))
+			{
+				return;
+			}
+
 			_semantics ??= new Semantics();
+			_semantics.Description = SemanticProperties.GetDescription(this);
+			_semantics.HeadingLevel = SemanticProperties.GetHeadingLevel(this);
+			_semantics.Hint = SemanticProperties.GetHint(this);
+		}
 
 		static double EnsurePositive(double value)
 		{

--- a/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement/VisualElement.cs
@@ -16,7 +16,10 @@ namespace Microsoft.Maui.Controls
 				[PlatformConfiguration.WindowsSpecific.VisualElement.AccessKeyVerticalOffsetProperty.PropertyName] = MapAccessKeyVerticalOffset,
 #endif
 				[nameof(BackgroundColor)] = MapBackgroundColor,
-				[nameof(Page.BackgroundImageSource)] = MapBackgroundImageSource
+				[nameof(Page.BackgroundImageSource)] = MapBackgroundImageSource,
+				[SemanticProperties.DescriptionProperty.PropertyName] = MapSemanticPropertiesDescriptionProperty,
+				[SemanticProperties.HintProperty.PropertyName] = MapSemanticPropertiesHintProperty,
+				[SemanticProperties.HeadingLevelProperty.PropertyName] = MapSemanticPropertiesHeadingLevelProperty,
 			};
 
 		internal static void RemapForControls()
@@ -33,6 +36,21 @@ namespace Microsoft.Maui.Controls
 		public static void MapBackgroundImageSource(IViewHandler handler, IView view)
 		{
 			handler.UpdateValue(nameof(Background));
+		}
+
+		static void MapSemanticPropertiesHeadingLevelProperty(IViewHandler handler, IView element) =>
+			(element as VisualElement)?.UpdateSemanticsFromMapper();
+
+		static void MapSemanticPropertiesHintProperty(IViewHandler handler, IView element) =>
+			(element as VisualElement)?.UpdateSemanticsFromMapper();
+
+		static void MapSemanticPropertiesDescriptionProperty(IViewHandler handler, IView element) =>
+			(element as VisualElement)?.UpdateSemanticsFromMapper();
+
+		void UpdateSemanticsFromMapper()
+		{
+			UpdateSemantics();
+			Handler?.UpdateValue(nameof(IView.Semantics));
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui.Controls.Platform
 		public ItemContentControl()
 		{
 			DefaultStyleKey = typeof(ItemContentControl);
+			IsTabStop = false;
 		}
 
 		public static readonly DependencyProperty MauiContextProperty = DependencyProperty.Register(

--- a/src/Controls/src/Core/SemanticProperties.cs
+++ b/src/Controls/src/Core/SemanticProperties.cs
@@ -5,46 +5,11 @@ namespace Microsoft.Maui.Controls
 {
 	public class SemanticProperties
 	{
-		public static readonly BindableProperty DescriptionProperty = BindableProperty.CreateAttached("Description", typeof(string), typeof(SemanticProperties), default(string), propertyChanged: OnDescriptionPropertyChanged);
+		public static readonly BindableProperty DescriptionProperty = BindableProperty.CreateAttached("Description", typeof(string), typeof(SemanticProperties), default(string));
 
-		public static readonly BindableProperty HintProperty = BindableProperty.CreateAttached("Hint", typeof(string), typeof(SemanticProperties), default(string), propertyChanged: OnHintPropertyChanged);
+		public static readonly BindableProperty HintProperty = BindableProperty.CreateAttached("Hint", typeof(string), typeof(SemanticProperties), default(string));
 
-		public static readonly BindableProperty HeadingLevelProperty = BindableProperty.CreateAttached("HeadingLevel", typeof(SemanticHeadingLevel), typeof(SemanticProperties), SemanticHeadingLevel.None, propertyChanged: OnHeadingLevelPropertyChanged);
-
-		static void OnHeadingLevelPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			UpdateSemanticsProperty(bindable,
-				(semantics) => semantics.HeadingLevel = (SemanticHeadingLevel)newValue);
-		}
-
-		static void OnDescriptionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			string value = null;
-			if (newValue != null)
-				value = newValue.ToString();
-
-			UpdateSemanticsProperty(bindable,
-				(semantics) => semantics.Description = value);
-		}
-
-		static void OnHintPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			string value = null;
-			if (newValue != null)
-				value = newValue.ToString();
-
-			UpdateSemanticsProperty(bindable,
-				(semantics) => semantics.Hint = value);
-		}
-
-		static void UpdateSemanticsProperty(BindableObject bindable, Action<Semantics> action)
-		{
-			if (bindable is VisualElement ve)
-				action.Invoke(ve.SetupSemantics());
-
-			if (bindable is IView fe)
-				fe.Handler?.UpdateValue(nameof(IView.Semantics));
-		}
+		public static readonly BindableProperty HeadingLevelProperty = BindableProperty.CreateAttached("HeadingLevel", typeof(SemanticHeadingLevel), typeof(SemanticProperties), SemanticHeadingLevel.None);
 
 		public static string GetDescription(BindableObject bindable)
 		{

--- a/src/Controls/tests/Core.UnitTests/SemanticPropertyUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SemanticPropertyUnitTests.cs
@@ -116,9 +116,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			public override void UpdateValue(string property)
 			{
-				SemanticDescription = (VirtualView as IView).Semantics.Description;
-				SemanticHint = (VirtualView as IView).Semantics.Hint;
-				SemanticHeadingLevel = (VirtualView as IView).Semantics.HeadingLevel;
+				if ((VirtualView as IView).Semantics is Semantics semantics)
+				{
+					SemanticDescription = semantics.Description;
+					SemanticHint = semantics.Hint;
+					SemanticHeadingLevel = semantics.HeadingLevel;
+				}
 
 				base.UpdateValue(property);
 			}

--- a/src/Core/src/Platform/Windows/MauiToolbar.xaml
+++ b/src/Core/src/Platform/Windows/MauiToolbar.xaml
@@ -22,7 +22,7 @@
 
             <Image x:Name="titleIcon" Grid.Column="0" />
 
-            <ContentControl x:Name="menuContent" Grid.Column="1"></ContentControl>
+            <ContentControl IsTabStop="False" x:Name="menuContent" Grid.Column="1"></ContentControl>
             
             <!-- This border is used so that the container for the TextBlock matches the height of the backbutton
                  and then we center the TextBlock to that. This causes the backbutton and textblock to line up.
@@ -31,7 +31,7 @@
                 <TextBlock VerticalAlignment="Center" x:Name="title" TextWrapping="NoWrap" Margin="10,0,0,0"/>
             </Border>
 
-            <ContentControl x:Name="titleView" Grid.Column="3" HorizontalAlignment="Stretch" 
+            <ContentControl IsTabStop="False" x:Name="titleView" Grid.Column="3" HorizontalAlignment="Stretch" 
                             HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" />
 
         </Grid>

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui.Platform
 
 		public WindowRootView()
 		{
+			IsTabStop = false;
 		}
 
 		internal double AppTitleBarActualHeight => AppTitleBarContentControl?.ActualHeight ?? 0;


### PR DESCRIPTION
### Description of Change

- Set `TabStop` to false for the the ContentControl used to house CollectionView content. For historical reasons the `ContentControl` on WinUI will always act as an empty `TabStop`
- Rework the `SemanticProperties` so that the `Semantic` property is ready and updated by the time PropertyChanged/Handler Update is called

### Issues Fixed
Fixes #8964
Fixes #8722
Fixes #8963
