### PR TITLE
Remove NET6 pinning from main branch

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,10 +5,5 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Microsoft.Build.NoTargets": "3.3.0"
-  },
-  "sdk": {
-    "version": "6.0.400",
-    "allowPrerelease": true,
-    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
### Description of Change

Now that we can build the main branch if we have .NET 7 workloads installed we don't need to pin it down to .NET 6. Removing the pinning will make life easier for places where we only have .NET7 workloads installed