### PR TITLE
Add HttpClient factory for UriImageSource

### DIFF
--- a/src/Controls/samples/Controls.Sample/ImageSourceHttpClientFactory.cs
+++ b/src/Controls/samples/Controls.Sample/ImageSourceHttpClientFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample;
+
+sealed class ImageSourceHttpClientFactory : IImageSourceHttpClientFactory
+{
+	readonly IHttpClientFactory _httpClientFactory;
+
+	public ImageSourceHttpClientFactory(IHttpClientFactory httpClientFactory)
+	{
+		_httpClientFactory = httpClientFactory;
+	}
+
+	public bool ShouldDispose => false;
+
+	public HttpClient CreateClient(Uri _)
+	{
+		// NOTE: possible to add logic depending upon image uri
+		return _httpClientFactory.CreateClient(DefaultHttpClientName);
+	}
+
+	public static string DefaultHttpClientName => nameof(ImageSourceHttpClientFactory);
+}

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0-rc.2.22472.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     <!--<PackageReference Include="Microsoft.Maui.Graphics.Skia" />-->

--- a/src/Controls/samples/Controls.Sample/MauiProgram.cs
+++ b/src/Controls/samples/Controls.Sample/MauiProgram.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
 using Maui.Controls.Sample.Controls;
 using Maui.Controls.Sample.Pages;
 using Maui.Controls.Sample.Services;
@@ -118,6 +120,14 @@ namespace Maui.Controls.Sample
 				logging.AddConsole();
 #endif
 			});
+
+			services.AddSingleton<IImageSourceHttpClientFactory, ImageSourceHttpClientFactory>();
+			services
+				.AddHttpClient(ImageSourceHttpClientFactory.DefaultHttpClientName, httpClient =>
+				{
+					httpClient.Timeout = TimeSpan.FromSeconds(5);
+					httpClient.DefaultRequestVersion = HttpVersion.Version20;
+				});
 
 			services.AddSingleton<ITextService, TextService>();
 			services.AddTransient<MainViewModel>();

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/ImagePage.xaml
@@ -4,15 +4,23 @@
     x:Class="Maui.Controls.Sample.Pages.ImagePage"
     xmlns:views="clr-namespace:Maui.Controls.Sample.Pages.Base"
     Title="Image">
-    <views:BasePage.Content>
+
+  <views:BasePage.Resources>
+    <Style TargetType="Image">
+      <Setter Property="MaximumHeightRequest" Value="400" />
+      <Setter Property="MaximumWidthRequest" Value="400" />
+    </Style>
+  </views:BasePage.Resources>
+
+  <views:BasePage.Content>
         <ScrollView>
             <VerticalStackLayout
                 Margin="12">
                 <Label
-                    Text="UriSource"
+                    Text="UriSource using ImageSourceHttpClientFactory"
                     Style="{StaticResource Headline}"/>
                 <Image 
-                    Source="https://aka.ms/campus.jpg"
+                    Source="https://news.microsoft.com/wp-content/uploads/prod/2022/07/hexagon_print.gif"
                     />
                 <Label
                     Text="FileSource"

