### PR TITLE
Using local function to fix multi-thread issues

### DIFF
--- a/src/Controls/src/Core/Shapes/PathFigureCollectionConverter.cs
+++ b/src/Controls/src/Core/Shapes/PathFigureCollectionConverter.cs
@@ -18,15 +18,6 @@ namespace Microsoft.Maui.Controls.Shapes
 		const bool AllowSign = true;
 		const bool AllowComma = true;
 
-		static bool _figureStarted;
-		static string _pathString;
-		static int _pathLength;
-		static int _curIndex;
-		static Point _lastStart;
-		static Point _lastPoint;
-		static Point _secondLastPoint;
-		static char _token;
-
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
 			var strValue = value?.ToString();
@@ -40,6 +31,15 @@ namespace Microsoft.Maui.Controls.Shapes
 		/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml" path="//Member[@MemberName='ParseStringToPathFigureCollection']/Docs/*" />
 		public static void ParseStringToPathFigureCollection(PathFigureCollection pathFigureCollection, string pathString)
 		{
+			bool figureStarted = default;
+			string currentPathString = default;
+			int pathLength = default;
+			int currentIndex = default;
+			Point lastStart = default;
+			Point lastPoint = default;
+			Point secondLastPoint = default;
+			char token = default;
+
 			if (pathString != null)
 			{
 				int curIndex = 0;
@@ -76,504 +76,510 @@ namespace Microsoft.Maui.Controls.Shapes
 
 				ParseToPathFigureCollection(pathFigureCollection, pathString, curIndex);
 			}
-		}
 
