### PR TITLE
Fix MenuFlyoutSubItemHandler to actually call MapIsEnabled

### DIFF
--- a/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.cs
+++ b/src/Core/src/Handlers/MenuFlyoutSubItem/MenuFlyoutSubItemHandler.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Maui.Handlers
 		{
 #if WINDOWS
 			[nameof(IMenuFlyoutSubItem.Text)] = MapText,
-			[nameof(IMenuFlyoutSubItem.Source)] = MapSource
+			[nameof(IMenuFlyoutSubItem.Source)] = MapSource,
+			[nameof(IMenuFlyoutSubItem.IsEnabled)] = MapIsEnabled,
 #endif
 		};
 


### PR DESCRIPTION
### Description of Change

Appears this one was missing from the mapper.