### PR TITLE
Don't fire appearing/disappearing with window

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -126,6 +126,11 @@ namespace Microsoft.Maui.Controls
 		void OnAppearing(object sender, EventArgs e)
 		{
 			// Update the Container level Toolbar with my Toolbar information
+			SetupToolbar();
+		}
+
+		void SetupToolbar()
+		{
 			if (FindMyToolbar() is not NavigationPageToolbar)
 			{
 				// If the root is a flyoutpage then we set the toolbar on the flyout page
@@ -225,15 +230,6 @@ namespace Microsoft.Maui.Controls
 		private protected override void OnHandlerChangedCore()
 		{
 			base.OnHandlerChangedCore();
-
-			if (Handler == null && FindMyToolbar() is IToolbar tb)
-			{
-				tb.Handler = null;
-				if (tb.Parent is Window w)
-					w.Toolbar = null;
-				else if (tb.Parent is Page p)
-					p.Toolbar = null;
-			}
 
 			if (Navigation is MauiNavigationImpl && InternalChildren.Count > 0)
 			{

--- a/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/NavigationPage/NavigationPage.Impl.cs
@@ -126,11 +126,6 @@ namespace Microsoft.Maui.Controls
 		void OnAppearing(object sender, EventArgs e)
 		{
 			// Update the Container level Toolbar with my Toolbar information
-			SetupToolbar();
-		}
-
-		void SetupToolbar()
-		{
 			if (FindMyToolbar() is not NavigationPageToolbar)
 			{
 				// If the root is a flyoutpage then we set the toolbar on the flyout page

--- a/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Android.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls
 	public partial class TabbedPage
 	{
 		IMauiContext MauiContext => this.Handler?.MauiContext ?? throw new InvalidOperationException("MauiContext cannot be null here");
-		TabbedPageManager _tabbedPageManager;
+		TabbedPageManager? _tabbedPageManager;
 
 		ViewPager2 CreatePlatformView()
 		{
@@ -34,38 +34,45 @@ namespace Microsoft.Maui.Controls
 
 		partial void OnHandlerChangingPartial(HandlerChangingEventArgs args)
 		{
-			if (args.OldHandler != null && args.NewHandler == null)
+			if (args.NewHandler != null &&
+				_tabbedPageManager != null &&
+				args.NewHandler.MauiContext != _tabbedPageManager.MauiContext)
+			{
+				DisconnectHandler();
+				_tabbedPageManager = null;
+			}
+			else if (args.OldHandler != null && args.NewHandler == null)
 				DisconnectHandler();
 		}
 
 		void DisconnectHandler()
 		{
-			_tabbedPageManager.SetElement(null);
+			_tabbedPageManager?.SetElement(null);
 		}
 
 		internal static void MapBarBackground(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._tabbedPageManager.UpdateBarBackground();
+			view._tabbedPageManager?.UpdateBarBackground();
 		}
 
 		internal static void MapBarBackgroundColor(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._tabbedPageManager.UpdateBarBackgroundColor();
+			view._tabbedPageManager?.UpdateBarBackgroundColor();
 		}
 
 		internal static void MapBarTextColor(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._tabbedPageManager.UpdateTabItemStyle();
+			view._tabbedPageManager?.UpdateTabItemStyle();
 		}
 
 		internal static void MapUnselectedTabColor(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._tabbedPageManager.UpdateTabItemStyle();
+			view._tabbedPageManager?.UpdateTabItemStyle();
 		}
 
 		internal static void MapSelectedTabColor(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._tabbedPageManager.UpdateTabItemStyle();
+			view._tabbedPageManager?.UpdateTabItemStyle();
 		}
 
 		internal static void MapItemsSource(ITabbedViewHandler handler, TabbedPage view)
@@ -85,12 +92,12 @@ namespace Microsoft.Maui.Controls
 
 		internal static void MapCurrentPage(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._tabbedPageManager.ScrollToCurrentPage();
+			view._tabbedPageManager?.ScrollToCurrentPage();
 		}
 
 		public static void MapIsSwipePagingEnabled(ITabbedViewHandler handler, TabbedPage view)
 		{
-			view._tabbedPageManager.UpdateSwipePaging();
+			view._tabbedPageManager?.UpdateSwipePaging();
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
@@ -66,8 +66,6 @@ namespace Microsoft.Maui.Controls
 
 		partial void OnHandlerChangingPartial(HandlerChangingEventArgs args)
 		{
-			_connectedToHandler = false;
-
 			if (args.OldHandler != null && args.NewHandler == null)
 				OnHandlerDisconnected(args.OldHandler.PlatformView as FrameworkElement);
 		}

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -493,6 +493,7 @@ namespace Microsoft.Maui.Controls
 
 		void IWindow.Destroying()
 		{
+			SendWindowDisppearing();
 			Destroying?.Invoke(this, EventArgs.Empty);
 			OnDestroying();
 

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Maui.Controls
 		List<IVisualTreeElement> _visualChildren;
 		Toolbar? _toolbar;
 		MenuBarTracker _menuBarTracker;
+		bool _isActivated;
 
 		IToolbar? IToolbarElement.Toolbar => Toolbar;
 		internal Toolbar? Toolbar
@@ -298,8 +299,20 @@ namespace Microsoft.Maui.Controls
 
 		internal bool IsActivated
 		{
-			get;
-			private set;
+			get
+			{
+				return _isActivated;
+			}
+			private set
+			{
+				if (_isActivated == value)
+					return;
+
+				_isActivated = value;
+
+				if (value)
+					SendWindowAppearing();
+			}
 		}
 
 		IFlowDirectionController FlowController => this;

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Maui.Controls
 		List<IVisualTreeElement> _visualChildren;
 		Toolbar? _toolbar;
 		MenuBarTracker _menuBarTracker;
-		bool _isActivated;
 
 		IToolbar? IToolbarElement.Toolbar => Toolbar;
 		internal Toolbar? Toolbar
@@ -299,22 +298,8 @@ namespace Microsoft.Maui.Controls
 
 		internal bool IsActivated
 		{
-			get
-			{
-				return _isActivated;
-			}
-			private set
-			{
-				if (_isActivated == value)
-					return;
-
-				_isActivated = value;
-
-				if (value)
-					SendWindowAppearing();
-				else
-					SendWindowDisppearing();
-			}
+			get;
+			private set;
 		}
 
 		IFlowDirectionController FlowController => this;

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -420,6 +420,7 @@ namespace Microsoft.Maui.Controls
 		void SendWindowDisppearing()
 		{
 			Page?.SendDisappearing();
+			IsActivated = false;
 		}
 
 		void OnModalPopped(Page modalPage)

--- a/src/Controls/src/Core/NavigationPageToolbar.cs
+++ b/src/Controls/src/Core/NavigationPageToolbar.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -20,6 +18,7 @@ namespace Microsoft.Maui.Controls
 		Page _rootPage;
 		List<NavigationPage> _navigationPagesStack = new List<NavigationPage>();
 		internal NavigationPage CurrentNavigationPage => _currentNavigationPage;
+		internal ToolbarTracker ToolbarTracker => _toolbarTracker;
 		public override Color BarTextColor { get => GetBarTextColor(); set => SetProperty(ref _barTextColor, value); }
 		public override Color IconColor { get => GetIconColor(); set => SetProperty(ref _iconColor, value); }
 		public override string Title { get => GetTitle(); set => SetProperty(ref _title, value); }

--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			_viewPager.RegisterOnPageChangeCallback(_listeners);
 		}
 
+		internal IMauiContext MauiContext => _context;
 		FragmentManager FragmentManager => _fragmentManager ?? (_fragmentManager = _context.GetFragmentManager());
 		public bool IsBottomTabPlacement => (Element != null) ? Element.OnThisPlatform().GetToolbarPlacement() == ToolbarPlacement.Bottom : false;
 
@@ -174,13 +175,22 @@ namespace Microsoft.Maui.Controls.Handlers
 			{
 				var fragment = _tabLayoutFragment;
 				_tabLayoutFragment = null;
-				_ = _context
+
+				var fragmentManager =
+					_context
 						.GetNavigationRootManager()
-						.FragmentManager
-						.BeginTransaction()
-						.Remove(fragment)
-						.SetReorderingAllowed(true)
-						.Commit();
+						.FragmentManager;
+
+				if (fragmentManager.IsAlive() && !fragmentManager.IsDestroyed)
+				{
+					_ = _context
+							.GetNavigationRootManager()
+							.FragmentManager
+							.BeginTransaction()
+							.Remove(fragment)
+							.SetReorderingAllowed(true)
+							.Commit();
+				}
 
 				_tabplacementId = 0;
 			}

--- a/src/Controls/src/Core/Toolbar.cs
+++ b/src/Controls/src/Core/Toolbar.cs
@@ -53,8 +53,12 @@ namespace Microsoft.Maui.Controls
 				if (_handler == value)
 					return;
 
+				var oldHandler = _handler;
 				OnHandlerChanging(_handler, value);
 				_handler = value;
+
+				if (oldHandler?.VirtualView == this)
+					oldHandler?.DisconnectHandler();
 			}
 		}
 

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
-		void DeActivatedFiresDisappearingEvent()
+		void DestroyedFiresDisappearingEvent()
 		{
 			int disappear = 0;
 			int appear = 0;
@@ -296,7 +296,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			cp.Appearing += (_, __) => appear++;
 			cp.Disappearing += (_, __) => disappear++;
 
-			window.Deactivated();
+			window.Destroying();
 			Assert.Equal(1, disappear);
 			Assert.Equal(0, appear);
 		}
@@ -314,8 +314,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			cp.Appearing += (_, __) => appear++;
 			cp.Disappearing += (_, __) => disappear++;
 
+			var app = window.Parent as TestApp;
 			Assert.Equal(0, disappear);
-			window.Deactivated();
+			window.Destroying();
+
+			// simulate platform requesting another window for the same page
+			_ = app.CreateWindow(cp);
+
 			window.Activated();
 			Assert.Equal(1, disappear);
 			Assert.Equal(1, appear);

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -67,38 +67,6 @@ namespace Microsoft.Maui.DeviceTests
 
 #if !IOS && !MACCATALYST
 
-
-		[Fact(DisplayName = "Toolbar Recreates With New MauiContext")]
-		public async Task ToolbarRecreatesWithNewMauiContext()
-		{
-			SetupBuilder();
-			var flyoutPage = new FlyoutPage()
-			{
-				Detail = new NavigationPage(new ContentPage() { Title = "Detail" }),
-				Flyout = new ContentPage() { Title = "Flyout" }
-			};
-
-			var window = new Window(flyoutPage);
-
-			var context1 = new ContextStub(MauiContext.Services);
-			var context2 = new ContextStub(MauiContext.Services);
-
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(window, (handler) =>
-			{
-				Assert.NotNull(flyoutPage.Toolbar);
-				Assert.NotNull(GetPlatformToolbar(handler));
-				return Task.CompletedTask;
-			}, context1);
-
-			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(window, (handler) =>
-			{
-				Assert.NotNull(flyoutPage.Toolbar);
-				Assert.NotNull(GetPlatformToolbar(handler));
-				return Task.CompletedTask;
-			}, context2);
-		}
-
-
 		[Fact(DisplayName = "FlyoutPage With Toolbar")]
 		public async Task FlyoutPageWithToolbar()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -67,6 +67,38 @@ namespace Microsoft.Maui.DeviceTests
 
 #if !IOS && !MACCATALYST
 
+
+		[Fact(DisplayName = "Toolbar Recreates With New MauiContext")]
+		public async Task ToolbarRecreatesWithNewMauiContext()
+		{
+			SetupBuilder();
+			var flyoutPage = new FlyoutPage()
+			{
+				Detail = new NavigationPage(new ContentPage() { Title = "Detail" }),
+				Flyout = new ContentPage() { Title = "Flyout" }
+			};
+
+			var window = new Window(flyoutPage);
+
+			var context1 = new ContextStub(MauiContext.Services);
+			var context2 = new ContextStub(MauiContext.Services);
+
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(window, (handler) =>
+			{
+				Assert.NotNull(flyoutPage.Toolbar);
+				Assert.NotNull(GetPlatformToolbar(handler));
+				return Task.CompletedTask;
+			}, context1);
+
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(window, (handler) =>
+			{
+				Assert.NotNull(flyoutPage.Toolbar);
+				Assert.NotNull(GetPlatformToolbar(handler));
+				return Task.CompletedTask;
+			}, context2);
+		}
+
+
 		[Fact(DisplayName = "FlyoutPage With Toolbar")]
 		public async Task FlyoutPageWithToolbar()
 		{

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.Android.cs
@@ -48,15 +48,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		public bool IsNavigationBarVisible(IElementHandler handler) =>
-			IsNavigationBarVisible(handler.MauiContext);
-
-		public bool IsNavigationBarVisible(IMauiContext mauiContext)
-		{
-			return GetPlatformToolbar(mauiContext)?
-					.LayoutParameters?.Height > 0;
-		}
-
 		string GetToolbarTitle(IElementHandler handler) =>
 			GetPlatformToolbar(handler).Title;
 	}

--- a/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/NavigationPage/NavigationPageTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 					handlers.AddHandler<Page, PageHandler>();
 					handlers.AddHandler<Window, WindowHandlerStub>();
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
 					handlers.AddHandler<Frame, FrameRenderer>();
 				});
 			});
@@ -209,6 +210,38 @@ namespace Microsoft.Maui.DeviceTests
 				await Task.Delay(100);
 
 				Assert.False(IsBackButtonVisible(navPage.Handler));
+			});
+		}
+
+		[Fact(DisplayName = "Pushing a Tabbed Page Doesn't Throw Exception")]
+		public async Task PushingATabbedPageDoesntThrowException()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage()
+			{
+				Title = "Page Title"
+			});
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var tabbedPage1 = CreateTabbedPage("1");
+				var tabbedPage2 = CreateTabbedPage("2");
+
+				await navPage.PushAsync(tabbedPage1);
+				tabbedPage1.SelectedItem = tabbedPage1.Children[1];
+				await OnLoadedAsync(tabbedPage1.Children[1]);
+				await navPage.PopAsync();
+				await navPage.PushAsync(tabbedPage2);
+
+				TabbedPage CreateTabbedPage(string title) => new TabbedPage()
+				{
+					Title = title,
+					Children =
+					{
+						new ContentPage(),
+						new ContentPage()
+					}
+				};
 			});
 		}
 #endif

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -28,23 +28,7 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
-					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
-					handlers.AddHandler<Layout, LayoutHandler>();
-					handlers.AddHandler<Image, ImageHandler>();
-					handlers.AddHandler<Label, LabelHandler>();
-					handlers.AddHandler<Page, PageHandler>();
-					handlers.AddHandler<Toolbar, ToolbarHandler>();
-					handlers.AddHandler<MenuBar, MenuBarHandler>();
-					handlers.AddHandler<MenuBarItem, MenuBarItemHandler>();
-					handlers.AddHandler<MenuFlyoutItem, MenuFlyoutItemHandler>();
-					handlers.AddHandler<MenuFlyoutSubItem, MenuFlyoutSubItemHandler>();
-					handlers.AddHandler<NavigationPage, NavigationViewHandler>();
-					handlers.AddHandler<ScrollView, ScrollViewHandler>();
-#if WINDOWS
-					handlers.AddHandler<ShellItem, ShellItemHandler>();
-					handlers.AddHandler<ShellSection, ShellSectionHandler>();
-					handlers.AddHandler<ShellContent, ShellContentHandler>();
-#endif
+					SetupShellHandlers(handlers);
 				});
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					SetupShellHandlers(handlers);
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
 				});
 			});
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Toolbar/ToolbarTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+using Xunit.Sdk;
+
+#if IOS || MACCATALYST
+using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
+#endif
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Toolbar)]
+	public partial class ToolbarTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
+					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Controls.Window, WindowHandlerStub>();
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+
+					SetupShellHandlers(handlers);
+				});
+			});
+		}
+
+#if !IOS && !MACCATALYST
+		[Theory(DisplayName = "Toolbar Recreates With New MauiContext")]
+		[InlineData(typeof(FlyoutPage))]
+		[InlineData(typeof(NavigationPage))]
+		[InlineData(typeof(TabbedPage))]
+		[InlineData(typeof(Shell))]
+		public async Task ToolbarRecreatesWithNewMauiContext(Type type)
+		{
+			SetupBuilder();
+			Page page = null;
+
+			if (type == typeof(FlyoutPage))
+			{
+				page = new FlyoutPage()
+				{
+					Detail = new NavigationPage(new ContentPage() { Title = "Detail" }),
+					Flyout = new ContentPage() { Title = "Flyout" }
+				};
+			}
+			else if (type == typeof(NavigationPage))
+			{
+				page = new NavigationPage(new ContentPage() { Title = "Nav Page" });
+			}
+			else if (type == typeof(TabbedPage))
+			{
+				page = new TabbedPage()
+				{
+					Children =
+					{
+						new NavigationPage(new ContentPage() { Title = "Tab Page 1" }),
+						new NavigationPage(new ContentPage() { Title = "Tab Page 2" })
+					}
+				};
+			}
+			else if (type == typeof(Shell))
+			{
+				page = new Shell() { CurrentItem = new ContentPage() { Title = "Shell Page" } };
+			}
+
+
+			var window = new Window(page);
+
+			var context1 = new ContextStub(MauiContext.Services);
+			var context2 = new ContextStub(MauiContext.Services);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, (handler) =>
+			{
+				var toolbar = GetToolbar(handler);
+				Assert.NotNull(toolbar);
+				Assert.True(IsNavigationBarVisible(handler));
+				return Task.CompletedTask;
+			}, context1);
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window, (handler) =>
+			{
+				var toolbar = GetToolbar(handler);
+				Assert.NotNull(toolbar);
+				Assert.True(IsNavigationBarVisible(handler));
+				return Task.CompletedTask;
+			}, context2);
+		}
+#endif
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowPageSwapTestCases.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowPageSwapTestCases.cs
@@ -14,13 +14,23 @@ namespace Microsoft.Maui.DeviceTests
 		private readonly List<object[]> _data = new()
 		{
 			new object[] { new WindowPageSwapTestCase(typeof(TabbedPage), typeof(Shell), typeof(FlyoutPage)) },
-			new object[] { new WindowPageSwapTestCase(typeof(Shell), typeof(NavigationPage), typeof(FlyoutPage)) },
+			new object[] { new WindowPageSwapTestCase(typeof(Shell), typeof(NavigationPage), typeof(FlyoutPage), typeof(Shell)) },
 			new object[] { new WindowPageSwapTestCase(typeof(NavigationPage), typeof(NavigationPage), typeof(Shell)) },
+			new object[] { new WindowPageSwapTestCase(typeof(Shell), typeof(FlyoutPageWithNavPage), typeof(TabbedPageWithNavPage), typeof(Shell)) },
 		};
 
 		public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+
