### PR TITLE
Add check to ensure measurement for AndExpandLayoutManager

### DIFF
--- a/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
+++ b/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
@@ -27,6 +27,13 @@ namespace Microsoft.Maui.Controls
 
 		public Size ArrangeChildren(Rect bounds)
 		{
+			if (_manager == null)
+			{
+				// This shouldn't really happen, but some compatibility layouts might be 
+				// forcing a layout without a measure, so we'll have to ensure measurement happens here
+				Measure(bounds.Width, bounds.Height);
+			}
+
 			return _manager.ArrangeChildren(bounds);
 		}
 

--- a/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
@@ -317,5 +317,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			Assert.Equal(testText, view0.Text);
 			Assert.Equal(vm, view0.BindingContext);
 		}
+
+		[Fact]
+		public void EnsuresMeasure()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var layout = new StackLayout();
+			layout.Add(view0);
+
+			(layout as Maui.ILayout).CrossPlatformArrange(new Rect(0, 0, 100, 100));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

The AndExpandLayoutManager doesn't have a check to ensure measurement when old-style controls/layouts force a layout without properly doing a measurement pass. These changes add the check to avoid a NullReferenceException, and an automated test to watch for this in the future.

### Issues Fixed

Fixes #8816