### PR TITLE
Use relative X position of tap when determining if the button was hit

### DIFF
--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -357,16 +357,16 @@ namespace Microsoft.Maui.Platform
 			if (motionEvent is null)
 				return false;
 
+			if (motionEvent.Action != MotionEventActions.Up)
+				return false;
+
 			var rBounds = getClearButtonDrawable?.Invoke()?.Bounds;
 			var buttonWidth = rBounds?.Width();
 
 			if (buttonWidth <= 0)
 				return false;
-
-			if (motionEvent.Action != MotionEventActions.Up)
-				return false;
-
-			var x = motionEvent.RawX;
+			
+			var x = motionEvent.GetX();
 			var y = motionEvent.GetY();
 
 			var flowDirection = platformView.LayoutDirection;


### PR DESCRIPTION
### Description of Change

The hit detection for the Clear button is using the raw X coordinate (screen space) from the motion event, but checking the position of the button in relative space. This change uses the relative X coordinate so that the hit detection is correct even if the Entry is not at the edge of the screen.

### Issues Fixed

Fixes #9954