### PR TITLE
PhoneCallManager no longer works on Windows 11

### DIFF
--- a/src/Essentials/src/PhoneDialer/PhoneDialer.uwp.cs
+++ b/src/Essentials/src/PhoneDialer/PhoneDialer.uwp.cs
@@ -6,13 +6,16 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 	partial class PhoneDialerImplementation : IPhoneDialer
 	{
 		public bool IsSupported =>
-			ApiInformation.IsTypePresent("Windows.ApplicationModel.Calls.PhoneCallManager");
+			true;
 
-		public void Open(string number)
+		public async void Open(string number)
 		{
 			ValidateOpen(number);
 
-			PhoneCallManager.ShowPhoneCallUI(number, string.Empty);
+			if (ApiInformation.IsTypePresent("Windows.ApplicationModel.Calls.PhoneCallManager"))
+				PhoneCallManager.ShowPhoneCallUI(number, string.Empty);
+			else
+				await Launcher.OpenAsync($"tel:{number}");
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

In Windows 11, the phone dialer no longer has anything, so we fall back to a normal launcher for `tel:`


Works around https://github.com/microsoft/WindowsAppSDK/issues/3003