### PR TITLE
Remove Android LaunchAdjacent flag for Essentials

### DIFF
--- a/src/Essentials/src/AppInfo/AppInfo.android.cs
+++ b/src/Essentials/src/AppInfo/AppInfo.android.cs
@@ -39,8 +39,6 @@ namespace Microsoft.Maui.ApplicationModel
 			settingsIntent.SetData(global::Android.Net.Uri.Parse("package:" + PackageName));
 
 			var flags = ActivityFlags.NewTask | ActivityFlags.NoHistory | ActivityFlags.ExcludeFromRecents;
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				flags |= ActivityFlags.LaunchAdjacent;
 			settingsIntent.SetFlags(flags);
 
 			context.StartActivity(settingsIntent);

--- a/src/Essentials/src/Email/Email.android.cs
+++ b/src/Essentials/src/Email/Email.android.cs
@@ -22,10 +22,6 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 		{
 			var intent = CreateIntent(message);
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-#if __ANDROID_24__
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				flags |= ActivityFlags.LaunchAdjacent;
-#endif
 			intent.SetFlags(flags);
 
 			Application.Context.StartActivity(intent);

--- a/src/Essentials/src/Launcher/Launcher.android.cs
+++ b/src/Essentials/src/Launcher/Launcher.android.cs
@@ -22,10 +22,6 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			var intent = new Intent(Intent.ActionView, AndroidUri.Parse(uri.OriginalString));
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-#if __ANDROID_24__
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				flags |= ActivityFlags.LaunchAdjacent;
-#endif
 			intent.SetFlags(flags);
 
 			Application.Context.StartActivity(intent);
@@ -42,10 +38,6 @@ namespace Microsoft.Maui.ApplicationModel
 
 			var chooserIntent = Intent.CreateChooser(intent, request.Title ?? string.Empty);
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-#if __ANDROID_24__
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				flags |= ActivityFlags.LaunchAdjacent;
-#endif
 			chooserIntent.SetFlags(flags);
 
 			Application.Context.StartActivity(chooserIntent);

--- a/src/Essentials/src/Map/Map.android.cs
+++ b/src/Essentials/src/Map/Map.android.cs
@@ -126,10 +126,6 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 			var intent = new Intent(Intent.ActionView, AndroidUri.Parse(uri));
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-#if __ANDROID_24__
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				flags |= ActivityFlags.LaunchAdjacent;
-#endif
 			intent.SetFlags(flags);
 
 			return intent;

--- a/src/Essentials/src/PhoneDialer/PhoneDialer.android.cs
+++ b/src/Essentials/src/PhoneDialer/PhoneDialer.android.cs
@@ -37,8 +37,6 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 			var dialIntent = ResolveDialIntent(phoneNumber);
 
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				flags |= ActivityFlags.LaunchAdjacent;
 			dialIntent.SetFlags(flags);
 
 			Application.Context.StartActivity(dialIntent);

--- a/src/Essentials/src/Sms/Sms.android.cs
+++ b/src/Essentials/src/Sms/Sms.android.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 			var intent = CreateIntent(message?.Body, message?.Recipients);
 
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
-			if (OperatingSystem.IsAndroidVersionAtLeast(24))
-				flags |= ActivityFlags.LaunchAdjacent;
 			intent.SetFlags(flags);
 
 			Application.Context.StartActivity(intent);


### PR DESCRIPTION
Port of Xamarin.Essentials PR: https://github.com/xamarin/Essentials/pull/2058

Original issue: https://github.com/xamarin/Essentials/issues/2023

We probably want to backport this to .NET 7