### PR TITLE
[MacCatalyst] Fix issue rendering background gradient in catalyst searchbar

### DIFF
--- a/src/Core/src/Platform/iOS/SearchBarExtensions.cs
+++ b/src/Core/src/Platform/iOS/SearchBarExtensions.cs
@@ -23,10 +23,13 @@ namespace Microsoft.Maui.Platform
 			if (background is SolidPaint solidPaint)
 				uiSearchBar.BarTintColor = solidPaint.Color.ToPlatform();
 
+			if(background is GradientPaint gradientPaint)
+				ViewExtensions.UpdateBackground(uiSearchBar, gradientPaint);
+						
 			if (background == null)
 				uiSearchBar.BarTintColor = UISearchBar.Appearance.BarTintColor;
 		}
-
+		
 		public static void UpdateIsEnabled(this UISearchBar uiSearchBar, ISearchBar searchBar)
 		{
 			uiSearchBar.UserInteractionEnabled = searchBar.IsEnabled;

--- a/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/SearchBar/SearchBarHandlerTests.iOS.cs
@@ -11,6 +11,24 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SearchBarHandlerTests
 	{
+		[Theory(DisplayName = "Gradient Background Initializes Correctly")]
+		[InlineData(0xFF0000)]
+		[InlineData(0x00FF00)]
+		[InlineData(0x0000FF)]
+		public async Task GradientBackgroundInitializesCorrectly(uint color)
+		{
+			var expected = Color.FromUint(color);
+
+			var brush = new LinearGradientPaintStub(Colors.Black, expected);
+
+			var searchBar = new SearchBarStub
+			{
+				Background = brush,
+			};
+
+			await ValidateHasColor(searchBar, expected);
+		}
+
 		[Fact]
 		public async Task ShouldShowCancelButtonToggles()
 		{


### PR DESCRIPTION
### Description of Change

Fix issue rendering background gradient in catalyst SearchBar.

<img width="517" alt="Captura de Pantalla 2022-10-11 a las 15 59 28" src="https://user-images.githubusercontent.com/6755973/195139665-ae37b510-dbb3-4b1d-9933-ffcc6e040e5e.png">
<img width="525" alt="Captura de Pantalla 2022-10-11 a las 14 53 27" src="https://user-images.githubusercontent.com/6755973/195139674-df532922-1274-4657-8ccd-aeaac8fa2718.png">

### Issues Fixed

Fixes #10482