### PR TITLE
[Android] Fix ObjectDisposedException on Android resizing images

### DIFF
--- a/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/PlatformImage.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.Graphics.Platform
 
 		public IImage Resize(float width, float height, ResizeMode resizeMode = ResizeMode.Fit, bool disposeOriginal = false)
 		{
-			using (var context = new PlatformBitmapExportContext((int)width, (int)height))
+			using (var context = new PlatformBitmapExportContext(width: (int)width, height: (int)height, disposeBitmap: disposeOriginal))
 			{
 				var fx = width / Width;
 				var fy = height / Height;


### PR DESCRIPTION
### Description of Change

Fix ObjectDisposedException on Android resizing images on Android. This already was fixed on net6 here https://github.com/dotnet/Microsoft.Maui.Graphics/pull/453/files Seems that moving the project to the maui repo we lost that change.

### Issues Fixed

Fixes #11255 
