### PR TITLE
[windows] ReadyToRun packages ahead of time

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -153,6 +153,8 @@
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.4.0" PrivateAssets="all" />
   </ItemGroup>
   <PropertyGroup>
+    <!-- The RIDs supported on Windows (used by ReadyToRun) -->
+    <WindowsMauiRuntimeIdentifiers>win-x64;win-x86;win-arm64</WindowsMauiRuntimeIdentifiers>
     <!-- We don't need to be warned that we are using a preview .NET -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->

--- a/eng/ReadyToRun.targets
+++ b/eng/ReadyToRun.targets
@@ -1,0 +1,42 @@
+<!-- Setup for packing R2R images on Windows -->
+<Project>
+
+  <PropertyGroup Condition=" '$(_MauiTargetPlatformIsWindows)' == 'true' ">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <RuntimeIdentifiers>$(WindowsMauiRuntimeIdentifiers)</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <!-- Avoid NETSDK1094 when RuntimeIdentifier is blank -->
+  <Target Name="_AfterResolveFrameworkReferences" AfterTargets="ResolveFrameworkReferences">
+    <PropertyGroup>
+      <PublishReadyToRun Condition=" '$(RuntimeIdentifier)' == '' ">false</PublishReadyToRun>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_PackForRuntimeIdentifiers"
+      Condition=" '$(_MauiTargetPlatformIsWindows)' == 'true' and '$(RuntimeIdentifier)' == '' "
+      AfterTargets="Build">
+    <ItemGroup>
+      <_RIDs Include="$(RuntimeIdentifiers)" />
+      <_Project Include="$(MSBuildProjectFile)" AdditionalProperties="RuntimeIdentifier=%(_RIDs.Identity)" />
+    </ItemGroup>
+    <!--
+      NOTE: running Build+Publish in two steps
+      1) The ReadyToRun MSBuild targets seem to just skip unless NoBuild=true
+      2) The ReadyToRun MSBuild targets fail if Build hasn't been run...
+    -->
+    <MSBuild
+        Projects="@(_Project)"
+        Targets="Build"
+        Properties="TargetFramework=$(TargetFramework)"
+        BuildInParallel="$(BuildInParallel)"
+    />
+    <MSBuild
+        Projects="@(_Project)"
+        Targets="Publish"
+        Properties="TargetFramework=$(TargetFramework);NoBuild=true"
+        BuildInParallel="$(BuildInParallel)"
+    />
+  </Target>
+
+</Project>

--- a/src/Compatibility/Core/src/Compatibility.csproj
+++ b/src/Compatibility/Core/src/Compatibility.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
+  <Import Project="$(MauiRootDirectory)eng/ReadyToRun.targets" />
 
   <ItemGroup>
     <Compile Remove="GTK\**" />

--- a/src/Controls/src/Core/Controls.Core.csproj
+++ b/src/Controls/src/Core/Controls.Core.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
+  <Import Project="$(MauiRootDirectory)eng/ReadyToRun.targets" />
 
   <ItemGroup>
     <Compile Remove="Internals\Legacy\**" />

--- a/src/Controls/src/Xaml/Controls.Xaml.csproj
+++ b/src/Controls/src/Xaml/Controls.Xaml.csproj
@@ -12,6 +12,8 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 
+	<Import Project="$(MauiRootDirectory)eng/ReadyToRun.targets" />
+
 	<PropertyGroup Condition="$(TargetFramework.Contains('-windows')) == true ">
 		<NoWarn>$(NoWarn);CA1416</NoWarn>
 		<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -10,6 +10,7 @@
     <NoWarn>$(NoWarn);CS1591;RS0041;RS0026;RS0027</NoWarn>
   </PropertyGroup>
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
+  <Import Project="$(MauiRootDirectory)eng/ReadyToRun.targets" />
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Essentials/src/Essentials.csproj
+++ b/src/Essentials/src/Essentials.csproj
@@ -12,6 +12,7 @@
     <NoWarn Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">$(NoWarn);CA1420</NoWarn>
   </PropertyGroup>
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />
+  <Import Project="$(MauiRootDirectory)eng/ReadyToRun.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\Graphics\src\Graphics\Graphics.csproj" />
   </ItemGroup>

