### PR TITLE
[Android] Fix Frame opacity

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
@@ -42,7 +42,7 @@
             <Frame
                 BackgroundColor="LightGray"
                 BorderColor="Red"
-                Opacity="0.2"
+                Opacity="0.5"
                 HasShadow="True">
                 <Label 
                     Text="Opacity 0.5" />

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
@@ -36,6 +36,17 @@
                 <Label 
                     Text="Has Shadow" />
             </Frame>
+            <Label
+                Text="Opacity"
+                Style="{StaticResource Headline}"/>
+            <Frame
+                BackgroundColor="LightGray"
+                BorderColor="Red"
+                Opacity="0.2"
+                HasShadow="True">
+                <Label 
+                    Text="Opacity 0.5" />
+            </Frame>
         </VerticalStackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/BoxViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/BoxViewPage.xaml
@@ -67,6 +67,17 @@
                 VerticalOptions="Center"
                 HorizontalOptions="Center" />
 
+            <Label
+                Text="Using Opacity"
+                Style="{StaticResource Headline}"/>
+            <BoxView
+                Color="Orange"
+                Opacity="0.5"
+                WidthRequest="160"
+                HeightRequest="160"
+                VerticalOptions="Center"
+                HorizontalOptions="Center" />
+
         </VerticalStackLayout>
     </ScrollView>
 </views:BasePage>

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				[Frame.CornerRadiusProperty.PropertyName] = (h, _) => h.UpdateCornerRadius(),
 				[Frame.BorderColorProperty.PropertyName] = (h, _) => h.UpdateBorderColor(),
 				[Microsoft.Maui.Controls.Compatibility.Layout.IsClippedToBoundsProperty.PropertyName] = (h, _) => h.UpdateClippedToBounds(),
-				[Frame.ContentProperty.PropertyName] = (h, _) => h.UpdateContent()
+				[Frame.ContentProperty.PropertyName] = (h, _) => h.UpdateContent(),
+				[VisualElement.OpacityProperty.PropertyName] = (h, v) => h.UpdateOpacity(v)
 			};
 
 		public static CommandMapper<Frame, FrameRenderer> CommandMapper


### PR DESCRIPTION
### Description of Change

Adds an entry into the property mapper for Android `FrameRenderer` to trigger `Opacity` handling when a `Frame` is initially created on Android

### Issues Fixed

Fixes #10220 _Frame.Opacity has no Effect_
Fixes part of #10503 _Opacity not applied to BoxView and Frame_ (the Frame opacity issue is the same as #10220 and a test is included that fails to reproduce the issue with BoxView).

### Details

I don't know if this the right approach. I've been following how handlers work, but `Frame` doesn't seem to follow the patterns exactly, presumably because it is mainly a compatibility control.

Stepping through the code, it looks like the initial properties are set using keys of the handlers, which does not contain `Opacity`, but updating the property works because it uses `ViewHandlerDelegator`.

This adds an entry to the `FrameRenderer` `PropertyMapper` that calls the `UpdateOpacity` extension method.


