### PR TITLE
Set windows placeholder vertical text alignment

### DIFF
--- a/src/Core/src/Platform/Windows/MauiTextBox.cs
+++ b/src/Core/src/Platform/Windows/MauiTextBox.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Maui.Platform
 	public static class MauiTextBox
 	{
 		const string ContentElementName = "ContentElement";
+		const string PlaceholderTextContentPresenterName = "PlaceholderTextContentPresenter";
 		const string DeleteButtonElementName = "DeleteButton";
 		const string ButtonStatesName = "ButtonStates";
 		const string ButtonVisibleStateName = "ButtonVisible";
@@ -34,10 +35,15 @@ namespace Microsoft.Maui.Platform
 			// TODO: cache the scrollViewer value on the textBox
 
 			var element = d as FrameworkElement;
-			var scrollViewer = element?.GetDescendantByName<ScrollViewer>(ContentElementName);
+			var verticalAlignment = GetVerticalTextAlignment(d);
 
+			var scrollViewer = element?.GetDescendantByName<ScrollViewer>(ContentElementName);
 			if (scrollViewer is not null)
-				scrollViewer.VerticalAlignment = GetVerticalTextAlignment(d);
+				scrollViewer.VerticalAlignment = verticalAlignment;
+
+			var placeholder = element?.GetDescendantByName<TextBlock>(PlaceholderTextContentPresenterName);
+			if (placeholder is not null)
+				placeholder.VerticalAlignment = verticalAlignment;
 		}
 
 		// IsDeleteButtonEnabled

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		GravityFlags GetNativeVerticalTextAlignment(EditorHandler editorHandler) =>
-			GetNativeEditor(editorHandler).Gravity;
+			GetNativeEditor(editorHandler).Gravity & GravityFlags.VerticalGravityMask;
 
 		GravityFlags GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
 			textAlignment.ToVerticalGravityFlags();

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Android.cs
@@ -154,6 +154,12 @@ namespace Microsoft.Maui.DeviceTests
 			return (textView.Gravity, textView.TextAlignment);
 		}
 
+		GravityFlags GetNativeVerticalTextAlignment(EditorHandler editorHandler) =>
+			GetNativeEditor(editorHandler).Gravity;
+
+		GravityFlags GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
+			textAlignment.ToVerticalGravityFlags();
+
 		bool GetNativeIsNumericKeyboard(EditorHandler editorHandler)
 		{
 			var textView = GetNativeEditor(editorHandler);

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.Windows.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Xunit;
 
-//using NativeTextAlignment = Microsoft.UI.Xaml.TextAlignment;
+using NativeVerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -54,6 +54,21 @@ namespace Microsoft.Maui.DeviceTests
 
 		//NativeTextAlignment GetNativeHorizontalTextAlignment(EditorHandler editorHandler) =>
 		//	GetNativeEditor(editorHandler).TextAlignment;
+
+		NativeVerticalAlignment GetNativeVerticalTextAlignment(EditorHandler editorHandler)
+		{
+			var textBox = GetNativeEditor(editorHandler);
+
+			var sv = textBox.GetDescendantByName<ScrollViewer>("ContentElement");
+			var placeholder = textBox.GetDescendantByName<TextBlock>("PlaceholderTextContentPresenter");
+
+			Assert.Equal(sv.VerticalAlignment, placeholder.VerticalAlignment);
+
+			return sv.VerticalAlignment;
+		}
+
+		NativeVerticalAlignment GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
+			textAlignment.ToPlatformVerticalAlignment();
 
 		bool IsInputScopeEquals(InputScope inputScope, InputScopeNameValue nameValue)
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.cs
@@ -370,6 +370,32 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(editor, () => expected, GetNativeIsChatKeyboard, expected);
 		}
 
+		[Theory(DisplayName = "Vertical TextAlignment Initializes Correctly")]
+		[InlineData(TextAlignment.Start)]
+		[InlineData(TextAlignment.Center)]
+		[InlineData(TextAlignment.End)]
+		public async Task VerticalTextAlignmentInitializesCorrectly(TextAlignment textAlignment)
+		{
+			var editor = new EditorStub
+			{
+				VerticalTextAlignment = textAlignment
+			};
+
+			var platformAlignment = GetNativeVerticalTextAlignment(textAlignment);
+
+			// attach for windows because it uses control templates
+			var values = await GetValueAsync(editor, (handler) =>
+				handler.PlatformView.AttachAndRun(() =>
+					new
+					{
+						ViewValue = editor.VerticalTextAlignment,
+						PlatformViewValue = GetNativeVerticalTextAlignment(handler)
+					}));
+
+			Assert.Equal(textAlignment, values.ViewValue);
+			Assert.Equal(platformAlignment, values.PlatformViewValue);
+		}
+
 		[Category(TestCategory.Editor)]
 		public class EditorTextStyleTests : TextStyleHandlerTests<EditorHandler, EditorStub>
 		{

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -270,6 +270,12 @@ namespace Microsoft.Maui.DeviceTests
 			return -1;
 		}
 
