### PR TITLE
[iOS] Allow transparent modal pages 

### DIFF
--- a/src/Controls/src/Core/Platform/iOS/ModalWrapper.cs
+++ b/src/Controls/src/Core/Platform/iOS/ModalWrapper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls.Platform
 				{
 					Color modalBkgndColor = ((Page)_modal.VirtualView).BackgroundColor;
 
-					if (modalBkgndColor?.Alpha > 0)
+					if (modalBkgndColor?.Alpha > 0 || modalBkgndColor == Colors.Transparent)
 						result = UIKit.UIModalPresentationStyle.OverFullScreen;
 				}
 


### PR DESCRIPTION
### Description of Change

Allow transparent modal pages on iOS.

Before
![transparent-before](https://user-images.githubusercontent.com/6755973/199965331-fd9bff0f-32c5-4389-8c40-ab0072288b11.gif)

After
![transparent-after](https://user-images.githubusercontent.com/6755973/199965279-cc4338bf-68c2-43fa-83d8-e1cb80bacbc3.gif)

### Issues Fixed

Fixes #8526
Fixes #11040 