### PR TITLE
If a UISwitch grows too wide it is no longer accessible

### DIFF
--- a/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Maui.Graphics;
 using ObjCRuntime;
 using UIKit;
 using RectangleF = CoreGraphics.CGRect;
@@ -7,6 +8,12 @@ namespace Microsoft.Maui.Handlers
 {
 	public partial class SwitchHandler : ViewHandler<ISwitch, UISwitch>
 	{
+		// the UISwitch control becomes inaccessible if it grows to a width > 101
+		// An issue has been logged with Apple
+		// This ensures that the UISwitch remains the natural size that iOS expects
+		// But the container can be used for setting BGColors and other features.
+		public override bool NeedsContainer => true;
+
 		protected override UISwitch CreatePlatformView()
 		{
 			return new UISwitch(RectangleF.Empty);

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -133,6 +133,7 @@ override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Mau
 override Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.CreatePlatformElement() -> UIKit.UIMenu!
 override Microsoft.Maui.Handlers.EditorHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.EntryHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
+override Microsoft.Maui.Handlers.SwitchHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.WindowHandler.ConnectHandler(UIKit.UIWindow! platformView) -> void
 override Microsoft.Maui.Platform.ContentView.SetNeedsLayout() -> void
 override Microsoft.Maui.Platform.LayoutView.HitTest(CoreGraphics.CGPoint point, UIKit.UIEvent? uievent) -> UIKit.UIView!

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -133,6 +133,7 @@ override Microsoft.Maui.Handlers.ScrollViewHandler.PlatformArrange(Microsoft.Mau
 override Microsoft.Maui.Handlers.MenuFlyoutSeparatorHandler.CreatePlatformElement() -> UIKit.UIMenu!
 override Microsoft.Maui.Handlers.EditorHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
 override Microsoft.Maui.Handlers.EntryHandler.SetVirtualView(Microsoft.Maui.IView! view) -> void
+override Microsoft.Maui.Handlers.SwitchHandler.NeedsContainer.get -> bool
 override Microsoft.Maui.Handlers.WindowHandler.ConnectHandler(UIKit.UIWindow! platformView) -> void
 override Microsoft.Maui.Platform.ContentView.SetNeedsLayout() -> void
 override Microsoft.Maui.Platform.LayoutView.HitTest(CoreGraphics.CGPoint point, UIKit.UIEvent? uievent) -> UIKit.UIView!

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.iOS.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.iOS.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		protected CATransform3D GetLayerTransform(IViewHandler viewHandler) =>
-			((UIView)viewHandler.PlatformView).Layer.Transform;
+			((UIView)viewHandler.ToPlatform()).Layer.Transform;
 
 		protected string GetAutomationId(IViewHandler viewHandler) =>
 			((UIView)viewHandler.PlatformView).AccessibilityIdentifier;
@@ -190,7 +190,7 @@ namespace Microsoft.Maui.DeviceTests
 			viewHandler.VirtualView.ToPlatform().GetBoundingBox();
 
 		protected System.Numerics.Matrix4x4 GetViewTransform(IViewHandler viewHandler) =>
-			((UIView)viewHandler.PlatformView).GetViewTransform();
+			((UIView)viewHandler.ToPlatform()).GetViewTransform();
 
 		protected string GetSemanticDescription(IViewHandler viewHandler) =>
 			GetAccessiblePlatformView(viewHandler).AccessibilityLabel;
@@ -203,11 +203,11 @@ namespace Microsoft.Maui.DeviceTests
 				? SemanticHeadingLevel.Level1 : SemanticHeadingLevel.None;
 
 		protected nfloat GetOpacity(IViewHandler viewHandler) =>
-			((UIView)viewHandler.PlatformView).Alpha;
+			((UIView)viewHandler.ToPlatform()).Alpha;
 
 		protected Visibility GetVisibility(IViewHandler viewHandler)
 		{
-			var platformView = (UIView)viewHandler.PlatformView;
+			var platformView = (UIView)viewHandler.ToPlatform();
 
 			foreach (var constraint in platformView.Constraints)
 			{

--- a/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Switch/SwitchHandlerTests.iOS.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using ObjCRuntime;
@@ -41,6 +42,25 @@ namespace Microsoft.Maui.DeviceTests
 			});
 
 			Assert.Equal(expected, color);
+		}
+
+		/// <summary>
+		/// If a UISwitch grows beyond 101 pixels it's no longer
+		/// clickable via Voice Over
+		/// </summary>
+		/// <returns></returns>
+		[Fact(DisplayName = "Ensure UISwitch Stays Below 101 Width")]
+		public async Task EnsureUISwitchStaysBelow101Width()
+		{
+			var switchStub = new SwitchStub()
+			{
+				Width = 400,
+				Height = 400
+			};
+
+			var width = await GetValueAsync(switchStub, handler => GetNativeSwitch(handler).Bounds.Width);
+
+			Assert.True(width < 100, $"UISwitch width is too much {width}");
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

If a UISwitch grows larger than 101 in width it's no longer toggleable via VO (bug has been logged with Apple)

You can test this inside MAUI by setting a width on a Switch or just place a Switch inside a VerticalStackLayout

AFAICT Switch is the only control that suffers from this behavior.