### PR TITLE
Make Grid spacing consistent when rows/columns are collapsed

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -302,14 +302,7 @@ namespace Microsoft.Maui.Layouts
 
 				for (int n = 0; n < definitions.Length; n++)
 				{
-					var current = definitions[n].Size;
-
-					if (current <= 0 && !definitions[n].IsStar)
-					{
-						continue;
-					}
-
-					sum += current;
+					sum += definitions[n].Size;
 
 					if (n > 0)
 					{

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		}
 
 		[Category(GridSpacing, GridAutoSizing)]
-		[Fact(DisplayName = "Empty rows should not incur additional row spacing")]
+		[Fact(DisplayName = "Empty rows should still count for row spacing")]
 		public void RowSpacingForEmptyRows()
 		{
 			var grid = CreateGridLayout(rows: "100, auto, 100", rowSpacing: 10);
@@ -382,16 +382,14 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0);
 			SetLocation(grid, view2, row: 2);
 
-			var manager = new GridLayoutManager(grid);
-			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
-
-			// Because the auto row has no content, we expect it to have height zero
-			// and we expect that it won't add more row spacing 
-			Assert.Equal(100 + 100 + 10, measure.Height);
+			var measure = MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
+			
+			Assert.Equal(100 + 100 + 10 + 10, measure.Height);
+			AssertArranged(view2, new Rect(0, 100 + 10 + 10, 100, 100));
 		}
 
 		[Category(GridSpacing, GridAutoSizing)]
-		[Fact(DisplayName = "Auto rows with collapsed views should not incur additional row spacing")]
+		[Fact(DisplayName = "Auto rows with collapsed views should still count for row spacing")]
 		public void RowSpacingForAutoRowsWithCollapsedViews()
 		{
 			var grid = CreateGridLayout(rows: "100, auto, 100", rowSpacing: 10);
@@ -406,12 +404,10 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			view1.Visibility.Returns(Visibility.Collapsed);
 
-			var manager = new GridLayoutManager(grid);
-			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			var measure = MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
 
-			// Because the auto row has no content, we expect it to have height zero
-			// and we expect that it won't add more row spacing 
-			Assert.Equal(100 + 100 + 10, measure.Height);
+			Assert.Equal(100 + 100 + 10 + 10, measure.Height);
+			AssertArranged(view2, new Rect(0, 100 + 10 + 10, 100, 100));
 		}
 
 		[Category(GridSpacing)]
@@ -445,6 +441,7 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			AssertArranged(view1, 110, 0, 100, 100);
 		}
 
+		[Category(GridSpacing)]
 		[Fact(DisplayName = "Measure should include column spacing")]
 		public void MeasureTwoColumnsWithSpacing()
 		{
@@ -485,10 +482,10 @@ namespace Microsoft.Maui.UnitTests.Layouts
 		}
 
 		[Category(GridSpacing, GridAutoSizing)]
-		[Fact(DisplayName = "Empty columns should not incur additional column spacing")]
+		[Fact(DisplayName = "Empty columns still count for column spacing")]
 		public void ColumnSpacingForEmptyColumns()
 		{
-			var grid = CreateGridLayout(columns: "100, auto, 100", colSpacing: 10);
+			var grid = CreateGridLayout(columns: "auto, auto, auto", colSpacing: 10);
 			var view0 = CreateTestView(new Size(100, 100));
 			var view2 = CreateTestView(new Size(100, 100));
 
@@ -496,16 +493,14 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			SetLocation(grid, view0);
 			SetLocation(grid, view2, col: 2);
 
-			var manager = new GridLayoutManager(grid);
-			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			var measure = MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
 
-			// Because the auto column has no content, we expect it to have width zero
-			// and we expect that it won't add more column spacing 
-			Assert.Equal(100 + 100 + 10, measure.Width);
+			Assert.Equal(100 + 100 + 10 + 10, measure.Width);
+			AssertArranged(view2, new Rect(100 + 10 + 10, 0, 100, 100));
 		}
 
 		[Category(GridSpacing, GridAutoSizing)]
-		[Fact(DisplayName = "Auto columns with collapsed views should not incur additional column spacing")]
+		[Fact(DisplayName = "Auto columns with collapsed views should still count for column spacing")]
 		public void AutoColumnsWithCollapsedViews()
 		{
 			var grid = CreateGridLayout(columns: "100, auto, 100", colSpacing: 10);
@@ -520,12 +515,10 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			view1.Visibility.Returns(Visibility.Collapsed);
 
-			var manager = new GridLayoutManager(grid);
-			var measure = manager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+			var measure = MeasureAndArrange(grid, double.PositiveInfinity, double.PositiveInfinity);
 
-			// Because the auto column has no content, we expect it to have width zero
-			// and we expect that it won't add more column spacing 
-			Assert.Equal(100 + 100 + 10, measure.Width);
+			Assert.Equal(100 + 100 + 10 + 10, measure.Width);
+			AssertArranged(view2, new Rect(100 + 10 + 10, 0, 100, 100));
 		}
 
 		[Category(GridSpan)]


### PR DESCRIPTION
### Description of Change

The rules for row/column spacing layout in Grids are slightly inconsistent and the tests are making incorrect assumptions. These changes make everything consistent (and consistent with other Grid systems).

### Issues Fixed

Fixes #10528

![image](https://user-images.githubusercontent.com/538025/194651160-7f13ce02-c0c9-42a5-a3cb-921b4d6c6cb3.png)

