### PR TITLE
Add a null-guard in MenuItem to prevent NRE

### DIFF
--- a/src/Controls/src/Core/MenuItem.cs
+++ b/src/Controls/src/Core/MenuItem.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Maui.Controls
 
 		void OnCommandCanExecuteChanged(object sender, EventArgs eventArgs)
 		{
-			IsEnabledCore = Command.CanExecute(CommandParameter);
+			IsEnabledCore = Command?.CanExecute(CommandParameter) ?? true;
 		}
 
 		void OnCommandChanged()


### PR DESCRIPTION
### Description of Change

Don't think it happens often, but still not a bad thing to have.
Port from https://github.com/xamarin/Xamarin.Forms/pull/15636

### Issues Fixed

Fixes https://github.com/xamarin/Xamarin.Forms/issues/15629