-		static void ParseToPathFigureCollection(PathFigureCollection pathFigureCollection, string pathString, int startIndex)
-		{
-			PathFigure pathFigure = null;
-
-			_pathString = pathString;
-			_pathLength = pathString.Length;
-			_curIndex = startIndex;
-
-			_secondLastPoint = new Point(0, 0);
-			_lastPoint = new Point(0, 0);
-			_lastStart = new Point(0, 0);
-
-			_figureStarted = false;
-
-			bool first = true;
-
-			char last_cmd = ' ';
-
-			while (ReadToken()) // Empty path is allowed in XAML
+			void ParseToPathFigureCollection(PathFigureCollection pathFigureCollection, string pathString, int startIndex)
 			{
-				char cmd = _token;
+				PathFigure pathFigure = null;
 
-				if (first)
+				currentPathString = pathString;
+				pathLength = pathString.Length;
+				currentIndex = startIndex;
+
+				secondLastPoint = new Point(0, 0);
+				lastPoint = new Point(0, 0);
+				lastStart = new Point(0, 0);
+
+				figureStarted = false;
+
+				bool first = true;
+
+				char last_cmd = ' ';
+
+				while (ReadToken()) // Empty path is allowed in XAML
 				{
-					if ((cmd != 'M') && (cmd != 'm'))  // Path starts with M|m
+					char cmd = token;
+
+					if (first)
 					{
-						ThrowBadToken();
-					}
-
-					first = false;
-				}
-
-				switch (cmd)
-				{
-					case 'm':
-					case 'M':
-						// XAML allows multiple points after M/m
-						_lastPoint = ReadPoint(cmd, !AllowComma);
-
-						pathFigure = new PathFigure
-						{
-							StartPoint = _lastPoint
-						};
-						pathFigureCollection.Add(pathFigure);
-
-						_figureStarted = true;
-						_lastStart = _lastPoint;
-						last_cmd = 'M';
-
-						while (IsNumber(AllowComma))
-						{
-							_lastPoint = ReadPoint(cmd, !AllowComma);
-
-							LineSegment lineSegment = new LineSegment
-							{
-								Point = _lastPoint
-							};
-							pathFigure.Segments.Add(lineSegment);
-
-							last_cmd = 'L';
-						}
-						break;
-
-					case 'l':
-					case 'L':
-					case 'h':
-					case 'H':
-					case 'v':
-					case 'V':
-						EnsureFigure();
-
-						do
-						{
-							switch (cmd)
-							{
-								case 'l':
-									_lastPoint = ReadPoint(cmd, !AllowComma);
-									break;
-								case 'L':
-									_lastPoint = ReadPoint(cmd, !AllowComma);
-									break;
-								case 'h':
-									_lastPoint.X += ReadNumber(!AllowComma);
-									break;
-								case 'H':
-									_lastPoint.X = ReadNumber(!AllowComma);
-									break;
-								case 'v':
-									_lastPoint.Y += ReadNumber(!AllowComma);
-									break;
-								case 'V':
-									_lastPoint.Y = ReadNumber(!AllowComma);
-									break;
-							}
-
-							pathFigure.Segments.Add(new LineSegment
-							{
-								Point = _lastPoint
-							});
-						}
-						while (IsNumber(AllowComma));
-
-						last_cmd = 'L';
-						break;
-
-					case 'c':
-					case 'C': // Cubic Bezier
-					case 's':
-					case 'S': // Smooth cublic Bezier
-						EnsureFigure();
-
-						do
-						{
-							Point p;
-
-							if ((cmd == 's') || (cmd == 'S'))
-							{
-								if (last_cmd == 'C')
-								{
-									p = Reflect();
-								}
-								else
-								{
-									p = _lastPoint;
-								}
-
-								_secondLastPoint = ReadPoint(cmd, !AllowComma);
-							}
-							else
-							{
-								p = ReadPoint(cmd, !AllowComma);
-
-								_secondLastPoint = ReadPoint(cmd, AllowComma);
-							}
-
-							_lastPoint = ReadPoint(cmd, AllowComma);
-
-							BezierSegment bezierSegment = new BezierSegment
-							{
-								Point1 = p,
-								Point2 = _secondLastPoint,
-								Point3 = _lastPoint
-							};
-
-							pathFigure.Segments.Add(bezierSegment);
-
-							last_cmd = 'C';
-						}
-						while (IsNumber(AllowComma));
-
-						break;
-
-					case 'q':
-					case 'Q': // Quadratic Bezier
-					case 't':
-					case 'T': // Smooth quadratic Bezier
-						EnsureFigure();
-
-						do
-						{
-							if ((cmd == 't') || (cmd == 'T'))
-							{
-								if (last_cmd == 'Q')
-								{
-									_secondLastPoint = Reflect();
-								}
-								else
-								{
-									_secondLastPoint = _lastPoint;
-								}
-
-								_lastPoint = ReadPoint(cmd, !AllowComma);
-							}
-							else
-							{
-								_secondLastPoint = ReadPoint(cmd, !AllowComma);
-								_lastPoint = ReadPoint(cmd, AllowComma);
-							}
-
-							QuadraticBezierSegment quadraticBezierSegment = new QuadraticBezierSegment
-							{
-								Point1 = _secondLastPoint,
-								Point2 = _lastPoint
-							};
-
-							pathFigure.Segments.Add(quadraticBezierSegment);
-
-							last_cmd = 'Q';
-						}
-						while (IsNumber(AllowComma));
-
-						break;
-
-					case 'a':
-					case 'A':
-						EnsureFigure();
-
-						do
-						{
-							// A 3,4 5, 0, 0, 6,7
-							double w = ReadNumber(!AllowComma);
-							double h = ReadNumber(AllowComma);
-							double rotation = ReadNumber(AllowComma);
-							bool large = ReadBool();
-							bool sweep = ReadBool();
-
-							_lastPoint = ReadPoint(cmd, AllowComma);
-
-							ArcSegment arcSegment = new ArcSegment
-							{
-								Size = new Size(w, h),
-								RotationAngle = rotation,
-								IsLargeArc = large,
-								SweepDirection = sweep ? SweepDirection.Clockwise : SweepDirection.CounterClockwise,
-								Point = _lastPoint
-							};
-
-							pathFigure.Segments.Add(arcSegment);
-						}
-						while (IsNumber(AllowComma));
-
-						last_cmd = 'A';
-						break;
-
-					case 'z':
-					case 'Z':
-						EnsureFigure();
-						pathFigure.IsClosed = true;
-						_figureStarted = false;
-						last_cmd = 'Z';
-
-						_lastPoint = _lastStart; // Set reference point to be first point of current figure
-						break;
-
-					default:
-						ThrowBadToken();
-						break;
-				}
-			}
-		}
-
-		static void EnsureFigure()
-		{
-			if (!_figureStarted)
-				_figureStarted = true;
-		}
-
-		static Point Reflect()
-		{
-			return new Point(
-				2 * _lastPoint.X - _secondLastPoint.X,
-				2 * _lastPoint.Y - _secondLastPoint.Y);
-		}
-
-		static bool More()
-		{
-			return _curIndex < _pathLength;
-		}
-
-		static bool SkipWhiteSpace(bool allowComma)
-		{
-			bool commaMet = false;
-
-			while (More())
-			{
-				char ch = _pathString[_curIndex];
-
-				switch (ch)
-				{
-					case ' ':
-					case '\n':
-					case '\r':
-					case '\t':
-						break;
-
-					case ',':
-						if (allowComma)
-						{
-							commaMet = true;
-							allowComma = false; // One comma only
-						}
-						else
+						if ((cmd != 'M') && (cmd != 'm'))  // Path starts with M|m
 						{
 							ThrowBadToken();
 						}
-						break;
 
-					default:
-						// Avoid calling IsWhiteSpace for ch in (' ' .. 'z']
-						if (((ch > ' ') && (ch <= 'z')) || !char.IsWhiteSpace(ch))
-						{
-							return commaMet;
-						}
-						break;
+						first = false;
+					}
+
+					switch (cmd)
+					{
+						case 'm':
+						case 'M':
+							// XAML allows multiple points after M/m
+							lastPoint = ReadPoint(cmd, !AllowComma);
+
+							pathFigure = new PathFigure
+							{
+								StartPoint = lastPoint
+							};
+							pathFigureCollection.Add(pathFigure);
+
+							figureStarted = true;
+							lastStart = lastPoint;
+							last_cmd = 'M';
+
+							while (IsNumber(AllowComma))
+							{
+								lastPoint = ReadPoint(cmd, !AllowComma);
+
+								LineSegment lineSegment = new LineSegment
+								{
+									Point = lastPoint
+								};
+								pathFigure.Segments.Add(lineSegment);
+
+								last_cmd = 'L';
+							}
+							break;
+
+						case 'l':
+						case 'L':
+						case 'h':
+						case 'H':
+						case 'v':
+						case 'V':
+							EnsureFigure();
+
+							do
+							{
+								switch (cmd)
+								{
+									case 'l':
+										lastPoint = ReadPoint(cmd, !AllowComma);
+										break;
+									case 'L':
+										lastPoint = ReadPoint(cmd, !AllowComma);
+										break;
+									case 'h':
+										lastPoint.X += ReadNumber(!AllowComma);
+										break;
+									case 'H':
+										lastPoint.X = ReadNumber(!AllowComma);
+										break;
+									case 'v':
+										lastPoint.Y += ReadNumber(!AllowComma);
+										break;
+									case 'V':
+										lastPoint.Y = ReadNumber(!AllowComma);
+										break;
+								}
+
+								pathFigure.Segments.Add(new LineSegment
+								{
+									Point = lastPoint
+								});
+							}
+							while (IsNumber(AllowComma));
+
+							last_cmd = 'L';
+							break;
+
+						case 'c':
+						case 'C': // Cubic Bezier
+						case 's':
+						case 'S': // Smooth cublic Bezier
+							EnsureFigure();
+
+							do
+							{
+								Point p;
+
+								if ((cmd == 's') || (cmd == 'S'))
+								{
+									if (last_cmd == 'C')
+									{
+										p = Reflect();
+									}
+									else
+									{
+										p = lastPoint;
+									}
+
+									secondLastPoint = ReadPoint(cmd, !AllowComma);
+								}
+								else
+								{
+									p = ReadPoint(cmd, !AllowComma);
+
+									secondLastPoint = ReadPoint(cmd, AllowComma);
+								}
+
+								lastPoint = ReadPoint(cmd, AllowComma);
+
+								BezierSegment bezierSegment = new BezierSegment
+								{
+									Point1 = p,
+									Point2 = secondLastPoint,
+									Point3 = lastPoint
+								};
+
+								pathFigure.Segments.Add(bezierSegment);
+
+								last_cmd = 'C';
+							}
+							while (IsNumber(AllowComma));
+
+							break;
+
+						case 'q':
+						case 'Q': // Quadratic Bezier
+						case 't':
+						case 'T': // Smooth quadratic Bezier
+							EnsureFigure();
+
+							do
+							{
+								if ((cmd == 't') || (cmd == 'T'))
+								{
+									if (last_cmd == 'Q')
+									{
+										secondLastPoint = Reflect();
+									}
+									else
+									{
+										secondLastPoint = lastPoint;
+									}
+
+									lastPoint = ReadPoint(cmd, !AllowComma);
+								}
+								else
+								{
+									secondLastPoint = ReadPoint(cmd, !AllowComma);
+									lastPoint = ReadPoint(cmd, AllowComma);
+								}
+
+								QuadraticBezierSegment quadraticBezierSegment = new QuadraticBezierSegment
+								{
+									Point1 = secondLastPoint,
+									Point2 = lastPoint
+								};
+
+								pathFigure.Segments.Add(quadraticBezierSegment);
+
+								last_cmd = 'Q';
+							}
+							while (IsNumber(AllowComma));
+
+							break;
+
+						case 'a':
+						case 'A':
+							EnsureFigure();
+
+							do
+							{
+								// A 3,4 5, 0, 0, 6,7
+								double w = ReadNumber(!AllowComma);
+								double h = ReadNumber(AllowComma);
+								double rotation = ReadNumber(AllowComma);
+								bool large = ReadBool();
+								bool sweep = ReadBool();
+
+								lastPoint = ReadPoint(cmd, AllowComma);
+
+								ArcSegment arcSegment = new ArcSegment
+								{
+									Size = new Size(w, h),
+									RotationAngle = rotation,
+									IsLargeArc = large,
+									SweepDirection = sweep ? SweepDirection.Clockwise : SweepDirection.CounterClockwise,
+									Point = lastPoint
+								};
+
+								pathFigure.Segments.Add(arcSegment);
+							}
+							while (IsNumber(AllowComma));
+
+							last_cmd = 'A';
+							break;
+
+						case 'z':
+						case 'Z':
+							EnsureFigure();
+							pathFigure.IsClosed = true;
+							figureStarted = false;
+							last_cmd = 'Z';
+
+							lastPoint = lastStart; // Set reference point to be first point of current figure
+							break;
+
+						default:
+							ThrowBadToken();
+							break;
+					}
 				}
-
-				_curIndex++;
 			}
 
