### PR TITLE
[build] Add support for Visual Studio on win-arm64

### DIFF
--- a/eng/automation/vs-workload.template.props
+++ b/eng/automation/vs-workload.template.props
@@ -27,7 +27,7 @@
     <ComponentResources Include="maui-maccatalyst"  Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Mac Catalyst" Description=".NET SDK Workload for building MAUI applications that target Mac Catalyst." />
     <ComponentResources Include="maui-ios"          Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for iOS" Description=".NET SDK Workload for building MAUI applications that target iOS." />
     <ComponentResources Include="maui-windows"      Version="@VS_COMPONENT_VERSION@" Category=".NET" Title=".NET MAUI SDK for Windows" Description=".NET SDK Workload for building MAUI applications that target Windows." />
-    <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Maui.Manifest*.nupkg" Version="@VS_COMPONENT_VERSION@" />
+    <WorkloadPackages Include="$(NuGetPackagePath)\Microsoft.NET.Sdk.Maui.Manifest*.nupkg" Version="@VS_COMPONENT_VERSION@" SupportsMachineArch="true" />
     <MultiTargetPackNames Include="Maui.Sdk;Maui.Templates" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change

Context: https://github.com/dotnet/maui/issues/11090
Context: https://github.com/xamarin/yaml-templates/pull/204
Context: https://github.com/xamarin/xamarin-android/pull/7471
Context: https://github.com/xamarin/xamarin-macios/pull/16935

Updates the VSMAN files generated for our .NET workload to support Visual Studio on windows-arm64.