### PR TITLE
Prepare MAUI to support building with NuGets

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.NuGets.Sdk.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.NuGets.Sdk.targets
@@ -1,0 +1,59 @@
+<Project>
+
+  <!--
+    Most of these properties and items are found in other places and we _could_ reuse and modify targets.
+    But, in an effort to not change to many things that already work, the NuGet support is duplicating a few
+    of the elements here. Not only is this OK, but in the later service releases and then in .NET 8+, all 
+    of this goes away.
+  -->
+
+  <!-- NOTE: These items are found in .nuspec\Microsoft.Maui.Controls.SingleProject.props -->
+  <PropertyGroup Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
+    <!-- All Windows apps require WinExe -->
+    <OutputType Condition="'$(OutputType)' == 'Exe'">WinExe</OutputType>
+    <!-- Generate ReadyToRun (AOT) when building for Release -->
+    <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and '$(Configuration)' == 'Release' and '$(OutputType)' == 'WinExe' ">true</PublishReadyToRun>
+  </PropertyGroup>
+
+  <!-- NOTE: These items are found in .nuspec\Microsoft.Maui.Controls.SingleProject.props -->
+  <!-- The Windows App SDK does not support AnyCPU without a RID, so make sure we pick the "best" one we can -->
+  <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' ">
+    <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>
+    <_SingleProjectRIDSpecified Condition="'$(RuntimeIdentifier)' != '' or '$(RuntimeIdentifiers)' != ''">true</_SingleProjectRIDSpecified>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(SingleProject)' == 'true' and '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows' and '$(_SingleProjectRIDRequired)' == 'true' and '$(_SingleProjectRIDSpecified)' != 'true' ">
+    <_SingleProjectHostArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_SingleProjectHostArchitecture>
+    <_SingleProjectHostArchitecture>$(_SingleProjectHostArchitecture.ToLower())</_SingleProjectHostArchitecture>
+    <RuntimeIdentifier>win10-$(_SingleProjectHostArchitecture)</RuntimeIdentifier>
+    <_MauiUsingDefaultRuntimeIdentifier>true</_MauiUsingDefaultRuntimeIdentifier>
+  </PropertyGroup>
+
+
+  <!-- Import any platform-specific targets files that set defaults -->
+  <Import Project="$(MicrosoftMauiSdkPlatformTargets)" Condition="'$(MicrosoftMauiSdkPlatformTargets)' != ''" />
+
+
+  <!-- NOTE: These items are found in .src\Workload\Microsoft.Maui.Sdk\Sdk\Microsoft.Maui.Sdk.After.targets -->
+  <!-- .NET MAUI features -->
+  <ItemGroup>
+    <ProjectCapability Include="Maui" />
+    <ProjectCapability Include="MauiAssets" />
+    <ProjectCapability Include="MauiBlazor" Condition=" '$(UsingMicrosoftNETSdkRazor)' == 'true' " />
+    <ProjectCapability Include="MauiCore" />
+    <ProjectCapability Include="MauiEssentials" />
+  </ItemGroup>
+
+  <!-- NOTE: These items are found in .nuspec\Microsoft.Maui.Controls.SingleProject.targets -->
+  <!-- SingleProject-specific features -->
+  <ItemGroup Condition=" '$(SingleProject)' == 'true' ">
+    <ProjectCapability Include="Msix" />
+    <ProjectCapability Include="MauiSingleProject" />
+    <ProjectCapability Include="LaunchProfiles" />
+    <!-- If VS is older than Dev17 -->
+    <ProjectCapability Include="XamarinStaticLaunchProfiles" Condition=" '$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' &lt; '17.0' " />
+    <!-- Otherwise define LaunchProfilesGroupByPlatformFilters by default -->
+    <ProjectCapability Include="LaunchProfilesGroupByPlatformFilters" Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &gt;= '17.0' " />
+    <ProjectCapability Include="SingleTargetBuildForStartupProjects" Condition=" '$(EnableSingleTargetBuildForStartupProjects)' != 'false' " />
+  </ItemGroup>
+
+</Project>

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/Sdk.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/Sdk.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' ">
+  <ItemGroup Condition=" '$(UseMauiNuGets)' != 'true' and '$(DisableImplicitFrameworkReferences)' != 'true' ">
     <FrameworkReference
         Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' "
         Include="Microsoft.Maui.Core"
@@ -24,9 +24,11 @@
     />
   </ItemGroup>
 
