### PR TITLE
[Android] Avoid to update Shell Toolbar colors if already disposed the Tracker

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarAppearanceTracker.cs
@@ -33,9 +33,17 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 		protected virtual void SetColors(AToolbar toolbar, IShellToolbarTracker toolbarTracker, Color foreground, Color background, Color title)
 		{
-			_shellContext.Shell.Toolbar.BarTextColor = title ?? ShellRenderer.DefaultTitleColor;
-			_shellContext.Shell.Toolbar.BarBackground = new SolidColorBrush(background ?? ShellRenderer.DefaultBackgroundColor);
-			_shellContext.Shell.Toolbar.IconColor = foreground ?? ShellRenderer.DefaultForegroundColor;
+			if (_disposed)
+				return;
+
+			Toolbar shellToolbar = _shellContext.Shell.Toolbar;
+
+			if (shellToolbar == null)
+				return;
+
+			shellToolbar.BarTextColor = title ?? ShellRenderer.DefaultTitleColor;
+			shellToolbar.BarBackground = new SolidColorBrush(background ?? ShellRenderer.DefaultBackgroundColor);
+			shellToolbar.IconColor = foreground ?? ShellRenderer.DefaultForegroundColor;
 		}
 
 		#region IDisposable

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarAppearanceTracker.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			if (_disposed)
 				return;
 
-			Toolbar shellToolbar = _shellContext.Shell.Toolbar;
+			Toolbar shellToolbar = _shellContext?.Shell?.Toolbar;
 
 			if (shellToolbar is null)
 				return;

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarAppearanceTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarAppearanceTracker.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			Toolbar shellToolbar = _shellContext.Shell.Toolbar;
 
-			if (shellToolbar == null)
+			if (shellToolbar is null)
 				return;
 
 			shellToolbar.BarTextColor = title ?? ShellRenderer.DefaultTitleColor;


### PR DESCRIPTION
### Description of Change

Avoid to update Shell Toolbar colors if already disposed the AppareanceTracker.

### Issues Fixed

Fixes #12460 
