### PR TITLE
[foldable] add TypeConverter to Pane1Length/Pane2Length properties

### DIFF
--- a/src/Controls/Foldable/src/TwoPaneView.cs
+++ b/src/Controls/Foldable/src/TwoPaneView.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Maui.Controls.Foldable
 		/// <summary>
 		/// Gets the calculated width (in wide mode) or height (in tall mode) of pane 1, or sets the GridLength value of pane 1.
 		/// </summary>
+		[System.ComponentModel.TypeConverter(typeof(GridLengthTypeConverter))]
 		public GridLength Pane1Length
 		{
 			get { return (GridLength)GetValue(Pane1LengthProperty); }
@@ -151,6 +152,7 @@ namespace Microsoft.Maui.Controls.Foldable
 		/// <summary>
 		/// Gets the calculated width (in wide mode) or height (in tall mode) of pane 2, or sets the GridLength value of pane 2.
 		/// </summary>
+		[System.ComponentModel.TypeConverter(typeof(GridLengthTypeConverter))]
 		public GridLength Pane2Length
 		{
 			get { return (GridLength)GetValue(Pane2LengthProperty); }


### PR DESCRIPTION
### Description of Change

Add a `TypeConverter` to `Pane1Length` and `Pane2Length` properties so they can be set in XAML

### Issues Fixed

Fixes #11240
