### PR TITLE
Set BackgroundColor for Label and a few others on templates

### DIFF
--- a/src/Core/src/Graphics/PaintExtensions.cs
+++ b/src/Core/src/Graphics/PaintExtensions.cs
@@ -36,5 +36,13 @@ namespace Microsoft.Maui.Graphics
 
 			return paint == null;
 		}
+
+		internal static bool IsTransparent(this Paint? paint)
+		{
+			if (paint is SolidPaint solidPaint)
+				return solidPaint.Color == Colors.Transparent;
+
+			return false;
+		}
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Maui.Handlers
 			base.PlatformArrange(frame);
 		}
 
+		internal static void MapBackground(ILabelHandler handler, ILabel label)
+		{
+			handler.PlatformView?.UpdateBackground(label);
+		}
+
 		public static void MapText(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateTextPlainText(label);

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Handlers
 	{
 		public static IPropertyMapper<ILabel, ILabelHandler> Mapper = new PropertyMapper<ILabel, ILabelHandler>(ViewHandler.ViewMapper)
 		{
-#if __IOS__ || TIZEN
+#if IOS || TIZEN
 			[nameof(ILabel.Background)] = MapBackground,
 			[nameof(ILabel.Opacity)] = MapOpacity,
 #elif WINDOWS
@@ -37,6 +37,9 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ILabel.Text)] = MapText,
 			[nameof(ITextStyle.TextColor)] = MapTextColor,
 			[nameof(ILabel.TextDecorations)] = MapTextDecorations,
+#if ANDROID
+			[nameof(ILabel.Background)] = MapBackground,
+#endif
 		};
 
 		public static CommandMapper<ILabel, ILabelHandler> CommandMapper = new(ViewCommandMapper)

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -165,7 +165,13 @@ namespace Microsoft.Maui.Platform
 		}
 
 		public static void UpdateBackground(this AView platformView, IView view) =>
-			platformView.UpdateBackground(view.Background);
+			platformView.UpdateBackground(view, false);
+
+		internal static void UpdateBackground(this AView platformView, IView view, bool treatTransparentAsNull) =>
+			platformView.UpdateBackground(view.Background, treatTransparentAsNull);
+
+		internal static void UpdateBackground(this TextView platformView, IView view) =>
+			UpdateBackground(platformView, view, true);
 
 		// TODO: NET7 make this public for net7.0
 		internal static void UpdateBackground(this EditText platformView, IView view)
@@ -190,7 +196,10 @@ namespace Microsoft.Maui.Platform
 			platformView.Background = layer;
 		}
 
-		public static void UpdateBackground(this AView platformView, Paint? background)
+		public static void UpdateBackground(this AView platformView, Paint? background) =>
+			UpdateBackground(platformView, background, false);
+
+		internal static void UpdateBackground(this AView platformView, Paint? background, bool treatTransparentAsNull)
 		{
 			var paint = background;
 
@@ -203,7 +212,14 @@ namespace Microsoft.Maui.Platform
 					mauiDrawable.Dispose();
 				}
 
-				if (paint is SolidPaint solidPaint)
+				if (treatTransparentAsNull && paint.IsTransparent())
+				{
+					// For controls where android treats transparent as null it's more
+					// performant to just set the background to null instead of
+					// giving it a transparent color/drawable
+					platformView.Background = null;
+				}
+				else if (paint is SolidPaint solidPaint)
 				{
 					if (solidPaint.Color is Color backgroundColor)
 						platformView.SetBackgroundColor(backgroundColor.ToPlatform());

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -147,6 +147,7 @@
 
     <Style TargetType="Label">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
+        <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -206,7 +207,7 @@
     </Style>
 
     <Style TargetType="RadioButton">
-        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BackgroundColor" Value="Transparent"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14"/>
@@ -333,7 +334,7 @@
 
     <Style TargetType="TimePicker">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
-        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BackgroundColor" Value="Transparent"/>
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="VisualStateManager.VisualStateGroups">


### PR DESCRIPTION
### Description of Change

- Set a background color for `Label` in our styles so when the `BGColor` is removed it can revert back to transparent
- translate transparent to `null` for the label control on android

### Issues Fixed

Fixes #10177