### PR TITLE
[Core] Changes disposing items in CollectionView

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewGallery.cs
@@ -50,6 +50,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 						GalleryBuilder.NavButton("Alternate Layout Galleries", () => new AlternateLayoutGallery(), Navigation),
 						GalleryBuilder.NavButton("Header/Footer Galleries", () => new HeaderFooterGallery(), Navigation),
 						GalleryBuilder.NavButton("Nested CollectionViews", () => new NestedGalleries.NestedCollectionViewGallery(), Navigation),
+						GalleryBuilder.NavButton("CollectionView Memory Benchmark", () => new CollectionViewMemoryBenchmark(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewMemoryBenchmark.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewMemoryBenchmark.xaml
@@ -1,0 +1,136 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Maui.Controls.Sample.Pages.CollectionViewGalleries.CollectionViewMemoryBenchmark"
+    xmlns:local="clr-namespace:Maui.Controls.Sample.Pages.CollectionViewGalleries"
+    Title="CollectionView Memory Benchmark">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            
+            <Color x:Key="Gray300">#ACACAC</Color>
+            <SolidColorBrush x:Key="Gray300Brush" Color="{StaticResource Gray300}"/>
+            
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <Grid
+            ColumnDefinitions="*,*,*"
+            ColumnSpacing="5"
+            RowDefinitions="40,60,20,20,*"
+            RowSpacing="5">
+
+            <Button
+                Grid.Column="0"
+                Clicked="Button_Clicked_1"
+                Text="Test 1" />
+            <Button
+                Grid.Column="1"
+                Clicked="Button_Clicked_2"
+                Text="Test 2" />
+            <Button
+                Grid.Column="2"
+                Clicked="Button_Clicked_3"
+                Text="Test 3" />
+
+            <Label
+                Grid.Row="1"
+                Grid.Column="0"
+                FontSize="Caption"
+                HorizontalTextAlignment="Center"
+                Text="BackgroundColor=&quot;{StaticResource Gray300}&quot;" />
+
+            <Label
+                Grid.Row="1"
+                Grid.Column="1"
+                FontSize="Caption"
+                HorizontalTextAlignment="Center"
+                Text="Background=&quot;{StaticResource Gray300}&quot;" />
+
+            <Label
+                Grid.Row="1"
+                Grid.Column="2"
+                FontSize="Caption"
+                HorizontalTextAlignment="Center"
+                Text="Background=&quot;{StaticResource Gray300Brush}&quot;" />
+
+            <Label
+                x:Name="LabelMemory"
+                Grid.Row="2"
+                Grid.ColumnSpan="3"
+                HorizontalTextAlignment="Center"
+                Text="Memory" />
+
+            <Label
+                x:Name="LabelAlive"
+                Grid.Row="3"
+                Grid.ColumnSpan="3"
+                HorizontalTextAlignment="Center"
+                Text="Objects alive" />
+
+            <CollectionView
+                x:Name="CollectionView1"
+                Grid.Row="4"
+                Grid.Column="0">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="local:DataModel">
+                        <VerticalStackLayout
+                            local:References.IsWatched="True"
+                            BackgroundColor="{StaticResource Gray300}">
+                            <Button Text="{Binding ID}" />
+                            <Label
+                                Margin="10"
+                                Text="{Binding Name}" />
+                            <Label
+                                Margin="10"
+                                Text="{Binding Data1}" />
+                        </VerticalStackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <CollectionView
+                x:Name="CollectionView2"
+                Grid.Row="4"
+                Grid.Column="1">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="local:DataModel">
+                        <VerticalStackLayout
+                            local:References.IsWatched="True"
+                            Background="{StaticResource Gray300}">
+                            <Button Text="{Binding ID}" />
+                            <Label
+                                Margin="10"
+                                Text="{Binding Name}" />
+                            <Label
+                                Margin="10"
+                                Text="{Binding Data1}" />
+                        </VerticalStackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <CollectionView
+                x:Name="CollectionView3"
+                Grid.Row="4"
+                Grid.Column="2">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="local:DataModel">
+                        <VerticalStackLayout
+                            local:References.IsWatched="True"
+                            Background="{StaticResource Gray300Brush}">
+                            <Button Text="{Binding ID}" />
+                            <Label
+                                Margin="10"
+                                Text="{Binding Name}" />
+                            <Label
+                                Margin="10"
+                                Text="{Binding Data1}" />
+                        </VerticalStackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewMemoryBenchmark.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewMemoryBenchmark.xaml.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
+{
+	public partial class CollectionViewMemoryBenchmark : ContentPage
+	{
+		int _id;
+
+		public CollectionViewMemoryBenchmark()
+		{
+			InitializeComponent();
+		}
+
+		async void Button_Clicked_1(object sender, EventArgs e)
+		{
+			CollectionView1.ItemsSource = GetNewData();
+			await UpdateMemoryAsync(1);
+		}
+
+		async void Button_Clicked_2(object sender, EventArgs e)
+		{
+			CollectionView2.ItemsSource = GetNewData();
+			await UpdateMemoryAsync(2);
+		}
+
+		async void Button_Clicked_3(object sender, EventArgs e)
+		{
+			CollectionView3.ItemsSource = GetNewData();
+			await UpdateMemoryAsync(3);
+		}
+
+		List<DataModel> GetNewData()
+		{
+			List<DataModel> data = new();
+
+			for (int i = 0; i < 5; i++)
+			{
+				_id += 1;
+				data.Add(new DataModel() { ID = _id, Name = $"Name{_id}", Data1 = "data1", Data2 = "data2", Data3 = "data3" });
+			}
+
+			return data;
+		}
+
+		async Task UpdateMemoryAsync(int testid)
+		{
+			await Task.Delay(500);
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			LabelMemory.Text = $"Memory {GC.GetTotalMemory(true):N0} after test {testid}";
+			LabelAlive.Text = $"Objects alive {References.GetAliveCount()}";
+
+			References.Print();
+		}
+	}
+
+	public class DataModel
+	{
+		public int ID { get; set; }
+		public string Name { get; set; }
+		public string Data1 { get; set; }
+		public string Data2 { get; set; }
+		public string Data3 { get; set; }
+	}
+
+	public static class References
+	{
+		static readonly List<WeakReference> Refs = new();
+
+		public static readonly BindableProperty IsWatchedProperty =
+			BindableProperty.CreateAttached("IsWatched", typeof(bool), typeof(References), false, propertyChanged: OnIsWatchedChanged);
+
+		public static bool GetIsWatched(BindableObject obj)
+		{
+			return (bool)obj.GetValue(IsWatchedProperty);
+		}
+
+		public static void SetIsWatched(BindableObject obj, bool value)
+		{
+			obj.SetValue(IsWatchedProperty, value);
+		}
+
+		static void OnIsWatchedChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			AddRef(bindable);
+		}
+
+		public static void AddRef(object p)
+		{
+			Refs.Add(new WeakReference(p));
+		}
+
+		public static void Print()
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			Refs.RemoveAll(a => !a.IsAlive);
+			foreach (WeakReference weakReference in Refs)
+				Debug.WriteLine("IsAlive: " + weakReference.Target?.GetType().Name);
+
+			Debug.WriteLine($"Total Refs still alive: {Refs.Count}");
+			Debug.WriteLine("---------------");
+		}
+
+		public static int GetAliveCount()
+		{
+			return Refs.Count(weakReference => weakReference.IsAlive);
+		}
+	}
+}

