### PR TITLE
[iOS] Fix crash disposing TabbedPage

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected Frame? Element
 		{
-			get { return _viewHandlerWrapper.Element; }
+			get { return _viewHandlerWrapper.Element ?? _element; }
 			set
 			{
 				if (value != null)

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected Frame? Element
 		{
-			get { return _viewHandlerWrapper.Element ?? _element; }
+			get { return _viewHandlerWrapper.Element ?? (_element as Frame); }
 			set
 			{
 				if (value != null)

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		GradientDrawable? _backgroundDrawable;
 		private IMauiContext? _mauiContext;
 		ViewHandlerDelegator<Frame> _viewHandlerWrapper;
+		VisualElement _element;
 		public event EventHandler<VisualElementChangedEventArgs>? ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs>? ElementPropertyChanged;
 
@@ -63,6 +64,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				if (value != null)
 					(this as IPlatformViewHandler).SetVirtualView(value);
+
+				_element = value;
 			}
 		}
 
@@ -337,8 +340,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void IElementHandler.SetMauiContext(IMauiContext mauiContext) =>
 			_mauiContext = mauiContext;
 
-		void IElementHandler.SetVirtualView(Maui.IElement view) =>
+		void IElementHandler.SetVirtualView(Maui.IElement view)
+		{
 			_viewHandlerWrapper.SetVirtualView(view, OnElementChanged, false);
+			_element = view as VisualElement;
+		}
 
 		void IElementHandler.UpdateValue(string property)
 		{

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void IElementHandler.SetVirtualView(Maui.IElement view)
 		{
 			_viewHandlerWrapper.SetVirtualView(view, OnElementChanged, false);
-			_element = view as VisualElement;
+			_element = view as Frame;
 		}
 
 		void IElementHandler.UpdateValue(string property)

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		GradientDrawable? _backgroundDrawable;
 		private IMauiContext? _mauiContext;
 		ViewHandlerDelegator<Frame> _viewHandlerWrapper;
-		VisualElement? _element;
+		Frame? _element;
 		public event EventHandler<VisualElementChangedEventArgs>? ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs>? ElementPropertyChanged;
 
@@ -59,7 +59,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		protected Frame? Element
 		{
-			get { return _viewHandlerWrapper.Element ?? (_element as Frame); }
+			get { return _viewHandlerWrapper.Element ?? _element; }
 			set
 			{
 				if (value != null)

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		GradientDrawable? _backgroundDrawable;
 		private IMauiContext? _mauiContext;
 		ViewHandlerDelegator<Frame> _viewHandlerWrapper;
-		VisualElement _element;
+		VisualElement? _element;
 		public event EventHandler<VisualElementChangedEventArgs>? ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs>? ElementPropertyChanged;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 	{
 		UIView _clickOffView;
 		UIViewController _detailController;
-
+		VisualElement _element;
 		bool _disposed;
 
 		UIViewController _flyoutController;
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		public VisualElement Element => _viewHandlerWrapper.Element;
+		public VisualElement Element => _viewHandlerWrapper.Element ?? _element;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -80,6 +80,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		public void SetElement(VisualElement element)
 		{
+
 			var flyoutPage = element as FlyoutPage;
 
 			_flyoutController = new ChildViewController();
@@ -88,6 +89,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			_clickOffView = new UIView();
 			_clickOffView.BackgroundColor = new Color(0, 0, 0, 0).ToPlatform();
 			_viewHandlerWrapper.SetVirtualView(element, OnElementChanged, false);
+			_element = element;
 			Presented = ((FlyoutPage)element).IsPresented;
 			Element.SizeChanged += PageOnSizeChanged;
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public static CommandMapper<NavigationPage, NavigationRenderer> CommandMapper = new CommandMapper<NavigationPage, NavigationRenderer>(ViewHandler.ViewCommandMapper);
 		ViewHandlerDelegator<NavigationPage> _viewHandlerWrapper;
 		bool _navigating = false;
+		VisualElement _element;
 
 		[Preserve(Conditional = true)]
 		public NavigationRenderer() : base(typeof(MauiControlsNavigationBar), null)
@@ -56,7 +57,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		NavigationPage NavPage => Element as NavigationPage;
 		INavigationPageController NavPageController => NavPage;
 
-		public VisualElement Element { get => _viewHandlerWrapper.Element; }
+		public VisualElement Element { get => _viewHandlerWrapper.Element ?? _element; }
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -74,6 +75,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public void SetElement(VisualElement element)
 		{
 			(this as IElementHandler).SetVirtualView(element);
+			_element = element;
 		}
 
 		public UIViewController ViewController
@@ -1556,6 +1558,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void IElementHandler.SetVirtualView(Maui.IElement view)
 		{
 			_viewHandlerWrapper.SetVirtualView(view, ElementChanged, false);
+			_element = view as VisualElement;
 
 			void ElementChanged(ElementChangedEventArgs<NavigationPage> e)
 			{

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -127,9 +127,14 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				_tabBarAppearance?.Dispose();
 				_tabBarAppearance = null;
 
-				Page.SendDisappearing();
-				Tabbed.PropertyChanged -= OnPropertyChanged;
-				Tabbed.PagesChanged -= OnPagesChanged;
+				Page?.SendDisappearing();
+				
+				if (Tabbed != null)
+				{
+					Tabbed.PropertyChanged -= OnPropertyChanged;
+					Tabbed.PagesChanged -= OnPagesChanged;
+				}
+				
 				FinishedCustomizingViewControllers -= HandleFinishedCustomizingViewControllers;
 			}
 

--- a/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/TabbedPage/iOS/TabbedRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
@@ -25,6 +26,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		bool? _defaultBarTranslucent;
 		IMauiContext _mauiContext;
 		UITabBarAppearance _tabBarAppearance;
+		VisualElement _element;
 
 		IMauiContext MauiContext => _mauiContext;
 		public static IPropertyMapper<TabbedPage, TabbedRenderer> Mapper = new PropertyMapper<TabbedPage, TabbedRenderer>(TabbedViewHandler.ViewMapper);
@@ -54,7 +56,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			get { return (TabbedPage)Element; }
 		}
 
-		public VisualElement Element => _viewHandlerWrapper.Element;
+		public VisualElement Element => _viewHandlerWrapper.Element ?? _element;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
@@ -69,6 +71,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public void SetElement(VisualElement element)
 		{
 			_viewHandlerWrapper.SetVirtualView(element, OnElementChanged, false);
+			_element = element;
 
 			FinishedCustomizingViewControllers += HandleFinishedCustomizingViewControllers;
 			Tabbed.PropertyChanged += OnPropertyChanged;
@@ -128,13 +131,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				_tabBarAppearance = null;
 
 				Page?.SendDisappearing();
-				
-				if (Tabbed != null)
-				{
-					Tabbed.PropertyChanged -= OnPropertyChanged;
-					Tabbed.PagesChanged -= OnPagesChanged;
-				}
-				
+
+				Tabbed.PropertyChanged -= OnPropertyChanged;
+				Tabbed.PagesChanged -= OnPagesChanged;
+
 				FinishedCustomizingViewControllers -= HandleFinishedCustomizingViewControllers;
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -7,11 +7,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using Xunit;
+
 
 #if IOS || MACCATALYST
 using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
@@ -32,12 +34,37 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
 					handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
 					handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
-					handlers.AddHandler(typeof(Controls.NavigationPage), typeof(NavigationViewHandler));
+#if IOS || MACCATALYST
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
 					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Frame, FrameRenderer>();
 					handlers.AddHandler<Controls.Window, WindowHandlerStub>();
 				});
 			});
 		}
+
+		[Fact]
+		public async Task PoppingFlyoutPageDoesntCrash()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage()) { Title = "App Page" };
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				var flyoutPage = new FlyoutPage()
+				{
+					Detail = new NavigationPage(new ContentPage() { Content = new Frame(), Title = "Detail" }),
+					Flyout = new ContentPage() { Title = "Flyout" }
+				};
+				await navPage.PushAsync(flyoutPage);
+				await navPage.PopAsync();
+			});
+		}
+
+
 #if !IOS && !MACCATALYST
 
 		[Fact(DisplayName = "FlyoutPage With Toolbar")]

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.Windows.cs
@@ -21,20 +21,6 @@ namespace Microsoft.Maui.DeviceTests
 	[Category(TestCategory.TabbedPage)]
 	public partial class TabbedPageTests : HandlerTestBase
 	{
-		void SetupBuilder()
-		{
-			EnsureHandlerCreated(builder =>
-			{
-				builder.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
-					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
-					handlers.AddHandler<Page, PageHandler>();
-					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
-				});
-			});
-		}
-
 		[Fact(DisplayName = "Toolbar Visible When Pushing To TabbedPage")]
 		public async Task ToolbarVisibleWhenPushingToTabbedPage()
 		{
@@ -227,19 +213,6 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(tabbedPage.CurrentPage, tabbedPage.Children[1]);
 				return Task.CompletedTask;
 			});