+		public class FlyoutPageWithNavPage : FlyoutPage
+		{
+		}
+
+		public class TabbedPageWithNavPage : TabbedPage
+		{
+		}
 	}
 
 	public class WindowPageSwapTestCase
@@ -50,6 +60,25 @@ namespace Microsoft.Maui.DeviceTests
 			Page returnValue = null;
 			if (result == typeof(ContentPage))
 				returnValue = Page;
+			else if (result == typeof(WindowPageSwapTestCases.FlyoutPageWithNavPage))
+			{
+				Page.Title ??= "Details Page";
+				returnValue = new WindowPageSwapTestCases.FlyoutPageWithNavPage()
+				{
+					Detail = new NavigationPage(Page) { Title = Page.Title },
+					Flyout = new ContentPage() { Title = "Flyout" }
+				};
+			}
+			else if (result == typeof(WindowPageSwapTestCases.TabbedPageWithNavPage))
+			{
+				returnValue = new WindowPageSwapTestCases.TabbedPageWithNavPage()
+				{
+					Children =
+					{
+						new NavigationPage(Page)
+					}
+				};
+			}
 			else if (result == typeof(FlyoutPage))
 			{
 				Page.Title ??= "Details Page";
@@ -119,5 +148,6 @@ namespace Microsoft.Maui.DeviceTests
 			return debugName;
 		}
 	}
