### PR TITLE
Add empty PointerOver states to Buttons to reduce confusion

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -42,6 +42,7 @@
                             <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" />
                         </VisualState.Setters>
                     </VisualState>
+                    <VisualState x:Name="PointerOver" />
                 </VisualStateGroup>
             </VisualStateGroupList>
         </Setter>
@@ -152,6 +153,7 @@
                             <Setter Property="Opacity" Value="0.5" />
                         </VisualState.Setters>
                     </VisualState>
+                    <VisualState x:Name="PointerOver" />
                 </VisualStateGroup>
             </VisualStateGroupList>
         </Setter>


### PR DESCRIPTION
### Description of Change

We've had multiple users run into issues with the Pressed VisualState on Buttons (see #9715 and #8309) - they set up a Pressed state, and then are confused when the state remains after releasing the Button. This is happening* because the Button is moving into the PointerOver state, which does not exist in their VisualState lists. Since the target state is not found, the Pressed state remains in effect until the user leaves the PointerOver state. 

This is similar to the behavior of a Pressed state with no PointerOver state defined in UWP/WinUI. The solution is to define a PointerOver state. To reduce confusion, we should just add a PointerOver state to our default templates.

* At the time these bugs were originally opened, the problem was likely the Focused state, because PointerOver didn't exist yet. But in the most recent release, PointerOver replaces Focused as the source of the problem; the Focused issue is dealt with by #11840.


