### PR TITLE
Fix insights from crashing when using Frame and CollectionView

### DIFF
--- a/src/Compatibility/Core/src/Windows/FrameRenderer.cs
+++ b/src/Compatibility/Core/src/Windows/FrameRenderer.cs
@@ -17,17 +17,6 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 			AutoPackage = false;
 		}
 
-		protected override AutomationPeer OnCreateAutomationPeer()
-		{
-			// We need an automation peer so we can interact with this in automated tests
-			if (Control == null)
-			{
-				return new FrameworkElementAutomationPeer(this);
-			}
-
-			return new FrameworkElementAutomationPeer(Control);
-		}
-
 		protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
 		{
 			base.OnElementChanged(e);

--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
@@ -23,17 +23,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			AutoPackage = false;
 		}
 
-		protected override AutomationPeer OnCreateAutomationPeer()
-		{
-			// We need an automation peer so we can interact with this in automated tests
-			if (Control == null)
-			{
-				return new FrameworkElementAutomationPeer(this);
-			}
-
-			return new FrameworkElementAutomationPeer(Control);
-		}
-
 		protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
 		{
 			base.OnElementChanged(e);

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -161,3 +161,4 @@ static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.I
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.MapToolbarDynamicOverflowEnabled(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 *REMOVED*static Microsoft.Maui.Controls.Toolbar.MapToolbarPlacement(Microsoft.Maui.Handlers.ToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
+*REMOVED*~override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer


### PR DESCRIPTION
### Description of Change

I don't know the exact cause but it looks like returning an empty `AutomationPeer` with `FrameRenderer` is causing Application Insights to crash. Seeing as how we aren't making use of this behavior right now, I feel like we should just remove and once we need to light this back up we can do so through other means. For example, if we need `FrameRenderer` to have an Automation Peer during automated testing we should just use a custom handler inside the tests instead of modifying the actual runtime behavior. 

### Issues Fixed

Fixes #8801

