### PR TITLE
Revert "[Windows] Fix default corner radius on Button"

### DIFF
--- a/src/Core/src/Platform/Windows/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Windows/ButtonExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Platform
 			var radius = buttonStroke.CornerRadius;
 
 			if (radius >= 0)
-				platformButton.Resources.SetValueForAllKey(CornerRadiusResourceKeys, WinUIHelpers.CreateCornerRadius(buttonStroke.CornerRadius));
+				platformButton.Resources.SetValueForAllKey(CornerRadiusResourceKeys, WinUIHelpers.CreateCornerRadius(radius));
 			else
 				platformButton.Resources.RemoveKeys(CornerRadiusResourceKeys);
 

--- a/src/Core/src/Platform/Windows/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Windows/ButtonExtensions.cs
@@ -50,10 +50,10 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCornerRadius(this Button platformButton, IButtonStroke buttonStroke)
 		{
-			var radius = buttonStroke.CornerRadius > -1 ? buttonStroke.CornerRadius : 0;
+			var radius = buttonStroke.CornerRadius;
 
 			if (radius >= 0)
-				platformButton.Resources.SetValueForAllKey(CornerRadiusResourceKeys, WinUIHelpers.CreateCornerRadius(radius));
+				platformButton.Resources.SetValueForAllKey(CornerRadiusResourceKeys, WinUIHelpers.CreateCornerRadius(buttonStroke.CornerRadius));
 			else
 				platformButton.Resources.RemoveKeys(CornerRadiusResourceKeys);
 

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.Windows.cs
@@ -38,6 +38,31 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.Equal(expectedValue, values.PlatformViewValue);
 		}
 
+		[Fact(DisplayName = "Rounded Maui Buttons Default Style")]
+		public async Task RoundedCornersMauiButtons()
+		{
+			var flatCornerRadius = 0;
+			var b = new Maui.Controls.Button();
+
+			var button = new ButtonStub()
+			{
+				// assign ButtonStub the default CornerRadius value of a Maui.Controls.Button
+				CornerRadius = b.CornerRadius
+			};
+
+			var values = await GetValueAsync(button, (handler) =>
+			{
+				return new
+				{
+					ViewValue = button.CornerRadius,
+					platformResources = handler.PlatformView.Resources
+				};
+			});
+
+			Assert.False(values.platformResources.ContainsKey("ControlCornerRadius"));
+			Assert.NotEqual(flatCornerRadius, values.ViewValue);
+		}
+
 		UI.Xaml.Controls.Button GetNativeButton(ButtonHandler buttonHandler) =>
 			buttonHandler.PlatformView;
 

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Maui.DeviceTests
 		[Fact(DisplayName = "Rounded Maui Buttons Default Style")]
 		public void RoundedCornersMauiButtons()
 		{
-			var button = new Microsoft.Maui.Controls.Button();
+			var button = new Button();
 			Assert.True(button.CornerRadius != 0);
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
@@ -161,6 +161,13 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Rounded Maui Buttons Default Style")]
+		public void RoundedCornersMauiButtons()
+		{
+			var button = new Microsoft.Maui.Controls.Button();
+			Assert.True(button.CornerRadius != 0);
+		}
+
 		void MovePlatformWindow(UI.Xaml.Window window, Rect rect)
 		{
 			var density = window.GetDisplayDensity();

--- a/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Window/WindowHandlerTests.Windows.cs
@@ -161,13 +161,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Rounded Maui Buttons Default Style")]
-		public void RoundedCornersMauiButtons()
-		{
-			var button = new Button();
-			Assert.True(button.CornerRadius != 0);
-		}
-
 		void MovePlatformWindow(UI.Xaml.Window window, Rect rect)
 		{
 			var density = window.GetDisplayDensity();


### PR DESCRIPTION
Reverts dotnet/maui#9515

dotnet/maui#9515 Allows all the platforms to have the same default button border radius, but we want to keep the Windows default rounded corner style on buttons. Thanks @mattleibow and @PureWeen for spotting this!
Also peer programmed with @rachelkang!

Before the revert (no rounded corners):
![Screen Shot 2022-10-12 at 3 34 27 PM](https://user-images.githubusercontent.com/50846373/195646539-6cf42824-d891-4624-bac0-f41d76f797b2.png)


After the revert (rounded corners):
![Screen Shot 2022-10-13 at 10 43 38 AM](https://user-images.githubusercontent.com/50846373/195646615-06694eea-b157-4cc5-b981-4cbb1eb94697.png)

Fixes #10644
