### PR TITLE
ItemContentControl - apply bindings once for ItemTemplate (Windows)

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/CollectionViewGallery.cs
@@ -50,6 +50,7 @@ namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
 						GalleryBuilder.NavButton("Alternate Layout Galleries", () => new AlternateLayoutGallery(), Navigation),
 						GalleryBuilder.NavButton("Header/Footer Galleries", () => new HeaderFooterGallery(), Navigation),
 						GalleryBuilder.NavButton("Nested CollectionViews", () => new NestedGalleries.NestedCollectionViewGallery(), Navigation),
+						GalleryBuilder.NavButton("Online images", () => new OnlineImages(), Navigation),
 					}
 				}
 			};

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/OnlineImages.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/OnlineImages.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:collectionviewgalleries="clr-namespace:Maui.Controls.Sample.Pages.CollectionViewGalleries"
+             x:Class="Maui.Controls.Sample.Pages.CollectionViewGalleries.OnlineImages"
+             Title="Online images">
+
+  <Grid>
+    <CollectionView x:Name="CollectionView" BackgroundColor="Yellow">
+      <CollectionView.ItemTemplate>
+        <DataTemplate x:DataType="collectionviewgalleries:OnlineImageInfo">
+          <Image HeightRequest="200" WidthRequest="200"  Source="{Binding Uri}" />
+        </DataTemplate>
+      </CollectionView.ItemTemplate>
+    </CollectionView>
+  </Grid>
+</ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/OnlineImages.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/CollectionViewGalleries/OnlineImages.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+using Microsoft.Maui.Dispatching;
+
+namespace Maui.Controls.Sample.Pages.CollectionViewGalleries
+{
+	public record OnlineImageInfo(string Uri);
+
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class OnlineImages : ContentPage
+	{
+		public OnlineImages()
+		{
+			InitializeComponent();
+
+			Dispatcher.DispatchAsync(SetItemsSource);
+		}
+
+		async Task SetItemsSource()
+		{
+			await Task.Delay(TimeSpan.FromSeconds(1));
+
+			CollectionView.ItemsSource = new ObservableCollection<OnlineImageInfo>
+			{
+				new ("https://news.microsoft.com/wp-content/uploads/prod/2022/07/hexagon_print.gif"),
+				new ("https://news.microsoft.com/wp-content/uploads/prod/2022/07/collaboration-controls-in-power-platform_print.gif"),
+				new ("https://news.microsoft.com/wp-content/uploads/prod/2022/07/Updatesin-Teams.png"),
+				new ("https://news.microsoft.com/wp-content/uploads/prod/2022/07/Expanded-Reactions.png"),
+				new ("https://news.microsoft.com/wp-content/uploads/prod/2022/04/Companion-Devices.jpg"),
+			};
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
+++ b/src/Controls/src/Core/Platform/Windows/CollectionView/ItemContentControl.cs
@@ -168,7 +168,6 @@ namespace Microsoft.Maui.Controls.Platform
 				// or if we need to switch DataTemplates (because this instance is being recycled)
 				// then we'll need to create the content from the template 
 				_visualElement = formsTemplate.CreateContent(dataContext, container) as VisualElement;
-				_visualElement.BindingContext = dataContext;
 				_renderer = _visualElement.ToHandler(mauiContext);
 
 				// We need to set IsPlatformStateConsistent explicitly; otherwise, it won't be set until the renderer's Loaded 
@@ -186,11 +185,11 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				// We are reusing this ItemContentControl and we can reuse the Element
 				_visualElement = _renderer.VirtualView as VisualElement;
-				_visualElement.BindingContext = dataContext;
 			}
 
 			Content = _renderer.ToPlatform();
 			itemsView?.AddLogicalChild(_visualElement);
+			_visualElement.BindingContext = dataContext;
 		}
 
 		void SetNativeStateConsistent(VisualElement visualElement)


### PR DESCRIPTION
There is an issue with the current implementation of `ItemsContentControl.Realize()` which ends up applying bindings twice when creating an item. Normally that would go unnoticed, but it has a major drawback in combination with `UriImageSource`. It starts fetching the image using `HttpClient` and then cancels the request, because a second request is started. That cancellation shows up as exceptions in the debug output, and the UI is noticeably sluggish. Exceptions are an expensive feature (mostly due to traversing the stack and building a stack trace).

### Debug log for sample application

I've added a page in the sample application do demonstrate the exceptions being thrown. The page contains a CollectionView with 5 items and the following ItemTemplate.

``` xml
<DataTemplate x:DataType="collectionviewgalleries:OnlineImageInfo">
     <Image HeightRequest="200" WidthRequest="200"  Source="{Binding Uri}" />
</DataTemplate>
```

```
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Microsoft.Maui.Controls.UriImageSource: Warning: Error getting stream for https://news.microsoft.com/wp-content/uploads/prod/2022/07/hexagon_print.gif

System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.Maui.Controls.StreamWrapper.GetStreamAsync(Uri uri, CancellationToken cancellationToken, HttpClient client)
   at Microsoft.Maui.Controls.UriImageSource.DownloadStreamAsync(Uri uri, CancellationToken cancellationToken)
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Microsoft.Maui.Controls.UriImageSource: Warning: Error getting stream for https://news.microsoft.com/wp-content/uploads/prod/2022/07/collaboration-controls-in-power-platform_print.gif

System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.Maui.Controls.StreamWrapper.GetStreamAsync(Uri uri, CancellationToken cancellationToken, HttpClient client)
   at Microsoft.Maui.Controls.UriImageSource.DownloadStreamAsync(Uri uri, CancellationToken cancellationToken)
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Microsoft.Maui.Controls.UriImageSource: Warning: Error getting stream for https://news.microsoft.com/wp-content/uploads/prod/2022/07/Updatesin-Teams.png

System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.Maui.Controls.StreamWrapper.GetStreamAsync(Uri uri, CancellationToken cancellationToken, HttpClient client)
   at Microsoft.Maui.Controls.UriImageSource.DownloadStreamAsync(Uri uri, CancellationToken cancellationToken)
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Microsoft.Maui.Controls.UriImageSource: Warning: Error getting stream for https://news.microsoft.com/wp-content/uploads/prod/2022/07/Expanded-Reactions.png

System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.Maui.Controls.StreamWrapper.GetStreamAsync(Uri uri, CancellationToken cancellationToken, HttpClient client)
   at Microsoft.Maui.Controls.UriImageSource.DownloadStreamAsync(Uri uri, CancellationToken cancellationToken)
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Exception thrown: 'System.Threading.Tasks.TaskCanceledException' in System.Private.CoreLib.dll
Microsoft.Maui.Controls.UriImageSource: Warning: Error getting stream for https://news.microsoft.com/wp-content/uploads/prod/2022/04/Companion-Devices.jpg

System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.Maui.Controls.StreamWrapper.GetStreamAsync(Uri uri, CancellationToken cancellationToken, HttpClient client)
   at Microsoft.Maui.Controls.UriImageSource.DownloadStreamAsync(Uri uri, CancellationToken cancellationToken)
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Microsoft.Maui.UriImageSourceService: Warning: Unable to load image URI 'https://news.microsoft.com/wp-content/uploads/prod/2022/07/hexagon_print.gif'.

System.InvalidOperationException: Unable to load image stream.
   at Microsoft.Maui.UriImageSourceService.GetImageSourceAsync(IUriImageSource imageSource, Single scale, CancellationToken cancellationToken)
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Exception thrown: 'System.InvalidOperationException' in System.Private.CoreLib.dll
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Microsoft.Maui.UriImageSourceService: Warning: Unable to load image URI 'https://news.microsoft.com/wp-content/uploads/prod/2022/07/collaboration-controls-in-power-platform_print.gif'.

System.InvalidOperationException: Unable to load image stream.
   at Microsoft.Maui.UriImageSourceService.GetImageSourceAsync(IUriImageSource imageSource, Single scale, CancellationToken cancellationToken)
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Exception thrown: 'System.InvalidOperationException' in System.Private.CoreLib.dll
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Microsoft.Maui.UriImageSourceService: Warning: Unable to load image URI 'https://news.microsoft.com/wp-content/uploads/prod/2022/07/Updatesin-Teams.png'.

System.InvalidOperationException: Unable to load image stream.
   at Microsoft.Maui.UriImageSourceService.GetImageSourceAsync(IUriImageSource imageSource, Single scale, CancellationToken cancellationToken)
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Exception thrown: 'System.InvalidOperationException' in System.Private.CoreLib.dll
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Microsoft.Maui.UriImageSourceService: Warning: Unable to load image URI 'https://news.microsoft.com/wp-content/uploads/prod/2022/07/Expanded-Reactions.png'.

System.InvalidOperationException: Unable to load image stream.
   at Microsoft.Maui.UriImageSourceService.GetImageSourceAsync(IUriImageSource imageSource, Single scale, CancellationToken cancellationToken)
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Exception thrown: 'System.InvalidOperationException' in System.Private.CoreLib.dll
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Microsoft.Maui.UriImageSourceService: Warning: Unable to load image URI 'https://news.microsoft.com/wp-content/uploads/prod/2022/04/Companion-Devices.jpg'.

System.InvalidOperationException: Unable to load image stream.
   at Microsoft.Maui.UriImageSourceService.GetImageSourceAsync(IUriImageSource imageSource, Single scale, CancellationToken cancellationToken)
Exception thrown: 'System.InvalidOperationException' in Microsoft.Maui.dll
Exception thrown: 'System.InvalidOperationException' in System.Private.CoreLib.dll
```

### Code fix

Callstack first call to ImageHandler.MapSource()
![image](https://user-images.githubusercontent.com/4621581/198885402-feaffbd7-9a7a-4676-b426-f72e946b0665.png)

Callstack second call to ImageHandler.MapSource() which cancel the first one
![image](https://user-images.githubusercontent.com/4621581/198885422-1c872ab1-b4eb-4f79-a2b1-070aa3a8396f.png)

Image request cancellation is handled in `ImageSourceServiceResultManager.BeginLoad()` and above is the two different code paths that trigger `BeginLoad()`, both originating from `ItemsContentControl.Realize()`. `ViewExtensions.ToHandler()` and `ItemsView.AddLogicalChild` will both apply bindings. The code fix is as simple as setting the `BindingContext` after those two calls.

> NOTE: The sample application page has no value after verification of this issue, and should be removed before merge.
