### PR TITLE
added monochrome element to the AdaptiveIconDrawableXml

### DIFF
--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Maui.Resizetizer
 <adaptive-icon xmlns:android=""http://schemas.android.com/apk/res/android"">
 	<background android:drawable=""@mipmap/{name}_background""/>
 	<foreground android:drawable=""@mipmap/{name}_foreground""/>
+	<monochrome android:drawable=""@mipmap/{name}_foreground"" />
 </adaptive-icon>";
 
 		public IEnumerable<ResizedImageInfo> Generate()


### PR DESCRIPTION


### Description of Change

To supporting user theming of app icons I've added the monochrome element to the AdaptiveIconDrawableXml.
And set it to the foreground icon.
### Issues Fixed

I've tried to add a Icon for a maui app and check the compatibility with custom user themed icons. 
But the icon didn't changed.
Tested in a emulator with Android 13 (API33)

Fixes #

After checking the ipmap-anydpi-v26/{outputName}.xml I've noticed that the monochrome element is missing according to the [Android Docuumentation](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive#add_your_adaptive_icon_to_your_app).
When I added the missing element to the AdaptiveIconDrawableXml my icon changed according to the selected icon theme.