### PR TITLE
Fix the implicit Windows DefineConstants

### DIFF
--- a/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.targets
+++ b/src/Workload/Microsoft.Maui.Sdk/Sdk/WinUI.targets
@@ -19,6 +19,14 @@
   </Target>
 
   <!--
+    Workaround for https://github.com/microsoft/WindowsAppSDK/issues/3108
+  -->
+  <Target
+    Name="_MauiAddImplicitDefineConstantsBeforeXamlPreCompile"
+    BeforeTargets="XamlPreCompile"
+    DependsOnTargets="AddImplicitDefineConstants" />
+
+  <!--
     Workaround for https://github.com/microsoft/WindowsAppSDK/issues/2684
   -->
   <Import Project="WinUI.Unpackaged.targets" Condition=" '$(WindowsPackageType)' == 'None' " />


### PR DESCRIPTION
### Description of Change

The .NET SDK assumes that the `CoreCompile` target is the only target that needs the defines. However, in the Windows App SDK, the `XamlPreCompile` target also needs it. The .NET SDK target to add these defines is new in .NET "Core" so the WinUI team never needed this and the .NET team never anticipated this.

This PR just adds a new target that just adds a dependency from `XamlPreCompile` to `AddImplicitDefineConstants` so that everything is defined.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #6815

Workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/8181

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
