### PR TITLE
Add BlazorWebView binaries to xmldocs artifacts

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -17,6 +17,7 @@ var NuGetOnlyPackages = new string[] {
     "Microsoft.Maui.Graphics.*.nupkg",
     "Microsoft.Maui.Controls.Maps.*.nupkg",
     "Microsoft.Maui.Maps.*.nupkg",
+    "Microsoft.AspNetCore.Components.WebView.*.nupkg",
 };
 
 ProcessTFMSwitches();
@@ -341,11 +342,22 @@ Task("dotnet-pack-docs")
         {
             foreach (var nupkg in GetFiles($"./artifacts/{pattern}"))
             {
-                var d = $"{tempDir}/{nupkg.GetFilename()}";
+                var filename = nupkg.GetFilename().ToString();
+                var d = $"{tempDir}/{filename}";
                 Unzip(nupkg, d);
                 DeleteFiles($"{d}/**/*.pri");
                 DeleteFiles($"{d}/**/*.aar");
                 DeleteFiles($"{d}/**/*.pdb");
+
+                if (filename.StartsWith("Microsoft.AspNetCore.Components.WebView.Wpf")
+                    || filename.StartsWith("Microsoft.AspNetCore.Components.WebView.WindowsForms"))
+                {
+                    CopyFiles($"{d}/lib/**/net?.?-windows?.?/**/*.dll", $"{destDir}");
+                    CopyFiles($"{d}/lib/**/net?.?-windows?.?/**/*.xml", $"{destDir}");    
+
+                    continue;
+                }
+
                 CopyFiles($"{d}/lib/**/{{net,netstandard}}?.?/**/*.dll", $"{destDir}");
                 CopyFiles($"{d}/lib/**/{{net,netstandard}}?.?/**/*.xml", $"{destDir}");
             }


### PR DESCRIPTION
### Description of Change

Follow up from #11257. This adds the binaries for `BlazorWebView` (WPF, WinForms, .NET MAUI and shared code) to our xml-docs artifacts so we can easily use them for our online API Docs browser.

Please backport to .NET 7!

### Issues Fixed

NA