### PR TITLE
Reboot on-prem agent after job completion

### DIFF
--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -4,6 +4,7 @@ parameters:
   device: '' # the xharness device to use
   cakeArgs: '' # additional cake args
   provisionatorChannel: 'latest'
+  agentPool: ''
   agentPoolAccessToken: ''
 
 steps:
@@ -44,7 +45,9 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
-  - ${{ if and(ne(parameters.agentPoolAccessToken, ''), startswith(variables['Agent.Name'], 'xambot-')) }}:
+  - ${{ if and(ne(parameters.agentPoolAccessToken, ''), eq(parameters.agentPool, 'MAUI')) }}:
     - template: agent-rebooter/mac.v1.yml@yaml-templates
       parameters:
+        Organization: xamarin
+        Project: public
         AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -7,6 +7,43 @@ parameters:
   agentPoolAccessToken: ''
 
 steps:
+  - template: provision.yml
+    parameters:
+      platform: macos
+      skipXcode: ${{ eq(parameters.platform, 'android') }}
+      provisionatorChannel: ${{ parameters.provisionatorChannel }}
+
+  - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
+    displayName: 'Install .NET'
+    retryCountOnTaskFailure: 3
+    env:
+      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
+      PRIVATE_BUILD: $(PrivateBuild)
+
+  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
+    displayName: 'Add .NET to PATH'
+
+  - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
+    displayName: 'Build the MSBuild Tasks'
+
+  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
+    displayName: $(Agent.JobName)
+    retryCountOnTaskFailure: 2
+
+  - task: PublishTestResults@2
+    displayName: Publish the $(System.PhaseName) test results
+    condition: always()
+    inputs:
+      testResultsFormat: xUnit
+      testResultsFiles: '$(TestResultsDirectory)/**/TestResults.xml'
+      testRunTitle: '$(System.PhaseName)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Artifacts
+    condition: always()
+    inputs:
+      artifactName: $(System.PhaseName)
+
   - template: agent-rebooter/mac.v1.yml@yaml-templates
     parameters:
       AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -8,6 +8,9 @@ parameters:
   agentPoolAccessToken: ''
 
 steps:
+  - pwsh: echo "Agent pool ${{ parameters.agentPoolName }}"
+    displayName: 'Show agent pool'
+
   - template: provision.yml
     parameters:
       platform: macos
@@ -44,9 +47,6 @@ steps:
     condition: always()
     inputs:
       artifactName: $(System.PhaseName)
-
-  - pwsh: echo "Agent pool ${{ parameters.agentPoolName }}"
-    displayName: 'Show agent pool'
 
   - ${{ if eq(parameters.agentPoolName, 'MAUI') }}:
     - template: agent-rebooter/mac.v1.yml@yaml-templates

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -45,8 +45,7 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
-  - powershell: |
-      Write-Host "Agent pool: ${{ parameters.agentPool }}"
+  - pwsh: echo "Agent pool ${{ parameters.agentPool }}"
     displayName: 'Show agent pool'
 
   - ${{ if eq(parameters.agentPool, 'MAUI') }}:

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -46,6 +46,4 @@ steps:
 
   - template: agent-rebooter/mac.v1.yml@yaml-templates
     parameters:
-      Organization: xamarin
-      Project: public
       AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -4,7 +4,7 @@ parameters:
   device: '' # the xharness device to use
   cakeArgs: '' # additional cake args
   provisionatorChannel: 'latest'
-  agentPool: ''
+  agentPoolName: ''
   agentPoolAccessToken: ''
 
 steps:
@@ -45,10 +45,10 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
-  - pwsh: echo "Agent pool"
+  - pwsh: echo "Agent pool ${{ parameters.agentPoolName }}"
     displayName: 'Show agent pool'
 
