### PR TITLE
Only include MauiXaml/Css when $(UseMaui)=true

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.in.props
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.in.props
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <!-- Default .NET MAUI files-->
-  <ItemGroup Condition=" '$(EnableDefaultMauiItems)' == 'true' and '$(EnableDefaultEmbeddedResourceItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+  <ItemGroup Condition=" '$(UseMaui)' == 'true' and '$(EnableDefaultMauiItems)' == 'true' and '$(EnableDefaultEmbeddedResourceItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
     <MauiXaml Condition=" '$(EnableDefaultXamlItems)' == 'true' "  Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
     <MauiCss  Condition=" '$(EnableDefaultCssItems)' == 'true' "   Include="**\*.css"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change

The AutoImport.props files is _always_ included din _all_ projects, and this means we are adding maui things to all sorts of projects - and now when we try build the maui repository, these are also being included.

**Note**

The other item groups are fine because they are not MAUI but SingleProject