### PR TITLE
[Tests] Ignore tests runs for Core/Controls/Blazor on 12.4 and Android API25

### DIFF
--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -101,12 +101,15 @@ stages:
           desc: Core
           android: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+          iosVersionsExclude: [ '12.4'] #Ignore while we don't get a fix
         - name: controls
           desc: Controls
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+          iosVersionsExclude: [ '12.4'] #Ignore while we don't get a fix
         - name: blazorwebview
           desc: BlazorWebView
           androidApiLevelsExclude: [ 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+          iosVersionsExclude: [ '12.4'] #Ignore while we don't get a fix

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -95,21 +95,25 @@ stages:
       projects:
         - name: essentials
           desc: Essentials
+          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable 
           android: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
         - name: core
           desc: Core
+          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable 
           android: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+          iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
-          iosVersionsExclude: [ '12.4'] #Ignore while we don't get a fix
         - name: controls
           desc: Controls
+          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable 
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
+          iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
-          iosVersionsExclude: [ '12.4'] #Ignore while we don't get a fix
         - name: blazorwebview
           desc: BlazorWebView
           androidApiLevelsExclude: [ 27, 26, 25, 24, 23, 22, 21 ] # BlazorWebView requires a recent version of Chrome
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
+          iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-          iosVersionsExclude: [ '12.4'] #Ignore while we don't get a fix
+          


### PR DESCRIPTION
### Description of Change

Right now the full test suite is failing on iOS 12.4, and we are ignoring those results, so don't run them until we get a fix. 

The API25 on Android also fails randomally a lot of times. Remove it for now

### Issues Fixed

Full test suite should be green on Devdiv 