### PR TITLE
Clean up the files in the xml-docs artifacts

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -330,7 +330,8 @@ Task("dotnet-pack-docs")
             Unzip(nupkg, d);
             DeleteFiles($"{d}/**/*.pri");
             DeleteFiles($"{d}/**/*.aar");
-            CopyDirectory($"{d}/ref", $"{destDir}");
+            CopyFiles($"{d}/lib/**/net*(standard)?.?/**/*.dll", $"{destDir}");
+            CopyFiles($"{d}/lib/**/net*(standard)?.?/**/*.xml", $"{destDir}");
         }
 
         // Get the docs for libraries separately distributed as NuGets
@@ -343,11 +344,12 @@ Task("dotnet-pack-docs")
                 DeleteFiles($"{d}/**/*.pri");
                 DeleteFiles($"{d}/**/*.aar");
                 DeleteFiles($"{d}/**/*.pdb");
-                CopyDirectory($"{d}/lib", $"{destDir}");
+                CopyFiles($"{d}/lib/**/net*(standard)?.?/*.dll", $"{destDir}");
+                CopyFiles($"{d}/lib/**/net*(standard)?.?/*.xml", $"{destDir}");
             }
         }
 
-        CleanDirectories(tempDir);
+        //CleanDirectories(tempDir);
     });
 
 Task("dotnet-pack")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -324,14 +324,15 @@ Task("dotnet-pack-docs")
         CleanDirectories(destDir);
 
         // Get the docs for .NET MAUI
-        foreach (var nupkg in GetFiles("./artifacts/Microsoft.Maui.*.Ref.*.nupkg"))
+        foreach (var nupkg in GetFiles("./artifacts/Microsoft.Maui.*.Ref.any.*.nupkg"))
         {
             var d = $"{tempDir}/{nupkg.GetFilename()}";
+            Information(d);
             Unzip(nupkg, d);
             DeleteFiles($"{d}/**/*.pri");
             DeleteFiles($"{d}/**/*.aar");
-            CopyFiles($"{d}/ref/**/net*(standard)?.?/**/*.dll", $"{destDir}");
-            CopyFiles($"{d}/ref/**/net*(standard)?.?/**/*.xml", $"{destDir}");
+            CopyFiles($"{d}/ref/**/net?.?/**/*.dll", $"{destDir}");
+            CopyFiles($"{d}/ref/**/net?.?/**/*.xml", $"{destDir}");
         }
 
         // Get the docs for libraries separately distributed as NuGets
@@ -344,8 +345,8 @@ Task("dotnet-pack-docs")
                 DeleteFiles($"{d}/**/*.pri");
                 DeleteFiles($"{d}/**/*.aar");
                 DeleteFiles($"{d}/**/*.pdb");
-                CopyFiles($"{d}/lib/**/net*(standard)?.?/*.dll", $"{destDir}");
-                CopyFiles($"{d}/lib/**/net*(standard)?.?/*.xml", $"{destDir}");
+                CopyFiles($"{d}/lib/**/net*(standard)?.?/**/*.dll", $"{destDir}");
+                CopyFiles($"{d}/lib/**/net*(standard)?.?/**/*.xml", $"{destDir}");
             }
         }
 

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -17,7 +17,6 @@ var NuGetOnlyPackages = new string[] {
     "Microsoft.Maui.Graphics.*.nupkg",
     "Microsoft.Maui.Controls.Maps.*.nupkg",
     "Microsoft.Maui.Maps.*.nupkg",
-    "Microsoft.AspNetCore.Components.WebView.Maui.*.nupkg",
 };
 
 ProcessTFMSwitches();
@@ -337,7 +336,7 @@ Task("dotnet-pack-docs")
             CopyFiles($"{d}/ref/**/net?.?/**/*.xml", $"{destDir}");
         }
 
