### PR TITLE
[Windows] Fix tablet mode detection

### DIFF
--- a/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
+++ b/src/Essentials/src/DeviceInfo/DeviceInfo.uwp.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Maui.Devices
 		static bool GetIsInTabletMode()
 		{
 			var supportsTablet = GetSystemMetrics(SM_TABLETPC) != 0;
-			var inTabletMode = GetSystemMetrics(SM_CONVERTIBLESLATEMODE) != 0;
+			var inTabletMode = GetSystemMetrics(SM_CONVERTIBLESLATEMODE) == 0;
 			return inTabletMode && supportsTablet;
 		}
 	}


### PR DESCRIPTION
### Description of Change

`DeviceInfo` on Windows currently uses `SM_CONVERTIBLESLATEMODE` to detect tablet mode. However the logic is currently:
`var inTabletMode = GetSystemMetrics(SM_CONVERTIBLESLATEMODE) != 0;`
But according to [the documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetrics):
> SM_CONVERTIBLESLATEMODE
> 0x2003
>Reflects the state of the laptop or slate mode, **0 for Slate Mode and non-zero otherwise**. When this system metric changes, the system sends a broadcast message via [WM_SETTINGCHANGE](https://learn.microsoft.com/en-us/windows/desktop/winmsg/wm-settingchange) with "ConvertibleSlateMode" in the LPARAM. Note that this system metric doesn't apply to desktop PCs. In that case, use [GetAutoRotationState](https://learn.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getautorotationstate).

So it appears 0 = slate mode, but the current logic is checking for anything other than 0.
### Issues Fixed

Fixes #11126 

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
