### PR TITLE
Allow * decompression during Arrange even when target size is smaller than desired size

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -679,26 +679,20 @@ namespace Microsoft.Maui.Layouts
 			{
 				if (_grid.VerticalLayoutAlignment == LayoutAlignment.Fill || Dimension.IsExplicitSet(_explicitGridHeight))
 				{
-					if (_grid.DesiredSize.Height < targetSize.Height)
-					{
-						// Reset the size on all star rows
-						ZeroOutStarSizes(_rows);
+					// Reset the size on all star rows
+					ZeroOutStarSizes(_rows);
 
-						// And compute them for the actual arrangement height
-						ResolveStarRows(targetSize.Height);
-					}
+					// And compute them for the actual arrangement height
+					ResolveStarRows(targetSize.Height);
 				}
 
 				if (_grid.HorizontalLayoutAlignment == LayoutAlignment.Fill || Dimension.IsExplicitSet(_explicitGridWidth))
 				{
-					if (_grid.DesiredSize.Width < targetSize.Width)
-					{
-						// Reset the size on all star rows
-						ZeroOutStarSizes(_columns);
+					// Reset the size on all star columns
+					ZeroOutStarSizes(_columns);
 
-						// And compute them for the actual arrangement width
-						ResolveStarColumns(targetSize.Width);
-					}
+					// And compute them for the actual arrangement width
+					ResolveStarColumns(targetSize.Width);
 				}
 			}
 

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -2316,5 +2316,28 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 			AssertArranged(view1, new Rect(20, 0, 20, 500));
 		}
+
+		[Fact]
+		[Category(GridStarSizing)]
+		public void StarsExpandToFixedSizes()
+		{
+			var grid = CreateGridLayout();
+			grid.DesiredSize.Returns(new Size(100, 120));
+			grid.Width.Returns(100);
+			grid.Height.Returns(120);
+
+			var view0 = CreateTestView(new Size(20, 20));
+			view0.Width.Returns(20);
+			view0.Height.Returns(20);
+			view0.HorizontalLayoutAlignment.Returns(LayoutAlignment.End);
+			view0.VerticalLayoutAlignment.Returns(LayoutAlignment.Start);
+
+			SetLocation(grid, view0);
+			SubstituteChildren(grid, view0);
+
+			_ = MeasureAndArrange(grid);
+
+			AssertArranged(view0, new Rect(0, 0, 100, 120));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

#10073 fixed a bug with measurement on Grid - prior to that, Grid would return greedy measurement values which asked for the entire available space when the Grid had '*' rows or columns. 

Part of that fix was the process of "decompressing" the measurement results when arranging the Grid into a space. The measurement step asked for the minimum space necessary for the views inside '*' rows/columns; the arrangement step needed to expand those rows/columns to fill the space given. 

However, there was a naive check in the decompression process to determine whether it was necessary, which did not properly account for margins and/or fixed-size containers. 

These changes remove the naive check and add an automated test for the situation demonstrated by the control template in #10491.

### Issues Fixed

Fixes #10491
fixes #10797
fixes #10301