-			return commaMet;
-		}
-
-		static bool ReadBool()
-		{
-			SkipWhiteSpace(AllowComma);
-
-			if (More())
+			void EnsureFigure()
 			{
-				_token = _pathString[_curIndex++];
+				if (!figureStarted)
+					figureStarted = true;
+			}
 
-				if (_token == '0')
+			Point Reflect()
+			{
+				return new Point(
+					2 * lastPoint.X - secondLastPoint.X,
+					2 * lastPoint.Y - secondLastPoint.Y);
+			}
+
+
+
+
+
+
+			bool More()
+			{
+				return currentIndex < pathLength;
+			}
+
+			bool SkipWhiteSpace(bool allowComma)
+			{
+				bool commaMet = false;
+
+				while (More())
+				{
+					char ch = currentPathString[currentIndex];
+
+					switch (ch)
+					{
+						case ' ':
+						case '\n':
+						case '\r':
+						case '\t':
+							break;
+
+						case ',':
+							if (allowComma)
+							{
+								commaMet = true;
+								allowComma = false; // One comma only
+							}
+							else
+							{
+								ThrowBadToken();
+							}
+							break;
+
+						default:
+							// Avoid calling IsWhiteSpace for ch in (' ' .. 'z']
+							if (((ch > ' ') && (ch <= 'z')) || !char.IsWhiteSpace(ch))
+							{
+								return commaMet;
+							}
+							break;
+					}
+
+					currentIndex++;
+				}
+
+				return commaMet;
+			}
+
+			bool ReadBool()
+			{
+				SkipWhiteSpace(AllowComma);
+
+				if (More())
+				{
+					token = currentPathString[currentIndex++];
+
+					if (token == '0')
+					{
+						return false;
+					}
+					else if (token == '1')
+					{
+						return true;
+					}
+				}
+
+				ThrowBadToken();
+
+				return false;
+			}
+
+			bool ReadToken()
+			{
+				SkipWhiteSpace(!AllowComma);
+
+				// Check for end of string
+				if (More())
+				{
+					token = currentPathString[currentIndex++];
+
+					return true;
+				}
+				else
 				{
 					return false;
 				}
-				else if (_token == '1')
+			}
+
+			void ThrowBadToken()
+			{
+				throw new FormatException(string.Format("UnexpectedToken \"{0}\" into {1}", currentPathString, currentIndex - 1));
+			}
+
+			Point ReadPoint(char cmd, bool allowcomma)
+			{
+				double x = ReadNumber(allowcomma);
+				double y = ReadNumber(AllowComma);
+
+				if (cmd >= 'a') // 'A' < 'a'. lower case for relative
 				{
-					return true;
+					x += lastPoint.X;
+					y += lastPoint.Y;
 				}
+
+				return new Point(x, y);
 			}
 
-			ThrowBadToken();
-
-			return false;
-		}
-
-		static bool ReadToken()
-		{
-			SkipWhiteSpace(!AllowComma);
-
-			// Check for end of string
-			if (More())
+			bool IsNumber(bool allowComma)
 			{
-				_token = _pathString[_curIndex++];
+				bool commaMet = SkipWhiteSpace(allowComma);
 
-				return true;
-			}
-			else
-			{
+				if (More())
+				{
+					token = currentPathString[currentIndex];
+
+					// Valid start of a number
+					if ((token == '.') || (token == '-') || (token == '+') || ((token >= '0') && (token <= '9'))
+						|| (token == 'I')  // Infinity
+						|| (token == 'N')) // NaN
+					{
+						return true;
+					}
+				}
+
+				if (commaMet) // Only allowed between numbers
+				{
+					ThrowBadToken();
+				}
+
 				return false;
 			}
-		}
 
