### PR TITLE
[iOS] Fix crash typing in Shell SearchHandler

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/SearchHandlerAppearanceTracker.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			button.SetImage(newIcon, UIControlState.Normal);
 			button.SetImage(newIcon, UIControlState.Selected);
 			button.SetImage(newIcon, UIControlState.Highlighted);
-			button.TintColor = button.ImageView.TintColor = targetColor.ToPlatform() ?? defaultTintColor;
+			button.TintColor = button.ImageView.TintColor = targetColor != null ? targetColor.ToPlatform() : defaultTintColor;
 		}
 
 		protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change

Fix crash typing in Shell SearchHandler on iOS. 

Avoid to use the ToPlatform extension method if the `targetColor` is already null.

### Issues Fixed

Fixes #10547