+		TextAlignment GetNativeVerticalTextAlignment(EditorHandler editorHandler) =>
+			GetNativeEditor(editorHandler).VerticalTextAlignment;
+
+		TextAlignment GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
+			textAlignment;
+
 #if !MACCATALYST
 		[Fact(DisplayName = "Completed Event Fires")]
 		public async Task CompletedEventFiresFromTappingDone()

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Maui.DeviceTests
 			GetNativeEntry(entryHandler).TextAlignment;
 
 		Android.Views.GravityFlags GetNativeVerticalTextAlignment(EntryHandler entryHandler) =>
-			GetNativeEntry(entryHandler).Gravity;
+			GetNativeEntry(entryHandler).Gravity & Android.Views.GravityFlags.VerticalGravityMask;
 
 		Android.Views.GravityFlags GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
 			textAlignment.ToVerticalGravityFlags();

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -78,32 +78,6 @@ namespace Microsoft.Maui.DeviceTests
 			values.PlatformViewValue.AssertHasFlag(expectedValue);
 		}
 
-		[Fact(DisplayName = "Vertical TextAlignment Initializes Correctly")]
-		public async Task VerticalTextAlignmentInitializesCorrectily()
-		{
-			var xplatVerticalTextAlignment = TextAlignment.End;
-
-			var entry = new EntryStub
-			{
-				Text = "Test",
-				VerticalTextAlignment = xplatVerticalTextAlignment
-			};
-
-			Android.Views.GravityFlags expectedValue = Android.Views.GravityFlags.Bottom;
-
-			var values = await GetValueAsync(entry, (handler) =>
-			{
-				return new
-				{
-					ViewValue = entry.VerticalTextAlignment,
-					PlatformViewValue = GetNativeVerticalTextAlignment(handler)
-				};
-			});
-
-			Assert.Equal(xplatVerticalTextAlignment, values.ViewValue);
-			values.PlatformViewValue.AssertHasFlag(expectedValue);
-		}
-
 		static AppCompatEditText GetNativeEntry(EntryHandler entryHandler) =>
 			entryHandler.PlatformView;
 
@@ -212,6 +186,9 @@ namespace Microsoft.Maui.DeviceTests
 
 		Android.Views.GravityFlags GetNativeVerticalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).Gravity;
+
+		Android.Views.GravityFlags GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
+			textAlignment.ToVerticalGravityFlags();
 
 		ImeAction GetNativeReturnType(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ImeOptions;

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Media;
 using Xunit;
 
 using NativeTextAlignment = Microsoft.UI.Xaml.TextAlignment;
-//using NativeVerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment;
+using NativeVerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -101,8 +101,11 @@ namespace Microsoft.Maui.DeviceTests
 		NativeTextAlignment GetNativeHorizontalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;
 
-		//NativeVerticalAlignment GetNativeVerticalTextAlignment(EntryHandler entryHandler) =>
-		//	GetNativeEntry(entryHandler).VerticalAlignment;
+		NativeVerticalAlignment GetNativeVerticalTextAlignment(EntryHandler entryHandler) =>
+			GetNativeEntry(entryHandler).VerticalAlignment;
+
+		NativeVerticalAlignment GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
+			textAlignment.ToPlatformVerticalAlignment();
 
 		int GetNativeCursorPosition(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).GetCursorPosition();

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Windows.cs
@@ -101,8 +101,17 @@ namespace Microsoft.Maui.DeviceTests
 		NativeTextAlignment GetNativeHorizontalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).TextAlignment;
 
-		NativeVerticalAlignment GetNativeVerticalTextAlignment(EntryHandler entryHandler) =>
-			GetNativeEntry(entryHandler).VerticalAlignment;
+		NativeVerticalAlignment GetNativeVerticalTextAlignment(EntryHandler entryHandler)
+		{
+			var textBox = GetNativeEntry(entryHandler);
+
+			var sv = textBox.GetDescendantByName<ScrollViewer>("ContentElement");
+			var placeholder = textBox.GetDescendantByName<TextBlock>("PlaceholderTextContentPresenter");
+
+			Assert.Equal(sv.VerticalAlignment, placeholder.VerticalAlignment);
+
+			return sv.VerticalAlignment;
+		}
 
 		NativeVerticalAlignment GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
 			textAlignment.ToPlatformVerticalAlignment();

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -508,14 +508,14 @@ namespace Microsoft.Maui.DeviceTests
 
 			var platformAlignment = GetNativeVerticalTextAlignment(textAlignment);
 
