### PR TITLE
Fix shapes and maps types collisions on XAML

### DIFF
--- a/src/Controls/Maps/src/Properties/AssemblyInfo.cs
+++ b/src/Controls/Maps/src/Properties/AssemblyInfo.cs
@@ -3,5 +3,5 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Internals;
 
 [assembly: Preserve]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui", "Microsoft.Maui.Controls.Maps", AssemblyName = "Microsoft.Maui.Controls.Maps")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui", "Microsoft.Maui.Maps", AssemblyName = "Microsoft.Maui.Maps")]
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui/maps", "Microsoft.Maui.Controls.Maps", AssemblyName = "Microsoft.Maui.Controls.Maps")]
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui/maps", "Microsoft.Maui.Maps", AssemblyName = "Microsoft.Maui.Maps")]

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/BasicMapGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/BasicMapGallery.xaml
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d"
-             x:Class="Maui.Controls.Sample.Pages.MapsGalleries.BasicMapGallery"
-             Title="Basic Map">
-
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+    mc:Ignorable="d"
+    x:Class="Maui.Controls.Sample.Pages.MapsGalleries.BasicMapGallery"
+    Title="Basic Map">
     <Grid RowDefinitions="Auto, Auto, *">
         <HorizontalStackLayout Grid.Row="0">
             <Switch x:Name="ShowUserLocationSwitch" Margin="5"/>
@@ -20,7 +21,7 @@
             <Switch x:Name="ScrollEnabledSwitch" Margin="5" IsToggled="True"/>
             <Label Text="Scroll enabled" VerticalOptions="Center"/>
         </HorizontalStackLayout>
-        <Map x:Name="basicMap" Grid.Row="2" 
+        <maps:Map x:Name="basicMap" Grid.Row="2" 
              IsShowingUser="{Binding IsToggled, Source={x:Reference ShowUserLocationSwitch}}"
              IsTrafficEnabled="{Binding IsToggled, Source={x:Reference ShowTrafficSwitch}}"
              IsZoomEnabled="{Binding IsToggled, Source={x:Reference ZoomEnabledSwitch}}"

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CircleGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/CircleGallery.xaml
@@ -3,11 +3,12 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Maui.Controls.Sample.Pages.MapsGalleries.CircleGallery"
+    xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
     xmlns:sensors="clr-namespace:Microsoft.Maui.Devices.Sensors;assembly=Microsoft.Maui.Essentials"
     Title="Circle Gallery">
-    <Map>
+    <maps:Map>
         <x:Arguments>
-            <MapSpan>
+            <maps:MapSpan>
                 <x:Arguments>
                     <sensors:Location>
                         <x:Arguments>
@@ -18,28 +19,28 @@
                     <x:Double>0.01</x:Double>
                     <x:Double>0.01</x:Double>
                 </x:Arguments>
-            </MapSpan>
+            </maps:MapSpan>
         </x:Arguments>
-        <Map.MapElements>
-            <Circle StrokeColor="#88FF0000"
+        <maps:Map.MapElements>
+            <maps:Circle StrokeColor="#88FF0000"
                          StrokeWidth="8"
                          FillColor="#88FFC0CB">
-                <Circle.Center>
+                <maps:Circle.Center>
                     <sensors:Location>
                         <x:Arguments>
                             <x:Double>37.79752</x:Double>
                             <x:Double>-122.40183</x:Double>
                         </x:Arguments>
                     </sensors:Location>
-                </Circle.Center>
-                <Circle.Radius>
-                    <Distance>
+                </maps:Circle.Center>
+                <maps:Circle.Radius>
+                    <maps:Distance>
                         <x:Arguments>
                             <x:Double>250</x:Double>
                         </x:Arguments>
-                    </Distance>
-                </Circle.Radius>
-            </Circle>
-        </Map.MapElements>
-    </Map>
+                    </maps:Distance>
+                </maps:Circle.Radius>
+            </maps:Circle>
+        </maps:Map.MapElements>
+    </maps:Map>
 </ContentPage>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapPinsGallery.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:maps="clr-namespace:Microsoft.Maui.Controls.Maps;assembly=Microsoft.Maui.Controls.Maps"
     mc:Ignorable="d"
     x:Class="Maui.Controls.Sample.Pages.MapsGalleries.MapPinsGallery"
     Title="Map Pins">
@@ -20,7 +21,7 @@
                 Text="Add 10 Pins" 
                 Clicked="OnAdd10PinsClicked" />
         </HorizontalStackLayout>