-        // Get the docs for libraries separately distributed as NuGets (and BlazorWebView)
+        // Get the docs for libraries separately distributed as NuGets
         foreach (var pattern in NuGetOnlyPackages)
         {
             foreach (var nupkg in GetFiles($"./artifacts/{pattern}"))

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -329,12 +329,10 @@ Task("dotnet-pack-docs")
         {
             var d = $"{tempDir}/{nupkg.GetFilename()}";
 
-            if (d.Contains(".DesignTools."))
-                continue;
-
             Unzip(nupkg, d);
             DeleteFiles($"{d}/**/*.pri");
             DeleteFiles($"{d}/**/*.aar");
+            DeleteFiles($"{d}/**/*.DesignTools.*");
             CopyFiles($"{d}/ref/**/net?.?/**/*.dll", $"{destDir}");
             CopyFiles($"{d}/ref/**/net?.?/**/*.xml", $"{destDir}");
         }
@@ -354,7 +352,7 @@ Task("dotnet-pack-docs")
             }
         }
 
-        //CleanDirectories(tempDir);
+        CleanDirectories(tempDir);
     });
 
 Task("dotnet-pack")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -347,8 +347,8 @@ Task("dotnet-pack-docs")
                 DeleteFiles($"{d}/**/*.pri");
                 DeleteFiles($"{d}/**/*.aar");
                 DeleteFiles($"{d}/**/*.pdb");
-                CopyFiles($"{d}/lib/**/net*(standard)?.?/**/*.dll", $"{destDir}");
-                CopyFiles($"{d}/lib/**/net*(standard)?.?/**/*.xml", $"{destDir}");
+                CopyFiles($"{d}/lib/**/{{net,netstandard}}?.?/**/*.dll", $"{destDir}");
+                CopyFiles($"{d}/lib/**/{{net,netstandard}}?.?/**/*.xml", $"{destDir}");
             }
         }
 

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -349,7 +349,7 @@ Task("dotnet-pack-docs")
             }
         }
 
-        //CleanDirectories(tempDir);
+        CleanDirectories(tempDir);
     });
 
 Task("dotnet-pack")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -17,6 +17,7 @@ var NuGetOnlyPackages = new string[] {
     "Microsoft.Maui.Graphics.*.nupkg",
     "Microsoft.Maui.Controls.Maps.*.nupkg",
     "Microsoft.Maui.Maps.*.nupkg",
+    "Microsoft.AspNetCore.Components.WebView.Maui.*.nupkg",
 };
 
 ProcessTFMSwitches();
@@ -327,7 +328,10 @@ Task("dotnet-pack-docs")
         foreach (var nupkg in GetFiles("./artifacts/Microsoft.Maui.*.Ref.any.*.nupkg"))
         {
             var d = $"{tempDir}/{nupkg.GetFilename()}";
-            Information(d);
+
+            if (d.Contains(".DesignTools."))
+                continue;
+
             Unzip(nupkg, d);
             DeleteFiles($"{d}/**/*.pri");
             DeleteFiles($"{d}/**/*.aar");
@@ -335,7 +339,7 @@ Task("dotnet-pack-docs")
             CopyFiles($"{d}/ref/**/net?.?/**/*.xml", $"{destDir}");
         }
 
-        // Get the docs for libraries separately distributed as NuGets
+        // Get the docs for libraries separately distributed as NuGets (and BlazorWebView)
         foreach (var pattern in NuGetOnlyPackages)
         {
             foreach (var nupkg in GetFiles($"./artifacts/{pattern}"))
@@ -350,7 +354,7 @@ Task("dotnet-pack-docs")
             }
         }
 
-        CleanDirectories(tempDir);
+        //CleanDirectories(tempDir);
     });
 
 Task("dotnet-pack")

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -330,8 +330,8 @@ Task("dotnet-pack-docs")
             Unzip(nupkg, d);
             DeleteFiles($"{d}/**/*.pri");
             DeleteFiles($"{d}/**/*.aar");
-            CopyFiles($"{d}/lib/**/net*(standard)?.?/**/*.dll", $"{destDir}");
-            CopyFiles($"{d}/lib/**/net*(standard)?.?/**/*.xml", $"{destDir}");
+            CopyFiles($"{d}/ref/**/net*(standard)?.?/**/*.dll", $"{destDir}");
+            CopyFiles($"{d}/ref/**/net*(standard)?.?/**/*.xml", $"{destDir}");
         }
 
         // Get the docs for libraries separately distributed as NuGets


### PR DESCRIPTION
This makes sure that only the files we need for the API docs generation show up in the xml-docs artifacts node