### PR TITLE
Don't use the main thread for networking

### DIFF
--- a/src/Essentials/test/DeviceTests/Tests/Connectivity_Tests.cs
+++ b/src/Essentials/test/DeviceTests/Tests/Connectivity_Tests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Maui.Networking;
 using Xunit;
 
@@ -20,6 +21,16 @@ namespace Microsoft.Maui.Essentials.DeviceTests
 		{
 			var profiles = Connectivity.ConnectionProfiles;
 			Assert.Equal(profiles.Count(), profiles.Distinct().Count());
+		}
+
+		[Fact]
+		public async Task Test()
+		{
+			var current = Connectivity.Current.NetworkAccess;
+
+			var thread = await Task.Run(() => Connectivity.Current.NetworkAccess);
+
+			Assert.Equal(current, thread);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The workaround tries to use MainThread as a single entry point, however this breaks if there is no window yet.

I tested this now and it works without issues:

 - Microsoft Windows: 10.0.22000.978
 - .NET MAUI: 6.0.540
 - .NET SDK: 7.0.100-rc.1.22431.12
 - Windows App SDK: 1.1.3

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes an issue where using the networking in app/window constructors throws with a missing main thread because essentials needs a window to get the main thread.

Reverts #10062

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
