### PR TITLE
Add `FrameRenderer` to all our existing tests and then resolve found issues

### DIFF
--- a/src/Controls/samples/Controls.Sample.Profiling/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Profiling/MainPage.xaml.cs
@@ -13,7 +13,7 @@ namespace Maui.Controls.Sample.Profiling
 		}
 
 		private void OnCounterClicked(object sender, EventArgs e)
-		{
+		{			
 			count++;
 			CounterLabel.Text = $"Current count: {count}";
 		}

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml
@@ -3,5 +3,5 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.MainPage"
     xmlns:local="clr-namespace:Maui.Controls.Sample">
-
+    <Frame BackgroundColor="Purple" WidthRequest="400" HeightRequest="400"></Frame>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MainPage.xaml.cs
@@ -14,5 +14,18 @@ namespace Maui.Controls.Sample
 		{
 			InitializeComponent();
 		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+		}
+
+		protected override void OnNavigatedTo(NavigatedToEventArgs args)
+		{
+			base.OnNavigatedTo(args);
+
+			var activity = Window?.Handler?.PlatformView;
+		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample.Sandbox/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample.Sandbox/MauiProgram.cs
@@ -2,6 +2,7 @@
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.LifecycleEvents;
 
 namespace Maui.Controls.Sample
 {
@@ -18,6 +19,6 @@ namespace Maui.Controls.Sample
 	class App : Application
 	{
 		protected override Window CreateWindow(IActivationState activationState) =>
-			new Window(new NavigationPage(new MainPage()));
+			new Window(new MainPage());
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
@@ -53,6 +53,17 @@
                     Text="Has Shadow" />
             </Frame>
             <Label
+                Text="Opacity"
+                Style="{StaticResource Headline}"/>
+            <Frame
+                BackgroundColor="LightGray"
+                BorderColor="Red"
+                Opacity="0.2"
+                HasShadow="True">
+                <Label 
+                    Text="Opacity 0.5" />
+            </Frame>
+            <Label
                 Text="IsClippedToBounds (False)"
                 Style="{StaticResource Headline}"/>
             <Frame

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
@@ -58,7 +58,7 @@
             <Frame
                 BackgroundColor="LightGray"
                 BorderColor="Red"
-                Opacity="0.2"
+                Opacity="0.5"
                 HasShadow="True">
                 <Label 
                     Text="Opacity 0.5" />

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/BoxViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/BoxViewPage.xaml
@@ -67,6 +67,17 @@
                 VerticalOptions="Center"
                 HorizontalOptions="Center" />
 
+            <Label
+                Text="Using Opacity"
+                Style="{StaticResource Headline}"/>
+            <BoxView
+                Color="Orange"
+                Opacity="0.5"
+                WidthRequest="160"
+                HeightRequest="160"
+                VerticalOptions="Center"
+                HorizontalOptions="Center" />
+
         </VerticalStackLayout>
     </ScrollView>
 </views:BasePage>

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -28,8 +28,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				[Frame.CornerRadiusProperty.PropertyName] = (h, _) => h.UpdateCornerRadius(),
 				[Frame.BorderColorProperty.PropertyName] = (h, _) => h.UpdateBorderColor(),
 				[Microsoft.Maui.Controls.Compatibility.Layout.IsClippedToBoundsProperty.PropertyName] = (h, _) => h.UpdateClippedToBounds(),
-				[Frame.ContentProperty.PropertyName] = (h, _) => h.UpdateContent(),
-				[VisualElement.OpacityProperty.PropertyName] = (h, v) => h.UpdateOpacity(v)
+				[Frame.ContentProperty.PropertyName] = (h, _) => h.UpdateContent()
 			};
 
 		public static CommandMapper<Frame, FrameRenderer> CommandMapper

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -6,14 +6,17 @@ using Android.Content;
 using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Views;
+using Android.Views.Inspectors;
 using AndroidX.CardView.Widget;
 using AndroidX.Core.View;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
+using static Android.Icu.Text.CaseMap;
 using AColor = Android.Graphics.Color;
 using ARect = Android.Graphics.Rect;
 using AView = Android.Views.View;
 using Color = Microsoft.Maui.Graphics.Color;
+using static Microsoft.Maui.Primitives.Dimension;
 
 namespace Microsoft.Maui.Controls.Handlers.Compatibility
 {
@@ -53,9 +56,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public event EventHandler<VisualElementChangedEventArgs>? ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs>? ElementPropertyChanged;
 
-		public FrameRenderer(Context context) : base(context)
+		public FrameRenderer(Context context) : this(context, Mapper)
 		{
-			_viewHandlerWrapper = new ViewHandlerDelegator<Frame>(Mapper, CommandMapper, this);
+		}
+
+		// TODO NET8 make public
+		internal FrameRenderer(Context context, IPropertyMapper mapper)
+			: this(context, mapper, CommandMapper)
+		{
+		}
+
+		internal FrameRenderer(Context context, IPropertyMapper mapper, CommandMapper commandMapper) : base(context)
+		{
+			_viewHandlerWrapper = new ViewHandlerDelegator<Frame>(mapper, commandMapper, this);
 		}
 
 		protected CardView Control => this;
@@ -74,8 +87,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		Size IViewHandler.GetDesiredSize(double widthMeasureSpec, double heightMeasureSpec)
 		{
+			double minWidth = 20;
+			if (IsExplicitSet(widthMeasureSpec) && !double.IsInfinity(widthMeasureSpec))
+				minWidth = widthMeasureSpec;
+
+			double minHeight = 20;
+			if (IsExplicitSet(widthMeasureSpec) && !double.IsInfinity(heightMeasureSpec))
+				minHeight = heightMeasureSpec;
+
 			return VisualElementRenderer<Frame>.GetDesiredSize(this, widthMeasureSpec, heightMeasureSpec,
-				new Size(20, 20));
+				new Size(minWidth, minHeight));
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				[Frame.CornerRadiusProperty.PropertyName] = (h, _) => h.UpdateCornerRadius(),
 				[Frame.BorderColorProperty.PropertyName] = (h, _) => h.UpdateBorderColor(),
 				[Microsoft.Maui.Controls.Compatibility.Layout.IsClippedToBoundsProperty.PropertyName] = (h, _) => h.UpdateClippedToBounds(),
-				[Frame.ContentProperty.PropertyName] = (h, _) => h.UpdateContent()
+				[Frame.ContentProperty.PropertyName] = (h, _) => h.UpdateContent(),
+				[VisualElement.OpacityProperty.PropertyName] = (h, v) => h.UpdateOpacity(v)
 			};
 
 		public static CommandMapper<Frame, FrameRenderer> CommandMapper

--- a/src/Controls/src/Core/Compatibility/Handlers/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/VisualElementRenderer.cs
@@ -252,13 +252,17 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			_ = view ?? throw new ArgumentNullException(nameof(view));
 
-			if (oldElement?.Handler != null)
-				oldElement.Handler = null;
-
 			currentVirtualView = (TElement)view;
 
 			if (currentVirtualView.Handler != nativeViewHandler)
 				currentVirtualView.Handler = nativeViewHandler;
+
+			// We set the previous virtual view to null after setting it on the incoming virtual view.
+			// This makes it easier for the incoming virtual view to have influence
+			// on how the exchange of handlers happens.
+			// We will just set the handler to null ourselves as a last resort cleanup
+			if (oldElement?.Handler != null)
+				oldElement.Handler = null;
 
 			_mapper = _defaultMapper;
 

--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
@@ -82,9 +82,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			Control.Arrange(new WRect(0, 0, finalSize.Width, finalSize.Height));
 			if (Element is IContentView cv)
-				cv.CrossPlatformArrange(new Rect(0, 0, finalSize.Width, finalSize.Height));
+			{
+				finalSize = cv.CrossPlatformArrange(new Rect(0, 0, finalSize.Width, finalSize.Height)).ToPlatform();
+			}
 
-			return finalSize;
+			return new global::Windows.Foundation.Size(Math.Max(0, finalSize.Width), Math.Max(0, finalSize.Height));
 		}
 
 		protected override global::Windows.Foundation.Size MeasureOverride(global::Windows.Foundation.Size availableSize)
@@ -92,7 +94,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var size = base.MeasureOverride(availableSize);
 
 			if (Element is IContentView cv)
-				size = cv.CrossPlatformMeasure(availableSize.Width, availableSize.Height).ToPlatform();
+				_ = cv.CrossPlatformMeasure(size.Width, size.Height);
 
 			return size;
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
@@ -18,7 +18,19 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public static CommandMapper<Frame, FrameRenderer> CommandMapper
 			= new CommandMapper<Frame, FrameRenderer>(VisualElementRendererCommandMapper);
 
-		public FrameRenderer() : base(Mapper, CommandMapper)
+		public FrameRenderer() : this(Mapper, CommandMapper)
+		{
+			AutoPackage = false;
+		}      
+		
+		// TODO NET8 make public
+		internal FrameRenderer(IPropertyMapper mapper)
+			: this( mapper, CommandMapper)
+		{
+		}
+
+		// TODO NET8 make public
+		internal FrameRenderer(IPropertyMapper mapper, CommandMapper commandMapper) : base(mapper, commandMapper)
 		{
 			AutoPackage = false;
 		}

--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/VisualElementRenderer.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			{
 				if (child is Maui.IElement childElement && childElement.Handler is IPlatformViewHandler nvh)
 				{
-					var size = nvh.GetDesiredSizeFromHandler(availableSize.Width, availableSize.Height);
+					var size = nvh.GetDesiredSizeFromHandler(width, height);
 					height = Math.Max(height, size.Height);
 					width = Math.Max(width, size.Width);
 				}

--- a/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/iOS/FrameRenderer.cs
@@ -24,6 +24,18 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			AddSubview(_actualView);
 		}
 
+		// TODO NET8 make public
+		internal FrameRenderer(IPropertyMapper mapper)
+			: this(mapper, CommandMapper)
+		{
+		}
+
+		// TODO NET8 make public
+		internal FrameRenderer(IPropertyMapper mapper, CommandMapper commandMapper) : base(mapper, commandMapper)
+		{
+			AutoPackage = false;
+		}
+
 		public override void AddSubview(UIView view)
 		{
 			if (view != _actualView)

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -14,25 +14,25 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public class FrameStub : Frame, IStubBase
 	{
-		public double MaximumWidth
+		double IStubBase.MaximumWidth
 		{
 			get => base.MaximumWidthRequest;
 			set => base.MaximumWidthRequest = value;
 		}
 
-		public double MaximumHeight
+		double IStubBase.MaximumHeight
 		{
 			get => base.MaximumHeightRequest;
 			set => base.MaximumHeightRequest = value;
 		}
 
-		public double MinimumWidth
+		double IStubBase.MinimumWidth
 		{
 			get => base.MinimumWidthRequest;
 			set => base.MinimumWidthRequest = value;
 		}
 
-		public double MinimumHeight
+		double IStubBase.MinimumHeight
 		{
 			get => base.MinimumHeightRequest;
 			set => base.MinimumHeightRequest = value;

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
@@ -13,26 +14,103 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public class FrameStub : Frame, IStubBase
 	{
-		public double MaximumWidth { get; set; }
-		public double MaximumHeight { get; set; }
-		public double MinimumWidth { get; set; }
-		public double MinimumHeight { get; set; }
-		public Visibility Visibility { get; set; }
-		public Semantics Semantics { get; set; }
-		double IStubBase.Width { get; set; }
-		double IStubBase.Height { get; set; }
-		Paint IStubBase.Background { get; set; }
-		IShape IStubBase.Clip { get; set; }
-		IElement IStubBase.Parent { get; set; }
+		public double MaximumWidth
+		{
+			get => base.MaximumWidthRequest;
+			set => base.MaximumWidthRequest = value;
+		}
+
+		public double MaximumHeight
+		{
+			get => base.MaximumHeightRequest;
+			set => base.MaximumHeightRequest = value;
+		}
+
+		public double MinimumWidth
+		{
+			get => base.MinimumWidthRequest;
+			set => base.MinimumWidthRequest = value;
+		}
+
+		public double MinimumHeight
+		{
+			get => base.MinimumHeightRequest;
+			set => base.MinimumHeightRequest = value;
+		}
+
+		public Visibility Visibility
+		{
+			get => base.IsVisible ? Visibility.Visible : Visibility.Hidden;
+			set
+			{
+				if (value == Visibility.Visible)
+					base.IsVisible = true;
+				else
+					base.IsVisible = false;
+			}
+		}
+
+		public Semantics Semantics
+		{
+			get;
+			set;
+		}
+
+		double IStubBase.Width
+		{
+			get => base.WidthRequest;
+			set => base.WidthRequest = value;
+		}
+
+		double IStubBase.Height
+		{
+			get => base.HeightRequest;
+			set => base.HeightRequest = value;
+		}
+
+		Paint IStubBase.Background
+		{
+			get => base.Background;
+			set => base.Background = value;
+		}
+
+		IShape IStubBase.Clip
+		{
+			get;
+			set;
+		}
+
+		IShape IView.Clip
+		{
+			get => (this as IStubBase).Clip;
+		}
+
+
+		IElement IStubBase.Parent
+		{
+			get => (IElement)base.Parent;
+			set => base.Parent = (Element)value;
+		}
 	}
 
 	[Category(TestCategory.Frame)]
-	public class FrameHandlerTest : HandlerTestBase<FrameRenderer, FrameStub>
+	public class FrameHandlerTest : HandlerTestBase<FrameRendererTest, FrameStub>
 	{
 		public FrameHandlerTest()
 		{
 
 		}
+	}
+
+	public class FrameRendererTest : FrameRenderer
+	{
+#if ANDROID
+
+		public FrameRendererTest() : base(MauiProgramDefaults.DefaultContext)
+		{
+		}
+
+#endif
 	}
 
 	[Category(TestCategory.Frame)]

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
@@ -10,6 +11,30 @@ using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
+	public class FrameStub : Frame, IStubBase
+	{
+		public double MaximumWidth { get; set; }
+		public double MaximumHeight { get; set; }
+		public double MinimumWidth { get; set; }
+		public double MinimumHeight { get; set; }
+		public Visibility Visibility { get; set; }
+		public Semantics Semantics { get; set; }
+		double IStubBase.Width { get; set; }
+		double IStubBase.Height { get; set; }
+		Paint IStubBase.Background { get; set; }
+		IShape IStubBase.Clip { get; set; }
+		IElement IStubBase.Parent { get; set; }
+	}
+
+	[Category(TestCategory.Frame)]
+	public class FrameHandlerTest : HandlerTestBase<FrameRenderer, FrameStub>
+	{
+		public FrameHandlerTest()
+		{
+
+		}
+	}
+
 	[Category(TestCategory.Frame)]
 	public partial class FrameTests : ControlsHandlerTestBase
 	{

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -50,11 +50,7 @@ namespace Microsoft.Maui.DeviceTests
 			}
 		}
 
-		public Semantics Semantics
-		{
-			get;
-			set;
-		}
+		public Semantics Semantics { get; set; } = new Semantics();
 
 		double IStubBase.Width
 		{
@@ -109,7 +105,27 @@ namespace Microsoft.Maui.DeviceTests
 		public FrameRendererTest() : base(MauiProgramDefaults.DefaultContext)
 		{
 		}
+		public FrameRendererTest(IPropertyMapper mapper)
+			: base(MauiProgramDefaults.DefaultContext, mapper)
+		{
+		}
 
+		public FrameRendererTest(IPropertyMapper mapper, CommandMapper commandMapper)
+			: base(MauiProgramDefaults.DefaultContext, mapper, commandMapper)
+		{
+		}
+
+#else
+
+		public FrameRendererTest(IPropertyMapper mapper)
+			: base(mapper)
+		{
+		}
+
+		public FrameRendererTest(IPropertyMapper mapper, CommandMapper commandMapper)
+			: base(mapper, commandMapper)
+		{
+		}
 #endif
 	}
 

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -117,6 +117,11 @@ namespace Microsoft.Maui.DeviceTests
 
 #else
 
+		public FrameRendererTest()
+		{
+
+		}
+
 		public FrameRendererTest(IPropertyMapper mapper)
 			: base(mapper)
 		{

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -58,7 +58,10 @@ namespace Microsoft.Maui.Handlers
 #if WINDOWS || MACCATALYST
 				[nameof(IContextFlyoutElement.ContextFlyout)] = MapContextFlyout,
 #endif
-			};
+#if ANDROID
+				["Initialize"] = (h, v) => ((PlatformView?)h.PlatformView)?.Initialize(v)
+#endif
+	};
 
 		public static CommandMapper<IView, IViewHandler> ViewCommandMapper = new()
 		{
@@ -128,10 +131,10 @@ namespace Microsoft.Maui.Handlers
 		{
 			base.SetVirtualView(element);
 
-			if (element is IView view)
-			{
-				((PlatformView?)PlatformView)?.Initialize(view);
-			}
+			//if (element is IView view)
+			//{
+			//	((PlatformView?)PlatformView)?.Initialize(view);
+			//}
 		}
 #endif
 

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -100,7 +100,11 @@ namespace Microsoft.Maui.Handlers
 
 		protected abstract void RemoveContainer();
 
-		public PlatformView? ContainerView { get; private protected set; }
+		public PlatformView? ContainerView 
+		{ 
+			get; 
+			private protected set; 
+		}
 
 		object? IViewHandler.ContainerView => ContainerView;
 

--- a/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
+++ b/src/Core/src/Handlers/View/ViewHandlerOfT.Android.cs
@@ -17,42 +17,15 @@ namespace Microsoft.Maui.Handlers
 		public override Size GetDesiredSize(double widthConstraint, double heightConstraint) =>
 			this.GetDesiredSizeFromHandler(widthConstraint, heightConstraint);
 
-		protected override void SetupContainer()
-		{
-			if (Context == null || PlatformView == null || ContainerView != null)
-				return;
+		protected override void SetupContainer() =>
+			this.SetupContainerFromHandler((handler) =>
+			{
+				var view = new WrapperView(handler!.MauiContext!.Context);
+				((ViewHandler<TVirtualView, TPlatformView>)handler).ContainerView = view;
+				return view;
+			});
 
-			var oldParent = (ViewGroup?)PlatformView.Parent;
-
-			var oldIndex = oldParent?.IndexOfChild(PlatformView);
-			oldParent?.RemoveView(PlatformView);
-
-			ContainerView ??= new WrapperView(Context);
-			((ViewGroup)ContainerView).AddView(PlatformView);
-
-			if (oldIndex is int idx && idx >= 0)
-				oldParent?.AddView(ContainerView, idx);
-			else
-				oldParent?.AddView(ContainerView);
-		}
-
-		protected override void RemoveContainer()
-		{
-			if (Context == null || PlatformView == null || ContainerView == null || PlatformView.Parent != ContainerView)
-				return;
-
-			var oldParent = (ViewGroup?)ContainerView.Parent;
-
-			var oldIndex = oldParent?.IndexOfChild(ContainerView);
-			oldParent?.RemoveView(ContainerView);
-
-			((ViewGroup)ContainerView).RemoveAllViews();
-			ContainerView = null;
-
-			if (oldIndex is int idx && idx >= 0)
-				oldParent?.AddView(PlatformView, idx);
-			else
-				oldParent?.AddView(PlatformView);
-		}
+		protected override void RemoveContainer() =>
+			this.RemoveContainerFromHandler((handler) => ((ViewHandler<TVirtualView, TPlatformView>)handler).ContainerView = null);
 	}
 }

--- a/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
@@ -191,5 +191,50 @@ namespace Microsoft.Maui
 			var deviceSize = (int)context!.ToPixels(size);
 			return MeasureSpecMode.Exactly.MakeMeasureSpec(deviceSize);
 		}
+		
+		internal static void SetupContainerFromHandler(this IPlatformViewHandler viewHandler, Func<IPlatformViewHandler, View> createContainerView)
+		{
+			var context = viewHandler.MauiContext?.Context;
+			var platformView = viewHandler.PlatformView;
+			var containerView = viewHandler.ContainerView;
+
+			if (context == null || platformView == null || containerView != null)
+				return;
+
+			var oldParent = (ViewGroup?)platformView.Parent;
+			var oldIndex = oldParent?.IndexOfChild(platformView);
+			oldParent?.RemoveView(platformView);
+
+			containerView = viewHandler.ContainerView ?? createContainerView.Invoke(viewHandler);
+			((ViewGroup)containerView).AddView(platformView);
+
+			if (oldIndex is int idx && idx >= 0)
+				oldParent?.AddView(containerView, idx);
+			else
+				oldParent?.AddView(containerView);
+		}
+
+		internal static void RemoveContainerFromHandler(this IPlatformViewHandler viewHandler, Action<IPlatformViewHandler> clearContainerView)
+		{
+			var context = viewHandler.MauiContext?.Context;
+			var platformView = viewHandler.PlatformView;
+			var containerView = viewHandler.ContainerView;
+
+			if (context == null || platformView == null || containerView == null || platformView.Parent != containerView)
+				return;
+
+			var oldParent = (ViewGroup?)containerView.Parent;
+
+			var oldIndex = oldParent?.IndexOfChild(containerView);
+			oldParent?.RemoveView(containerView);
+
+			((ViewGroup)containerView).RemoveAllViews();
+			clearContainerView.Invoke(viewHandler);
+
+			if (oldIndex is int idx && idx >= 0)
+				oldParent?.AddView(platformView, idx);
+			else
+				oldParent?.AddView(platformView);
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Windows.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Windows.cs
@@ -177,12 +177,14 @@ namespace Microsoft.Maui.DeviceTests
 		protected SemanticHeadingLevel GetSemanticHeading(IViewHandler viewHandler) =>
 			(SemanticHeadingLevel)AutomationProperties.GetHeadingLevel((FrameworkElement)viewHandler.PlatformView);
 
-		protected double GetOpacity(IViewHandler viewHandler) =>
-			((FrameworkElement)viewHandler.PlatformView).Opacity;
+		protected double GetOpacity(IViewHandler viewHandler)
+		{
+			return viewHandler.ToPlatform().Opacity;
+		}
 
 		double GetTranslationX(IViewHandler viewHandler)
 		{
-			var platformView = (FrameworkElement)viewHandler.PlatformView;
+			var platformView = viewHandler.ToPlatform();
 
 			if (platformView.RenderTransform is CompositeTransform composite)
 				return composite.TranslateX;
@@ -191,7 +193,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		double GetTranslationY(IViewHandler viewHandler)
 		{
-			var platformView = (FrameworkElement)viewHandler.PlatformView;
+			var platformView = viewHandler.ToPlatform();
 
 			if (platformView.RenderTransform is CompositeTransform composite)
 				return composite.TranslateY;
@@ -200,7 +202,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		double GetScaleX(IViewHandler viewHandler)
 		{
-			var platformView = (FrameworkElement)viewHandler.PlatformView;
+			var platformView = viewHandler.ToPlatform();
 
 			if (platformView.RenderTransform is ScaleTransform scale)
 				return scale.ScaleX;
@@ -211,7 +213,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		double GetScaleY(IViewHandler viewHandler)
 		{
-			var platformView = (FrameworkElement)viewHandler.PlatformView;
+			var platformView = viewHandler.ToPlatform();
 
 			if (platformView.RenderTransform is ScaleTransform scale)
 				return scale.ScaleY;
@@ -222,7 +224,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		double GetRotation(IViewHandler viewHandler)
 		{
-			var platformView = (FrameworkElement)viewHandler.PlatformView;
+			var platformView = viewHandler.ToPlatform();
 
 			if (platformView.RenderTransform is CompositeTransform composite)
 				return composite.Rotation;
@@ -231,7 +233,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		double GetRotationX(IViewHandler viewHandler)
 		{
-			var platformView = (FrameworkElement)viewHandler.PlatformView;
+			var platformView = viewHandler.ToPlatform();
 
 			if (platformView.Projection is PlaneProjection projection)
 				return -projection.RotationX;
@@ -240,7 +242,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		double GetRotationY(IViewHandler viewHandler)
 		{
-			var platformView = (FrameworkElement)viewHandler.PlatformView;
+			var platformView = viewHandler.ToPlatform();
 
 			if (platformView.Projection is PlaneProjection projection)
 				return -projection.RotationY;
@@ -249,7 +251,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected Visibility GetVisibility(IViewHandler viewHandler)
 		{
-			var platformView = (FrameworkElement)viewHandler.PlatformView;
+			var platformView = viewHandler.ToPlatform();
 
 			if (platformView.Visibility == UI.Xaml.Visibility.Visible && platformView.Opacity == 0)
 				return Visibility.Hidden;

--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestAssemblyViewModel.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/ViewModels/TestAssemblyViewModel.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 		TestState _result;
 		TestState _resultFilter;
 		RunStatus _runStatus;
-		string? _searchQuery;
+		string? _searchQuery = "Frame";
 
 		string? _detailText;
 		string? _displayName;


### PR DESCRIPTION
### Description of Change

- This PR condenses all of the `HandlerTestBase` code into `TestUtils.DeviceTests.Runners` so that it can be reused by all of our runners. Blazor/Controls/Core has been accumulating a lot of the same code and I really want to use the generic handler tests we have inside Core to test `FrameRenderer` and other renderers inside controls
- Fix Frame

### Issues Fixed


Fixes #10220
Fixes #10503
Fixes #10503
Fixes #8840