### PR TITLE
Ensure that star rows and columns cannot exceed the available space

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -735,7 +735,7 @@ namespace Microsoft.Maui.Layouts
 					var start = cell.Row;
 					var end = start + cell.RowSpan;
 
-					var desiredHeight = _childrenToLayOut[cell.ViewIndex].DesiredSize.Height;
+					var desiredHeight = Math.Min(_gridHeightConstraint, _childrenToLayOut[cell.ViewIndex].DesiredSize.Height);
 
 					ExpandStarsInSpan(desiredHeight, _rows, copy, start, end);
 				}
@@ -763,7 +763,7 @@ namespace Microsoft.Maui.Layouts
 					var start = cell.Column;
 					var end = start + cell.ColumnSpan;
 
-					var cellRequiredWidth = _childrenToLayOut[cell.ViewIndex].DesiredSize.Width;
+					var cellRequiredWidth = Math.Min(_gridWidthConstraint, _childrenToLayOut[cell.ViewIndex].DesiredSize.Width);
 
 					ExpandStarsInSpan(cellRequiredWidth, _columns, copy, start, end);
 				}
@@ -774,7 +774,14 @@ namespace Microsoft.Maui.Layouts
 			static Definition[] ScratchCopy(Definition[] original)
 			{
 				var copy = new Definition[original.Length];
-				original.CopyTo(copy, 0);
+
+				for (int n = 0; n < original.Length; n++)
+				{
+					copy[n] = new Definition(original[n].GridLength)
+					{
+						Size = original[n].Size
+					};
+				}
 
 				// zero out the star sizes in the copy
 				ZeroOutStarSizes(copy);

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Maui.Controls;
@@ -2279,6 +2280,48 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			_ = MeasureAndArrange(grid, double.PositiveInfinity, 200);
 
 			view0.Received().Measure(Arg.Is(double.PositiveInfinity), Arg.Any<double>());
+		}
+
+		[Fact]
+		[Category(GridStarSizing)]
+		public void StarColumnWidthLimitedToGridWidth()
+		{
+			var grid = CreateGridLayout(columns: "*", rows: "Auto, Auto");
+
+			var screenWidth = 500;
+
+			var view0 = CreateTestView(new Size(600, 20));
+			var view1 = CreateTestView(new Size(100, 20));
+
+			SetLocation(grid, view0);
+			SetLocation(grid, view1, row: 1);
+
+			SubstituteChildren(grid, view0, view1);
+
+			_ = MeasureAndArrange(grid, screenWidth, 200);
+
+			AssertArranged(view1, new Rect(0, 20, 500, 20));
+		}
+
+		[Fact]
+		[Category(GridStarSizing)]
+		public void StarRowHeightLimitedToGridHeight()
+		{
+			var grid = CreateGridLayout(rows: "*", columns: "Auto, Auto");
+
+			var screenHeight = 500;
+
+			var view0 = CreateTestView(new Size(20, 600));
+			var view1 = CreateTestView(new Size(20, 100));
+
+			SetLocation(grid, view0);
+			SetLocation(grid, view1, col: 1);
+
+			SubstituteChildren(grid, view0, view1);
+
+			_ = MeasureAndArrange(grid, 200, screenHeight);
+
+			AssertArranged(view1, new Rect(20, 0, 20, 500));
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

When a View in a star row/column exceeds the available size, the star/row column measurement is returning the exceeding value. Instead, it should top out at the available space. These changes ensure that.

### Issues Fixed

Fixes #10183

