### PR TITLE
Fix permissions in Windows

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.uwp.cs
+++ b/src/Essentials/src/Permissions/Permissions.uwp.cs
@@ -62,14 +62,10 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class CalendarRead : BasePlatformPermission
 		{
-			protected override Func<IEnumerable<string>> RequiredDeclarations => () =>
-				new[] { "appointments" };
 		}
 
 		public partial class CalendarWrite : BasePlatformPermission
 		{
-			protected override Func<IEnumerable<string>> RequiredDeclarations => () =>
-				new[] { "appointments" };
 		}
 
 		public partial class Camera : BasePlatformPermission
@@ -78,9 +74,6 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class ContactsRead : BasePlatformPermission
 		{
-			protected override Func<IEnumerable<string>> RequiredDeclarations => () =>
-				new[] { "contacts" };
-
 			public override async Task<PermissionStatus> CheckStatusAsync()
 			{
 				EnsureDeclared();
@@ -95,9 +88,6 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class ContactsWrite : BasePlatformPermission
 		{
-			protected override Func<IEnumerable<string>> RequiredDeclarations => () =>
-				   new[] { "contacts" };
-
 			public override async Task<PermissionStatus> CheckStatusAsync()
 			{
 				EnsureDeclared();
@@ -120,9 +110,6 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class LocationWhenInUse : BasePlatformPermission
 		{
-			protected override Func<IEnumerable<string>> RequiredDeclarations => () =>
-				new[] { "location" };
-
 			public override Task<PermissionStatus> CheckStatusAsync()
 			{
 				EnsureDeclared();
@@ -146,9 +133,6 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class LocationAlways : BasePlatformPermission
 		{
-			protected override Func<IEnumerable<string>> RequiredDeclarations => () =>
-				new[] { "location" };
-
 			public override Task<PermissionStatus> CheckStatusAsync()
 			{
 				EnsureDeclared();
@@ -166,8 +150,6 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class Microphone : BasePlatformPermission
 		{
-			protected override Func<IEnumerable<string>> RequiredDeclarations => () =>
-				new[] { "microphone" };
 		}
 
 		public partial class NetworkState : BasePlatformPermission

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -6,3 +6,10 @@ override Microsoft.Maui.Devices.Sensors.Location.GetHashCode() -> int
 ~override Microsoft.Maui.Devices.Sensors.Location.Equals(object obj) -> bool
 ~static Microsoft.Maui.Devices.Sensors.Location.operator !=(Microsoft.Maui.Devices.Sensors.Location left, Microsoft.Maui.Devices.Sensors.Location right) -> bool
 ~static Microsoft.Maui.Devices.Sensors.Location.operator ==(Microsoft.Maui.Devices.Sensors.Location left, Microsoft.Maui.Devices.Sensors.Location right) -> bool
+*REMOVED*~override Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.RequiredDeclarations.get -> System.Func<System.Collections.Generic.IEnumerable<string>>
+*REMOVED*~override Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite.RequiredDeclarations.get -> System.Func<System.Collections.Generic.IEnumerable<string>>
+*REMOVED*~override Microsoft.Maui.ApplicationModel.Permissions.ContactsRead.RequiredDeclarations.get -> System.Func<System.Collections.Generic.IEnumerable<string>>
+*REMOVED*~override Microsoft.Maui.ApplicationModel.Permissions.ContactsWrite.RequiredDeclarations.get -> System.Func<System.Collections.Generic.IEnumerable<string>>
+*REMOVED*~override Microsoft.Maui.ApplicationModel.Permissions.LocationAlways.RequiredDeclarations.get -> System.Func<System.Collections.Generic.IEnumerable<string>>
+*REMOVED*~override Microsoft.Maui.ApplicationModel.Permissions.LocationWhenInUse.RequiredDeclarations.get -> System.Func<System.Collections.Generic.IEnumerable<string>>
+*REMOVED*~override Microsoft.Maui.ApplicationModel.Permissions.Microphone.RequiredDeclarations.get -> System.Func<System.Collections.Generic.IEnumerable<string>>


### PR DESCRIPTION
### Description of Change

Permissions no longer need to be declared in the manifests.

It is still useful to check using the correct APIs to detect if the user has manually disabled things.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #8842

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
