### PR TITLE
[Tests] Ignore tooltip tests

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -85,7 +85,7 @@ stages:
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off
-        iosVersions: [ 'latest', '14.5', '13.7', '12.4' ]
+        iosVersions: [ 'latest', '15.5', '14.5', '13.7', '12.4' ]
         provisionatorChannel: ${{ parameters.provisionatorChannel }}
       ${{ if not(or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv')))) }}:
         androidApiLevels: [ 30, 23 ]

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
@@ -97,6 +97,11 @@ namespace Microsoft.Maui.DeviceTests
 				return;
 #endif
 
+#if IOS || MACCATALYST
+			// Tooltips are only as from iOS 15
+			if (!(OperatingSystem.IsMacCatalystVersionAtLeast(15) || OperatingSystem.IsIOSVersionAtLeast(15)))
+				return;
+#endif
 			var control = (TElement)Activator.CreateInstance(typeof(TElement));
 			control.ToolTip = new ToolTip() { Content = expected };
 

--- a/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/View/ViewHandlerTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Maui.DeviceTests
 #endif
 
 #if IOS || MACCATALYST
-			// Tooltips are only as from iOS 15
+			// ToolTips are only available on iOS 15+
 			if (!(OperatingSystem.IsMacCatalystVersionAtLeast(15) || OperatingSystem.IsIOSVersionAtLeast(15)))
 				return;
 #endif


### PR DESCRIPTION
### Description of Change

Fixes for the device tests full run 
Ignore tooltip tests on iOS api's they aren't supported.
Add iOS 15 to the test matrix

### Issues Fixed

None