### PR TITLE
Fix minimum sizing for * cells with multiple children

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -810,7 +810,7 @@ namespace Microsoft.Maui.Layouts
 					{
 						if (updated[n].IsStar)
 						{
-							updated[n].Update(toAdd);
+							updated[n].Size += toAdd;
 						}
 					}
 				}

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -1436,6 +1436,26 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			Assert.Equal(expectedHeight, measure.Height);
 		}
 
+		[Theory]
+		[InlineData("*", "*")]
+		[InlineData("auto", "auto")]
+		public void MeasureRespectsLargestChildMinimumSize(string columns, string rows)
+		{
+			var grid = CreateGridLayout(columns: columns, rows: rows);
+			var view0 = CreateTestView(new Size(100, 100));
+			var view1 = CreateTestView(new Size(200, 200));
+
+			SubstituteChildren(grid, view0, view1);
+			SetLocation(grid, view0);
+			SetLocation(grid, view1);
+
+			var layoutManager = new GridLayoutManager(grid);
+			var measure = layoutManager.Measure(double.PositiveInfinity, double.PositiveInfinity);
+
+			Assert.Equal(200, measure.Height);
+			Assert.Equal(200, measure.Width);
+		}
+
 		[Category(GridAbsoluteSizing)]
 		[Theory]
 		[InlineData(50, 10, 50)]


### PR DESCRIPTION
### Description of Change

With multiple views sharing a * row/column cell where the second view has a minimum size defined, the row/column does not size appropriately to contain the second view. 

These changes fix that. 

### Issues Fixed

No issue created yet.