### PR TITLE
Update templates to have separate default for framework selection

### DIFF
--- a/src/Templates/src/templates/maui-blazor/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/ide.host.json
@@ -13,6 +13,12 @@
               "hostId": "vs", 
               "componentType": "SetupComponent" 
         }
-    
-   ]
+   ],
+   "symbolInfo": [
+    {
+      "id": "Framework",
+      "persistenceScope": "shared",
+      "persistenceScopeName": "maui"
+    }
+  ]
 }

--- a/src/Templates/src/templates/maui-lib/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/ide.host.json
@@ -13,6 +13,12 @@
               "hostId": "vs", 
               "componentType": "SetupComponent" 
         }
-    
-   ]
+   ],
+   "symbolInfo": [
+    {
+      "id": "Framework",
+      "persistenceScope": "shared",
+      "persistenceScopeName": "maui"
+    }
+  ] 
 }

--- a/src/Templates/src/templates/maui-lib/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/ide.host.json
@@ -20,5 +20,5 @@
       "persistenceScope": "shared",
       "persistenceScopeName": "maui"
     }
-  ] 
+  ]
 }

--- a/src/Templates/src/templates/maui-mobile/.template.config/ide.host.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/ide.host.json
@@ -13,6 +13,12 @@
               "hostId": "vs", 
               "componentType": "SetupComponent" 
         }
-    
-   ]
+   ],
+   "symbolInfo": [
+    {
+      "id": "Framework",
+      "persistenceScope": "shared",
+      "persistenceScopeName": "maui"
+    }
+  ]
 }


### PR DESCRIPTION
### Description of Change

This change allows .NET MAUI projects to have a different default framework version selection (e.g. .NET 6 or .NET 7) from other .NET projects in Visual Studio.

Needed because the .NET MAUI only installs a certain Android SDK together with a .NET version. With .NET 7 that will be Android SDK 33, where the default selection will be .NET 6 (because LTS) and that targets SDK 31, which causes potential issues.

### Issues Fixed

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1654352 (internal link)
