### PR TITLE
[Tizen] Add requesting re-layout step

### DIFF
--- a/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Tizen.cs
+++ b/src/Core/src/Handlers/ScrollView/ScrollViewHandler.Tizen.cs
@@ -104,6 +104,12 @@ namespace Microsoft.Maui.Handlers
 
 		void OnContentLayoutUpdated()
 		{
+			var viewGroup = _contentHandler?.PlatformView as LayoutViewGroup;
+			if (viewGroup != null)
+			{
+				viewGroup.IsLayoutUpdating++;
+			}
+
 			var platformGeometry = PlatformView.GetBounds().ToDP();
 			var measuredSize = VirtualView.CrossPlatformMeasure(platformGeometry.Width, platformGeometry.Height);
 
@@ -115,6 +121,11 @@ namespace Microsoft.Maui.Handlers
 				UpdateContentSize();
 			}
 			_measureCache = measuredSize;
+
+			if (viewGroup != null)
+			{
+				viewGroup.IsLayoutUpdating--;
+			}
 		}
 
 		public static void MapContent(IScrollViewHandler handler, IScrollView scrollView)

--- a/src/Core/src/Platform/Tizen/LayoutViewGroup.cs
+++ b/src/Core/src/Platform/Tizen/LayoutViewGroup.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Maui.Platform
 		Size _measureCache;
 
 		bool _needMeasureUpdate;
+		internal int IsLayoutUpdating { get; set; } = 0;
 
 		public LayoutViewGroup(IView view)
 		{
@@ -28,6 +29,10 @@ namespace Microsoft.Maui.Platform
 		{
 			_needMeasureUpdate = true;
 			MarkChanged();
+			if (IsLayoutUpdating == 0)
+			{
+				Layout.RequestLayout();
+			}
 		}
 
 		public void ClearNeedMeasureUpdate()
@@ -64,6 +69,7 @@ namespace Microsoft.Maui.Platform
 
 		void OnLayoutUpdated(object? sender, LayoutEventArgs e)
 		{
+			IsLayoutUpdating++;
 			var platformGeometry = this.GetBounds().ToDP();
 
 			if (_needMeasureUpdate || _measureCache != platformGeometry.Size)
@@ -76,6 +82,7 @@ namespace Microsoft.Maui.Platform
 				platformGeometry.Y = 0;
 				CrossPlatformArrange?.Invoke(platformGeometry);
 			}
+			IsLayoutUpdating--;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

There was an issue case updating children layout option after done layouting.
This PR adds requesting re-layout in this case.

For example when updating the row option in Grid `grid.SetRow(item, row_num)`.
<image src="https://user-images.githubusercontent.com/14328614/206614288-e973d3d5-b7b3-452d-9586-70300a02bcea.gif" width="300" />


