### PR TITLE
[WinUI] Fix RefreshView crash if no content is specified

### DIFF
--- a/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
+++ b/src/Core/src/Handlers/RefreshView/RefreshViewHandler.Windows.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Handlers
 		static void UpdateContent(IRefreshViewHandler handler)
 		{
 			handler.PlatformView.Content =
-				handler.VirtualView.Content.ToPlatform(handler.MauiContext!);
+				handler.VirtualView.Content?.ToPlatform(handler.MauiContext!);
 		}
 
 		static void UpdateRefreshColor(IRefreshViewHandler handler)

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBase.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBase.cs
@@ -127,6 +127,9 @@ namespace Microsoft.Maui.DeviceTests
 			where THandler : IElementHandler, new()
 			where TCustomHandler : THandler, new()
 		{
+			if (element.Handler is TCustomHandler t)
+				return t;
+
 			mauiContext ??= MauiContext;
 			var handler = Activator.CreateInstance<TCustomHandler>();
 			InitializeViewHandler(element, handler, mauiContext);

--- a/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
+++ b/src/Core/tests/DeviceTests/Core.DeviceTests.csproj
@@ -45,7 +45,6 @@
     <Compile Remove="Handlers\Fonts\*.cs" />
     <Compile Remove="Handlers\Image\*.cs" />
     <Compile Remove="Handlers\ImageButton\*.cs" />
-    <Compile Remove="Handlers\RefreshView\*.cs" />
     <Compile Remove="Handlers\ShapeView\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">

--- a/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/CheckBox/CheckBoxHandlerTests.iOS.cs
@@ -20,7 +20,11 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			var onValue = await GetValueAsync(checkboxStub, (handler) => GetNativeCheckBox(handler).AccessibilityValue);
-			checkboxStub.IsChecked = false;
+			await SetValueAsync(checkboxStub, false, (handler, value) =>
+			{
+				handler.VirtualView.IsChecked = value;
+				handler.UpdateValue(nameof(ICheckBox.IsChecked));
+			});
 			var offValue = await GetValueAsync(checkboxStub, (handler) => GetNativeCheckBox(handler).AccessibilityValue);
 
 			Assert.Equal("1", onValue);

--- a/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.Android.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.DeviceTests
 		MauiSwipeRefreshLayout GetNativeRefreshView(RefreshViewHandler RefreshViewHandler) =>
 			(MauiSwipeRefreshLayout)RefreshViewHandler.PlatformView;
 
-		bool GetNativeIsRefreshing(RefreshViewHandler RefreshViewHandler) =>
+		bool GetPlatformIsRefreshing(RefreshViewHandler RefreshViewHandler) =>
 			GetNativeRefreshView(RefreshViewHandler).Refreshing;
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.Windows.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Maui.Handlers;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class RefreshViewHandlerTests
+	{
+		RefreshContainer GetNativeRefreshView(RefreshViewHandler RefreshViewHandler) =>
+			RefreshViewHandler.PlatformView;
+
+		bool GetPlatformIsRefreshing(RefreshViewHandler RefreshViewHandler) =>
+			GetNativeRefreshView(RefreshViewHandler).Visualizer?.State == RefreshVisualizerState.Refreshing;
+	}
+}

--- a/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.cs
@@ -18,7 +18,25 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				IsRefreshing = isRefreshing,
 			};
-			await ValidatePropertyInitValue(RefreshView, () => isRefreshing, GetNativeIsRefreshing, isRefreshing);
+
+#if !WINDOWS
+			await Assert();
+#else
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				await CreateHandler(RefreshView)
+					.PlatformView
+					.AttachAndRun(async () =>
+					{
+						await Wait(() => GetPlatformIsRefreshing((RefreshViewHandler)RefreshView.Handler) == isRefreshing);
+						await Assert();
+					});
+			});
+#endif
+			Task Assert()
+			{
+				return ValidatePropertyInitValue(RefreshView, () => isRefreshing, GetPlatformIsRefreshing, isRefreshing);
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/RefreshView/RefreshViewHandlerTests.iOS.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.DeviceTests
 		MauiRefreshView GetNativeRefreshView(RefreshViewHandler RefreshViewHandler) =>
 			(MauiRefreshView)RefreshViewHandler.PlatformView;
 
-		bool GetNativeIsRefreshing(RefreshViewHandler RefreshViewHandler) =>
+		bool GetPlatformIsRefreshing(RefreshViewHandler RefreshViewHandler) =>
 			GetNativeRefreshView(RefreshViewHandler).IsRefreshing;
 	}
 }

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -144,16 +144,15 @@ namespace Microsoft.Maui.DeviceTests
 				await tcs.Task;
 				view.Unloaded += OnViewUnloaded;
 
-				// continue with the run
 				T result;
 				try
 				{
 					result = await Run(action);
-					grid.Children.Clear();
 				}
 				finally
 				{
-					await unloadedTcs.Task;
+					grid.Children.Clear();
+					await unloadedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
 					await Task.Delay(10);
 					window.Close();
 				}


### PR DESCRIPTION
### Description of Change

If the user hasn't specified content for the `RefreshView` it will crash on `Windows` with an NRE. This PR fixes it so the `Content` property on the `RefreshContainer` will just set to `null` if the `RefreshView` has no Content specified. 

This PR also enables all the `RefreshView` tests in core. I verified that they all pass. 