-  - ${{ if eq(parameters.agentPool, 'MAUI') }}:
+  - ${{ if eq(parameters.agentPoolName, 'MAUI') }}:
     - template: agent-rebooter/mac.v1.yml@yaml-templates
       parameters:
         Organization: xamarin

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -44,6 +44,7 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
+  # This must always be placed as the last step in the job
   - template: agent-rebooter/mac.v1.yml@yaml-templates
     parameters:
       AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -45,7 +45,7 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
-  - pwsh: |
+  - powershell: |
       Write-Host "Agent pool: ${{ parameters.agentPool }}"
     displayName: 'Show agent pool'
 

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -4,6 +4,7 @@ parameters:
   device: '' # the xharness device to use
   cakeArgs: '' # additional cake args
   provisionatorChannel: 'latest'
+  agentPoolAccessToken: ''
 
 steps:
   - template: provision.yml
@@ -42,3 +43,8 @@ steps:
     condition: always()
     inputs:
       artifactName: $(System.PhaseName)
+
+  - ${{ if and(ne(parameters.agentPoolAccessToken, ''), startswith(variables['Agent.Name'], 'xambot-')) }}:
+    - template: agent-rebooter/mac.v1.yml@yaml-templates
+      parameters:
+        AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -4,13 +4,9 @@ parameters:
   device: '' # the xharness device to use
   cakeArgs: '' # additional cake args
   provisionatorChannel: 'latest'
-  agentPoolName: ''
   agentPoolAccessToken: ''
 
 steps:
-  - pwsh: echo "Agent pool ${{ parameters.agentPoolName }}"
-    displayName: 'Show agent pool'
-
   - template: provision.yml
     parameters:
       platform: macos
@@ -48,9 +44,8 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
-  - ${{ if eq(parameters.agentPoolName, 'MAUI') }}:
-    - template: agent-rebooter/mac.v1.yml@yaml-templates
-      parameters:
-        Organization: xamarin
-        Project: public
-        AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
+  - template: agent-rebooter/mac.v1.yml@yaml-templates
+    parameters:
+      Organization: xamarin
+      Project: public
+      AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -45,7 +45,7 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
-  - ${{ if and(ne(parameters.agentPoolAccessToken, ''), eq(parameters.agentPool, 'MAUI')) }}:
+  - ${{ if eq(parameters.agentPool, 'MAUI') }}:
     - template: agent-rebooter/mac.v1.yml@yaml-templates
       parameters:
         Organization: xamarin

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -45,6 +45,10 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
+  - pwsh: |
+      Write-Host "Agent pool: ${{ parameters.agentPool }}"
+    displayName: 'Show agent pool'
+
   - ${{ if eq(parameters.agentPool, 'MAUI') }}:
     - template: agent-rebooter/mac.v1.yml@yaml-templates
       parameters:

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -45,7 +45,7 @@ steps:
     inputs:
       artifactName: $(System.PhaseName)
 
-  - pwsh: echo "Agent pool ${{ parameters.agentPool }}"
+  - pwsh: echo "Agent pool"
     displayName: 'Show agent pool'
 
   - ${{ if eq(parameters.agentPool, 'MAUI') }}:

--- a/eng/pipelines/common/device-tests-steps.yml
+++ b/eng/pipelines/common/device-tests-steps.yml
@@ -7,43 +7,6 @@ parameters:
   agentPoolAccessToken: ''
 
 steps:
