### PR TITLE
[Tizen] Fixes Border measure issue to reflect Width/HeightRequest

### DIFF
--- a/src/Core/src/Handlers/Border/BorderHandler.Tizen.cs
+++ b/src/Core/src/Handlers/Border/BorderHandler.Tizen.cs
@@ -26,11 +26,6 @@ namespace Microsoft.Maui.Handlers
 			ContainerView?.UpdateBackground(VirtualView.Background);
 		}
 
-		public override Graphics.Size GetDesiredSize(double widthConstraint, double heightConstraint)
-		{
-			return VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
-		}
-
 		public override void SetVirtualView(IView view)
 		{
 			base.SetVirtualView(view);

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1924,7 +1924,6 @@ override Microsoft.Maui.GridLength.ToString() -> string!
 override Microsoft.Maui.Handlers.ActivityIndicatorHandler.CreatePlatformView() -> Tizen.UIExtensions.NUI.GraphicsView.ActivityIndicator!
 override Microsoft.Maui.Handlers.ApplicationHandler.CreatePlatformElement() -> Tizen.Applications.CoreApplication!
 override Microsoft.Maui.Handlers.BorderHandler.CreatePlatformView() -> Microsoft.Maui.Platform.ContentViewGroup!
-override Microsoft.Maui.Handlers.BorderHandler.GetDesiredSize(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Handlers.BorderHandler.SetupContainer() -> void
 override Microsoft.Maui.Handlers.BorderHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.ButtonHandler.ConnectHandler(Tizen.UIExtensions.NUI.Button! platformView) -> void


### PR DESCRIPTION
### Description of Change
 * Border measure is not working correctly with Width/HeightRequest, this PR fixes it
 * `ContentViewGroup` that is a PlatformView of BorderHandler is already implement IMeasurable interface, so it works well with `ViewHandler.GetDesiredSize` so I remove overrided `GetDesiredSize` on BorderHandler

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
