### PR TITLE
Add NeedsExactMeasure check for Editor on Android

### DIFF
--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -124,56 +124,10 @@ namespace Microsoft.Maui.Handlers
 			PlatformView.Icon = obj;
 		}
 
-		bool NeedsExactMeasure()
-		{
-			if (VirtualView.VerticalLayoutAlignment != Primitives.LayoutAlignment.Fill
-				&& VirtualView.HorizontalLayoutAlignment != Primitives.LayoutAlignment.Fill)
-			{
-				// Layout Alignments of Start, Center, and End will be laying out the TextView at its measured size,
-				// so we won't need another pass with MeasureSpecMode.Exactly
-				return false;
-			}
-
-			if (VirtualView.Width >= 0 && VirtualView.Height >= 0)
-			{
-				// If the Width and Height are both explicit, then we've already done MeasureSpecMode.Exactly in 
-				// both dimensions; no need to do it again
-				return false;
-			}
-
-			// We're going to need a second measurement pass so TextView can properly handle alignments
-			return true;
-		}
-
 		public override void PlatformArrange(Rect frame)
 		{
-			var platformView = this.ToPlatform();
-
-			if (platformView == null || Context == null)
-			{
-				return;
-			}
-
-			if (frame.Width < 0 || frame.Height < 0)
-			{
-				return;
-			}
-
-			// Depending on our layout situation, the TextView may need an additional measurement pass at the final size
-			// in order to properly handle any TextAlignment properties.
-			if (NeedsExactMeasure())
-			{
-				platformView.Measure(MakeMeasureSpecExact(frame.Width), MakeMeasureSpecExact(frame.Height));
-			}
-
+			this.PrepareForTextViewArrange(frame);
 			base.PlatformArrange(frame);
-		}
-
-		int MakeMeasureSpecExact(double size)
-		{
-			// Convert to a platform size to create the spec for measuring
-			var deviceSize = (int)Context!.ToPixels(size);
-			return MeasureSpecMode.Exactly.MakeMeasureSpec(deviceSize);
 		}
 
 		bool OnTouch(IButton? button, AView? v, MotionEvent? e)

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -133,9 +133,7 @@ namespace Microsoft.Maui.Handlers
 				VirtualView.SelectionLength = selectedTextLength;
 		}
 
-#pragma warning disable RS0016 // Add public types and members to the declared API
 		public override void PlatformArrange(Rect frame)
-#pragma warning restore RS0016 // Add public types and members to the declared API
 		{
 			this.PrepareForTextViewArrange(frame);
 			base.PlatformArrange(frame);

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -2,6 +2,7 @@
 using Android.Views;
 using Android.Views.InputMethods;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Graphics;
 using static Android.Views.View;
 
 namespace Microsoft.Maui.Handlers
@@ -80,7 +81,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapCharacterSpacing(IEditorHandler handler, IEditor editor) =>
 			handler.PlatformView?.UpdateCharacterSpacing(editor);
 
-		public static void MapMaxLength(IEditorHandler handler, IEditor editor) =>
+		public static void MapMaxLength(IEditorHandler handler, IEditor editor)	=>
 			handler.PlatformView?.UpdateMaxLength(editor);
 
 		public static void MapIsReadOnly(IEditorHandler handler, IEditor editor) =>
@@ -92,7 +93,7 @@ namespace Microsoft.Maui.Handlers
 		public static void MapFont(IEditorHandler handler, IEditor editor) =>
 			handler.PlatformView?.UpdateFont(editor, handler.GetRequiredService<IFontManager>());
 
-		public static void MapHorizontalTextAlignment(IEditorHandler handler, IEditor editor) =>
+		public static void MapHorizontalTextAlignment(IEditorHandler handler, IEditor editor) => 
 			handler.PlatformView?.UpdateHorizontalTextAlignment(editor);
 
 		public static void MapVerticalTextAlignment(IEditorHandler handler, IEditor editor) =>
@@ -130,6 +131,14 @@ namespace Microsoft.Maui.Handlers
 
 			if (VirtualView.SelectionLength != selectedTextLength)
 				VirtualView.SelectionLength = selectedTextLength;
+		}
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+		public override void PlatformArrange(Rect frame)
+#pragma warning restore RS0016 // Add public types and members to the declared API
+		{
+			this.PrepareForTextViewArrange(frame);
+			base.PlatformArrange(frame);
 		}
 	}
 }

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -11,25 +11,7 @@ namespace Microsoft.Maui.Handlers
 
 		public override void PlatformArrange(Rect frame)
 		{
-			var platformView = this.ToPlatform();
-
-			if (platformView == null || Context == null)
-			{
-				return;
-			}
-
-			if (frame.Width < 0 || frame.Height < 0)
-			{
-				return;
-			}
-
-			// Depending on our layout situation, the TextView may need an additional measurement pass at the final size
-			// in order to properly handle any TextAlignment properties.
-			if (NeedsExactMeasure())
-			{
-				platformView.Measure(MakeMeasureSpecExact(frame.Width), MakeMeasureSpecExact(frame.Height));
-			}
-
+			this.PrepareForTextViewArrange(frame);
 			base.PlatformArrange(frame);
 		}
 
