### PR TITLE
[Blazor] Prevent locking on packaged app content

### DIFF
--- a/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
+++ b/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs
@@ -107,8 +107,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 					var winUIItem = await Package.Current.InstalledLocation.TryGetItemAsync(relativePath);
 					if (winUIItem != null)
 					{
-						var contentStream = await Package.Current.InstalledLocation.OpenStreamForReadAsync(relativePath);
-						stream = contentStream.AsRandomAccessStream();
+						using var contentStream = await Package.Current.InstalledLocation.OpenStreamForReadAsync(relativePath);
+
+						var memStream = new MemoryStream();
+						contentStream.CopyTo(memStream);
+						stream = new InMemoryRandomAccessStream();
+						await stream.WriteAsync(memStream.GetWindowsRuntimeBuffer());
 					}
 				}
 				else


### PR DESCRIPTION
Uses the same copying logic we use elsewhere, but for packaged app content:

https://github.com/dotnet/maui/blob/08b347751a39add7bcc4b5faf61e011943eed356/src/BlazorWebView/src/Maui/Windows/WinUIWebViewManager.cs#L132-L135

