### PR TITLE
Add a condition to skip the AutoImport.props

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.in.props
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/AutoImport.in.props
@@ -8,7 +8,7 @@
     </MauiXaml>
   </ItemDefinitionGroup>
 
-  <ItemGroup Condition=" '$(UseMaui)' == 'true' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') and '$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+  <ItemGroup Condition=" '$(_MauiSkipSdkAutoImport)' != 'true' and '$(UseMaui)' == 'true' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') and '$(TargetFrameworkVersion)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
     <!-- %(Sdk) is only here if something later needs to identify these -->
     <Using Include="Microsoft.Extensions.DependencyInjection" Sdk="Maui" />
     <Using Include="Microsoft.Maui" Sdk="Maui" />
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <!-- Default .NET MAUI files-->
-  <ItemGroup Condition=" '$(UseMaui)' == 'true' and '$(EnableDefaultMauiItems)' == 'true' and '$(EnableDefaultEmbeddedResourceItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+  <ItemGroup Condition=" '$(_MauiSkipSdkAutoImport)' != 'true' and '$(UseMaui)' == 'true' and '$(EnableDefaultMauiItems)' == 'true' and '$(EnableDefaultEmbeddedResourceItems)' == 'true' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
     <MauiXaml Condition=" '$(EnableDefaultXamlItems)' == 'true' "  Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
     <MauiCss  Condition=" '$(EnableDefaultCssItems)' == 'true' "   Include="**\*.css"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
   </ItemGroup>
@@ -42,7 +42,7 @@
   -->
 
   <!-- Android -->
-  <ItemGroup Condition=" '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'android' and '$(MonoAndroidResourcePrefix)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+  <ItemGroup Condition=" '$(_MauiSkipSdkAutoImport)' != 'true' and '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'android' and '$(MonoAndroidResourcePrefix)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
     <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.xml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.axml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.png" />
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <!-- iOS -->
-  <ItemGroup Condition=" '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'ios' and '$(iOSProjectFolder)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+  <ItemGroup Condition=" '$(_MauiSkipSdkAutoImport)' != 'true' and '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'ios' and '$(iOSProjectFolder)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
     <None
         Include="$(iOSProjectFolder)Info.plist"
         Condition="Exists('$(iOSProjectFolder)Info.plist')"
@@ -91,7 +91,7 @@
   </ItemGroup>
 
   <!-- MacCatalyst -->
-  <ItemGroup Condition=" '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+  <ItemGroup Condition=" '$(_MauiSkipSdkAutoImport)' != 'true' and '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
     <None
         Include="$(MacCatalystProjectFolder)Info.plist"
         Condition="Exists('$(MacCatalystProjectFolder)Info.plist')"
@@ -126,7 +126,7 @@
   </ItemGroup>
 
   <!-- Windows -->
-  <ItemGroup Condition=" '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'windows' and '$(WindowsProjectFolder)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
+  <ItemGroup Condition=" '$(_MauiSkipSdkAutoImport)' != 'true' and '$(EnableDefaultMauiItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'windows' and '$(WindowsProjectFolder)' != '' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@')) ">
     <Manifest
         Include="$(ApplicationManifest)"
         Condition="Exists('$(ApplicationManifest)')" />


### PR DESCRIPTION
### Description of Change

Adding `'$(_MauiSkipSdkAutoImport)' != 'true'` so that the imports can be skipped.

This is part of the effort to make MAUI work with NuGets. Right now, the AutoImport _always_ runs when the `maui` workload is installed. This is technically what we want for general users, but in order to develop the NuGets, we can't have that. The version of MAUI that ships with NuGets will not have this issue as the AutoImport will be in the NuGet package.