### PR TITLE
[Android] Ensure SearchView meets min size requirements

### DIFF
--- a/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
+++ b/src/Core/src/Handlers/SearchBar/SearchBarHandler.Android.cs
@@ -1,6 +1,8 @@
-﻿using Android.Content.Res;
+﻿using Android.Content;
+using Android.Content.Res;
 using Android.Views;
 using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using static AndroidX.AppCompat.Widget.SearchView;
 using SearchView = AndroidX.AppCompat.Widget.SearchView;
 
@@ -12,18 +14,14 @@ namespace Microsoft.Maui.Handlers
 
 		static ColorStateList? DefaultPlaceholderTextColors { get; set; }
 
-		EditText? _editText;
+		MauiSearchView? _platformSearchView;
 
-		public EditText? QueryEditor => _editText;
+		public EditText? QueryEditor => _platformSearchView?._queryEditor;
 
 		protected override SearchView CreatePlatformView()
 		{
-			var searchView = new SearchView(Context);
-			searchView.SetIconifiedByDefault(false);
-
-			_editText = searchView.GetFirstChildOfType<EditText>();
-
-			return searchView;
+			_platformSearchView = new MauiSearchView(Context);
+			return _platformSearchView;
 		}
 
 		protected override void ConnectHandler(SearchView platformView)

--- a/src/Core/src/Platform/Android/MauiSearchView.cs
+++ b/src/Core/src/Platform/Android/MauiSearchView.cs
@@ -1,0 +1,41 @@
+﻿using System.Reflection.Metadata.Ecma335;
+using Android.Content;
+using Android.Views;
+using Android.Widget;
+using Java.IO;
+using SearchView = AndroidX.AppCompat.Widget.SearchView;
+
+namespace Microsoft.Maui.Platform
+{
+	public class MauiSearchView : SearchView
+	{
+		internal EditText? _queryEditor;
+
+		public MauiSearchView(Context context) : base(context)
+		{
+			Initialize();
+		}
+
+		void Initialize()
+		{
+			SetIconifiedByDefault(false);
+
+			_queryEditor = this.GetFirstChildOfType<EditText>();
+
+			if (_queryEditor?.LayoutParameters is LinearLayout.LayoutParams layoutParams)
+			{
+				layoutParams.Height = LinearLayout.LayoutParams.MatchParent;
+				layoutParams.Gravity = GravityFlags.FillVertical;
+			}
+
+			var searchCloseButtonIdentifier = Resource.Id.search_close_btn;
+			if (searchCloseButtonIdentifier > 0)
+			{
+				var image = FindViewById<ImageView>(searchCloseButtonIdentifier);
+
+				if (image != null)
+					image.SetMinimumWidth((int?)Context?.ToPixels(44) ?? 0);
+			}
+		}
+	}
+}

--- a/src/Core/src/Platform/Android/MauiSearchView.cs
+++ b/src/Core/src/Platform/Android/MauiSearchView.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection.Metadata.Ecma335;
-using Android.Content;
+﻿using Android.Content;
 using Android.Views;
 using Android.Widget;
 using Java.IO;

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -98,6 +98,8 @@ Microsoft.Maui.IMenuFlyoutSeparator
 Microsoft.Maui.IToolTipElement
 Microsoft.Maui.IToolTipElement.ToolTip.get -> Microsoft.Maui.ToolTip?
 Microsoft.Maui.IWindow.FrameChanged(Microsoft.Maui.Graphics.Rect frame) -> void
+Microsoft.Maui.Platform.MauiSearchView
+Microsoft.Maui.Platform.MauiSearchView.MauiSearchView(Android.Content.Context! context) -> void
 Microsoft.Maui.ToolTip
 Microsoft.Maui.ToolTip.Content.get -> object?
 Microsoft.Maui.ToolTip.Content.set -> void

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Android.Content;
 using Android.Widget;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
@@ -115,6 +116,14 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.NotNull(editText);
 			});
 		}
+
+		double GetInputFieldHeight(SearchBarHandler searchBarHandler)
+		{
+			var control = GetNativeSearchBar(searchBarHandler);
+			var editText = control.GetChildrenOfType<EditText>().FirstOrDefault();
+			return MauiContext.Context.FromPixels((double)editText.MeasuredHeight);
+		}
+
 
 		static SearchView GetNativeSearchBar(SearchBarHandler searchBarHandler) =>
 			searchBarHandler.PlatformView;

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.Windows.cs
@@ -36,5 +36,10 @@ namespace Microsoft.Maui.DeviceTests
 				nativeSearchBar.AssertContainsColor(color);
 			});
 		}
+
+		double GetInputFieldHeight(SearchBarHandler searchBarHandler)
+		{
+			return GetNativeSearchBar(searchBarHandler).ActualHeight;
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -138,6 +138,21 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAsync(searchBar);
 		}
 
+		[Fact(DisplayName = "Default Input Field is at least 44dp high")]
+		public async Task DefaultInputFieldIsAtLeast44DpHigh()
+		{
+			var searchBar = new SearchBarStub();
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler(searchBar);
+				await AssertionExtensions.AttachAndRun(handler.PlatformView, () =>
+				{
+					var height = GetInputFieldHeight(handler);
+					Assert.True(height >= 44);
+				});
+			});
+		}
+
 #if !WINDOWS
 		[Theory]
 		[InlineData(true)]

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.cs
@@ -141,7 +141,12 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Default Input Field is at least 44dp high")]
 		public async Task DefaultInputFieldIsAtLeast44DpHigh()
 		{
-			var searchBar = new SearchBarStub();
+			var searchBar = new SearchBarStub()
+			{
+				Text = "search bar text",
+				Width = 200
+			};
+
 			await InvokeOnMainThreadAsync(async () =>
 			{
 				var handler = CreateHandler(searchBar);

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -109,6 +109,11 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(xplatCharacterSpacing, values.PlatformViewValue);
 		}
 
+		double GetInputFieldHeight(SearchBarHandler searchBarHandler)
+		{
+			return GetNativeSearchBar(searchBarHandler).Bounds.Height;
+		}
+
 		static UISearchBar GetNativeSearchBar(SearchBarHandler searchBarHandler) =>
 			(UISearchBar)searchBarHandler.PlatformView;
 

--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -252,6 +252,8 @@
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />
         <Setter Property="FontSize" Value="14" />
+        <Setter Property="MinimumHeightRequest" Value="44"/>
+        <Setter Property="MinimumWidthRequest" Value="44"/>
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">


### PR DESCRIPTION
### Description of Change

Ensure Android EditText takes up the full height of the SearchView
Refactor code into new MauiSearchView

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #2956

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