--- a/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs
+++ b/src/Controls/src/Core/Handlers/Items/Android/Adapters/ItemsViewAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Android.Content;
 using Android.Widget;
 using AndroidX.RecyclerView.Widget;
@@ -13,6 +14,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		where TItemsViewSource : IItemsViewSource
 	{
 		protected readonly TItemsView ItemsView;
+		readonly List<ItemContentView> ContentViews;
 		readonly Func<View, Context, ItemContentView> _createItemContentView;
 		protected internal TItemsViewSource ItemsSource;
 
@@ -22,6 +24,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 		protected internal ItemsViewAdapter(TItemsView itemsView, Func<View, Context, ItemContentView> createItemContentView = null)
 		{
 			ItemsView = itemsView ?? throw new ArgumentNullException(nameof(itemsView));
+			ContentViews = new List<ItemContentView>();
 
 			UpdateUsingItemTemplate();
 
@@ -85,6 +88,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			}
 
 			var itemContentView = _createItemContentView.Invoke(ItemsView, context);
+			ContentViews.Add(itemContentView);
 
 			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate, IsSelectionEnabled(parent, viewType));
 		}
@@ -108,6 +112,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				if (disposing)
 				{
+					foreach (var contentView in ContentViews)
+					{
+						contentView.Recycle();
+					}
+					ContentViews.Clear();
+
 					ItemsSource?.Dispose();
 					ItemsView.PropertyChanged -= ItemsViewPropertyChanged;
 				}

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -123,6 +123,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				CollectionViewSource = null;
 			}
 
