### PR TITLE
Fix window events when swapping out a page

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty PageProperty = BindableProperty.Create(
 			nameof(Page), typeof(Page), typeof(Window), default(Page?),
 			propertyChanging: OnPageChanging,
-			propertyChanged: OnPageChanged);
+			propertyChanged: (b, o, n) => ((Window)b).OnPageChanged(o as Page, n as Page));
 
 		public static readonly BindableProperty FlowDirectionProperty =
 			BindableProperty.Create(nameof(FlowDirection), typeof(FlowDirection), typeof(Window), FlowDirection.MatchParent, propertyChanging: FlowDirectionChanging, propertyChanged: FlowDirectionChanged);
@@ -586,31 +586,26 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		static void OnPageChanged(BindableObject bindable, object oldValue, object newValue)
+		void OnPageChanged(Page? oldPage, Page? newPage)
 		{
-			if (bindable is not Window window)
-				return;
-
-			var oldPage = oldValue as Page;
 			if (oldPage != null)
 			{
-				window.InternalChildren.Remove(oldPage);
+				InternalChildren.Remove(oldPage);
 				oldPage.HandlerChanged -= OnPageHandlerChanged;
 				oldPage.HandlerChanging -= OnPageHandlerChanging;
 			}
 
 			if (oldPage is Shell shell)
-				shell.PropertyChanged += ShellPropertyChanged;
+				shell.PropertyChanged -= ShellPropertyChanged;
 
-			var newPage = newValue as Page;
 			if (newPage != null)
 			{
-				window.InternalChildren.Add(newPage);
-				newPage.NavigationProxy.Inner = window.NavigationProxy;
-				window._menuBarTracker.Target = newPage;
+				InternalChildren.Add(newPage);
+				newPage.NavigationProxy.Inner = NavigationProxy;
+				_menuBarTracker.Target = newPage;
 			}
 
-			window.ModalNavigationManager.SettingNewPage();
+			ModalNavigationManager.SettingNewPage();
 
 			if (newPage != null)
 			{
@@ -624,24 +619,24 @@ namespace Microsoft.Maui.Controls
 			if (newPage is Shell newShell)
 				newShell.PropertyChanged += ShellPropertyChanged;
 
-			window?.Handler?.UpdateValue(nameof(IWindow.FlowDirection));
+			Handler?.UpdateValue(nameof(IWindow.FlowDirection));
+		}
 
-			void OnPageHandlerChanged(object? sender, EventArgs e)
-			{
-				window.ModalNavigationManager.PageAttachedHandler();
-				window.AlertManager.Subscribe();
-			}
+		void OnPageHandlerChanged(object? sender, EventArgs e)
+		{
+			ModalNavigationManager.PageAttachedHandler();
+			AlertManager.Subscribe();
+		}
 
-			void OnPageHandlerChanging(object? sender, HandlerChangingEventArgs e)
-			{
-				window.AlertManager.Unsubscribe();
-			}
+		void OnPageHandlerChanging(object? sender, HandlerChangingEventArgs e)
+		{
+			AlertManager.Unsubscribe();
+		}
 
-			void ShellPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-			{
-				if (e.PropertyName == nameof(Shell.Title))
-					window?.Handler?.UpdateValue(nameof(ITitledElement.Title));
-			}
+		void ShellPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == nameof(Shell.Title))
+				Handler?.UpdateValue(nameof(ITitledElement.Title));
 		}
 
 		bool IWindow.BackButtonClicked()

--- a/src/Controls/tests/Core.UnitTests/TestClasses/TestApp.cs
+++ b/src/Controls/tests/Core.UnitTests/TestClasses/TestApp.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	public class TestApp : Application
 	{
-		ContentPage _withPage;
+		Page _withPage;
 		TestWindow _window;
 
 		public TestApp() : base(false)
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			return _window ?? new TestWindow(_withPage ?? new ContentPage());
 		}
 
-		public TestWindow CreateWindow(ContentPage withPage)
+		public TestWindow CreateWindow(Page withPage)
 		{
 			_withPage = withPage;
 			return (TestWindow)(this as IApplication).CreateWindow(null);

--- a/src/Controls/tests/Core.UnitTests/WindowsTests.cs
+++ b/src/Controls/tests/Core.UnitTests/WindowsTests.cs
@@ -447,6 +447,54 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(double.NaN, coreWindow.MaximumHeight);
 		}
 
+		[Fact]
+		public void ShellTitleChangePropagatesToWindow()
+		{
+			var app = new TestApp();
+			var shell = new ShellTestBase.TestShell() { Title = "test" };
+			var window = app.CreateWindow();
+			bool fired = false;
+			window.Page = shell;
+			window.Handler = new WindowHandlerStub(new PropertyMapper<IWindow, WindowHandlerStub>()
+			{
+				[nameof(IWindow.Title)] = (_, _) => fired = true
+			});
+
+			// reset after setting handler
+			fired = false;
+			shell.Title = "new title";
+
+
+			Assert.Equal(shell.Title, (window as IWindow).Title);
+			Assert.True(fired);
+		}
+
+		[Fact]
+		public void PreviousShellDisconnectsFromWindowPropertyChanged()
+		{
+			var app = new TestApp();
+			var oldShell = new Shell() { Title = "Old Shell" };
+			var window = app.CreateWindow(oldShell);
+			bool fired = false;
+
+			window.Handler = new WindowHandlerStub(new PropertyMapper<IWindow, WindowHandlerStub>()
+			{
+				[nameof(IWindow.Title)] = (_, _) =>
+				{
+					fired = true;
+				}
+			});
+
+			window.Page = new Shell() { Title = "test" };
+
+			// reset after setting handler
+			fired = false;
+
+			oldShell.Title = "new title";
+			Assert.Equal("test", (window as IWindow).Title);
+			Assert.False(fired);
+		}
+
 		[Theory]
 		[InlineData(double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN, double.NaN)]
 		[InlineData(-1, -1, -1, -1, -1, -1, double.NaN, double.NaN)]


### PR DESCRIPTION
### Description of Change

The `Page` bindable property changed method on `Window` was using a set of local functions. 

![image](https://user-images.githubusercontent.com/5375137/202780285-a7d43c97-35bb-4a56-a195-4fb6fa56cfd1.png)

Because these local functions aren't static and they create a closures the logic to unsubscribe didn't actually work.  This PR moves the `OnPageChanged` code to be an instance method on `Window` and moves all the subscriptions to all be instance methods on `Window` instead of local functions. 