### PR TITLE
Fix Modal page offset measuring for AdjustPan and AdjustResize

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellFlyoutTemplatedContentRenderer.cs
@@ -123,21 +123,17 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				// so we want to delay loading to the latest possible point in time so
 				// it doesn't delay initial startup.
 				GenericGlobalLayoutListener ggll = null;
-				ggll = new GenericGlobalLayoutListener(InitialLoad);
-				sfl.ViewTreeObserver.AddOnGlobalLayoutListener(ggll);
+				ggll = new GenericGlobalLayoutListener(InitialLoad, sfl);
 
-				void InitialLoad()
+				void InitialLoad(GenericGlobalLayoutListener listener, AView view)
 				{
 					OnFlyoutViewLayoutChanging();
 
 					if (_flyoutContentView == null || ggll == null)
 						return;
 
-					var listener = ggll;
 					ggll = null;
-
-					// Once initial load has finished let's just attach to Layout Changing
-					sfl.ViewTreeObserver.RemoveOnGlobalLayoutListener(listener);
+					listener.Invalidate();
 					sfl.LayoutChanging += OnFlyoutViewLayoutChanging;
 				}
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellToolbarTracker.cs
@@ -77,8 +77,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			_drawerLayout = drawerLayout ?? throw new ArgumentNullException(nameof(drawerLayout));
 			_appBar = _platformToolbar.Parent.GetParentOfType<AppBarLayout>();
 
-			_globalLayoutListener = new GenericGlobalLayoutListener(() => UpdateNavBarHasShadow(Page));
-			_appBar.ViewTreeObserver.AddOnGlobalLayoutListener(_globalLayoutListener);
+			_globalLayoutListener = new GenericGlobalLayoutListener((_,_) => UpdateNavBarHasShadow(Page), _appBar);
 			_platformToolbar.SetNavigationOnClickListener(this);
 			((IShellController)ShellContext.Shell).AddFlyoutBehaviorObserver(this);
 			ShellContext.Shell.Toolbar.PropertyChanged += OnToolbarPropertyChanged;
