### PR TITLE
Reconcile PointerOver, Pressed, and Focused states 

### DIFF
--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -367,10 +367,12 @@ namespace Microsoft.Maui.Controls
 			if (IsEnabled && IsPressed)
 			{
 				VisualStateManager.GoToState(this, ButtonElement.PressedVisualState);
+				System.Diagnostics.Debug.WriteLine($">>>>>> Pressed");
 			}
-			
-			// Fall through to handle other states
-			base.ChangeVisualState();
+			else
+			{
+				base.ChangeVisualState();
+			}
 		}
 
 		protected override void OnBindingContextChanged()

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -368,10 +368,9 @@ namespace Microsoft.Maui.Controls
 			{
 				VisualStateManager.GoToState(this, ButtonElement.PressedVisualState);
 			}
-			else
-			{
-				base.ChangeVisualState();
-			}
+			
+			// Fall through to handle other states
+			base.ChangeVisualState();
 		}
 
 		protected override void OnBindingContextChanged()

--- a/src/Controls/src/Core/Button.cs
+++ b/src/Controls/src/Core/Button.cs
@@ -367,7 +367,6 @@ namespace Microsoft.Maui.Controls
 			if (IsEnabled && IsPressed)
 			{
 				VisualStateManager.GoToState(this, ButtonElement.PressedVisualState);
-				System.Diagnostics.Debug.WriteLine($">>>>>> Pressed");
 			}
 			else
 			{

--- a/src/Controls/src/Core/ButtonElement.cs
+++ b/src/Controls/src/Core/ButtonElement.cs
@@ -110,13 +110,12 @@ namespace Microsoft.Maui.Controls
 		/// <param name="ButtonElementManager">The button element implementation to trigger the commands and events on.</param>
 		public static void ElementReleased(VisualElement visualElement, IButtonElement ButtonElementManager)
 		{
-			if (visualElement.IsEnabled == true)
-			{
-				IButtonController buttonController = ButtonElementManager as IButtonController;
-				ButtonElementManager.SetIsPressed(false);
-				visualElement.ChangeVisualStateInternal();
-				ButtonElementManager.PropagateUpReleased();
-			}
+			// Even if the button is disabled, we still want to remove the Pressed state;
+			// the button may have been disabled by the the pressing action
+
+			ButtonElementManager.SetIsPressed(false);
+			visualElement.ChangeVisualStateInternal();
+			ButtonElementManager.PropagateUpReleased();
 		}
 	}
 }

--- a/src/Controls/src/Core/ButtonElement.cs
+++ b/src/Controls/src/Core/ButtonElement.cs
@@ -112,7 +112,6 @@ namespace Microsoft.Maui.Controls
 		{
 			// Even if the button is disabled, we still want to remove the Pressed state;
 			// the button may have been disabled by the the pressing action
-
 			ButtonElementManager.SetIsPressed(false);
 			visualElement.ChangeVisualStateInternal();
 			ButtonElementManager.PropagateUpReleased();

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1095,21 +1095,17 @@ namespace Microsoft.Maui.Controls
 
 		protected internal virtual void ChangeVisualState()
 		{
-			bool transitioned = false;
-
 			if (!IsEnabled)
 			{
-				transitioned = VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
 			}
 			else if (IsPointerOver && !transitioned)
 			{
-				transitioned = VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
-				System.Diagnostics.Debug.WriteLine($">>>>>> PointerOver");
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
 			}
 			else if(!transitioned)
 			{
-				transitioned = VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal);
-				System.Diagnostics.Debug.WriteLine($">>>>>> Normal");
+				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal);
 			}
 
 			if (IsEnabled)

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1095,14 +1095,31 @@ namespace Microsoft.Maui.Controls
 
 		protected internal virtual void ChangeVisualState()
 		{
+			bool transitioned = false;
+
 			if (!IsEnabled)
-				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
-			else if (IsPointerOver)
-				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
-			else if (IsFocused)
-				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Focused);
-			else
-				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal);
+			{
+				transitioned = VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
+			}
+			else if (IsPointerOver && !transitioned)
+			{
+				transitioned = VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
+				System.Diagnostics.Debug.WriteLine($">>>>>> PointerOver");
+			}
+			else if(!transitioned)
+			{
+				transitioned = VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal);
+				System.Diagnostics.Debug.WriteLine($">>>>>> Normal");
+			}
+
+			if (IsEnabled)
+			{
+				// Focus needs to be handled independently; otherwise, if no actual Focus state is supplied
+				// in the control's visual states, the state can end up stuck in PointerOver after the pointer
+				// exits and the control still has focus.
+				VisualStateManager.GoToState(this,
+					IsFocused ? VisualStateManager.CommonStates.Focused : VisualStateManager.CommonStates.Unfocused);
+			}
 		}
 
 		static void OnVisualChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -1099,11 +1099,11 @@ namespace Microsoft.Maui.Controls
 			{
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Disabled);
 			}
