### PR TITLE
Propagate Flyout Selected Item w/ AsMultipleItems

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/AppShell.xaml
@@ -16,7 +16,7 @@
         <ShellContent Icon="coffee.png" Title = "Button Page" ContentTemplate="{DataTemplate pages:ButtonPage}"></ShellContent>
         <ShellContent Title = "Semantics Page"  ContentTemplate="{DataTemplate pages:SemanticsPage}"></ShellContent>
     </FlyoutItem>
-    <FlyoutItem Title = "Flyout Item 2">
+    <FlyoutItem Title = "Flyout Item 2" FlyoutDisplayOptions="AsMultipleItems">
 	  <ShellSection Title = "Tab 1">
 	        <ShellContent  Icon="calculator.png" Title = "Flyout Gallery" ContentTemplate="{DataTemplate shellPages:ShellChromeGallery}"></ShellContent>
       	  <ShellContent  Icon="coffee.png" Title = "Button Page" ContentTemplate="{DataTemplate pages:ButtonPage}"></ShellContent>

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -56,9 +56,12 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		void OnMenuItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
 		{
-			var item = args.InvokedItemContainer?.DataContext as Element;
-			if (item != null)
-				(VirtualView as IShellController)?.OnFlyoutItemSelected(item);
+			var item = args.InvokedItemContainer?.DataContext;
+
+			if (item is NavigationViewItemViewModel nvm && nvm.Data is Element e)
+				(VirtualView as IShellController)?.OnFlyoutItemSelected(e);
+			else if (item is Element e2)
+				(VirtualView as IShellController)?.OnFlyoutItemSelected(e2);
 		}
 
 		void OnApplyTemplateFinished(object sender, System.EventArgs e)

--- a/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellHandler.Windows.cs
@@ -172,11 +172,13 @@ namespace Microsoft.Maui.Controls.Handlers
 		public static void MapItems(ShellHandler handler, Shell view)
 		{
 			handler.PlatformView.UpdateMenuItemSource();
+			handler.UpdateValue(nameof(Shell.CurrentItem));
 		}
 
 		public static void MapFlyoutItems(ShellHandler handler, Shell view)
 		{
 			handler.PlatformView.UpdateMenuItemSource();
+			handler.UpdateValue(nameof(Shell.CurrentItem));
 		}
 
 		void UpdateFlyoutHeaderBehavior(Shell view)

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -125,11 +125,6 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		void MapMenuItems()
 		{
-			// NavigationView makes a lot of changes to properties before it's been loaded
-			// So we like to just wait until it's loaded to project our changes over it
-			if (!ShellItemNavigationView.IsLoaded)
-				return;
-
 			IShellItemController shellItemController = VirtualView;
 			var items = new List<BaseShellItem>();
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -81,6 +81,12 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		void SyncNavigationStack(bool animated)
 		{
+			// Current Item might transition to null while visibility is adjusting on shell
+			// so we just ignore this and eventually when shell knows
+			// the next current item it will request to sync again
+			if (VirtualView.CurrentItem == null)
+				return;
+
 			List<IView> pageStack = new List<IView>()
 			{
 				(VirtualView.CurrentItem as IShellContentController).GetOrCreateContent()

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutItemView.cs
@@ -52,7 +52,13 @@ namespace Microsoft.Maui.Controls.Platform
 				_content = null;
 			}
 
-			var bo = (BindableObject)args.NewValue;
+			BindableObject bo = null;
+
+			if (args.NewValue is NavigationViewItemViewModel vm && vm.Data is BindableObject bindableObject)
+				bo = bindableObject;
+			else
+				bo = (BindableObject)args.NewValue;
+
 			var element = bo as Element;
 			_shell = element?.FindParentOfType<Shell>();
 			DataTemplate dataTemplate = (_shell as IShellController)?.GetFlyoutItemDataTemplate(bo);

--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutTemplateSelector.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellFlyoutTemplateSelector.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Maui.Controls.Platform
 			if (item is MenuItem)
 				return MenuItemTemplate;
 
+			if (item is NavigationViewItemViewModel nvm && nvm.Data is MenuItem)
+				return MenuItemTemplate;
+
 			return BaseShellItemTemplate;
 		}
 	}

--- a/src/Controls/src/Core/Platform/Windows/Styles/ShellStyles.xaml
+++ b/src/Controls/src/Core/Platform/Windows/Styles/ShellStyles.xaml
@@ -10,12 +10,12 @@
     xmlns:maui="using:Microsoft.Maui.Controls.Platform">
     <x:Double x:Key="NavigationViewItemOnLeftMinHeight">0</x:Double>
     <DataTemplate x:Key="ShellFlyoutBaseShellItemTemplate">
