### PR TITLE
Don't set editor action to handled

### DIFF
--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Maui.Handlers
 				}
 			}
 
-			e.Handled = true;
+			e.Handled = false;
 		}
 
 		private void OnSelectionChanged(object? sender, EventArgs e)

--- a/src/Core/src/Platform/Android/KeyboardManager.cs
+++ b/src/Core/src/Platform/Android/KeyboardManager.cs
@@ -2,25 +2,27 @@ using System;
 using Android.App;
 using Android.Content;
 using Android.OS;
+using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
+using AndroidX.Core.View;
 using AView = Android.Views.View;
 
-namespace Microsoft.Maui.Controls.Platform
+namespace Microsoft.Maui.Platform
 {
 	internal static class KeyboardManager
 	{
 		internal static void HideKeyboard(this AView inputView, bool overrideValidation = false)
 		{
-			if (inputView == null)
+			if (inputView?.Context == null)
 				throw new ArgumentNullException(nameof(inputView) + " must be set before the keyboard can be hidden.");
 
-			using (var inputMethodManager = (InputMethodManager)inputView.Context.GetSystemService(Context.InputMethodService))
+			using (var inputMethodManager = (InputMethodManager)inputView.Context.GetSystemService(Context.InputMethodService)!)
 			{
 				if (!overrideValidation && !(inputView is EditText || inputView is TextView || inputView is SearchView))
 					throw new ArgumentException("inputView should be of type EditText, SearchView, or TextView");
 
-				IBinder windowToken = inputView.WindowToken;
+				var windowToken = inputView.WindowToken;
 				if (windowToken != null && inputMethodManager != null)
 					inputMethodManager.HideSoftInputFromWindow(windowToken, HideSoftInputFlags.None);
 			}
@@ -28,10 +30,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal static void ShowKeyboard(this TextView inputView)
 		{
-			if (inputView == null)
+			if (inputView?.Context == null)
 				throw new ArgumentNullException(nameof(inputView) + " must be set before the keyboard can be shown.");
 
-			using (var inputMethodManager = (InputMethodManager)inputView.Context.GetSystemService(Context.InputMethodService))
+			using (var inputMethodManager = (InputMethodManager)inputView.Context.GetSystemService(Context.InputMethodService)!)
 			{
 				// The zero value for the second parameter comes from 
 				// https://developer.android.com/reference/android/view/inputmethod/InputMethodManager#showSoftInput(android.view.View,%20int)
@@ -42,7 +44,7 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal static void ShowKeyboard(this SearchView searchView)
 		{
-			if (searchView == null)
+			if (searchView?.Context == null || searchView?.Resources == null)
 			{
 				throw new ArgumentNullException(nameof(searchView));
 			}
@@ -64,7 +66,7 @@ namespace Microsoft.Maui.Controls.Platform
 				return;
 			}
 
-			using (var inputMethodManager = (InputMethodManager)searchView.Context.GetSystemService(Context.InputMethodService))
+			using (var inputMethodManager = (InputMethodManager)searchView.Context.GetSystemService(Context.InputMethodService)!)
 			{
 				// The zero value for the second parameter comes from 
 				// https://developer.android.com/reference/android/view/inputmethod/InputMethodManager#showSoftInput(android.view.View,%20int)
@@ -101,6 +103,16 @@ namespace Microsoft.Maui.Controls.Platform
 			};
 
 			view.Post(ShowKeyboard);
+		}
+
+		public static bool IsSoftKeyboardVisible(this AView view)
+		{
+			var insets = ViewCompat.GetRootWindowInsets(view);
+			if (insets == null)
+				return false;
+									
+			var result = insets.IsVisible(WindowInsetsCompat.Type.Ime());
+			return result;
 		}
 	}
 }

--- a/src/Core/src/Properties/AssemblyInfo.cs
+++ b/src/Core/src/Properties/AssemblyInfo.cs
@@ -34,4 +34,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("CommunityToolkit.Maui.Markup.UnitTests")]
 [assembly: InternalsVisibleTo("Reloadify-emit")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils.DeviceTests.Runners")]
+[assembly: InternalsVisibleTo("Microsoft.Maui.TestUtils.DeviceTests")]
 [assembly: InternalsVisibleTo("Microsoft.Maui.DeviceTests.Shared")]

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -493,6 +494,95 @@ namespace Microsoft.Maui.DeviceTests
 				nameof(IEntry.CharacterSpacing),
 				() => entry.CharacterSpacing = newSize);
 		}
