### PR TITLE
Initial code for replacing the deployment manager

### DIFF
--- a/.nuspec/Microsoft.Maui.Controls.SingleProject.props
+++ b/.nuspec/Microsoft.Maui.Controls.SingleProject.props
@@ -5,6 +5,8 @@
     <WindowsPackageType Condition=" '$(WindowsPackageType)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' == 'WinExe' ">MSIX</WindowsPackageType>
     <WindowsAppSDKSelfContained Condition=" '$(WindowsAppSDKSelfContained)' == '' and '$(WindowsPackageType)' == 'None' and '$(OutputType)' == 'WinExe' ">true</WindowsAppSDKSelfContained>
     <WindowsAppSdkBootstrapInitialize Condition=" '$(WindowsAppSdkBootstrapInitialize)' == '' and '$(EnableMsixTooling)' == 'true' and '$(OutputType)' != 'WinExe' ">false</WindowsAppSdkBootstrapInitialize>
+    <!-- We have our own manager to avoid crashing the app -->
+    <WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>
     <PublishAppXPackage Condition=" '$(PublishAppXPackage)' == '' and '$(EnableMsixTooling)' == 'true' and '$(WindowsPackageType)' == 'MSIX' ">true</PublishAppXPackage>
     <PublishReadyToRun Condition=" '$(PublishReadyToRun)' == '' and '$(Configuration)' == 'Release' and '$(OutputType)' != '' and '$(OutputType)' != 'Library' ">true</PublishReadyToRun>
     <_SingleProjectRIDRequired Condition="'$(OutputType)' == 'WinExe'">true</_SingleProjectRIDRequired>

--- a/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
+++ b/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
@@ -27,17 +27,6 @@ internal static class DeploymentManagerAutoInitializer
 
 	public static DeploymentResult Result { get; private set; } = null!;
 
-	public static void ThrowIfFailed()
-	{
-		if (Result?.Status == DeploymentStatus.Ok)
-			return;
-
-		if (Result?.ExtendedError is null)
-			throw new SystemException($"Unknown WindowsAppRuntime.DeploymentManager.Initialize error.");
-
-		throw new SystemException($"WindowsAppRuntime.DeploymentManager.Initialize error (0x{Result.ExtendedError?.HResult:X}): {Result.ExtendedError?.Message}", Result.ExtendedError);
-	}
-
 	public static void LogIfFailed(IServiceProvider services)
 	{
 		if (Result?.Status == DeploymentStatus.Ok)
@@ -47,9 +36,15 @@ internal static class DeploymentManagerAutoInitializer
 		if (logger is null)
 			return;
 
-		if (Result?.ExtendedError is null)
+		var error = Result?.ExtendedError;
+		if (error is null)
+		{
 			logger.LogError($"Unknown WindowsAppRuntime.DeploymentManager.Initialize error.");
+		}
 		else
-			logger.LogError(Result.ExtendedError, "WindowsAppRuntime.DeploymentManager.Initialize error ({HResult}): {ErrorMessage}", Result.ExtendedError?.HResult, Result.ExtendedError?.Message);
+		{
+			var hresult = string.Format("0x{0:X}", error.HResult);
+			logger.LogError(error, "WindowsAppRuntime.DeploymentManager.Initialize error ({HResult}): {ErrorMessage}", hresult, error.Message);
+		}
 	}
 }

--- a/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
+++ b/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
@@ -14,8 +14,15 @@ internal static class DeploymentManagerAutoInitializer
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	internal static void AccessWindowsAppSDK()
 	{
-		//var options = new DeploymentInitializeOptions();
-		//Result = DeploymentManager.Initialize(options);
+		try
+		{
+			var options = new DeploymentInitializeOptions();
+			Result = DeploymentManager.Initialize(options);
+		}
+		catch (Exception ex)
+		{
+			Result = new DeploymentResult(DeploymentStatus.Unknown, ex);
+		}
 	}
 
 	public static DeploymentResult Result { get; private set; } = null!;

--- a/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
+++ b/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
@@ -26,10 +26,12 @@ namespace Microsoft.Maui
 			throw new global::System.SystemException($"WindowsAppRuntime.DeploymentManager.Initialize error (0x{Result.ExtendedError?.HResult:X}): {Result.ExtendedError?.Message}", Result.ExtendedError);
 		}
 
