### PR TITLE
Notify Button ImageSource changes correctly

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Button/Button.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Button/Button.Impl.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
@@ -15,6 +15,8 @@ namespace Microsoft.Maui.Controls
 				Handler?.UpdateValue(nameof(IButtonStroke.StrokeColor));
 			else if (propertyName == BorderWidthProperty.PropertyName)
 				Handler?.UpdateValue(nameof(IButtonStroke.StrokeThickness));
+			else if (propertyName == ImageSourceProperty.PropertyName)
+				Handler?.UpdateValue(nameof(IImage.Source));
 		}
 
 		void IButton.Clicked()

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.Android.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Android.Text;
 using AndroidX.AppCompat.Widget;
@@ -75,6 +75,31 @@ namespace Microsoft.Maui.DeviceTests
 
 			Assert.Equal(xplatCharacterSpacing, values.ViewValue);
 			Assert.Equal(expectedValue, values.PlatformViewValue, EmCoefficientPrecision);
+		}
+
+		[Theory]
+		[InlineData("red.png", "#FF0000")]
+		[InlineData("green.png", "#00FF00")]
+		public async Task ImageSourceUpdatesCorrectly(string filename, string colorHex)
+		{
+			var image = new ButtonStub
+			{
+				ImageSource = new FileImageSourceStub("black.png"),
+			};
+
+			// Update the Button Icon
+			image.ImageSource = new FileImageSourceStub(filename);
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler(image);
+
+				bool imageLoaded = await Wait(() => ImageSourceLoaded(handler));
+
+				Assert.True(imageLoaded);
+				var expectedColor = Color.FromArgb(colorHex);
+				await handler.PlatformView.AssertContainsColor(expectedColor);
+			});
 		}
 
 		AppCompatButton GetNativeButton(ButtonHandler buttonHandler) =>


### PR DESCRIPTION
### Description of Change

Notify Button ImageSource changes correctly.

![fix-8459](https://user-images.githubusercontent.com/6755973/200316090-6c020146-54a7-4e61-ba3a-8f7a148081da.gif)

![image](https://user-images.githubusercontent.com/6755973/200312814-58d48ed4-53be-46fd-ab5b-7e267c13a853.png)

### Issues Fixed

Fixes #8459 
Fixes #10709