### PR TITLE
Allow to dynamically add/remove the Frame content

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml
@@ -90,6 +90,52 @@
                         Aspect="AspectFill"
                         Source="cover1.jpg" />
                 </Frame>
+                <Label
+                    Text="Content"
+                    Style="{StaticResource Headline}"/>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Button 
+                        Grid.Row="0" 
+                        Grid.Column="0" 
+                        x:Name="AddContentButton" 
+                        Text="Add Content" 
+                        Clicked="OnAddContentButtonClicked"
+                        Margin="10" />
+                    <Button 
+                        Grid.Row="0" 
+                        Grid.Column="1" 
+                        x:Name="ReplaceContentButton" 
+                        Text="Replace Content" 
+                        Clicked="OnReplaceContentButtonClicked"
+                        Margin="10" />
+                    <Button 
+                        Grid.Row="0" 
+                        Grid.Column="2" 
+                        x:Name="RemoveContentButton" 
+                        Text="Remove Content" 
+                        Clicked="OnRemoveContentButtonClicked"
+                        Margin="10" />
+                    <Frame 
+                        Grid.Row="1" 
+                        Grid.Column="0" 
+                        Grid.ColumnSpan="3" 
+                        x:Name="ContentFrame" 
+                        Padding="0"
+                        BorderColor="Black" 
+                        Margin="10">
+                        <!-- Empty on purpose -->
+                    </Frame>
+                </Grid>
+                
             </VerticalStackLayout>
         </ScrollView>
     </views:BasePage.Content>

--- a/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Compatibility/FramePage.xaml.cs
@@ -1,4 +1,8 @@
-﻿namespace Maui.Controls.Sample.Pages
+﻿using System;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace Maui.Controls.Sample.Pages
 {
 	public partial class FramePage
 	{
@@ -11,5 +15,36 @@
 		{
 			HasShadowFrame.HasShadow = !HasShadowFrame.HasShadow;
 		}
+		
+		void OnAddContentButtonClicked(object sender, EventArgs e)
+		{
+			ContentFrame.Content = new Label 
+			{ 
+				Text= "Content", 
+				HorizontalOptions = LayoutOptions.Center, 
+				VerticalOptions = LayoutOptions.Center, 
+				Margin = 12 
+			};
+		}
+
+		void OnReplaceContentButtonClicked(object sender, EventArgs e)
+		{
+			if (ContentFrame.Content == null)
+				return;
+
+			ContentFrame.Content = new Label
+			{
+				Text = "Updated Content",
+				BackgroundColor = Colors.Red,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Margin = 12
+			};
+		}
+
+		void OnRemoveContentButtonClicked(object sender, EventArgs e)
+		{
+			ContentFrame.Content = null;
+		}
 	}
-}
+}	

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -337,15 +337,13 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		void UpdateContent()
 		{
+			if (ChildCount == 1)
+				RemoveViewAt(0);
+
 			var content = Element?.Content;
 
 			if (content == null || _mauiContext == null)
-			{
-				if (ChildCount == 1)
-					RemoveViewAt(0);
-
 				return;
-			}
 
 			var platformView = content.ToPlatform(_mauiContext);
 			AddView(platformView);

--- a/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Windows/FrameRenderer.cs
@@ -135,7 +135,10 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		void PackChild()
 		{
 			if (Element.Content == null)
+			{
+				Control.Child = null;
 				return;
+			}
 
 			Control.Child = Element.Content.ToPlatform(MauiContext);
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.Android.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+using AndroidX.AppCompat.Widget;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class FrameTests
+	{
+		[Fact(DisplayName = "Update Frame Content Test")]
+		public async Task UpdateFrameContentTest()
+		{
+			SetupBuilder();
+
+			var layout = new StackLayout();
+
+			var frame = new Frame()
+			{
+				HeightRequest = 300,
+				WidthRequest = 300,
+				Content = new Label()
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					Text = "Content"
+				}
+			};
+
+			var button = new Button()
+			{
+				Text = "Remove Frame Content"
+			};
+
+			layout.Add(frame);
+			layout.Add(button);
+
+			var frameContent =
+				await InvokeOnMainThreadAsync(async () =>
+					await frame.ToPlatform(MauiContext).AttachAndRun(() =>
+					{
+						return frame.Content;
+					})
+				);
+
+			Assert.NotNull(frameContent);
+
+			var clicked = false;
+
+			button.Clicked += delegate
+			{
+				frame.Content = null;
+				clicked = true;
+			};
+
+			await PerformClick(button as IButton);
+
+			Assert.True(clicked);
+
+			Assert.Null(frame.Content);
+		}
+
+		Task PerformClick(IButton button)
+		{
+			return InvokeOnMainThreadAsync(() =>
+			{
+				GetNativeButton(CreateHandler<ButtonHandler>(button)).PerformClick();
+			});
+		}
+
+		AppCompatButton GetNativeButton(ButtonHandler buttonHandler) =>
+			buttonHandler.PlatformView;
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Maui.DeviceTests
 				builder.ConfigureMauiHandlers(handlers =>
 				{
 					handlers.AddHandler<StackLayout, LayoutHandler>();
+					handlers.AddHandler<Button, ButtonHandler>();
 					handlers.AddHandler<Entry, EntryHandler>();
 					handlers.AddHandler<Frame, FrameRenderer>();
 					handlers.AddHandler<Frame, FrameRenderer>();


### PR DESCRIPTION
### Description of Change

The current issues (not include iOS where the different actions are working correctly):

| Action      | Android | Windows     |
| :---        |    :----:   |          ---: |
| Add Content      | Works       | Works  |
| Update Content   | Add the new content maintaining the old one        | Works      |
| Remove Content   | Works        | Not working      |

The PRs include changes to fix the wrong cases.

To validate it use the new sample added to the Frame page inside the .NET MAUI Gallery (also included device test).

![image](https://user-images.githubusercontent.com/6755973/212318465-67289daf-a8cc-4af0-bdba-01afe3c5cab7.png)

### Issues Fixed

Fixes #12628
