### PR TITLE
Fix being unable to access some resources

### DIFF
--- a/src/Controls/src/Core/ResourceDictionary.cs
+++ b/src/Controls/src/Core/ResourceDictionary.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/ResourceDictionary.xml" path="//Member[@MemberName='ContainsKey']/Docs/*" />
 		public bool ContainsKey(string key)
 		{
-			return _innerDictionary.ContainsKey(key);
+			return _innerDictionary.ContainsKey(key) || (_mergedInstance?._innerDictionary?.ContainsKey(key) ?? false);
 		}
 
 		[IndexerName("Item")]

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh8799.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh8799.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Microsoft.Maui.Controls.Xaml.UnitTests"
+        x:Class="Microsoft.Maui.Controls.Xaml.UnitTests.Gh8799">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Gh8799ResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    
+    <Label x:Name="Gh8799Label" />
+</ContentPage>

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh8799.xaml.cs
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh8799.xaml.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Xaml.UnitTests
+{
+	public partial class Gh8799 : ContentPage
+	{
+		public Gh8799()
+		{
+			InitializeComponent();
+
+			this.Gh8799Label.Style = Resources["Gh8799Text"] as Style;
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[Test]
+			public void CanAccessNamedStyleWhenLoadedIntoMergedDictionaryBySource([Values(false, true)] bool useCompiledXaml)
+			{
+				var layout = new Gh8799();
+				Assert.That(layout, Is.Not.Null);
+			}
+		}
+	}
+}

--- a/src/Controls/tests/Xaml.UnitTests/Issues/Gh8799ResourceDictionary.xaml
+++ b/src/Controls/tests/Xaml.UnitTests/Issues/Gh8799ResourceDictionary.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ResourceDictionary
+        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Style TargetType="Label" x:Key="Gh8799Text">
+        <Setter Property="TextColor" Value="Red" />
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->

When a ResourceDictionary is included by specifying the path to a separate [.xaml] file, this is stored internally in a separate 
(merged) dictionary to those resources specified directly in the same file. The method that looked up resources by name didn't account for the two internal collections. Now it does.

As you can see elsewhere in the same file (https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/ResourceDictionary.cs#L185), there are attempts to access the separate merged instance, but this must have been overlooked in the `ContainsKey` method.


Test also included.


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #8799

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
