### PR TITLE
Revert "Bump Microsoft.CodeAnalysis.CSharp from 4.2.0 to 4.3.1 (#10541)"

### DIFF
--- a/src/Controls/src/SourceGen/Controls.SourceGen.csproj
+++ b/src/Controls/src/SourceGen/Controls.SourceGen.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TestUtils/src/DeviceTests.Runners.SourceGen/TestUtils.DeviceTests.Runners.SourceGen.csproj
+++ b/src/TestUtils/src/DeviceTests.Runners.SourceGen/TestUtils.DeviceTests.Runners.SourceGen.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change

Until the new public preview is released, we should leave this at 4.2.0 
https://github.com/dotnet/roslyn/issues/63780#issuecomment-1271571400
