### PR TITLE
Ensure invisible views don't get rows/columns when generating AndExpand layouts

### DIFF
--- a/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
+++ b/src/Controls/src/Core/Layout/AndExpandLayoutManager.cs
@@ -56,9 +56,15 @@ namespace Microsoft.Maui.Controls
 				RowSpacing = stackLayout.Spacing,
 			};
 
+			var row = 0;
 			for (int n = 0; n < stackLayout.Count; n++)
 			{
 				var child = stackLayout[n];
+
+				if (child.Visibility != Visibility.Visible)
+				{
+					continue;
+				}
 
 				if (child is View view && view.VerticalOptions.Expands)
 				{
@@ -70,7 +76,9 @@ namespace Microsoft.Maui.Controls
 				}
 
 				grid.Add(child);
-				grid.SetRow(child, n);
+				grid.SetRow(child, row);
+
+				row += 1;
 			}
 
 			return grid;
@@ -85,9 +93,15 @@ namespace Microsoft.Maui.Controls
 				ColumnSpacing = stackLayout.Spacing
 			};
 
+			var column = 0;
 			for (int n = 0; n < stackLayout.Count; n++)
 			{
 				var child = stackLayout[n];
+
+				if (child.Visibility != Visibility.Visible)
+				{
+					continue;
+				}
 
 				if (child is View view && view.HorizontalOptions.Expands)
 				{
@@ -99,7 +113,9 @@ namespace Microsoft.Maui.Controls
 				}
 
 				grid.Add(child);
-				grid.SetColumn(child, n);
+				grid.SetColumn(child, column);
+
+				column += 1;
 			}
 
 			return grid;

--- a/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 		}
 
 		[Fact]
-		public void InvisibleViewsDoNotCreateColumns() 
+		public void InvisibleViewsDoNotCreateColumns()
 		{
 			var view0 = new TestView
 			{

--- a/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
@@ -376,5 +376,53 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 
 			Assert.Equal(0, view1.Bounds.Top);
 		}
+
+		[Fact]
+		public void RevisibleViewsDoCreateColumns()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = false
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = true
+			};
+
+			var layout = SetUpTestLayout(StackOrientation.Horizontal, view0, view1);
+
+			view0.IsVisible = true;
+			MeasureAndArrange(layout);
+			Assert.Equal(TestAreaWidth / 2, view1.Bounds.Left);
+		}
+
+		[Fact]
+		public void RevisibleViewsDoCreateRows()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = false
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = true
+			};
+
+			var layout = SetUpTestLayout(StackOrientation.Vertical, view0, view1);
+
+			view0.IsVisible = true;
+			MeasureAndArrange(layout);
+			Assert.Equal(TestAreaHeight / 2, view1.Bounds.Top);
+		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/AndExpandTests.cs
@@ -332,5 +332,49 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 
 			(layout as Maui.ILayout).CrossPlatformArrange(new Rect(0, 0, 100, 100));
 		}
+
+		[Fact]
+		public void InvisibleViewsDoNotCreateColumns() 
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = false
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = true
+			};
+
+			var layout = SetUpTestLayout(StackOrientation.Horizontal, view0, view1);
+
+			Assert.Equal(0, view1.Bounds.Left);
+		}
+
+		[Fact]
+		public void InvisibleViewsDoNotCreateRows()
+		{
+			var view0 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = false
+			};
+
+			var view1 = new TestView
+			{
+				Text = "Hello",
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = true
+			};
+
+			var layout = SetUpTestLayout(StackOrientation.Vertical, view0, view1);
+
+			Assert.Equal(0, view1.Bounds.Top);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change

When generating the underlying representation of a legacy AndExpand StackLayout, space is being allotted for invisible Views. These changes check View visibility before allotting space.

### Issues Fixed

Fixes #11678
fixes #11454