+			var itemContentControls = ListViewBase.GetChildren<ItemContentControl>();
+
+			foreach (ItemContentControl itemContentControl in itemContentControls)
+			{
+				itemContentControl.Dispose();
+			}
+
 			if (VirtualView?.ItemsSource == null)
 			{
 				ListViewBase.ItemsSource = null;

--- a/src/Controls/src/Core/Items/ItemsView.cs
+++ b/src/Controls/src/Core/Items/ItemsView.cs
@@ -139,6 +139,32 @@ namespace Microsoft.Maui.Controls
 			_logicalChildren.Remove(element);
 			OnChildRemoved(element, oldLogicalIndex);
 			VisualDiagnostics.OnChildRemoved(this, element, oldLogicalIndex);
+			DisconnectLogicalChild(element);
+		}
+
+
+		void DisconnectLogicalChild(Element element)
+		{
+#if ANDROID || IOS || MACCATALYST || WINDOWS
+			if (element.Handler is IPlatformViewHandler platformHandler)
+			{
+				foreach (Element child in element.Descendants())
+				{
+					if (child is VisualElement ve)
+					{
+						ve.Handler?.DisconnectHandler();
+
+						if (ve.Handler is IDisposable veHandlerDisposable)
+							veHandlerDisposable.Dispose();
+					}
+				}
+
+				platformHandler.DisconnectHandler();
+
+				if (platformHandler is IDisposable platformHandlerDisposable)
+					platformHandlerDisposable.Dispose();
+			}
+#endif
 		}
 
 		internal override IReadOnlyList<Element> LogicalChildrenInternal => _logicalChildren.AsReadOnly();

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -9,7 +9,7 @@ using Microsoft.Maui.Controls.Platform;
 
 namespace Microsoft.Maui.Controls.Platform
 {
-	public class ItemContentControl : ContentControl
+	public class ItemContentControl : ContentControl, IDisposable
 	{
 		VisualElement _visualElement;
 		IViewHandler _renderer;
@@ -141,6 +141,24 @@ namespace Microsoft.Maui.Controls.Platform
 				_visualElement.PropertyChanged += OnViewPropertyChanged;
 				UpdateSemanticProperties(_visualElement);
 			}
+		}
+
+		public void Dispose()
+		{
+			if (FormsContainer is ItemsView itemsView && _renderer?.VirtualView is Element element)
+			{
+				itemsView.RemoveLogicalChild(element);
+				element = null;
+			}
+
+			FormsDataContext = null;
+			FormsDataTemplate = null;
+			FormsContainer = null;
+			DataContext = null;
+			MauiContext = null;
+
+			_renderer.DisconnectHandler();
+			_renderer = null;
 		}
 
 		internal void Realize()

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ Microsoft.Maui.Controls.MenuFlyout.MenuFlyout() -> void
 Microsoft.Maui.Controls.MenuFlyout.Count.get -> int
 Microsoft.Maui.Controls.MenuFlyout.IsReadOnly.get -> bool
 Microsoft.Maui.Controls.MenuFlyout.RemoveAt(int index) -> void
+Microsoft.Maui.Controls.Platform.ItemContentControl.Dispose() -> void
 Microsoft.Maui.Controls.Platform.ShellNavigationViewItem
 Microsoft.Maui.Controls.Platform.ShellNavigationViewItem.ShellNavigationViewItem() -> void
 Microsoft.Maui.Controls.Platform.ShellNavigationViewItemAutomationPeer

