### PR TITLE
Invoke provisionator with AUTH_TOKEN_GITHUB_COM set

### DIFF
--- a/eng/pipelines/common/controlgallery-android.yml
+++ b/eng/pipelines/common/controlgallery-android.yml
@@ -8,6 +8,8 @@ steps:
     inputs:
       provisioning_script: $(provisionator.path)
       provisioning_extra_args: $(provisionator.extraArguments)
+    env:
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
   
   - task: Bash@3
     displayName: 'Cake Provision'

--- a/eng/pipelines/common/controlgallery-ios.yml
+++ b/eng/pipelines/common/controlgallery-ios.yml
@@ -7,6 +7,8 @@ steps:
     condition: ne(variables['REQUIRED_XCODE'], '')
     inputs:
       provisioning_script: $(provisionator.xcode)
+    env:
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provisionator'
@@ -14,6 +16,8 @@ steps:
     inputs:
       provisioning_script: $(provisionator.path)
       provisioning_extra_args: $(provisionator.extraArguments)
+    env:
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
   - script: |
       echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"

--- a/eng/pipelines/common/controlgallery-windows.yml
+++ b/eng/pipelines/common/controlgallery-windows.yml
@@ -8,6 +8,8 @@ steps:
     inputs:
       provisioning_script: $(provisionator.path)
       provisioning_extra_args: $(provisionator.extraArguments)
+    env:
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
   - powershell: |
       $(System.DefaultWorkingDirectory)/build.ps1 --target provision --TeamProject="$(System.TeamProject)"

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -100,6 +100,7 @@ steps:
         provisioning_script: $(provisionator.vs)
       env:
         PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
+        AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"


### PR DESCRIPTION
### Description of Change

Per [1658536](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1658536), we are updating all call sites of provisionator in CI to include setting AUTH_TOKEN_GITHUB_COM to allow us to support downloading from private blob containers through dl.internalx.com
