### PR TITLE
Workaround Android a11y scrollview bug

### DIFF
--- a/src/Templates/src/templates/maui-mobile/MainPage.xaml
+++ b/src/Templates/src/templates/maui-mobile/MainPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MauiApp._1.MainPage">
 
-    <ScrollView>
+    <ScrollView AutomationProperties.IsInAccessibleTree="False">
         <VerticalStackLayout
             Spacing="25"
             Padding="30,0"


### PR DESCRIPTION
### Description of Change

There's currently an accessibility bug (shown in screenshot below) on the Android platform where a ScrollView is in the accessibility tree and the elements within a ScrollView are not individually accessible. This is a current workaround for it, so we'll use it in our templates to keep them accessible.

| Current default behavior with bug | Expected behavior with workaround |
|---|---|
|![image](https://user-images.githubusercontent.com/21988533/200384111-10889d37-24d1-411e-9dcc-8e6c0e96b915.png)|![image](https://user-images.githubusercontent.com/21988533/200384628-c34957b2-edbe-4d6e-a3fd-5683e7998715.png)|

Related to https://github.com/dotnet/maui/issues/8524
