### PR TITLE
Sizing and inset math corrections for Button contentlayout

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ButtonPage.xaml
@@ -125,7 +125,7 @@
                     Style="{StaticResource Headline}"/>
                 <Button 
                     x:Name="positionChange" ContentLayout="Top" TextColor="White" Background="Black" 
-                    ImageSource="settings.png" Text="settings" />
+                    ImageSource="settings.png" Text="settings" Clicked="OnPositionChange" />
                 <Button 
                     WidthRequest="200"  HorizontalOptions="Fill" x:Name="decreaseSpacing" Text="Decrease Spacing" 
                     Clicked="OnDecreaseSpacing" TextColor="White" Background="Black" ></Button>

--- a/src/Controls/src/Core/Platform/Android/Extensions/ButtonExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ButtonExtensions.cs
@@ -53,11 +53,11 @@ namespace Microsoft.Maui.Controls.Platform
 						break;
 					case ButtonContentLayout.ImagePosition.Left:
 						materialButton.Icon = icon;
-						materialButton.IconGravity = MaterialButton.IconGravityStart;
+						materialButton.IconGravity = MaterialButton.IconGravityTextStart;
 						break;
 					case ButtonContentLayout.ImagePosition.Right:
 						materialButton.Icon = icon;
-						materialButton.IconGravity = MaterialButton.IconGravityEnd;
+						materialButton.IconGravity = MaterialButton.IconGravityTextEnd;
 						break;
 				}
 			}

--- a/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
+++ b/src/Controls/src/Core/Platform/iOS/Extensions/ButtonExtensions.cs
@@ -90,10 +90,12 @@ namespace Microsoft.Maui.Controls.Platform
 
 				var titleRect = platformButton.GetTitleBoundingRect();
 				var titleWidth = titleRect.Width;
+				var titleHeight = titleRect.Height;
 				var imageWidth = image.Size.Width;
 				var imageHeight = image.Size.Height;
 				var buttonWidth = platformButton.Bounds.Width;
 				var buttonHeight = platformButton.Bounds.Height;
+				var sharedSpacing = spacing / 2;
 
 				// These are just used to shift the image and title to center
 				// Which makes the later math easier to follow
@@ -110,11 +112,11 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 					else
 					{
-						imageInsets.Top -= (buttonHeight - imageHeight) / 2;
-						imageInsets.Bottom += (buttonHeight - imageHeight) / 2;
+						imageInsets.Top -= (titleHeight / 2) + sharedSpacing;
+						imageInsets.Bottom += titleHeight / 2;
 
-						titleInsets.Top += (imageHeight / 2 + spacing);
-						titleInsets.Bottom -= imageHeight / 2;
+						titleInsets.Top += imageHeight / 2;
+						titleInsets.Bottom -= (imageHeight / 2) + sharedSpacing;
 					}
 				}
 				else if (layout.Position == ButtonContentLayout.ImagePosition.Bottom)
@@ -125,11 +127,11 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 					else
 					{
-						imageInsets.Top += (buttonHeight - imageHeight) / 2;
-						imageInsets.Bottom -= (buttonHeight - imageHeight) / 2;
+						imageInsets.Top += titleHeight / 2;
+						imageInsets.Bottom -= (titleHeight / 2) + sharedSpacing;
 					}
 
-					titleInsets.Top -= (imageHeight / 2 + spacing);
+					titleInsets.Top -= (imageHeight / 2) + sharedSpacing;
 					titleInsets.Bottom += imageHeight / 2;
 				}
 				else if (layout.Position == ButtonContentLayout.ImagePosition.Left)
@@ -140,12 +142,12 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 					else
 					{
-						imageInsets.Left -= (buttonWidth - imageWidth) / 2;
-						imageInsets.Right += (buttonWidth - imageWidth) / 2;
+						imageInsets.Left -= (titleWidth / 2) + sharedSpacing;
+						imageInsets.Right += titleWidth / 2;
 					}
 
-					titleInsets.Left += (imageWidth / 2);
-					titleInsets.Right -= (imageWidth / 2 + spacing);
+					titleInsets.Left += imageWidth / 2;
+					titleInsets.Right -= (imageWidth / 2) + sharedSpacing;
 				}
 				else if (layout.Position == ButtonContentLayout.ImagePosition.Right)
 				{
@@ -155,12 +157,12 @@ namespace Microsoft.Maui.Controls.Platform
 					}
 					else
 					{
-						imageInsets.Left += (buttonWidth - imageWidth) / 2;
-						imageInsets.Right -= (buttonWidth - imageWidth) / 2;
+						imageInsets.Left += titleWidth / 2;
+						imageInsets.Right -= (titleWidth / 2) + sharedSpacing;
 					}
 
-					titleInsets.Left -= (imageWidth / 2 + spacing);
-					titleInsets.Right += (imageWidth / 2);
+					titleInsets.Left -= (imageWidth / 2) + sharedSpacing;
+					titleInsets.Right += imageWidth / 2;
 				}
 			}
 


### PR DESCRIPTION
### Description of Change

The size calculations for setting the image and text insets when displaying both on a Button were incorrect on iOS. I read up on the (now deprecated) UIEdgeInsets for UIButton and offsetting the spacing between the text and image seemed to be the right path to our goal of matching the behavior of other platforms, and achieving the developer's goal for common button styles. 

### Issues Fixed

Fixes #8528 and #10005

This fix targets iOS and Mac Catalyst only

### After Image Comparison (Android, iOS, Mac)
![button-comparisons](https://user-images.githubusercontent.com/41873/192164660-b5db853a-5c2a-42a3-b704-082fc59f479d.png)

### Before Image Comparison (Android, iOS, Mac)
![button-comparisons-before](https://user-images.githubusercontent.com/41873/192165306-9af20721-e233-4e5c-99b8-1d9973122671.png)

### Sandbox Sample

[Controls.Sample.Sandbox.zip](https://github.com/dotnet/maui/files/9641810/Controls.Sample.Sandbox.zip)

