### PR TITLE
Fix catalyst secondary click to match windows

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -81,15 +81,15 @@ namespace Maui.Controls.Sample.Pages
 				Text = "Right click me¡",
 				BackgroundColor = Colors.Coral
 			};
-			var rigthClickGesture = new TapGestureRecognizer
+			var rightClickGesture = new TapGestureRecognizer
 			{
 				Command = TapCommand,
 				CommandParameter = Colors.Coral,
 				NumberOfTapsRequired = 1,
 				Buttons = ButtonsMask.Secondary
 			};
-			rigthClickGesture.Tapped += OnTapped;
-			rightClickLabel.GestureRecognizers.Add(rigthClickGesture);
+			rightClickGesture.Tapped += OnTapped;
+			rightClickLabel.GestureRecognizers.Add(rightClickGesture);
 			horizontal2.Children.Add(rightClickLabel);
 
 			var rightorLeftClickLabel = new Label
@@ -97,7 +97,8 @@ namespace Maui.Controls.Sample.Pages
 				Text = "Right or Left click me¡",
 				BackgroundColor = Colors.Green
 			};
-			var rigthOrLeftClickGesture = new TapGestureRecognizer
+			
+			var rightOrLeftClickGesture = new TapGestureRecognizer
 			{
 				Command = TapCommand,
 				CommandParameter = Colors.Green,
@@ -105,17 +106,17 @@ namespace Maui.Controls.Sample.Pages
 				Buttons = ButtonsMask.Secondary | ButtonsMask.Primary
 			};
 
-			rigthOrLeftClickGesture.Tapped += OnTapped;
-			rightorLeftClickLabel.GestureRecognizers.Add(rigthOrLeftClickGesture);
+			rightOrLeftClickGesture.Tapped += OnTapped;
+			rightorLeftClickLabel.GestureRecognizers.Add(rightOrLeftClickGesture);
 			horizontal2.Children.Add(rightorLeftClickLabel);
 
-			var rightorLeftClickLabel2Taps = new Label
+			var rightOrLeftClickLabel2Taps = new Label
 			{
 				Text = "Double Click Me! ",
 				BackgroundColor = Colors.Green,
 			};
 
-			var rigthOrLeftClickGesture2Taps = new TapGestureRecognizer
+			var rightOrLeftClickGesture2Taps = new TapGestureRecognizer
 			{
 				Command = TapCommand,
 				CommandParameter = Colors.Green,
@@ -123,9 +124,9 @@ namespace Maui.Controls.Sample.Pages
 				Buttons = ButtonsMask.Secondary | ButtonsMask.Primary
 			};
 
-			rigthOrLeftClickGesture2Taps.Tapped += OnTapped;
-			rightorLeftClickLabel2Taps.GestureRecognizers.Add(rigthOrLeftClickGesture2Taps);
-			horizontal2.Children.Add(rightorLeftClickLabel2Taps);
+			rightOrLeftClickGesture2Taps.Tapped += OnTapped;
+			rightOrLeftClickLabel2Taps.GestureRecognizers.Add(rightOrLeftClickGesture2Taps);
+			horizontal2.Children.Add(rightOrLeftClickLabel2Taps);
 
 			changeColorBoxView = new Label
 			{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/TapGestureGalleryPage.cs
@@ -53,7 +53,7 @@ namespace Maui.Controls.Sample.Pages
 
 			var doubleTapLabel = new Label
 			{
-				Text = "Double Tap me!!",
+				Text = "Double Tap me!! Right Clicking Me Shouldn't Do Anything!",
 				BackgroundColor = Colors.Aqua
 			};
 			var doubleTapGesture = new TapGestureRecognizer
@@ -61,10 +61,71 @@ namespace Maui.Controls.Sample.Pages
 				Command = TapCommand,
 				CommandParameter = Colors.Aqua,
 				NumberOfTapsRequired = 2,
+				Buttons = ButtonsMask.Secondary | ButtonsMask.Primary
 			};
 			doubleTapGesture.Tapped += OnTapped;
 			doubleTapLabel.GestureRecognizers.Add(doubleTapGesture);
 			horizontal.Add(doubleTapLabel);
