### PR TITLE
Fix crash using BackButtonBehavior and navigating to root

### DIFF
--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Maui.Controls
 			void OnBackButtonCanExecuteChanged(object sender, EventArgs e)
 			{
 				BackButtonEnabled =
-					_backButtonCommand.CanExecute(_backButtonBehavior.CommandParameter);
+					_backButtonCommand != null && _backButtonCommand.CanExecute(_backButtonBehavior?.CommandParameter);
 			}
 		}
 

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -10,9 +12,10 @@ namespace Microsoft.Maui.Controls
 	internal class ShellToolbar : Toolbar
 	{
 		Shell _shell;
-		Page _currentPage;
-		BackButtonBehavior _backButtonBehavior;
+		Page? _currentPage;
+		BackButtonBehavior? _backButtonBehavior;
 		ToolbarTracker _toolbarTracker = new ToolbarTracker();
+		ICommand? _backButtonCommand;
 #if WINDOWS
 		MenuBarTracker _menuBarTracker = new MenuBarTracker();
 #endif
@@ -77,7 +80,7 @@ namespace Microsoft.Maui.Controls
 			_menuBarTracker.Target = _shell;
 #endif
 
-			Page previousPage = null;
+			Page? previousPage = null;
 			if (stack.Count > 1)
 				previousPage = stack[stack.Count - 1];
 
@@ -131,7 +134,6 @@ namespace Microsoft.Maui.Controls
 				DynamicOverflowEnabled = PlatformConfiguration.WindowsSpecific.Page.GetToolbarDynamicOverflowEnabled(currentPage);
 		}
 
-		ICommand _backButtonCommand;
 		void UpdateBackbuttonBehavior()
 		{
 			var bbb = Shell.GetBackButtonBehavior(_currentPage);
@@ -140,37 +142,43 @@ namespace Microsoft.Maui.Controls
 				return;
 
 			if (_backButtonBehavior != null)
-				_backButtonBehavior.PropertyChanged -= OnBackButtonPropertyChanged;
+				_backButtonBehavior.PropertyChanged -= OnBackButtonCommandPropertyChanged;
 
 			_backButtonBehavior = bbb;
 
 			if (_backButtonBehavior != null)
-				_backButtonBehavior.PropertyChanged += OnBackButtonPropertyChanged;
+				_backButtonBehavior.PropertyChanged += OnBackButtonCommandPropertyChanged;
 
-			void OnBackButtonPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-			{
-				ApplyChanges();
-
-				if (_backButtonBehavior.Command == _backButtonCommand)
-					return;
-
-				if (_backButtonCommand != null)
-					_backButtonCommand.CanExecuteChanged -= OnBackButtonCanExecuteChanged;
-
-				_backButtonCommand = _backButtonBehavior.Command;
-
-				if (_backButtonCommand != null)
-					_backButtonCommand.CanExecuteChanged += OnBackButtonCanExecuteChanged;
-			}
-
-			void OnBackButtonCanExecuteChanged(object sender, EventArgs e)
-			{
-				BackButtonEnabled =
-					_backButtonCommand != null && _backButtonCommand.CanExecute(_backButtonBehavior?.CommandParameter);
-			}
+			UpdateBackButtonBehaviorCommand();
 		}
 
-		void OnCurrentPagePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		void OnBackButtonCommandPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			ApplyChanges();
+			UpdateBackButtonBehaviorCommand();
+		}
+
+		void UpdateBackButtonBehaviorCommand()
+		{
+			if (_backButtonBehavior?.Command == _backButtonCommand)
+				return;
+
+			if (_backButtonCommand != null)
+				_backButtonCommand.CanExecuteChanged -= OnBackButtonCanExecuteChanged;
+
+			_backButtonCommand = _backButtonBehavior?.Command;
+
+			if (_backButtonCommand != null)
+				_backButtonCommand.CanExecuteChanged += OnBackButtonCanExecuteChanged;
+		}
+
+		void OnBackButtonCanExecuteChanged(object? sender, EventArgs e)
+		{
+			BackButtonEnabled =
+				_backButtonCommand != null && _backButtonCommand.CanExecute(_backButtonBehavior?.CommandParameter);
+		}
+
+		void OnCurrentPagePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			if (e.Is(Page.TitleProperty))
 				UpdateTitle();
@@ -195,7 +203,7 @@ namespace Microsoft.Maui.Controls
 				return;
 			}
 
