### PR TITLE
[release/7.0.1xx-sr1.2] Disable the windows deployment manager by default

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -5,6 +5,8 @@
     <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' == 'WinExe' ">MSIX</WindowsPackageType>
     <WindowsAppSDKSelfContained Condition=" '$(WindowsAppSDKSelfContained)' == '' and '$(WindowsPackageType)' == 'None' and '$(OutputType)' == 'WinExe' ">true</WindowsAppSDKSelfContained>
     <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
+    <!-- Workaround to avoid https://github.com/microsoft/WindowsAppSDK/issues/3316 -->
+    <WindowsAppSdkDeploymentManagerInitialize Condition=" '$(WindowsAppSdkDeploymentManagerInitialize)' == '' and '$(EnableMsixTooling)' == 'true' ">false</WindowsAppSdkDeploymentManagerInitialize>
     <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
     <PublishReadyToRun Condition=" '$(Configuration)' == 'Release' and '$(PublishReadyToRun)' == '' ">true</PublishReadyToRun>
     <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>

--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -5,7 +5,7 @@
     <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' == 'WinExe' ">MSIX</WindowsPackageType>
     <WindowsAppSDKSelfContained Condition=" '$(WindowsAppSDKSelfContained)' == '' and '$(WindowsPackageType)' == 'None' and '$(OutputType)' == 'WinExe' ">true</WindowsAppSDKSelfContained>
     <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
-    <!-- Workaround to avoid https://github.com/microsoft/WindowsAppSDK/issues/3316 -->
+    <!-- Workaround to avoid https://github.com/microsoft/WindowsAppSDK/issues/3316 or https://github.com/dotnet/maui/issues/12080 -->
     <WindowsAppSdkDeploymentManagerInitialize Condition=" '$(WindowsAppSdkDeploymentManagerInitialize)' == '' and '$(EnableMsixTooling)' == 'true' ">false</WindowsAppSdkDeploymentManagerInitialize>
     <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
     <PublishReadyToRun Condition=" '$(Configuration)' == 'Release' and '$(PublishReadyToRun)' == '' ">true</PublishReadyToRun>


### PR DESCRIPTION
### Description of Change

Version 1.2 of the Windows App SDK introduced a new Deployment Manager for MSIX packages, but due to a bug in Windows 10, this fails to work correctly if the app is not running elevated.

This PR disables the deployment manager by default - reverting back to 1.1 behavior - however there may be some missing/broken features. I am unsure of the correctness or scope, but it appears to maybe include OS notifications. But I am not sure if that is popping or receiving from the internet. (I'll update once I know for sure this is all correct)

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Avoids https://github.com/microsoft/WindowsAppSDK/issues/3197

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