-		static void ThrowBadToken()
-		{
-			throw new FormatException(string.Format("UnexpectedToken \"{0}\" into {1}", _pathString, _curIndex - 1));
-		}
-
-		static Point ReadPoint(char cmd, bool allowcomma)
-		{
-			double x = ReadNumber(allowcomma);
-			double y = ReadNumber(AllowComma);
-
-			if (cmd >= 'a') // 'A' < 'a'. lower case for relative
+			double ReadNumber(bool allowComma)
 			{
-				x += _lastPoint.X;
-				y += _lastPoint.Y;
-			}
-
-			return new Point(x, y);
-		}
-
-		static bool IsNumber(bool allowComma)
-		{
-			bool commaMet = SkipWhiteSpace(allowComma);
-
-			if (More())
-			{
-				_token = _pathString[_curIndex];
-
-				// Valid start of a number
-				if ((_token == '.') || (_token == '-') || (_token == '+') || ((_token >= '0') && (_token <= '9'))
-					|| (_token == 'I')  // Infinity
-					|| (_token == 'N')) // NaN
+				if (!IsNumber(allowComma))
 				{
-					return true;
+					ThrowBadToken();
 				}
-			}
 
-			if (commaMet) // Only allowed between numbers
-			{
-				ThrowBadToken();
-			}
+				bool simple = true;
+				int start = currentIndex;
 
-			return false;
-		}
-
-		static double ReadNumber(bool allowComma)
-		{
-			if (!IsNumber(allowComma))
-			{
-				ThrowBadToken();
-			}
-
-			bool simple = true;
-			int start = _curIndex;
-
-			// Allow for a sign
-			// 
-			// There are numbers that cannot be preceded with a sign, for instance, -NaN, but it's
-			// fine to ignore that at this point, since the CLR parser will catch this later.
-			if (More() && ((_pathString[_curIndex] == '-') || _pathString[_curIndex] == '+'))
-			{
-				_curIndex++;
-			}
-
-			// Check for Infinity (or -Infinity).
-			if (More() && (_pathString[_curIndex] == 'I'))
-			{
-				// Don't bother reading the characters, as the CLR parser will
-				// do this for us later.
-				_curIndex = Math.Min(_curIndex + 8, _pathLength); // "Infinity" has 8 characters
-				simple = false;
-			}
-			// Check for NaN
-			else if (More() && (_pathString[_curIndex] == 'N'))
-			{
-				//
-				// Don't bother reading the characters, as the CLR parser will
-				// do this for us later.
-				//
-				_curIndex = Math.Min(_curIndex + 3, _pathLength); // "NaN" has 3 characters
-				simple = false;
-			}
-			else
-			{
-				SkipDigits(!AllowSign);
-
-				// Optional period, followed by more digits
-				if (More() && (_pathString[_curIndex] == '.'))
+				// Allow for a sign
+				// 
+				// There are numbers that cannot be preceded with a sign, for instance, -NaN, but it's
+				// fine to ignore that at this point, since the CLR parser will catch this later.
+				if (More() && ((currentPathString[currentIndex] == '-') || currentPathString[currentIndex] == '+'))
 				{
+					currentIndex++;
+				}
+
+				// Check for Infinity (or -Infinity).
+				if (More() && (currentPathString[currentIndex] == 'I'))
+				{
+					// Don't bother reading the characters, as the CLR parser will
+					// do this for us later.
+					currentIndex = Math.Min(currentIndex + 8, pathLength); // "Infinity" has 8 characters
 					simple = false;
-					_curIndex++;
+				}
+				// Check for NaN
+				else if (More() && (currentPathString[currentIndex] == 'N'))
+				{
+					//
+					// Don't bother reading the characters, as the CLR parser will
+					// do this for us later.
+					//
+					currentIndex = Math.Min(currentIndex + 3, pathLength); // "NaN" has 3 characters
+					simple = false;
+				}
+				else
+				{
 					SkipDigits(!AllowSign);
+
+					// Optional period, followed by more digits
+					if (More() && (currentPathString[currentIndex] == '.'))
+					{
+						simple = false;
+						currentIndex++;
+						SkipDigits(!AllowSign);
+					}
+
+					// Exponent
+					if (More() && ((currentPathString[currentIndex] == 'E') || (currentPathString[currentIndex] == 'e')))
+					{
+						simple = false;
+						currentIndex++;
+						SkipDigits(AllowSign);
+					}
 				}
 
-				// Exponent
-				if (More() && ((_pathString[_curIndex] == 'E') || (_pathString[_curIndex] == 'e')))
+				if (simple && (currentIndex <= (start + 8))) // 32-bit integer
 				{
-					simple = false;
-					_curIndex++;
-					SkipDigits(AllowSign);
+					int sign = 1;
+
+					if (currentPathString[start] == '+')
+					{
+						start++;
+					}
+					else if (currentPathString[start] == '-')
+					{
+						start++;
+						sign = -1;
+					}
+
+					int value = 0;
+
+					while (start < currentIndex)
+					{
+						value = value * 10 + (currentPathString[start] - '0');
+						start++;
+					}
+
+					return value * sign;
+				}
+				else
+				{
+					string subString = currentPathString.Substring(start, currentIndex - start);
+
+					try
+					{
+						return Convert.ToDouble(subString, CultureInfo.InvariantCulture);
+					}
+					catch (FormatException)
+					{
+						throw new FormatException(string.Format("UnexpectedToken \"{0}\" into {1}", start, currentPathString));
+					}
 				}
 			}
 
-			if (simple && (_curIndex <= (start + 8))) // 32-bit integer
+			void SkipDigits(bool signAllowed)
 			{
-				int sign = 1;
-
-				if (_pathString[start] == '+')
+				// Allow for a sign
+				if (signAllowed && More() && ((currentPathString[currentIndex] == '-') || currentPathString[currentIndex] == '+'))
 				{
-					start++;
-				}
-				else if (_pathString[start] == '-')
-				{
-					start++;
-					sign = -1;
+					currentIndex++;
 				}
 
-				int value = 0;
-
-				while (start < _curIndex)
+				while (More() && (currentPathString[currentIndex] >= '0') && (currentPathString[currentIndex] <= '9'))
 				{
-					value = value * 10 + (_pathString[start] - '0');
-					start++;
-				}
-
-				return value * sign;
-			}
-			else
-			{
-				string subString = _pathString.Substring(start, _curIndex - start);
-
-				try
-				{
-					return Convert.ToDouble(subString, CultureInfo.InvariantCulture);
-				}
-				catch (FormatException)
-				{
-					throw new FormatException(string.Format("UnexpectedToken \"{0}\" into {1}", start, _pathString));
+					currentIndex++;
 				}
 			}
 		}
 
