### PR TITLE
First draft of pulling apart text wrapping, max lines, and text overflow

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Label/Label.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Maui.Handlers;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.Maui.Controls
 {
@@ -25,15 +25,29 @@ namespace Microsoft.Maui.Controls
 			[nameof(ILabel.Font)] = MapFont,
 			[nameof(TextColor)] = MapTextColor,
 #endif
-			[nameof(Label.LineBreakMode)] = MapLineBreakMode,
-			[nameof(Label.MaxLines)] = MapMaxLines,
 		};
 
-		internal static new void RemapForControls()
+		static void AddLegacyMultilineMappings() 
+		{
+			var mapper = ControlsLabelMapper as PropertyMapper<Label, LabelHandler>;
+
+			mapper.Add(nameof(Label.LineBreakMode), MapLineBreakMode);
+			mapper.Add(nameof(Label.MaxLines),  MapMaxLines);
+
+			// Does this even work? Why is there no "Remove"?
+			mapper[nameof(IMultilineText.MaximumLines)] = null;
+		}
+
+		internal static void RemapForControls(CompatibilityOptions options = null)
 		{
 			// Adjust the mappings to preserve Controls.Label legacy behaviors
 			// ILabel does not include the TextType property, so we map it here to handle HTML text
 			// And we map some of the other property handlers to Controls-specific versions that avoid stepping on HTML text settings
+
+			if (options != null && options.LabelMultilineLegacyBehavior)
+			{
+				AddLegacyMultilineMappings();
+			}
 
 			LabelHandler.Mapper = ControlsLabelMapper;
 		}

--- a/src/Controls/src/Core/Hosting/CompatibilityOptions.cs
+++ b/src/Controls/src/Core/Hosting/CompatibilityOptions.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Microsoft.Maui.Controls
+{
+	public class CompatibilityOptions 
+	{
+		public bool LabelMultilineLegacyBehavior { get; set; } = true;
+	}
+}

--- a/src/Controls/src/Core/Hosting/Effects/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Core/Hosting/Effects/AppHostBuilderExtensions.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Hosting;
 
 namespace Microsoft.Maui.Controls.Hosting
