### PR TITLE
Use a faster search when checking for item in SortedList

### DIFF
--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Utils/SortedList.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Utils/SortedList.cs
@@ -18,21 +18,10 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 
 		public int IndexOf(T item)
 		{
-			// PERF hint: this is a O(n) algorithm but could be rewritten as a O(log n) one.
 			if (Count == 0)
 				return ~0;
 
-			for (var i = 0; i < Count; i++)
-			{
-				var existing = this[i];
-				var compare = _comparer.Compare(item, existing);
-				if (compare == 0)
-					return i;
-				if (compare < 0)
-					return ~i;
-			}
-
-			return ~Count;
+			return _list.BinarySearch(item, _comparer);
 		}
 
 		public void Insert(int index, T item)


### PR DESCRIPTION
### Description of Change

The runner takes a long time to load up all the tests after discovery. Partly that's because SortedList is using a linear search to find whether items are already in the list. 

This updates SortedList to use a binary search.

### Issues Fixed

Drastically speeds up loading of the runner for DeviceTests.