-			else if (IsPointerOver && !transitioned)
+			else if (IsPointerOver)
 			{
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.PointerOver);
 			}
-			else if(!transitioned)
+			else
 			{
 				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal);
 			}

--- a/src/Controls/src/Core/VisualStateManager.cs
+++ b/src/Controls/src/Core/VisualStateManager.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Maui.Controls
 			public const string Focused = "Focused";
 			public const string Selected = "Selected";
 			public const string PointerOver = "PointerOver";
+			internal const string Unfocused = "Unfocused";
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/VisualStateManager.xml" path="//Member[@MemberName='VisualStateGroupsProperty']/Docs/*" />

--- a/src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs
@@ -70,7 +70,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			((IButtonController)view).SendReleased();
 
-			Assert.True(released == isEnabled ? true : false);
+			// Released should always fire, even if the button is disabled
+			// Otherwise, a press which disables a button will leave it in the
+			// Pressed state forever
+			Assert.True(released);
 		}
 
 		protected override Button CreateSource()

--- a/src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ButtonUnitTest.cs
@@ -1,5 +1,6 @@
 using System;
 using Xunit;
+using static Microsoft.Maui.Controls.Core.UnitTests.VisualStateTestHelpers;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
@@ -232,6 +233,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.Equal(layout1.Position, bcl.Position);
 			Assert.Equal(layout1.Spacing, bcl.Spacing);
+		}
+
+		[Fact]
+		public void PressedVisualState()
+		{
+			var vsgList = CreateTestStateGroups();
+			var stateGroup = vsgList[0];
+			var element = new Button();
+			VisualStateManager.SetVisualStateGroups(element, vsgList);
+
+			element.SendPressed();
+			Assert.Equal(stateGroup.CurrentState.Name, PressedStateName);
+			
+			element.SendReleased();
+			Assert.NotEqual(stateGroup.CurrentState.Name, PressedStateName);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/CheckBoxUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/CheckBoxUnitTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Xunit;
+using static Microsoft.Maui.Controls.Core.UnitTests.VisualStateTestHelpers;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
@@ -43,6 +44,24 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			Assert.False(fired);
 		}
-	}
 
+		[Fact]
+		public void CheckedVisualStates()
+		{
+			var vsgList = CreateTestStateGroups();
+			string checkedStateName = CheckBox.IsCheckedVisualState;
+			var checkedState = new VisualState() { Name = checkedStateName };
+			var stateGroup = vsgList[0];
+			stateGroup.States.Add(checkedState);
+
+			var element = new CheckBox();
+			VisualStateManager.SetVisualStateGroups(element, vsgList);
+
+			element.IsChecked = true;
+			Assert.Equal(checkedStateName, stateGroup.CurrentState.Name);
+
+			element.IsChecked = false;
+			Assert.NotEqual(checkedStateName, stateGroup.CurrentState.Name);
+		}
+	}
 }

--- a/src/Controls/tests/Core.UnitTests/ImageButtonUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageButtonUnitTest.cs
@@ -3,10 +3,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using static Microsoft.Maui.Controls.Core.UnitTests.VisualStateTestHelpers;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
-
 	public class ImageButtonTests : CommandSourceTests<ImageButton>
 	{
 		[Fact]
@@ -41,7 +41,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.Equal(25, result.Request.Width);
 			Assert.Equal(5, result.Request.Height);
 		}
-
 
 		[Fact]
 		public void TestAspectFillSizingWithConstrainedHeight()
@@ -350,7 +349,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			get { return ImageButton.CommandParameterProperty; }
 		}
 
