### PR TITLE
[Android] Don't null binding context when recycling items

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/ItemContentView.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		{
 			if (this.IsAlive())
 			{
-				RequestLayout();
+				PlatformInterop.RequestLayoutIfNeeded(this);
 			}
 			else if (sender is VisualElement ve)
 			{

--- a/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/TemplatedItemViewHolder.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			itemsView.RemoveLogicalChild(View);
-			View.BindingContext = null;
 		}
 
 		public void Bind(object itemBindingContext, ItemsView itemsView,


### PR DESCRIPTION
### Description of Change

Setting the binding context to `null` when recycling items means that the item has to update all of its properties when being recycled, and again when the item is re-bound to a different binding context. This wastes cycles when the item is put into the recycling pool, and again when it's re-used (since most items will have very similar properties even if the underlying data has changed). 

We only started doing this in Forms because of intermittent ObjectDisposedExceptions when items were ejected from the recycling pool and the garbage collection timing hit wrong (see https://github.com/xamarin/Xamarin.Forms/pull/8768). But now that all of the update run through [CanInvokeMappers](https://github.com/dotnet/maui/blob/19f2387c7e16f56dd49035b45a26ba6632923982/src/Core/src/Handlers/ElementHandlerExtensions.cs#L88) we don't have to worry about that scenario.

### Issues Fixed

Makes the CollectionView on Android very slightly faster while scrolling around.

