### PR TITLE
[Android] Align dash effect between Border and Shapes

### DIFF
--- a/src/Core/src/Graphics/MauiDrawable.Android.cs
+++ b/src/Core/src/Graphics/MauiDrawable.Android.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Maui.Graphics
 
 		public void SetBorderDash(float[]? strokeDashArray, double strokeDashOffset)
 		{
-			if (strokeDashArray == null || strokeDashArray.Length == 0)
+			if (strokeDashArray is null || strokeDashArray.Length == 0)
 				_borderPathEffect = null;
 			else
 			{

--- a/src/Core/src/Graphics/MauiDrawable.Android.cs
+++ b/src/Core/src/Graphics/MauiDrawable.Android.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Maui.Graphics
 
 		public void SetBorderDash(float[]? strokeDashArray, double strokeDashOffset)
 		{
-			if (strokeDashArray == null || strokeDashArray.Length == 0 || strokeDashOffset <= 0)
+			if (strokeDashArray == null || strokeDashArray.Length == 0)
 				_borderPathEffect = null;
 			else
 			{

--- a/src/Core/tests/DeviceTests/Handlers/Border/BorderHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Border/BorderHandlerTests.cs
@@ -53,6 +53,29 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidateHasColor(border, expected);
 		}
 
+		[Theory(DisplayName = "Dashed Stroke Initializes Correctly")]
+		[InlineData(0xFFFF0000)]
+		[InlineData(0xFF00FF00)]
+		[InlineData(0xFF0000FF)]
+		public async Task DashedStrokeInitializesCorrectly(uint color)
+		{
+			var expected = Color.FromUint(color);
+
+			var border = new BorderStub()
+			{
+				Content = new LabelStub { Text = "Stroke", TextColor = Colors.Black },
+				Shape = new RectangleShapeStub(),
+				Background = new SolidPaintStub(Colors.White),
+				Stroke = new SolidPaintStub(expected),
+				StrokeDashPattern = new float[2] { 1, 1 }, 
+				StrokeThickness = 6,
+				Height = 100,
+				Width = 300
+			};
+
+			await ValidateHasColor(border, expected);
+		}
+
 		[Theory(DisplayName = "StrokeShape Initializes Correctly")]
 		[InlineData("Rectangle")]
 		[InlineData("RoundRectangle")]


### PR DESCRIPTION
### Description of Change

Align dash effect between Border and Shapes on Android. Required to have a dash offset applied on Border when it doesn't happen with Shapes. With the changes in this PR, the behavior is the same.

![image](https://user-images.githubusercontent.com/6755973/212730598-c3e277cf-e1ab-4186-948f-6a182144665e.png)

### Issues Fixed

Fixes #12650