### PR TITLE
Vibrate - Detect zero duration and return early

### DIFF
--- a/src/Essentials/src/Vibration/Vibration.android.cs
+++ b/src/Essentials/src/Vibration/Vibration.android.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Devices
 			Permissions.EnsureDeclared<Permissions.Vibrate>();
 
 			var time = (long)duration.TotalMilliseconds;
-			if (time == 0)
+			if (time <= 0)
 				return;
 #if __ANDROID_26__
 			if (OperatingSystem.IsAndroidVersionAtLeast(26))

--- a/src/Essentials/src/Vibration/Vibration.android.cs
+++ b/src/Essentials/src/Vibration/Vibration.android.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Maui.Devices
 			Permissions.EnsureDeclared<Permissions.Vibrate>();
 
 			var time = (long)duration.TotalMilliseconds;
+			if (time == 0)
+				return;
 #if __ANDROID_26__
 			if (OperatingSystem.IsAndroidVersionAtLeast(26))
 			{


### PR DESCRIPTION
### Description of Change

`CreateOneShot` method doesn't accept a duration of zero as documented here:

https://learn.microsoft.com/en-us/dotnet/api/android.os.vibrationeffect.createoneshot?view=xamarin-android-sdk-12

However, zero is valid for the MAUI `Vibrate` method: https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.devices.vibration.vibrate?view=net-maui-7.0

So we need to detect this and return early to avoid this exception:

```
Java.Lang.IllegalArgumentException: 'at least one timing must be non-zero (segments=[Step{amplitude=-1.0, frequency=0.0, duration=0}])'
```

### Issues Fixed

It was easier to fix this directly than to create a whole issue and take the time to make a reproduction project.