### PR TITLE
[Windows] Fix Slider crash using the same Minimum, Maximum value

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/SliderPage.xaml
@@ -67,9 +67,16 @@
                     Clicked="OnUpdateMinimumButtonClicked" />
                 <Button
                     Text="Update Maximum"
-                    Clicked="OnUpdateMaximumButtonClicked" /> 
-            </HorizontalStackLayout>
-        </VerticalStackLayout>
+                    Clicked="OnUpdateMaximumButtonClicked" />
+                </HorizontalStackLayout>
+                <Label
+                    Text="Edge case - Same Minimum, Maximum and Value"
+                    Style="{StaticResource Headline}"/>
+                <Slider 
+                    Maximum="100"
+                    Minimum="100" 
+                    Value="100" />
+            </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>
 </views:BasePage>

--- a/src/Core/src/Platform/Windows/SliderExtensions.cs
+++ b/src/Core/src/Platform/Windows/SliderExtensions.cs
@@ -9,7 +9,14 @@ namespace Microsoft.Maui.Platform
 	{
 		static void UpdateIncrement(this Slider nativeSlider, ISlider slider)
 		{
-			double stepping = Math.Min((slider.Maximum - slider.Minimum) / 1000, 1);
+			var difference = slider.Maximum - slider.Minimum;
+
+			double stepping = 1;
+
+			// Setting the Slider SmallChange property to 0 would throw an System.ArgumentException.
+			if (difference != 0)
+				stepping = Math.Min((difference) / 1000, 1);
+
 			nativeSlider.StepFrequency = stepping;
 			nativeSlider.SmallChange = stepping;
 		}

--- a/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.Windows.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.UI.Xaml.Controls;
 using Xunit;
 
@@ -6,6 +7,34 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class SliderHandlerTests
 	{
+		// https://github.com/dotnet/maui/issues/12405
+		[Theory(DisplayName = "Platform Slider SmallChange Initializes Correctly")]
+		[InlineData(0, 1, 0)]
+		[InlineData(0, 1, 0.5)]
+		[InlineData(0, 1, 1)]
+		[InlineData(0, 100, 0)]
+		[InlineData(0, 100, 1)]
+		[InlineData(0, 100, 5)]
+		[InlineData(0, 100, 50)]
+		[InlineData(0, 100, 100)]
+		[InlineData(0, 100, 10000)]
+		[InlineData(0, 100, -10000)]
+		[InlineData(0, 10000, 10000)]
+		[InlineData(0, 10000, -10000)]
+		public async Task SmallChangeInitializesCorrectly(double min, double max, double value)
+		{
+			var slider = new SliderStub()
+			{
+				Maximum = max,
+				Minimum = min,
+				Value = value
+			};
+
+			var expected = await GetValueAsync(slider, GetSmallChange);
+		
+			Assert.True(expected != 0);
+		}
+
 		Slider GetNativeSlider(SliderHandler sliderHandler) =>
 			sliderHandler.PlatformView;
 
@@ -17,5 +46,8 @@ namespace Microsoft.Maui.DeviceTests
 
 		double GetNativeMaximum(SliderHandler sliderHandler) =>
 			GetNativeSlider(sliderHandler).Maximum;
+
+		double GetSmallChange(SliderHandler sliderHandler) =>
+		GetNativeSlider(sliderHandler).SmallChange;
 	}
 }


### PR DESCRIPTION
### Description of Change

Fix WinUI Slider edge case setting the **SmallChange** property from Minimum and Maximum values.

![image](https://user-images.githubusercontent.com/6755973/211308528-ed71a20d-7699-4913-b8ec-cf8a592009ea.png)

### Issues Fixed

Fixes #12405 