### PR TITLE
Change storyboard color space

### DIFF
--- a/src/SingleProject/Resizetizer/src/Resources/MauiSplash.storyboard
+++ b/src/SingleProject/Resizetizer/src/Resources/MauiSplash.storyboard
@@ -24,7 +24,7 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="{color.red}" green="{color.green}" blue="{color.blue}" alpha="{color.alpha}" colorSpace="custom" customColorSpace="displayP3"/>
+                        <color key="backgroundColor" red="{color.red}" green="{color.green}" blue="{color.blue}" alpha="{color.alpha}" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
### Description of Change

Changed the color space to sRGB on the default storyboard to get the color of the view to match the color of the image when the image is transparent and resizetizer applies a background color. 

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/41873/194635249-90302ad3-a56c-4fba-a0b4-48ab30af5654.png">

https://developer.apple.com/documentation/coregraphics/cgcolorspacemodel?language=objc

**Before:**

![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 13 19 59](https://user-images.githubusercontent.com/41873/194629341-fb43883b-68d0-4812-bead-b24c5cf9d7aa.png)

**After:**

![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 13 43 02](https://user-images.githubusercontent.com/41873/194629556-540c05e9-f2e0-4fd4-b9c7-30b924a9c7a1.png)




### Issues Fixed

Fixes #9405 


