### PR TITLE
Fix Element.ChildRemoved event sender

### DIFF
--- a/src/Controls/src/Core/Element.cs
+++ b/src/Controls/src/Core/Element.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Maui.Controls
 		{
 			child.Parent = null;
 
-			ChildRemoved?.Invoke(child, new ElementEventArgs(child));
+			ChildRemoved?.Invoke(this, new ElementEventArgs(child));
 
 			VisualDiagnostics.OnChildRemoved(this, child, oldLogicalIndex);
 

--- a/src/Controls/tests/Core.UnitTests/ElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ElementTests.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			bool added = false;
 			root.DescendantAdded += (sender, args) =>
 			{
-				Assert.Same(args.Element, child);
+				Assert.Same(root, sender);
+				Assert.Same(child, args.Element);
 				added = true;
 			};
 
@@ -75,7 +76,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			bool added = false;
 			root.DescendantAdded += (sender, args) =>
 			{
-				Assert.Same(args.Element, child2);
+				Assert.Same(root, sender);
+				Assert.Same(child2, args.Element);
 				added = true;
 			};
 
@@ -100,6 +102,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			bool tier2added = false;
 			root.DescendantAdded += (sender, args) =>
 			{
+				Assert.Same(root, sender);
+
 				if (!tier1added)
 					tier1added = ReferenceEquals(child, args.Element);
 				if (!tier2added)
@@ -123,7 +127,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			bool removed = false;
 			root.DescendantRemoved += (sender, args) =>
 			{
-				Assert.Same(args.Element, child);
+				Assert.Same(root, sender);
+				Assert.Same(child, args.Element);
 				removed = true;
 			};
 
@@ -144,7 +149,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			bool removed = false;
 			root.DescendantRemoved += (sender, args) =>
 			{
-				Assert.Same(args.Element, child2);
+				Assert.Same(root, sender);
+				Assert.Same(child2, args.Element);
 				removed = true;
 			};
 
@@ -171,6 +177,8 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			bool tier2removed = false;
 			root.DescendantRemoved += (sender, args) =>
 			{
+				Assert.Same(root, sender);
+
 				if (!tier1removed)
 					tier1removed = ReferenceEquals(child, args.Element);
 				if (!tier2removed)
@@ -181,6 +189,39 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.True(tier1removed);
 			Assert.True(tier2removed);
+		}
+
+		[Fact]
+		public void ChildAdded()
+		{
+			var root = new TestElement();
+
+			var child = new TestElement();
+
+			root.ChildAdded += (sender, args) =>
+			{
+				Assert.Same(root, sender);
+				Assert.Same(child, args.Element);
+			};
+
+			root.Children.Add(child);
+		}
+
+		[Fact]
+		public void ChildRemoved()
+		{
+			var root = new TestElement();
+			
+			var child = new TestElement();
+			root.Children.Add(child);
+
+			root.ChildRemoved += (sender, args) =>
+			{
+				Assert.Same(root, sender);
+				Assert.Same(child, args.Element);
+			};
+
+			root.Children.Remove(child);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ElementTests.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 
 			root.Children.Add(child);
+			Assert.True(added);
 		}
 
 		[Fact]
@@ -82,6 +83,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 
 			child.Children.Add(child2);
+			Assert.True(added);
 		}
 
 		[Fact]
@@ -133,6 +135,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 
 			root.Children.Remove(child);
+			Assert.True(removed);
 		}
 
 		[Fact]
@@ -155,6 +158,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			};
 
 			child.Children.Remove(child2);
+			Assert.True(removed);
 		}
 
 		[Fact]
@@ -198,13 +202,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			var child = new TestElement();
 
+			bool added = false;
 			root.ChildAdded += (sender, args) =>
 			{
 				Assert.Same(root, sender);
 				Assert.Same(child, args.Element);
+				added = true;
 			};
 
 			root.Children.Add(child);
+			Assert.True(added);
 		}
 
 		[Fact]
@@ -215,13 +222,16 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var child = new TestElement();
 			root.Children.Add(child);
 
+			bool removed = false;
 			root.ChildRemoved += (sender, args) =>
 			{
 				Assert.Same(root, sender);
 				Assert.Same(child, args.Element);
+				removed = true;
 			};
 
 			root.Children.Remove(child);
+			Assert.True(removed);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Passes the correct sender for the `Element.ChildRemoved` event.

### Issues Fixed

Fixes #11720
Fixes #12633

