### PR TITLE
Modify generics on replaced mappers inside `Controls` to cover more types. 

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Element/Element.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.Android.cs
@@ -17,5 +17,17 @@ namespace Microsoft.Maui.Controls
 			Platform.AutomationPropertiesProvider.SetImportantForAccessibility(
 				handler.PlatformView as Android.Views.View, element);
 		}
+
+		static void MapAutomationPropertiesIsInAccessibleTree(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesIsInAccessibleTree(handler, e);
+		}
+
+		static void MapAutomationPropertiesExcludedWithChildren(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesExcludedWithChildren(handler, e);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Element/Element.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.Standard.cs
@@ -14,5 +14,17 @@ namespace Microsoft.Maui.Controls
 		public static void MapAutomationPropertiesExcludedWithChildren(IElementHandler handler, Element element)
 		{
 		}
+
+		static void MapAutomationPropertiesIsInAccessibleTree(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesIsInAccessibleTree(handler, e);
+		}
+
+		static void MapAutomationPropertiesExcludedWithChildren(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesExcludedWithChildren(handler, e);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Element/Element.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.Tizen.cs
@@ -15,5 +15,17 @@ namespace Microsoft.Maui.Controls
 		{
 			//TODO : Need to impl
 		}
+
+		static void MapAutomationPropertiesIsInAccessibleTree(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesIsInAccessibleTree(handler, e);
+		}
+
+		static void MapAutomationPropertiesExcludedWithChildren(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesExcludedWithChildren(handler, e);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Element/Element.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.Windows.cs
@@ -27,5 +27,17 @@ namespace Microsoft.Maui.Controls
 		public static void MapAutomationPropertiesExcludedWithChildren(IElementHandler handler, Element view)
 		{
 		}
+
+		static void MapAutomationPropertiesIsInAccessibleTree(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesIsInAccessibleTree(handler, e);
+		}
+
+		static void MapAutomationPropertiesExcludedWithChildren(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesExcludedWithChildren(handler, e);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Element/Element.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Maui.Controls
 	/// <include file="../../../../docs/Microsoft.Maui.Controls/Element.xml" path="Type[@FullName='Microsoft.Maui.Controls.Element']/Docs/*" />
 	public partial class Element
 	{
-		public static IPropertyMapper<Maui.IElement, IElementHandler> ControlsElementMapper = new PropertyMapper<Element, IElementHandler>(ViewHandler.ViewMapper)
+		public static IPropertyMapper<Maui.IElement, IElementHandler> ControlsElementMapper = new PropertyMapper<IElement, IElementHandler>(ViewHandler.ViewMapper)
 		{
 			[AutomationProperties.IsInAccessibleTreeProperty.PropertyName] = MapAutomationPropertiesIsInAccessibleTree,
 			[AutomationProperties.ExcludedWithChildrenProperty.PropertyName] = MapAutomationPropertiesExcludedWithChildren,

--- a/src/Controls/src/Core/HandlerImpl/Element/Element.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Element/Element.iOS.cs
@@ -39,5 +39,17 @@ namespace Microsoft.Maui.Controls
 			var _defaultAccessibilityElementsHidden = Control.AccessibilityElementsHidden || Control is UIControl;
 			Control.AccessibilityElementsHidden = (bool)((bool?)view.GetValue(AutomationProperties.ExcludedWithChildrenProperty) ?? _defaultAccessibilityElementsHidden);
 		}
+
+		static void MapAutomationPropertiesIsInAccessibleTree(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesIsInAccessibleTree(handler, e);
+		}
+
+		static void MapAutomationPropertiesExcludedWithChildren(IElementHandler handler, IElement element)
+		{
+			if (element is Element e)
+				MapAutomationPropertiesExcludedWithChildren(handler, e);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Android.cs
@@ -6,9 +6,16 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout) => MapInputTransparent((ILayoutHandler)handler, layout);
+		public static void MapInputTransparent(LayoutHandler handler, Layout layout) =>
+			UpdateInputTransparent(handler, layout);
 
-		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout) =>
+			UpdateInputTransparent(handler, layout);
+
+		static void MapInputTransparent(IViewHandler handler, IView layout) =>
+			UpdateInputTransparent(handler, layout);
+
+		static void UpdateInputTransparent(IViewHandler handler, IView layout)
 		{
 			if (handler.PlatformView is LayoutViewGroup layoutViewGroup)
 			{
@@ -16,13 +23,10 @@ namespace Microsoft.Maui.Controls
 				layoutViewGroup.InputTransparent = layout.InputTransparent;
 			}
 
-			layout.UpdateDescendantInputTransparent();
-		}
-
-		static void MapInputTransparent(IViewHandler handler, IView layout)
-		{
-			if (handler is ILayoutHandler lh && layout is Layout l)
-				MapInputTransparent(lh, l);
+			if (layout is Layout l)
+			{
+				l.UpdateDescendantInputTransparent();
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Android.cs
@@ -18,5 +18,11 @@ namespace Microsoft.Maui.Controls
 
 			layout.UpdateDescendantInputTransparent();
 		}
+
+		static void MapInputTransparent(IViewHandler handler, IView layout)
+		{
+			if (handler is ILayoutHandler lh && layout is Layout l)
+				MapInputTransparent(lh, l);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Standard.cs
@@ -6,6 +6,16 @@
 
 		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
 		{
+			if (handler is LayoutHandler h)
+			{
+				MapInputTransparent(h, layout);
+			}
+		}
+
+		static void MapInputTransparent(IViewHandler handler, IView layout)
+		{
+			if (handler is ILayoutHandler lh && layout is Layout l)
+				MapInputTransparent(lh, l);
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Standard.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Standard.cs
@@ -2,20 +2,10 @@
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout) => MapInputTransparent((ILayoutHandler)handler, layout);
+		public static void MapInputTransparent(LayoutHandler handler, Layout layout) { }
 
-		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
-		{
-			if (handler is LayoutHandler h)
-			{
-				MapInputTransparent(h, layout);
-			}
-		}
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout) { }
 
-		static void MapInputTransparent(IViewHandler handler, IView layout)
-		{
-			if (handler is ILayoutHandler lh && layout is Layout l)
-				MapInputTransparent(lh, l);
-		}
+		static void MapInputTransparent(IViewHandler handler, IView layout) { }
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Tizen.cs
@@ -23,5 +23,11 @@
 				handler.PlatformView.Sensitive = true;
 			}
 		}
+
+		static void MapInputTransparent(IViewHandler handler, IView layout)
+		{
+			if (handler is ILayoutHandler lh && layout is Layout l)
+				MapInputTransparent(lh, l);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Tizen.cs
@@ -11,10 +11,9 @@
 		static void MapInputTransparent(IViewHandler handler, IView layout) =>
 			UpdateInputTransparent(handler, layout);
 
-		static void UpdateInputTransparent(IViewHandler viewHandler, IView view)
+		static void UpdateInputTransparent(IViewHandler handler, IView view)
 		{
-			if (viewHandler is not IPlatformViewHandler handler ||
-				handler.PlatformView == null || 
+			if (handler.PlatformView is not Microsoft.Maui.Platform.LayoutViewGroup platformView || 
 				view is not Layout layout)
 			{
 				return;
@@ -23,15 +22,15 @@
 			if (layout.CascadeInputTransparent)
 			{
 				// Sensitive property on NUI View was false, disabled all touch event including children
-				handler.PlatformView.Sensitive = !layout.InputTransparent;
-				handler.PlatformView.InputTransparent = false;
+				platformView.Sensitive = !layout.InputTransparent;
+				platformView.InputTransparent = false;
 			}
 			else
 			{
 				// InputTransparent property on LayoutViewGroup was false,
 				// Only LayoutViewGroup event was disabled but children are allowed
-				handler.PlatformView.InputTransparent = layout.InputTransparent;
-				handler.PlatformView.Sensitive = true;
+				platformView.InputTransparent = layout.InputTransparent;
+				platformView.Sensitive = true;
 			}
 		}
 	}

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Tizen.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Tizen.cs
@@ -2,12 +2,23 @@
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout) => MapInputTransparent((ILayoutHandler)handler, layout);
+		public static void MapInputTransparent(LayoutHandler handler, Layout layout) =>
+			UpdateInputTransparent(handler, layout);
 
-		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout) =>
+			UpdateInputTransparent(handler, layout);
+
+		static void MapInputTransparent(IViewHandler handler, IView layout) =>
+			UpdateInputTransparent(handler, layout);
+
+		static void UpdateInputTransparent(IViewHandler viewHandler, IView view)
 		{
-			if (handler.PlatformView == null)
+			if (viewHandler is not IPlatformViewHandler handler ||
+				handler.PlatformView == null || 
+				view is not Layout layout)
+			{
 				return;
+			}
 
 			if (layout.CascadeInputTransparent)
 			{
@@ -22,12 +33,6 @@
 				handler.PlatformView.InputTransparent = layout.InputTransparent;
 				handler.PlatformView.Sensitive = true;
 			}
-		}
-
-		static void MapInputTransparent(IViewHandler handler, IView layout)
-		{
-			if (handler is ILayoutHandler lh && layout is Layout l)
-				MapInputTransparent(lh, l);
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
@@ -9,5 +9,11 @@
 			handler.PlatformView?.UpdateInputTransparent(handler, layout);
 			layout.UpdateDescendantInputTransparent();
 		}
+
+		static void MapInputTransparent(IViewHandler handler, IView layout)
+		{
+			if (handler is ILayoutHandler lh && layout is Layout l)
+				MapInputTransparent(lh, l);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.Windows.cs
@@ -1,19 +1,27 @@
-﻿namespace Microsoft.Maui.Controls
+﻿using Microsoft.UI.Xaml;
+
+namespace Microsoft.Maui.Controls
 {
 	public partial class Layout
 	{
-		public static void MapInputTransparent(LayoutHandler handler, Layout layout) => MapInputTransparent((ILayoutHandler)handler, layout);
+		public static void MapInputTransparent(LayoutHandler handler, Layout layout) =>
+			UpdateInputTransparent(handler, layout);
 
-		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
-		{
-			handler.PlatformView?.UpdateInputTransparent(handler, layout);
-			layout.UpdateDescendantInputTransparent();
-		}
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout) =>
+			UpdateInputTransparent(handler, layout);
 
-		static void MapInputTransparent(IViewHandler handler, IView layout)
+		static void MapInputTransparent(IViewHandler handler, IView layout) =>
+			UpdateInputTransparent(handler, layout);
+
+		static void UpdateInputTransparent(IViewHandler handler, IView layout)
 		{
-			if (handler is ILayoutHandler lh && layout is Layout l)
-				MapInputTransparent(lh, l);
+			if (handler.PlatformView is FrameworkElement fe)
+				fe.UpdateInputTransparent(handler, layout);
+
+			if (layout is Layout l)
+			{
+				l.UpdateDescendantInputTransparent();
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.iOS.cs
@@ -3,18 +3,23 @@
 	public partial class Layout
 	{
 		public static void MapInputTransparent(LayoutHandler handler, Layout layout) =>
-			MapInputTransparent((ILayoutHandler)handler, layout);
+			UpdateInputTransparent(handler, layout);
 
-		public static void MapInputTransparent(ILayoutHandler handler, Layout layout)
-		{
-			handler.PlatformView?.UpdateInputTransparent(handler, layout);
-			layout.UpdateDescendantInputTransparent();
-		}
+		public static void MapInputTransparent(ILayoutHandler handler, Layout layout) =>
+			UpdateInputTransparent(handler, layout);
 
-		static void MapInputTransparent(IViewHandler handler, IView layout)
+		static void MapInputTransparent(IViewHandler handler, IView layout) =>
+			UpdateInputTransparent(handler, layout);
+
+		static void UpdateInputTransparent(IViewHandler handler, IView layout)
 		{
-			if (handler is ILayoutHandler lh && layout is Layout l)
-				MapInputTransparent(lh, l);
+			if (handler.PlatformView is UIKit.UIView uiView)
+				uiView.UpdateInputTransparent(handler, layout);
+
+			if (layout is Layout l)
+			{
+				l.UpdateDescendantInputTransparent();
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/Layout/Layout.iOS.cs
+++ b/src/Controls/src/Core/HandlerImpl/Layout/Layout.iOS.cs
@@ -10,5 +10,11 @@
 			handler.PlatformView?.UpdateInputTransparent(handler, layout);
 			layout.UpdateDescendantInputTransparent();
 		}
+
+		static void MapInputTransparent(IViewHandler handler, IView layout)
+		{
+			if (handler is ILayoutHandler lh && layout is Layout l)
+				MapInputTransparent(lh, l);
+		}
 	}
 }

--- a/src/Controls/src/Core/HandlerImpl/View/View.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/View/View.Impl.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.Controls
 
 		protected PropertyMapper propertyMapper;
 
-		protected PropertyMapper<T> GetRendererOverrides<T>() where T : IView =>
+		internal protected PropertyMapper<T> GetRendererOverrides<T>() where T : IView =>
 			(PropertyMapper<T>)(propertyMapper as PropertyMapper<T> ?? (propertyMapper = new PropertyMapper<T>()));
 
 		PropertyMapper IPropertyMapperView.GetPropertyMapperOverrides() => propertyMapper;

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Maui.Controls
 			set => SetValue(CascadeInputTransparentProperty, value);
 		}
 
-		public static IPropertyMapper<IView, IViewHandler> ControlsLayoutMapper = new PropertyMapper<Layout, LayoutHandler>(ControlsVisualElementMapper)
+		public static IPropertyMapper<IView, IViewHandler> ControlsLayoutMapper = new PropertyMapper<IView, IViewHandler>(ControlsVisualElementMapper)
 		{
 			[nameof(CascadeInputTransparent)] = MapInputTransparent,
 			[nameof(IView.InputTransparent)] = MapInputTransparent,

--- a/src/Controls/tests/DeviceTests/Elements/Accessibility/AccessibilityTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Accessibility/AccessibilityTests.cs
@@ -78,10 +78,17 @@ namespace Microsoft.Maui.DeviceTests
 				foreach (var control in new AllControlsTestCase())
 				{
 					var view = (IView)Activator.CreateInstance((Type)control[0]);
-					if (view is VisualElement ve)
+					if (view is View ve)
 					{
 						ve.WidthRequest = 50;
 						ve.HeightRequest = 50;
+
+						MockAccessibilityExpectations(ve);
+					}
+
+					if (view is IPropertyMapperView pmv)
+					{
+						var viewMapper = pmv.GetPropertyMapperOverrides();
 					}
 
 					layout.Add(view);

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
@@ -34,16 +34,19 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			protected override MauiAppBuilder ConfigureBuilder(MauiAppBuilder builder)
 			{
-				return builder.ConfigureMauiHandlers(handlers =>
-				{
-					handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 
+				return
+					base
+						.ConfigureBuilder(builder)
+						.ConfigureMauiHandlers(handlers =>
+						{
+							handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 #if WINDOWS || ANDROID
-					handlers.AddHandler<Toolbar, ToolbarHandler>();
+							handlers.AddHandler<Toolbar, ToolbarHandler>();
 #else
-					handlers.AddHandler<NavigationPage, Controls.Handlers.Compatibility.NavigationRenderer>();
+							handlers.AddHandler<NavigationPage, Controls.Handlers.Compatibility.NavigationRenderer>();
 #endif
-				});
+						});
 			}
 
 			[Fact]

--- a/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/VisualElementTests.cs
@@ -1,10 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
-using Microsoft.Maui.Platform;
 using Xunit;
 #if IOS || MACCATALYST
 using NavigationViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.NavigationRenderer;
@@ -13,16 +10,31 @@ using NavigationViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.Nav
 namespace Microsoft.Maui.DeviceTests
 {
 	[Category(TestCategory.VisualElement)]
-#if ANDROID || IOS || MACCATALYST
-	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
-#endif
 	public partial class VisualElementTests : ControlsHandlerTestBase
 	{
-		void SetupBuilder()
+		[Fact]
+		public async Task CanCreateHandler()
 		{
-			EnsureHandlerCreated(builder =>
+			var image = new Image();
+			await CreateHandlerAsync<ImageHandler>(image);
+		}
+
+		[Fact]
+		public async Task SettingHandlerDoesNotThrow()
+		{
+			var image = new Image();
+			var handler = await CreateHandlerAsync<ImageHandler>(image);
+			image.Handler = handler;
+		}
+
+#if ANDROID || IOS || MACCATALYST
+		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+#endif
+		public class NewWindowCollection : ControlsHandlerTestBase
+		{
+			protected override MauiAppBuilder ConfigureBuilder(MauiAppBuilder builder)
 			{
-				builder.ConfigureMauiHandlers(handlers =>
+				return builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler<NavigationPage, NavigationViewHandler>();
 
@@ -32,138 +44,116 @@ namespace Microsoft.Maui.DeviceTests
 					handlers.AddHandler<NavigationPage, Controls.Handlers.Compatibility.NavigationRenderer>();
 #endif
 				});
-			});
-		}
+			}
 
-		[Fact]
-		public async Task CanCreateHandler()
-		{
-			var image = new Image();
-
-			await CreateHandlerAsync<ImageHandler>(image);
-		}
-
-		[Fact]
-		public async Task SettingHandlerDoesNotThrow()
-		{
-			var image = new Image();
-
-			var handler = await CreateHandlerAsync<ImageHandler>(image);
-
-			image.Handler = handler;
-		}
-
-		[Fact]
-		public async Task LoadedAndUnloadedFire()
-		{
-			var editor = new Editor();
-
-			int unloaded = 0;
-			int loaded = 0;
-			editor.Loaded += (_, __) => loaded++;
-			editor.Unloaded += (_, __) => unloaded++;
-
-			await CreateHandlerAndAddToWindow<EditorHandler>(editor, (handler) =>
+			[Fact]
+			public async Task LoadedAndUnloadedFire()
 			{
-				Assert.Equal(1, loaded);
-				Assert.Equal(0, unloaded);
-			});
+				var editor = new Editor();
 
-			Assert.Equal(1, loaded);
-			Assert.Equal(1, unloaded);
-		}
+				int unloaded = 0;
+				int loaded = 0;
+				editor.Loaded += (_, __) => loaded++;
+				editor.Unloaded += (_, __) => unloaded++;
 
-		[Fact]
-		public async Task LoadedAndUnloadedFireWhenParentRemoved()
-		{
-			var editor = new Editor();
-			var layout = new VerticalStackLayout()
-			{
-				editor
-			};
-
-			var parentLayout = new VerticalStackLayout()
-			{
-				layout
-			};
-
-			int unloaded = 0;
-			int loaded = 0;
-			editor.Loaded += (_, __) => loaded++;
-			editor.Unloaded += (_, __) => unloaded++;
-
-			await CreateHandlerAndAddToWindow<LayoutHandler>(parentLayout, async (handler) =>
-			{
-				parentLayout.Remove(layout);
-				await OnUnloadedAsync(layout);
-				await OnUnloadedAsync(editor);
+				await CreateHandlerAndAddToWindow<EditorHandler>(editor, (handler) =>
+				{
+					Assert.Equal(1, loaded);
+					Assert.Equal(0, unloaded);
+				});
 
 				Assert.Equal(1, loaded);
 				Assert.Equal(1, unloaded);
+			}
 
-				parentLayout.Add(layout);
-				await OnLoadedAsync(layout);
-				await OnLoadedAsync(editor);
+			[Fact]
+			public async Task LoadedAndUnloadedFireWhenParentRemoved()
+			{
+				var editor = new Editor();
+				var layout = new VerticalStackLayout()
+				{
+					editor
+				};
+
+				var parentLayout = new VerticalStackLayout()
+				{
+					layout
+				};
+
+				int unloaded = 0;
+				int loaded = 0;
+				editor.Loaded += (_, __) => loaded++;
+				editor.Unloaded += (_, __) => unloaded++;
+
+				await CreateHandlerAndAddToWindow<LayoutHandler>(parentLayout, async (handler) =>
+				{
+					parentLayout.Remove(layout);
+					await OnUnloadedAsync(layout);
+					await OnUnloadedAsync(editor);
+
+					Assert.Equal(1, loaded);
+					Assert.Equal(1, unloaded);
+
+					parentLayout.Add(layout);
+					await OnLoadedAsync(layout);
+					await OnLoadedAsync(editor);
+
+					Assert.Equal(2, loaded);
+					Assert.Equal(1, unloaded);
+				});
+
+				await Task.Delay(1000);
 
 				Assert.Equal(2, loaded);
-				Assert.Equal(1, unloaded);
-			});
+				Assert.Equal(2, unloaded);
+			}
 
-			await Task.Delay(1000);
-
-			Assert.Equal(2, loaded);
-			Assert.Equal(2, unloaded);
-		}
-
-		[Fact]
-		public async Task NavigatedToFiresAfterLoaded()
-		{
-			SetupBuilder();
-
-			var navPage = new NavigationPage(new ContentPage());
-			var page = new ContentPage();
-
-			int loaded = 0;
-			bool loadedFired = false;
-
-			page.Loaded += (_, __) => loaded++;
-			page.NavigatedTo += (_, __) => loadedFired = (loaded == 1);
-
-			await CreateHandlerAndAddToWindow<NavigationViewHandler>(navPage, async (handler) =>
+			[Fact]
+			public async Task NavigatedToFiresAfterLoaded()
 			{
-				await navPage.PushAsync(page);
-				Assert.True(loadedFired);
-			});
-		}
+				var navPage = new NavigationPage(new ContentPage());
+				var page = new ContentPage();
 
-		[Fact]
-		public async Task LoadedFiresOnPushedPage()
-		{
-			SetupBuilder();
+				int loaded = 0;
+				bool loadedFired = false;
 
-			var navPage = new NavigationPage(new ContentPage());
-			var page = new ContentPage();
+				page.Loaded += (_, __) => loaded++;
+				page.NavigatedTo += (_, __) => loadedFired = (loaded == 1);
 
-			int unloaded = 0;
-			int loaded = 0;
-			page.Loaded += (_, __) => loaded++;
-			page.Unloaded += (_, __) => unloaded++;
+				await CreateHandlerAndAddToWindow<NavigationViewHandler>(navPage, async (handler) =>
+				{
+					await navPage.PushAsync(page);
+					Assert.True(loadedFired);
+				});
+			}
 
-			await CreateHandlerAndAddToWindow<NavigationViewHandler>(navPage, async (handler) =>
+			[Fact]
+			public async Task LoadedFiresOnPushedPage()
 			{
-				Assert.Equal(0, loaded);
-				Assert.Equal(0, unloaded);
+				var navPage = new NavigationPage(new ContentPage());
+				var page = new ContentPage();
 
-				await navPage.PushAsync(page);
+				int unloaded = 0;
+				int loaded = 0;
+				page.Loaded += (_, __) => loaded++;
+				page.Unloaded += (_, __) => unloaded++;
 
-				Assert.Equal(1, loaded);
-				Assert.Equal(0, unloaded);
+				await CreateHandlerAndAddToWindow<NavigationViewHandler>(navPage, async (handler) =>
+				{
+					Assert.Equal(0, loaded);
+					Assert.Equal(0, unloaded);
 
-				await navPage.PopAsync();
+					await navPage.PushAsync(page);
 
-				Assert.Equal(1, loaded);
-				Assert.Equal(1, unloaded);
-			});
+					Assert.Equal(1, loaded);
+					Assert.Equal(0, unloaded);
+
+					await navPage.PopAsync();
+
+					Assert.Equal(1, loaded);
+					Assert.Equal(1, unloaded);
+				});
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/MapperTests.cs
+++ b/src/Controls/tests/DeviceTests/MapperTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public class MapperTests : ControlsHandlerTestBase
+	{
+		[Theory]
+		[ClassData(typeof(MapperGenericTypeCases))]
+		public void ValidateMapperGenerics(IPropertyMapper propertyMapper, Type viewType, Type handlerType)
+		{
+			EnsureHandlerCreated(builder => builder.ConfigureMauiHandlers(h => h.AddMauiControlsHandlers()));
+			var generics = propertyMapper.GetType().GenericTypeArguments;
+			Assert.Equal(viewType, generics[0]);
+			Assert.Equal(handlerType, generics[1]);
+		}
+
+		class MapperGenericTypeCases : IEnumerable<object[]>
+		{
+			private readonly List<object[]> _data = new()
+			{
+				new object[] { VisualElement.ControlsVisualElementMapper, typeof(IView), typeof(IViewHandler) },
+				new object[] { Element.ControlsElementMapper, typeof(IElement), typeof(IElementHandler) },
+				new object[] { ViewHandler.ViewMapper, typeof(IView), typeof(IViewHandler) },
+				new object[] { ElementHandler.ElementMapper, typeof(IElement), typeof(IElementHandler) },
+			};
+
+			public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/MauiProgram.cs
+++ b/src/Controls/tests/DeviceTests/MauiProgram.cs
@@ -17,27 +17,10 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static IApplication DefaultTestApp => MauiProgramDefaults.DefaultTestApp;
 
-		public static MauiApp CreateMauiApp()
-		{
-#if IOS || MACCATALYST
-
-			// https://github.com/dotnet/maui/issues/11853
-			// I'd like to just have this added to the tests this relates to but 
-			// due to the issue above, I have to do it here for now. 
-			// Once 11853 has been resolved, I'll move this back into the relevant test files.
-			Controls.Element
-				.ControlsElementMapper
-				.ModifyMapping(AutomationProperties.IsInAccessibleTreeProperty.PropertyName, (handler, view, action) =>
-				{
-					(handler.PlatformView as UIKit.UIView)?.SetupAccessibilityExpectationIfVoiceOverIsOff();
-					action.Invoke(handler, view);
-				});
-#endif
-
-			return MauiProgramDefaults.CreateMauiApp(new List<Assembly>()
+		public static MauiApp CreateMauiApp() =>
+			MauiProgramDefaults.CreateMauiApp(new List<Assembly>()
 			{
 				typeof(MauiProgram).Assembly
 			});
-		}
 	}
 }

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -169,7 +169,9 @@ namespace Microsoft.Maui
 			SetPropertyCore(key, (h, v) =>
 			{
 				if (v is TVirtualView vv)
+				{
 					action?.Invoke((TViewHandler)h, vv);
+				}
 				else if (Chained != null)
 				{
 					foreach (var chain in Chained)

--- a/src/Core/src/PropertyMapper.cs
+++ b/src/Core/src/PropertyMapper.cs
@@ -169,9 +169,7 @@ namespace Microsoft.Maui
 			SetPropertyCore(key, (h, v) =>
 			{
 				if (v is TVirtualView vv)
-				{
 					action?.Invoke((TViewHandler)h, vv);
-				}
 				else if (Chained != null)
 				{
 					foreach (var chain in Chained)

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -89,7 +89,13 @@ namespace Microsoft.Maui.DeviceTests
 			view.Semantics.Description = "Test";
 			var important = await GetValueAsync(view, handler => view.IsAccessibilityElement());
 
-			Assert.True(important);
+			// On iOS the UIStepper control is a UIControl but iOS sets IsAccessibilityElement
+			// to false because it's a composite control
+			// https://github.com/dotnet/maui/issues/11762
+			if (OperatingSystem.IsIOS() && view is IStepper)
+				Assert.False(important);
+			else
+				Assert.True(important);
 		}
 
 		[Fact(DisplayName = "Setting Semantic Hint makes element accessible")]
@@ -101,7 +107,13 @@ namespace Microsoft.Maui.DeviceTests
 			view.Semantics.Hint = "Test";
 			var important = await GetValueAsync(view, handler => view.IsAccessibilityElement());
 
-			Assert.True(important);
+			// On iOS the UIStepper control is a UIControl but iOS sets IsAccessibilityElement
+			// to false because it's a composite control
+			// https://github.com/dotnet/maui/issues/11762
+			if (OperatingSystem.IsIOS() && view is IStepper)
+				Assert.False(important);
+			else
+				Assert.True(important);
 		}
 
 		[Fact(DisplayName = "Semantic Description is set correctly"

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task SettingSemanticDescriptionMakesElementAccessible()
 		{
 			var view = new TStub();
+			MockAccessibilityExpectations(view);
+
 			view.Semantics.Description = "Test";
 			var important = await GetValueAsync(view, handler => view.IsAccessibilityElement());
 
@@ -94,6 +96,8 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task SettingSemanticHintMakesElementAccessible()
 		{
 			var view = new TStub();
+			MockAccessibilityExpectations(view);
+
 			view.Semantics.Hint = "Test";
 			var important = await GetValueAsync(view, handler => view.IsAccessibilityElement());
 

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -89,13 +89,7 @@ namespace Microsoft.Maui.DeviceTests
 			view.Semantics.Description = "Test";
 			var important = await GetValueAsync(view, handler => view.IsAccessibilityElement());
 
-			// On iOS the UIStepper control is a UIControl but iOS sets IsAccessibilityElement
-			// to false because it's a composite control
-			// https://github.com/dotnet/maui/issues/11762
-			if (OperatingSystem.IsIOS() && view is IStepper)
-				Assert.False(important);
-			else
-				Assert.True(important);
+			Assert.True(important);
 		}
 
 		[Fact(DisplayName = "Setting Semantic Hint makes element accessible")]
@@ -107,13 +101,7 @@ namespace Microsoft.Maui.DeviceTests
 			view.Semantics.Hint = "Test";
 			var important = await GetValueAsync(view, handler => view.IsAccessibilityElement());
 
-			// On iOS the UIStepper control is a UIControl but iOS sets IsAccessibilityElement
-			// to false because it's a composite control
-			// https://github.com/dotnet/maui/issues/11762
-			if (OperatingSystem.IsIOS() && view is IStepper)
-				Assert.False(important);
-			else
-				Assert.True(important);
+			Assert.True(important);
 		}
 
 		[Fact(DisplayName = "Semantic Description is set correctly"

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Semantic Description is set correctly"
-#if __ANDROID__
+#if ANDROID
 			, Skip = "This value can't be validated through automated tests"
 #endif
 		)]
@@ -114,7 +114,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact(DisplayName = "Semantic Hint is set correctly"
-#if __ANDROID__
+#if ANDROID
 			, Skip = "This value can't be validated through automated tests"
 #endif
 		)]
@@ -246,7 +246,7 @@ namespace Microsoft.Maui.DeviceTests
 
 
 		[Theory(DisplayName = "Native View Transforms are not empty"
-#if __IOS__
+#if IOS
 					, Skip = "https://github.com/dotnet/maui/issues/3600"
 #endif
 			)]
@@ -268,7 +268,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Theory(DisplayName = "View Renders To Image"
-#if !__ANDROID__
+#if !ANDROID
 			, Skip = "iOS and Windows can't render elements to images from test runner. It's missing the required root windows."
 #endif
 			)]

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.cs
@@ -160,6 +160,21 @@ namespace Microsoft.Maui.DeviceTests
 
 		protected Task ValidateHasColor(IView view, Color color, Action action = null) =>
 			ValidateHasColor(view, color, typeof(THandler), action);
+			
+		void MockAccessibilityExpectations(TStub view)
+		{
+#if IOS || MACCATALYST
+			var mapperOverride = new PropertyMapper<TStub, THandler>();
+			view.PropertyMapperOverrides = mapperOverride;
+
+			mapperOverride
+				.ModifyMapping(nameof(IView.Semantics), (handler, view, _) =>
+				{
+					(handler.PlatformView as UIKit.UIView)?.SetupAccessibilityExpectationIfVoiceOverIsOff();
+					mapperOverride.Chained[0]!.UpdateProperty(handler, view, nameof(IView.Semantics));
+				});
+#endif
+		}
 	}
 }
 #endif

--- a/src/Core/tests/DeviceTests.Shared/Stubs/IStubBase.cs
+++ b/src/Core/tests/DeviceTests.Shared/Stubs/IStubBase.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.DeviceTests.Stubs
 {
-	public interface IStubBase : IView, IVisualTreeElement, IToolTipElement
+	public interface IStubBase : IView, IVisualTreeElement, IToolTipElement, IPropertyMapperView
 	{
 		new string AutomationId { get; set; }
 
@@ -59,6 +59,8 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		new bool InputTransparent { get; set; }
 		new IElement Parent { get; set; }
+
+		PropertyMapper PropertyMapperOverrides { get; set; }
 	}
 
 }

--- a/src/Core/tests/DeviceTests/MauiProgram.cs
+++ b/src/Core/tests/DeviceTests/MauiProgram.cs
@@ -16,27 +16,10 @@ namespace Microsoft.Maui.DeviceTests
 
 		public static IApplication DefaultTestApp { get; private set; }
 
-		public static MauiApp CreateMauiApp()
-		{
-
-#if IOS || MACCATALYST
-
-			// https://github.com/dotnet/maui/issues/11853
-			// I'd like to just have this added to the tests this relates to but 
-			// due to the issue above, I have to do it here for now. 
-			// Once 11853 has been resolved, I'll move this back into the relevant test files.
-			ViewHandler
-				.ViewMapper
-				.ModifyMapping(nameof(IView.Semantics), (handler, view, action) =>
-				{
-					(handler.PlatformView as UIKit.UIView)?.SetupAccessibilityExpectationIfVoiceOverIsOff();
-					action.Invoke(handler, view);
-				});
-#endif
-			return MauiProgramDefaults.CreateMauiApp(new List<Assembly>()
+		public static MauiApp CreateMauiApp() =>
+			MauiProgramDefaults.CreateMauiApp(new List<Assembly>()
 			{
 				typeof(MauiProgram).Assembly
 			});
-		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Stubs/StubBase.cs
+++ b/src/Core/tests/DeviceTests/Stubs/StubBase.cs
@@ -146,6 +146,14 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 
 		IVisualTreeElement IVisualTreeElement.GetVisualParent() => this.Parent as IVisualTreeElement;
 
+		PropertyMapper IPropertyMapperView.GetPropertyMapperOverrides() =>
+			PropertyMapperOverrides;
+
+		public PropertyMapper PropertyMapperOverrides
+		{
+			get;
+			set;
+		}
 
 		public bool IsLoaded
 		{


### PR DESCRIPTION
### Description of Change

This modifies the generic types for the mappers that `Controls` is replacing on `ViewHandler` and `ElementHandler` inside core.  The `ViewHandler` mapper gets replaced with `IPropertyMapper<Layout, LayoutHandler>` which means anything added to the `ViewHandler.Mapper` that doesn't implement `Layout` and `LayoutHandler` will just get ignored (read attached issue for more context). 

This `Remapping` happens inside the `CreateBuilder` call which means that it's very confusing where in the lifecycle of your app that you can add or modify `Mappers` on `ViewHandler`

### Issues Fixed
Fixes #11853