-        <maui:ShellNavigationViewItem  x:Name="navItem">
+        <maui:ShellNavigationViewItem  x:Name="navItem" MenuItemsSource="{Binding MenuItemsSource}">
             <maui:ShellFlyoutItemView IsTabStop="false" IsSelected="{Binding IsSelected, ElementName=navItem, Mode=TwoWay}"></maui:ShellFlyoutItemView>
         </maui:ShellNavigationViewItem>
     </DataTemplate>
     <DataTemplate x:Key="ShellFlyoutMenuItemTemplate">
-        <maui:ShellNavigationViewItem x:Name="navItem">
+        <maui:ShellNavigationViewItem x:Name="navItem" MenuItemsSource="{Binding MenuItemsSource}">
             <maui:ShellFlyoutItemView IsTabStop="false" IsSelected="{Binding IsSelected, ElementName=navItem, Mode=TwoWay}"></maui:ShellFlyoutItemView>
         </maui:ShellNavigationViewItem>
     </DataTemplate>

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -334,7 +334,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-
 		[Fact(DisplayName = "Selected Item On ShellView Correct With Implict Flyout Item")]
 		public async Task SelectedItemOnShellViewCorrectWithImplictFlyoutItem()
 		{
@@ -378,19 +377,17 @@ namespace Microsoft.Maui.DeviceTests
 				var navigationView =
 					handler.PlatformView as MauiNavigationView;
 
-				var menuItems = navigationView.MenuItemsSource as IList<NavigationViewItemViewModel>;
-
-				Assert.Equal(flyoutItem1, navigationView.SelectedItem);
+				Assert.Equal(flyoutItem1, (navigationView.SelectedItem as NavigationViewItemViewModel).Data);
 
 				// Switch to Shell Section 
 				shell.CurrentItem = flyoutItem2ShellSection;
 				await OnLoadedAsync(page2);
-				Assert.Equal(flyoutItem2ShellSection, navigationView.SelectedItem);
+				Assert.Equal(flyoutItem2ShellSection, (navigationView.SelectedItem as NavigationViewItemViewModel).Data);
 
 				// Switch to Shell Content 
 				shell.CurrentItem = flyoutItem3ShellContent;
 				await OnLoadedAsync(page3);
-				Assert.Equal(flyoutItem3ShellContent, navigationView.SelectedItem);
+				Assert.Equal(flyoutItem3ShellContent, (navigationView.SelectedItem as NavigationViewItemViewModel).Data);
 			});
 		}
 
@@ -525,13 +522,13 @@ namespace Microsoft.Maui.DeviceTests
 				var selectedTabItem = tabbedView.SelectedItem as NavigationViewItemViewModel;
 
 				// check that the initial flyout item is selected
-				Assert.Equal(rootView.SelectedItem, flyoutItems[0][0]);
+				Assert.Equal((rootView.SelectedItem as NavigationViewItemViewModel).Data, flyoutItems[0][0]);
 				Assert.Equal(selectedTabItem.Data, flyoutItem.Items[0].Items[0]);
 
 				tabbedView.SelectedItem = platformTabItems[1].MenuItemsSource[1];
 
 				// Verify that the flyout item updates
-				Assert.Equal(rootView.SelectedItem, flyoutItems[0][1]);
+				Assert.Equal((rootView.SelectedItem as NavigationViewItemViewModel).Data, flyoutItems[0][1]);
 			});
 		}
 	}

--- a/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewItemViewModel.cs
@@ -29,6 +29,26 @@ namespace Microsoft.Maui.Platform
 
 	internal static class NavigationViewItemViewModelExtensions
 	{
+		public static NavigationViewItemViewModel? GetWithData(this IEnumerable<NavigationViewItemViewModel> dest, object data)
+		{
+			foreach (var item in dest)
+			{
+				if (item.Data == data)
+				{
+					return item;
+				}
+			}
+
+			return null;
+		}
+
+		public static bool TryGetWithData(this IEnumerable<NavigationViewItemViewModel> dest, object data, out NavigationViewItemViewModel? vm)
+		{
+			var result = GetWithData(dest, data);
+			vm = result;
+			return result != null;
+		}
+
 		public static void SyncItems<T>(
 			this ObservableCollection<NavigationViewItemViewModel> dest,
 			IList<T> source,

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestCaseViewModel.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestCaseViewModel.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 
 		public string AssemblyFileName { get; }
 
-		public string DisplayName => TestResult?.TestResultMessage?.Test?.DisplayName ?? TestCase.DisplayName;
+		public string DisplayName => (_testResults.Count > 1) ? TestResult?.TestResultMessage?.Test?.DisplayName ?? TestCase.DisplayName : TestCase.DisplayName;
 
 		public string? Message
 		{


### PR DESCRIPTION
### Description of Change

Shell wasn't correctly taking into account when the FlyoutItems are made up of children elements via `AsMultipleItems`

### Issues Fixed
Fixes #9761