--- a/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
+++ b/src/Graphics/src/Graphics.Win2D/Graphics.Win2D.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</AssemblyName>
     <IsTrimmable>false</IsTrimmable>
+    <RuntimeIdentifiers Condition=" '$(_MauiTargetPlatformIsWindows)' == 'true' ">$(WindowsMauiRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Graphics/src/Graphics/Graphics.csproj
+++ b/src/Graphics/src/Graphics/Graphics.csproj
@@ -14,6 +14,7 @@
     <IsTrimmable>false</IsTrimmable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CA1307;CA1309;CS1591</NoWarn>
+    <RuntimeIdentifiers Condition=" '$(_MauiTargetPlatformIsWindows)' == 'true' ">$(WindowsMauiRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 
   <Import Project="$(MauiNuSpecDirectory)Microsoft.Maui.Controls.MultiTargeting.targets" />

--- a/src/Workload/Microsoft.Maui.Controls.Runtime/Microsoft.Maui.Controls.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Controls.Runtime/Microsoft.Maui.Controls.Runtime.csproj
@@ -14,12 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Compatibility/Core/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Controls.Compatibility.dll')" />
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Compatibility/Core/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Controls.Compatibility.pdb')" />
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Controls.dll')" />
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Controls.pdb')" />
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Xaml/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Controls.Xaml.dll')" />
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Xaml/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Controls.Xaml.pdb')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Compatibility/Core/src/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.Controls.Compatibility.dll')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Compatibility/Core/src/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.Controls.Compatibility.pdb')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.Controls.dll')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Core/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.Controls.pdb')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Xaml/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.Controls.Xaml.dll')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Controls/src/Xaml/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.Controls.Xaml.pdb')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/%(FullTfm)/%(FileName)%(Extension)" />
     <_PackageFiles Include="@(None)" PackagePath="lib/%(FullTfm)" TargetPath="lib/%(FullTfm)" />
   </ItemGroup>

--- a/src/Workload/Microsoft.Maui.Core.Runtime/Microsoft.Maui.Core.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Core.Runtime/Microsoft.Maui.Core.Runtime.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Core/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.dll')" />
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Core/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.pdb')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Core/src/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.dll')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Core/src/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.pdb')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/%(FullTfm)/%(FileName)%(Extension)" />
     <_PackageFiles Include="@(None)" PackagePath="lib/%(FullTfm)" TargetPath="lib/%(FullTfm)" />
   </ItemGroup>

--- a/src/Workload/Microsoft.Maui.Essentials.Runtime/Microsoft.Maui.Essentials.Runtime.csproj
+++ b/src/Workload/Microsoft.Maui.Essentials.Runtime/Microsoft.Maui.Essentials.Runtime.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Essentials/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Essentials.dll')" />
-    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Essentials/src/bin/$(Configuration)/%(Tfm)/Microsoft.Maui.Essentials.pdb')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Essentials/src/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.Essentials.dll')" />
+    <None Include="@(_TargetPlatform->'$(MauiRootDirectory)src/Essentials/src/bin/$(Configuration)/%(Tfm)/$(OutputPathSuffix)Microsoft.Maui.Essentials.pdb')" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" Visible="false" Link="lib/%(FullTfm)/%(FileName)%(Extension)" />
     <_PackageFiles Include="@(None)" PackagePath="lib/%(FullTfm)" TargetPath="lib/%(FullTfm)" />
   </ItemGroup>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -10,6 +10,8 @@
     <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">win</_MauiPlatformName>
     <_MauiPlatformName Condition=" '$(TargetPlatformIdentifier)' != 'windows' ">$(TargetPlatformIdentifier.ToLowerInvariant())</_MauiPlatformName>
     <_MauiPlatformName Condition=" '$(_MauiPlatformName)' == '' ">any</_MauiPlatformName>
