### PR TITLE
iOS15 WindowStateManager Window Support

### DIFF
--- a/src/Essentials/src/Platform/WindowStateManager.ios.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.ios.cs
@@ -59,17 +59,14 @@ namespace Microsoft.Maui.ApplicationModel
 			if (viewController != null)
 				return viewController;
 
-#pragma warning disable CA1416 // TODO: 'UIApplication.KeyWindow' is unsupported on: 'ios' 13.0 and later.
-			var window = UIApplication.SharedApplication.KeyWindow;
+			var window = GetKeyWindow();
 
 			if (window != null && window.WindowLevel == UIWindowLevel.Normal)
 				viewController = window.RootViewController;
 
 			if (viewController == null)
 			{
-				// This call site is reachable on: 'iOS' 10.0 and later. 'UIApplication.Windows.get' is unsupported on: 'ios' 15.0 and later.
-				window = UIApplication.SharedApplication
-					.Windows
+				window = GetWindows()?
 					.OrderByDescending(w => w.WindowLevel)
 					.FirstOrDefault(w => w.RootViewController != null && w.WindowLevel == UIWindowLevel.Normal);
 
@@ -84,23 +81,43 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public UIWindow? GetCurrentUIWindow()
 		{
-			// This call site is reachable on: 'iOS' 10.0 and later.0 'UIApplication.KeyWindow.get' is unsupported on: 'ios' 13.0 and later.
-			var window = UIApplication.SharedApplication.KeyWindow;
+			var window = GetKeyWindow();
 
 			if (window != null && window.WindowLevel == UIWindowLevel.Normal)
 				return window;
 
 			if (window == null)
 			{
-				// This call site is reachable on: 'iOS' 10.0 and later. 'UIApplication.Windows.get' is unsupported on: 'ios' 15.0 and later.
-				window = UIApplication.SharedApplication
-					.Windows
+				window = GetWindows()?
 					.OrderByDescending(w => w.WindowLevel)
 					.FirstOrDefault(w => w.RootViewController != null && w.WindowLevel == UIWindowLevel.Normal);
 			}
-#pragma warning restore CA1416
 
 			return window;
+		}
+
+		UIWindow? GetKeyWindow()
+		{
+			if(OperatingSystem.IsIOSVersionAtLeast(13))
+			{
+				var scenes = UIApplication.SharedApplication.ConnectedScenes;
+				var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
+				return windowScene?.Windows.First();
+			}
+
+			return UIApplication.SharedApplication.KeyWindow;
+		}
+
+		UIWindow[]? GetWindows()
+		{
+			if (OperatingSystem.IsIOSVersionAtLeast(15))
+			{
+				var scenes = UIApplication.SharedApplication.ConnectedScenes;
+				var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
+				return windowScene?.Windows;
+			}
+
+			return UIApplication.SharedApplication.Windows;
 		}
 	}
 }

--- a/src/Essentials/src/Platform/WindowStateManager.ios.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.ios.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Maui.ApplicationModel
 			{
 				var scenes = UIApplication.SharedApplication.ConnectedScenes;
 				var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
-				return windowScene?.Windows.First();
+				return windowScene?.Windows.FirstOrDefault();
 			}
 
 			return UIApplication.SharedApplication.KeyWindow;

--- a/src/Essentials/src/Platform/WindowStateManager.ios.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.ios.cs
@@ -96,27 +96,31 @@ namespace Microsoft.Maui.ApplicationModel
 			return window;
 		}
 
-		UIWindow? GetKeyWindow()
+		static UIWindow? GetKeyWindow()
 		{
-			if(OperatingSystem.IsIOSVersionAtLeast(13))
+			// if we have scene support, use that
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
 			{
 				var scenes = UIApplication.SharedApplication.ConnectedScenes;
 				var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
 				return windowScene?.Windows.FirstOrDefault();
 			}
 
+			// use the windows property (up to 13.0)
 			return UIApplication.SharedApplication.KeyWindow;
 		}
 
-		UIWindow[]? GetWindows()
+		static UIWindow[]? GetWindows()
 		{
-			if (OperatingSystem.IsIOSVersionAtLeast(15))
+			// if we have scene support, use that
+			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
 			{
 				var scenes = UIApplication.SharedApplication.ConnectedScenes;
 				var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
 				return windowScene?.Windows;
 			}
 
+			// use the windows property (up to 15.0)
 			return UIApplication.SharedApplication.Windows;
 		}
 	}

--- a/src/Essentials/test/DeviceTests/Tests/WindowStateManager_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/WindowStateManager_Tests.cs
@@ -25,9 +25,8 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		[Trait(Traits.InteractionType, Traits.InteractionTypes.Machine)]
 		public void GetCurrentUIViewController()
 		{
-			var windows = WindowStateManager.Default.GetCurrentUIViewController();
-			Assert.NotNull(windows);
-			Assert.NotEmpty(windows);
+			var viewController = WindowStateManager.Default.GetCurrentUIViewController();
+			Assert.NotNull(viewController);
 		}
 #endif
 	}

--- a/src/Essentials/test/DeviceTests/Tests/WindowStateManager_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/WindowStateManager_Tests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Authentication;
+using Xunit;
+
+namespace Microsoft.Maui.Essentials.DeviceTests
+{
+	[Category("WindowStateManager")]
+	public class WindowStateManager_Tests
+	{
+#if __IOS__
+		[Fact]
+		[Trait(Traits.InteractionType, Traits.InteractionTypes.Machine)]
+		public void GetCurrentUIWindow()
+		{
+			var window = WindowStateManager.Default.GetCurrentUIWindow();
+			Assert.NotNull(window);
+		}
+
+		[Fact]
+		[Trait(Traits.InteractionType, Traits.InteractionTypes.Machine)]
+		public void GetCurrentUIViewController()
+		{
+			var windows = WindowStateManager.Default.GetCurrentUIViewController();
+			Assert.NotNull(windows);
+			Assert.NotEmpty(windows);
+		}
+#endif
+	}
+}


### PR DESCRIPTION
### Description of Change
Fix warnings for iOS13/15 for `KeyWindow` and `Windows` on `UIApplication.SharedApplication`.  These are deprecated and cause unexpected behavior in parts of Essentials such as `WebAuthenticator` (where it was discovered).

After applying this change and building locally, my app works on the iOS 15.5 simulator.

### Issues Fixed
`WebAuthenticator` doesn't work in iOS15 because no `UIWindow` get's returned for the `PresentationContextProvider`.  This implements a new way to get the `KeyWindow` and `Windows`.

Fixes #10534 