### PR TITLE
Make iOS Label HTML behavior compatible with Forms

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Label/Label.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Label/Label.iOS.cs
@@ -68,8 +68,10 @@ namespace Microsoft.Maui.Controls
 			if (label?.HasFormattedTextSpans ?? false)
 				return;
 
-			if (label?.TextType == TextType.Html)
+			if (label?.TextType == TextType.Html && FontIsDefault(label))
 			{
+				// If no explicit font has been specified and we're displaying HTML, 
+				// let the HTML determine the font
 				return;
 			}
 
@@ -81,8 +83,10 @@ namespace Microsoft.Maui.Controls
 			if (label?.HasFormattedTextSpans ?? false)
 				return;
 
-			if (label?.TextType == TextType.Html)
+			if (label?.TextType == TextType.Html && label.GetValue(TextColorProperty) == null)
 			{
+				// If no explicit text color has been specified and we're displaying HTML, 
+				// let the HTML determine the colors
 				return;
 			}
 
@@ -97,6 +101,26 @@ namespace Microsoft.Maui.Controls
 		public static void MapMaxLines(ILabelHandler handler, Label label)
 		{
 			handler.PlatformView?.UpdateMaxLines(label);
+		}
+
+		static bool FontIsDefault(Label label)
+		{
+			if (label.IsSet(Label.FontAttributesProperty))
+			{
+				return false;
+			}
+
+			if (label.IsSet(Label.FontFamilyProperty))
+			{
+				return false;
+			}
+
+			if (label.IsSet(Label.FontSizeProperty))
+			{
+				return false;
+			}
+
+			return true;
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Threading.Tasks;
+using Foundation;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -361,6 +363,90 @@ namespace Microsoft.Maui.DeviceTests
 
 				await normalBitmap.AssertEqual(formattedBitmap);
 			});
+		}
+
+		[Fact]
+		public async Task TextColorAppliesEvenInHtmlMode() 
+		{
+			// Note: this is specifically a Controls-level rule that's inherited from Forms
+			// There's no reason other SDKs need to force a TextColor property when dealing 
+			// with HTML text (since HTML text has its own color handling)
+
+			var label = new Label
+			{
+				TextType = TextType.Html,
+				TextColor = Colors.Red,
+				Text = "<p>Test</p>"
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<LabelHandler>(label);
+				Assert.Equal(Colors.Red, TextColor(handler));
+			});
+		}
+
+		[Fact]
+		public async Task FontStuffAppliesEvenInHtmlMode()
+		{
+			// Note: this is specifically a Controls-level rule that's inherited from Forms
+			// There's no reason other SDKs need to force font properties when dealing 
+			// with HTML text (since HTML can do that on its own)
+
+			var label = new Label
+			{
+				TextType = TextType.Html,
+				FontSize = 64, 
+				FontFamily = "Baskerville",
+				Text = "<p>Test</p>"
+			};
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var handler = CreateHandler<LabelHandler>(label);
+				AssertEquivalentFont(handler, label.ToFont());
+			});
+		}
+
+		Color TextColor(LabelHandler handler)
+		{
+#if __IOS__
+			return GetPlatformLabel(handler).TextColor.ToColor();
+#elif __ANDROID__
+			return ((uint)GetPlatformLabel(handler).CurrentTextColor).ToColor();
+#elif WINDOWS
+			return (GetPlatformLabel(handler).Foreground as UI.Xaml.Media.SolidColorBrush).Color.ToColor();
+#endif
+		}
+
+		static void AssertEquivalentFont(LabelHandler handler, Font font) 
+		{
+			var fontManager = (IFontManager)handler.MauiContext.Services.GetService(typeof(IFontManager));
+
+#if __IOS__
+			var targetTypeface = fontManager.GetFont(font);
+			var platformTypeface = handler.PlatformView.AttributedText.GetUIKitAttributes(0, out NSRange range).Font;
+			var targetFontSize = fontManager.GetFont(font).PointSize;
+
+			Assert.Equal(targetTypeface, platformTypeface);
+			Assert.Equal(targetFontSize, platformTypeface.PointSize);
+#elif __ANDROID__
+			var targetTypeface = fontManager.GetTypeface(font);
+			var targetFontSize = handler.MauiContext.Context.ToPixels(fontManager.GetFontSize(font).Value);		
+			var platformTypeface = handler.PlatformView.Typeface;
+			var platformFontSize = handler.PlatformView.TextSize;
+
+			Assert.Equal(targetTypeface, platformTypeface);
+			Assert.Equal(targetFontSize, platformFontSize);
+#elif WINDOWS
+			var targetFontStyle = font.ToFontStyle();
+			var targetFontWeight = font.ToFontWeight();
+			var platformFontStyle = handler.PlatformView.FontStyle;
+			var platformFontWeight = handler.PlatformView.FontWeight;
+
+			Assert.Equal(targetFontStyle, platformFontStyle);
+			Assert.Equal(targetFontWeight, platformFontWeight);
+#endif
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Label/LabelTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Threading.Tasks;
+#if __IOS__
 using Foundation;
+#endif
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Graphics;


### PR DESCRIPTION
### Description of Change

In MAUI.Controls on iOS, TextColor and Font properties aren't being applied at all if the TextType is set to HTML. While this is perfectly reasonable in theory, in practice it differs from the other platforms and from the behavior of iOS on Forms. So for ease of migration and consistency, this change reinstates the Forms behavior.

### Issues Fixed

Fixes #4230