+
+#if ANDROID
+		[Fact]
+		public async Task NextMovesToNextEntrySuccessfully()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler<VerticalStackLayoutStub, LayoutHandler>();
+					handler.AddHandler<EntryStub, EntryHandler>();
+				});
+			});
+
+			var layout = new VerticalStackLayoutStub();
+
+			var entry1 = new EntryStub
+			{
+				Text = "Entry 1",
+				ReturnType = ReturnType.Next
+			};
+
+			var entry2 = new EntryStub
+			{
+				Text = "Entry 2",
+				ReturnType = ReturnType.Next
+			};
+
+			layout.Add(entry1);
+			layout.Add(entry2);
+
+			layout.Width = 100;
+			layout.Height = 150;
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var contentViewHandler = CreateHandler<LayoutHandler>(layout);
+				await contentViewHandler.PlatformView.AttachAndRun(async () =>
+				{
+					await entry1.SendKeyboardReturnType(ReturnType.Next);
+					await entry2.WaitForFocused();
+					Assert.True(entry2.IsFocused);
+				});
+			});
+		}
+
+		[Fact]
+		public async Task DoneClosesKeyboard()
+		{
+			EnsureHandlerCreated(builder =>
+			{
+				builder.ConfigureMauiHandlers(handler =>
+				{
+					handler.AddHandler<VerticalStackLayoutStub, LayoutHandler>();
+					handler.AddHandler<EntryStub, EntryHandler>();
+				});
+			});
+
+			var layout = new VerticalStackLayoutStub();
+
+			var entry1 = new EntryStub
+			{
+				Text = "Entry 1",
+				ReturnType = ReturnType.Done
+			};
+
+			var entry2 = new EntryStub
+			{
+				Text = "Entry 2",
+				ReturnType = ReturnType.Done
+			};
+
+			layout.Add(entry1);
+			layout.Add(entry2);
+
+			layout.Width = 100;
+			layout.Height = 150;
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var handler = CreateHandler<LayoutHandler>(layout);
+				await handler.PlatformView.AttachAndRun(async () =>
+				{
+					await entry1.SendKeyboardReturnType(ReturnType.Done);
+					await entry1.WaitForKeyboardToHide();
+				});
+			});
+		}
+#endif
 
 		[Category(TestCategory.Entry)]
 		public class EntryTextStyleTests : TextStyleHandlerTests<EntryHandler, EntryStub>

--- a/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/LayoutStub.cs
@@ -77,7 +77,9 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public int Count => _children.Count;
 		public bool IsReadOnly => _children.IsReadOnly;
 
-		ILayoutManager LayoutManager => _layoutManager ??= new LayoutManagerStub();
+		ILayoutManager LayoutManager => _layoutManager ??= CreateLayoutManager();
+
+		protected virtual ILayoutManager CreateLayoutManager() => new LayoutManagerStub();
 
 		public bool IgnoreSafeArea => false;
 

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -95,6 +95,11 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		{
 			Frame = bounds;
 			DesiredSize = bounds.Size;
+
+			// If this view is attached to the visual tree then let's arrange it
+			if (IsLoaded)
+				Handler?.PlatformArrange(Frame);
+
 			return DesiredSize;
 		}
 
@@ -139,5 +144,14 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		IReadOnlyList<Maui.IVisualTreeElement> IVisualTreeElement.GetVisualChildren() => this.Children.Cast<IVisualTreeElement>().ToList().AsReadOnly();
 
 		IVisualTreeElement IVisualTreeElement.GetVisualParent() => this.Parent as IVisualTreeElement;