-        <Map 
+        <maps:Map 
             x:Name="pinsMap" 
             Grid.Row="1"
             MapClicked="OnMapClicked" />

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapTypeGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/MapTypeGallery.xaml
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d"
-             x:Class="Maui.Controls.Sample.Pages.MapsGalleries.MapTypeGallery"
-             Title="Map Type">
-
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+    mc:Ignorable="d"
+    x:Class="Maui.Controls.Sample.Pages.MapsGalleries.MapTypeGallery"
+    Title="Map Type">
     <Grid 
         RowDefinitions="Auto, Auto, *">
         <HorizontalStackLayout Grid.Row="0">
@@ -30,7 +31,7 @@
             Minimum="1"
             Value="12"
             ValueChanged="OnSliderValueChanged" />
-        <Map 
+        <maps:Map 
             x:Name="mapTypeMap" 
             Grid.Row="2" />
     </Grid>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PinItemsSourceGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PinItemsSourceGallery.xaml
@@ -4,25 +4,26 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:Maui.Controls.Sample.Pages.MapsGalleries"
     x:Class="Maui.Controls.Sample.Pages.MapsGalleries.PinItemsSourceGallery"
+    xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
     Title="Databinding pins Gallery (Collection)">
     <Grid Margin="10,35,10,10">
         <Grid.RowDefinitions>
             <RowDefinition />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Map x:Name="map"
+        <maps:Map x:Name="map"
                   MapClicked="OnMapClicked"
                   ItemsSource="{Binding Locations}">
             <!-- Alternatively, set ItemTemplateSelector to MapItemTemplateSelector -->
-            <Map.ItemTemplate>
+            <maps:Map.ItemTemplate>
                 <DataTemplate>
-                    <Pin 
+                    <maps:Pin 
                         Location="{Binding Position}"
                         Address="{Binding Address}"
                         Label="{Binding Description}" />
                 </DataTemplate>    
-            </Map.ItemTemplate>
-        </Map>
+            </maps:Map.ItemTemplate>
+        </maps:Map>
         <ScrollView Grid.Row="1"
                     Orientation="Horizontal">
             <StackLayout Orientation="Horizontal"

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PolygonsGallery.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/MapsGalleries/PolygonsGallery.xaml
@@ -4,16 +4,16 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:maps="clr-namespace:Microsoft.Maui.Controls.Maps;assembly=Microsoft.Maui.Controls.Maps"
+    xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
     xmlns:sensors="clr-namespace:Microsoft.Maui.Devices.Sensors;assembly=Microsoft.Maui.Essentials"
     mc:Ignorable="d"
     x:Class="Maui.Controls.Sample.Pages.MapsGalleries.PolygonsGallery"
     Title="Polygon/Polyline Gallery">
     <StackLayout>
-        <Map 
+        <maps:Map 
             x:Name="MapElementsMap">
             <x:Arguments>
-                <MapSpan>
+                <maps:MapSpan>
                     <x:Arguments>
                         <sensors:Location>
                             <x:Arguments>
@@ -24,9 +24,9 @@
                         <x:Double>0.1</x:Double>
                         <x:Double>0.1</x:Double>
                     </x:Arguments>
-                </MapSpan>
+                </maps:MapSpan>
             </x:Arguments>
-            <Map.MapElements>
+            <maps:Map.MapElements>
                 <maps:Polygon 
                     StrokeColor="#FF9900"
                     StrokeWidth="8"
@@ -213,8 +213,8 @@
                         </sensors:Location>
                     </maps:Polyline.Geopath>
                 </maps:Polyline>
-            </Map.MapElements>
-        </Map>
+            </maps:Map.MapElements>
+        </maps:Map>
         <Button 
             Text="Clear MapElements"
             Clicked="OnClearMapElementsClicked"/>


### PR DESCRIPTION
### Description of Change

In the xmlns used by Maui we had also registered the Maps libraries. Although it is ideal to use `<Map />` instead of `<maps:Map />` there are types with the same name colliding (for example, Polygon). For that reason, when using Polygon using Maps, it defaults to the type used in Maps and not the shape.

In Xamarin.Forms we do not register maps in the default xmlns requiring to always use a XAML namespace. In .NET MAUI we could do something similar although the work with maps depending on the scenario could be complex. Maps is divided into two namespaces:
-Microsoft.Maui.Controls.Maps
-Microsoft.Maui.Maps

Using maps with polygons would require creating two XAML namespaces and knowing when to use one and another depending on where each type is defined. For this reason, in this PR I move maps to a xmlns that includes all the namespaces used for maps.

With this changes, we also fix the collision:
![image](https://user-images.githubusercontent.com/6755973/211792279-f69f6a25-2ea0-4e52-97ec-5b8da5023e17.png)

However, this is a **breaking** change.

### Issues Fixed

Fixes #12364 