### PR TITLE
Ignore Authenticate Reunion NuGet sources - net7

### DIFF
--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -98,7 +98,7 @@ steps:
         PROVISIONATOR_CHANNEL: ${{ parameters.provisionatorChannel }}
         AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
     # Provision Additional Software
-    - task: xamops.azdevex.provisionator-task.provisionator@1
+    - task: xamops.azdevex.provisionator-task.provisionator@2
       displayName: 'Provision Additional Software'
       condition: and(eq('${{ parameters.provisioning }}', 'true'),ne('${{ parameters.poolName }}', 'Azure Pipelines'))
       inputs:

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -5,17 +5,6 @@ parameters:
   provisionatorChannel: 'latest'
 
 steps:
-  - task: UseDotNet@2                 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops
-    displayName: 'Use .NET SDK 6'
-    inputs:
-      packageType: sdk
-      version: 6.0.x
-
-  - pwsh: |
-      dotnet --version
-      dotnet --list-sdks
-    displayName: 'Show .NET SDK info'
-
   # Prepare macOS
   - ${{ if eq(parameters.platform, 'macos') }}:
     - template: agent-cleanser/v1.yml@xamarin-templates
@@ -89,7 +78,6 @@ steps:
       inputs:
         certSecureFile: 'Components Mac Certificate.p12'
 
-
   # Prepare Windows
   - ${{ if eq(parameters.platform, 'windows') }}:
     - powershell: |
@@ -125,6 +113,22 @@ steps:
       displayName: 'Setup MSBuild Paths'
       condition: eq(variables['provisioningVS'], 'true')
 
+  # Prepare Both
+  - task: UseDotNet@2
+    displayName: 'Use .NET SDK 6'
+    inputs:
+      packageType: sdk
+      version: 6.0.x
+
+  - pwsh: |
+      dotnet --version
+      dotnet --list-sdks
+    displayName: 'Show .NET SDK info'
+
+  - pwsh: ./build.ps1 --target provision
+    displayName: 'Cake Provision'
+    condition: eq(variables['provisioningCake'], 'true')
+
   - task: PowerShell@2
     condition: eq(variables['PrivateBuild'], 'true')
     displayName: Setup Private Feeds Credentials
@@ -136,16 +140,15 @@ steps:
   - pwsh: dotnet nuget locals all --clear
     displayName: 'Clear all NuGet caches'
 
-
   # Prepare for Reunion packages
-  - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-    - task: NuGetAuthenticate@0
-      displayName: 'Authenticate Reunion NuGet sources'
-      inputs:
-        nuGetServiceConnections: Project.Reunion.nuget.internal
-    - pwsh: |
-        $path = '$(Build.SourcesDirectory)\NuGet.config'
-        [xml]$xml = Get-Content $path
-        $xml.configuration.RemoveChild($xml.configuration.disabledPackageSources)
-        $xml.Save($path)
-      displayName: 'Add "wasdk-internal" to NuGet.config'
+  # - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+  #   - task: NuGetAuthenticate@0
+  #     displayName: 'Authenticate Reunion NuGet sources'
+  #     inputs:
+  #       nuGetServiceConnections: Project.Reunion.nuget.internal
+  #   - pwsh: |
+  #       $path = '$(Build.SourcesDirectory)\NuGet.config'
+  #       [xml]$xml = Get-Content $path
+  #       $xml.configuration.RemoveChild($xml.configuration.disabledPackageSources)
+  #       $xml.Save($path)
+  #     displayName: 'Add "wasdk-internal" to NuGet.config'


### PR DESCRIPTION
### Description of Change

- Seems the reunion feed is not working, i don't think we need it now
- Also fix a issue where agent cleaner was cleaning the installed dotnet version