### PR TITLE
[Android] Measure SwipeItem content before layout

### DIFF
--- a/src/Core/src/Platform/Android/MauiSwipeView.cs
+++ b/src/Core/src/Platform/Android/MauiSwipeView.cs
@@ -615,6 +615,12 @@ namespace Microsoft.Maui.Platform
 							b = contentHeight;
 							break;
 					}
+
+					child.Measure(
+						MeasureSpec.MakeMeasureSpec(swipeItemWidth, MeasureSpecMode.AtMost),
+						MeasureSpec.MakeMeasureSpec(swipeItemHeight, MeasureSpecMode.AtMost)
+					);
+					
 					child.Layout(l, t, r, b);
 
 					i++;


### PR DESCRIPTION
### Description of Change

SwipeItem content is not being measured before layout on Android; these changes add the missing measure call.

### Issues Fixed

Fixes #6018