### PR TITLE
Remove dead IScreenshotResult XML Doc link

### DIFF
--- a/src/Essentials/src/Screenshot/Screenshot.shared.cs
+++ b/src/Essentials/src/Screenshot/Screenshot.shared.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Maui.Media
 		Task<Stream> OpenReadAsync(ScreenshotFormat format = ScreenshotFormat.Png, int quality = 100);
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 
-		/// <include file="../../docs/Microsoft.Maui.Essentials/IScreenshotResult.xml" path="//Member[@MemberName='CopyToAsync']/Docs/*" />
 		Task CopyToAsync(Stream destination, ScreenshotFormat format = ScreenshotFormat.Png, int quality = 100);
 	}
 


### PR DESCRIPTION
Removes a reference to an external XML doc node that doesn't exist (anymore). This is needed to keep our API Docs pipeline working.

Fixes https://github.com/dotnet/dotnet-maui-api-docs/issues/31