### PR TITLE
Align Shapes Fill property behavior with Xamarin.Forms

### DIFF
--- a/src/Core/src/Graphics/ShapeDrawable.cs
+++ b/src/Core/src/Graphics/ShapeDrawable.cs
@@ -100,10 +100,7 @@ namespace Microsoft.Maui.Graphics
 		{
 			if (ShapeView == null || ShapeView.Shape == null)
 				return;
-
-			if (!path.Closed)
-				return;
-
+				
 			canvas.SaveState();
 
 			canvas.FillColor = Colors.Transparent;

--- a/src/Core/tests/DeviceTests/Handlers/ShapeView/ShapeViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ShapeView/ShapeViewHandlerTests.cs
@@ -117,5 +117,26 @@ namespace Microsoft.Maui.DeviceTests
 
 			await ValidateNativeFill(polygon, Colors.Lime);
 		}
+
+		[Theory(DisplayName = "Polyline Background Initializes Correctly")]
+		[InlineData(0xFF0000)]
+		[InlineData(0x00FF00)]
+		[InlineData(0x0000FF)]
+		public async Task PolylineBackgroundInitializesCorrectly(uint color)
+		{
+			var expected = Color.FromUint(color);
+
+			var polyline = new ShapeViewStub()
+			{
+				Shape = new PolylineShapeStub { Points = new PointCollectionStub() { new Point(10, 10), new Point(100, 50), new Point(50, 90) } },
+				Stroke = new SolidPaintStub(Colors.Green),
+				Background = new SolidPaintStub(expected),
+				StrokeThickness = 4,
+				Height = 50,
+				Width = 100
+			};
+
+			await ValidateHasColor(polyline, expected);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Align Shapes Fill property behavior with Xamarin.Forms. With this changes, the Fill property (like in Xamarin.Forms) works with Polyline or not closed shapes.

![image](https://user-images.githubusercontent.com/6755973/192322544-e032c5d1-5b52-4c5d-9386-5ce34023ec44.png)

### Issues Fixed

Fixes #9759 