### PR TITLE
Suppress obsolete path for EndPDFContent 

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/iOS/PlatformPdfExportContext.cs
+++ b/src/Graphics/src/Graphics/Platforms/iOS/PlatformPdfExportContext.cs
@@ -71,7 +71,9 @@ namespace Microsoft.Maui.Graphics.Platform
 #if IOS16_0_OR_GREATER
 					UIGraphics.EndPDFContext();
 #else
+#pragma warning disable CS0618 // Type or member is obsolete
 					UIGraphics.EndPDFContent();
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 				}
 				catch (Exception exc)


### PR DESCRIPTION
### Description of Change

It looks like when you're building NET6 TFMs with the NET7 sdk that the DEFINE for `IOS16_0_OR_GREATER` isn't set so we need to suppress this path for our main branch in order to be able to build locally with global workloads.