### PR TITLE
Disconnect lifecycle callback when nav removed

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -80,11 +80,7 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			public IEnumerator<object[]> GetEnumerator()
 			{
-#if IOS || MACCATALYST // Shell currently fails to run in CI for tests
-				for (int i = 0; i < 1; i++)
-#else
 				for (int i = 0; i < 2; i++)
-#endif
 				{
 					Func<Page> rootPage;
 
@@ -92,6 +88,10 @@ namespace Microsoft.Maui.DeviceTests
 						rootPage = () => new NavigationPage(new ContentPage());
 					else
 						rootPage = () => new Shell() { CurrentItem = new ContentPage() };
+
+					yield return new object[] {
+						rootPage(), new NavigationPage(new ContentPage())
+					};
 
 					yield return new object[] {
 						rootPage(), new ContentPage()


### PR DESCRIPTION
### Description of Change

Fix Android `StackNavigationManager` so it unwires the `Fragment` life cycle callbacks if the `StackNavigationManager` has been disconnected from the xplat view. 

### Issues Fixed
Fixes #10235
