### PR TITLE
[android] remove Xamarin.AndroidX.Legacy.Support.V4

### DIFF
--- a/eng/AndroidX.targets
+++ b/eng/AndroidX.targets
@@ -9,8 +9,8 @@
         Version="1.4.0.3"
     />
     <PackageReference
-        Update="Xamarin.AndroidX.Legacy.Support.V4"
-        Version="1.0.0.15"
+        Update="Xamarin.AndroidX.SwipeRefreshLayout"
+        Version="1.1.0.10"
     />
     <PackageReference
         Update="Xamarin.AndroidX.Lifecycle.LiveData"

--- a/src/Compatibility/Android.AppLinks/src/Compatibility.Android.AppLinks.csproj
+++ b/src/Compatibility/Android.AppLinks/src/Compatibility.Android.AppLinks.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Firebase.AppIndexing" Version="120.0.0.10" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
+++ b/src/Compatibility/ControlGallery/src/Android/Compatibility.ControlGallery.Android.csproj
@@ -40,7 +40,6 @@
     <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
     <PackageReference Include="Xamarin.AndroidX.Browser" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
     <PackageReference Include="Xamarin.AndroidX.Palette" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>

--- a/src/Compatibility/ControlGallery/src/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
+++ b/src/Compatibility/ControlGallery/src/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
@@ -3,7 +3,6 @@
     <PackageReference Include="Xamarin.AndroidX.Browser" />
     <PackageReference Include="Xamarin.AndroidX.Palette" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
   </ItemGroup>
   <Import Project="..\..\..\..\..\eng\AndroidX.targets" />

--- a/src/Compatibility/ControlGallery/src/EmbeddingTestBeds/Embedding.Droid/MainActivity.cs
+++ b/src/Compatibility/ControlGallery/src/EmbeddingTestBeds/Embedding.Droid/MainActivity.cs
@@ -1,15 +1,9 @@
 ﻿using System;
 using Android.App;
 using Android.OS;
-#if __ANDROID_29__
 using AndroidX.Fragment.App;
 using Fragment = AndroidX.Fragment.App.Fragment;
 using FragmentTransaction = AndroidX.Fragment.App.FragmentTransaction;
-#else
-using Android.Support.V4.App;
-using Fragment = Android.Support.V4.App.Fragment;
-using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
-#endif
 using Android.Views;
 using Embedding.XF;
 using Xamarin.Forms;

--- a/src/Compatibility/ControlGallery/src/EmbeddingTestBeds/Embedding.Droid/SecondActivity.cs
+++ b/src/Compatibility/ControlGallery/src/EmbeddingTestBeds/Embedding.Droid/SecondActivity.cs
@@ -1,15 +1,9 @@
 ﻿using System;
 using Android.App;
 using Android.OS;
-#if __ANDROID_29__
 using AndroidX.Fragment.App;
 using Fragment = AndroidX.Fragment.App.Fragment;
 using FragmentTransaction = AndroidX.Fragment.App.FragmentTransaction;
-#else
-using Android.Support.V4.App;
-using Fragment = Android.Support.V4.App.Fragment;
-using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
-#endif
 using Android.Views;
 using Embedding.XF;
 using Xamarin.Forms.Platform.Android;

--- a/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
+++ b/src/Compatibility/Maps/src/Android/Compatibility.Maps.Android.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="118.1.0" />
   </ItemGroup>
 

--- a/src/Controls/Foldable/src/Controls.Foldable.csproj
+++ b/src/Controls/Foldable/src/Controls.Foldable.csproj
@@ -32,7 +32,6 @@
   <ItemGroup Condition=" '$(UseMaui)' != 'true' and '$(TargetPlatformIdentifier)' == 'android' ">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' ">
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava" />

--- a/src/Core/src/Core.csproj
+++ b/src/Core/src/Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Xamarin.Android.Glide" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
     <PackageReference Include="Xamarin.Google.Android.Material" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" />
+    <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.Fragment" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.Runtime" />

--- a/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
+++ b/src/Workload/Microsoft.Maui.Sdk/Microsoft.Maui.Sdk.csproj
@@ -87,8 +87,8 @@
     </XmlPeek>
     <XmlPeek
         XmlInputPath="$(MauiRootDirectory)eng\AndroidX.targets"
-        Query="/Project/ItemGroup/PackageReference[@Update='Xamarin.AndroidX.Legacy.Support.V4']/@Version">
-      <Output TaskParameter="Result" PropertyName="_XamarinAndroidXLegacySupportV4Version" />
+        Query="/Project/ItemGroup/PackageReference[@Update='Xamarin.AndroidX.SwipeRefreshLayout']/@Version">
+      <Output TaskParameter="Result" PropertyName="_XamarinAndroidXSwipeRefreshLayoutVersion" />
     </XmlPeek>
     <XmlPeek
         XmlInputPath="$(MauiRootDirectory)eng\AndroidX.targets"
