### PR TITLE
[Android] Setup `Frame` with all of the missing `Mapper` methods 

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -28,7 +28,27 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				[Frame.CornerRadiusProperty.PropertyName] = (h, _) => h.UpdateCornerRadius(),
 				[Frame.BorderColorProperty.PropertyName] = (h, _) => h.UpdateBorderColor(),
 				[Microsoft.Maui.Controls.Compatibility.Layout.IsClippedToBoundsProperty.PropertyName] = (h, _) => h.UpdateClippedToBounds(),
-				[Frame.ContentProperty.PropertyName] = (h, _) => h.UpdateContent()
+				[Frame.ContentProperty.PropertyName] = (h, _) => h.UpdateContent(),
+
+				// TODO NET8. These are all needed because the AndroidBatchMapper doesn't run via the mapper it's a manual call on ViewHandler
+				// With NET8 we can move the BatchMapper call to the actual ViewHandler.Mapper. 
+				// Because we most likely want to backport these fixes to NET7, I've just opted to add these manually for now on Frame
+				[nameof(IView.AutomationId)] = (h, v) => ViewHandler.MapAutomationId(h, v),
+				[nameof(IView.IsEnabled)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.IsEnabled)),
+				[nameof(IView.Visibility)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.Visibility)),
+				[nameof(IView.MinimumHeight)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.MinimumHeight)),
+				[nameof(IView.MinimumWidth)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.MinimumWidth)),
+				[nameof(IView.Opacity)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.Opacity)),
+				[nameof(IView.TranslationX)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.TranslationX)),
+				[nameof(IView.TranslationY)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.TranslationY)),
+				[nameof(IView.Scale)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.Scale)),
+				[nameof(IView.ScaleX)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.ScaleX)),
+				[nameof(IView.ScaleY)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.ScaleY)),
+				[nameof(IView.Rotation)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.Rotation)),
+				[nameof(IView.RotationX)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.RotationX)),
+				[nameof(IView.RotationY)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.RotationY)),
+				[nameof(IView.AnchorX)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.AnchorX)),
+				[nameof(IView.AnchorY)] = (h, v) => ViewRenderer.VisualElementRendererMapper.UpdateProperty(h, v, nameof(IView.AnchorY)),
 			};
 
 		public static CommandMapper<Frame, FrameRenderer> CommandMapper
@@ -80,8 +100,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		Size IViewHandler.GetDesiredSize(double widthMeasureSpec, double heightMeasureSpec)
 		{
+			double minWidth = 20;
+			if (Primitives.Dimension.IsExplicitSet(widthMeasureSpec) && !double.IsInfinity(widthMeasureSpec))
+				minWidth = widthMeasureSpec;
+
+			double minHeight = 20;
+			if (Primitives.Dimension.IsExplicitSet(widthMeasureSpec) && !double.IsInfinity(heightMeasureSpec))
+				minHeight = heightMeasureSpec;
+
 			return VisualElementRenderer<Frame>.GetDesiredSize(this, widthMeasureSpec, heightMeasureSpec,
-				new Size(20, 20));
+				new Size(minWidth, minHeight));
 		}
 
 		protected override void Dispose(bool disposing)

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameHandlerTest.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameHandlerTest.Android.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class FrameHandlerTest
+	{
+		public override Task ContainerViewInitializesCorrectly()
+		{
+			// https://github.com/dotnet/maui/pull/12218
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameHandlerTest.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameHandlerTest.cs
@@ -1,11 +1,11 @@
-﻿#if WINDOWS
+﻿#if WINDOWS || ANDROID
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.DeviceTests.Stubs;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.Frame)]
-	public class FrameHandlerTest : HandlerTestBase<FrameHandlerTest.FrameRendererWithEmptyCtor, FrameStub>
+	public partial class FrameHandlerTest : HandlerTestBase<FrameHandlerTest.FrameRendererWithEmptyCtor, FrameStub>
 	{
 		public FrameHandlerTest()
 		{

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Clip Initializes ContainerView Correctly")]
-		public async Task ContainerViewInitializesCorrectly()
+		public async virtual Task ContainerViewInitializesCorrectly()
 		{
 			var view = new TStub
 			{


### PR DESCRIPTION
### Description of Change

The `AndroidBatchMapper` is manually called on `ViewHandler` meaning if you have a `Handler` that just uses the `ViewHandler.Mapper` and doesn't use our base class then everything inside `AndroidBatchMapper` won't run.  I have a different PR that fixes this across the [board](https://github.com/dotnet/maui/pull/10751). This PR isolates the changes to `Frame` specifically to minimize the effect of this PR. 

This PR also takes the `Container` code we have in `ViewHandler` and applies to `Frame` so that `Frame` can benefit from all the `Container` scenarios as well. 

### Issues Fixed
Fixes #10220
Fixes #10503
Fixes #10503
Fixes #8840