### PR TITLE
[Actions] Provide an action that will automatically bump the unified pipeline.

### DIFF
--- a/.github/workflows/sdk-insertion-bump.yml
+++ b/.github/workflows/sdk-insertion-bump.yml
@@ -1,0 +1,34 @@
+name: Notify release branch change
+
+on:
+  # trigger for main and release branches.
+  push:
+    branches:
+      - '*'
+
+jobs:
+  pingRemote:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Parse commit
+        shell: pwsh
+        id: commit_title
+        run: |
+          Write-Host "Commit message is $Env:COMMIT_MESSAGE"
+          $title = ($Env:COMMIT_MESSAGE -split '\n')[0]
+          "COMMIT_TITLE=$title" >> $env:GITHUB_OUTPUT
+        env:
+          COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
+
+      - name: 'Update remote repository'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.SERVICEACCOUNT_PAT }}
+          event-type: 'sdk_insertion' 
+          repository: 'xamarin/sdk-insertions'
+          client-payload: '{"repository": "dotnet/maui", "branch": "${{ github.ref_name }}", "commit": "${{ github.sha }}", "commit_message": "${{ steps.commit_title.outputs.COMMIT_TITLE }}"}'
+
+


### PR DESCRIPTION
The action will send a repositoyr_dispatch to the sdk-insertions repo action. The sdk-insertions action will take care of bumping the version used to build maui based on the branches that are configured.