-  - template: provision.yml
-    parameters:
-      platform: macos
-      skipXcode: ${{ eq(parameters.platform, 'android') }}
-      provisionatorChannel: ${{ parameters.provisionatorChannel }}
-
-  - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic
-    displayName: 'Install .NET'
-    retryCountOnTaskFailure: 3
-    env:
-      DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
-      PRIVATE_BUILD: $(PrivateBuild)
-
-  - pwsh: echo "##vso[task.prependpath]$(DotNet.Dir)"
-    displayName: 'Add .NET to PATH'
-
-  - pwsh: ./build.ps1 --target=dotnet-buildtasks --configuration="Release"
-    displayName: 'Build the MSBuild Tasks'
-
-  - pwsh: ./build.ps1 -Script eng/devices/${{ parameters.platform }}.cake --project="${{ parameters.path }}" --device=${{ parameters.device }} --results="$(TestResultsDirectory)" --binlog="$(LogDirectory)" ${{ parameters.cakeArgs }}
-    displayName: $(Agent.JobName)
-    retryCountOnTaskFailure: 2
-
-  - task: PublishTestResults@2
-    displayName: Publish the $(System.PhaseName) test results
-    condition: always()
-    inputs:
-      testResultsFormat: xUnit
-      testResultsFiles: '$(TestResultsDirectory)/**/TestResults.xml'
-      testRunTitle: '$(System.PhaseName)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifacts
-    condition: always()
-    inputs:
-      artifactName: $(System.PhaseName)
-
   - template: agent-rebooter/mac.v1.yml@yaml-templates
     parameters:
       AgentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -4,6 +4,7 @@ parameters:
   androidApiLevels: [ 30 ]
   iosVersions: [ 'latest' ]
   provisionatorChannel: 'latest'
+  agentPoolAccessToken: ''
   projects:
     - name: name
       desc: Human Description
@@ -38,6 +39,7 @@ stages:
                       path: ${{ project.android }}
                       device: android-emulator-32_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
+                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
 
   - stage: ios_device_tests
     displayName: iOS Device Tests
@@ -64,3 +66,4 @@ stages:
                       ${{ if ne(version, 'latest') }}:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