@@ -83,34 +65,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapLineHeight(ILabelHandler handler, ILabel label)
 		{
 			handler.PlatformView?.UpdateLineHeight(label);
-		}
-
-		bool NeedsExactMeasure()
-		{
-			if (VirtualView.VerticalLayoutAlignment != Primitives.LayoutAlignment.Fill
-				&& VirtualView.HorizontalLayoutAlignment != Primitives.LayoutAlignment.Fill)
-			{
-				// Layout Alignments of Start, Center, and End will be laying out the TextView at its measured size,
-				// so we won't need another pass with MeasureSpecMode.Exactly
-				return false;
-			}
-
-			if (VirtualView.Width >= 0 && VirtualView.Height >= 0)
-			{
-				// If the Width and Height are both explicit, then we've already done MeasureSpecMode.Exactly in 
-				// both dimensions; no need to do it again
-				return false;
-			}
-
-			// We're going to need a second measurement pass so TextView can properly handle alignments
-			return true;
-		}
-
-		int MakeMeasureSpecExact(double size)
-		{
-			// Convert to a native size to create the spec for measuring
-			var deviceSize = (int)Context!.ToPixels(size);
-			return MeasureSpecMode.Exactly.MakeMeasureSpec(deviceSize);
 		}
 	}
 }

--- a/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
+++ b/src/Core/src/Handlers/ViewHandlerExtensions.Android.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+using Android.Content;
 using Android.Views;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
@@ -131,6 +133,63 @@ namespace Microsoft.Maui
 			platformView.Layout((int)left, (int)top, (int)right, (int)bottom);
 
 			viewHandler.Invoke(nameof(IView.Frame), frame);
+		}
+
+		internal static void PrepareForTextViewArrange(this IViewHandler handler, Rect frame) 
+		{
+			if (frame.Width < 0 || frame.Height < 0)
+			{
+				return;
+			}
+
+			var platformView = handler.ToPlatform();
+			var context = platformView?.Context;
+
+			if (platformView == null || context == null)
+			{
+				return;
+			}
+
+			var virtualView = handler.VirtualView;
+			if (virtualView == null)
+			{
+				return;
+			}
+
+			// Depending on our layout situation, the TextView may need an additional measurement pass at the final size
+			// in order to properly handle any TextAlignment properties and some internal bookkeeping
+			if (virtualView.NeedsExactMeasure())
+			{
+				platformView.Measure(context.MakeMeasureSpecExact(frame.Width), context.MakeMeasureSpecExact(frame.Height));
+			}
+		}
+
+		internal static bool NeedsExactMeasure(this IView virtualView) 
+		{
+			if (virtualView.VerticalLayoutAlignment != Primitives.LayoutAlignment.Fill
+				&& virtualView.HorizontalLayoutAlignment != Primitives.LayoutAlignment.Fill)
+			{
+				// Layout Alignments of Start, Center, and End will be laying out the TextView at its measured size,
+				// so we won't need another pass with MeasureSpecMode.Exactly
+				return false;
+			}
+
+			if (virtualView.Width >= 0 && virtualView.Height >= 0)
+			{
+				// If the Width and Height are both explicit, then we've already done MeasureSpecMode.Exactly in 
+				// both dimensions; no need to do it again
+				return false;
+			}
+
+			// We're going to need a second measurement pass so TextView can properly handle alignments
+			return true;
+		}
+
+		internal static int MakeMeasureSpecExact(this Context context, double size) 
+		{
+			// Convert to a native size to create the spec for measuring
+			var deviceSize = (int)context!.ToPixels(size);
+			return MeasureSpecMode.Exactly.MakeMeasureSpec(deviceSize);
 		}
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -112,6 +112,7 @@ Microsoft.Maui.IWindow.MinimumHeight.get -> double
 Microsoft.Maui.IWindow.MinimumWidth.get -> double
 Microsoft.Maui.IWindow.X.get -> double
 Microsoft.Maui.IWindow.Y.get -> double
+override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
 override Microsoft.Maui.Handlers.MenuFlyoutHandler.CreatePlatformElement() -> object!
 override Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.CreatePlatformElement() -> object!
 override Microsoft.Maui.Handlers.EditorHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void


### PR DESCRIPTION
### Description of Change

Adds the exact measure check for Editor (similar to what we use for Button/Label) when the final size is expanded for Fill layout purposes. This ensures that the internal TextView's bookkeeping is using the full width/height of the control as laid out, rather than just the minimally measured portion required to display the text/placeholder. 

Unfortunately, we don't have a good way to automate testing for this, since it relies on direct keyboard input and we don't have good automation for the in device tests right now. 

### Issues Fixed

Fixes #8232
Fixes #7627