### PR TITLE
Fix WinAppSDK 12 Additional resources keys

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Core/NavigationGallery.xaml.cs
@@ -80,12 +80,18 @@ namespace Maui.Controls.Sample.Pages
 			if (_currentNavStack == null)
 			{
 				_currentNavStack = Navigation.NavigationStack.ToList();
-				(Parent as IStackNavigationView).RequestNavigation(
-				new NavigationRequest(
-					new List<NavigationGallery>
-					{
-						new NavigationGallery()
-					}, false));
+
+				var stackNavigationView = Parent as IStackNavigationView;
+
+				if (stackNavigationView == null && Parent is FlyoutPage fp)
+					stackNavigationView = fp.Detail as IStackNavigationView;
+
+				stackNavigationView.RequestNavigation(
+					new NavigationRequest(
+						new List<NavigationGallery>
+						{
+							new NavigationGallery()
+						}, false));
 			}
 			else
 			{

--- a/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/TabbedPage/TabbedPage.Windows.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Maui.Controls
 				_navigationView.SetApplicationResource("NavigationViewMinimalHeaderMargin", null);
 				_navigationView.SetApplicationResource("NavigationViewHeaderMargin", null);
 				_navigationView.SetApplicationResource("NavigationViewContentMargin", null);
+				_navigationView.SetApplicationResource("NavigationViewMinimalContentMargin", null);
 
 				return _navigationView;
 			}

--- a/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Shell/ShellItemHandler.Windows.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Maui.Controls.Handlers
 			platformView.SetApplicationResource("NavigationViewMinimalHeaderMargin", null);
 			platformView.SetApplicationResource("NavigationViewHeaderMargin", null);
 			platformView.SetApplicationResource("NavigationViewContentMargin", null);
+			platformView.SetApplicationResource("NavigationViewMinimalContentMargin", null);
 
 			_mauiNavigationView.Loaded += OnNavigationViewLoaded;
 			return platformView;

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			var labelFrame =
 				await InvokeOnMainThreadAsync(() =>
-					frame.ToHandler(MauiContext).PlatformView.AttachAndRun(async () =>
+					frame.ToPlatform(MauiContext).AttachAndRun(async () =>
 					{
 						(frame as IView).Measure(300, 300);
 						(frame as IView).Arrange(new Graphics.Rect(0, 0, 300, 300));

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -440,6 +440,23 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact]
+		public async Task EmptyShellHasNoTopMargin()
+		{
+			SetupBuilder();
+
+			var mainPage = new ContentPage();
+			var shell = new Shell() { CurrentItem = mainPage };
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			{
+				var position = mainPage.ToPlatform().GetLocationOnScreen();
+				var appTitleBarHeight = GetWindowRootView(handler).AppTitleBarActualHeight;
+
+				Assert.True(Math.Abs(position.Value.Y - appTitleBarHeight) < 1);
+			});
+		}
+
 		protected async Task OpenFlyout(ShellHandler shellRenderer, TimeSpan? timeOut = null)
 		{
 			timeOut = timeOut ?? TimeSpan.FromSeconds(2);

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -77,9 +77,10 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			});
 
-			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, (handler) =>
+			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, async (handler) =>
 			{
 				var mauiToolBar = GetPlatformToolbar(handler);
+				await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y > 0);
 				var position = mauiToolBar.GetLocationOnScreen();
 				var appTitleBarHeight = GetWindowRootView(handler).AppTitleBarActualHeight;
 
@@ -112,6 +113,7 @@ namespace Microsoft.Maui.DeviceTests
 						if (nextRootPage is NavigationPage || nextRootPage is Shell)
 						{
 							var mauiToolBar = GetPlatformToolbar(handler);
+							await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y > 0);
 							var position = mauiToolBar.GetLocationOnScreen();
 							var appTitleBarHeight = GetWindowRootView(handler).AppTitleBarActualHeight;
 

--- a/src/Core/src/Platform/Windows/WindowRootView.cs
+++ b/src/Core/src/Platform/Windows/WindowRootView.cs
@@ -197,6 +197,8 @@ namespace Microsoft.Maui.Platform
 				var contentMargin = new WThickness(0, _appTitleBarHeight, 0, 0);
 				this.SetApplicationResource("NavigationViewContentMargin", contentMargin);
 				this.SetApplicationResource("NavigationViewMinimalContentMargin", contentMargin);
+				this.SetApplicationResource("NavigationViewBorderThickness",  new WThickness(0));
+
 				this.RefreshThemeResources();
 			}
 		}


### PR DESCRIPTION
### Description of Change

- Remove the BorderThickness added to the `SplitView` control so that everything is snug. 
- The inner `NavigationView` needs to remove the `NavigationViewBorderThickness` key used to offset from the TitleBar otherwise the inner `NavigationView` will have a top margin


### Tests
All of these issues were found when running existing Tests against 1.2 WinAppSDK