-		static void SkipDigits(bool signAllowed)
-		{
-			// Allow for a sign
-			if (signAllowed && More() && ((_pathString[_curIndex] == '-') || _pathString[_curIndex] == '+'))
-			{
-				_curIndex++;
-			}
-
-			while (More() && (_pathString[_curIndex] >= '0') && (_pathString[_curIndex] <= '9'))
-			{
-				_curIndex++;
-			}
-		}
 
 		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 			=> throw new NotSupportedException();


### PR DESCRIPTION
### Description of Change

I replace the static fields to the local variable by local function. I remove all static fields to fix multi-thread issues.

And I run the bechmark code and I find the performance is improved. Benchmark code: https://github.com/lindexi/lindexi_gd/tree/83b9cf707c311dbc1dd52aa4518a3e131294bd72/JenealehiKedelyuneaga

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19042.1706/20H2/October2020Update)
Intel Core i7-9700K CPU 3.60GHz (Coffee Lake), 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2


|          Method |                 args |      Mean |     Error |    StdDev |   Gen0 |   Gen1 | Allocated |
|---------------- |--------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| RunNewConverter | M13.(...)-05z [2189] | 19.842 μs | 0.1075 μs | 0.1006 μs | 2.4719 | 0.0610 |  15.16 KB |
| RunOldConverter | M13.(...)-05z [2189] | 20.131 μs | 0.0633 μs | 0.0592 μs | 2.4719 | 0.0610 |  15.16 KB |
| RunNewConverter | M16,(...)6,0z [1072] |  9.696 μs | 0.0512 μs | 0.0478 μs | 1.2970 | 0.0153 |      8 KB |
| RunOldConverter | M16,(...)6,0z [1072] | 10.098 μs | 0.0446 μs | 0.0417 μs | 1.2970 | 0.0153 |      8 KB |
| RunNewConverter | M16.(...)6,0z [1015] |  9.616 μs | 0.0500 μs | 0.0417 μs | 1.4038 | 0.0153 |   8.68 KB |
| RunOldConverter | M16.(...)6,0z [1015] | 10.067 μs | 0.0433 μs | 0.0405 μs | 1.4038 | 0.0153 |   8.68 KB |
| RunNewConverter | M16.(...)1,0z [1134] |  9.891 μs | 0.0539 μs | 0.0450 μs | 1.2817 | 0.0153 |   7.91 KB |
| RunOldConverter | M16.(...)1,0z [1134] | 10.281 μs | 0.0330 μs | 0.0309 μs | 1.2817 | 0.0153 |   7.91 KB |
| RunNewConverter |  M27.(...)8,0z [958] |  8.739 μs | 0.0467 μs | 0.0437 μs | 1.1292 | 0.0153 |      7 KB |
| RunOldConverter |  M27.(...)8,0z [958] |  9.175 μs | 0.0301 μs | 0.0282 μs | 1.1292 | 0.0153 |      7 KB |
| RunNewConverter | M7.4(...)6,0z [1116] | 10.075 μs | 0.0294 μs | 0.0229 μs | 1.3428 | 0.0153 |   8.27 KB |
| RunOldConverter | M7.4(...)6,0z [1116] | 10.407 μs | 0.0331 μs | 0.0309 μs | 1.3428 | 0.0153 |   8.27 KB |
| RunNewConverter |  M8.4(...)3,0z [705] |  6.521 μs | 0.0277 μs | 0.0259 μs | 0.8850 | 0.0076 |   5.43 KB |
| RunOldConverter |  M8.4(...)3,0z [705] |  6.848 μs | 0.1022 μs | 0.0956 μs | 0.8850 | 0.0076 |   5.43 KB |
| RunNewConverter | M8.5(...)1,0z [1070] |  9.804 μs | 0.1008 μs | 0.0842 μs | 1.2512 | 0.0153 |   7.73 KB |
| RunOldConverter | M8.5(...)1,0z [1070] | 10.178 μs | 0.0492 μs | 0.0436 μs | 1.2512 | 0.0153 |   7.73 KB |

### Issues Fixed



Fixes https://github.com/dotnet/maui/issues/11321

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
