### PR TITLE
Always disconnect when handler changes

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Maui.Controls
 
 		partial void OnHandlerChangingPartial(HandlerChangingEventArgs args)
 		{
-			if (args.OldHandler != null && args.NewHandler == null)
-				OnHandlerDisconnected(args.OldHandler.PlatformView as FrameworkElement);
+			if (args?.OldHandler?.PlatformView is FrameworkElement fe)
+				OnHandlerDisconnected(fe);
 		}
 
 		void OnHandlerConnected()


### PR DESCRIPTION
### Description of Change

If the handler (or MauiContext) changes we need to always disconnect from the previous handler so the new code can wire up. 

This code is already validated by the `ToolbarRecreatesWithNewMauiContext` test