### PR TITLE
[Android] Fix crash navigating on Shell using a custom TitleView

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Android.cs
@@ -75,14 +75,21 @@ namespace Microsoft.Maui.Controls
 			_ = MauiContext.Context ?? throw new ArgumentNullException(nameof(MauiContext.Context));
 
 			VisualElement titleView = TitleView;
+
 			if (_platformTitleViewHandler != null)
 			{
-				Type? rendererType = null;
+				Type? titleViewHandlerType = null;
+				Type? titleViewVirtualViewType = null;
 
 				if (titleView != null)
-					rendererType = MauiContext.Handlers.GetHandlerType(titleView.GetType());
+					titleViewHandlerType = MauiContext.Handlers.GetHandlerType(titleView.GetType());
+				
+				if (_platformTitleViewHandler.VirtualView != null)
+					titleViewVirtualViewType = _platformTitleViewHandler.VirtualView.GetType();
 
-				if (titleView == null || titleView.Handler?.GetType() != rendererType)
+				if (titleView == null || 
+					titleView.Handler?.GetType() != titleViewHandlerType ||
+					titleView.GetType() != titleViewVirtualViewType)
 				{
 					if (_platformTitleView != null)
 						_platformTitleView.Child = null;


### PR DESCRIPTION
### Description of Change

Fix crash navigating on Shell using a custom TitleView on Android. 

Added validation between VirtualView types to know if the previous TitleView instance should be disposed.

To test the changes:
- Use the sample https://github.com/jmblakl/MauiTitleViewIssue
- Navigate to the page that can be navigated to from the tabbed page with a nested layout. Then click the button to navigate back to the '//HomePage' in which contains the TitleView that has a nested layout. Repeat the step several times.
- It shouldn't crash.

### Issues Fixed

Fixes #10006 