--- a/src/Core/src/Handlers/View/ViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Windows.cs
@@ -26,6 +26,9 @@ namespace Microsoft.Maui.Handlers
 
 			platformView.GotFocus -= OnPlatformViewGotFocus;
 			platformView.LostFocus -= OnPlatformViewLostFocus;
+
+			if (platformView is IDisposable disposable)
+				disposable.Dispose();
 		}
 
 		static partial void MappingFrame(IViewHandler handler, IView view)

--- a/src/Core/src/Platform/Android/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Android/LayoutViewGroup.cs
@@ -3,15 +3,13 @@ using Android.Content;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
-using Android.Widget;
-using Microsoft.Maui.Graphics;
 using ARect = Android.Graphics.Rect;
 using Rectangle = Microsoft.Maui.Graphics.Rect;
 using Size = Microsoft.Maui.Graphics.Size;
 
 namespace Microsoft.Maui.Platform
 {
-	public class LayoutViewGroup : ViewGroup
+	public class LayoutViewGroup : ViewGroup, IDisposable
 	{
 		readonly ARect _clipRect = new();
 		readonly Context _context;

--- a/src/Core/src/Platform/Windows/LayoutPanel.cs
+++ b/src/Core/src/Platform/Windows/LayoutPanel.cs
@@ -9,7 +9,7 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 
 namespace Microsoft.Maui.Platform
 {
-	public class LayoutPanel : Panel
+	public class LayoutPanel : Panel, IDisposable
 	{
 		Canvas? _backgroundLayer;
 
@@ -17,6 +17,11 @@ namespace Microsoft.Maui.Platform
 		internal Func<Rect, Size>? CrossPlatformArrange { get; set; }
 
 		public bool ClipsToBounds { get; set; }
+
+		public void Dispose()
+		{
+			Children.Clear();
+		}
 
 		// TODO: Possibly reconcile this code with ViewHandlerExtensions.MeasureVirtualView
 		// If you make changes here please review if those changes should also

--- a/src/Core/src/Platform/iOS/LayoutView.cs
+++ b/src/Core/src/Platform/iOS/LayoutView.cs
@@ -5,7 +5,7 @@ using UIKit;
 
 namespace Microsoft.Maui.Platform
 {
-	public class LayoutView : MauiView
+	public class LayoutView : MauiView, IDisposable
 	{
 		bool _userInteractionEnabled;
 

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -99,6 +99,7 @@ Microsoft.Maui.IMenuFlyoutSeparator
 Microsoft.Maui.IToolTipElement
 Microsoft.Maui.IToolTipElement.ToolTip.get -> Microsoft.Maui.ToolTip?
 Microsoft.Maui.IWindow.FrameChanged(Microsoft.Maui.Graphics.Rect frame) -> void
+Microsoft.Maui.Platform.LayoutPanel.Dispose() -> void
 Microsoft.Maui.ToolTip
 Microsoft.Maui.ToolTip.Content.get -> object?
 Microsoft.Maui.ToolTip.Content.set -> void


### PR DESCRIPTION
### Description of Change

Changes (disconnecting and disposing Handlers) disposing items in Windows CollectionView. 
Testing with a CollectionView having 1000 items scrolling up and down. This is the current behavior:

![cv-perf-01-1](https://user-images.githubusercontent.com/6755973/194909802-8cc6914c-3186-4acc-a98d-da00ed560ab4.png)
![cv-perf-01-2](https://user-images.githubusercontent.com/6755973/194909813-1b1d8a17-6bc3-418a-988f-43901b882ccd.png)

After the changes:
![cv-perf-02-1](https://user-images.githubusercontent.com/6755973/194910076-57ba4029-4434-4cdb-8639-0122314c5162.png)
![cv-perf-02-2](https://user-images.githubusercontent.com/6755973/194910091-4f498e27-91dc-4b63-b259-4125024a63fa.png)
The memory consumption and the references count is much lower with the changes.

Forcing a GC.Collect doing scroll:
![cv-perf-02-3](https://user-images.githubusercontent.com/6755973/194910754-96b56549-2e7a-413a-8f28-77aa9bc346f5.png)
We can see how memory is constantly collected and in this case the memory does not increase.

### Issues Fixed

Fixes #10560