### PR TITLE
Update margin for minimal display mode

### DIFF
--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -193,7 +193,9 @@ namespace Microsoft.Maui.Platform
 				_appTitleBarHeight = AppTitleBarContentControl.ActualHeight;
 				NavigationViewControl?.UpdateAppTitleBar(_appTitleBarHeight);
 
-				this.SetApplicationResource("NavigationViewContentMargin", new WThickness(0, _appTitleBarHeight, 0, 0));
+				var contentMargin = new WThickness(0, _appTitleBarHeight, 0, 0);
+				this.SetApplicationResource("NavigationViewContentMargin", contentMargin);
+				this.SetApplicationResource("NavigationViewMinimalContentMargin", contentMargin);
 				this.RefreshThemeResources();
 			}
 		}


### PR DESCRIPTION
### Description of Change

WinAppSDK introduced an additional content margin resource that we need to adjust in order to take into account the custom titlebar.

#### Previously

![image](https://user-images.githubusercontent.com/5375137/191815088-3485f603-3f1e-493b-acae-4f6dcdb9f5d6.png)

#### Now

![image](https://user-images.githubusercontent.com/5375137/191814649-7d81f127-d6e4-4162-84ab-a541e38e7269.png)
