### PR TITLE
[Tizen] Use Microsoft.Maui.Graphics.Skia.Views.SkiaGraphicsView

### DIFF
--- a/src/Core/src/Platform/Tizen/MauiPageControl.cs
+++ b/src/Core/src/Platform/Tizen/MauiPageControl.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Skia.Views;
 using Tizen.UIExtensions.Common;
 using Tizen.UIExtensions.NUI;
-using Tizen.UIExtensions.NUI.GraphicsView;
 using NExtents = Tizen.NUI.Extents;
 using NLayoutParamPolicies = Tizen.NUI.BaseComponents.LayoutParamPolicies;
 using NLinearLayout = Tizen.NUI.LinearLayout;

--- a/src/Core/src/Platform/Tizen/MauiSearchBar.cs
+++ b/src/Core/src/Platform/Tizen/MauiSearchBar.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Skia.Views;
 using Tizen.NUI;
 using Tizen.UIExtensions.Common;
 using Tizen.UIExtensions.NUI;
 using TSize = Tizen.UIExtensions.Common.Size;
-using TSkiaGraphicsView = Tizen.UIExtensions.NUI.GraphicsView.SkiaGraphicsView;
 using TTextAlignment = Tizen.UIExtensions.Common.TextAlignment;
+using NColor = Tizen.NUI.Color;
 
 namespace Microsoft.Maui.Platform
 {
@@ -16,12 +17,12 @@ namespace Microsoft.Maui.Platform
 		const double Radius = 8;
 
 		Entry _entry;
-		TSkiaGraphicsView _searchButton;
+		SkiaGraphicsView _searchButton;
 		PointStateType _lastPointState;
 
 		public MauiSearchBar()
 		{
-			BackgroundColor = new Tizen.NUI.Color(0.9f, 0.9f, 0.9f, 1);
+			BackgroundColor = new NColor(0.9f, 0.9f, 0.9f, 1);
 
 			_entry = new Entry
 			{
@@ -29,7 +30,7 @@ namespace Microsoft.Maui.Platform
 				VerticalTextAlignment = TTextAlignment.Center,
 			};
 			_entry.KeyEvent += OnKeyEvent;
-			_searchButton = new TSkiaGraphicsView
+			_searchButton = new SkiaGraphicsView
 			{
 				Focusable = true,
 				Drawable = new SearchIcon(),

--- a/src/Core/src/Platform/Tizen/MauiShapeView.cs
+++ b/src/Core/src/Platform/Tizen/MauiShapeView.cs
@@ -1,5 +1,5 @@
 ﻿using Tizen.UIExtensions.Common;
-using Tizen.UIExtensions.NUI.GraphicsView;
+using Microsoft.Maui.Graphics.Skia.Views;
 
 namespace Microsoft.Maui.Platform
 {

--- a/src/Core/src/Platform/Tizen/MauiStepper.cs
+++ b/src/Core/src/Platform/Tizen/MauiStepper.cs
@@ -3,12 +3,12 @@ using Tizen.NUI;
 using Tizen.NUI.BaseComponents;
 using Tizen.UIExtensions.Common;
 using Tizen.UIExtensions.NUI;
-using Tizen.UIExtensions.NUI.GraphicsView;
 using NView = Tizen.NUI.BaseComponents.View;
 using TColor = Tizen.UIExtensions.Common.Color;
 using NColor = Tizen.NUI.Color;
 using TSize = Tizen.UIExtensions.Common.Size;
 using MaterialIcons = Tizen.UIExtensions.Common.GraphicsView.MaterialIcons;
+using MaterialIconButton = Tizen.UIExtensions.NUI.GraphicsView.MaterialIconButton;
 
 namespace Microsoft.Maui.Platform
 {

--- a/src/Core/src/Platform/Tizen/WrapperView.cs
+++ b/src/Core/src/Platform/Tizen/WrapperView.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Skia.Views;
 using Tizen.UIExtensions.Common;
 using Tizen.UIExtensions.NUI;
-using Tizen.UIExtensions.NUI.GraphicsView;
 using NView = Tizen.NUI.BaseComponents.View;
 using TRect = Tizen.UIExtensions.Common.Rect;
 using TSize = Tizen.UIExtensions.Common.Size;


### PR DESCRIPTION
### Description of Change

Use `Microsoft.Maui.Graphics.SkiaGraphicsView` instead of `Tizen.UIExtensions.NUI.GraphicsView`.
Because `Microsoft.Maui.Graphics` provides `SkiaGraphicsView`, there is need  to use `Tizen.UIExtensions.NUI.GraphicsView` anymore.

<img src="https://user-images.githubusercontent.com/1029134/192661851-498d34b5-fc7e-4817-87ac-2c659eec1b8a.png" width=240 /> <img src="https://user-images.githubusercontent.com/1029134/192661862-9132798c-0d79-4501-96d8-a985b0bd1607.png" width=240 /> <img src="https://user-images.githubusercontent.com/1029134/192661871-81708d86-e8ff-43c8-9499-822f2a4eb6f2.png" width=240 />

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
