### PR TITLE
Toggle IsEnabled on Layout children when IsEnabled changes

### DIFF
--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -305,6 +305,7 @@ namespace Microsoft.Maui.Controls
 		{
 			[nameof(CascadeInputTransparent)] = MapInputTransparent,
 			[nameof(IView.InputTransparent)] = MapInputTransparent,
+			[nameof(IView.IsEnabled)] = MapIsEnabled,
 		};
 
 		void UpdateDescendantInputTransparent()
@@ -321,6 +322,25 @@ namespace Microsoft.Maui.Controls
 				if (this[n] is VisualElement visualElement)
 				{
 					visualElement.InputTransparent = true;
+				}
+			}
+		}
+
+		internal static void MapIsEnabled(ILayoutHandler handler, Layout layout)
+		{
+			layout.UpdateDescendantIsEnabled();
+		}
+
+		void UpdateDescendantIsEnabled() 
+		{
+			var isEnabled = IsEnabled;
+
+			// Set all the child IsEnabled values to match this one
+			for (int n = 0; n < Count; n++)
+			{
+				if (this[n] is VisualElement visualElement)
+				{
+					visualElement.IsEnabled = isEnabled;
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change

Offering this as an alternative to #6892.

This change modifies the Layouts in MAUI.Controls to toggle the `IsEnabled` property of all their children whenever the `IsEnabled` property of the Layout is changed. 

This change deliberately avoids handling IsEnabled on Layouts in the Core layer; as far as Core is concerned, IsEnabled has _no_ effect on Layouts at all. This leaves the option for implementing SDKs to make their own decisions on question about how enabling/disabling Layouts should affect child controls (questions like the ones posed in [this comment](https://github.com/dotnet/maui/pull/6892#pullrequestreview-965318576)). 

As for the Controls layer, this implementation is very simple; when a Layout's `IsEnabled` property is set to `false`, all of its children have their `IsEnabled` property set to `false`. When the Layout's property is set to `true`, the children's properties are set to `true`. This differs from the Forms implementation in several ways, which I would argue are improvements.

In Forms, child controls are unaffected when Layout.IsEnabled is set to `false`. Rather, touch input to the backing control (DefaultRenderer) is blocked entirely. This effectively disables interaction with the controls via touch, but in some cases other interaction (keyboard, voice command, etc.) is still possible. This is confusing. The implementation in the PR _actually_ disables the child controls, preventing accidental interactions.

Also, the child controls in Forms are not _visibly_ disabled; they retain their "enabled" visual states. Since this PR's implementation actually disables the controls, they apply their platform "disabled" visuals, and they have their cross-platform "disabled" visual states applied.

In Forms, interrogating the `IsEnabled` properties of child controls will return `true` even though they've been effectively (sort of) disabled. This PR will return non-confusing values when checking `IsEnabled` on child controls. 

One major divergence from Forms is the option to re-enable a child control which has been disabled by disabling its container. This provides a flexibility that Forms did not. 

### Issues Fixed

Fixes #5287

