### PR TITLE
[Windows] Updated used ListViewItem style (avoid CornerRadius etc)

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewRenderer.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			internal ListViewRenderer ListViewRenderer { get; }
 			public ListViewTransparent(ListViewRenderer listViewRenderer) : base()
 			{
+				this.ApplyListViewStyles();
 				ListViewRenderer = listViewRenderer;
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewStyles.xaml
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/Windows/ListViewStyles.xaml
@@ -154,7 +154,7 @@
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="IsHoldingEnabled" Value="True" />
-        <Setter Property="Padding" Value="12, 0, 0, 0" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />

--- a/src/Controls/src/Core/Compatibility/Handlers/TableView/Windows/TableViewRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TableView/Windows/TableViewRenderer.cs
@@ -34,15 +34,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				if (Control == null)
 				{
-
-					SetNativeControl(new Microsoft.UI.Xaml.Controls.ListView
+					var listView = new Microsoft.UI.Xaml.Controls.ListView
 					{
 						ItemContainerStyle = (Microsoft.UI.Xaml.Style)Microsoft.UI.Xaml.Application.Current.Resources["MauiListViewItem"],
 						ItemTemplate = (Microsoft.UI.Xaml.DataTemplate)Microsoft.UI.Xaml.Application.Current.Resources["CellTemplate"],
 						GroupStyle = { new GroupStyle { HidesIfEmpty = false, HeaderTemplate = (Microsoft.UI.Xaml.DataTemplate)Microsoft.UI.Xaml.Application.Current.Resources["TableSection"] } },
 						HeaderTemplate = (Microsoft.UI.Xaml.DataTemplate)Microsoft.UI.Xaml.Application.Current.Resources["TableRoot"],
 						SelectionMode = Microsoft.UI.Xaml.Controls.ListViewSelectionMode.Single
-					});
+					};
+
+					listView.ApplyListViewStyles();
+
+					SetNativeControl(listView);
 
 					// You can't set ItemsSource directly to a CollectionViewSource, it crashes.
 					Control.SetBinding(WItemsControl.ItemsSourceProperty, "");

--- a/src/Controls/src/Core/Platform/Windows/ListViewExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/ListViewExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using WListView = Microsoft.UI.Xaml.Controls.ListView;
+using WCornerRadius = Microsoft.UI.Xaml.CornerRadius;
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	internal static class ListViewExtensions
+	{
+		public static void ApplyListViewStyles(this WListView listView)
+		{
+			// https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/ListViewItem_themeresources_21h1.xaml#L298
+			listView.SetApplicationResource("ListViewItemCornerRadius", new WCornerRadius(0));
+
+			// https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/ListViewItem_themeresources_21h1.xaml#L314
+			listView.SetApplicationResource("ListViewItemSelectionIndicatorVisualEnabled", false);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Alternate PR for 
https://github.com/dotnet/maui/pull/8584

![image](https://user-images.githubusercontent.com/5375137/191615255-7df723fb-1057-4563-a7ac-22033ffc1d2d.png)


Removed forced padding and corner radius in Windows ListViewItem.

With the changes, the ListViewItem style is like in Xamarin.Forms: the selection is changing the background color, without a default corner radius etc.

### Issues Fixed

Fixes #8564 
Fixes #8580
Fixes #8581