-		}
-
-
-		TabbedPage CreateBasicTabbedPage()
-		{
-			return new TabbedPage()
-			{
-				Title = "Tabbed Page",
-				Children =
-				{
-					new ContentPage() { Title = "Page 1" }
-				}
-			};
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -48,10 +48,6 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
 			{
-				// When the current active page is a TabbedPage then
-				// we put to toolbar inside the PaneFooter so it's
-				// to the right of the tabs
-
 				await navPage.PushAsync(CreateBasicTabbedPage());
 				await navPage.PopAsync();
 			});

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+
+namespace Microsoft.Maui.DeviceTests
+{
+
+	[Category(TestCategory.TabbedPage)]
+	public partial class TabbedPageTests : HandlerTestBase
+	{
+		void SetupBuilder()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handlers =>
+				{
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler<Page, PageHandler>();
+
+#if IOS || MACCATALYST
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+					handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+				});
+			});
+		}
+
+		[Fact]
+		public async Task PoppingTabbedPageDoesntCrash()
+		{
+			SetupBuilder();
+			var navPage = new NavigationPage(new ContentPage()) { Title = "App Page" };
+
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				// When the current active page is a TabbedPage then
+				// we put to toolbar inside the PaneFooter so it's
+				// to the right of the tabs
+
+				await navPage.PushAsync(CreateBasicTabbedPage());
+				await navPage.PopAsync();
+			});
+		}
+
+		TabbedPage CreateBasicTabbedPage()
+		{
+			return new TabbedPage()
+			{
+				Title = "Tabbed Page",
+				Children =
+				{
+					new ContentPage() { Title = "Page 1" }
+				}
+			};
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Fix issue disposing TabbedPage on iOS. For the compatibility handlers the `Element` is being accessed through a shim. The problem with doing this is that the shim nulls out the `element` before the dispose call happens. I realize that I could have reversed the calls inside the shim so dispose is called before the element is set to null but it seems really risky to change the ordering of things at this point. So, I instead went down a path of least change. I also applied this concept to a few other compatibility handlers we have. 

### Issues Fixed

Fixes #10362