@@ -107,7 +107,7 @@
     </XmlPeek>
     <ItemGroup>
       <_ValuesToReplace Include="_XamarinAndroidXBrowserVersion"              PropertyName="_XamarinAndroidXBrowserVersion" />
-      <_ValuesToReplace Include="_XamarinAndroidXLegacySupportV4Version"      PropertyName="_XamarinAndroidXLegacySupportV4Version" />
+      <_ValuesToReplace Include="_XamarinAndroidXSwipeRefreshLayoutVersion"   PropertyName="_XamarinAndroidXSwipeRefreshLayoutVersion" />
       <_ValuesToReplace Include="_XamarinAndroidXLifecycleLiveDataVersion"    PropertyName="_XamarinAndroidXLifecycleLiveDataVersion" />
       <_ValuesToReplace Include="_XamarinAndroidXNavigationVersion"           PropertyName="_XamarinAndroidXNavigationVersion" />
       <_ValuesToReplace Include="_XamarinGoogleAndroidMaterialVersion"        PropertyName="_XamarinGoogleAndroidMaterialVersion" />

--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/BundledVersions.in.targets
@@ -86,7 +86,7 @@
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="@_XamarinAndroidXBrowserVersion@" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="@_XamarinAndroidXLegacySupportV4Version@" IsImplicitlyDefined="true">
+    <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" Version="@_XamarinAndroidXSwipeRefreshLayoutVersion@" IsImplicitlyDefined="true">
       <PrivateAssets Condition=" '$(OutputType)' == 'Library' and '$(AndroidApplication)' != 'true' ">all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="@_XamarinAndroidXLifecycleLiveDataVersion@" IsImplicitlyDefined="true">


### PR DESCRIPTION
In reviewing:

https://github.com/dotnet/maui/issues/10901#issuecomment-1354975448

I found `Xamarin.AndroidX.Legacy.Support.V4` triggers the warning:

    R8 : warning : Missing class androidx.window.extensions.WindowExtensions

`AndroidX.Legacy.Support.V4` is a package for supporting *really* old Android API levels like 7, 11, etc.

Details here: https://stackoverflow.com/a/59484158

The Android workload in .NET 6/7 only supports API 21+. That made me think, why is .NET MAUI using `AndroidX.Legacy.Support.V4` at all? Turns out, it's not!

I tried directly removing the package, and got:

    src\Core\src\Platform\Android\MauiSwipeRefreshLayout.cs(10,16): error CS0234: The type or namespace name 'SwipeRefreshLayout' does not exist in
    the namespace 'AndroidX' (are you missing an assembly reference?)

It looks like this is just a dependency of `Xamarin.AndroidX.Legacy.Support.V4`. Instead we can just use this package directly instead:

    <PackageReference Include="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.1.0.10" />

The end result, is we just removed Android packages that are not used at all. We still use the same library for `SwipeRefreshLayout`.

## Results ##

Android app sizes improved from this change:

    > apkdiff -f com.companyname.maui_before-Signed.apk com.companyname.maui_after-Signed.apk
    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
    +   1,598,040 classes.dex
    -           6 META-INF/androidx.asynclayoutinflater_asynclayoutinflater.version *1
    -           6 META-INF/androidx.legacy_legacy-support-core-ui.version *1
    -           6 META-INF/androidx.legacy_legacy-support-v4.version *1
    -           6 META-INF/androidx.media_media.version *1
    -         455 assemblies/assemblies.blob
    -         564 res/layout/notification_media_action.xml *1
    -         744 res/layout/notification_media_cancel_action.xml *1
    -       1,292 res/layout/notification_template_media.xml *1
    -       1,584 META-INF/BNDLTOOL.SF
    -       1,584 META-INF/MANIFEST.MF
    -       1,696 res/layout/notification_template_big_media.xml *1
    -       1,824 res/layout/notification_template_big_media_narrow.xml *1
    -       2,456 resources.arsc
    -       2,756 res/layout/notification_template_media_custom.xml *1
    -       2,872 res/layout/notification_template_lines_media.xml *1
    -       3,044 res/layout/notification_template_big_media_custom.xml *1
    -       3,216 res/layout/notification_template_big_media_narrow_custom.xml *1
    -   2,030,636 classes2.dex
    Summary:
    -      24,111 Other entries -0.35% (of 6,880,759)
    -     432,596 Dalvik executables -3.46% (of 12,515,440)
    +           0 Shared libraries 0.00% (of 12,235,904)
    -     169,179 Package size difference -1.12% (of 15,123,185)

Most notably, `*.dex` executables are ~432kb smaller. So small, in fact, that the project template no longer needs multi-dex anymore!
