### PR TITLE
Use the correct property when asking the UICollectionViewLayout to update

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/HeightConstrainedTemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/HeightConstrainedTemplatedCell.cs
@@ -20,18 +20,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override (bool, Size) NeedsContentSizeUpdate(Size currentSize)
 		{
-			var size = Size.Zero;
-
 			if (PlatformHandler?.VirtualView == null)
 			{
-				return (false, size);
+				return (false, currentSize);
 			}
 
 			var bounds = PlatformHandler.VirtualView.Frame;
 
 			if (bounds.Width <= 0 || bounds.Height <= 0)
 			{
-				return (false, size);
+				return (false, currentSize);
 			}
 
 			var desiredBounds = PlatformHandler.VirtualView.Measure(double.PositiveInfinity, bounds.Height);
@@ -39,8 +37,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (desiredBounds.Width == currentSize.Width)
 			{
 				// Nothing in the cell needs more room, so leave it as it is
-				return (false, size);
+				return (false, currentSize);
 			}
+
+			// Keep the current height in the updated content size
+			desiredBounds.Height = bounds.Height;
 
 			return (true, desiredBounds);
 		}

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -16,7 +16,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public IItemsViewSource ItemsSource { get; protected set; }
 		public TItemsView ItemsView { get; }
+
+		// ItemsViewLayout provides an accessor to the typed UICollectionViewLayout. It's also important to note that the
+		// initial UICollectionViewLayout which is passed in to the ItemsViewController (and accessed via the Layout property)
+		// _does not_ get updated when the layout is updated for the CollectionView. That property only refers to the
+		// original layout. So it's unlikely that you would ever want to use .Layout; use .ItemsViewLayout instead.
+		// See https://developer.apple.com/documentation/uikit/uicollectionviewcontroller/1623980-collectionviewlayout
 		protected ItemsViewLayout ItemsViewLayout { get; set; }
+				
 		bool _initialized;
 		bool _isEmpty = true;
 		bool _emptyViewDisplayed;
@@ -303,7 +310,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			{
 				if (cell == visibleCells[n])
 				{
-					Layout?.InvalidateLayout();
+					ItemsViewLayout?.InvalidateLayout();
 					return;
 				}
 			}

--- a/src/Controls/src/Core/Handlers/Items/iOS/WidthConstrainedTemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/WidthConstrainedTemplatedCell.cs
@@ -20,18 +20,16 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override (bool, Size) NeedsContentSizeUpdate(Size currentSize)
 		{
-			var size = Size.Zero;
-
 			if (PlatformHandler?.VirtualView == null)
 			{
-				return (false, size);
+				return (false, currentSize);
 			}
 
 			var bounds = PlatformHandler.VirtualView.Frame;
 
 			if (bounds.Width <= 0 || bounds.Height <= 0)
 			{
-				return (false, size);
+				return (false, currentSize);
 			}
 
 			var desiredBounds = PlatformHandler.VirtualView.Measure(bounds.Width, double.PositiveInfinity);
@@ -39,8 +37,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			if (desiredBounds.Height == currentSize.Height)
 			{
 				// Nothing in the cell needs more room, so leave it as it is
-				return (false, size);
+				return (false, currentSize);
 			}
+
+			// Keep the current width in the updated content size
+			desiredBounds.Width = bounds.Width;
 
 			return (true, desiredBounds);
 		}


### PR DESCRIPTION
### Description of Change

The ItemsViewController correctly watches for cell content size updates and attempts to invalidate the layout when they occur. Unfortunately, it's asking the wrong UICollectionViewLayout to update. The `Layout` property on UICollectionViewController always refers to the UICollectionViewLayout with which the controller was constructed; that property does not update when the layout is updated (https://developer.apple.com/documentation/uikit/uicollectionviewcontroller/1623980-collectionviewlayout). So while the `ItemsViewLayout` property is up-to-date, `Layout` is not. 

These changes invalidate the layout of the `ItemsViewLayout` instead of `Layout`, which allows the cell sizes to update. They also avoid caching some incorrect sizes (and asking for extra updates) when determining cell content size changes. 

### Issues Fixed

Fixes #3643