+
 
 }

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.cs
@@ -93,15 +93,14 @@ namespace Microsoft.Maui.DeviceTests
 						// Shell currently doesn't create the handler on the xplat toolbar with Android
 						// Because Android has lots of toolbars spread out between the viewpagers that
 						var platformToolBar = GetPlatformToolbar(handler);
-						var toolBar = toolbar;
-						Assert.Equal(platformToolBar != null, toolBar != null);
+						Assert.Equal(platformToolBar != null, toolbar != null);
 
 						if (platformToolBar != null)
 						{
 							if (DeviceInfo.Current.Platform == DevicePlatform.WinUI ||
 								window.Page is not Shell)
 							{
-								Assert.Equal(toolBar?.Handler?.PlatformView, platformToolBar);
+								Assert.Equal(toolbar?.Handler?.PlatformView, platformToolBar);
 							}
 
 							Assert.True(IsNavigationBarVisible(handler));

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Android.cs
@@ -165,6 +165,15 @@ namespace Microsoft.Maui.DeviceTests
 			return toolBar;
 		}
 
+		public bool IsNavigationBarVisible(IElementHandler handler) =>
+			IsNavigationBarVisible(handler.MauiContext);
+
+		public bool IsNavigationBarVisible(IMauiContext mauiContext)
+		{
+			return GetPlatformToolbar(mauiContext)?
+					.LayoutParameters?.Height > 0;
+		}
+
 		protected bool IsBackButtonVisible(IElementHandler handler)
 		{
 			if (GetPlatformToolbar(handler)?.NavigationIcon is DrawerArrowDrawable dad)

--- a/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
+++ b/src/Controls/tests/DeviceTests/HandlerTestBase.Windows.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using WAppBarButton = Microsoft.UI.Xaml.Controls.AppBarButton;
 using Xunit;
 using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -112,17 +113,21 @@ namespace Microsoft.Maui.DeviceTests
 
 		public bool IsNavigationBarVisible(IMauiContext mauiContext)
 		{
-			var navView = GetMauiNavigationView(mauiContext);
-			var header = navView?.Header as WFrameworkElement;
+			var header = GetPlatformToolbar(mauiContext);
 			return header?.Visibility == UI.Xaml.Visibility.Visible;
 		}
 
-		protected MauiToolbar GetPlatformToolbar(IElementHandler handler)
+		protected MauiToolbar GetPlatformToolbar(IMauiContext mauiContext)
 		{
-			var navView = (RootNavigationView)GetMauiNavigationView(handler.MauiContext);
-			MauiToolbar windowHeader = (MauiToolbar)navView.Header;
-			return windowHeader;
+			var navView = (RootNavigationView)GetMauiNavigationView(mauiContext);
+			if (navView.PaneDisplayMode == NavigationViewPaneDisplayMode.Top)
+				return (MauiToolbar)navView.PaneFooter;
+
+			return (MauiToolbar)navView.Header;
 		}
+
+		protected MauiToolbar GetPlatformToolbar(IElementHandler handler) =>
+			GetPlatformToolbar(handler.MauiContext);
 
 		public bool ToolbarItemsMatch(
 			IElementHandler handler,

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -27,6 +27,7 @@
 		public const string SearchBar = "SearchBar";
 		public const string Shell = "Shell";
 		public const string TabbedPage = "TabbedPage";
+		public const string Toolbar = "Toolbar";
 		public const string TemplatedView = "TemplatedView";
 		public const string VisualElement = "VisualElement";
 		public const string VisualElementTree = "VisualElementTree";

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Android.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Android.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Handlers
 		private protected override void OnDisconnectHandler(object platformView)
 		{
 			base.OnDisconnectHandler(platformView);
-			if (platformView is MaterialToolbar mt)
+			if (platformView is MaterialToolbar mt && mt.IsAlive())
 				mt.RemoveFromParent();
 		}
 

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -95,13 +95,11 @@ namespace Microsoft.Maui.Handlers
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(handler.MauiContext)} null");
 
-			PlatformView? mauiToolbar = null;
 			if (toolbarElement.Toolbar != null)
 			{
-				mauiToolbar = toolbarElement.Toolbar.ToPlatform(handler.MauiContext);
+				var toolBar = toolbarElement.Toolbar.ToPlatform(handler.MauiContext);
+				handler.MauiContext.GetNavigationRootManager().SetToolbar(toolBar);
 			}
-
-			handler.MauiContext.GetNavigationRootManager().SetToolbar(mauiToolbar);
 		}
 
 		public static void MapContextFlyout(IViewHandler handler, IView view)

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -95,11 +95,13 @@ namespace Microsoft.Maui.Handlers
 		{
 			_ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(handler.MauiContext)} null");
 
