### PR TITLE
Prevent mobile and lib templates from opening editors if in VS

### DIFF
--- a/src/Templates/src/templates/maui-lib/.template.config/template.json
+++ b/src/Templates/src/templates/maui-lib/.template.config/template.json
@@ -23,7 +23,7 @@
     "postActions": [
         {
             "id": "openInEditor",
-            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\" && HostIdentifier != \"vs\")",
             "description": "Opens Class1.cs in the editor.",
             "manualInstructions": [],
             "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -26,7 +26,7 @@
     "postActions": [
         {
             "id": "openInEditor",
-            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\" && HostIdentifier != \"vs\")",
             "description": "Opens MainPage.xaml in the editor.",
             "manualInstructions": [],
             "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",


### PR DESCRIPTION
With the Maui overview page in VS, it doesn't quite make sense to have the other documents open on project creation. The overview page only displays in the **class library** and **application** projects.
![image](https://user-images.githubusercontent.com/32918747/213316149-e732b126-1cf0-4583-b0c3-af9863ed0c3f.png)


### Description of Change

Added `HostIdentifier != \"vs\"` to the post action condition. That way the action isn't executed when VS is creating a new project.

### Issues Fixed

Fixes #12755

