### PR TITLE
[Windows] Display alerts by Window

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml
@@ -10,21 +10,34 @@
             Padding="12"
             Spacing="6">
 
-            <Label Text="Current Window Frame:" />
-            <Label Text="{Binding Window.X, StringFormat='X = {0:0.00}'}" />
-            <Label Text="{Binding Window.Y, StringFormat='Y = {0:0.00}'}" />
-            <Label Text="{Binding Window.Width, StringFormat='W = {0:0.00}'}" />
-            <Label Text="{Binding Window.Height, StringFormat='H = {0:0.00}'}" />
+            <Label 
+                Text="Current Window Frame:" />
+            <Label 
+                Text="{Binding Window.X, StringFormat='X = {0:0.00}'}" />
+            <Label 
+                Text="{Binding Window.Y, StringFormat='Y = {0:0.00}'}" />
+            <Label 
+                Text="{Binding Window.Width, StringFormat='W = {0:0.00}'}" />
+            <Label 
+                Text="{Binding Window.Height, StringFormat='H = {0:0.00}'}" />
 
-            <Label Text="Open/Close Windows:" />
+            <Label 
+                Text="Open/Close Windows:" />
             <Button
                 Clicked="OnNewWindowClicked"
                 Text="Open a new Window" />
             <Button
                 Clicked="OnCloseWindowClicked"
                 Text="Close this Window" />
-
-            <Label Text="Control Size:" />
+            
+            <Label 
+                Text="Dialogs:" />
+            <Button
+                Clicked="OnOpenDialogClicked"
+                Text="Open Dialog" />
+            
+            <Label 
+                Text="Control Size:" />
             <Button
                 Clicked="OnSetMinSize"
                 Text="Set the minimum size to 640x480" />
@@ -38,7 +51,8 @@
                 Clicked="OnSetCustomSize"
                 Text="Set window size to 700x500" />
 
-            <Label Text="Control Position:" />
+            <Label
+                Text="Control Position:" />
             <Button
                 Clicked="OnCenterWindow"
                 Text="Center window" />

--- a/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/MultiWindowPage.xaml.cs
@@ -24,6 +24,11 @@ namespace Maui.Controls.Sample.Pages
 			Application.Current.CloseWindow(Window);
 		}
 
+		async void OnOpenDialogClicked(object sender, EventArgs e)
+		{
+			await DisplayAlert("Information", "The dialog should open by Window.", "Ok");
+		}
+
 		void OnSetMaxSize(object sender, EventArgs e)
 		{
 			Window.MaximumWidth = 800;

--- a/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/AlertManager/AlertManager.Windows.cs
@@ -70,6 +70,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 			async void OnAlertRequested(Page sender, AlertArguments arguments)
 			{
+				// Verify that the page making the request is part of the current Window. 
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				string content = arguments.Message ?? string.Empty;
 				string title = arguments.Title ?? string.Empty;
 
@@ -123,6 +127,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 			async void OnPromptRequested(Page sender, PromptArguments arguments)
 			{
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				var promptDialog = new PromptDialog
 				{
 					Title = arguments.Title ?? string.Empty,
@@ -157,6 +164,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void OnActionSheetRequested(Page sender, ActionSheetArguments arguments)
 			{
+				if (!PageIsInThisWindow(sender))
+					return;
+
 				bool userDidSelect = false;
 
 				if (arguments.FlowDirection == FlowDirection.MatchParent)
@@ -230,6 +240,17 @@ namespace Microsoft.Maui.Controls.Platform
 					return prompt.Input;
 
 				return null;
+			}
+
+			bool PageIsInThisWindow(Page page)
+			{
+				var window = page?.Window;
+				var platformWindow = window?.MauiContext.GetPlatformWindow();
+
+				if (platformWindow?.GetHashCode() == Window.GetHashCode())
+					return true;
+
+				return false;
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change

Currently when displaying alerts are displayed in all the opened windows. This PR include changes to display the alert only in the current parent window.

![fix-10026](https://user-images.githubusercontent.com/6755973/192775086-329ea592-48d7-40bb-b387-3dddfceab720.gif)

### Issues Fixed

Fixes #10026