+			PlatformView? mauiToolbar = null;
 			if (toolbarElement.Toolbar != null)
 			{
-				var toolBar = toolbarElement.Toolbar.ToPlatform(handler.MauiContext);
-				handler.MauiContext.GetNavigationRootManager().SetToolbar(toolBar);
+				mauiToolbar = toolbarElement.Toolbar.ToPlatform(handler.MauiContext);
 			}
+
+			handler.MauiContext.GetNavigationRootManager().SetToolbar(mauiToolbar);
 		}
 
 		public static void MapContextFlyout(IViewHandler handler, IView view)

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -3,15 +3,10 @@ using System.Collections.Generic;
 using Android.Content;
 using Android.OS;
 using Android.Views;
-using AndroidX.AppCompat.View;
-using AndroidX.AppCompat.Widget;
-using AndroidX.CoordinatorLayout.Widget;
-using AndroidX.DrawerLayout.Widget;
+using AndroidX.Fragment.App;
 using AndroidX.Navigation;
 using AndroidX.Navigation.Fragment;
 using AndroidX.Navigation.UI;
-using Google.Android.Material.AppBar;
-using Kotlin.Collections;
 using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
 using AView = Android.Views.View;
 
@@ -298,8 +293,7 @@ namespace Microsoft.Maui.Platform
 				if (_navHost?.NavController != null && _navHost.NavController.IsAlive())
 					_navHost.NavController.RemoveOnDestinationChangedListener(_fragmentLifecycleCallbacks);
 
