### PR TITLE
Update .NET MAUI find version command in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -59,7 +59,7 @@ body:
     id: version-that-worked
     attributes:
       label: Last version that worked well
-      description: Is there a version on which this _did_ work? If yes, which one? If no or unknown, please select `Unknown/Other`.  Run `dotnet --version` to find your version.
+      description: Is there a version on which this _did_ work? If yes, which one? If no or unknown, please select `Unknown/Other`.  Run `dotnet workload list` to find your version.
       options:
         - 6.0 Release Candidate 2 or older
         - 6.0 Release Candidate 3


### PR DESCRIPTION
### Description of Change

@mattleibow updated one instance of `dotnet --version` but there was another reference I assume needed updating