### PR TITLE
Fix the ordering registration for tests

### DIFF
--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected override MauiAppBuilder ConfigureBuilder(MauiAppBuilder mauiAppBuilder)
 		{
-			mauiAppBuilder.Services.TryAddSingleton<IApplication>((_) => new ApplicationStub());
+			mauiAppBuilder.Services.AddSingleton<IApplication>((_) => new ApplicationStub());
 			return mauiAppBuilder.ConfigureTestBuilder();
 		}
 
@@ -67,7 +67,7 @@ namespace Microsoft.Maui.DeviceTests
 			return CreateHandler<THandler>(view, MauiContext);
 		}
 
-		protected async Task<THandler> CreateHandlerAsync<THandler>(IElement view) 
+		protected async Task<THandler> CreateHandlerAsync<THandler>(IElement view)
 			where THandler : IElementHandler, new() =>
 			await InvokeOnMainThreadAsync(() => CreateHandler<THandler>(view));
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -448,10 +448,11 @@ namespace Microsoft.Maui.DeviceTests
 			var mainPage = new ContentPage();
 			var shell = new Shell() { CurrentItem = mainPage };
 
-			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
 			{
-				var position = mainPage.ToPlatform().GetLocationOnScreen();
+				Assert.True(await AssertionExtensions.Wait(() => mainPage.ToPlatform().GetLocationOnScreen().Value.Y > 0));
 				var appTitleBarHeight = GetWindowRootView(handler).AppTitleBarActualHeight;
+				var position = mainPage.ToPlatform().GetLocationOnScreen();
 
 				Assert.True(Math.Abs(position.Value.Y - appTitleBarHeight) < 1);
 			});
@@ -555,7 +556,7 @@ namespace Microsoft.Maui.DeviceTests
 				shell.FlyoutBehavior = FlyoutBehavior.Locked;
 			});
 
-			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
 			{
 				var flyoutItems = shell.FlyoutItems.Cast<IReadOnlyList<Element>>().ToList();
 				var rootView = handler.PlatformView as MauiNavigationView;
@@ -571,6 +572,9 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(selectedTabItem.Data, flyoutItem.Items[0].Items[0]);
 
 				tabbedView.SelectedItem = platformTabItems[1].MenuItemsSource[1];
+
+				// Wait for the selected item to propagate to the rootview
+				await AssertionExtensions.Wait(() => (rootView.SelectedItem as NavigationViewItemViewModel).Data == flyoutItems[0][1]);
 
 				// Verify that the flyout item updates
 				Assert.Equal((rootView.SelectedItem as NavigationViewItemViewModel).Data, flyoutItems[0][1]);

--- a/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Window/WindowTests.Windows.cs
@@ -80,7 +80,10 @@ namespace Microsoft.Maui.DeviceTests
 			await CreateHandlerAndAddToWindow<IWindowHandler>(mainPage, async (handler) =>
 			{
 				var mauiToolBar = GetPlatformToolbar(handler);
-				await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y > 0);
+
+				Assert.NotNull(mauiToolBar);
+				Assert.True(await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y > 0));
+
 				var position = mauiToolBar.GetLocationOnScreen();
 				var appTitleBarHeight = GetWindowRootView(handler).AppTitleBarActualHeight;
 
@@ -113,7 +116,10 @@ namespace Microsoft.Maui.DeviceTests
 						if (nextRootPage is NavigationPage || nextRootPage is Shell)
 						{
 							var mauiToolBar = GetPlatformToolbar(handler);
-							await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y > 0);
+
+							Assert.NotNull(mauiToolBar);
+							Assert.True(await AssertionExtensions.Wait(() => mauiToolBar.GetLocationOnScreen().Value.Y > 0));
+
 							var position = mauiToolBar.GetLocationOnScreen();
 							var appTitleBarHeight = GetWindowRootView(handler).AppTitleBarActualHeight;
 

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBase.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBase.cs
@@ -30,13 +30,14 @@ namespace Microsoft.Maui.DeviceTests
 			_isCreated = true;
 
 
-			var appBuilder = ConfigureBuilder(MauiApp.CreateBuilder());
+			var appBuilder = MauiApp.CreateBuilder();
 
+			appBuilder.Services.AddSingleton<IDispatcherProvider>(svc => TestDispatcher.Provider);
+			appBuilder.Services.AddScoped<IDispatcher>(svc => TestDispatcher.Current);
+			appBuilder.Services.AddSingleton<IApplication>((_) => new CoreApplicationStub());
+
+			appBuilder = ConfigureBuilder(appBuilder);
 			additionalCreationActions?.Invoke(appBuilder);
-
-			appBuilder.Services.TryAddSingleton<IDispatcherProvider>(svc => TestDispatcher.Provider);
-			appBuilder.Services.TryAddScoped<IDispatcher>(svc => TestDispatcher.Current);
-			appBuilder.Services.TryAddSingleton<IApplication>((_) => new ApplicationStub());
 
 			_mauiApp = appBuilder.Build();
 			_servicesProvider = _mauiApp.Services;

--- a/src/Core/tests/DeviceTests.Shared/Stubs/CoreApplicationStub.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/CoreApplicationStub.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	class ApplicationStub : IApplication
+	class CoreApplicationStub : IApplication
 	{
 		readonly List<IWindow> _windows = new List<IWindow>();
 


### PR DESCRIPTION
### Description of Change

The order for registering services after we consolidated the testing code isn't quite correct on windows. 

Currently on Windows it wires up the `TestDispatcher` and then that gets replaced by a application scoped `Dispatcher` which then returns null. 

This PR fixes the ordering so the `TestDispatcher` registration replaces the `Application` level singleton registration