### PR TITLE
Retain the cursor position when transforming the text

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Editor/Editor.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Editor/Editor.Android.cs
@@ -3,8 +3,16 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Editor
 	{
-		public static void MapText(EditorHandler handler, Editor editor) =>
+		public static void MapText(EditorHandler handler, Editor editor)
+		{
+			if (handler.DataFlowDirection == DataFlowDirection.FromPlatform)
+			{
+				Platform.EditTextExtensions.UpdateTextFromPlatform(handler.PlatformView, editor);
+				return;
+			}
+
 			MapText((IEditorHandler)handler, editor);
+		}
 
 		public static void MapText(IEditorHandler handler, Editor editor)
 		{

--- a/src/Controls/src/Core/HandlerImpl/Entry/Entry.Android.cs
+++ b/src/Controls/src/Core/HandlerImpl/Entry/Entry.Android.cs
@@ -10,8 +10,16 @@ namespace Microsoft.Maui.Controls
 		public static void MapImeOptions(EntryHandler handler, Entry entry) =>
 			MapImeOptions((IEntryHandler)handler, entry);
 
-		public static void MapText(EntryHandler handler, Entry entry) =>
+		public static void MapText(EntryHandler handler, Entry entry)
+		{
+			if (handler.DataFlowDirection == DataFlowDirection.FromPlatform)
+			{
+				Platform.EditTextExtensions.UpdateTextFromPlatform(handler.PlatformView, entry);
+				return;
+			}
+
 			MapText((IEntryHandler)handler, entry);
+		}
 
 		public static void MapImeOptions(IEntryHandler handler, Entry entry)
 		{

--- a/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
+++ b/src/Controls/src/Core/Platform/Android/Extensions/EditTextExtensions.cs
@@ -24,24 +24,15 @@ namespace Microsoft.Maui.Controls.Platform
 				(editText.InputType & InputTypes.TextVariationPassword) == InputTypes.TextVariationPassword ||
 				(editText.InputType & InputTypes.NumberVariationPassword) == InputTypes.NumberVariationPassword;
 
-			// Setting the text causes the cursor to be reset to position zero.
-			// So, let's retain the current cursor position and calculate a new cursor
-			// position if the text was modified by a Converter.
 			var oldText = editText.Text ?? string.Empty;
-			var newText = TextTransformUtilites.GetTransformedText(
-				inputView?.Text,
-				isPasswordEnabled ? TextTransform.None : inputView.TextTransform
-				);
+			var newText = TextTransformUtilites.GetTransformedText(inputView?.Text,
+					isPasswordEnabled ? TextTransform.None : inputView.TextTransform);
 
 			if (oldText != newText)
-				editText.Text = newText;
-
-			// Re-calculate the cursor offset position if the text was modified by a Converter.
-			// but if the text is being set by code, let's just move the cursor to the end.
-			var cursorOffset = newText.Length - oldText.Length;
-			int cursorPosition = editText.IsFocused ? editText.GetCursorPosition(cursorOffset) : editText.Text.Length;
-
-			editText.SetSelection(cursorPosition);
+			{
+				// Update the text and keep the cursor position 
+				editText.SetTextKeepState(newText);
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.Android.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Handlers;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		void SetPlatformText(EditorHandler editorHandler, string text) =>
-			GetPlatformControl(editorHandler).Text = text;
+			GetPlatformControl(editorHandler).SetTextKeepState(text);
 
 		int GetPlatformCursorPosition(EditorHandler editorHandler)
 		{
@@ -37,6 +38,24 @@ namespace Microsoft.Maui.DeviceTests
 				return textView.SelectionEnd - textView.SelectionStart;
 
 			return -1;
+		}
+
+		[Fact]
+		public async Task CursorPositionPreservedWhenTextTransformPresent()
+		{
+			var editor = new Editor
+			{
+				Text = "TET", 
+				TextTransform = TextTransform.Uppercase
+			};
+
+			await SetValueAsync<int, EditorHandler>(editor, 2, (h, s) => h.PlatformView.SetSelection(2));
+
+			Assert.Equal(2, editor.CursorPosition);
+
+			await SetValueAsync<string, EditorHandler>(editor, "TEsT", SetPlatformText);
+
+			Assert.Equal(2, editor.CursorPosition);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Editor/EditorTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test"
 			};
 
-			await SetValueAsync<string, EditorHandler>(editor, text, SetPlatformText);
+			await SetValueAsync<string, EditorHandler>(editor, text, (h, s) => h.VirtualView.Text = s);
 
 			Assert.Equal(text.Length, editor.CursorPosition);
 		}
@@ -285,7 +285,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test"
 			};
 
-			await SetValueAsync<string, EditorHandler>(editor, text, SetPlatformText);
+			await SetValueAsync<string, EditorHandler>(editor, text, (h, s) => h.VirtualView.Text = s);
 
 			Assert.Equal(0, editor.SelectionLength);
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.Android.cs
@@ -1,6 +1,9 @@
 ﻿using System.Threading.Tasks;
 using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Handlers;
+using static System.Net.Mime.MediaTypeNames;
+using Xunit;
+using Microsoft.Maui.Controls;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -15,7 +18,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		void SetPlatformText(EntryHandler entryHandler, string text) =>
-			GetPlatformControl(entryHandler).Text = text;
+			GetPlatformControl(entryHandler).SetTextKeepState(text);
 
 		int GetPlatformCursorPosition(EntryHandler entryHandler)
 		{
@@ -35,6 +38,24 @@ namespace Microsoft.Maui.DeviceTests
 				return editText.SelectionEnd - editText.SelectionStart;
 
 			return -1;
+		}
+
+		[Fact]
+		public async Task CursorPositionPreservedWhenTextTransformPresent() 
+		{
+			var entry = new Entry
+			{
+				Text = "TET",
+				TextTransform = TextTransform.Uppercase
+			};
+
+			await SetValueAsync<int, EntryHandler>(entry, 2, (h, s) => h.PlatformView.SetSelection(2));
+
+			Assert.Equal(2, entry.CursorPosition);
+
+			await SetValueAsync<string, EntryHandler>(entry, "TEsT", SetPlatformText);
+
+			Assert.Equal(2, entry.CursorPosition);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test"
 			};
 
-			await SetValueAsync<string, EntryHandler>(entry, text, SetPlatformText);
+			await SetValueAsync<string, EntryHandler>(entry, text, (h, s) => h.VirtualView.Text = s);
 
 			Assert.Equal(text.Length, entry.CursorPosition);
 		}
@@ -243,7 +243,7 @@ namespace Microsoft.Maui.DeviceTests
 				Text = "Test"
 			};
 
