### PR TITLE
[iOS] ItemsViewController add `_measurementCells` null checks

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 			if (_isEmpty)
 			{
-				_measurementCells.Clear();
+				_measurementCells?.Clear();
 				ItemsViewLayout?.ClearCellSizeCache();
 			}
 
@@ -222,7 +222,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public virtual void UpdateItemsSource()
 		{
-			_measurementCells.Clear();
+			_measurementCells?.Clear();
 			ItemsViewLayout?.ClearCellSizeCache();
 			ItemsSource?.Dispose();
 			ItemsSource = CreateItemsViewSource();
@@ -266,7 +266,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var bindingContext = ItemsSource[indexPath];
 
 			// If we've already created a cell for this index path (for measurement), re-use the content
-			if (_measurementCells.TryGetValue(bindingContext, out TemplatedCell measurementCell))
+			if (_measurementCells != null && _measurementCells.TryGetValue(bindingContext, out TemplatedCell measurementCell))
 			{
 				_measurementCells.Remove(bindingContext);
 				measurementCell.ContentSizeChanged -= CellContentSizeChanged;
@@ -613,7 +613,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			UpdateTemplatedCell(templatedCell, indexPath);
 
 			// Keep this cell around, we can transfer the contents to the actual cell when the UICollectionView creates it
-			_measurementCells[ItemsSource[indexPath]] = templatedCell;
+			if (_measurementCells != null)
+				_measurementCells[ItemsSource[indexPath]] = templatedCell;
 
 			return templatedCell;
 		}


### PR DESCRIPTION
### Description of Change

This is a port of a fix in Xamarin.Forms: https://github.com/xamarin/Xamarin.Forms/pull/15638

Original comment:

> In the `ItemsViewController` multiple methods (i.e. `UICollectionViewController.GetCell()` which calls `ItemsViewController.UpdateTemplatedCell()` and `UICollectionViewController.GetItemsCount()` and `UICollectionViewController.NumberOfSections()` which both call `ItemsViewController.CheckForEmptySource()`) can be called by iOS after `ItemsViewController.Dispose()` has been called and `_measurementCells` has been set to `null`. There are already null checks for `_measurementCells` in certain places, but not all. This should cover the rest of the cases where it can be null.

Original issue: https://github.com/xamarin/Xamarin.Forms/issues/15637