+
+			var horizontal2 = new HorizontalStackLayout
+			{
+				Spacing = 20,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+			vertical.Add(horizontal2);
+
+
+			var rightClickLabel = new Label
+			{
+				Text = "Right click me¡",
+				BackgroundColor = Colors.Coral
+			};
+			var rigthClickGesture = new TapGestureRecognizer
+			{
+				Command = TapCommand,
+				CommandParameter = Colors.Coral,
+				NumberOfTapsRequired = 1,
+				Buttons = ButtonsMask.Secondary
+			};
+			rigthClickGesture.Tapped += OnTapped;
+			rightClickLabel.GestureRecognizers.Add(rigthClickGesture);
+			horizontal2.Children.Add(rightClickLabel);
+
+			var rightorLeftClickLabel = new Label
+			{
+				Text = "Right or Left click me¡",
+				BackgroundColor = Colors.Green
+			};
+			var rigthOrLeftClickGesture = new TapGestureRecognizer
+			{
+				Command = TapCommand,
+				CommandParameter = Colors.Green,
+				NumberOfTapsRequired = 1,
+				Buttons = ButtonsMask.Secondary | ButtonsMask.Primary
+			};
+
+			rigthOrLeftClickGesture.Tapped += OnTapped;
+			rightorLeftClickLabel.GestureRecognizers.Add(rigthOrLeftClickGesture);
+			horizontal2.Children.Add(rightorLeftClickLabel);
+
+			var rightorLeftClickLabel2Taps = new Label
+			{
+				Text = "Double Click Me! ",
+				BackgroundColor = Colors.Green,
+			};
+
+			var rigthOrLeftClickGesture2Taps = new TapGestureRecognizer
+			{
+				Command = TapCommand,
+				CommandParameter = Colors.Green,
+				NumberOfTapsRequired = 2,
+				Buttons = ButtonsMask.Secondary | ButtonsMask.Primary
+			};
+
+			rigthOrLeftClickGesture2Taps.Tapped += OnTapped;
+			rightorLeftClickLabel2Taps.GestureRecognizers.Add(rigthOrLeftClickGesture2Taps);
+			horizontal2.Children.Add(rightorLeftClickLabel2Taps);
 
 			changeColorBoxView = new Label
 			{
@@ -105,41 +166,6 @@ namespace Maui.Controls.Sample.Pages
 			tripleClickGesture.Tapped += OnTapped;
 			tripleClicklabel.GestureRecognizers.Add(tripleClickGesture);
 			horizontal.Children.Add(tripleClicklabel);
-
-			var rightClickLabel = new Label
-			{
-				Text = "Right click me¡",
-				BackgroundColor = Colors.Coral
-			};
-			var rigthClickGesture = new TapGestureRecognizer
-			{
-				Command = TapCommand,
-				CommandParameter = Colors.Coral,
-				NumberOfTapsRequired = 1,
-				Buttons = ButtonsMask.Secondary
-			};
-			rigthClickGesture.Tapped += OnTapped;
-			rightClickLabel.GestureRecognizers.Add(rigthClickGesture);
-			horizontal.Children.Add(rightClickLabel);
-
-
-			var rightorLeftClickLabel = new Label
-			{
-				Text = "Right or Left click me¡",
-				BackgroundColor = Colors.Green
-			};
-			var rigthOrLeftClickGesture = new TapGestureRecognizer
-			{
-				Command = TapCommand,
-				CommandParameter = Colors.Green,
-				NumberOfTapsRequired = 1,
-				Buttons = ButtonsMask.Secondary | ButtonsMask.Primary
-			};
-
-			rigthOrLeftClickGesture.Tapped += OnTapped;
-			rightorLeftClickLabel.GestureRecognizers.Add(rigthOrLeftClickGesture);
-			horizontal.Children.Add(rightorLeftClickLabel);
-
 
 			Content = vertical;
 		}

--- a/src/Controls/samples/Controls.Sample/ViewModels/GesturesViewModel.cs
+++ b/src/Controls/samples/Controls.Sample/ViewModels/GesturesViewModel.cs
@@ -11,16 +11,16 @@ namespace Maui.Controls.Sample.ViewModels
 		{
 			new SectionModel(typeof(DragAndDropBetweenLayouts), "Drag And Drop",
 				"Drag and Drop Views."),
-			new SectionModel(typeof(PinchGestureTestPage), "Pinch Gesture",
-				"Pinch Gesture."),
 			new SectionModel(typeof(PanGestureGalleryPage), "Pan Gesture",
 				"Pan Gesture."),
+			new SectionModel(typeof(PinchGestureTestPage), "Pinch Gesture",
+				"Pinch Gesture."),
+			new SectionModel(typeof(PointerGestureGalleryPage), "Pointer Gesture",
+				"Pointer Gesture."),
 			new SectionModel(typeof(SwipeGestureGalleryPage), "Swipe Gesture",
 				"Swipe Gesture."),
 			new SectionModel(typeof(TapGestureGalleryPage), "Tap Gesture",
 				"Tap Gesture."),
-			new SectionModel(typeof(PointerGestureGalleryPage), "Pointer Gesture",
-				"Pointer Gesture."),
 		};
 	}
 }

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				if (e is RightTappedRoutedEventArgs)
 				{
-					// Currently we only support single right clicks on WinUI
+					// Currently we only support single right clicks
 					if ((g.Buttons & ButtonsMask.Secondary) == ButtonsMask.Secondary)
 						return g.NumberOfTapsRequired == 1;
 					else

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.Windows.cs
@@ -565,11 +565,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 			bool ValidateGesture(TapGestureRecognizer g)
 			{
-				if (e is RightTappedRoutedEventArgs &&
-					(g.Buttons & ButtonsMask.Secondary) == ButtonsMask.Secondary)
+				if (e is RightTappedRoutedEventArgs)
 				{
 					// Currently we only support single right clicks on WinUI
-					return g.NumberOfTapsRequired == 1;
+					if ((g.Buttons & ButtonsMask.Secondary) == ButtonsMask.Secondary)
+						return g.NumberOfTapsRequired == 1;
+					else
+						return false;
 				}
 
 				if ((g.Buttons & ButtonsMask.Primary) != ButtonsMask.Primary)

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -811,7 +811,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 				public override UIContextMenuConfiguration? GetConfigurationForMenu(UIContextMenuInteraction interaction, CGPoint location)
 				{
-					ProcessRecognizerHandlerTap(_gestureManager, _recognizer, location, 1);
+					ProcessRecognizerHandlerTap(_gestureManager, _recognizer, location, TapGestureRecognizer?.NumberOfTapsRequired ?? int.MaxValue);
 					return null;
 				}
 			}

--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -811,7 +811,9 @@ namespace Microsoft.Maui.Controls.Platform
 
 				public override UIContextMenuConfiguration? GetConfigurationForMenu(UIContextMenuInteraction interaction, CGPoint location)
 				{
-					ProcessRecognizerHandlerTap(_gestureManager, _recognizer, location, TapGestureRecognizer?.NumberOfTapsRequired ?? int.MaxValue);
+					if (TapGestureRecognizer?.NumberOfTapsRequired == 1)
+						ProcessRecognizerHandlerTap(_gestureManager, _recognizer, location, 1);
+
 					return null;
 				}
 			}


### PR DESCRIPTION
### Description of Change

Modify Catalyst so that secondary click only fires if the user has set the `NumberOfClicks` to 1. This is currently how it works on windows as well.  We don't want to just fire secondary click regardless of the value of ` NumberOfClicks` because that makes the world a bit weird once/if we actually implement `NumberOfClicks`

Fixes #10464
