### PR TITLE
Update Editor.cs To solve HorizontalTextAlignment  problem

### DIFF
--- a/src/Controls/src/Core/Editor.cs
+++ b/src/Controls/src/Core/Editor.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty AutoSizeProperty = BindableProperty.Create(nameof(AutoSize), typeof(EditorAutoSizeOption), typeof(Editor), defaultValue: EditorAutoSizeOption.Disabled, propertyChanged: (bindable, oldValue, newValue)
 			=> ((Editor)bindable)?.UpdateAutoSizeOption());
 
-		public static readonly BindableProperty HorizontalTextAlignmentProperty = TextAlignmentElement.HorizontalTextAlignmentProperty;
+		public static readonly BindableProperty HorizontalTextAlignmentProperty = BindableProperty.Create(nameof(HorizontalTextAlignment), typeof(TextAlignment), typeof(Editor), TextAlignment.Start);
 
 		public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create(nameof(VerticalTextAlignment), typeof(TextAlignment), typeof(Editor), TextAlignment.Start);
 


### PR DESCRIPTION
### Description of Change
**HorizontalTextAlignmentProperty** has been changed.

<!-- Enter description of the fix in this section -->
Implementation of **HorizontalTextAlignmentProperty** now is same as **VerticalTextAlignmentProperty**

### Issues Fixed

Let's Imagine we have an **Editor** named **TxtMessage** and this codes :

```
    bool alt = true;
    private async void OnCounterClicked(object sender, EventArgs e)
    {
        TxtMessage.HorizontalTextAlignment = alt ? TextAlignment.End : TextAlignment.Start;
        TxtMessage.VerticalTextAlignment = alt ? TextAlignment.End : TextAlignment.Start;
        return;
    }
```
The result will be something like this :

![Test](https://user-images.githubusercontent.com/10775073/198702107-3af1d6a1-28f2-412f-932e-a39abd11b214.gif)

As you saw **VerticalTextAlignment** worked well but **HorizontalTextAlignment** did not worked.

But after changing (Line 47) the problem should be solved.

Please Visit [https://github.com/dotnet/maui/issues/10987](https://github.com/dotnet/maui/issues/10987)
