### PR TITLE
Set bottom margin back to zero when removing Bottom Tabs

### DIFF
--- a/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
+++ b/src/Controls/src/Core/Platform/Android/TabbedPageManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using Android.App.Roles;
 using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
@@ -183,6 +184,8 @@ namespace Microsoft.Maui.Controls.Handlers
 
 				if (fragmentManager.IsAlive() && !fragmentManager.IsDestroyed)
 				{
+					SetContentBottomMargin(0);
+
 					_ = _context
 							.GetNavigationRootManager()
 							.FragmentManager
@@ -232,12 +235,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					return;
 
 				_tabLayoutFragment = new ViewFragment(BottomNavigationView);
-
-				var layoutContent = rootManager.RootView.FindViewById(Resource.Id.navigationlayout_content);
-				if (layoutContent.LayoutParameters is ViewGroup.MarginLayoutParams cl)
-				{
-					cl.BottomMargin = _context.Context.Resources.GetDimensionPixelSize(Resource.Dimension.design_bottom_navigation_height);
-				}
+				SetContentBottomMargin(_context.Context.Resources.GetDimensionPixelSize(Resource.Dimension.design_bottom_navigation_height));
 			}
 			else
 			{
@@ -246,11 +244,7 @@ namespace Microsoft.Maui.Controls.Handlers
 					return;
 
 				_tabLayoutFragment = new ViewFragment(TabLayout);
-				var layoutContent = rootManager.RootView.FindViewById(Resource.Id.navigationlayout_content);
-				if (layoutContent.LayoutParameters is ViewGroup.MarginLayoutParams cl)
-				{
-					cl.BottomMargin = 0;
-				}
+				SetContentBottomMargin(0);
 			}
 
 			_tabplacementId = id;
@@ -260,6 +254,16 @@ namespace Microsoft.Maui.Controls.Handlers
 					.Replace(id, _tabLayoutFragment)
 					.SetReorderingAllowed(true)
 					.Commit();
+		}
+
+		void SetContentBottomMargin(int bottomMargin)
+		{
+			var rootManager = _context.GetNavigationRootManager();
+			var layoutContent = rootManager.RootView?.FindViewById(Resource.Id.navigationlayout_content);
+			if (layoutContent != null && layoutContent.LayoutParameters is ViewGroup.MarginLayoutParams cl)
+			{
+				cl.BottomMargin = bottomMargin;
+			}
 		}
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -367,8 +367,11 @@ namespace Microsoft.Maui.DeviceTests
 
 			// Wait for the layout to propagate to the platform
 			await AssertionExtensions.Wait(
-				() => !frameworkElement.GetBoundingBox().Size.Equals(Size.Zero)
-			);
+				() =>
+				{
+					var size = frameworkElement.GetBoundingBox().Size;
+					return size.Height > 0 && size.Width > 0;
+				});
 
 			void OnBatchCommitted(object sender, Controls.Internals.EventArg<VisualElement> e)
 			{

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
+					handlers.AddHandler(typeof(VerticalStackLayout), typeof(LayoutHandler));
 					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
 					handlers.AddHandler<Page, PageHandler>();
 
@@ -53,16 +54,68 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-		TabbedPage CreateBasicTabbedPage()
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public async Task NavigatingAwayFromTabbedPageResizesContentPage(bool bottomTabs)
 		{
-			return new TabbedPage()
+			SetupBuilder();
+
+			var tabbedPage = CreateBasicTabbedPage(bottomTabs);
+			var navPage = new NavigationPage(tabbedPage);
+
+			var layout1 = new VerticalStackLayout()
 			{
-				Title = "Tabbed Page",
-				Children =
-				{
-					new ContentPage() { Title = "Page 1" }
-				}
+				Background = SolidColorBrush.Green
 			};
+
+			(tabbedPage.CurrentPage as ContentPage).Content = layout1;
+			await CreateHandlerAndAddToWindow<WindowHandlerStub>(new Window(navPage), async (handler) =>
+			{
+				await OnFrameSetToNotEmpty(layout1);
+				var pageHeight = tabbedPage.CurrentPage.Height;
+				var newPage = new ContentPage()
+				{
+					Background = SolidColorBrush.Purple,
+					Content = new VerticalStackLayout()
+				};
+
+				await navPage.PushAsync(newPage);
+				await OnFrameSetToNotEmpty(newPage);
+
+				Assert.True(newPage.Content.Height > pageHeight);
+			});
+		}
+
+		TabbedPage CreateBasicTabbedPage(bool bottomTabs = false, bool isSmoothScrollEnabled = true, IEnumerable<Page> pages = null)
+		{
+			pages = pages ?? new List<Page>()
+			{
+				new ContentPage() { Title = "Page 1" }
+			};
+
+			var tabs = new TabbedPage()
+			{
+				Title = "Tabbed Page"
+			};
+
+			foreach (var page in pages)
+			{
+				tabs.Children.Add(page);
+			}
+
+			if (bottomTabs)
+			{
+				Controls.PlatformConfiguration.AndroidSpecific.TabbedPage.SetToolbarPlacement(tabs, Controls.PlatformConfiguration.AndroidSpecific.ToolbarPlacement.Bottom);
+			}
+			else
+			{
+				Controls.PlatformConfiguration.AndroidSpecific.TabbedPage.SetToolbarPlacement(tabs,
+					Controls.PlatformConfiguration.AndroidSpecific.ToolbarPlacement.Top);
+			}
+
+			Controls.PlatformConfiguration.AndroidSpecific.TabbedPage.SetIsSmoothScrollEnabled(tabs, isSmoothScrollEnabled);
+			return tabs;
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -55,7 +55,9 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Theory]
+#if ANDROID
 		[InlineData(true)]
+#endif
 		[InlineData(false)]
 		public async Task NavigatingAwayFromTabbedPageResizesContentPage(bool bottomTabs)
 		{


### PR DESCRIPTION
### Description of Change

Space is made for the bottom tabs by setting a bottom margin on the content, but we are failing to remove that margin once the tabs are removed. This PR resets that margin back to zero once the tabs have been removed.

### Issues Fixed
Fixes #9512