### PR TITLE
Toggle IsEnabled on Layout children when IsEnabled changes, Version 2

### DIFF
--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -328,19 +328,19 @@ namespace Microsoft.Maui.Controls
 
 		internal static void MapIsEnabled(ILayoutHandler handler, Layout layout)
 		{
-			layout.UpdateDescendantIsEnabled();
+			layout.UpdateDescendantsEnabled();
 		}
 
-		void UpdateDescendantIsEnabled() 
+		void UpdateDescendantsEnabled() 
 		{
 			var isEnabled = IsEnabled;
 
-			// Set all the child IsEnabled values to match this one
+			// Let all the child views know they should update their IsEnabled mappings
 			for (int n = 0; n < Count; n++)
 			{
 				if (this[n] is VisualElement visualElement)
 				{
-					visualElement.IsEnabled = isEnabled;
+					visualElement.Handler?.UpdateValue(nameof(IsEnabled));
 				}
 			}
 		}

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -305,6 +305,7 @@ namespace Microsoft.Maui.Controls
 		{
 			[nameof(CascadeInputTransparent)] = MapInputTransparent,
 			[nameof(IView.InputTransparent)] = MapInputTransparent,
+			[nameof(IView.IsEnabled)] = MapIsEnabled,
 		};
 
 		void UpdateDescendantInputTransparent()
@@ -321,6 +322,25 @@ namespace Microsoft.Maui.Controls
 				if (this[n] is VisualElement visualElement)
 				{
 					visualElement.InputTransparent = true;
+				}
+			}
+		}
+
+		internal static void MapIsEnabled(ILayoutHandler handler, Layout layout)
+		{
+			layout.UpdateDescendantIsEnabled();
+		}
+
+		void UpdateDescendantIsEnabled() 
+		{
+			var isEnabled = IsEnabled;
+
+			// Set all the child IsEnabled values to match this one
+			for (int n = 0; n < Count; n++)
+			{
+				if (this[n] is VisualElement visualElement)
+				{
+					visualElement.IsEnabled = isEnabled;
 				}
 			}
 		}

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateIsEnabled(this AView platformView, IView view)
 		{
-			platformView.Enabled = view.IsEnabled;
+			var ancestorsEnabled = AreAncestorsEnabled(view);
+			platformView.Enabled = view.IsEnabled && ancestorsEnabled;
 		}
 
 		public static void Focus(this AView platformView, FocusRequest request)

--- a/src/Core/src/Platform/ViewExtensions.cs
+++ b/src/Core/src/Platform/ViewExtensions.cs
@@ -117,5 +117,20 @@ namespace Microsoft.Maui.Platform
 			return taskCompletionSource.Task.WaitAsync(timeOut.Value);
 		}
 #endif
+
+		static bool AreAncestorsEnabled(IView view)
+		{
+			if (view.Parent is IView parentView)
+			{
+				if (!parentView.IsEnabled)
+				{
+					return false;
+				}
+
+				return AreAncestorsEnabled(parentView);
+			}
+
+			return true;
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/ViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/ViewExtensions.cs
@@ -27,8 +27,11 @@ namespace Microsoft.Maui.Platform
 				FocusManager.TryMoveFocus(direction, new FindNextElementOptions { SearchRoot = elem });
 		}
 
-		public static void UpdateIsEnabled(this FrameworkElement platformView, IView view) =>
-			(platformView as Control)?.UpdateIsEnabled(view.IsEnabled);
+		public static void UpdateIsEnabled(this FrameworkElement platformView, IView view)
+		{
+			var ancestorsEnabled = AreAncestorsEnabled(view);
+			(platformView as Control)?.UpdateIsEnabled(view.IsEnabled && ancestorsEnabled);
+		}
 
 		public static void Focus(this FrameworkElement platformView, FocusRequest request)
 		{

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Maui.Platform
 			if (platformView is not UIControl uiControl)
 				return;
 
-			uiControl.Enabled = view.IsEnabled;
+			var ancestorsEnabled = AreAncestorsEnabled(view);
+			uiControl.Enabled = view.IsEnabled && ancestorsEnabled;
 		}
 
 		public static void Focus(this UIView platformView, FocusRequest request)


### PR DESCRIPTION
### Description of Change

Alternative to #12365 

This version leaves any bound/set values for IsEnabled on VisualElement alone, but the mapping to the platform disabled value takes into account any disabled value in an ancestor container. 

Draft for now, because it's late on a Friday. I'll add tests and flesh it all out next week. Obviously it needs to update values when child views are added/removed to/from the layouts. 

### Issues Fixed

Fixes #5287

