### PR TITLE
[Essentials] add Bluetooth permissions

### DIFF
--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -195,6 +195,37 @@ namespace Microsoft.Maui.ApplicationModel
 				Task.FromResult(IsDeclaredInManifest(Manifest.Permission.BatteryStats) ? PermissionStatus.Granted : PermissionStatus.Denied);
 		}
 
+		public partial class Bluetooth : BasePlatformPermission
+		{
+			public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+			{
+				get
+				{
+					var permissions = new List<(string, bool)>();
+
+					// When targeting Android 11 or lower, AccessFineLocation is required for Bluetooth.
+					// For Android 12 and above, it is optional.
+					if (Application.Context.ApplicationInfo.TargetSdkVersion <= BuildVersionCodes.R || IsDeclaredInManifest(Manifest.Permission.AccessFineLocation))
+						permissions.Add((Manifest.Permission.AccessFineLocation, true));
+
+#if __ANDROID_31__
+					if (OperatingSystem.IsAndroidVersionAtLeast(31) && Application.Context.ApplicationInfo.TargetSdkVersion >= BuildVersionCodes.S)
+					{
+						// new runtime permissions on Android 12
+						if (IsDeclaredInManifest(Manifest.Permission.BluetoothScan))
+							permissions.Add((Manifest.Permission.BluetoothScan, true));
+						if (IsDeclaredInManifest(Manifest.Permission.BluetoothConnect))
+							permissions.Add((Manifest.Permission.BluetoothConnect, true));
+						if (IsDeclaredInManifest(Manifest.Permission.BluetoothAdvertise))
+							permissions.Add((Manifest.Permission.BluetoothAdvertise, true));
+					}
+#endif
+
+					return permissions.ToArray();
+				}
+			}
+		}
+
 		public partial class CalendarRead : BasePlatformPermission
 		{
 			public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>

--- a/src/Essentials/src/Permissions/Permissions.ios.tvos.watchos.cs
+++ b/src/Essentials/src/Permissions/Permissions.ios.tvos.watchos.cs
@@ -59,6 +59,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class Bluetooth : BasePlatformPermission
+		{
+		}
+
 		public partial class CalendarRead : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/Permissions/Permissions.macos.cs
+++ b/src/Essentials/src/Permissions/Permissions.macos.cs
@@ -68,6 +68,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class Bluetooth : BasePlatformPermission
+		{
+		}
+
 		public partial class CalendarRead : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/Permissions/Permissions.netstandard.cs
+++ b/src/Essentials/src/Permissions/Permissions.netstandard.cs
@@ -27,6 +27,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class Bluetooth : BasePlatformPermission
+		{
+		}
+
 		public partial class CalendarRead : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/Permissions/Permissions.shared.cs
+++ b/src/Essentials/src/Permissions/Permissions.shared.cs
@@ -124,6 +124,13 @@ namespace Microsoft.Maui.ApplicationModel
 		}
 
 		/// <summary>
+		/// Represents permission to communicate via Bluetooth (scanning, connecting and/or advertising).
+		/// </summary>
+		public partial class Bluetooth
+		{
+		}
+
+		/// <summary>
 		/// Represents permission to read the device calendar information.
 		/// </summary>
 		public partial class CalendarRead

--- a/src/Essentials/src/Permissions/Permissions.tizen.cs
+++ b/src/Essentials/src/Permissions/Permissions.tizen.cs
@@ -90,6 +90,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class Bluetooth : BasePlatformPermission
+		{
+		}
+
 		public partial class CalendarRead : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/Permissions/Permissions.uwp.cs
+++ b/src/Essentials/src/Permissions/Permissions.uwp.cs
@@ -60,6 +60,10 @@ namespace Microsoft.Maui.ApplicationModel
 		{
 		}
 
+		public partial class Bluetooth : BasePlatformPermission
+		{
+		}
+
 		public partial class CalendarRead : BasePlatformPermission
 		{
 		}

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Shipped.txt
@@ -78,6 +78,7 @@
 ~override Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission.RequestAsync() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
 ~override Microsoft.Maui.ApplicationModel.Permissions.Battery.CheckStatusAsync() -> System.Threading.Tasks.Task<Microsoft.Maui.ApplicationModel.PermissionStatus>
 ~override Microsoft.Maui.ApplicationModel.Permissions.Battery.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
+~override Microsoft.Maui.ApplicationModel.Permissions.Bluetooth.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
 ~override Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
 ~override Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
 ~override Microsoft.Maui.ApplicationModel.Permissions.Camera.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]
@@ -396,6 +397,8 @@ Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission
 Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission.BasePlatformPermission() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Battery
 Microsoft.Maui.ApplicationModel.Permissions.Battery.Battery() -> void
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth.Bluetooth() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.CalendarRead() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Shipped.txt
@@ -395,6 +395,8 @@ Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission
 Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission.BasePlatformPermission() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Battery
 Microsoft.Maui.ApplicationModel.Permissions.Battery.Battery() -> void
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth.Bluetooth() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.CalendarRead() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Shipped.txt
@@ -395,6 +395,8 @@ Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission
 Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission.BasePlatformPermission() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Battery
 Microsoft.Maui.ApplicationModel.Permissions.Battery.Battery() -> void
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth.Bluetooth() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.CalendarRead() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -361,6 +361,8 @@ Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission
 Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission.BasePlatformPermission() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Battery
 Microsoft.Maui.ApplicationModel.Permissions.Battery.Battery() -> void
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth.Bluetooth() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.CalendarRead() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Shipped.txt
@@ -358,6 +358,8 @@ Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission
 Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission.BasePlatformPermission() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Battery
 Microsoft.Maui.ApplicationModel.Permissions.Battery.Battery() -> void
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth.Bluetooth() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.CalendarRead() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Shipped.txt
@@ -346,6 +346,8 @@ Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission
 Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission.BasePlatformPermission() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Battery
 Microsoft.Maui.ApplicationModel.Permissions.Battery.Battery() -> void
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth.Bluetooth() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.CalendarRead() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Shipped.txt
@@ -346,6 +346,8 @@ Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission
 Microsoft.Maui.ApplicationModel.Permissions.BasePlatformPermission.BasePlatformPermission() -> void
 Microsoft.Maui.ApplicationModel.Permissions.Battery
 Microsoft.Maui.ApplicationModel.Permissions.Battery.Battery() -> void
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth
+Microsoft.Maui.ApplicationModel.Permissions.Bluetooth.Bluetooth() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead
 Microsoft.Maui.ApplicationModel.Permissions.CalendarRead.CalendarRead() -> void
 Microsoft.Maui.ApplicationModel.Permissions.CalendarWrite


### PR DESCRIPTION
### Description of Change

* Android 12 (S) / API 31 has a new Bluetooth permission scheme (to be requested at runtime)
* there are three different flavors; we request those that are present in the manifest
* for older Android versions, there are no runtime permissions for Bluetooth, but Bluetooth requires location permission

### Issues Fixed

Fixes #12264

