### PR TITLE
Remove old versions from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,17 +44,14 @@ body:
       label: Version with bug
       description: In what version do you see this issue? Run `dotnet workload list` to find your version.
       options:
-        - 6.0 Release Candidate 2 or older
-        - 6.0 Release Candidate 3
         - 6.0.312
         - 6.0.400
         - 6.0.408
         - 6.0.419
         - 6.0.424
         - 6.0.486
-        - 7.0 Release Candidate 1
-        - 7.0 Release Candidate 2
         - 7.0 (current)
+        - 8.0 previews
         - Unknown/Other (please specify)
     validations:
       required: true
@@ -64,15 +61,13 @@ body:
       label: Last version that worked well
       description: Is there a version on which this _did_ work? If yes, which one? If no or unknown, please select `Unknown/Other`.  Run `dotnet workload list` to find your version.
       options:
-        - 6.0 Release Candidate 2 or older
-        - 6.0 Release Candidate 3
         - 6.0.312
         - 6.0.400
         - 6.0.408
         - 6.0.419
         - 6.0.424
-        - 7.0 Release Candidate 1
-        - 7.0 Release Candidate 2
+        - 7.0 (current)
+        - 8.0 previews
         - Unknown/Other
     validations:
       required: true


### PR DESCRIPTION
Removed old 6.0 versions and 7.0 previews. Added new 8.0 item so we don't have to rush when the first 8.0 previews are out.