### PR TITLE
Fix Windows CollectionView EmptyView alignment

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterEmptyView.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterEmptyView.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterEmptyView">
+
+  <Grid RowDefinitions="Auto,Auto,*" RowSpacing="15">
+
+    <HorizontalStackLayout Grid.Row="0"
+                           Spacing="15">
+      <Label Text="HorizontalOptions" VerticalOptions="Center" />
+      <RadioButton Content="Start" Value="{x:Static LayoutOptions.Start}" CheckedChanged="SetHorizontalOptions" />
+      <RadioButton IsChecked="True" Content="Center" Value="{x:Static LayoutOptions.Center}" CheckedChanged="SetHorizontalOptions" />
+      <RadioButton Content="End" Value="{x:Static LayoutOptions.End}" CheckedChanged="SetHorizontalOptions" />
+    </HorizontalStackLayout>
+
+    <HorizontalStackLayout Grid.Row="1"
+                           Spacing="15">
+      <Label Text="VerticalOptions" VerticalOptions="Center" />
+      <RadioButton Content="Start" Value="{x:Static LayoutOptions.Start}" CheckedChanged="SetVerticalOptions" />
+      <RadioButton IsChecked="True" Content="Center" Value="{x:Static LayoutOptions.Center}" CheckedChanged="SetVerticalOptions" />
+      <RadioButton Content="End" Value="{x:Static LayoutOptions.End}" CheckedChanged="SetVerticalOptions" />
+    </HorizontalStackLayout>
+
+    <CollectionView x:Name="Collection"
+                    Grid.Row="2"
+                    Header="Just a string as a header"
+                    Footer="This footer is also a string" />
+
+  </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterEmptyView.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterEmptyView.xaml.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class HeaderFooterEmptyView : ContentPage
+	{
+		public HeaderFooterEmptyView()
+		{
+			InitializeComponent();
+			UpdateEmptyView();
+		}
+
+		LayoutOptions _horizontalOptions = LayoutOptions.Center;
+		LayoutOptions _verticalOptions = LayoutOptions.Center;
+
+		void SetHorizontalOptions(object sender, CheckedChangedEventArgs _)
+		{
+			var radioButton = (RadioButton)sender;
+			if (radioButton.IsChecked)
+			{
+				_horizontalOptions = (LayoutOptions)radioButton.Value;
+				UpdateEmptyView();
+			}
+		}
+
+		void SetVerticalOptions(object sender, CheckedChangedEventArgs _)
+		{
+			var radioButton = (RadioButton)sender;
+			if (radioButton.IsChecked)
+			{
+				_verticalOptions = (LayoutOptions)radioButton.Value;
+				UpdateEmptyView();
+			}
+		}
+
+		void UpdateEmptyView()
+		{
+			Collection.EmptyView = new Label
+			{
+				Text = "Nothing to show",
+				HorizontalOptions = _horizontalOptions,
+				VerticalOptions = _verticalOptions
+			};
+		}
+	}
+}

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGallery.cs
@@ -25,6 +25,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries.HeaderFooterGalleri
 						GalleryBuilder.NavButton("Header/Footer (Grid)", () => new HeaderFooterGrid(), Navigation),
 						GalleryBuilder.NavButton("Footer Only (String)", () => new FooterOnlyString(), Navigation),
 						GalleryBuilder.NavButton("Header/Footer (Grid Horizontal)", () => new HeaderFooterGridHorizontal(), Navigation),
+						GalleryBuilder.NavButton("Header/Footer/EmptyView", () => new HeaderFooterEmptyView(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Windows.cs
@@ -18,6 +18,11 @@ using WASDKDataTemplate = Microsoft.UI.Xaml.DataTemplate;
 using WASDKScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility;
 using WRect = Windows.Foundation.Rect;
 using WVisibility = Microsoft.UI.Xaml.Visibility;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.Maui.Controls;
+using System.Threading.Tasks;
+using HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment;
+using VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment;
 
 namespace Microsoft.Maui.Controls.Handlers.Items
 {
@@ -387,7 +392,30 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var handler = view.ToHandler(MauiContext);
 			var platformView = handler.ContainerView ?? handler.PlatformView;
 
-			return platformView as FrameworkElement;
+			if (platformView == null)
+			{
+				return null;
+			}
+
+			platformView.HorizontalAlignment = view.HorizontalOptions.ToCore() switch
+			{
+				Primitives.LayoutAlignment.Fill => HorizontalAlignment.Stretch,
+				Primitives.LayoutAlignment.Start => HorizontalAlignment.Left,
+				Primitives.LayoutAlignment.Center => HorizontalAlignment.Center,
+				Primitives.LayoutAlignment.End => HorizontalAlignment.Right,
+				_ => throw new ArgumentOutOfRangeException()
+			};
+
+			platformView.VerticalAlignment = view.VerticalOptions.ToCore() switch
+			{
+				Primitives.LayoutAlignment.Fill => VerticalAlignment.Stretch,
+				Primitives.LayoutAlignment.Start => VerticalAlignment.Top,
+				Primitives.LayoutAlignment.Center => VerticalAlignment.Center,
+				Primitives.LayoutAlignment.End => VerticalAlignment.Bottom,
+				_ => throw new ArgumentOutOfRangeException()
+			};
+
+			return platformView;
 		}
 
 		internal void HandleScroll(ScrollViewer scrollViewer)

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemsViewStyles.xaml
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemsViewStyles.xaml
@@ -67,7 +67,8 @@
         <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}">
             <Grid>
                 <ContentControl x:Name="EmptyViewContentControl" 
-                                HorizontalContentAlignment="Stretch" VerticalAlignment="Stretch"/>
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"/>
                 <ScrollViewer x:Name="ScrollViewer" 
                                 TabNavigation="{TemplateBinding TabNavigation}"
                                 HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"


### PR DESCRIPTION
### Description of Change

Allow EmptyView to be aligned by HorizontalOptions / VerticalOptions.

This change makes it easier to deal with #6247 by centering the EmptyView. #6247 is not straight forward to solve, and I made a comment about my findings.

A new sample gallery view is included.

![image](https://user-images.githubusercontent.com/4621581/197368200-f2f8705b-5359-4e11-9866-22b27e82da04.png)

NOTE: Changes to HorizontalOptions / VerticalOptions after intitial creation will not propagate. It can easily be dealt with by recreating the EmptyView.
