### PR TITLE
Fix shadow visibility on Windows

### DIFF
--- a/src/Core/src/Platform/Windows/WrapperView.cs
+++ b/src/Core/src/Platform/Windows/WrapperView.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Maui.Platform
 			Children.Add(_borderPath);
 		}
 
+		long _visibilityDependencyPropertyCallbackToken;
 		public FrameworkElement? Child
 		{
 			get { return _child; }
@@ -41,6 +42,7 @@ namespace Microsoft.Maui.Platform
 				if (_child != null)
 				{
 					_child.SizeChanged -= OnChildSizeChanged;
+					_child.UnregisterPropertyChangedCallback(VisibilityProperty, _visibilityDependencyPropertyCallbackToken);
 					Children.Remove(_child);
 				}
 
@@ -49,6 +51,7 @@ namespace Microsoft.Maui.Platform
 
 				_child = value;
 				_child.SizeChanged += OnChildSizeChanged;
+				_visibilityDependencyPropertyCallbackToken = _child.RegisterPropertyChangedCallback(VisibilityProperty, OnChildVisibilityChanged);
 				Children.Add(_child);
 			}
 		}
@@ -140,6 +143,16 @@ namespace Microsoft.Maui.Platform
 			UpdateClip();
 			UpdateBorder();
 			UpdateShadow();
+		}
+
+		void OnChildVisibilityChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			// OnChildSizeChanged does not fire for Visibility changes to child
+			if (sender is FrameworkElement child && _shadowCanvas.Children.Count > 0)
+			{
+				var shadowHost = _shadowCanvas.Children[0];
+				shadowHost.Visibility = child.Visibility;
+			}
 		}
 
 		void DisposeShadow()


### PR DESCRIPTION
In the current implementation a shadow will stay visible if the attached view is hidden (`IsVisible = false`). This only happens on Windows.

![image](https://user-images.githubusercontent.com/4621581/198857388-c98b23ee-a559-4cc6-8a72-d767b4b4862f.png)

![image](https://user-images.githubusercontent.com/4621581/198857400-e5f7f7ad-ecd4-415c-b92a-67a31b02f241.png)

