### PR TITLE
[Windows] Fix issue with items not filling horizontal space in CollectionView

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/StructuredItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/StructuredItemsViewHandler.Windows.cs
@@ -5,6 +5,7 @@ using WStyle = Microsoft.UI.Xaml.Style;
 using Microsoft.Maui.Controls.Platform;
 using WScrollMode = Microsoft.UI.Xaml.Controls.ScrollMode;
 using WASDKApp = Microsoft.UI.Xaml.Application;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
@@ -194,6 +195,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			style.Setters.Add(new WSetter(GridViewItem.MarginProperty, margin));
 			style.Setters.Add(new WSetter(GridViewItem.PaddingProperty, WinUIHelpers.CreateThickness(0)));
+			style.Setters.Add(new WSetter(Control.HorizontalContentAlignmentProperty, HorizontalAlignment.Stretch));
 
 			return style;
 		}
@@ -207,6 +209,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			style.Setters.Add(new WSetter(ListViewItem.MarginProperty, margin));
 			style.Setters.Add(new WSetter(GridViewItem.PaddingProperty, WinUIHelpers.CreateThickness(0)));
+			style.Setters.Add(new WSetter(Control.HorizontalContentAlignmentProperty, HorizontalAlignment.Stretch));
 
 			return style;
 		}
@@ -219,6 +222,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var style = new WStyle(typeof(ListViewItem));
 
 			style.Setters.Add(new WSetter(ListViewItem.PaddingProperty, padding));
+			style.Setters.Add(new WSetter(Control.VerticalContentAlignmentProperty, VerticalAlignment.Stretch));
 
 			return style;
 		}


### PR DESCRIPTION
### Description of Change

The bug in #7531 was hiding another bug where the item content for CollectionView items on Windows did not have its content alignment set to Stretch. These changes set the content container to stretch the content over the available space, which allows the cross-platform layout options to handle the actual positioning/alignment.

### Issues Fixed

Items in sample gallery CollectionView not filling their horizontal space; probably some others I haven't found yet.