### PR TITLE
Set window soft input via window mapper

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Application/Application.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application/Application.cs
@@ -6,6 +6,8 @@
 			new PropertyMapper<Application, ApplicationHandler>(ApplicationHandler.Mapper)
 			{
 #if ANDROID
+				// There is also a mapper on Window for this property since this property is relevant at the window level for
+				// Android not the application level
 				[PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName] = MapWindowSoftInputModeAdjust,
 #endif
 			};

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Android.cs
@@ -3,6 +3,7 @@ using System;
 using Android.App;
 using Android.Views;
 using AndroidX.AppCompat.App;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.Maui.Controls
@@ -19,6 +20,21 @@ namespace Microsoft.Maui.Controls
 
 		public static void MapContent(IWindowHandler handler, IWindow view)
 		{
+		}
+
+		internal static void MapWindowSoftInputModeAdjust(IWindowHandler handler, IWindow view)
+		{
+			if (view.Parent is Application app)
+			{
+				var setting = PlatformConfiguration.AndroidSpecific.Application.GetWindowSoftInputModeAdjust(app);
+				view.UpdateWindowSoftInputModeAdjust(setting.ToPlatform());
+			}
+		}
+
+		private protected override void OnParentChangedCore()
+		{
+			base.OnParentChangedCore();
+			Handler?.UpdateValue(PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName);
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Maui.Controls
 				[PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName] = MapWindowSoftInputModeAdjust,
 #endif
 			};