@@ -175,9 +174,6 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 			if (disposing)
 			{
-				if (_appBar.IsAlive() && _appBar.ViewTreeObserver.IsAlive())
-					_appBar.ViewTreeObserver.RemoveOnGlobalLayoutListener(_globalLayoutListener);
-
 				_globalLayoutListener.Invalidate();
 
 				if (_backButtonBehavior != null)

--- a/src/Controls/src/Core/Platform/Android/GenericGlobalLayoutListener.cs
+++ b/src/Controls/src/Core/Platform/Android/GenericGlobalLayoutListener.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Maui.Controls.Platform
 			{
 				targetView.ViewTreeObserver.RemoveOnGlobalLayoutListener(this);
 			}
+
+			_targetView = null;
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/Android/GenericGlobalLayoutListener.cs
+++ b/src/Controls/src/Core/Platform/Android/GenericGlobalLayoutListener.cs
@@ -1,22 +1,31 @@
-#nullable disable
 using System;
 using Android.Views;
+using AView = Android.Views.View;
 using Object = Java.Lang.Object;
 
 namespace Microsoft.Maui.Controls.Platform
 {
 	internal class GenericGlobalLayoutListener : Object, ViewTreeObserver.IOnGlobalLayoutListener
 	{
-		Action _callback;
+		Action<GenericGlobalLayoutListener, AView?>? _callback;
+		WeakReference<AView>? _targetView;
 
-		public GenericGlobalLayoutListener(Action callback)
+		public GenericGlobalLayoutListener(Action<GenericGlobalLayoutListener, AView?> callback, AView? targetView = null)
 		{
 			_callback = callback;
+
+			if (targetView?.ViewTreeObserver != null)
+			{
+				_targetView = new WeakReference<AView>(targetView);
+				targetView.ViewTreeObserver.AddOnGlobalLayoutListener(this);
+			}
 		}
 
 		public void OnGlobalLayout()
 		{
-			_callback?.Invoke();
+			AView? targetView = null;
+			_targetView?.TryGetTarget(out targetView);
+			_callback?.Invoke(this, targetView);
 		}
 
 		protected override void Dispose(bool disposing)
@@ -30,6 +39,14 @@ namespace Microsoft.Maui.Controls.Platform
 		internal void Invalidate()
 		{
 			_callback = null;
+
+			if (_targetView != null &&
+				_targetView.TryGetTarget(out var targetView) &&
+				targetView.IsAlive() &&
+				targetView.ViewTreeObserver != null)
+			{
+				targetView.ViewTreeObserver.RemoveOnGlobalLayoutListener(this);
+			}
 		}
 	}
 }

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Maui.Controls.Platform
 	internal partial class ModalNavigationManager
 	{
 		ViewGroup? _modalParentView;
+
+		// This is only here for the device tests to use.
+		// With the device tests we have a `FakeActivityRootView` and a `WindowTestFragment`
+		// that we use to replicate the `DecorView` and `MainActivity`
+		// The tests will set this to the `FakeActivityRootView` so that the `modals`
+		// are part of the correct testing space.
+		// If/When we move to opening new activities we can remove this code.
 		internal void SetModalParentView(ViewGroup viewGroup)
 		{
 			_modalParentView = viewGroup;

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -18,16 +18,16 @@ namespace Microsoft.Maui.Controls.Platform
 {
 	internal partial class ModalNavigationManager
 	{
+		ViewGroup? _modalParentView;
+		internal void SetModalParentView(ViewGroup viewGroup)
+		{
+			_modalParentView = viewGroup;
+		}
+
 		ViewGroup GetModalParentView()
 		{
-			var currentRootView = (GetCurrentRootView()?.Parent) as ViewGroup;
-
-			if (_window?.PlatformActivity?.GetWindow() == _window)
-			{
-				currentRootView = _window?.PlatformActivity?.Window?.DecorView as ViewGroup;
-			}
-
-			return currentRootView ??
+			return _modalParentView ??
+				_window?.PlatformActivity?.Window?.DecorView as ViewGroup ??
 				throw new InvalidOperationException("Root View Needs to be set");
 		}
 
@@ -191,7 +191,7 @@ namespace Microsoft.Maui.Controls.Platform
 			return handled;
 		}
 
-		sealed class ModalContainer : FitWindowsFrameLayout
+		sealed class ModalContainer : ViewGroup
 		{
 			AView _backgroundView;
 			IMauiContext? _windowMauiContext;

--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Maui.Controls.Platform
 					return;
 				}
 
-				if ((_currentRootViewHeight != view.MeasuredHeight || _currentRootViewWidth != view.MeasuredHeight)
+				if ((_currentRootViewHeight != view.MeasuredHeight || _currentRootViewWidth != view.MeasuredWidth)
 					&& this.ViewTreeObserver != null)
 				{
 					// When the keyboard closes Android calls layout but doesn't call remeasure.

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.Android.cs
@@ -198,6 +198,11 @@ namespace Microsoft.Maui.DeviceTests
 				FakeActivityRootView.AddView(handler.PlatformViewUnderTest);
 				handler.PlatformViewUnderTest.LayoutParameters = new FitWindowsFrameLayout.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent);
 
+				if (_window is Window window)
+				{
+					window.ModalNavigationManager.SetModalParentView(FakeActivityRootView);
+				}
+
 				return FakeActivityRootView;
 			}
 

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Android.cs
@@ -2,91 +2,106 @@
 using System.Threading.Tasks;
 using Java.Lang;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using WindowSoftInputModeAdjust = Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class ModalTests : ControlsHandlerTestBase
 	{
-		[Fact]
-		public async Task ModalPageMarginCorrectAfterKeyboardOpens()
+		[Theory]
+		[InlineData(WindowSoftInputModeAdjust.Resize)]
+		[InlineData(WindowSoftInputModeAdjust.Pan)]
+		public async Task ModalPageMarginCorrectAfterKeyboardOpens(WindowSoftInputModeAdjust panSize)
 		{
 			SetupBuilder();
 
 			var navPage = new NavigationPage(new ContentPage());
-
-			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
+			var window = new Window(navPage);
+			await CreateHandlerAndAddToWindow<IWindowHandler>(window,
 				async (handler) =>
 				{
-					VerticalStackLayout layout = new VerticalStackLayout();
-					List<Entry> entries = new List<Entry>();
-					ContentPage modalPage = new ContentPage()
+					try
 					{
-						Content = layout
-					};
+						window.UpdateWindowSoftInputModeAdjust(panSize.ToPlatform());
+						VerticalStackLayout layout = new VerticalStackLayout();
+						List<Entry> entries = new List<Entry>();
+						ContentPage modalPage = new ContentPage()
+						{
+							Content = layout
+						};
 
-					for (int i = 0; i < 30; i++)
-					{
-						var entry = new Entry();
-						entries.Add(entry);
-						layout.Add(entry);
+						for (int i = 0; i < 30; i++)
+						{
+							var entry = new Entry();
+							entries.Add(entry);
+							layout.Add(entry);
+						}
+
+						await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
+						await OnLoadedAsync(entries[0]);
+
+						var pageBoundingBox = modalPage.GetBoundingBox();
+
+						Entry testEntry = entries[0];
+						foreach (var entry in entries)
+						{
+							var entryBox = entry.GetBoundingBox();
+
+							// Locate the lowest visible entry
+							if ((entryBox.Y + (entryBox.Height * 2)) > pageBoundingBox.Height)
+								break;
+
+							testEntry = entry;
+						}
+
+						await AssertionExtensions.HideKeyboardForView(testEntry);
+						var rootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
+						var modalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
+						var originalModalPageSize = modalPage.GetBoundingBox();
+
+						await AssertionExtensions.ShowKeyboardForView(testEntry);
+
+						// Type text into the entries
+						testEntry.Text = "Typing";
+
+						bool offsetMatchesWhenKeyboardOpened = await AssertionExtensions.Wait(() =>
+						{
+							var keyboardOpenRootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
+							var keyboardOpenModalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
+
+							var originalDiff = Math.Abs(rootPageOffsetY - modalOffsetY);
+							var openDiff = Math.Abs(keyboardOpenRootPageOffsetY - keyboardOpenModalOffsetY);
+
+
+							return Math.Abs(originalDiff - openDiff) <= 0.2;
+						});
+
+						Assert.True(offsetMatchesWhenKeyboardOpened, "Modal page has an invalid offset when open");
+
+						await AssertionExtensions.HideKeyboardForView(testEntry);
+
+						bool offsetMatchesWhenKeyboardClosed = await AssertionExtensions.Wait(() =>
+						{
+							var keyboardClosedRootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
+							var keyboardClosedModalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
+
+							return rootPageOffsetY == keyboardClosedRootPageOffsetY &&
+									modalOffsetY == keyboardClosedModalOffsetY;
+						});
+
+						Assert.True(offsetMatchesWhenKeyboardClosed, "Modal page failed to return to expected offset");
+
+						var finalModalPageSize = modalPage.GetBoundingBox();
+						Assert.Equal(originalModalPageSize, finalModalPageSize);
 					}
-
-					await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
-					await OnLoadedAsync(entries[0]);
-
-					var pageBoundingBox = modalPage.GetBoundingBox();
-
-					Entry testEntry = entries[0];
-					foreach (var entry in entries)
+					finally
 					{
-						var entryBox = entry.GetBoundingBox();
-
-						// Locate the lowest visible entry
-						if ((entryBox.Y + (entryBox.Height * 2)) > pageBoundingBox.Height)
-							break;
-
-						testEntry = entry;
+						window.UpdateWindowSoftInputModeAdjust(WindowSoftInputModeAdjust.Resize.ToPlatform());
 					}
-
-					await AssertionExtensions.HideKeyboardForView(testEntry);
-					var rootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
-					var modalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
-
-					await AssertionExtensions.ShowKeyboardForView(testEntry);
-
-					// Type text into the entries
-					testEntry.Text = "Typing";
-
-					// Validate that the correct offset was maintained when the window pan adjusted
-					bool offsetMatchesWhenKeyboardOpened = await AssertionExtensions.Wait(() =>
-					{
-						var keyboardOpenRootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
-						var keyboardOpenModalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
-
-						var originalDiff = Math.Abs(rootPageOffsetY - modalOffsetY);
-						var openDiff = Math.Abs(keyboardOpenRootPageOffsetY - keyboardOpenModalOffsetY);
-
-
-						return Math.Abs(originalDiff - openDiff) <= 0.2;
-					});
-
-					Assert.True(offsetMatchesWhenKeyboardOpened, "Modal page has an invalid offset when open");
-
-					await AssertionExtensions.HideKeyboardForView(testEntry);
-
-					bool offsetMatchesWhenKeyboardClosed = await AssertionExtensions.Wait(() =>
-					{
-						var keyboardClosedRootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
-						var keyboardClosedModalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
-
-						return rootPageOffsetY == keyboardClosedRootPageOffsetY &&
-								modalOffsetY == keyboardClosedModalOffsetY;
-					});
-
-					Assert.True(offsetMatchesWhenKeyboardClosed, "Modal page failed to return to expected offset");
 				});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Android.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Java.Lang;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
@@ -40,6 +37,56 @@ namespace Microsoft.Maui.DeviceTests
 					await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
 					await OnLoadedAsync(entries[0]);
 
+					var pageBoundingBox = modalPage.GetBoundingBox();
+
+					Entry testEntry = entries[0];
+					foreach (var entry in entries)
+					{
+						var entryBox = entry.GetBoundingBox();
+
+						// Locate the lowest visible entry
+						if ((entryBox.Y + (entryBox.Height * 2)) > pageBoundingBox.Height)
+							break;
+
+						testEntry = entry;
+					}
+
+					await AssertionExtensions.HideKeyboardForView(testEntry);
+					var rootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
+					var modalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
+
+					await AssertionExtensions.ShowKeyboardForView(testEntry);
+
+					// Type text into the entries
+					testEntry.Text = "Typing";
+
+					// Validate that the correct offset was maintained when the window pan adjusted
+					bool offsetMatchesWhenKeyboardOpened = await AssertionExtensions.Wait(() =>
+					{
+						var keyboardOpenRootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
+						var keyboardOpenModalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
+
+						var originalDiff = Math.Abs(rootPageOffsetY - modalOffsetY);
+						var openDiff = Math.Abs(keyboardOpenRootPageOffsetY - keyboardOpenModalOffsetY);
+
+
+						return Math.Abs(originalDiff - openDiff) <= 0.2;
+					});
+
+					Assert.True(offsetMatchesWhenKeyboardOpened, "Modal page has an invalid offset when open");
+
+					await AssertionExtensions.HideKeyboardForView(testEntry);
+
+					bool offsetMatchesWhenKeyboardClosed = await AssertionExtensions.Wait(() =>
+					{
+						var keyboardClosedRootPageOffsetY = navPage.CurrentPage.GetLocationOnScreen().Value.Y;
+						var keyboardClosedModalOffsetY = modalPage.GetLocationOnScreen().Value.Y;
+
+						return rootPageOffsetY == keyboardClosedRootPageOffsetY &&
+								modalOffsetY == keyboardClosedModalOffsetY;
+					});
+
+					Assert.True(offsetMatchesWhenKeyboardClosed, "Modal page failed to return to expected offset");
 				});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.Android.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class ModalTests : ControlsHandlerTestBase
+	{
+		[Fact]
+		public async Task ModalPageMarginCorrectAfterKeyboardOpens()
+		{
+			SetupBuilder();
+
+			var navPage = new NavigationPage(new ContentPage());
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(new Window(navPage),
+				async (handler) =>
+				{
+					VerticalStackLayout layout = new VerticalStackLayout();
+					List<Entry> entries = new List<Entry>();
+					ContentPage modalPage = new ContentPage()
+					{
+						Content = layout
+					};
+
+					for (int i = 0; i < 30; i++)
+					{
+						var entry = new Entry();
+						entries.Add(entry);
+						layout.Add(entry);
+					}
+
+					await navPage.CurrentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(entries[0]);
+
+				});
+		}
+	}
+}

--- a/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Modal/ModalTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Maui.DeviceTests
 
 					handlers.AddHandler(typeof(Controls.Shell), typeof(ShellHandler));
 					handlers.AddHandler<Layout, LayoutHandler>();
+					handlers.AddHandler<Entry, EntryHandler>();
 					handlers.AddHandler<Image, ImageHandler>();
 					handlers.AddHandler<Label, LabelHandler>();
 					handlers.AddHandler<Toolbar, ToolbarHandler>();

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Android.cs
@@ -108,6 +108,13 @@ namespace Microsoft.Maui.DeviceTests
 			await view.WaitForKeyboardToShow(timeout);
 		}
 
+		public static async Task HideKeyboardForView(this AView view, int timeout = 1000)
+		{
+			await view.FocusView(timeout);
+			KeyboardManager.HideKeyboard(view);
+			await view.WaitForKeyboardToHide(timeout);
+		}
+
 		public static async Task WaitForKeyboardToShow(this AView view, int timeout = 1000)
 		{
 			var result = await Wait(() => KeyboardManager.IsSoftKeyboardVisible(view), timeout);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.Windows.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Maui.DeviceTests
 			throw new NotImplementedException();
 		}
 
+		public static Task HideKeyboardForView(this FrameworkElement view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
 		public static Task<string> CreateColorAtPointError(this CanvasBitmap bitmap, WColor expectedColor, int x, int y) =>
 			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
 

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.cs
@@ -110,12 +110,13 @@ namespace Microsoft.Maui.DeviceTests
 		public static Task SendValueToKeyboard(this IView view, char value, int timeout = 1000) =>
 			view.ToPlatform().SendValueToKeyboard(value, timeout);
 
-
 		public static Task SendKeyboardReturnType(this IView view, ReturnType returnType, int timeout = 1000) =>
 			view.ToPlatform().SendKeyboardReturnType(returnType, timeout);
 
 		public static Task ShowKeyboardForView(this IView view, int timeout = 1000) =>
 			view.ToPlatform().ShowKeyboardForView(timeout);
+		public static Task HideKeyboardForView(this IView view, int timeout = 1000) =>
+			view.ToPlatform().HideKeyboardForView(timeout);
 
 		public static Task WaitForUnFocused(this IView view, int timeout = 1000) =>
 			view.ToPlatform().WaitForUnFocused(timeout);

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Maui.DeviceTests
 			throw new NotImplementedException();
 		}
 
+		public static Task HideKeyboardForView(this UIView view, int timeout = 1000)
+		{
+			throw new NotImplementedException();
+		}
+
 		public static string CreateColorAtPointError(this UIImage bitmap, UIColor expectedColor, int x, int y) =>
 			CreateColorError(bitmap, $"Expected {expectedColor} at point {x},{y} in renderered view.");
 


### PR DESCRIPTION
### Description of Change

- Instead of using the positions of the underlying view just use the inset guides. This way when ResizePan or Orientation changes happen you still have stable values.
- If the base view of the app changes size, that's an indication to us that we need to trigger a new measure/layout change of the modal view as well. In forms we did this inside the `PageRenderer` here I'm just doing it inside the Modal code. 
  - This mainly came up when set to AdjustResize but also applies when changing the orientation 
- Simplified the GenericGlobalLayoutListener a bit so it's self cleaning and we don't just duplicate the code used to add/remove/disconnect it. 

Hopefully in .NET 8 we'll be able to convert to a DialogFragment over this weird layering that's left over from forms. I have the basics of the DialogFragment working but that would be too large of a shift for .NET7 and I'd like to port these fixes back to .NET 7

### Testing Notes
Try really hard to break the layout of the modal window
- bring up the keyboard
- rotate the device
- type in to the keyboard
- try setting the app to adjustresize vs pan
- try out the repros on the attached fixes

One known issue is that if the app recreates it doesn't repush the modal stack. So, if you hit an exception about the `ModalContainer` that's a different issue. I'm mainly concerned with layout issues here.

### Issues Fixed


Fixes #11286
Fixes #12406 
Fixes #12647
Fixes #12637