-				if (_navHost?.ChildFragmentManager != null && _navHost.ChildFragmentManager.IsAlive())
-					_navHost.ChildFragmentManager.UnregisterFragmentLifecycleCallbacks(_fragmentLifecycleCallbacks);
+				ChildFragmentManager?.UnregisterFragmentLifecycleCallbacks(_fragmentLifecycleCallbacks);
 
 				_fragmentLifecycleCallbacks.Disconnect();
 				_fragmentLifecycleCallbacks = null;
@@ -352,7 +346,7 @@ namespace Microsoft.Maui.Platform
 			{
 				_fragmentLifecycleCallbacks = new Callbacks(this);
 				NavHost.NavController.AddOnDestinationChangedListener(_fragmentLifecycleCallbacks);
-				NavHost.ChildFragmentManager.RegisterFragmentLifecycleCallbacks(_fragmentLifecycleCallbacks, false);
+				ChildFragmentManager?.RegisterFragmentLifecycleCallbacks(_fragmentLifecycleCallbacks, false);
 			}
 
 			ApplyNavigationRequest(e);
@@ -388,6 +382,23 @@ namespace Microsoft.Maui.Platform
 
 		protected virtual void OnDestinationChanged(NavController navController, NavDestination navDestination, Bundle? bundle)
 		{
+		}
+
+		FragmentManager? ChildFragmentManager
+		{
+			get
+			{
+				// If you try to access `ChildFragmentManager` and the `NavHost`
+				// isn't attached to a context then android will throw an IllegalStateException
+				if (_navHost.IsAlive() &&
+					_navHost?.Context != null &&
+					_navHost.ChildFragmentManager.IsAlive())
+				{
+					return _navHost.ChildFragmentManager;
+				}
+
+				return null;
+			}
 		}
 
 		internal class StackLayoutInflater : LayoutInflater

