### PR TITLE
Tests embed screenshot

### DIFF
--- a/src/Compatibility/Core/tests/Android/AssertionExtensions.cs
+++ b/src/Compatibility/Core/tests/Android/AssertionExtensions.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 {
 	internal static class AssertionExtensions
 	{
+		public static string CreateColorTag(string base64image)
+			=> $"![Image](data:image/png;base64,{base64image})";
+
 		public static string CreateColorAtPointError(this Bitmap bitmap, AColor expectedColor, int x, int y)
 		{
 			return CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
@@ -20,7 +23,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 			{
 				bitmap.Compress(Bitmap.CompressFormat.Png, 0, ms);
 				var imageAsString = Convert.ToBase64String(ms.ToArray());
-				return $"{message}. This is what it looked like:<img>{imageAsString}</img>";
+				return $"{message}. This is what it looked like: {CreateColorTag(imageAsString)}";
 			}
 		}
 

--- a/src/Compatibility/Core/tests/Android/AssertionExtensions.cs
+++ b/src/Compatibility/Core/tests/Android/AssertionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.UnitTests
 	internal static class AssertionExtensions
 	{
 		public static string CreateColorTag(string base64image)
-			=> $"![Image](data:image/png;base64,{base64image})";
+			=> $"<img src=\"data:image/png;base64,{base64image}\" alt=\"screenshot\" />";
 
 		public static string CreateColorAtPointError(this Bitmap bitmap, AColor expectedColor, int x, int y)
 		{

--- a/src/Compatibility/Core/tests/iOS/AssertionExtensions.cs
+++ b/src/Compatibility/Core/tests/iOS/AssertionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS.UnitTests
 	internal static class AssertionExtensions
 	{
 		public static string CreateColorTag(string base64image)
-			=> $"![Image](data:image/png;base64,{base64image})";
+			=> $"<img src=\"data:image/png;base64,{base64image}\" alt=\"screenshot\" />";
 
 		public static string CreateColorAtPointError(this UIImage bitmap, UIColor expectedColor, int x, int y)
 		{

--- a/src/Compatibility/Core/tests/iOS/AssertionExtensions.cs
+++ b/src/Compatibility/Core/tests/iOS/AssertionExtensions.cs
@@ -9,18 +9,21 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS.UnitTests
 {
 	internal static class AssertionExtensions
 	{
+		public static string CreateColorTag(string base64image)
+			=> $"![Image](data:image/png;base64,{base64image})";
+
 		public static string CreateColorAtPointError(this UIImage bitmap, UIColor expectedColor, int x, int y)
 		{
 			var data = bitmap.AsPNG();
 			var imageAsString = data.GetBase64EncodedString(Foundation.NSDataBase64EncodingOptions.None);
-			return $"Expected {expectedColor} at point {x},{y} in renderered view. This is what it looked like:<img>{imageAsString}</img>";
+			return $"Expected {expectedColor} at point {x},{y} in renderered view. This is what it looked like: {CreateColorTag(imageAsString)}";
 		}
 
 		public static string CreateColorError(this UIImage bitmap, string message)
 		{
 			var data = bitmap.AsPNG();
 			var imageAsString = data.GetBase64EncodedString(Foundation.NSDataBase64EncodingOptions.None);
-			return $"{message}. This is what it looked like:<img>{imageAsString}</img>";
+			return $"{message}. This is what it looked like: {CreateColorTag(imageAsString)}";
 		}
 
 		public static UIImage ToBitmap(this UIView view)

--- a/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Image/ImageHandlerTests.cs
@@ -61,7 +61,9 @@ namespace Microsoft.Maui.DeviceTests
 					handler.UpdateValue(nameof(IImage.Source));
 					await image.Wait();
 
-					await platformView.AssertContainsColor(Colors.Blue.ToPlatform());
+					// TODO: Switch back to Blue to unbreak test
+					// Broken to test the test runner results display
+					await platformView.AssertContainsColor(Colors.Green.ToPlatform());
 
 					// the second one does not
 					image.Source = new FileImageSourceStub(secondPath);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -130,10 +130,10 @@ namespace Microsoft.Maui.DeviceTests
 			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
 
 		public static string CreateColorError(this Bitmap bitmap, string message) =>
-			$"{message} This is what it looked like:<img>{bitmap.ToBase64String()}</img>";
+			$"{message} This is what it looked like: {CreateColorTag(bitmap.ToBase64String())}";
 
 		public static string CreateEqualError(this Bitmap bitmap, Bitmap other, string message) =>
-			$"{message} This is what it looked like: <img>{bitmap.ToBase64String()}</img> and <img>{other.ToBase64String()}</img>";
+			$"{message} This is what it looked like: {CreateColorTag(bitmap.ToBase64String())} and {CreateColorTag(other.ToBase64String())}";
 
 		public static AColor ColorAtPoint(this Bitmap bitmap, int x, int y, bool includeAlpha = false)
 		{

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Maui.DeviceTests
 			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
 
 		public static async Task<string> CreateColorError(this CanvasBitmap bitmap, string message) =>
-			$"{message} This is what it looked like:<img>{await bitmap.ToBase64String()}</img>";
+			$"{message} This is what it looked like: {CreateColorTag(await bitmap.ToBase64String())}";
 
 		public static async Task<string> CreateEqualError(this CanvasBitmap bitmap, CanvasBitmap other, string message) =>
-			$"{message} This is what it looked like: <img>{await bitmap.ToBase64String()}</img> and <img>{await other.ToBase64String()}</img>";
+			$"{message} This is what it looked like: {CreateColorTag(await bitmap.ToBase64String())} and {CreateColorTag(await other.ToBase64String())}";
 
 		public static async Task<string> ToBase64String(this CanvasBitmap bitmap)
 		{

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		static readonly Random rnd = new Random();
 
+		public static string CreateColorTag(string base64image)
+			=> $"![Image](data:image/png;base64,{base64image})";
+
 		public static async Task<bool> Wait(Func<bool> exitCondition, int timeout = 1000)
 		{
 			while ((timeout -= 100) > 0)

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Maui.DeviceTests
 		static readonly Random rnd = new Random();
 
 		public static string CreateColorTag(string base64image)
-			=> $"![Image](data:image/png;base64,{base64image})";
+			=> $"<img src=\"data:image/png;base64,{base64image}\" alt=\"screenshot\" />";
 
 		public static async Task<bool> Wait(Func<bool> exitCondition, int timeout = 1000)
 		{

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -51,10 +51,10 @@ namespace Microsoft.Maui.DeviceTests
 			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
 
 		public static string CreateColorError(this UIImage bitmap, string message) =>
-			$"{message} This is what it looked like:<img>{bitmap.ToBase64String()}</img>";
+			$"{message} This is what it looked like: {CreateColorTag(bitmap.ToBase64String())}";
 
 		public static string CreateEqualError(this UIImage bitmap, UIImage other, string message) =>
-			$"{message} This is what it looked like: <img>{bitmap.ToBase64String()}</img> and <img>{other.ToBase64String()}</img>";
+			$"{message} This is what it looked like: {CreateColorTag(bitmap.ToBase64String())} and {CreateColorTag(other.ToBase64String())}";
 
 		public static string ToBase64String(this UIImage bitmap)
 		{


### PR DESCRIPTION
### Description of Change

We currently embed base64 images in exceptions for test failures, but just in a <img></img> tag with no real markup, so they are only visible as strings in the results.

It looks as though devops parses exceptions for markdown, so there's a chance using a markdown image syntax could make them appear in the results as actual images.

This attempts to do this, as well as refactors the image tag creation a bit.