@@ -39,6 +41,8 @@ namespace Microsoft.Maui.Controls.Hosting
 
 	public static partial class AppHostBuilderExtensions
 	{
+		static bool _compatibilityBehaviorsConfigured;
+
 		public static MauiAppBuilder ConfigureEffects(this MauiAppBuilder builder, Action<IEffectsBuilder> configureDelegate)
 		{
 			builder.Services.TryAddSingleton<EffectsFactory>();
@@ -46,6 +50,55 @@ namespace Microsoft.Maui.Controls.Hosting
 			{
 				builder.Services.AddSingleton<EffectsRegistration>(new EffectsRegistration(configureDelegate));
 			}
+
+			return builder;
+		}
+
+		public static MauiAppBuilder ConfigureCompatibilityBehaviors(this MauiAppBuilder builder, Action<CompatibilityOptions> configure)
+		{
+			if (_compatibilityBehaviorsConfigured)
+			{
+				return builder;
+			}
+
+			var options = new CompatibilityOptions();
+			configure(options);
+
+			// Make sure this is available if anything needs it at runtime
+			builder.Services.AddSingleton(options);
+
+			// Update the mappings from Core to match the Controls behaviors carried over from old versions
+			builder.RemapForControls(options);
+
+			_compatibilityBehaviorsConfigured = true;
+
+			return builder;
+		}
+
+		internal static MauiAppBuilder RemapForControls(this MauiAppBuilder builder, CompatibilityOptions flags)
+		{
+			// Update the mappings for IView/View to work specifically for Controls
+			Application.RemapForControls();
+			VisualElement.RemapForControls();
+			Label.RemapForControls(flags);
+			Button.RemapForControls();
+			CheckBox.RemapForControls();
+			DatePicker.RemapForControls();
+			RadioButton.RemapForControls();
+			FlyoutPage.RemapForControls();
+			Toolbar.RemapForControls();
+			Window.RemapForControls();
+			Editor.RemapForControls();
+			Entry.RemapForControls();
+			Picker.RemapForControls();
+			SearchBar.RemapForControls();
+			TabbedPage.RemapForControls();
+			TimePicker.RemapForControls();
+			Layout.RemapForControls();
+			ScrollView.RemapForControls();
+			RefreshView.RemapForControls();
+			Shape.RemapForControls();
+			WebView.RemapForControls();
 
 			return builder;
 		}

--- a/src/Controls/src/Core/Label.cs
+++ b/src/Controls/src/Core/Label.cs
@@ -114,6 +114,17 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty TextTypeProperty = BindableProperty.Create(nameof(TextType), typeof(TextType), typeof(Label), TextType.Text,
 			propertyChanged: (bindable, oldvalue, newvalue) => ((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged));
 
+		public static readonly BindableProperty TextOverflowModeProperty = BindableProperty.Create(nameof(TextOverflowMode), 
+			typeof(TextOverflowMode), typeof(Label), TextOverflowMode.None, propertyChanged: Invalidate);
+
+		public static readonly BindableProperty TextWrapModeProperty = BindableProperty.Create(nameof(TextWrapMode),
+			typeof(TextWrapMode), typeof(Label), TextWrapMode.None, propertyChanged: Invalidate);
+
+		static void Invalidate(BindableObject bindable, object oldValue, object newValue) 
+		{
+			((Label)bindable).InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
+		}
+
 		readonly Lazy<PlatformConfigurationRegistry<Label>> _platformConfigurationRegistry;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
@@ -148,6 +159,18 @@ namespace Microsoft.Maui.Controls
 		{
 			get { return (LineBreakMode)GetValue(LineBreakModeProperty); }
 			set { SetValue(LineBreakModeProperty, value); }
+		}
+
+		public TextOverflowMode TextOverflowMode
+		{
+			get { return (TextOverflowMode)GetValue(TextOverflowModeProperty); }
+			set { SetValue(TextOverflowModeProperty, value); }
+		}
+
+		public TextWrapMode TextWrapMode
+		{
+			get { return (TextWrapMode)GetValue(TextWrapModeProperty); }
+			set { SetValue(TextWrapModeProperty, value); }
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='Text']/Docs/*" />
@@ -228,6 +251,8 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(MaxLinesProperty, value);
 		}
 
+		int Microsoft.Maui.IMultilineText.MaximumLines => MaxLines;
+
 		/// <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='Padding']/Docs/*" />
 		public Thickness Padding
 		{
@@ -295,7 +320,6 @@ namespace Microsoft.Maui.Controls
 				GestureController.CompositeGestureRecognizers.Add(new ChildGestureRecognizer() { GestureRecognizer = gestureRecognizer });
 		}
 
-
 		void RemoveSpans(IEnumerable spans)
 		{
 			foreach (Span span in spans)
@@ -312,7 +336,6 @@ namespace Microsoft.Maui.Controls
 					if (spanRecognizer is ChildGestureRecognizer childGestureRecognizer && childGestureRecognizer.GestureRecognizer == gestureRecognizer)
 						GestureController.CompositeGestureRecognizers.Remove(spanRecognizer);
 		}
-
 
 		void Span_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
@@ -420,5 +443,7 @@ namespace Microsoft.Maui.Controls
 		{
 			InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 		}
+
+
 	}
 }

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Maui.Controls.Hosting
 		{
 			builder.Services.TryAddSingleton<IApplication>(implementationFactory);
 			builder.SetupDefaults();
+
 			return builder;
 		}
 
@@ -173,7 +174,8 @@ namespace Microsoft.Maui.Controls.Hosting
 #if WINDOWS
 			builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IMauiInitializeService, MauiControlsInitializer>());
 #endif
-			builder.RemapForControls();
+
+			builder.ConfigureCompatibilityBehaviors(compatOptions => { });
 
 			return builder;
 		}
@@ -201,7 +203,6 @@ namespace Microsoft.Maui.Controls.Hosting
 			}
 		}
 
-
 		internal static MauiAppBuilder ConfigureImageSourceHandlers(this MauiAppBuilder builder)
 		{
 			builder.ConfigureImageSources(services =>
@@ -211,34 +212,6 @@ namespace Microsoft.Maui.Controls.Hosting
 				services.AddService<StreamImageSource>(svcs => new StreamImageSourceService(svcs.CreateLogger<StreamImageSourceService>()));
 				services.AddService<UriImageSource>(svcs => new UriImageSourceService(svcs.CreateLogger<UriImageSourceService>()));
 			});
-
-			return builder;
-		}
-
-		internal static MauiAppBuilder RemapForControls(this MauiAppBuilder builder)
-		{
-			// Update the mappings for IView/View to work specifically for Controls
-			Application.RemapForControls();
-			VisualElement.RemapForControls();
-			Label.RemapForControls();
-			Button.RemapForControls();
-			CheckBox.RemapForControls();
-			DatePicker.RemapForControls();
-			RadioButton.RemapForControls();
-			FlyoutPage.RemapForControls();
-			Toolbar.RemapForControls();
-			Window.RemapForControls();
-			Editor.RemapForControls();
-			Entry.RemapForControls();
-			Picker.RemapForControls();
-			SearchBar.RemapForControls();
-			TabbedPage.RemapForControls();
-			TimePicker.RemapForControls();
-			Layout.RemapForControls();
-			ScrollView.RemapForControls();
-			RefreshView.RemapForControls();
-			Shape.RemapForControls();
-			WebView.RemapForControls();
 
 			return builder;
 		}

--- a/src/Core/src/Core/ILabel.cs
+++ b/src/Core/src/Core/ILabel.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Maui
 	/// <summary>
 	/// Represents a View that displays text.
 	/// </summary>
-	public interface ILabel : IView, IText, ITextAlignment, IPadding
+	public interface ILabel : IView, IText, ITextAlignment, IPadding, IOverflowableText, IMultilineText
 	{
 		/// <summary>
 		/// Gets the text decoration applied to the Label.
@@ -13,7 +13,6 @@ namespace Microsoft.Maui
 
 		/// <summary>
 		/// Gets the line height applied to the Label.
-		/// Underline and strike-through text decorations can be applied.
 		/// </summary>
 		double LineHeight { get; }
 	}

--- a/src/Core/src/Core/IText.cs
+++ b/src/Core/src/Core/IText.cs
@@ -10,4 +10,28 @@ namespace Microsoft.Maui
 		/// </summary>
 		string Text { get; }
 	}
+
+	public interface IOverflowableText : IText 
+	{
+		/// <summary>
+		/// Specifies how to handle text which exceeds the available space
+		/// </summary>
+		TextOverflowMode TextOverflowMode { get; }
+	}
+
+	public interface IMultilineText : IText 
+	{ 
+		/// <summary>
+		/// The maximum number of lines which can be displayed by the control. 
+		/// </summary>
+		/// <remarks>
+		/// All values below 1 are treated as "no limit".
+		/// </remarks>
+		int MaximumLines { get; }
+
+		/// <summary>
+		/// Specifies how the control will handle text wrapping
+		/// </summary>
+		TextWrapMode TextWrapMode { get; }
+	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -85,6 +85,21 @@ namespace Microsoft.Maui.Handlers
 			handler.PlatformView?.UpdateLineHeight(label);
 		}
 
+		public static void MapMaximumLines(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateMaximumLines(label);
+		}
+
+		public static void MapTextWrapMode(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateTextWrapMode(label);
+		}
+
+		public static void MapTextOverflowMode(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateTextOverflowMode(label);
+		}
+
 		bool NeedsExactMeasure()
 		{
 			if (VirtualView.VerticalLayoutAlignment != Primitives.LayoutAlignment.Fill

--- a/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
@@ -16,5 +16,8 @@ namespace Microsoft.Maui.Handlers
 		public static void MapMaxLines(ILabelHandler handler, ILabel label) { }
 		public static void MapPadding(ILabelHandler handler, ILabel label) { }
 		public static void MapLineHeight(ILabelHandler handler, ILabel label) { }
+		public static void MapMaximumLines(ILabelHandler handler, ILabel label) { }
+		public static void MapTextWrapMode(ILabelHandler handler, ILabel label) { }
+		public static void MapTextOverflowMode(ILabelHandler handler, ILabel label) { }
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Tizen.cs
@@ -60,5 +60,9 @@ namespace Microsoft.Maui.Handlers
 
 		[MissingMapper]
 		public static void MapPadding(ILabelHandler handler, ILabel label) { }
+
+		public static void MapMaximumLines(ILabelHandler handler, ILabel label) { }
+		public static void MapTextWrapMode(ILabelHandler handler, ILabel label) { }
+		public static void MapTextOverflowMode(ILabelHandler handler, ILabel label) { }
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Windows.cs
@@ -82,5 +82,20 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapLineHeight(ILabelHandler handler, ILabel label) =>
 			handler.PlatformView?.UpdateLineHeight(label);
+
+		public static void MapMaximumLines(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateMaximumLines(label);
+		}
+
+		public static void MapTextWrapMode(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateTextWrapMode(label);
+		}
+
+		public static void MapTextOverflowMode(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateTextOverflowMode(label);
+		}
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Maui.Handlers
 #if ANDROID
 			[nameof(ILabel.Background)] = MapBackground,
 #endif
+
+			[nameof(IMultilineText.MaximumLines)] = MapMaximumLines,
+			[nameof(IMultilineText.TextWrapMode)] = MapTextWrapMode,
+			[nameof(IOverflowableText.TextOverflowMode)] = MapTextOverflowMode,
 		};
 
 		public static CommandMapper<ILabel, ILabelHandler> CommandMapper = new(ViewCommandMapper)

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -81,5 +81,20 @@ namespace Microsoft.Maui.Handlers
 			// so we need to make sure those are applied, too
 			handler.PlatformView?.UpdateHorizontalTextAlignment(label);
 		}
+
+		public static void MapMaximumLines(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateMaximumLines(label);
+		}
+
+		public static void MapTextWrapMode(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateTextWrapMode(label);
+		}
+
+		public static void MapTextOverflowMode(ILabelHandler handler, ILabel label) 
+		{
+			handler.PlatformView?.UpdateTextOverflowMode(label);
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/TextBlockExtensions.cs
+++ b/src/Core/src/Platform/Windows/TextBlockExtensions.cs
@@ -86,6 +86,60 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		public static void UpdateMaximumLines(this TextBlock platformControl, ILabel label) 
+		{
+			var maxLines = label.MaximumLines;
+			if (maxLines < 1)
+			{
+				maxLines = 0;
+			}
+
+			platformControl.MaxLines = maxLines;
+		}
+
+		public static void UpdateTextWrapMode(this TextBlock platformControl, ILabel label)
+		{
+			switch (label.TextWrapMode)
+			{
+				case TextWrapMode.None:
+					platformControl.TextWrapping = TextWrapping.NoWrap;
+					break;
+				case TextWrapMode.Word:
+					platformControl.TextWrapping = TextWrapping.WrapWholeWords;
+					break;
+				case TextWrapMode.Character:
+					platformControl.TextWrapping = TextWrapping.Wrap;
+					break;
+			}
+		}
+
+		public static void UpdateTextOverflowMode(this TextBlock platformControl, ILabel label)
+		{
+			switch (label.TextOverflowMode)
+			{
+				case TextOverflowMode.None:
+					platformControl.TextTrimming = TextTrimming.None;
+					break;
+				case TextOverflowMode.Truncate:
+					platformControl.TextTrimming = TextTrimming.Clip;
+					break;
+				case TextOverflowMode.EllipsizeEnd:
+					// This is a mode that Windows has built in
+					platformControl.TextTrimming = TextTrimming.WordEllipsis;
+					break;
+				case TextOverflowMode.EllipsizeStart:
+					// Start and middle aren't built into Windows. For the moment, we'll just
+					// ignore that, do end, and document that these two don't really work. 
+					// Eventually, we might be able to work out a scheme or a custom TextBlock
+					// which _does_ handle these cases.
+					platformControl.TextTrimming = TextTrimming.WordEllipsis;
+					break;
+				case TextOverflowMode.EllipsizeMiddle:
+					platformControl.TextTrimming = TextTrimming.WordEllipsis;
+					break;
+			}
+		}
+
 		public static void UpdateHorizontalTextAlignment(this TextBlock platformControl, ILabel label)
 		{
 			// We don't have a FlowDirection yet, so there's nothing to pass in here. 

--- a/src/Core/src/Platform/iOS/LabelExtensions.cs
+++ b/src/Core/src/Platform/iOS/LabelExtensions.cs
@@ -92,5 +92,71 @@ namespace Microsoft.Maui.Platform
 		{
 			platformLabel.Text = label.Text;
 		}
+
+		public static void UpdateMaximumLines(this UILabel platformLabel, ILabel label)
+		{
+			if (label.TextWrapMode == TextWrapMode.None)
+			{
+				// No wrapping, so constrain to one line
+				platformLabel.Lines = 1;
+				return;
+			}
+
+			var maxLines = label.MaximumLines;
+
+			if (maxLines < 1)
+			{
+				maxLines = 0; // as many lines as needed
+			}
+
+			platformLabel.Lines = maxLines;
+		}
+
+		public static void UpdateTextWrapMode(this UILabel platformLabel, ILabel label)
+		{
+			// iOS 14 also gives us LineBreakStrategy to work with, but none of the values
+			// actually apply to our options. The default is standard, which is what we want.
+
+			switch (label.TextWrapMode)
+			{
+				case TextWrapMode.None:
+					platformLabel.LineBreakMode = UILineBreakMode.Clip;
+					break;
+				case TextWrapMode.Word:
+					platformLabel.LineBreakMode = UILineBreakMode.WordWrap;
+					break;
+				case TextWrapMode.Character:
+					platformLabel.LineBreakMode = UILineBreakMode.CharacterWrap;
+					break;
+			}
+
+			// We have to update max lines, too, because the wrap value may affect it
+			platformLabel.UpdateMaximumLines(label);
+		}
+
+		public static void UpdateTextOverflowMode(this UILabel platformLabel, ILabel label)
+		{
+			switch (label.TextOverflowMode)
+			{
+				case TextOverflowMode.None:
+				case TextOverflowMode.Truncate:
+					platformLabel.UpdateTextWrapMode(label);
+					break;
+				case TextOverflowMode.EllipsizeEnd:
+					// Note that this will blow away the TextWrapMode setting
+					// But this will work with multiple lines
+					platformLabel.LineBreakMode = UILineBreakMode.TailTruncation;
+					break;
+				case TextOverflowMode.EllipsizeStart:
+					// Note that this will blow away the TextWrapMode setting
+					// But this will work with multiple lines
+					platformLabel.LineBreakMode = UILineBreakMode.HeadTruncation;
+					break;
+				case TextOverflowMode.EllipsizeMiddle:
+					// Note that this will truncate the text to a single line.
+					platformLabel.LineBreakMode = UILineBreakMode.MiddleTruncation;
+					break;
+			}
+		}
 	}
 }

--- a/src/Core/src/Primitives/TextOverflowMode.cs
+++ b/src/Core/src/Primitives/TextOverflowMode.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Maui
+{
+	public enum TextOverflowMode 
+	{
+		None,			// Text just keeps laying out
+		Truncate,		// Text is cut off
+		EllipsizeEnd,	// Text is cut off at the end with ...
+		EllipsizeStart,	// Text is cut off at the start with ...
+		EllipsizeMiddle	// Text is spliced in the middle with ...
+	}
+}

--- a/src/Core/src/Primitives/TextWrapMode.cs
+++ b/src/Core/src/Primitives/TextWrapMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Maui
+{
+	public enum TextWrapMode
+	{
+		None,       // Text does not wrap, regardless of number of lines allowed
+		Word,       // Text wraps at word boundaries
+		Character   // Text wraps at character boundaries (possibly mid-word)
+	}
+}


### PR DESCRIPTION
### Description of Change

First pass at implementing the spec from #5835. 

This will make the various text wrapping, text overflow, and max lines properties available and mapped in Core so they will be available to 3rd-party SDK developers to either use as-is or customize. 

This also adds a first pass at a mechanism for toggling the remappings in Controls that we added to preserve old (Forms) behaviors for some groups of properties. By default, users still get the old `LinebreakMode` option, and it (and `MaxLines`) still work as they did (and sometimes _didn't_) in Forms. But this can be disabled in the builder to allow for the Core behaviors to come through instead:

```
appBuilder.ConfigureCompatibilityBehaviors(options => {
    options.LabelMultilineLegacyBehavior = false;
});
```

This has been tested and works on Android and Windows; implemented but untested on iOS/Catalyst. Still need to add all the API file stuff, and to write the /// docs. 

Feedback on naming/mapping is very welcome. 
