### PR TITLE
[Tizen] Add handing Label.TextType

### DIFF
--- a/src/Controls/src/Core/Platform/Tizen/Extensions/FormattedStringExtensions.cs
+++ b/src/Controls/src/Core/Platform/Tizen/Extensions/FormattedStringExtensions.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.Maui.Controls.Internals;
+using TFormattedString = Tizen.UIExtensions.Common.FormattedString;
+using TSpan = Tizen.UIExtensions.Common.Span;
+
+namespace Microsoft.Maui.Controls.Platform
+{
+	public static class FormattedStringExtensions
+	{
+		public static TFormattedString ToFormattedString(this Label label)
+			=> ToFormattedText(
+				label.FormattedText,
+				label.TextColor,
+				label.RequireFontManager(),
+				label.ToFont(),
+				label.TextTransform,
+				label.TextDecorations);
+
+		internal static TFormattedString ToFormattedText(
+			this FormattedString formattedString,
+			Graphics.Color defaultColor,
+			IFontManager fontManager,
+			Font? defaultFont = null,
+			TextTransform defaultTextTransform = TextTransform.Default,
+			TextDecorations defaultTextDecorations = TextDecorations.None)
+		{
+			if (formattedString == null)
+				return new TFormattedString();
+
+			var defaultFontSize = defaultFont?.Size ?? fontManager.DefaultFontSize;
+			var formattedText = new TFormattedString();
+
+			for (int i = 0; i < formattedString.Spans.Count; i++)
+			{
+				Span span = formattedString.Spans[i];
+				var transform = span.TextTransform != TextTransform.Default ? span.TextTransform : defaultTextTransform;
+				var text = TextTransformUtilites.GetTransformedText(span.Text, transform);
+
+				if (text == null)
+					continue;
+
+				var nativeSpan = new TSpan() { Text = text };
+				var textColor = span.TextColor ?? defaultColor;
+
+				if (textColor is not null)
+					nativeSpan.ForegroundColor = textColor.ToPlatform();
+
+				if (span.BackgroundColor is not null)
+					nativeSpan.BackgroundColor = span.BackgroundColor.ToPlatform();
+
+				var font = span.ToFont(defaultFontSize);
+				if (font.IsDefault && defaultFont.HasValue)
+					font = defaultFont.Value;
+
+				if (!font.IsDefault)
+				{
+					nativeSpan.FontSize = font.Size.ToScaledPoint();
+					nativeSpan.FontFamily = fontManager.GetFontFamily(span.FontFamily);
+				}
+
+				nativeSpan.LineHeight = span.LineHeight;
+
+				var textDecorations = span.IsSet(Span.TextDecorationsProperty)
+					? span.TextDecorations
+					: defaultTextDecorations;
+				if (textDecorations.HasFlag(TextDecorations.Strikethrough) || textDecorations.HasFlag(TextDecorations.Underline))
+					nativeSpan.TextDecorations = span.TextDecorations.ToPlatform();
+
+				formattedText.Spans.Add(nativeSpan);
+			}
+			return formattedText;
+		}
+	}
+}

--- a/src/Controls/src/Core/Platform/Tizen/Extensions/TextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Tizen/Extensions/TextExtensions.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Maui.Platform;
-using Microsoft.Maui.Controls.Internals;
+﻿using Microsoft.Maui.Controls.Internals;
+using Tizen.UIExtensions.NUI;
 using TEntry = Tizen.UIExtensions.NUI.Entry;
 using TEditor = Tizen.UIExtensions.NUI.Editor;
 using TLabel = Tizen.UIExtensions.NUI.Label;
