### PR TITLE
Fix UpdateSemantics for UIStepper and UIPagerControl

### DIFF
--- a/src/Core/src/Platform/iOS/SemanticExtensions.cs
+++ b/src/Core/src/Platform/iOS/SemanticExtensions.cs
@@ -24,9 +24,16 @@ namespace Microsoft.Maui.Platform
 			platformView.AccessibilityLabel = semantics.Description;
 			platformView.AccessibilityHint = semantics.Hint;
 
-			// UIControl elements automatically have IsAccessibilityElement set to true
-			if (platformView is not UIControl && (!string.IsNullOrWhiteSpace(semantics.Hint) || !string.IsNullOrWhiteSpace(semantics.Description)))
-				platformView.IsAccessibilityElement = true;
+			if ((!string.IsNullOrWhiteSpace(semantics.Hint) || !string.IsNullOrWhiteSpace(semantics.Description)))
+			{
+				// Most UIControl elements automatically have IsAccessibilityElement set to true
+				if (platformView is not UIControl)
+					platformView.IsAccessibilityElement = true;
+				// UIStepper and UIPageControl inherit from UIControl but iOS marks `IsAccessibilityElement` to false
+				// because they are composite controls.
+				else if (platformView is UIStepper || platformView is UIPageControl)
+					platformView.IsAccessibilityElement = true;
+			}
 
 			if (semantics.IsHeading)
 			{

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -87,13 +87,7 @@ namespace Microsoft.Maui.DeviceTests
 			view.Semantics.Description = "Test";
 			var important = await GetValueAsync(view, handler => view.IsAccessibilityElement());
 
-			// On iOS the UIStepper control is a UIControl but iOS sets IsAccessibilityElement
-			// to false because it's a composite control
-			// https://github.com/dotnet/maui/issues/11762
-			if (OperatingSystem.IsIOS() && view is IStepper)
-				Assert.False(important);
-			else
-				Assert.True(important);
+			Assert.True(important);
 		}
 
 		[Fact(DisplayName = "Setting Semantic Hint makes element accessible")]
@@ -103,13 +97,7 @@ namespace Microsoft.Maui.DeviceTests
 			view.Semantics.Hint = "Test";
 			var important = await GetValueAsync(view, handler => view.IsAccessibilityElement());
 
-			// On iOS the UIStepper control is a UIControl but iOS sets IsAccessibilityElement
-			// to false because it's a composite control
-			// https://github.com/dotnet/maui/issues/11762
-			if (OperatingSystem.IsIOS() && view is IStepper)
-				Assert.False(important);
-			else
-				Assert.True(important);
+			Assert.True(important);
 		}
 
 		[Fact(DisplayName = "Semantic Description is set correctly"


### PR DESCRIPTION
### Description of Change

For the most part iOS will default anything that inherits from `UIControl` as being important for accessibility so we don't automatically toggle any of these controls to being `ImportantForAccessibility`. `UIPagerControl` and `UIStepper` both inherit from `UIControl` but since they are both composite controls iOS marks `IsImportantForAccessibility` to false so we need to account for this. 
