### PR TITLE
Grant requested permissions in BlazorWebChromeClient automatically

### DIFF
--- a/src/BlazorWebView/src/Maui/Android/BlazorWebChromeClient.cs
+++ b/src/BlazorWebView/src/Maui/Android/BlazorWebChromeClient.cs
@@ -1,14 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Android.Content;
 using Android.Net;
 using Android.OS;
 using Android.Webkit;
+using File = Java.IO.File;
 using Microsoft.Maui;
 using Microsoft.Maui.Devices;
 using Microsoft.Maui.Storage;
-using File = Java.IO.File;
 
 namespace Microsoft.AspNetCore.Components.WebView.Maui
 {
@@ -38,6 +39,18 @@ namespace Microsoft.AspNetCore.Components.WebView.Maui
 
 			CallFilePickerAsync(filePathCallback, fileChooserParams).FireAndForget();
 			return true;
+		}
+
+		public override void OnPermissionRequest(PermissionRequest? request)
+		{
+			base.OnPermissionRequest(request);
+
+			if (request is null)
+			{
+				return;
+			}
+
+			request.Grant(request.GetResources());
 		}
 
 		private static async Task CallFilePickerAsync(IValueCallback filePathCallback, FileChooserParams? fileChooserParams)


### PR DESCRIPTION
### Description of Change
When using the Blazor Hybrid on Android and a permission is needed in JavaScript or Blazor, the permission is neither granted or requested to approve by the user. There is a workaround which is implemented in this pull request, because I don't see any security issues to grant the permission for the Blazor side and the normal permission request is still necessary.

The change is that when a permission is requested in the `BlazorWebChromeClient` it is always granted automatically.


### Issues Fixed
#6565
#4768
#4170
#3694