### PR TITLE
Dispose empty sets and try/catch exceptions

### DIFF
--- a/src/Essentials/src/Platform/WindowStateManager.ios.cs
+++ b/src/Essentials/src/Platform/WindowStateManager.ios.cs
@@ -101,9 +101,18 @@ namespace Microsoft.Maui.ApplicationModel
 			// if we have scene support, use that
 			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
 			{
-				var scenes = UIApplication.SharedApplication.ConnectedScenes;
-				var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
-				return windowScene?.Windows.FirstOrDefault();
+				try
+				{
+					using var scenes = UIApplication.SharedApplication.ConnectedScenes;
+					var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
+					return windowScene?.Windows.FirstOrDefault();
+				}
+				catch (InvalidCastException)
+				{
+					// HACK: Workaround for https://github.com/xamarin/xamarin-macios/issues/13704
+					//       This only throws if the collection is empty.
+					return null;
+				}
 			}
 
 			// use the windows property (up to 13.0)
@@ -115,9 +124,18 @@ namespace Microsoft.Maui.ApplicationModel
 			// if we have scene support, use that
 			if (OperatingSystem.IsIOSVersionAtLeast(13) || OperatingSystem.IsMacCatalystVersionAtLeast(13))
 			{
-				var scenes = UIApplication.SharedApplication.ConnectedScenes;
-				var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
-				return windowScene?.Windows;
+				try
+				{
+					using var scenes = UIApplication.SharedApplication.ConnectedScenes;
+					var windowScene = scenes.ToArray<UIWindowScene>().FirstOrDefault();
+					return windowScene?.Windows;
+				}
+				catch (InvalidCastException)
+				{
+					// HACK: Workaround for https://github.com/xamarin/xamarin-macios/issues/13704
+					//       This only throws if the collection is empty.
+					return null;
+				}
 			}
 
 			// use the windows property (up to 15.0)


### PR DESCRIPTION
### Description of Change

There seems to be a bug in the iOS/Mac Catalyst SDK where empty "collections" that are generic all use the same pointer. This causes the first reference to win and the rest throw.

This PR has a very strong error-situation-avoidance feel to it, see comments...

### Issues Fixed


Workarounds for:
 - https://github.com/xamarin/xamarin-macios/issues/16378
 - https://github.com/xamarin/xamarin-macios/issues/13704
