### PR TITLE
Design time converters should return TRUE for CanConvertFrom string

### DIFF
--- a/src/Controls/src/Core.Design/GridLengthCollectionDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/GridLengthCollectionDesignTypeConverter.cs
@@ -1,10 +1,16 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Linq;
 
 namespace Microsoft.Maui.Controls.Design
 {
 	public class GridLengthCollectionDesignTypeConverter : TypeConverter
 	{
+		// This tells XAML this converter can be used to process strings
+		// Without this the values won't show up as hints
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+			=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{
 			if (value?.ToString() is string strValue)

--- a/src/Controls/src/Core.Design/GridLengthDesignTypeConverter.cs
+++ b/src/Controls/src/Core.Design/GridLengthDesignTypeConverter.cs
@@ -6,6 +6,10 @@ namespace Microsoft.Maui.Controls.Design
 {
 	public class GridLengthDesignTypeConverter : TypeConverter
 	{
+		// This tells XAML this converter can be used to process strings
+		// Without this the values won't show up as hints
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+			=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
 		public override bool IsValid(ITypeDescriptorContext context, object value)
 		{

--- a/src/Controls/tests/Core.Design.UnitTests/GridLengthCollectionDesignTypeConverterTests.cs
+++ b/src/Controls/tests/Core.Design.UnitTests/GridLengthCollectionDesignTypeConverterTests.cs
@@ -5,6 +5,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	public class GridLengthCollectionDesignTypeConverterTests
 	{
+		[Fact]
+		public void GridLengthCollection_CanConvertFromString()
+		{
+			GridLengthCollectionDesignTypeConverter converter = new GridLengthCollectionDesignTypeConverter();
+			bool canConvert = converter.CanConvertFrom(typeof(string));
+			Assert.True(canConvert);
+		}
+
 		[Theory]
 		[InlineData("*,auto,123")]
 		[InlineData("  *, AUTO  ,    123 ")]

--- a/src/Controls/tests/Core.Design.UnitTests/GridLengthDesignTypeConverterTests.cs
+++ b/src/Controls/tests/Core.Design.UnitTests/GridLengthDesignTypeConverterTests.cs
@@ -5,6 +5,14 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	public class GridLengthDesignTypeConverterTests
 	{
+		[Fact]
+		public void GridLength_CanConvertFromString()
+		{
+			GridLengthDesignTypeConverter converter = new GridLengthDesignTypeConverter();
+			bool canConvert = converter.CanConvertFrom(typeof(string));
+			Assert.True(canConvert);
+		}
+
 		[Theory]
 		[InlineData("auto")]
 		[InlineData("Auto ")]


### PR DESCRIPTION
Fixes #10968.
Verified by replacing Microsoft.Maui.Controls.DesignTools.dll locally and manually testing repro scenario