+
 		internal static void RemapForControls()
 		{
 			WindowHandler.Mapper = Mapper;

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -5,7 +5,14 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Window
 	{
-		public static IPropertyMapper<IWindow, WindowHandler> ControlsWindowMapper = new PropertyMapper<IWindow, WindowHandler>(WindowHandler.Mapper);
+		public static IPropertyMapper<IWindow, WindowHandler> ControlsWindowMapper =
+			new PropertyMapper<IWindow, WindowHandler>(WindowHandler.Mapper)
+			{
+#if ANDROID
+				// This property is also on the Application Mapper since that's where the attached property exists				
+				[PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName] = MapWindowSoftInputModeAdjust,
+#endif
+			};
 
 		internal static void RemapForControls()
 		{

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.cs
@@ -6,17 +6,20 @@ namespace Microsoft.Maui.Controls
 	public partial class Window
 	{
 		public static IPropertyMapper<IWindow, WindowHandler> ControlsWindowMapper =
-			new PropertyMapper<IWindow, WindowHandler>(WindowHandler.Mapper)
+			new PropertyMapper<IWindow, WindowHandler>(WindowHandler.Mapper);
+
+		// ControlsWindowMapper incorrectly typed to WindowHandler
+		static IPropertyMapper<IWindow, IWindowHandler> Mapper =
+			new PropertyMapper<IWindow, IWindowHandler>(ControlsWindowMapper)
 			{
 #if ANDROID
 				// This property is also on the Application Mapper since that's where the attached property exists				
 				[PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName] = MapWindowSoftInputModeAdjust,
 #endif
 			};
-
 		internal static void RemapForControls()
 		{
-			WindowHandler.Mapper = ControlsWindowMapper;
+			WindowHandler.Mapper = Mapper;
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Android/Extensions/ApplicationExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/ApplicationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Android.App;
 using Android.Content;
+using Android.Media;
 using Android.Views;
 using Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific;
 using AApplication = Android.App.Application;
@@ -10,32 +11,24 @@ namespace Microsoft.Maui.Controls.Platform
 	{
 		public static void UpdateWindowSoftInputModeAdjust(this AApplication platformView, Application application)
 		{
-			var adjust = SoftInput.AdjustPan;
-
-			if (Application.Current != null)
+			if (application is IApplication app)
 			{
-				WindowSoftInputModeAdjust elementValue = Application.Current.OnThisPlatform().GetWindowSoftInputModeAdjust();
-
-				switch (elementValue)
-				{
-					case WindowSoftInputModeAdjust.Resize:
-						adjust = SoftInput.AdjustResize;
-						break;
-					case WindowSoftInputModeAdjust.Unspecified:
-						adjust = SoftInput.AdjustUnspecified;
-						break;
-					default:
-						adjust = SoftInput.AdjustPan;
-						break;
-				}
+				foreach (var window in app.Windows)
+					window?.Handler?.UpdateValue(PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName);
 			}
+		}
 
-			IMauiContext mauiContext = application.FindMauiContext(true);
-			Context context = mauiContext?.Context;
-			Activity activity = context.GetActivity();
-
-			activity?.Window?.SetSoftInputMode(adjust);
-
+		internal static SoftInput ToPlatform(this WindowSoftInputModeAdjust windowSoftInputModeAdjust)
+		{
+			switch (windowSoftInputModeAdjust)
+			{
+				case WindowSoftInputModeAdjust.Resize:
+					return SoftInput.AdjustResize;
+				case WindowSoftInputModeAdjust.Unspecified:
+					return SoftInput.AdjustUnspecified;
+				default:
+					return SoftInput.AdjustPan;
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Application/ApplicationTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Application/ApplicationTests.Android.cs
@@ -43,32 +43,48 @@ namespace Microsoft.Maui.DeviceTests
 
 				await InvokeOnMainThreadAsync(() =>
 				{
-					// Setup application stub
-					var app = MauiContext.Services.GetService<IApplication>() as SoftInputModeApplication;
-					app.Handler = app.ToHandler(MauiContext);
+					var handlers = new List<IElementHandler>();
 
-					// Setup window
-					var windowHandler = (SoftInputWindowHandlerStub)app.Window.ToHandler(MauiContext);
-					app.Window.Handler = windowHandler;
+					try
+					{
+						// Setup application stub
+						var app = MauiContext.Services.GetService<IApplication>() as SoftInputModeApplication;
+						app.Handler = app.ToHandler(MauiContext);
 
-					// Validate that the Soft Input initializes to AdjustPan
-					Assert.Equal(ASoftInput.AdjustPan, windowHandler.LastASoftInputSet);
+						handlers.Add(app.Handler);
 
-					// Set to Resize
-					Controls.PlatformConfiguration.AndroidSpecific.Application.SetWindowSoftInputModeAdjust(
-						app,
-						Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust.Resize);
+						// Setup window
+						var windowHandler = (SoftInputWindowHandlerStub)app.Window.ToHandler(MauiContext);
+						app.Window.Handler = windowHandler;
 
-					// Validate the mapper on the window handler is called with correct value
-					Assert.Equal(ASoftInput.AdjustResize, windowHandler.LastASoftInputSet);
+						handlers.Insert(0, app.Window.Handler);
 
-					// Set to Pan
-					Controls.PlatformConfiguration.AndroidSpecific.Application.SetWindowSoftInputModeAdjust(
-						app,
-						Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust.Pan);
+						// Validate that the Soft Input initializes to AdjustPan
+						Assert.Equal(ASoftInput.AdjustPan, windowHandler.LastASoftInputSet);
 
-					// Validate the mapper on the window handler is called with correct value
-					Assert.Equal(ASoftInput.AdjustPan, windowHandler.LastASoftInputSet);
+						// Set to Resize
+						Controls.PlatformConfiguration.AndroidSpecific.Application.SetWindowSoftInputModeAdjust(
+							app,
+							Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust.Resize);
+
+						// Validate the mapper on the window handler is called with correct value
+						Assert.Equal(ASoftInput.AdjustResize, windowHandler.LastASoftInputSet);
+
+						// Set to Pan
+						Controls.PlatformConfiguration.AndroidSpecific.Application.SetWindowSoftInputModeAdjust(
+							app,
+							Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust.Pan);
+
+						// Validate the mapper on the window handler is called with correct value
+						Assert.Equal(ASoftInput.AdjustPan, windowHandler.LastASoftInputSet);
+					}
+					finally
+					{
+						foreach (var handler in handlers)
+						{
+							handler.DisconnectHandler();
+						}
+					}
 				});
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/Application/ApplicationTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Application/ApplicationTests.Android.cs
@@ -1,0 +1,147 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using ASoftInput = Android.Views.SoftInput;
+using AApplication = Android.App.Application;
+using AActivity = Android.App.Activity;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	[Category(TestCategory.Application)]
+	public partial class ApplicationTests : ControlsHandlerTestBase
+	{
+		[Category(TestCategory.Application)]
+		public class SoftInputModeTests : ControlsHandlerTestBase
+		{
+			[Fact]
+			public async Task SoftInputModeDefaultsToAdjustPan()
+			{
+				await InvokeOnMainThreadAsync(() =>
+				{
+					Assert.Equal(ASoftInput.AdjustPan, GetSoftInput());
+				});
+			}
+
+			[Fact]
+			public async Task SoftInputModeSetOnApplicationPropagatesToWindowHandlers()
+			{
+				EnsureHandlerCreated((builder) =>
+				{
+					builder.Services.AddSingleton<IApplication>((_) => new SoftInputModeApplication());
+					builder.ConfigureMauiHandlers(handler =>
+					{
+						handler.AddHandler<SoftInputModeWindow, SoftInputWindowHandlerStub>();
+						handler.AddHandler<SoftInputModeApplication, SoftInputApplicationHandlerStub>();
+					});
+				});
+
+				await InvokeOnMainThreadAsync(() =>
+				{
+					// Setup application stub
+					var app = MauiContext.Services.GetService<IApplication>() as SoftInputModeApplication;
+					app.Handler = app.ToHandler(MauiContext);
+
+					// Setup window
+					var windowHandler = (SoftInputWindowHandlerStub)app.Window.ToHandler(MauiContext);
+					app.Window.Handler = windowHandler;
+
+					// Validate that the Soft Input initializes to AdjustPan
+					Assert.Equal(ASoftInput.AdjustPan, windowHandler.LastASoftInputSet);
+
+					// Set to Resize
+					Controls.PlatformConfiguration.AndroidSpecific.Application.SetWindowSoftInputModeAdjust(
+						app,
+						Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust.Resize);
+
+					// Validate the mapper on the window handler is called with correct value
+					Assert.Equal(ASoftInput.AdjustResize, windowHandler.LastASoftInputSet);
+
+					// Set to Pan
+					Controls.PlatformConfiguration.AndroidSpecific.Application.SetWindowSoftInputModeAdjust(
+						app,
+						Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust.Pan);
+
+					// Validate the mapper on the window handler is called with correct value
+					Assert.Equal(ASoftInput.AdjustPan, windowHandler.LastASoftInputSet);
+				});
+			}
+
+			ASoftInput GetSoftInput() =>
+				GetSoftInput(MauiContext.Context.GetActivity());
+
+			ASoftInput GetSoftInput(AActivity aActivity) =>
+				aActivity.Window.Attributes.SoftInputMode;
+
+			class SoftInputApplicationHandlerStub : ApplicationHandler
+			{
+				public SoftInputApplicationHandlerStub() : base(Application.ControlsApplicationMapper)
+				{
+				}
+
+				protected override AApplication CreatePlatformElement()
+				{
+					return new AApplication();
+				}
+			}
+
+			class SoftInputModeApplication : Application, IApplication
+			{
+				public SoftInputModeWindow Window { get; } = new SoftInputModeWindow();
+
+				public SoftInputModeApplication() : base(false)
+				{
+					Window.Parent = this;
+				}
+
+				IReadOnlyList<IWindow> IApplication.Windows
+				{
+					get
+					{
+						return new List<IWindow>() { Window };
+					}
+				}
+			}
+
+			class SoftInputModeWindow : Window
+			{
+
+			}
+
+			class SoftInputWindowHandlerStub : ElementHandler<IWindow, AActivity>, IWindowHandler
+			{
+				public ASoftInput LastASoftInputSet { get; private set; } = ASoftInput.AdjustUnspecified;
+
+				public static IPropertyMapper<IWindow, SoftInputWindowHandlerStub> StubMapper =
+					new PropertyMapper<IWindow, SoftInputWindowHandlerStub>()
+					{
+						[Controls.PlatformConfiguration.AndroidSpecific.Application.WindowSoftInputModeAdjustProperty.PropertyName] = MapWindowSoftInputModeAdjust
+					};
+
+				public static void MapWindowSoftInputModeAdjust(SoftInputWindowHandlerStub arg1, IWindow arg2)
+				{
+					if (arg2.Parent is Application app)
+					{
+						var setting = Controls.PlatformConfiguration.AndroidSpecific.Application.GetWindowSoftInputModeAdjust(app);
+						arg1.LastASoftInputSet = setting.ToPlatform();
+					}
+				}
+
+				public SoftInputWindowHandlerStub() : base(StubMapper, null)
+				{
+
+				}
+
+				protected override AActivity CreatePlatformElement()
+				{
+					return new AActivity();
+				}
+			}
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Application/ApplicationTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Application/ApplicationTests.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ApplicationTests : ControlsHandlerTestBase
+	{
+	}
+}

--- a/src/Controls/tests/DeviceTests/MauiProgram.cs
+++ b/src/Controls/tests/DeviceTests/MauiProgram.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.DeviceTests
 		public static Microsoft.UI.Xaml.Window CurrentWindow => MauiProgramDefaults.DefaultWindow;
 #endif
 
-		public static IApplication DefaultTestApp { get; private set; }
+		public static IApplication DefaultTestApp => MauiProgramDefaults.DefaultTestApp;
 
 		public static MauiApp CreateMauiApp() =>
 			MauiProgramDefaults.CreateMauiApp(new List<Assembly>()

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -2,6 +2,7 @@
 {
 	public static class TestCategory
 	{
+		public const string Application = "Application";
 		public const string Behavior = "Behavior";
 		public const string Button = "Button";
 		public const string CheckBox = "CheckBox";

--- a/src/Core/src/Platform/Android/WindowExtensions.cs
+++ b/src/Core/src/Platform/Android/WindowExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Android.App;
+using Android.Content;
 using Android.Content.Res;
+using Android.Views;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Platform;
 
@@ -19,6 +21,16 @@ namespace Microsoft.Maui
 				Orientation.Square => DisplayOrientation.Portrait,
 				_ => DisplayOrientation.Unknown
 			};
+		}
+
+		internal static void UpdateWindowSoftInputModeAdjust(this IWindow platformView, SoftInput inputMode)
+		{
+			var activity = platformView?.Handler?.PlatformView as Activity ??
+							platformView?.Handler?.MauiContext?.GetPlatformWindow();
+
+			activity?
+				.Window?
+				.SetSoftInputMode(inputMode);
 		}
 	}
 }

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -40,18 +40,11 @@ namespace Microsoft.Maui
 
 		protected virtual void UpdatePropertyCore(string key, IElementHandler viewHandler, IElement virtualView)
 		{
-			try
-			{
-				if (!viewHandler.CanInvokeMappers())
-					return;
+			if (!viewHandler.CanInvokeMappers())
+				return;
 
-				var action = GetProperty(key);
-				action?.Invoke(viewHandler, virtualView);
-			}
-			catch (InvalidCastException exc)
-			{
-				throw new Exception(key, exc);
-			}
+			var action = GetProperty(key);
+			action?.Invoke(viewHandler, virtualView);
 		}
 
 		public virtual Action<IElementHandler, IElement>? GetProperty(string key)

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -40,11 +40,18 @@ namespace Microsoft.Maui
 
 		protected virtual void UpdatePropertyCore(string key, IElementHandler viewHandler, IElement virtualView)
 		{
-			if (!viewHandler.CanInvokeMappers())
-				return;
+			try
+			{
+				if (!viewHandler.CanInvokeMappers())
+					return;
 
-			var action = GetProperty(key);
-			action?.Invoke(viewHandler, virtualView);
+				var action = GetProperty(key);
+				action?.Invoke(viewHandler, virtualView);
+			}
+			catch (InvalidCastException exc)
+			{
+				throw new Exception(key, exc);
+			}
 		}
 
 		public virtual Action<IElementHandler, IElement>? GetProperty(string key)


### PR DESCRIPTION
### Description of Change

Move the code that sets the `SoftInputMode` to the `WindowHandler`. Currently it's on the `ApplicationHandler` but at that point none of the `Android` windows have been created so the mapper at the application level basically does nothing.

- The code at the application level now just iterates over all open windows and sets the value
- The window mapper grabs the value at the application level and then applies it to the window [(we should mostly likely create a window platform specific for this property) ](https://github.com/dotnet/maui/issues/11355)

### Issues Fixed

Fixes #11274
Fixes #5721
Fixes #10978 
Fixes #6933 
Fixes #7588 
Fixes #7861
Fixes #9458
