### PR TITLE
[iOS] Avoid propagate Map tap event tapping a Pin on iOS

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml
@@ -1,18 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d"
-             x:Class="Maui.Controls.Sample.Pages.MapsGalleries.MapPinsGallery"
-             Title="Map Pins">
-
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Maui.Controls.Sample.Pages.MapsGalleries.MapPinsGallery"
+    Title="Map Pins">
     <Grid RowDefinitions="Auto, *">
-        <HorizontalStackLayout Grid.Row="0">
-            <Button Text="Add Pin" Clicked="AddPin_Clicked" />
-            <Button Text="Remove Pin" Clicked="RemovePin_Clicked" />
-            <Button Text="Add 10 Pins" Clicked="Add10Pins_Clicked" />
+        <HorizontalStackLayout
+            Grid.Row="0">
+            <Button 
+                Text="Add Pin" 
+                Clicked="OnAddPinClicked" />
+            <Button 
+                Text="Remove Pin"
+                Clicked="OnRemovePinClicked" />
+            <Button 
+                Text="Add 10 Pins" 
+                Clicked="OnAdd10PinsClicked" />
         </HorizontalStackLayout>
-        <Map x:Name="pinsMap" Grid.Row="1" />
+        <Map 
+            x:Name="pinsMap" 
+            Grid.Row="1"
+            MapClicked="OnMapClicked" />
     </Grid>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml.cs
@@ -8,8 +8,8 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class MapPinsGallery
 	{
-		private readonly Random _locationRandomSeed = new();
-		private int _locationIncrement = 0;
+		readonly Random _locationRandomSeed = new();
+		int _locationIncrement = 0;
 
 		// TODO generate actual random pins
 		private readonly Position[] _randomLocations =
@@ -62,26 +62,26 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 				Location = new Position(47.64232, -122.13684),
 			};
 
-			microsoftPin.MarkerClicked += (s, a) =>
+			microsoftPin.MarkerClicked += (sender, args) =>
 			{
-				DisplayAlert("Marker", "OK", "OK");
+				DisplayAlert("Marker", $"Marker Clicked: {((Pin)sender).Label}", "OK");
 			};
 
 			// TODO this doesn't seem to work on iOS?
-			microsoftPin.InfoWindowClicked += (s, a) =>
+			microsoftPin.InfoWindowClicked += (sender, args) =>
 			{
-				DisplayAlert("Info", "OK", "OK");
+				DisplayAlert("Info", $"Info Window Clicked: {((Pin)sender).Label}", "OK");
 			};
 
 			pinsMap.Pins.Add(microsoftPin);
 		}
 
-		private void AddPin_Clicked(object sender, EventArgs e)
+		void OnAddPinClicked(object sender, EventArgs e)
 		{
 			AddPin();
 		}
 
-		private void RemovePin_Clicked(object sender, EventArgs e)
+		void OnRemovePinClicked(object sender, EventArgs e)
 		{
 			if (pinsMap.Pins.Count > 0)
 			{
@@ -90,7 +90,7 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			}
 		}
 
-		private void Add10Pins_Clicked(object sender, EventArgs e)
+		void OnAdd10PinsClicked(object sender, EventArgs e)
 		{
 			for (int i = 0; i <= 10; i++)
 			{
@@ -98,13 +98,18 @@ namespace Maui.Controls.Sample.Pages.MapsGalleries
 			}
 		}
 
-		private void AddPin()
+		void AddPin()
 		{
 			pinsMap.Pins.Add(new Pin()
 			{
 				Label = $"Location {_locationIncrement++}",
 				Location = _randomLocations[_locationRandomSeed.Next(0, _randomLocations.Length)],
 			});
+		}
+
+		void OnMapClicked(object sender, MapClickedEventArgs e)
+		{
+			DisplayAlert("Map", $"Map {e.Location.Latitude}, {e.Location.Longitude} clicked.", "Ok");
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Avoid propagate Map tap event tapping a Pin on iOS. With this changes, we align the behavior between platforms.

![fix-map-clips](https://user-images.githubusercontent.com/6755973/203561219-9ed788b6-6c6c-488a-a87c-4146cd797bb5.gif)

### Issues Fixed

Fixes #11532 
