### PR TITLE
Fix how PopToRoot propagates to handler

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.cs
@@ -35,6 +35,11 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 				flyoutHeaderBehavior.SelectedIndex = 0;
 			}
 		}
+		protected override void OnNavigatedTo(NavigatedToEventArgs args)
+		{
+			base.OnNavigatedTo(args);
+			popToRoot.IsVisible = Navigation.NavigationStack.Count > 1;
+		}
 
 		async void OnPushPage(object sender, EventArgs e)
 		{
@@ -46,6 +51,13 @@ namespace Maui.Controls.Sample.Pages.ShellGalleries
 			if (Navigation.NavigationStack.Count > 1)
 				await Navigation.PopAsync();
 		}
+
+		async void OnPopToRoot(object sender, EventArgs e)
+		{
+			await Navigation.PopToRootAsync();
+		}
+
+
 
 		void OnFlyoutHeaderBehaviorSelectedIndexChanged(object sender, EventArgs e)
 		{

--- a/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/ShellGalleries/ShellChromeGallery.xaml
@@ -33,6 +33,7 @@
                 Text="Pop Page"
                 Style="{StaticResource Headline}"/>
             <Button Text="Pop Page" Clicked="OnPopPage" />
+            <Button x:Name="popToRoot" IsVisible="False" Text="Pop To Root" Clicked="OnPopToRoot" />
             <Label
                 Text="Toggle SearchHandler"
                 Style="{StaticResource Headline}"/>

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Maui.Controls.Handlers
 		}
 
 		void OnNavigationRequested(object? sender, NavigationRequestedEventArgs e)
-		{			
+		{
 			SyncNavigationStack(e.Animated, e);
 		}
 

--- a/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellSectionHandler.Windows.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.Handlers
 
 		public static void MapCurrentItem(ShellSectionHandler handler, ShellSection item)
 		{
-			handler.SyncNavigationStack(false);
+			handler.SyncNavigationStack(false, null);
 		}
 
 		ShellSection? _shellSection;
@@ -75,11 +75,11 @@ namespace Microsoft.Maui.Controls.Handlers
 		}
 
 		void OnNavigationRequested(object? sender, NavigationRequestedEventArgs e)
-		{
-			SyncNavigationStack(e.Animated);
+		{			
+			SyncNavigationStack(e.Animated, e);
 		}
 
-		void SyncNavigationStack(bool animated)
+		void SyncNavigationStack(bool animated, NavigationRequestedEventArgs? e)
 		{
 			// Current Item might transition to null while visibility is adjusting on shell
 			// so we just ignore this and eventually when shell knows
@@ -92,9 +92,15 @@ namespace Microsoft.Maui.Controls.Handlers
 				(VirtualView.CurrentItem as IShellContentController).GetOrCreateContent()
 			};
 
-			for (var i = 1; i < VirtualView.Navigation.NavigationStack.Count; i++)
+			// PopToRoot in the xplat code fires before the navigation stack has been updated
+			// Once we get shell all converted over to newer navigation APIs this will all be a bit
+			// less leaky
+			if (e?.RequestType != NavigationRequestType.PopToRoot)
 			{
-				pageStack.Add(VirtualView.Navigation.NavigationStack[i]);
+				for (var i = 1; i < VirtualView.Navigation.NavigationStack.Count; i++)
+				{
+					pageStack.Add(VirtualView.Navigation.NavigationStack[i]);
+				}
 			}
 
 			// The point of this is to push the shell navigation over to using the INavigationStack

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -225,6 +225,27 @@ namespace Microsoft.Maui.DeviceTests
 		}
 #endif
 
+		[Fact(DisplayName = "PopToRootAsync correctly navigates to root page")]
+		public async Task PopToRootAsyncCorrectlyNavigationsBackToRootPage()
+		{
+			SetupBuilder();
+			var rootPage = new ContentPage();
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = rootPage;
+			});
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(shell, async (handler) =>
+			{
+				await shell.Navigation.PushAsync(new ContentPage());
+				await shell.Navigation.PushAsync(new ContentPage());
+				await shell.Navigation.PushAsync(new ContentPage());
+				await shell.Navigation.PushAsync(new ContentPage());
+				await shell.Navigation.PopToRootAsync();
+				await OnLoadedAsync(rootPage);
+			});
+		}
+
 		[Fact(DisplayName = "FlyoutContent Renderers When FlyoutBehavior Starts As Locked")]
 		public async Task FlyoutContentRenderersWhenFlyoutBehaviorStartsAsLocked()
 		{

--- a/src/Core/src/Platform/Windows/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Windows/StackNavigationManager.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Maui.Platform
 			NavigationTransitionInfo? transition = GetNavigationTransition(args);
 			_currentPage = newPageStack[newPageStack.Count - 1];
 
-			_ = _currentPage ?? throw new InvalidOperationException("Navigatoin Request Contains Null Elements");
+			_ = _currentPage ?? throw new InvalidOperationException("Navigation Request Contains Null Elements");
 			if (previousNavigationStack.Count < args.NavigationStack.Count)
 			{
 				Type destinationPageType = GetDestinationPageType();


### PR DESCRIPTION
### Description of Change

Shell on windows currently uses the `xplat` nav stack to re-arrange itself once a navigation is requested. In all cases (except PopToRootAsync) the navstack is modified before the call is propagated to the platform. I could have reversed these calls as another way to fix this issue but I'm not confident about the ramifications of doing that.  So, for this PR I've just modified the shell handler to handle PopToRootAsync itself. 

### Issues Fixed

Fixes #10524