### PR TITLE
Make MediaPicker capture methods work in Android 13+

### DIFF
--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -62,7 +62,10 @@ namespace Microsoft.Maui.Media
 				throw new FeatureNotSupportedException();
 
 			await Permissions.EnsureGrantedAsync<Permissions.Camera>();
-			await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
+				// StorageWrite no longer exists starting from Android API 33
+			if (!OperatingSystem.IsAndroidVersionAtLeast(33))
+				await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
+			
 
 			var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
 


### PR DESCRIPTION
### Description of Change

In Android 13+ android.permission.WRITE_EXTERNAL_STORAGE no longer exists, and requesting it always returns `Denied`. AFAIK it is not needed for the media capture in this Android version either, though I may be wrong.
This PR is created to make at least some progress towards solving #11275. Because currently there's no way to get the MediaPicker.Capture functions working on Android 13.

My apologies, this is a bit of  a cruddy PR, but since the issue has been open since November, and it seems no-one has made progress on it, I'm trying. If this PR is unsuitable, I hope it at least gets some attention to the issue. It is really annoying that MAUI builds Android API 33 by default, but the current MediaPicker capture code can never work on Android API 33.

I looked at [Permissions.android.cs](https://github.com/dotnet/maui/blob/d1cdd12707ba0639fa2eabf346c8c3524b09c374/src/Essentials/src/Permissions/Permissions.android.cs#L442) and I think the storage read and write permission there are overdue a rewrite. The code there is 100% incompatible with Android 13 / API 33 which MAUI is meant to support. However, I don't know enough about the code base to make such rigorous changes, so I hope someone will look at that soon.

### Issues Fixed

* Fixes #11275
* Fixes #11211