-  <Import Project="BundledVersions.targets" />
-  <Import Project="Microsoft.Maui.Sdk.targets" Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true' " />
-  <Import Project="Microsoft.Maui.Core.Sdk.targets" Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' " />
-  <Import Project="Microsoft.Maui.Controls.Sdk.targets" Condition=" '$(UseMaui)' == 'true' " />
+  <Import Project="BundledVersions.targets" Condition=" '$(UseMauiNuGets)' != 'true' " />
+  <Import Project="Microsoft.Maui.Sdk.targets" Condition=" ('$(UseMauiNuGets)' != 'true') and ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true') " />
+  <Import Project="Microsoft.Maui.Core.Sdk.targets" Condition=" ('$(UseMauiNuGets)' != 'true') and ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true') " />
+  <Import Project="Microsoft.Maui.Controls.Sdk.targets" Condition=" ('$(UseMauiNuGets)' != 'true') and ('$(UseMaui)' == 'true') " />
+
+  <Import Project="Microsoft.Maui.NuGets.Sdk.targets" Condition=" '$(UseMauiNuGets)' == 'true' " />
 
 </Project>

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
@@ -1,12 +1,12 @@
 <Project>
 
-  <ItemGroup Condition=" '$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' ">
+  <ItemGroup Condition=" '$(UseMaui)' == 'true' or '$(UseMauiNuGets)' == 'true' or '$(UseMauiCore)' == 'true' ">
     <ProjectCapability Include="UseMauiCore" />
-    <ProjectCapability Condition=" '$(UseMaui)' == 'true' " Include="UseMaui" />
+    <ProjectCapability Condition=" '$(UseMaui)' == 'true' or '$(UseMauiNuGets)' == 'true' " Include="UseMaui" />
   </ItemGroup>
 
   <Import
-      Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true') and ($([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@'))) "
+      Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiNuGets)' == 'true' or '$(UseMauiCore)' == 'true' or '$(UseMauiEssentials)' == 'true' or '$(UseMauiAssets)' == 'true') and ($([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@'))) "
       Project="Sdk.targets" Sdk="Microsoft.Maui.Sdk.net@MAUI_DOTNET_VERSION_MAJOR@"
   />
   <Import

--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.targets
@@ -15,7 +15,11 @@
   />
 
   <Import
-      Condition=" '$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true' "
+      Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true') and ('$(UseMauiNuGets)' != 'true') and ($([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_DOTNET_VERSION@'))) "
+      Project="Sdk.targets" Sdk="Microsoft.Maui.Resizetizer.Sdk"
+  />
+  <Import
+      Condition=" ('$(UseMaui)' == 'true' or '$(UseMauiAssets)' == 'true') and ($([MSBuild]::VersionEquals($(TargetFrameworkVersion), '@MAUI_PREVIOUS_DOTNET_VERSION@'))) "
       Project="Sdk.targets" Sdk="Microsoft.Maui.Resizetizer.Sdk"
   />
 


### PR DESCRIPTION
### Description of Change

Before we can properly start testing #11206 we need a way to disable most of the Maui bits. Pretty much everything except for a few things that the IDE/NuGet needs to restore correctly. In fact, Maui does not need workloads to function, except in a few specific cases:

* Changing `$(OutputType)`from `Exe` to `WinExe` - this affects NuGet restore (all platforms except Windows use `Exe`)
* Setting the default `$(PublishReadyToRun)` - this affects NuGet restore
* Setting the default Windows RIDs - this affects NuGet restore
* Setting `@(ProjectCapability)` - this is needed by the IDE on first evaluation

There is one other case where some other Windows defaults (`$(WindowsPackageType)` , `$(WindowsAppSDKSelfContained)`, `$(WindowsAppSdkBootstrapInitialize)`, `$(PublishAppXPackage)`) need to be set, however this can come later and we can just import a file from a NuGet using the `$(MicrosoftMauiSdkPlatformTargets)` property.

### How It Works

This PR just adds a new property to set in the csproj: `<UseMauiNuGets>` to use _in place of_ `<UseMaui>` to indicate to the workload the "mode" of imports. This new property then disables the import of the normal targets and imports the special NuGets targets.

It does not import any packages nor does it change behavior in any other targets.


### Other Notes

* The `<UseMauiNuGets>` property _can_ be used alongside `<UseMaui>`, however the former basically negates the latter - but this is less cognitive load to just add 1 property than to add/remove/replace.
* The .NET 6 TFMs totally ignore the `<UseMauiNuGets>` property.
* The properties are just to make things pretty, but they are not needed and the targets file can be directly added to the end of your .csproj after removing the `<UseMaui>` property.
* Related to #11206