### PR TITLE
Fixed a typo on the Display Info Width documentation

### DIFF
--- a/src/Essentials/docs/Microsoft.Maui.Essentials/DisplayInfo.xml
+++ b/src/Essentials/docs/Microsoft.Maui.Essentials/DisplayInfo.xml
@@ -320,7 +320,7 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the width of the scrreen for the current orientation.</summary>
+        <summary>Gets the width of the screen for the current orientation.</summary>
         <value>The width in pixels.</value>
         <remarks></remarks>
       </Docs>

--- a/src/Essentials/docs/en/Xamarin.Essentials/DisplayInfo.xml
+++ b/src/Essentials/docs/en/Xamarin.Essentials/DisplayInfo.xml
@@ -320,7 +320,7 @@
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the width of the scrreen for the current orientation.</summary>
+        <summary>Gets the width of the screen for the current orientation.</summary>
         <value>The width in pixels.</value>
         <remarks></remarks>
       </Docs>


### PR DESCRIPTION
### Description of Change

This change fixes a minor typo on the word "scrreen" from the documentation on the `Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo.Width `

### Issues Fixed

The word changed from "scrreen" to "screen"

Fixes #

No issue related.