--- a/src/Controls/src/Core/IImageSourceHttpClientFactory.cs
+++ b/src/Controls/src/Core/IImageSourceHttpClientFactory.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+using System;
+using System.Net.Http;
+
+namespace Microsoft.Maui.Controls;
+
+public interface IImageSourceHttpClientFactory
+{
+	bool ShouldDispose { get; }
+	HttpClient CreateClient(Uri imageUri);
+}

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -128,3 +128,6 @@ static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> 
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.ILayoutManagerFactory
 ~Microsoft.Maui.Controls.ILayoutManagerFactory.CreateLayoutManager(Microsoft.Maui.Controls.Layout layout) -> Microsoft.Maui.Layouts.ILayoutManager
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.ShouldDispose.get -> bool
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.CreateClient(System.Uri! imageUri) -> System.Net.Http.HttpClient!

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -123,3 +123,6 @@ static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> 
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.ILayoutManagerFactory
 ~Microsoft.Maui.Controls.ILayoutManagerFactory.CreateLayoutManager(Microsoft.Maui.Controls.Layout layout) -> Microsoft.Maui.Layouts.ILayoutManager
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.ShouldDispose.get -> bool
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.CreateClient(System.Uri! imageUri) -> System.Net.Http.HttpClient!

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -123,3 +123,6 @@ static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> 
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.ILayoutManagerFactory
 ~Microsoft.Maui.Controls.ILayoutManagerFactory.CreateLayoutManager(Microsoft.Maui.Controls.Layout layout) -> Microsoft.Maui.Layouts.ILayoutManager
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.ShouldDispose.get -> bool
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.CreateClient(System.Uri! imageUri) -> System.Net.Http.HttpClient!

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -7448,3 +7448,6 @@ static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.T
 ~static Microsoft.Maui.Controls.Layout.MapInputTransparent(Microsoft.Maui.Handlers.LayoutHandler handler, Microsoft.Maui.Controls.Layout layout) -> void
 ~static Microsoft.Maui.Controls.RadioButton.MapContent(Microsoft.Maui.Handlers.RadioButtonHandler handler, Microsoft.Maui.Controls.RadioButton radioButton) -> void
 ~static Microsoft.Maui.Controls.SearchBar.MapText(Microsoft.Maui.Handlers.SearchBarHandler handler, Microsoft.Maui.Controls.SearchBar searchBar) -> void
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.ShouldDispose.get -> bool
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.CreateClient(System.Uri! imageUri) -> System.Net.Http.HttpClient!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -136,3 +136,6 @@ static Microsoft.Maui.Controls.Toolbar.MapTitleIcon(Microsoft.Maui.Handlers.IToo
 static Microsoft.Maui.Controls.Toolbar.MapTitleView(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 static Microsoft.Maui.Controls.Toolbar.MapToolbarItems(Microsoft.Maui.Handlers.IToolbarHandler! arg1, Microsoft.Maui.Controls.Toolbar! arg2) -> void
 *REMOVED*~override Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.OnCreateAutomationPeer() -> Microsoft.UI.Xaml.Automation.Peers.AutomationPeer
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.ShouldDispose.get -> bool
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.CreateClient(System.Uri! imageUri) -> System.Net.Http.HttpClient!

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -110,3 +110,6 @@ static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> 
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.ILayoutManagerFactory
 ~Microsoft.Maui.Controls.ILayoutManagerFactory.CreateLayoutManager(Microsoft.Maui.Controls.Layout layout) -> Microsoft.Maui.Layouts.ILayoutManager
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.ShouldDispose.get -> bool
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.CreateClient(System.Uri! imageUri) -> System.Net.Http.HttpClient!

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -110,3 +110,6 @@ static readonly Microsoft.Maui.Controls.TapGestureRecognizer.ButtonsProperty -> 
 *REMOVED*Microsoft.Maui.Controls.TapGestureRecognizer.Tapped -> System.EventHandler?
 Microsoft.Maui.Controls.ILayoutManagerFactory
 ~Microsoft.Maui.Controls.ILayoutManagerFactory.CreateLayoutManager(Microsoft.Maui.Controls.Layout layout) -> Microsoft.Maui.Layouts.ILayoutManager
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.ShouldDispose.get -> bool
+Microsoft.Maui.Controls.IImageSourceHttpClientFactory.CreateClient(System.Uri! imageUri) -> System.Net.Http.HttpClient!


### PR DESCRIPTION
The current implementation of `UriImageSource` does not use a `HttpClient` factory, but instead creates a new `HttpClient` inline. This leads to a couple of drawbacks, not being able to;

- Tuning timeouts
- Doing retries (using Polly)
- Setting a proxy (very likely to be used)
- Setting authorization header (most likely to be used)

### HttpClient factory

Added interface `IImageSourceHttpClientFactory` with method `CreateClient(Uri imageUri)`. This will return a `HttpClient`, possibly with logic tied to the image uri. `UriImageSource` uses this interface to get hold on an `HttpClient` instance.

### Dependency injection

`IImageSourceHttpClientFactory` is provided through dependency injection, and in lack of a registration `DefaultImageSourceHttpClientFactory` will be used (which preserves the current behavior).

### A note on System.Net.Http.IHttpClientFactory 

It would have been natural to take dependency on `Microsoft.Extensions.Http` NuGet and use its `IHttpClientFactory `. But adding more assemblies only hurt startup performance, so I went the route of creating an interface `IImageSourceHttpClientFactory`.

### Controls sample application

For the sample application an implementation `ImageSourceHttpClientFactory` is provided which delegates to `IHttpClientFactory`. A named `HttpClient ` is configured in the `MauiProgram`.

> Test that the named `HttpClient` is being used by setting a breakpoint in the lambda in `MauiProgram`.

### Documentation

There is still documentation to do if the proposal is accepted.

- Add code documentation
- Add MAUI user documentation

