### PR TITLE
[ci] Include shortened MSIs in multi-target drop

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -28,6 +28,6 @@
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />
     <ComponentResources Include="maui-windows"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Windows" Description=".NET SDK Workload for building MAUI applications that target Windows." />
     <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Maui.Manifest*.nupkg" Version="@VS_COMPONENT_VERSION@" />
-    <MultiTargetPackNames Include="Microsoft.Maui.Sdk;Microsoft.Maui.Templates" />
+    <MultiTargetPackNames Include="Maui.Sdk;Maui.Templates" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The `<MultiTargetPackNames/>` item group is used as filter to determine the VS Drop location that workload MSIs should be uploaded to.  Any packs with names that match the items in this group will be uploaded to a "multitarget" drop that can be used across VS versions.

Commit e857f744 shortened most of the MSI file names, breaking this filtering system.  The filter has been updated to account for the shorter MSI names.