### PR TITLE
[Windows] Correctly disable MenuBarItems 

### DIFF
--- a/src/Controls/tests/Core.UnitTests/Menu/MenuFlyoutSubItemTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Menu/MenuFlyoutSubItemTests.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Windows.Input;
 using Microsoft.Maui.Handlers;
 using Xunit;
 
@@ -10,6 +11,38 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Menu
 	public class MenuFlyoutSubItemTests :
 		MenuTestBase<MenuFlyoutSubItem, IMenuElement, MenuFlyoutItem, MenuFlyoutSubItemHandlerUpdate>
 	{
+		[Fact]
+		public void StartsEnabled()
+		{
+			MenuBarItem menuBarItem = new MenuBarItem();
+			Assert.True(menuBarItem.IsEnabled);
+		}
+
+		[Fact]
+		public void DisableWorks()
+		{
+			MenuBarItem menuBarItem = new MenuBarItem();
+			menuBarItem.IsEnabled = false;
+			Assert.False(menuBarItem.IsEnabled);
+		}
+
+		[Fact]
+		public void CommandPropertyChangesEnabled()
+		{
+			MenuFlyoutItem menuBarItem = new MenuFlyoutItem();
+
+			bool canExecute = true;
+			var command = new Command((p) => { }, (p) => p != null && (bool)p);
+			menuBarItem.CommandParameter = true;
+			menuBarItem.Command = command;
+
+			Assert.True(menuBarItem.IsEnabled);
+			menuBarItem.CommandParameter = false;
+			Assert.False(menuBarItem.IsEnabled);
+			menuBarItem.CommandParameter = true;
+			Assert.True(menuBarItem.IsEnabled);
+		}
+
 		protected override int GetIndex(MenuFlyoutSubItemHandlerUpdate handlerUpdate) =>
 			handlerUpdate.Index;
 

--- a/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.Windows.cs
+++ b/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.Windows.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Maui.Platform;
-using Microsoft.UI.Xaml.Controls;
+﻿using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Handlers
 {

--- a/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.cs
+++ b/src/Core/src/Handlers/MenuBarItem/MenuBarItemHandler.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.Handlers
 		{
 #if WINDOWS
 			[nameof(IMenuBarItem.Text)] = MapText,
+			[nameof(IMenuBarItem.IsEnabled)] = MapIsEnabled,
 #endif
 		};
 


### PR DESCRIPTION
### Description of Change

Correctly disable MenuBarItems on Windows.

![fix-menu-enabled](https://user-images.githubusercontent.com/6755973/204285802-24f10e3b-989a-4387-bee0-365e166c0c11.gif)

### Issues Fixed

Fixes #11602