### PR TITLE
fix issue 9255 (Wrong Date format DatePicker Windows)

### DIFF
--- a/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
+++ b/src/Core/src/Platform/Windows/CalendarDatePickerExtensions.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Maui.Platform
 			{
 				var day = format.Count(x => x == 'd');
 
-				if (day == 3)
+				if (day == 2)
+					return "{day.integer(2)}";
+				else if (day == 3)
 					return "{day dayofweek.abbreviated}";
 				else if (day == 4)
 					return "{dayofweek.full}";
@@ -114,8 +116,10 @@ namespace Microsoft.Maui.Platform
 			{
 				var month = format.Count(x => x == 'M');
 
-				if (month <= 2)
+				if (month < 2)
 					return "{month.integer}";
+				else if (month == 2)
+					return "{month.integer(2)}";
 				else if (month == 3)
 					return "{month.abbreviated}";
 				else


### PR DESCRIPTION
### Description of Change

Fix bad date format for Windows platform.
Bug description:
If the date format is set to yyyy-MM-dd.
In Android the date shows as 2022-08-09.
In Windows the date shows as 2022-8-9.

### Issues Fixed

Fixes [9255](https://github.com/dotnet/maui/issues/9255)