-
 		[Fact]
 		public void TestBindingContextPropagation()
 		{
@@ -420,6 +418,21 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				?.SendClicked();
 
 			Assert.False(invoked);
+		}
+
+		[Fact]
+		public void PressedVisualState()
+		{
+			var vsgList = CreateTestStateGroups();
+			var stateGroup = vsgList[0];
+			var element = new ImageButton();
+			VisualStateManager.SetVisualStateGroups(element, vsgList);
+
+			element.SendPressed();
+			Assert.Equal(stateGroup.CurrentState.Name, PressedStateName);
+
+			element.SendReleased();
+			Assert.NotEqual(stateGroup.CurrentState.Name, PressedStateName);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/ImageButtonUnitTest.cs
+++ b/src/Controls/tests/Core.UnitTests/ImageButtonUnitTest.cs
@@ -319,7 +319,10 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 			((IButtonController)view).SendReleased();
 
-			Assert.True(released == isEnabled ? true : false);
+			// Released should always fire, even if the button is disabled
+			// Otherwise, a press which disables a button will leave it in the
+			// Pressed state forever
+			Assert.True(released);
 		}
 
 		protected override ImageButton CreateSource()

--- a/src/Controls/tests/Core.UnitTests/SwitchUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/SwitchUnitTests.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Xunit;
+using static Microsoft.Maui.Controls.Core.UnitTests.VisualStateTestHelpers;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
@@ -150,6 +150,29 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			VisualStateManager.SetVisualStateGroups(switch1, CreateTestStateGroupsWithoutNormalState());
 			var groups1 = VisualStateManager.GetVisualStateGroups(switch1);
 			Assert.Null(groups1[0].CurrentState);
+		}
+
+		[Fact]
+		public void OnOffVisualStates()
+		{
+			var vsgList = VisualStateTestHelpers.CreateTestStateGroups();
+			var stateGroup = vsgList[0];
+			var element = new Switch();
+			VisualStateManager.SetVisualStateGroups(element, vsgList);
+
+			string onStateName = Switch.SwitchOnVisualState;
+			string offStateName = Switch.SwitchOffVisualState;
+			var onState = new VisualState() { Name = onStateName };
+			var offState = new VisualState() { Name = offStateName };
+
+			stateGroup.States.Add(onState);
+			stateGroup.States.Add(offState);
+
+			element.IsToggled = true;
+			Assert.Equal(stateGroup.CurrentState.Name, onStateName);
+
+			element.IsToggled = false;
+			Assert.Equal(stateGroup.CurrentState.Name, offStateName);
 		}
 	}
 

--- a/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualElementTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Maui.Primitives;
 using Xunit;
+using static Microsoft.Maui.Controls.Core.UnitTests.VisualStateTestHelpers;
+
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
 	public class VisualElementTests
@@ -67,6 +69,18 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			visualElement.Background = brush2;
 			Assert.Equal(bc1, brush2.BindingContext);
 
