### PR TITLE
[Android] [Splash Screen] fixes #10275 

### DIFF
--- a/src/SingleProject/Resizetizer/src/GenerateSplashAndroidResources.cs
+++ b/src/SingleProject/Resizetizer/src/GenerateSplashAndroidResources.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Maui.Resizetizer
 			writer.WriteAttributeString("android", "gravity", Namespace, "center");
 
 			writer.WriteStartElement("bitmap");
-			writer.WriteAttributeString("android", "gravity", Namespace, "fill");
+			writer.WriteAttributeString("android", "gravity", Namespace, "center");
 			writer.WriteAttributeString("android", "src", Namespace, "@drawable/" + splash.OutputName);
 			writer.WriteAttributeString("android", "mipMap", Namespace, "true");
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/testdata/androidsplash/maui_splash_image.xml
+++ b/src/SingleProject/Resizetizer/test/UnitTests/testdata/androidsplash/maui_splash_image.xml
@@ -6,7 +6,7 @@
     android:height="108dp"
     android:gravity="center">
     <bitmap
-      android:gravity="fill"
+      android:gravity="center"
       android:src="{drawable}"
       android:mipMap="true" />
   </item>


### PR DESCRIPTION
### Description of Change

As far as i can tell Resizetizer already changes the size of the splash screen to the base size (according to screen density) therefore i think we could use `android:gravity="center"` instead of `android:gravity="fill"` for splash screens. This fixes cases were non-square images are set for `MauiSplashScreen` like https://github.com/dotnet/maui/issues/10275


As the Android documentation states the FILL attribute can grow the size of the object to fit the container
https://developer.android.com/reference/android/view/Gravity#FILL
CENTER on the other hand doesn't change the size of the object
https://developer.android.com/reference/android/view/Gravity#FILL
i could only test these changes on Android 11

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #
https://github.com/dotnet/maui/issues/10275
<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
