### PR TITLE
Validate authenticity of compatibility renderer

### DIFF
--- a/src/Compatibility/Core/src/MauiHandlersCollectionExtensions.cs
+++ b/src/Compatibility/Core/src/MauiHandlersCollectionExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 		public static IMauiHandlersCollection AddCompatibilityRenderer<TControlType, TRenderer>(this IMauiHandlersCollection handlersCollection)
 			where TControlType : IView
 		{
-			//Internals.Registrar.CheckIfRendererIsCompatibilityRenderer(typeof(TRenderer));
+			Internals.Registrar.CheckIfRendererIsCompatibilityRenderer(typeof(TRenderer));
 			Hosting.MauiAppBuilderExtensions.CheckForCompatibility();
 			handlersCollection.AddCompatibilityRenderer<TControlType, TControlType, TRenderer>();
 

--- a/src/Compatibility/Core/src/MauiHandlersCollectionExtensions.cs
+++ b/src/Compatibility/Core/src/MauiHandlersCollectionExtensions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 	{
 		public static IMauiHandlersCollection TryAddCompatibilityRenderer(this IMauiHandlersCollection handlersCollection, Type controlType, Type rendererType)
 		{
+			Internals.Registrar.CheckIfRendererIsCompatibilityRenderer(rendererType);
 			Hosting.MauiAppBuilderExtensions.CheckForCompatibility();
 			Internals.Registrar.Registered.Register(controlType, rendererType);
 
@@ -22,6 +23,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 
 		public static IMauiHandlersCollection AddCompatibilityRenderer(this IMauiHandlersCollection handlersCollection, Type controlType, Type rendererType)
 		{
+			Internals.Registrar.CheckIfRendererIsCompatibilityRenderer(rendererType);
 			Hosting.MauiAppBuilderExtensions.CheckForCompatibility();
 			Internals.Registrar.Registered.Register(controlType, rendererType);
 
@@ -37,6 +39,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 		public static IMauiHandlersCollection AddCompatibilityRenderer<TControlType, TMauiType, TRenderer>(this IMauiHandlersCollection handlersCollection)
 			where TMauiType : IView
 		{
+			Internals.Registrar.CheckIfRendererIsCompatibilityRenderer(typeof(TRenderer));
 			Hosting.MauiAppBuilderExtensions.CheckForCompatibility();
 			Internals.Registrar.Registered.Register(typeof(TControlType), typeof(TRenderer));
 
@@ -51,6 +54,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Hosting
 		public static IMauiHandlersCollection AddCompatibilityRenderer<TControlType, TRenderer>(this IMauiHandlersCollection handlersCollection)
 			where TControlType : IView
 		{
+			//Internals.Registrar.CheckIfRendererIsCompatibilityRenderer(typeof(TRenderer));
 			Hosting.MauiAppBuilderExtensions.CheckForCompatibility();
 			handlersCollection.AddCompatibilityRenderer<TControlType, TControlType, TRenderer>();
 

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Maui.Controls.Internals
 			if (handlerType == null)
 				return null;
 
+			Registrar.CheckIfRendererIsCompatibilityRenderer(handlerType);
+
 			object handler = DependencyResolver.ResolveOrCreate(handlerType);
 
 			return (TRegistrable)handler;
@@ -102,6 +104,8 @@ namespace Microsoft.Maui.Controls.Internals
 			else
 			{
 				Type handlerType = GetHandlerType(type, visual?.GetType() ?? _defaultVisualType);
+				Registrar.CheckIfRendererIsCompatibilityRenderer(handlerType);
+
 				if (handlerType != null)
 					returnValue = (TRegistrable)DependencyResolver.ResolveOrCreate(handlerType, source, visual?.GetType(), args);
 			}
@@ -480,6 +484,17 @@ namespace Microsoft.Maui.Controls.Internals
 			DependencyService.Initialize(assemblies);
 
 			Profile.FrameEnd();
+		}
+
+		internal static void CheckIfRendererIsCompatibilityRenderer(Type rendererType)
+		{
+			if (typeof(IRegisterable).IsAssignableFrom(rendererType))
+				return;
+
+			if (typeof(IElementHandler).IsAssignableFrom(rendererType))
+			{
+				throw new Exception($"{rendererType} will work with AddHandler. Please use AddHandler instead of AddCompatibilityRenderer.");
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Registrar.cs
+++ b/src/Controls/src/Core/Registrar.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Maui.Controls.Internals
 
 			if (typeof(IElementHandler).IsAssignableFrom(rendererType))
 			{
-				throw new Exception($"{rendererType} will work with AddHandler. Please use AddHandler instead of AddCompatibilityRenderer.");
+				throw new InvalidOperationException($"{rendererType} will work with AddHandler. Please use AddHandler instead of AddCompatibilityRenderer.");
 			}
 		}
 	}

--- a/src/Controls/tests/Core.UnitTests/HostBuilderAppTests.cs
+++ b/src/Controls/tests/Core.UnitTests/HostBuilderAppTests.cs
@@ -165,6 +165,28 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.True(handlersCalled);
 		}
 
+		[Fact]
+		public void RegisteringHandlerWithAddCompatibilityRendererThrowsException()
+		{
+			MauiAppBuilderExtensions.ResetCompatibilityCheck();
+			bool handlersCalled = false;
+			var builder = MauiApp.CreateBuilder().UseMauiApp<ApplicationStub>();
+
+			var mauiApp =
+				builder.ConfigureMauiHandlers(collection =>
+				{
+					handlersCalled = true;
+
+					Assert.Throws<InvalidOperationException>(() =>
+							collection.AddCompatibilityRenderer(typeof(ButtonHandlerStub), typeof(Object))
+						);
+				})
+				.Build();
+
+			_ = mauiApp.Services.GetRequiredService<IMauiHandlersFactory>();
+			Assert.True(handlersCalled);
+		}
+
 		public class TrackingConfigurationSource : IConfigurationSource
 		{
 			public int ProvidersBuilt { get; set; }


### PR DESCRIPTION
### Description of Change

Currently we have two path ways for compatibility that users can take
1) Compatibility Handlers
2) Compatibility Renderers

This PR will throw an exception to help guide the user to a better place. 

#### Compatibility Renderers
These use the entire legacy structure of renderers so they have to be registered through the shim system

#### Compatibility Handlers
These are base classes that are API equivalent to renderers but they work via `IViewHandler`. 

#### Points of confusion

`Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers.VisualElementRenderer` is a compatibility renderer
where as
`Microsoft.Maui.Controls.Handlers.Compatibility.VisualElementRenderer` is a compatibility handler

The theory behind the Compatibility Handlers will be a way to completely remove the shim layer and provide a set of handlers that are API equivalent to XF Renderers but are able to work with the new Handler system. This makes it a lot easier to make things work with MAUI while providing an easier migration path.  We haven't fully realized this idea yet as we need to still weigh the best approach based on user feedback. Currently we are using the compatibility handlers successfully to bring over `ListView`, `TableView`, `Frame`, and `Shell (ios/android)`. They should also provide an easy way for anyone to migrate a renderer based on `VisualElementRenderer`.

It might have been better to just call them `VisualElementHandler`'s or `VisualElementRendererHandler` but the perfect world goal would be to just completely remove the compatibility dll and then it becomes a non issue. Since that's not the world we've arrived to yet we instead have confusion and this PR.

### Issues Fixed
Fixes #10537

