### PR TITLE
[Windows] Map the Window title to the automation name property

### DIFF
--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Devices;
 using Microsoft.Maui.LifecycleEvents;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Automation;
 using Windows.Graphics;

--- a/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIWindow.cs
@@ -6,6 +6,7 @@ using Microsoft.Maui.LifecycleEvents;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Automation;
 using Windows.Graphics;
 
 namespace Microsoft.Maui
@@ -170,7 +171,13 @@ namespace Microsoft.Maui
 				fe.GetDescendantByName<TextBlock>("AppTitle") is TextBlock tb)
 			{
 				tb.Text = Title;
+				UpdateSemanticsDescription(tb, Title);
 			}
+		}
+
+		void UpdateSemanticsDescription(FrameworkElement frameworkElement, string description)
+		{
+			AutomationProperties.SetName(frameworkElement, description);
 		}
 
 		[DllImport("shell32.dll", CharSet = CharSet.Auto)]


### PR DESCRIPTION
### Description of Change

Map the Window title to the automation name property.

### Issues Fixed

Fixes #10131 