+    <_MauiRuntimePackRuntimeIdentifiers Condition=" '$(TargetPlatformIdentifier)' == 'windows' ">win-x64;win-x86;win-arm64</_MauiRuntimePackRuntimeIdentifiers>
+    <_MauiRuntimePackRuntimeIdentifiers Condition=" '$(_MauiRuntimePackRuntimeIdentifiers)' == '' ">$(_MauiPlatformName)</_MauiRuntimePackRuntimeIdentifiers>
     <_MauiRuntimePackAlwaysCopyLocal Condition=" '$(_MauiPlatformName)' == 'any' ">true</_MauiRuntimePackAlwaysCopyLocal>
   </PropertyGroup>
 
@@ -25,7 +27,7 @@
         TargetingPackName="Microsoft.Maui.Core.Ref.$(_MauiPlatformName)"
         TargetingPackVersion="$(_MauiRuntimePackVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Core.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
+        RuntimePackRuntimeIdentifiers="$(_MauiRuntimePackRuntimeIdentifiers)"
         Profile="$(TargetPlatformIdentifier)"
         RuntimePackAlwaysCopyLocal="$(_MauiRuntimePackAlwaysCopyLocal)"
     />
@@ -39,7 +41,7 @@
         TargetingPackName="Microsoft.Maui.Controls.Ref.$(_MauiPlatformName)"
         TargetingPackVersion="$(_MauiRuntimePackVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Controls.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
+        RuntimePackRuntimeIdentifiers="$(_MauiRuntimePackRuntimeIdentifiers)"
         Profile="$(TargetPlatformIdentifier)"
         RuntimePackAlwaysCopyLocal="$(_MauiRuntimePackAlwaysCopyLocal)"
     />
@@ -53,7 +55,7 @@
         TargetingPackName="Microsoft.Maui.Essentials.Ref.$(_MauiPlatformName)"
         TargetingPackVersion="$(_MauiRuntimePackVersion)"
         RuntimePackNamePatterns="Microsoft.Maui.Essentials.Runtime.**RID**"
