### PR TITLE
Exclude incompatible files from daily dotnet format workflow

### DIFF
--- a/.github/workflows/dotnet-format-daily.yml
+++ b/.github/workflows/dotnet-format-daily.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Run dotnet format
-        run: dotnet format whitespace ./src --folder --exclude Templates/src
+        run: dotnet format whitespace ./src --folder --exclude Templates/src BlazorWebView/src/SharedSource/BlazorWebViewDeveloperTools.cs BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs Graphics/src/Graphics.Win2D/W2DCanvas.cs Graphics/src/Graphics.Win2D/W2DExtensions.cs
     
       - name: Commit files
         if: steps.format.outputs.has-changes == 'true'


### PR DESCRIPTION
Some C# files use '#if' to include/exclude code and that does not work well with the dotnet format command.