### PR TITLE
[Housekeeping] Add more Frame Device tests

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
@@ -60,6 +60,68 @@ namespace Microsoft.Maui.DeviceTests
 			// validate label is centered in the frame
 			Assert.True(Math.Abs(((300 - labelFrame.Width) / 2) - labelFrame.X) < 1);
 			Assert.True(Math.Abs(((300 - labelFrame.Height) / 2) - labelFrame.Y) < 1);
+		}
+
+		[Theory(DisplayName = "Frame BackgroundColor Initializes Correctly")]
+		[InlineData("#FF0000")]
+		[InlineData("#00FF00")]
+		[InlineData("#0000FF")]
+		[InlineData("#000000")]
+		public async Task FrameBackgroundColorInitializesCorrectly(string colorHex)
+		{
+			SetupBuilder();
+
+			var expectedColor = Graphics.Color.FromArgb(colorHex);
+
+			var frame = new Frame()
+			{
+				BackgroundColor = expectedColor,
+				HeightRequest = 300,
+				WidthRequest = 300,
+				Content = new Label()
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					Text = "BackgroundColor"
+				}
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var platformView = frame.ToPlatform(MauiContext);
+				platformView.AssertContainsColor(expectedColor);
+			});
+		}
+
+		[Theory(DisplayName = "Frame BorderColor Initializes Correctly")]
+		[InlineData("#FF0000")]
+		[InlineData("#00FF00")]
+		[InlineData("#0000FF")]
+		[InlineData("#000000")]
+		public async Task FrameBorderColorInitializesCorrectly(string colorHex)
+		{
+			SetupBuilder();
+
+			var expectedColor = Graphics.Color.FromArgb(colorHex);
+
+			var frame = new Frame()
+			{
+				BorderColor = expectedColor,
+				HeightRequest = 300,
+				WidthRequest = 300,
+				Content = new Label()
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					Text = "BorderColor"
+				}
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var platformView = frame.ToPlatform(MauiContext);
+				platformView.AssertContainsColor(expectedColor);
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Working on https://github.com/dotnet/maui/pull/11055  I missed some Frame device tests related to background colors, border etc. This PR adds more device tests.

![image](https://user-images.githubusercontent.com/6755973/199486558-1ec8bd6b-51d6-43ec-8990-747d7f3800f5.png)