-			Page currentPage = _shell.GetCurrentShellPage() as Page;
+			Page? currentPage = _shell.GetCurrentShellPage() as Page;
 			if (currentPage?.IsSet(Page.TitleProperty) == true)
 			{
 				Title = currentPage.Title ?? String.Empty;

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Windows.Input;
@@ -15,7 +16,6 @@ namespace Microsoft.Maui.Controls
 		Page? _currentPage;
 		BackButtonBehavior? _backButtonBehavior;
 		ToolbarTracker _toolbarTracker = new ToolbarTracker();
-		ICommand? _backButtonCommand;
 #if WINDOWS
 		MenuBarTracker _menuBarTracker = new MenuBarTracker();
 #endif
@@ -98,13 +98,6 @@ namespace Microsoft.Maui.Controls
 			BackButtonVisible = backButtonVisible && stack.Count > 1;
 			BackButtonEnabled = _backButtonBehavior?.IsEnabled ?? true;
 
-			if (_backButtonBehavior?.Command != null)
-			{
-				BackButtonEnabled =
-					BackButtonEnabled &&
-					_backButtonBehavior.Command.CanExecute(_backButtonBehavior.CommandParameter);
-			}
-
 			UpdateTitle();
 
 			if (_currentPage != null &&
@@ -148,33 +141,11 @@ namespace Microsoft.Maui.Controls
 
 			if (_backButtonBehavior != null)
 				_backButtonBehavior.PropertyChanged += OnBackButtonCommandPropertyChanged;
-
-			UpdateBackButtonBehaviorCommand();
 		}
 
-		void OnBackButtonCommandPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+		void OnBackButtonCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			ApplyChanges();
-		}
-
-		void UpdateBackButtonBehaviorCommand()
-		{
-			if (_backButtonBehavior?.Command == _backButtonCommand)
-				return;
-
-			if (_backButtonCommand != null)
-				_backButtonCommand.CanExecuteChanged -= OnBackButtonCanExecuteChanged;
-
-			_backButtonCommand = _backButtonBehavior?.Command;
-
-			if (_backButtonCommand != null)
-				_backButtonCommand.CanExecuteChanged += OnBackButtonCanExecuteChanged;
-		}
-
-		void OnBackButtonCanExecuteChanged(object? sender, EventArgs e)
-		{
-			BackButtonEnabled =
-				_backButtonCommand != null && _backButtonCommand.CanExecute(_backButtonBehavior?.CommandParameter);
 		}
 
 		void OnCurrentPagePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/Controls/src/Core/ShellToolbar.cs
+++ b/src/Controls/src/Core/ShellToolbar.cs
@@ -155,7 +155,6 @@ namespace Microsoft.Maui.Controls
 		void OnBackButtonCommandPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			ApplyChanges();
-			UpdateBackButtonBehaviorCommand();
 		}
 
 		void UpdateBackButtonBehaviorCommand()

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -102,6 +102,29 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task BackButtonBehaviorCommandFromPoppedPageIsCorrectlyUnsubscribedFrom()
+		{
+			var firstPage = new ContentPage();
+			var secondPage = new ContentPage();
+			bool canExecute = true;
+			var backButtonBehavior = new BackButtonBehavior();
+			TestShell testShell = new TestShell(firstPage);
+
+			await testShell.Navigation.PushAsync(secondPage);
+
+			Shell.SetBackButtonBehavior(secondPage, backButtonBehavior);
+
+			backButtonBehavior.Command = new Command(() => { }, () => canExecute);
+
+			await testShell.Navigation.PopAsync();
+
+			canExecute = false;
+			(backButtonBehavior.Command as Command).ChangeCanExecute();
+
+			Assert.True(testShell.Toolbar.BackButtonEnabled);
+		}
+
+		[Fact]
 		public async Task ShellToolbarUpdatesFromNewBackButtonBehavior()
 		{
 			var page = new ContentPage();

--- a/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellToolbarTests.cs
@@ -125,6 +125,27 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		}
 
 		[Fact]