-		public static void LogIfFailed(ILogger logger)
+		public static void LogIfFailed(IServiceProvider services)
 		{
 			if (Result?.Status == DeploymentStatus.Ok)
 				return;
+
+			var logger = services.CreateLogger<DeploymentManagerAutoInitializer>();
 
 			if (Result?.ExtendedError is null)
 				loger.LogError($"Unknown WindowsAppRuntime.DeploymentManager.Initialize error.");

--- a/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
+++ b/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.LifecycleEvents;
+
+namespace Microsoft.Maui
+{
+	internal static class DeploymentManagerAutoInitializer
+	{
+		[global::System.Runtime.CompilerServices.ModuleInitializer]
+		internal static void AccessWindowsAppSDK()
+		{
+			Result = global::Microsoft.Windows.ApplicationModel.WindowsAppRuntime.DeploymentManager.Initialize(new());
+		}
+
+		public static global::Microsoft.Windows.ApplicationModel.WindowsAppRuntime.DeploymentResult Result { get; private set; }
+
+		public static void ThrowIfFailed()
+		{
+			throw new Exception("yay");
+
+			if (Result?.Status == DeploymentStatus.Ok)
+				return;
+
+			if (Result?.ExtendedError is null)
+				throw new global::System.SystemException($"Unknown WindowsAppRuntime.DeploymentManager.Initialize error.");
+
+			throw new global::System.SystemException($"WindowsAppRuntime.DeploymentManager.Initialize error (0x{Result.ExtendedError?.HResult:X}): {Result.ExtendedError?.Message}", Result.ExtendedError);
+		}
+	}
+}

--- a/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
+++ b/src/Core/src/Platform/Windows/DeploymentManagerAutoInitializer.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Maui
 
 		public static void ThrowIfFailed()
 		{
-			throw new Exception("yay");
-
 			if (Result?.Status == DeploymentStatus.Ok)
 				return;
 
@@ -26,6 +24,17 @@ namespace Microsoft.Maui
 				throw new global::System.SystemException($"Unknown WindowsAppRuntime.DeploymentManager.Initialize error.");
 
 			throw new global::System.SystemException($"WindowsAppRuntime.DeploymentManager.Initialize error (0x{Result.ExtendedError?.HResult:X}): {Result.ExtendedError?.Message}", Result.ExtendedError);
+		}
+
+		public static void LogIfFailed(ILogger logger)
+		{
+			if (Result?.Status == DeploymentStatus.Ok)
+				return;
+
+			if (Result?.ExtendedError is null)
+				loger.LogError($"Unknown WindowsAppRuntime.DeploymentManager.Initialize error.");
+
+			loger.LogError($"WindowsAppRuntime.DeploymentManager.Initialize error (0x{Result.ExtendedError?.HResult:X}): {Result.ExtendedError?.Message}", Result.ExtendedError);
 		}
 	}
 }

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Maui
 
 			Services = applicationContext.Services;
 
+			DeploymentManagerAutoInitializer.LogOrSomething();
+
 			Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 
 			Application = Services.GetRequiredService<IApplication>();

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui
 
 			Services = applicationContext.Services;
 
-			DeploymentManagerAutoInitializer.LogIfFailed(Services.CreateLogger<DeploymentManagerAutoInitializer>());
+			DeploymentManagerAutoInitializer.LogIfFailed(Services);
 
 			Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 

--- a/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
+++ b/src/Core/src/Platform/Windows/MauiWinUIApplication.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Maui
 
 			Services = applicationContext.Services;
 
-			DeploymentManagerAutoInitializer.LogOrSomething();
+			DeploymentManagerAutoInitializer.LogIfFailed(Services.CreateLogger<DeploymentManagerAutoInitializer>());
 
 			Services.InvokeLifecycleEvents<WindowsLifecycle.OnLaunching>(del => del(this, args));
 


### PR DESCRIPTION
### Description of Change

After _several_ different attempts at avoiding the deployment manager just crashing the app, we found that it was going to cause bigger issues lateron in some situations:

Looking at winui docs I see this: https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/deployment-architecture#key-terms

We lose these features when we disable the deployment manager:

* **Main package**  
  Package that contains background tasks to keep track of dynamic dependencies, and enables automatic updates to the Framework package from the Microsoft Store.
* **Singleton package**  
  Contains background tasks, services, app extensions, and other components not included in the Framework package such as Push Notifications. This is generally a single long-running process that is brokered between apps.

So, this PR does the best and disables the _default_ deployment manager and then we have our own version that does not crash apps, but does the better thing and log to the output - along with an exception and stack trace.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Works around https://github.com/microsoft/microsoft-ui-xaml/issues/8182
Avoids https://github.com/dotnet/maui/issues/12080