+			// attach for windows because it uses control templates
 			var values = await GetValueAsync(entry, (handler) =>
-			{
-				return new
-				{
-					ViewValue = entry.VerticalTextAlignment,
-					PlatformViewValue = GetNativeVerticalTextAlignment(handler)
-				};
-			});
+				handler.PlatformView.AttachAndRun(() =>
+					new
+					{
+						ViewValue = entry.VerticalTextAlignment,
+						PlatformViewValue = GetNativeVerticalTextAlignment(handler)
+					}));
 
 			Assert.Equal(textAlignment, values.ViewValue);
 			Assert.Equal(platformAlignment, values.PlatformViewValue);

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -495,6 +495,32 @@ namespace Microsoft.Maui.DeviceTests
 				() => entry.CharacterSpacing = newSize);
 		}
 
+		[Theory(DisplayName = "Vertical TextAlignment Initializes Correctly")]
+		[InlineData(TextAlignment.Start)]
+		[InlineData(TextAlignment.Center)]
+		[InlineData(TextAlignment.End)]
+		public async Task VerticalTextAlignmentInitializesCorrectly(TextAlignment textAlignment)
+		{
+			var entry = new EntryStub
+			{
+				VerticalTextAlignment = textAlignment
+			};
+
+			var platformAlignment = GetNativeVerticalTextAlignment(textAlignment);
+
+			var values = await GetValueAsync(entry, (handler) =>
+			{
+				return new
+				{
+					ViewValue = entry.VerticalTextAlignment,
+					PlatformViewValue = GetNativeVerticalTextAlignment(handler)
+				};
+			});
+
+			Assert.Equal(textAlignment, values.ViewValue);
+			Assert.Equal(platformAlignment, values.PlatformViewValue);
+		}
+
 #if ANDROID
 		[Fact]
 		public async Task NextMovesToNextEntrySuccessfully()

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -38,32 +38,6 @@ namespace Microsoft.Maui.DeviceTests
 			values.PlatformViewValue.AssertHasFlag(expectedValue);
 		}
 
-		[Fact(DisplayName = "Vertical TextAlignment Initializes Correctly")]
-		public async Task VerticalTextAlignmentInitializesCorrectily()
-		{
-			var xplatVerticalTextAlignment = TextAlignment.End;
-
-			var entry = new EntryStub
-			{
-				Text = "Test",
-				VerticalTextAlignment = xplatVerticalTextAlignment
-			};
-
-			UIControlContentVerticalAlignment expectedValue = UIControlContentVerticalAlignment.Bottom;
-
-			var values = await GetValueAsync(entry, (handler) =>
-			{
-				return new
-				{
-					ViewValue = entry.VerticalTextAlignment,
-					PlatformViewValue = GetNativeVerticalTextAlignment(handler)
-				};
-			});
-
-			Assert.Equal(xplatVerticalTextAlignment, values.ViewValue);
-			values.PlatformViewValue.AssertHasFlag(expectedValue);
-		}
-
 		[Fact(DisplayName = "ReturnType Initializes Correctly")]
 		public async Task ReturnTypeInitializesCorrectly()
 		{
@@ -195,6 +169,9 @@ namespace Microsoft.Maui.DeviceTests
 
 		UIControlContentVerticalAlignment GetNativeVerticalTextAlignment(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).VerticalAlignment;
+
+		UIControlContentVerticalAlignment GetNativeVerticalTextAlignment(TextAlignment textAlignment) =>
+			textAlignment.ToPlatformVertical();
 
 		UIReturnKeyType GetNativeReturnType(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).ReturnKeyType;


### PR DESCRIPTION
### Description of Change

Make sure to also set the placeholder vertical alignment.

The images below show 4 entries and 4 editors. The entry by default is centered and the editor by default is top aligned.

| Before | After |
|:-:|:-:|
|![image](https://user-images.githubusercontent.com/1096616/207415011-06e76fa8-5c76-4aa6-8f36-50900a6b993e.png)| ![image](https://user-images.githubusercontent.com/1096616/207415440-ab2c5f76-ead4-496e-afd8-491f3dbeb0c3.png)|


### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

- Fixes #7844
- Fixes #8770


<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