-        RuntimePackRuntimeIdentifiers="$(_MauiPlatformName)"
+        RuntimePackRuntimeIdentifiers="$(_MauiRuntimePackRuntimeIdentifiers)"
         Profile="$(TargetPlatformIdentifier)"
         RuntimePackAlwaysCopyLocal="$(_MauiRuntimePackAlwaysCopyLocal)"
     />

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -123,6 +123,33 @@
     }
   },
   "packs": {
+    "Microsoft.Maui.Core.Runtime.win": {
+      "kind": "framework",
+      "version": "@VERSION@",
+      "alias-to": {
+        "win-x86": "Microsoft.Maui.Core.Runtime.win-x86",
+        "win-x64": "Microsoft.Maui.Core.Runtime.win-x64",
+        "win-arm64": "Microsoft.Maui.Core.Runtime.win-arm64"
+      }
+    },
+    "Microsoft.Maui.Controls.Runtime.win": {
+      "kind": "framework",
+      "version": "@VERSION@",
+      "alias-to": {
+        "win-x86": "Microsoft.Maui.Controls.Runtime.win-x86",
+        "win-x64": "Microsoft.Maui.Controls.Runtime.win-x64",
+        "win-arm64": "Microsoft.Maui.Controls.Runtime.win-arm64"
+      }
+    },
+    "Microsoft.Maui.Essentials.Runtime.win": {
+      "kind": "framework",
+      "version": "@VERSION@",
+      "alias-to": {
+        "win-x86": "Microsoft.Maui.Essentials.Runtime.win-x86",
+        "win-x64": "Microsoft.Maui.Essentials.Runtime.win-x64",
+        "win-arm64": "Microsoft.Maui.Essentials.Runtime.win-arm64"
+      }
+    },
     "Microsoft.AspNetCore.Components.WebView.Maui": {
       "kind": "library",
       "version": "@VERSION@"
@@ -167,7 +194,15 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Core.Runtime.win": {
+    "Microsoft.Maui.Core.Runtime.win-x86": {
+      "kind": "framework",
+      "version": "@VERSION@"
+    },
+    "Microsoft.Maui.Core.Runtime.win-x64": {
+      "kind": "framework",
+      "version": "@VERSION@"
+    },
+    "Microsoft.Maui.Core.Runtime.win-arm64": {
       "kind": "framework",
       "version": "@VERSION@"
     },
@@ -215,7 +250,15 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Controls.Runtime.win": {
+    "Microsoft.Maui.Controls.Runtime.win-x86": {
+      "kind": "framework",
+      "version": "@VERSION@"
+    },
+    "Microsoft.Maui.Controls.Runtime.win-x64": {
+      "kind": "framework",
+      "version": "@VERSION@"
+    },
+    "Microsoft.Maui.Controls.Runtime.win-arm64": {
       "kind": "framework",
       "version": "@VERSION@"
     },
@@ -263,7 +306,15 @@
       "kind": "framework",
       "version": "@VERSION@"
     },
-    "Microsoft.Maui.Essentials.Runtime.win": {
+    "Microsoft.Maui.Essentials.Runtime.win-x86": {
+      "kind": "framework",
+      "version": "@VERSION@"
+    },
+    "Microsoft.Maui.Essentials.Runtime.win-x64": {
+      "kind": "framework",
+      "version": "@VERSION@"
+    },
+    "Microsoft.Maui.Essentials.Runtime.win-arm64": {
       "kind": "framework",
       "version": "@VERSION@"
     },

--- a/src/Workload/README.md
+++ b/src/Workload/README.md
@@ -27,6 +27,9 @@ The idea, is a project to be able to set `$(UseMaui)`:
 * `Microsoft.Maui.Essentials.Runtime.[platform]`
 * `Microsoft.Maui.Templates`
 
+Note that `[platform]` on Windows will be a `RuntimeIdentifier` such
+as `win-x86`, `win-x64`, or `win-arm64`.
+
 BlazorWebView is an addition to MAUI, project can currently opt into
 it by adding `.Razor` to the `Sdk` attribute.
 

--- a/src/Workload/Shared/Common.targets
+++ b/src/Workload/Shared/Common.targets
@@ -8,5 +8,6 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <IncludeSymbols>false</IncludeSymbols>
     <NoWarn>$(NoWarn);NU5100;NU5128;NU5130;NU5131</NoWarn>
+    <IntermediateOutputPath>obj\$(Configuration)\$(MauiPlatformName)</IntermediateOutputPath>
   </PropertyGroup>
 </Project>

--- a/src/Workload/Shared/FrameworkList.targets
+++ b/src/Workload/Shared/FrameworkList.targets
@@ -6,6 +6,11 @@
   </ItemGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="6.0.0-beta.21065.3" />
+  <ItemGroup>
+    <!-- Workaround a NuGet restore error -->
+    <PackageReference Remove="Microsoft.DotNet.Build.Tasks.Installers" />
+    <PackageReference Remove="Microsoft.DotNet.Build.Tasks.Packaging" />
+  </ItemGroup>
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)"/>
 
   <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->

--- a/src/Workload/Shared/Frameworks.targets
+++ b/src/Workload/Shared/Frameworks.targets
@@ -1,8 +1,10 @@
 <Project>
 
   <PropertyGroup Condition=" '$(MauiPlatformName)' != '' ">
-    <!-- NOTE: $(MauiPlatformName) is expected to be passed in: android, maccatalyst, ios, or win -->
+    <!-- NOTE: $(MauiPlatformName) is expected to be passed in: android, maccatalyst, ios, win-x86, win-x64, or win-arm64 -->
     <PackageId>$(PackageId).$(MauiPlatformName)</PackageId>
+    <!-- If $(MauiPlatformName) is a $(RuntimeIdentifier), use /publish/ -->
+    <OutputPathSuffix Condition=" $(MauiPlatformName.Contains('-')) ">$(MauiPlatformName)/publish/</OutputPathSuffix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(MauiPlatformName)' == '' ">
     <IsPackable>false</IsPackable>
@@ -16,35 +18,35 @@
         Tfm="net$(_MauiDotNetVersion)"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'android' "
+        Condition=" $(MauiPlatformName.StartsWith('android')) "
         Include="net$(_MauiDotNetVersion)-android$(AndroidTargetFrameworkVersion)"
         FullTfm="%(Identity)"
         Tfm="net$(_MauiDotNetVersion)-android"
         Profile="Android"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'ios' "
+        Condition=" $(MauiPlatformName.StartsWith('ios')) "
         Include="net$(_MauiDotNetVersion)-ios$(IosTargetFrameworkVersion)"
         FullTfm="%(Identity)"
         Tfm="net$(_MauiDotNetVersion)-ios"
         Profile="iOS"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'maccatalyst' "
+        Condition=" $(MauiPlatformName.StartsWith('maccatalyst')) "
         Include="net$(_MauiDotNetVersion)-maccatalyst$(MacCatalystTargetFrameworkVersion)"
         FullTfm="%(Identity)"
         Tfm="net$(_MauiDotNetVersion)-maccatalyst"
         Profile="MacCatalyst"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'win' "
+        Condition=" $(MauiPlatformName.StartsWith('win')) "
         Include="net$(_MauiDotNetVersion)-windows$(WindowsTargetFrameworkVersion)"
         FullTfm="%(Identity)"
         Tfm="net$(_MauiDotNetVersion)-windows$(WindowsTargetFrameworkVersion)"
         Profile="Windows"
     />
     <_TargetPlatform
-        Condition=" '$(MauiPlatformName)' == 'tizen' "
+        Condition=" $(MauiPlatformName.StartsWith('tizen')) "
         Include="net$(_MauiDotNetVersion)-tizen$(TizenTargetFrameworkVersion)"
         FullTfm="%(Identity)"
         Tfm="net$(_MauiDotNetVersion)-tizen"
@@ -57,11 +59,30 @@
   <ItemGroup>
     <_Platforms Include="any;android;maccatalyst;ios" />
     <_Platforms Include="tizen" Condition="'$(IncludeTizenTargetFrameworks)' == 'true'" />
-    <_Platforms Include="win" Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'" />
+    <!-- NOTE: we leave out "win" on purpose, they are explicitly built per-RID -->
   </ItemGroup>
 
   <Target Name="_PackPerPlatform" Condition=" '$(MauiPlatformName)' == '' " AfterTargets="Build">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Pack" Properties="MauiPlatformName=%(_Platforms.Identity)" />
+    <ItemGroup>
+      <_RIDs Include="$(WindowsMauiRuntimeIdentifiers)" />
+      <_Project Include="$(MSBuildProjectFullPath)" AdditionalProperties="MauiPlatformName=%(_Platforms.Identity)" />
+      <!-- Windows runtime packs for each RID -->
+      <_Project
+          Condition=" '$(IncludeWindowsTargetFrameworks)' == 'true' and $(MSBuildProjectName.Contains('.Runtime')) "
+          Include="$(MSBuildProjectFullPath)"
+          AdditionalProperties="MauiPlatformName=%(_RIDs.Identity)"
+      />
+      <_Project
+          Condition=" '$(IncludeWindowsTargetFrameworks)' == 'true' and !$(MSBuildProjectName.Contains('.Runtime')) "
+          Include="$(MSBuildProjectFullPath)"
+          AdditionalProperties="MauiPlatformName=win"
+      />
+    </ItemGroup>
+    <MSBuild
+        Projects="@(_Project)"
+        Targets="Pack"
+        BuildInParallel="$(BuildInParallel)"
+    />
   </Target>
 
 </Project>


### PR DESCRIPTION
Fixes #11493

If you start PerfView, and then hit F5 to launch a MAUI app, a decent chunk of time is spent in `clrjit`:

| Name                       | Inc % |  Inc |
| ---                        | ---:  | ---: |
| module clrjit <<clrjit!?>> | 34.8  |  655 |

You can drill down to the `JITStats` report, to see interesting numbers such as:

| Name                             | JitTime (ms) | Num Compilations |
| ---                              | ---:         | ---:             |
| TOTAL                            |       1,112.1|            4,491 |
| WinRT.Runtime.dll                |        235.0 |              587 |
| Microsoft.Maui.Controls.dll      |        221.9 |            1,267 |
| Microsoft.Maui.Controls.Xaml.dll |        128.7 |              355 |
| MyMauiAppBefore.dll              |        127.2 |              113 |
| Microsoft.Maui.dll               |         99.0 |              487 |
| Microsoft.WinUI.dll              |         86.2 |              689 |

If we use ReadyToRun on the .NET MAUI assemblies, we get a much better result:

| Name                             | JitTime (ms) | Num Compilations |
| ---                              | ---:         | ---:             |
| TOTAL                            |        678.8 |            2,354 |
| WinRT.Runtime.dll                |        216.0 |              594 |
| MyMauiAppAfter.dll               |        148.0 |               66 |
| Microsoft.WinUI.dll              |         93.1 |              690 |
| Microsoft.Maui.Controls.dll      |          0.2 |                1 |

Where the remaining assemblies appear to have disappeared from this report completely.

The overall numbers are also improved:

| Name                       | Inc % |  Inc |
| ---                        | ---:  | ---: |
| module clrjit <<clrjit!?>> | 26.0  |  378 |

## Overall Startup ##

Building a `dotnet new maui` app unpackaged (`WindowPackageType=None`), I can see the overall time difference in a Debug build on my Windows PC:

```
Before:
0:00:00.713508
0:00:00.710401
0:00:00.8575007
0:00:00.708123
0:00:00.728967
Average(ms): 743.6999400000001
Std Err(ms): 28.682541557079638
Std Dev(ms): 64.13611268909274

After:
0:00:00.5733569
0:00:00.5811488
0:00:00.5862774
0:00:00.5774222
0:00:00.5904521
Average(ms): 581.73148
Std Err(ms): 3.0476023535559817
Std Dev(ms): 6.814646030939524
```

So, I believe this saves about 160ms of app launch time from the inner dev loop.

## Package Size ##

The impact to .NET MAUI's package size is:

Before:

| File                                        | Size (bytes) |
| ---                                         | ---:         |
| Microsoft.Maui.Controls.Runtime.win.nupkg   |      1205856 |
| Microsoft.Maui.Core.Runtime.win.nupkg       |       362430 |
| Microsoft.Maui.Essentials.Runtime.win.nupkg |       136621 |
| TOTAL                                       |      1704907 |

After:

| File                                              | Size (bytes) |
| ---                                               | ---:         |
| Microsoft.Maui.Controls.Runtime.win-arm64.nupkg   |      2720437 |
| Microsoft.Maui.Controls.Runtime.win-x64.nupkg     |      2769275 |
| Microsoft.Maui.Controls.Runtime.win-x86.nupkg     |      2581618 |
| Microsoft.Maui.Core.Runtime.win-arm64.nupkg       |       728382 |
| Microsoft.Maui.Core.Runtime.win-x64.nupkg         |       743622 |
| Microsoft.Maui.Core.Runtime.win-x86.nupkg         |       704380 |
| Microsoft.Maui.Essentials.Runtime.win-arm64.nupkg |       267409 |
| Microsoft.Maui.Essentials.Runtime.win-x64.nupkg   |       271540 |
| Microsoft.Maui.Essentials.Runtime.win-x86.nupkg   |       257231 |
| TOTAL                                             |     10979816 |

So adds about ~9.2MB.