### PR TITLE
Don't watch for changes on an ImmutableBrush

### DIFF
--- a/src/Controls/src/Core/ImmutableBrush.cs
+++ b/src/Controls/src/Core/ImmutableBrush.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Graphics;
+﻿using System;
+using Microsoft.Maui.Graphics;
 
 namespace Microsoft.Maui.Controls
 {
@@ -18,6 +19,11 @@ namespace Microsoft.Maui.Controls
 		{
 			get => (Color)GetValue(ColorProperty);
 			set { }
+		}
+
+		private protected override void OnParentChangingCore(Element oldParent, Element newParent)
+		{
+			throw new InvalidOperationException("Parent cannot be set on this Brush.");
 		}
 	}
 }

--- a/src/Controls/src/Core/Shapes/Shape.cs
+++ b/src/Controls/src/Core/Shapes/Shape.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 		void UpdateBrushParent(Brush brush)
 		{
-			if (brush != null)
+			if (brush != null && brush is not ImmutableBrush)
 				brush.Parent = this;
 		}
 

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -245,6 +245,9 @@ namespace Microsoft.Maui.Controls
 
 		void NotifyBackgroundChanges()
 		{
+			if (Background is ImmutableBrush)
+				return;
+
 			if (Background != null)
 			{
 				Background.Parent = this;
@@ -257,6 +260,9 @@ namespace Microsoft.Maui.Controls
 
 		void StopNotifyingBackgroundChanges()
 		{
+			if (Background is ImmutableBrush)
+				return;
+
 			if (Background != null)
 			{
 				Background.Parent = null;

--- a/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BrushUnitTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Maui.Graphics;
 using Xunit;
 
@@ -93,6 +94,20 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			var gradientStop = new GradientStop();
 			_ = gradientStop.GetHashCode();
 			// This test is just validating that calling `GetHashCode` doesn't throw
+		}
+
+		[Fact]
+		public void ImmutableBrushDoesntSetParent()
+		{
+			var grid = new Grid();
+			grid.Background = SolidColorBrush.Green;
+			Assert.Null(SolidColorBrush.Green.Parent);
+		}
+
+		[Fact]
+		public void InvalidOperationExceptionWhenSettingParentOnImmutableBrush()
+		{
+			Assert.Throws<InvalidOperationException>(() => SolidColorBrush.Green.Parent = new Grid());
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

If we're using an ImmutableBrush on the `Background` then don't set the `Parent` or watch for `PropertyChanges`. The `ImmutableBrush` is just a `SolidColorBrush` and it's Immutable so changes won't occur.  

### Issues Fixed
Fixes #12345