+		}
+
+		[Fact]
+		public void FocusedElementGetsFocusedVisualState()
+		{
+			var vsgList = CreateTestStateGroups();
+			var stateGroup = vsgList[0];
+			var element = new Button();
+			VisualStateManager.SetVisualStateGroups(element, vsgList);
+
+			element.SetValue(VisualElement.IsFocusedPropertyKey, true);
+			Assert.Equal(stateGroup.CurrentState.Name, FocusedStateName);
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateManagerTests.cs
@@ -6,50 +6,12 @@ using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
 using Xunit;
+using static Microsoft.Maui.Controls.Core.UnitTests.VisualStateTestHelpers;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests
 {
-
 	public class VisualStateManagerTests : IDisposable
 	{
-		const string NormalStateName = "Normal";
-		const string InvalidStateName = "Invalid";
-		const string FocusedStateName = "Focused";
-		const string DisabledStateName = "Disabled";
-		const string CommonStatesName = "CommonStates";
-
-		static VisualStateGroupList CreateTestStateGroups()
-		{
-			var stateGroups = new VisualStateGroupList();
-			var visualStateGroup = new VisualStateGroup { Name = CommonStatesName };
-			var normalState = new VisualState { Name = NormalStateName };
-			var invalidState = new VisualState { Name = InvalidStateName };
-			var focusedState = new VisualState { Name = FocusedStateName };
-			var disabledState = new VisualState { Name = DisabledStateName };
-
-			visualStateGroup.States.Add(normalState);
-			visualStateGroup.States.Add(invalidState);
-			visualStateGroup.States.Add(focusedState);
-			visualStateGroup.States.Add(disabledState);
-
-			stateGroups.Add(visualStateGroup);
-
-			return stateGroups;
-		}
-
-		static VisualStateGroupList CreateStateGroupsWithoutNormalState()
-		{
-			var stateGroups = new VisualStateGroupList();
-			var visualStateGroup = new VisualStateGroup { Name = CommonStatesName };
-			var invalidState = new VisualState { Name = InvalidStateName };
-
-			visualStateGroup.States.Add(invalidState);
-
-			stateGroups.Add(visualStateGroup);
-
-			return stateGroups;
-		}
-
 		[Fact]
 		public void InitialStateIsNormalIfAvailable()
 		{
@@ -182,7 +144,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void GroupNamesMustBeUniqueWithinGroupList()
 		{
 			IList<VisualStateGroup> vsgs = CreateTestStateGroups();
-			var secondGroup = new VisualStateGroup { Name = CommonStatesName };
+			var secondGroup = new VisualStateGroup { Name = CommonStatesGroupName };
 
 			Assert.Throws<InvalidOperationException>(() => vsgs.Add(secondGroup));
 		}
@@ -234,7 +196,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			label1.SetValue(VisualElement.IsFocusedPropertyKey, false);
 			groups1 = VisualStateManager.GetVisualStateGroups(label1);
 			Assert.Equal(groups1[0].CurrentState.Name, NormalStateName);
-
 		}
 
 		[Fact]
@@ -334,7 +295,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void CanRemoveAStateAndAddANewStateWithTheSameName()
 		{
 			var stateGroups = new VisualStateGroupList();
-			var visualStateGroup = new VisualStateGroup { Name = CommonStatesName };
+			var visualStateGroup = new VisualStateGroup { Name = CommonStatesGroupName };
 			var normalState = new VisualState { Name = NormalStateName };
 			var invalidState = new VisualState { Name = InvalidStateName };
 
@@ -353,7 +314,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 		public void CanRemoveAGroupAndAddANewGroupWithTheSameName()
 		{
 			var stateGroups = new VisualStateGroupList();
-			var visualStateGroup = new VisualStateGroup { Name = CommonStatesName };
+			var visualStateGroup = new VisualStateGroup { Name = CommonStatesGroupName };
 			var secondVisualStateGroup = new VisualStateGroup { Name = "Whatevs" };
 			var normalState = new VisualState { Name = NormalStateName };
 			var invalidState = new VisualState { Name = InvalidStateName };

--- a/src/Controls/tests/Core.UnitTests/VisualStateTestHelpers.cs
+++ b/src/Controls/tests/Core.UnitTests/VisualStateTestHelpers.cs
@@ -1,0 +1,49 @@
+﻿namespace Microsoft.Maui.Controls.Core.UnitTests
+{
+	public class VisualStateTestHelpers 
+	{
+		public const string NormalStateName = "Normal";
+		public const string PressedStateName = "Pressed";
+		public const string InvalidStateName = "Invalid";
+		public const string UnfocusedStateName = "Unfocused";
+		public const string FocusedStateName = "Focused";
+		public const string DisabledStateName = "Disabled";
+		public const string CommonStatesGroupName = "CommonStates";
+		public const string FocusStatesGroupName = "FocusStates";
+
+		public static VisualStateGroupList CreateTestStateGroups()
+		{
+			var stateGroups = new VisualStateGroupList();
+			var commonStatesGroup = new VisualStateGroup { Name = CommonStatesGroupName };
+			var normalState = new VisualState { Name = NormalStateName };
+			var focusState = new VisualState { Name = FocusedStateName };
+			var pressedState = new VisualState { Name = PressedStateName };
+			var invalidState = new VisualState { Name = InvalidStateName };
+
+			var disabledState = new VisualState { Name = DisabledStateName };
+
+			commonStatesGroup.States.Add(normalState);
+			commonStatesGroup.States.Add(pressedState);
+			commonStatesGroup.States.Add(invalidState);
+			commonStatesGroup.States.Add(focusState);
+			commonStatesGroup.States.Add(disabledState);
+
+			stateGroups.Add(commonStatesGroup);
+
+			return stateGroups;
+		}
+
+		public static VisualStateGroupList CreateStateGroupsWithoutNormalState()
+		{
+			var stateGroups = new VisualStateGroupList();
+			var visualStateGroup = new VisualStateGroup { Name = CommonStatesGroupName };
+			var invalidState = new VisualState { Name = InvalidStateName };
+
+			visualStateGroup.States.Add(invalidState);
+
+			stateGroups.Add(visualStateGroup);
+
+			return stateGroups;
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Allows the Pressed state of a Button to be released even if the Button is disabled. Allows the PointerOver state to be deactivated even if the VisualElement still has Focus. Decouples Focus states from the other common states. 

### Issues Fixed

Addresses the Windows portion of #9753 (which might be the only remaining part of that issue).
fixes #7377
fixes #8877


