### PR TITLE
Add await for color check to avoid crash and fix DispatcherTest

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.Android.cs
@@ -49,11 +49,11 @@ namespace Microsoft.Maui.DeviceTests
 
 		Task ValidateHasColor(Label label, Color color, Action action = null)
 		{
-			return InvokeOnMainThreadAsync(() =>
+			return InvokeOnMainThreadAsync(async () =>
 			{
 				var labelHandler = CreateHandler<LabelHandler>(label);
 				action?.Invoke();
-				labelHandler.PlatformView.AssertContainsColor(color);
+				await labelHandler.PlatformView.AssertContainsColor(color);
 			});
 		}
 	}


### PR DESCRIPTION
### Description of Change
- This is a simplified version of this [PR](https://github.com/dotnet/maui/pull/11016) so that we can remove the crashers first. The ValidateHasColor call is wrong everywhere which is leading it to cause false positives. If you correctly await the `ValidateHasColor` check then it correctly fails.
- Label test validating color is currently missing an await. This was causing the test to complete, and the AppBuilder to dispose before the view under test was removed from the window. This was leading to latent android events firing from layout changed code that would then try to use the disposed AppBuilder
- Reworked DispatcherTest slightly so it runs better when part of a full test run
