### PR TITLE
Disable WinUI optional extras by default

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -5,6 +5,8 @@
     <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' == 'WinExe' ">MSIX</WindowsPackageType>
     <WindowsAppSDKSelfContained Condition=" '$(WindowsAppSDKSelfContained)' == '' and '$(WindowsPackageType)' == 'None' and '$(OutputType)' == 'WinExe' ">true</WindowsAppSDKSelfContained>
     <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
+    <WindowsAppSdkDeploymentManagerInitialize Condition=" '$(WindowsAppSdkDeploymentManagerInitialize)' == '' and '$(EnableMsixTooling)' == 'true' ">false</WindowsAppSdkDeploymentManagerInitialize>
+    <WindowsAppSdkUndockedRegFreeWinRTInitialize Condition=" '$(WindowsAppSdkUndockedRegFreeWinRTInitialize)' == '' and '$(EnableMsixTooling)' == 'true' ">false</WindowsAppSdkUndockedRegFreeWinRTInitialize>
     <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
     <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and '$(Configuration)' == 'Release' and '$(OutputType)' != '' and '$(OutputType)' != 'Library' ">true</PublishReadyToRun>
     <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>


### PR DESCRIPTION



### Description of Change

It appears to be related to Windows App SDK target ordering but since we set the `WindowsPackageType` to `MSIX`, it triggers a set of operations and defaults that we do not want. By not specifying anything vs specifying MSIX (what we want) we get different behavior for the "same" thing.

As a result this PR sets the desired defaults back to what they would have been had we not set MSIX.

The reason for `WindowsAppSdkDeploymentManagerInitialize` is because the deployment manager is a module initializer and thus causes OPTIONAL things to be needed. If you still want it, then you still can set `<WindowsAppSdkDeploymentManagerInitialize>true</WindowsAppSdkDeploymentManagerInitialize>` in your csproj.

### Issues Fixed

Works around https://github.com/microsoft/microsoft-ui-xaml/issues/8182
Avoids https://github.com/dotnet/maui/issues/12080