+
+
+		public bool IsLoaded
+		{
+			get
+			{
+				return (Handler as IPlatformViewHandler)?.PlatformView?.IsLoaded() == true;
+			}
+		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/VerticalStackLayoutStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/VerticalStackLayoutStub.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Layouts;
+
+namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	public class VerticalStackLayoutStub : LayoutStub, IStackLayout
+	{
+		public double Spacing => 0;
+
+		protected override ILayoutManager CreateLayoutManager()
+		{
+			return new VerticalStackLayoutManager(this);
+		}
+	}
+}

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -15,6 +15,41 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public static partial class AssertionExtensions
 	{
+		public static Task WaitForKeyboardToShow(this FrameworkElement view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task WaitForKeyboardToHide(this FrameworkElement view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task SendValueToKeyboard(this FrameworkElement view, char value, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task SendKeyboardReturnType(this FrameworkElement view, ReturnType returnType, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task WaitForFocused(this FrameworkElement view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task FocusView(this FrameworkElement view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task ShowKeyboardForView(this FrameworkElement view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
 		public static Task<string> CreateColorAtPointError(this CanvasBitmap bitmap, WColor expectedColor, int x, int y) =>
 			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
+using Microsoft.Maui.Platform;
 using Xunit;
 using Xunit.Sdk;
 
@@ -50,6 +50,82 @@ namespace Microsoft.Maui.DeviceTests
 
 			var diff = Math.Abs(expected - actual);
 			Assert.True(diff <= epsilon, $"Expected: {expected}. Actual: {actual}. Diff: {diff} Epsilon: {epsilon}.{message}");
+		}
+
+
+
+		public static Task WaitForKeyboardToShow(this IView view, int timeout = 1000)
+		{
+#if !PLATFORM
+			return Task.CompletedTask;
+#else
+			return view.ToPlatform().WaitForKeyboardToShow(timeout);
+#endif
+		}
+
+		public static Task WaitForKeyboardToHide(this IView view, int timeout = 1000)
+		{
+#if !PLATFORM
+			return Task.CompletedTask;
+#else
+			return view.ToPlatform().WaitForKeyboardToHide(timeout);
+#endif
+		}
+
+		/// <summary>
+		/// Shane: I haven't fully tested this API. I was trying to use this to send "ReturnType"
+		/// and then found the correct API. But, I figured this would be useful to have so I left it here
+		/// so a future tester can hopefully use it and be successful!
+		/// </summary>
+		/// <param name="view"></param>
+		/// <param name="value"></param>
+		/// <param name="timeout"></param>
+		/// <returns></returns>
+		public static Task SendValueToKeyboard(this IView view, char value, int timeout = 1000)
+		{
+#if !PLATFORM
+			return Task.CompletedTask;
+#else
+			return view.ToPlatform().SendValueToKeyboard(value, timeout);
+#endif
+		}
+
+
+		public static Task SendKeyboardReturnType(this IView view, ReturnType returnType, int timeout = 1000)
+		{
+#if !PLATFORM
+			return Task.CompletedTask;
+#else
+			return view.ToPlatform().SendKeyboardReturnType(returnType, timeout);
+#endif
+		}
+
+		public static Task ShowKeyboardForView(this IView view, int timeout = 1000)
+		{
+#if !PLATFORM
+			return Task.CompletedTask;
+#else
+			return view.ToPlatform().ShowKeyboardForView(timeout);
+#endif
+		}
+
+		public static Task WaitForFocused(this IView view, int timeout = 1000)
+		{
+#if !PLATFORM
+			return Task.CompletedTask;
+#else
+			return view.ToPlatform().WaitForFocused(timeout);
+#endif
+		}
+
+		public static Task FocusView(this IView view, int timeout = 1000)
+		{
+
+#if !PLATFORM
+			return Task.CompletedTask;
+#else
+			return view.ToPlatform().FocusView(timeout);
+#endif
 		}
 	}
 }

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.True(diff <= epsilon, $"Expected: {expected}. Actual: {actual}. Diff: {diff} Epsilon: {epsilon}.{message}");
 		}
 
-
+#if !TIZEN
 
 		public static Task WaitForKeyboardToShow(this IView view, int timeout = 1000)
 		{
@@ -127,5 +127,9 @@ namespace Microsoft.Maui.DeviceTests
 			return view.ToPlatform().FocusView(timeout);
 #endif
 		}
+
+
+#endif
+
 	}
 }

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -12,6 +12,41 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public static partial class AssertionExtensions
 	{
+		public static Task WaitForKeyboardToShow(this UIView view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task WaitForKeyboardToHide(this UIView view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task SendValueToKeyboard(this UIView view, char value, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task SendKeyboardReturnType(this UIView view, ReturnType returnType, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task WaitForFocused(this UIView view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task FocusView(this UIView view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static Task ShowKeyboardForView(this UIView view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
 		public static string CreateColorAtPointError(this UIImage bitmap, UIColor expectedColor, int x, int y) =>
 			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
 


### PR DESCRIPTION
### Description of Change

At some point super early in the life of `XF` the "Handled" option on the `EditorAction` event was being set to `true`. This basically causes `Androids` default behavior to not run, which automatically handles closing the keyboard if your `ReturnType` is set to `Complete` and it handles moving to the next field automatically.  In `XF` we just kept building custom solutions since we were setting `Handled` to true. We basically recreated the `keyboard close` and then `next focus` behavior ourselves. 

- This PR has no effect if the user is using an attached keyboard. With an attached keyboard the enter key always moves to the next field which is the desired behavior for accessibility and expectation from the user purposes. If you have a use case or want to be hostile to keyboard users, then you can subscribe to the EditorAction event for the platform view on `Entry` and set the `Handled` property to true

### Issues Fixed

Fixes #5724
Fixes #10858
Fixes #8302
