### PR TITLE
Run Android tests on background thread

### DIFF
--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestActivity.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestActivity.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 	{
 		public TaskCompletionSource<Bundle> TaskCompletionSource { get; } = new TaskCompletionSource<Bundle>();
 
-		protected override async void OnCreate(Bundle? savedInstanceState)
+		protected override void OnCreate(Bundle? savedInstanceState)
 		{
 			base.OnCreate(savedInstanceState);
 

--- a/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestActivity.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/HeadlessRunner/Android/MauiTestActivity.cs
@@ -15,20 +15,24 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.HeadlessRunner
 		{
 			base.OnCreate(savedInstanceState);
 
-			try
-			{
-				var runner = MauiTestInstrumentation.Current.Services.GetRequiredService<HeadlessTestRunner>();
+			// Do the work on the background thread to avoid a keyDispatchingTimedOut ANR
+            Task.Run(async () =>
+            { 
+				try
+				{
+					var runner = MauiTestInstrumentation.Current.Services.GetRequiredService<HeadlessTestRunner>();
 
-				var bundle = await runner.RunTestsAsync();
+					var bundle = await runner.RunTestsAsync();
 
-				TaskCompletionSource.TrySetResult(bundle);
-			}
-			catch (Exception ex)
-			{
-				TaskCompletionSource.TrySetException(ex);
-			}
+					TaskCompletionSource.TrySetResult(bundle);
+				}
+				catch (Exception ex)
+				{
+					TaskCompletionSource.TrySetException(ex);
+				}
 
-			Finish();
+				Finish();
+			});
 		}
 	}
 }


### PR DESCRIPTION
Hi.  We have  copied the Maui `TestUtils` source code into our project, and use it for running device tests on Android emulators, which we do in our GitHub Actions CI.  This has been working well, except that at first we were getting a lot of intermittent `keyDispatchingTimedOut` errors such as the following:

```
info: Starting default instrumentation class on io.sentry.dotnet.maui.device.testapp (exit code 0 == success)
info: Running instrumentation class {default} took 43.3624407 seconds
warn: Skipping output line due to key-value-pair parse failure: 'INSTRUMENTATION_RESULT: longMsg=Input dispatching timed out (a751cb4 io.sentry.dotnet.maui.device.testapp/io.sentry.dotnet.maui.device.testapp.TestActivity (server) is not responding. Waited 5051ms for FocusEvent(hasFocus=true))'
info: Short message:
      keyDispatchingTimedOut
fail: No value for 'return-code' provided in instrumentation result. This may indicate a crashed test (see log)
info: Wrote current ADB log to /Users/runner/work/sentry-dotnet/sentry-dotnet/./test_output/adb-logcat-io.sentry.dotnet.maui.device.testapp-default.log
info: Attempting to remove apk 'io.sentry.dotnet.maui.device.testapp'..
info: Successfully uninstalled io.sentry.dotnet.maui.device.testapp
XHarness exit code: 82 (RETURN_CODE_NOT_SET)
Error: The process '/bin/sh' failed with exit code 82
```
(See https://github.com/getsentry/sentry-dotnet/issues/1927)

After some investigation, we realized this was caused because the headless test runner is executing its tests on the main UI thread.  We fixed it in our project with https://github.com/getsentry/sentry-dotnet/pull/1929 some time ago - we no longer get `keyDispatchingTimedOut` errors.

Since it's been working well for us, I thought I should contribute it back here.