+		public async Task BackButtonUpdatesWhenSetToNewCommand()
+		{
+			var firstPage = new ContentPage();
+			var secondPage = new ContentPage();
+			bool canExecute = true;
+			var backButtonBehavior = new BackButtonBehavior();
+			TestShell testShell = new TestShell(firstPage);
+
+			await testShell.Navigation.PushAsync(secondPage);
+
+			Shell.SetBackButtonBehavior(secondPage, backButtonBehavior);
+
+			backButtonBehavior.Command = new Command(() => { }, () => true);
+			Assert.True(testShell.Toolbar.BackButtonEnabled);
+			backButtonBehavior.Command = new Command(() => { }, () => false);
+			Assert.False(testShell.Toolbar.BackButtonEnabled);
+			backButtonBehavior.Command = null;
+			Assert.True(testShell.Toolbar.BackButtonEnabled);
+		}
+
+		[Fact]
 		public async Task ShellToolbarUpdatesFromNewBackButtonBehavior()
 		{
 			var page = new ContentPage();

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -596,6 +596,45 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Navigate to Root with BackButtonBehavior no Crash")]
+		public async Task NavigateToRootWithBackButtonBehaviorNoCrash()
+		{
+			SetupBuilder();
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new ContentPage();
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				Assert.False(IsBackButtonVisible(shell.Handler));
+				var secondPage = new ContentPage();
+				await shell.Navigation.PushAsync(secondPage);
+				Assert.True(IsBackButtonVisible(shell.Handler));
+
+				bool canExecute = true;
+				Command command = new Command(() => { }, () => canExecute);
+				BackButtonBehavior behavior = new BackButtonBehavior()
+				{
+					IsVisible = false,
+					Command = command
+				};
+
+				Shell.SetBackButtonBehavior(secondPage, behavior);
+				Assert.False(IsBackButtonVisible(shell.Handler));
+				behavior.IsVisible = true;
+				NavigationPage.SetHasBackButton(shell.CurrentPage, true);
+
+				await shell.Navigation.PopToRootAsync(false);
+				await Task.Delay(100);
+				canExecute = false;
+
+				command.ChangeCanExecute();
+				Assert.NotNull(shell.Handler);
+			});
+		}
+
 		protected Task<Shell> CreateShellAsync(Action<Shell> action) =>
 			InvokeOnMainThreadAsync(() =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -596,6 +596,38 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "Navigate to Root with BackButtonBehavior no Crash")]
+		public async Task NavigateToRootWithBackButtonBehaviorNoCrash()
+		{
+			SetupBuilder();
+
+			var shell = await CreateShellAsync(shell =>
+			{
+				shell.CurrentItem = new ContentPage();
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				Assert.False(IsBackButtonVisible(shell.Handler));
+				await shell.Navigation.PushAsync(new ContentPage());
+				Assert.True(IsBackButtonVisible(shell.Handler));
+
+				BackButtonBehavior behavior = new BackButtonBehavior()
+				{
+					IsVisible = false
+				};
+
+				Shell.SetBackButtonBehavior(shell.CurrentPage, behavior);
+				Assert.False(IsBackButtonVisible(shell.Handler));
+				behavior.IsVisible = true;
+				NavigationPage.SetHasBackButton(shell.CurrentPage, true);
+
+				await shell.Navigation.PopToRootAsync(false);
+				await Task.Delay(100);
+				Assert.NotNull(shell.Handler);
+			});
+		}
+
 		protected Task<Shell> CreateShellAsync(Action<Shell> action) =>
 			InvokeOnMainThreadAsync(() =>
 			{

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -596,38 +596,6 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		[Fact(DisplayName = "Navigate to Root with BackButtonBehavior no Crash")]
-		public async Task NavigateToRootWithBackButtonBehaviorNoCrash()
-		{
-			SetupBuilder();
-
-			var shell = await CreateShellAsync(shell =>
-			{
-				shell.CurrentItem = new ContentPage();
-			});
-
-			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
-			{
-				Assert.False(IsBackButtonVisible(shell.Handler));
-				await shell.Navigation.PushAsync(new ContentPage());
-				Assert.True(IsBackButtonVisible(shell.Handler));
-
-				BackButtonBehavior behavior = new BackButtonBehavior()
-				{
-					IsVisible = false
-				};
-
-				Shell.SetBackButtonBehavior(shell.CurrentPage, behavior);
-				Assert.False(IsBackButtonVisible(shell.Handler));
-				behavior.IsVisible = true;
-				NavigationPage.SetHasBackButton(shell.CurrentPage, true);
-
-				await shell.Navigation.PopToRootAsync(false);
-				await Task.Delay(100);
-				Assert.NotNull(shell.Handler);
-			});
-		}
-
 		protected Task<Shell> CreateShellAsync(Action<Shell> action) =>
 			InvokeOnMainThreadAsync(() =>
 			{


### PR DESCRIPTION
### Description of Change

Fix crash using BackButtonBehavior and navigating to root.

`ShellToolbar` had a bunch of excess code for figuring out changes to the `Command` property on `BackButtonBehavior`. All of that code is already inside `BackButtonBehavior` so I just deleted it. 

### Issues Fixed

Fixes #11401 
Fixes #10514