### PR TITLE
Fix FilePicker on Windows Unpackaged

### DIFF
--- a/src/Essentials/samples/Samples/ViewModel/FilePickerViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/FilePickerViewModel.cs
@@ -114,7 +114,9 @@ namespace Samples.ViewModel
 				return;
 
 			// copy it locally
-			var copyPath = Path.Combine(FileSystem.CacheDirectory, result.FileName);
+			var copyDir = FileSystem.CacheDirectory;
+			Directory.CreateDirectory(copyDir);
+			var copyPath = Path.Combine(copyDir, result.FileName);
 			using (var destination = File.Create(copyPath))
 			using (var source = await result.OpenReadAsync())
 				await source.CopyToAsync(destination);

--- a/src/Essentials/src/FilePicker/FilePicker.uwp.cs
+++ b/src/Essentials/src/FilePicker/FilePicker.uwp.cs
@@ -40,8 +40,11 @@ namespace Microsoft.Maui.Storage
 					resultList.Add(file);
 			}
 
-			foreach (var file in resultList)
-				StorageApplicationPermissions.FutureAccessList.Add(file);
+			if (AppInfoUtils.IsPackagedApp)
+			{
+				foreach (var file in resultList)
+					StorageApplicationPermissions.FutureAccessList.Add(file);
+			}
 
 			return resultList.Select(storageFile => new FileResult(storageFile));
 		}


### PR DESCRIPTION



### Description of Change

The `StorageApplicationPermissions.FutureAccessList` API is not needed and crashes the app in unpackaged apps: https://github.com/microsoft/WindowsAppSDK/issues/2995

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #10313
<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
