### PR TITLE
Make OnShouldReceiveMapTouch static

### DIFF
--- a/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
+++ b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Maui.Maps.Platform
 			return mapElement?.ToHandler(handler?.MauiContext!).PlatformView as T;
 		}
 
-		bool OnShouldReceiveMapTouch(UIGestureRecognizer recognizer, UITouch touch)
+		static bool OnShouldReceiveMapTouch(UIGestureRecognizer recognizer, UITouch touch)
 		{
 			if (touch.View is MKAnnotationView)
 				return false;


### PR DESCRIPTION
### Description of Change

To avoid possible memory leaks, make `OnShouldReceiveMapTouch` static. 