+using TFormattedString = Tizen.UIExtensions.Common.FormattedString;
+using TSpan = Tizen.UIExtensions.Common.Span;
 
 namespace Microsoft.Maui.Controls.Platform
 {
@@ -32,7 +31,27 @@ namespace Microsoft.Maui.Controls.Platform
 
 		public static void UpdateText(this TLabel platformLabel, Label label)
 		{
-			platformLabel.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
+			switch (label.TextType)
+			{
+				case TextType.Text:
+					if (label.FormattedText != null)
+						platformLabel.FormattedText = label.ToFormattedString();
+					else
+						platformLabel.Text = TextTransformUtilites.GetTransformedText(label.Text, label.TextTransform);
+					break;
+				case TextType.Html:
+					platformLabel.UpdateTextHtml(label);
+					break;
+			}
+		}
+
+		static void UpdateTextHtml(this TLabel platformLabel, Label label)
+		{
+			var formattedText = new TFormattedString();
+			var htmlSpan = new TSpan() { Text = label.Text };
+			formattedText.Spans.Add(htmlSpan);
+			platformLabel.EnableMarkup = true;
+			platformLabel.Text = formattedText.ToMarkupText();
 		}
 	}
 }

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1642,6 +1642,7 @@ Microsoft.Maui.Controls.Platform.ElementChangedEventArgs<TElement>.ElementChange
 Microsoft.Maui.Controls.Platform.ElementChangedEventArgs<TElement>.NewElement.get -> TElement?
 Microsoft.Maui.Controls.Platform.ElementChangedEventArgs<TElement>.OldElement.get -> TElement?
 Microsoft.Maui.Controls.Platform.FontExtensions
+Microsoft.Maui.Controls.Platform.FormattedStringExtensions
 Microsoft.Maui.Controls.Platform.GestureHandler
 Microsoft.Maui.Controls.Platform.GestureHandler.Attach(Microsoft.Maui.IViewHandler! handler) -> void
 Microsoft.Maui.Controls.Platform.GestureHandler.Detach() -> void
@@ -5888,6 +5889,7 @@ virtual Microsoft.Maui.Controls.Window.OnStopped() -> void
 ~static Microsoft.Maui.Controls.Platform.ButtonExtensions.UpdateText(this Tizen.UIExtensions.NUI.Button platformButton, Microsoft.Maui.Controls.Button button) -> void
 ~static Microsoft.Maui.Controls.Platform.CollectionViewExtensions.ToLayoutManager(this Microsoft.Maui.Controls.IItemsLayout layout, Microsoft.Maui.Controls.ItemSizingStrategy sizing = Microsoft.Maui.Controls.ItemSizingStrategy.MeasureFirstItem) -> Tizen.UIExtensions.NUI.ICollectionViewLayoutManager
 ~static Microsoft.Maui.Controls.Platform.FontExtensions.ToNativeFontFamily(this string self, Microsoft.Maui.IFontManager fontManager) -> string
+~static Microsoft.Maui.Controls.Platform.FormattedStringExtensions.ToFormattedString(this Microsoft.Maui.Controls.Label label) -> Tizen.UIExtensions.Common.FormattedString
 ~static Microsoft.Maui.Controls.Platform.ImageExtensions.LoadImage(this Tizen.NUI.BaseComponents.ImageView image, Microsoft.Maui.Controls.ImageSource source) -> System.Threading.Tasks.Task
 ~static Microsoft.Maui.Controls.Platform.ImageExtensions.LoadImageAsync(this Tizen.NUI.BaseComponents.ImageView image, Microsoft.Maui.Controls.FileImageSource imageSource) -> System.Threading.Tasks.Task<bool>
 ~static Microsoft.Maui.Controls.Platform.ImageExtensions.LoadImageAsync(this Tizen.NUI.BaseComponents.ImageView image, Microsoft.Maui.Controls.StreamImageSource imageSource) -> System.Threading.Tasks.Task<bool>