--- a/src/Core/src/Platform/Windows/NavigationRootManager.cs
+++ b/src/Core/src/Platform/Windows/NavigationRootManager.cs
@@ -59,6 +59,9 @@ namespace Microsoft.Maui.Platform
 		{
 			if (_rootView.Content != null)
 			{
+				// Clear out the toolbar that was set from the previous content
+				SetToolbar(null);
+
 				// We need to make sure to clear out the root view content 
 				// before creating the new view.
 				// Otherwise the new view might try to act on the old content.
@@ -99,6 +102,7 @@ namespace Microsoft.Maui.Platform
 		public virtual void Disconnect()
 		{
 			_platformWindow.Activated -= OnWindowActivated;
+			SetToolbar(null);
 			_rootView.Content = null;
 			_disconnected = true;
 		}


### PR DESCRIPTION
### Description of Change

After reviewing `XF` behavior it looks like it makes sense to rollback this [PR](https://github.com/dotnet/maui/pull/8542). AFAICT Android is the only platform that ties `Disappearing/Appearing` to the app being backgrounded. On XF if you were to make the root page just a `ContentPage` than it wouldn't fire `Disappearing/Appearing` when you backgrounded the app.  It would only do so if you were using a page type that used a fragment to render the child page.  

The thing to keep in mind with `Appearing` is that the majority of people currently use it for an initial data load and if it's navigated to and away from within the context of the app. That's how most of `XF` worked. The only scenario in `XF` that didn't work like this is on `Android` if your page was a child of another page. Meaning that 1/4th of Android in `XF` worked the same as WinUI/iOS. 

- This makes the `WinUI` behavior match `Catalyst` and XF. AFAICT Catalyst currently doesn't fire any of our lifecycles events if you change focus to a different application. The only path that executes is if you minimize the app and then click on a different app then it calls `ResignActivation`. 
- This breaks parts of how `XF` worked with Android but it makes it consistent with all other platforms and it makes android consistent regardless if it's nested inside other pages or not.
- This makes `iOS` consistent with XF
- Disappearing now fires from destroyed (which now matches XF)
- WinUI still doesn't fire `Disappearing` when minimized. This is consistent with XF. 

Previously the toolbar depended on the disappearing/appearing behavior to recreate itself as well so that code had to be modified which led to a little bit of a rabbit hole
- Fixed an issue where recreating the TabbedPage would fail on Android
- fixed various permutations on WinUI where the toolbar wasn't unsetting correctly
- added a bunch more tests

### Issues Fixed

Fixes #9473
Fixes #10566
