### PR TITLE
Remove unnecessary Frame set in Shape

### DIFF
--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
 
 namespace Microsoft.Maui.Controls.Shapes
 {
@@ -173,11 +174,6 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		PathF IShape.PathForBounds(Graphics.Rect viewBounds)
 		{
-			if (HeightRequest < 0 && WidthRequest < 0)
-			{
-				Frame = viewBounds;
-			}
-
 			var path = GetPath();
 
 #if !(NETSTANDARD || !PLATFORM)


### PR DESCRIPTION
### Description of Change

Shape has an unnecessary (and incorrect) extra setting of Frame which (under the right circumstances) causes infinite layout loops when interacting with the VisualDiagnosticOverlay on Android.

This set is left over from an earlier iteration of Border (which is a Shape) - it may have once served a purpose, or it may have always been wrong. The value it uses is incorrect (it blindly uses the view bounds, rather than the actual bounds of the Shape), and the Arrange method eventually corrects it, so the value is never really used to draw the shape. 

However, setting it triggers the Frame part mappings (X, Y, Width, Height) if the incorrectly computed value happens to be different from the correctly computed one. And triggering those mappings causes a call to RequestLayout. Which is fine unless you happen to have the VisualDiagnosticOverlay running, because that RequestLayout call bubbles up to the DecorView, and the layout event fired by DecorView causes the overlay to invalidate. Which triggers a re-draw of the Shape, and the process loops forever. 

tl;dr; - the set isn't required, and its side effects are awful.

### Issues Fixed

Fixes #11704
Fixes #12268