### PR TITLE
Correctly propagate BindingContext in all ContentView scenarios

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ContentViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ContentViewPage.xaml
@@ -10,6 +10,9 @@
         <ScrollView>
             <StackLayout
                 Padding="12">
+                <Label
+                    Text="Default"
+                    Style="{StaticResource Headline}"/>
                 <controls:CardView 
                     BorderColor="DarkGray"
                     CardTitle="Slavko Vlasic"
@@ -34,6 +37,27 @@
                     CardDescription="In pellentesque odio eget augue elementum lobortis. Sed augue massa, rhoncus eu nisi vitae, egestas."
                     IconBackgroundColor="SlateGray"
                     IconImageSource="dotnet_bot.png" />
+                <Label
+                    Text="BindingContext"
+                    Style="{StaticResource Headline}"/>
+                <Label 
+                    Text="Content" />
+                <ContentView>
+                    <ContentView.Content>
+                        <Label 
+                            Text="{Binding Text}" />
+                    </ContentView.Content>
+                </ContentView>
+                <Label 
+                    Text="ControlTemplate" />
+                <ContentView>
+                    <ContentView.ControlTemplate>
+                        <ControlTemplate>
+                            <Label 
+                                Text="{Binding Text}" />
+                        </ControlTemplate>
+                    </ContentView.ControlTemplate>
+                </ContentView>
             </StackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ContentViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ContentViewPage.xaml.cs
@@ -5,6 +5,31 @@
 		public ContentViewPage()
 		{
 			InitializeComponent();
+
+			BindingContext = new ContentViewModel();
+		}
+	}
+
+	public class ContentViewModel : BindableObject
+	{
+		private string _text;
+
+		public MainViewModel()
+		{
+			_text = "Content";
+		}
+
+		public string Text
+		{
+			get => _text;
+			set
+			{
+				if (_text != value)
+				{
+					_text = value;
+					OnPropertyChanged();
+				}
+			}
 		}
 	}
 }

--- a/src/Controls/samples/Controls.Sample/Pages/Layouts/ContentViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Layouts/ContentViewPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace Maui.Controls.Sample.Pages
+﻿using Microsoft.Maui.Controls;
+
+namespace Maui.Controls.Sample.Pages
 {
 	public partial class ContentViewPage
 	{
@@ -14,7 +16,7 @@
 	{
 		private string _text;
 
-		public MainViewModel()
+		public ContentViewModel()
 		{
 			_text = "Content";
 		}

--- a/src/Controls/src/Core/ContentView.cs
+++ b/src/Controls/src/Core/ContentView.cs
@@ -21,12 +21,15 @@ namespace Microsoft.Maui.Controls
 		{
 			base.OnBindingContextChanged();
 
-			View content = Content;
+			IView content = Content;
+
+			if (content == null && (this as IContentView)?.PresentedContent is IView presentedContent)
+				content = presentedContent;
+
 			ControlTemplate controlTemplate = ControlTemplate;
-			if (content != null && controlTemplate != null)
-			{
-				SetInheritedBindingContext(content, BindingContext);
-			}
+
+			if (content is BindableObject bindableContent && controlTemplate != null)
+				SetInheritedBindingContext(bindableContent, BindingContext);
 		}
 
 		internal override void OnControlTemplateChanged(ControlTemplate oldValue, ControlTemplate newValue)

--- a/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.cs
@@ -51,5 +51,30 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.True(GetContentChildCount(contentViewHandler) == 3);
 			});
 		}
+
+		[Fact]
+		public async Task PropagateContextCorrectly()
+		{
+			SetupBuilder();
+
+			var bindingContext = new object();
+			
+			var child = new Label { Text = "Content 1" };
+
+			var contentView = new Microsoft.Maui.Controls.ContentView
+			{
+				BindingContext = bindingContext
+			};
+
+			var contentViewHandler = await CreateHandlerAsync<ContentViewHandler>(contentView);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				contentView.Content = child;
+				Assert.True(GetChildCount(contentViewHandler) == 1);
+				Assert.True(GetContentChildCount(contentViewHandler) == 0);
+				Assert.True(child.BindingContext == bindingContext);
+			});
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/ContentView/ContentViewTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.DeviceTests
 			await InvokeOnMainThreadAsync(() =>
 			{
 				contentView.Content = child;
-				Assert.True(GetChildCount(contentViewHandler) == 1);
+				Assert.Equal(1, GetChildCount(contentViewHandler));
 				Assert.True(GetContentChildCount(contentViewHandler) == 0);
 				Assert.True(child.BindingContext == bindingContext);
 			});


### PR DESCRIPTION
### Description of Change

Correctly propagate BindingContext in all ContentView scenarios.

### Issues Fixed

Fixes #12470 