### PR TITLE
[Housekeeping] Added more Frame samples to Core Gallery

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
@@ -36,6 +36,32 @@
                 <Label 
                     Text="Has Shadow" />
             </Frame>
+            <Label
+                Text="IsClippedToBounds (False)"
+                Style="{StaticResource Headline}"/>
+            <Frame
+                IsClippedToBounds="False"
+                Padding="0"
+                BackgroundColor="LightGray"
+                BorderColor="Red"
+                CornerRadius="24">
+                <Image 
+                    Aspect="AspectFill"
+                    Source="cover1.jpg" />
+            </Frame>
+            <Label
+                Text="IsClippedToBounds (True)"
+                Style="{StaticResource Headline}"/>
+            <Frame
+                IsClippedToBounds="True"
+                Padding="0"
+                BackgroundColor="LightGray"
+                BorderColor="Red"
+                CornerRadius="24">
+                <Image 
+                    Aspect="AspectFill"
+                    Source="cover1.jpg" />
+            </Frame>
         </VerticalStackLayout>
     </views:BasePage.Content>
 </views:BasePage>


### PR DESCRIPTION
### Description of Change

To validate #10483 (cannot reproduce the issue), added more Frame samples to Core Gallery.

<img width="522" alt="Captura de Pantalla 2022-10-11 a las 17 53 20" src="https://user-images.githubusercontent.com/6755973/195140709-fa6409b3-f466-4069-bb61-f703e6ad4217.png">