--- a/src/Core/src/Fonts/EmbeddedFontLoader.Tizen.cs
+++ b/src/Core/src/Fonts/EmbeddedFontLoader.Tizen.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Maui
 		/// <inheritdoc/>
 		public string? LoadFont(EmbeddedFont font)
 		{
+			var fontResourcePath = IOPath.Combine(TApplication.Current.DirectoryInfo.Resource, _fontCacheFolderName);
+			var fontResourceFilePath = IOPath.Combine(fontResourcePath, font.FontName!);
+			if (File.Exists(fontResourceFilePath))
+			{
+				return IOPath.GetFileNameWithoutExtension(fontResourceFilePath);
+			}
+
 			if (FontCacheDirectory == null)
 			{
 				FontCacheDirectory = Directory.CreateDirectory(IOPath.Combine(TApplication.Current.DirectoryInfo.Data, _fontCacheFolderName));
@@ -28,7 +35,10 @@ namespace Microsoft.Maui
 			var filePath = IOPath.Combine(FontCacheDirectory.FullName, font.FontName!);
 			var name = IOPath.GetFileNameWithoutExtension(filePath);
 			if (File.Exists(filePath))
+			{
 				return name;
+			}
+
 			try
 			{
 				using (var fileStream = File.Create(filePath))
@@ -38,6 +48,8 @@ namespace Microsoft.Maui
 
 					font.ResourceStream.CopyTo(fileStream);
 				}
+				Tizen.NUI.FontClient.Instance.AddCustomFontDirectory(FontCacheDirectory.FullName);
+
 				return name;
 			}
 			catch (Exception ex)

--- a/src/Core/src/Fonts/FontManager.Tizen.cs
+++ b/src/Core/src/Fonts/FontManager.Tizen.cs
@@ -51,8 +51,7 @@ namespace Microsoft.Maui
 			if (index != -1)
 			{
 				string font = cleansedFont.Substring(0, index);
-				string style = cleansedFont.Substring(index + 1);
-				return $"{font}:style={style}";
+				return $"{font}";
 			}
 			else
 			{
@@ -79,8 +78,7 @@ namespace Microsoft.Maui
 			if (index != -1)
 			{
 				string font = cleansedFont.Substring(0, index);
-				string style = cleansedFont.Substring(index + 1);
-				return $"{font}:style={style}";
+				return $"{font}";
 			}
 			else
 			{

--- a/src/Core/src/Platform/Tizen/MauiApplication.cs
+++ b/src/Core/src/Platform/Tizen/MauiApplication.cs
@@ -4,12 +4,16 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.LifecycleEvents;
 using Tizen.Applications;
 using Tizen.NUI;
+using IOPath = System.IO.Path;
+using TApplication = Tizen.Applications.Application;
 using NView = Tizen.NUI.BaseComponents.View;
 
 namespace Microsoft.Maui
 {
 	public abstract class MauiApplication : NUIApplication, IPlatformApplication
 	{
+		const string _fontCacheFolderName = "fonts";
+
 		internal Func<bool>? _handleBackButtonPressed;
 
 		IMauiContext _applicationContext = null!;
@@ -27,6 +31,9 @@ namespace Microsoft.Maui
 			base.OnPreCreate();
 			FocusManager.Instance.EnableDefaultAlgorithm(true);
 			NView.SetDefaultGrabTouchAfterLeave(true);
+
+			var fontResourcePath = IOPath.Combine(TApplication.Current.DirectoryInfo.Resource, _fontCacheFolderName);
+			FontClient.Instance.AddCustomFontDirectory(fontResourcePath);
 
 			var mauiApp = CreateMauiApp();
 			var rootContext = new MauiContext(mauiApp.Services);


### PR DESCRIPTION
### Description of Change

This PR adds
- handling Label.TextType features including FormattedText and Html type of text.
- updating Font loading process to include MauiFont as a custom font path.

At this point, Tizen.UIExtensions package which actually process the `span` creates a new line for each spans. This will be fixed in Tizen.UIExtensions package.
<image src="https://user-images.githubusercontent.com/14328614/199875898-ec0e58b3-4eb0-46f4-9aaa-6318269975c5.png" width="300" />
