### PR TITLE
Revert "[android] bring back `$(AndroidLinkResources)` by default"

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.targets
+++ b/.nuspec/Microsoft.Maui.Controls.targets
@@ -11,7 +11,6 @@
 		<SkipMicrosoftUIXamlCheckTargetPlatformVersion Condition="'$(SkipMicrosoftUIXamlCheckTargetPlatformVersion)'==''">true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
 		<SkipMicrosoftUIXamlCheckTargetPlatformVersion Condition="'$(SkipMicrosoftUIXamlCheckTargetPlatformVersion)'=='false'"></SkipMicrosoftUIXamlCheckTargetPlatformVersion>
 		<AndroidUseDefaultAotProfile Condition="'$(AndroidEnableProfiledAot)' == 'true' and '$(AndroidUseDefaultAotProfile)' == ''">false</AndroidUseDefaultAotProfile>
-		<AndroidLinkResources Condition=" '$(AndroidLinkResources)' == '' And '$(Configuration)' == 'Release' ">True</AndroidLinkResources>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Description of Change

This reverts commit b73147e124cfc983a18ac2d7884fc7667b4eaf7d.

Fixes: https://github.com/dotnet/sdk/issues/28880