### PR TITLE
Cache grid cell measurements to avoid re-measures on second pass

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -330,6 +330,19 @@ namespace Microsoft.Maui.Layouts
 				CompressStarMeasurements();
 			}
 
+			Size MeasureCell(Cell cell, double width, double height)
+			{
+				if (cell.LastMeasureHeight == height && cell.LastMeasureWidth == width)
+				{
+					return cell.LastMeasureResult;
+				}
+
+				var result = _childrenToLayOut[cell.ViewIndex].Measure(width, height);
+				cell.CacheMeasure(width, height, result);
+
+				return result;
+			}
+
 			void MeasureCellsWithUnknowns()
 			{
 				for (int n = 0; n < _cells.Length; n++)
@@ -346,7 +359,7 @@ namespace Microsoft.Maui.Layouts
 					var availableWidth = cell.IsColumnSpanAuto ? double.PositiveInfinity : AvailableWidth(cell);
 					var availableHeight = cell.IsRowSpanAuto ? double.PositiveInfinity : AvailableHeight(cell);
 
-					var measure = _childrenToLayOut[cell.ViewIndex].Measure(availableWidth, availableHeight);
+					var measure = MeasureCell(cell, availableWidth, availableHeight);
 
 					if (cell.IsColumnSpanAuto)
 					{
@@ -583,7 +596,7 @@ namespace Microsoft.Maui.Layouts
 						continue;
 					}
 
-					var measure = _childrenToLayOut[cell.ViewIndex].Measure(width, height);
+					var measure = MeasureCell(cell, width, height);
 
 					if (cell.IsColumnSpanStar && cell.ColumnSpan > 1)
 					{
@@ -910,6 +923,17 @@ namespace Microsoft.Maui.Layouts
 			{
 				// Avoiding Enum.HasFlag here for performance reasons; we don't need the type check
 				return (a & b) == b;
+			}
+
+			public double LastMeasureWidth { get; private set; } = -1;
+			public double LastMeasureHeight { get; private set; } = -1;
+			public Size LastMeasureResult { get; private set; }
+
+			public void CacheMeasure(double width, double height, Size result) 
+			{
+				LastMeasureHeight = height;
+				LastMeasureWidth = width;
+				LastMeasureResult = result;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

In some layout scenarios Grids have to make a second measure pass for some items. When they do, it's possible that the second pass is measuring with the exact same constraints as the first.

These changes cache the result of the first measure pass and use them during the second measure pass if the constraints are unchanged, avoiding the unnecessary measure pass. 

### Issues Fixed

Reduces the impact in scenarios like the one described in #11140. 