-			await SetValueAsync<string, EntryHandler>(entry, text, SetPlatformText);
+			await SetValueAsync<string, EntryHandler>(entry, text, (h, s) => h.VirtualView.Text = s);
 
 			Assert.Equal(0, entry.SelectionLength);
 		}

--- a/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
+++ b/src/Core/src/Handlers/Editor/EditorHandler.Android.cs
@@ -118,8 +118,15 @@ namespace Microsoft.Maui.Handlers
 			}
 		}
 
-		void OnTextChanged(object? sender, Android.Text.TextChangedEventArgs e) =>
+		void OnTextChanged(object? sender, Android.Text.TextChangedEventArgs e)
+		{
+			// Let the mapping know that the update is coming from changes to the platform control
+			DataFlowDirection = DataFlowDirection.FromPlatform;
 			VirtualView?.UpdateText(e);
+			
+			// Reset to the default direction
+			DataFlowDirection = DataFlowDirection.ToPlatform;
+		}
 
 		private void OnSelectionChanged(object? sender, EventArgs e)
 		{

--- a/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.Android.cs
@@ -135,7 +135,13 @@ namespace Microsoft.Maui.Handlers
 				return;
 			}
 
+			// Let the mapping know that the update is coming from changes to the platform control
+			DataFlowDirection = DataFlowDirection.FromPlatform;
 			VirtualView.UpdateText(e);
+
+			// Reset to the default direction
+			DataFlowDirection = DataFlowDirection.ToPlatform;
+
 			MapClearButtonVisibility(this, VirtualView);
 		}
 

--- a/src/Core/src/Handlers/View/DataFlowDirection.cs
+++ b/src/Core/src/Handlers/View/DataFlowDirection.cs
@@ -1,0 +1,21 @@
+﻿#if __IOS__ || MACCATALYST
+using PlatformView = UIKit.UIView;
+#elif __ANDROID__
+using PlatformView = Android.Views.View;
+#elif WINDOWS
+using PlatformView = Microsoft.UI.Xaml.FrameworkElement;
+#elif TIZEN
+using PlatformView = Tizen.NUI.BaseComponents.View;
+#elif (NETSTANDARD || !PLATFORM)
+#endif
+
+namespace Microsoft.Maui.Handlers
+{
+	//	Allows mappings to make decisions based on whether the cross-platform properties are updating the platform UI or vice-versa
+	//  TODO Consider making this public for .NET 8
+	internal enum DataFlowDirection 
+	{
+		ToPlatform,
+		FromPlatform
+	}
+}

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Maui.Handlers
 
 		bool _hasContainer;
 
+		internal DataFlowDirection DataFlowDirection { get; set; }
+
 		protected ViewHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null)
 			: base(mapper, commandMapper ?? ViewCommandMapper)
 		{


### PR DESCRIPTION
### Description of Change

When an Entry has a text transform applied, the managed cursor position tracking algorithm fails and the cursor is reset to 0. This change uses the native Android method for setting the text and preserving the cursor state.

Update:

Text input updates in Controls have two different situations they need to handle. When the cross-platform property is updated, it needs to set the text in the control and move the cursor position to the end. But when the platform control is updating the cross-platform property, we _don't_ want to force the cursor to the end; we want it to stay in place. And in some situations, we also need to update the text in place (e.g., when using a TextTransform) while preserving the cursor location. 

So the mappings need a way to determine which is happening. These changes add a mechanism to the handlers which can indicate when the data is flowing cross-platform -> platform (the default), and when it's flowing the other way (from the platform control to the cross-platform property). 

### Issues Fixed

Fixes #11313