### PR TITLE
Allow CommunityToolkit to avoid reflection to access the CollectionView controller

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.iOS.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected TItemsView ItemsView => VirtualView;
 
-		protected ItemsViewController<TItemsView> Controller { get; private set; }
+		protected internal ItemsViewController<TItemsView> Controller { get; private set; }
 
 		protected abstract ItemsViewLayout SelectLayout();
 


### PR DESCRIPTION
### Description of Change

Update protected to internal

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes https://github.com/CommunityToolkit/Maui/pull/751

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
