### PR TITLE
Ensure no crashing for < iOS 12 due to PointerGesture incompatibility

### DIFF
--- a/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
+++ b/src/Controls/src/Core/Platform/GestureManager/GestureManager.iOS.cs
@@ -223,7 +223,8 @@ namespace Microsoft.Maui.Controls.Platform
 			}
 
 			var pointerGestureRecognizer = recognizer as PointerGestureRecognizer;
-			if (pointerGestureRecognizer != null)
+
+			if (pointerGestureRecognizer != null && OperatingSystem.IsIOSVersionAtLeast(13))
 			{
 				var uiRecognizer = CreatePointerRecognizer(r =>
 				{
@@ -405,6 +406,8 @@ namespace Microsoft.Maui.Controls.Platform
 			return result;
 		}
 
+		[SupportedOSPlatform("ios13.0")]
+		[SupportedOSPlatform("maccatalyst13.0")]
 		CustomHoverGestureRecognizer CreatePointerRecognizer(Action<UIHoverGestureRecognizer> action)
 		{
 			var result = new CustomHoverGestureRecognizer(action);

--- a/src/Controls/src/Core/Platform/iOS/CustomHoverGestureRecognizer.cs
+++ b/src/Controls/src/Core/Platform/iOS/CustomHoverGestureRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using Foundation;
 using ObjCRuntime;
 using UIKit;
@@ -6,21 +7,19 @@ using PreserveAttribute = Microsoft.Maui.Controls.Internals.PreserveAttribute;
 
 namespace Microsoft.Maui.Controls.Platform.iOS;
 
+[SupportedOSPlatform("ios13.0")]
+[SupportedOSPlatform("maccatalyst13.0")]
 internal class CustomHoverGestureRecognizer : UIHoverGestureRecognizer
 {
 	NSObject _target;
-
-#pragma warning disable CA1416
+	
 	public CustomHoverGestureRecognizer(NSObject target, Selector action) : base(target, action)
 	{
 		_target = target;
 	}
-#pragma warning restore CA1416
 
-#pragma warning disable CA1416
 	internal CustomHoverGestureRecognizer(Action<UIHoverGestureRecognizer> action)
 		: this(new Callback(action), Selector.FromHandle(Selector.GetHandle("target:"))!) { }
-#pragma warning restore CA1416
 
 	[Register("__UIHoverGestureRecognizer")]
 	class Callback : Token


### PR DESCRIPTION
### Description of Change

UIHoverGestureRecognizer is supported in iOS 13+ which means PointerGesture is supported only on iOS 13+.
Our code now reflects this properly with the relevant versioning attributes and conditions

### Issues Fixed

Fixes #11525