+                      agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -39,7 +39,6 @@ stages:
                       path: ${{ project.android }}
                       device: android-emulator-32_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolName: ${{ parameters.androidPool.name }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
 
   - stage: ios_device_tests
@@ -67,5 +66,4 @@ stages:
                       ${{ if ne(version, 'latest') }}:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPoolName: ${{ parameters.iosPool.name }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -39,6 +39,7 @@ stages:
                       path: ${{ project.android }}
                       device: android-emulator-32_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
+                      agentPool: ${{ parameters.androidPool }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
 
   - stage: ios_device_tests
@@ -66,4 +67,5 @@ stages:
                       ${{ if ne(version, 'latest') }}:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
+                      agentPool: ${{ parameters.iosPool }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/device-tests.yml
+++ b/eng/pipelines/common/device-tests.yml
@@ -39,7 +39,7 @@ stages:
                       path: ${{ project.android }}
                       device: android-emulator-32_${{ api }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPool: ${{ parameters.androidPool }}
+                      agentPoolName: ${{ parameters.androidPool.name }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}
 
   - stage: ios_device_tests
@@ -67,5 +67,5 @@ stages:
                       ${{ if ne(version, 'latest') }}:
                         device: ios-simulator-64_${{ version }}
                       provisionatorChannel: ${{ parameters.provisionatorChannel }}
-                      agentPool: ${{ parameters.iosPool }}
+                      agentPoolName: ${{ parameters.iosPool.name }}
                       agentPoolAccessToken: ${{ parameters.agentPoolAccessToken }}

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,4 +1,6 @@
 variables:
+- name: AgentPoolAccessToken
+  value: $(botdeploy--azdo--token--register--xamarin-public--untrusted)
 - name: Codeql.Enabled
   value: true
 - name: BuildVersion

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -66,5 +66,3 @@ variables:
   - group: DotNetBuilds storage account read tokens
   - group: AzureDevOps-Artifact-Feeds-Pats
 - group: Xamarin-Secrets
-- name: AgentPoolAccessToken
-  value: '$(botdeploy--azdo--token--register--xamarin-public--untrusted)'

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,6 +1,4 @@
 variables:
-- name: AgentPoolAccessToken
-  value: $(botdeploy--azdo--token--register--xamarin-public--untrusted)
 - name: Codeql.Enabled
   value: true
 - name: BuildVersion

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -66,3 +66,5 @@ variables:
   - group: DotNetBuilds storage account read tokens
   - group: AzureDevOps-Artifact-Feeds-Pats
 - group: Xamarin-Secrets
+- name: AgentPoolAccessToken
+  value: '$(botdeploy--azdo--token--register--xamarin-public--untrusted)'

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -82,7 +82,7 @@ stages:
     parameters:
       androidPool: ${{ parameters.androidPool }}
       iosPool: ${{ parameters.iosPool }}
-      agentPoolAccessToken: $(AgentPoolAccessToken)
+      agentPoolAccessToken: $(botdeploy--azdo--token--register--xamarin-public--untrusted)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -44,6 +44,8 @@ pr:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: AgentPoolAccessToken
+    value: $(botdeploy--azdo--token--register--xamarin-public--untrusted)
 
 parameters:
   - name: provisionatorChannel

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -44,7 +44,6 @@ pr:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
-  - group: Xamarin-Secrets
 
 parameters:
   - name: provisionatorChannel

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -43,6 +43,7 @@ pr:
     - THIRD-PARTY-NOTICES.TXT
 
 variables:
+  - group: Xamarin-Secrets
   - template: /eng/pipelines/common/variables.yml
 
 parameters:
@@ -82,6 +83,7 @@ stages:
     parameters:
       androidPool: ${{ parameters.androidPool }}
       iosPool: ${{ parameters.iosPool }}
+      agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -43,8 +43,8 @@ pr:
     - THIRD-PARTY-NOTICES.TXT
 
 variables:
-  - group: Xamarin-Secrets
   - template: /eng/pipelines/common/variables.yml
+  - group: Xamarin-Secrets
 
 parameters:
   - name: provisionatorChannel

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -77,7 +77,7 @@ resources:
       name: xamarin/yaml-templates
       endpoint: xamarin
       ref: refs/heads/main
-      
+
 stages:
 
   - template: common/device-tests.yml
@@ -98,18 +98,18 @@ stages:
       projects:
         - name: essentials
           desc: Essentials
-          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable 
+          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           android: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
           ios: $(System.DefaultWorkingDirectory)/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
         - name: core
           desc: Core
-          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable 
+          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           android: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
           iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
         - name: controls
           desc: Controls
-          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable 
+          androidApiLevelsExclude: [25] # Ignore for now API25 since the runs's are not stable
           android: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
           iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/Controls/tests/DeviceTests/Controls.DeviceTests.csproj
@@ -119,4 +119,4 @@ stages:
           android: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
           iosVersionsExclude: [ '12.4'] # Ignore iOS 12.4 while we can't make it work on CI
           ios: $(System.DefaultWorkingDirectory)/src/BlazorWebView/tests/MauiDeviceTests/MauiBlazorWebView.DeviceTests.csproj
-          
+

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -76,7 +76,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/dev/bond/rebooter-org   # UNDONE: DO NOT MERGE TO MAIN
+      ref: refs/heads/main
       
 stages:
 

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -82,7 +82,7 @@ stages:
     parameters:
       androidPool: ${{ parameters.androidPool }}
       iosPool: ${{ parameters.iosPool }}
-      agentPoolAccessToken: $(botdeploy--azdo--token--register--xamarin-public--untrusted)
+      agentPoolAccessToken: $(AgentPoolAccessToken)
       ${{ if or(parameters.BuildEverything, and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'devdiv'))) }}:
         androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23 ]
         # androidApiLevels: [ 30, 29, 28, 27, 26, 25, 24, 23, 22, 21 ] # fix the issue of getting the test results off

--- a/eng/pipelines/device-tests.yml
+++ b/eng/pipelines/device-tests.yml
@@ -75,7 +75,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/main
+      ref: refs/heads/dev/bond/rebooter-org   # UNDONE: DO NOT MERGE TO MAIN
       
 stages:
 


### PR DESCRIPTION
Evaluate rebooting an on-prem Mac agent after job completion as a means of improving reliability for jobs run against on-prem Mac agents

This PR is dependent on https://github.com/xamarin/yaml-templates/pull/221. The PR removes hard-coded assumptions about the DevDiv org and provides support for other orgs such as Xamarin