### PR TITLE
Fix MauiIcon ForegroundScale on systems with comma as decimal separator

### DIFF
--- a/src/SingleProject/Resizetizer/src/ResizeImageInfo.cs
+++ b/src/SingleProject/Resizetizer/src/ResizeImageInfo.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Microsoft.Build.Framework;
 using SkiaSharp;
@@ -95,7 +96,7 @@ namespace Microsoft.Maui.Resizetizer
 				if (bool.TryParse(image.GetMetadata("IsAppIcon"), out var iai))
 					info.IsAppIcon = iai;
 
-				if (float.TryParse(image.GetMetadata("ForegroundScale"), out var fsc))
+				if (float.TryParse(image.GetMetadata("ForegroundScale"), NumberStyles.Number, CultureInfo.InvariantCulture, out var fsc))
 					info.ForegroundScale = fsc;
 
 				var fgFile = image.GetMetadata("ForegroundFile");


### PR DESCRIPTION
### Description of Change

<!-- Enter description of the fix in this section -->
Specifying the `ForegroundScale` with a dot caused an issue on systems with commas as decimal separators. The image got upscaled instead of downscaled on those systems because the `ForegroundScale` was parsed without passing `InvariantCulture` as culture info. Because of this, the existing implementation only worked on systems with a dot as a decimal separator.

In order to solve the issue, the InvariantCulture get's now used when parsing `ForegroundScale`
### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #11685

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
