### PR TITLE
Don't explicitly copy to the build server

### DIFF
--- a/.nuspec/Microsoft.Maui.Resizetizer.targets
+++ b/.nuspec/Microsoft.Maui.Resizetizer.targets
@@ -405,17 +405,6 @@
                 <TargetPath>%(_MauiSplashImages.Filename)%(_MauiSplashImages.Extension)</TargetPath>
             </BundleResource>
         </ItemGroup>
-        <!-- If on Windows, using build host, copy the files over to build server host too -->
-        <ItemGroup Condition="'$(BuildSessionId)' != '' and '$(_ResizetizerIsiOSSpecificApp)' == 'True' and '$(IsMacEnabled)'=='true'">
-            <_MauiSplashToCopyToBuildServer Include="@(_MauiSplashAssets)">
-                <TargetPath>%(Identity)</TargetPath>
-            </_MauiSplashToCopyToBuildServer>
-        </ItemGroup>
-        <CopyFilesToBuildServer
-            Condition="'$(BuildSessionId)' != '' and '$(_ResizetizerIsiOSSpecificApp)' == 'True' and '$(IsMacEnabled)'=='true'"
-            SessionId="$(BuildSessionId)"
-            Files="@(_MauiSplashToCopyToBuildServer)"
-        />
 
         <!-- UWP / WinUI -->
         <GenerateSplashAssets
@@ -531,18 +520,6 @@
             <TizenTpkUserIncludeFiles Include="@(_MauiFontCopied)"  Condition="'@(_MauiFontCopied)' != ''" TizenTpkSubDir="res\fonts\" />
         </ItemGroup>
 
-        <!-- iOS Only -->
-        <!-- If on Windows, using build host, copy the files over to build server host too -->
-        <ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
-            <_MauiFontsToCopyToBuildServer Include="@(_MauiFontBundleResource);@(_MauiFontPListFiles)">
-                <TargetPath>%(Identity)</TargetPath>
-            </_MauiFontsToCopyToBuildServer>
-        </ItemGroup>
-        <CopyFilesToBuildServer
-            Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
-            SessionId="$(BuildSessionId)"
-            Files="@(_MauiFontsToCopyToBuildServer)" />
-
         <!-- Touch/create our stamp file for outputs -->
         <Touch Files="$(_MauiFontStampFile)" AlwaysCreate="True" />
 
@@ -601,18 +578,6 @@
 
             <FileWrites Include="@(_ResizetizerCollectedBundleResourceImages)" />
         </ItemGroup>
-
-        <!-- iOS Only -->
-        <!-- If on Windows, using build host, copy the files over to build server host too -->
-        <ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
-            <_MauiImagesToCopyToBuildServer Include="@(_ResizetizerCollectedBundleResourceImages)">
-                <TargetPath>%(Identity)</TargetPath>
-            </_MauiImagesToCopyToBuildServer>
-        </ItemGroup>
-        <CopyFilesToBuildServer
-            Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
-            SessionId="$(BuildSessionId)"
-            Files="@(_MauiImagesToCopyToBuildServer)" />
 
         <!-- Android -->
         <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">


### PR DESCRIPTION
### Description of Change

We no longer have a need to explicitly copy files to the build server as items referenced are now copied automatically:

* InterfaceDefinition
* PartialAppManifest
* BundleResource
* ImageAsset