### PR TITLE
[Android] Fix crash relaunching App from sharing item

### DIFF
--- a/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Android.cs
@@ -67,7 +67,8 @@ namespace Microsoft.Maui.Handlers
 
 		void Clear(LayoutViewGroup platformView)
 		{
-			platformView.RemoveAllViews();
+			if (platformView != null && !platformView.IsDisposed())
+				platformView.RemoveAllViews();
 		}
 
 		public void Clear()


### PR DESCRIPTION
### Description of Change

Fix crash relaunching App from sharing item on Android. Check if layout childrens are already disposed.

![fix-10384](https://user-images.githubusercontent.com/6755973/193568468-f83b5bd6-69c8-41a9-86dc-821b08a05a64.gif)

### Issues Fixed

Fixes #10384