### PR TITLE
Fix password placeholder font issue on Android

### DIFF
--- a/src/Core/src/Platform/Android/EditTextExtensions.cs
+++ b/src/Core/src/Platform/Android/EditTextExtensions.cs
@@ -298,8 +298,6 @@ namespace Microsoft.Maui.Platform
 				editText.KeyListener = LocalizedDigitsKeyListener.Create(editText.InputType);
 			}
 
-			bool hasPassword = false;
-
 			if (textInput is IEntry entry && entry.IsPassword)
 			{
 				if ((nativeInputTypeToUpdate & InputTypes.ClassText) == InputTypes.ClassText)
@@ -307,8 +305,6 @@ namespace Microsoft.Maui.Platform
 
 				if ((nativeInputTypeToUpdate & InputTypes.ClassNumber) == InputTypes.ClassNumber)
 					nativeInputTypeToUpdate |= InputTypes.NumberVariationPassword;
-
-				hasPassword = true;
 			}
 
 			editText.InputType = nativeInputTypeToUpdate;
@@ -316,7 +312,7 @@ namespace Microsoft.Maui.Platform
 			if (textInput is IEditor)
 				editText.InputType |= InputTypes.TextFlagMultiLine;
 
-			if (hasPassword && textInput is IElement element)
+			if (textInput is IElement element)
 			{
 				var services = element.Handler?.MauiContext?.Services;
 


### PR DESCRIPTION
### Description of Change

Change to respect font in the same way for both the placeholder and text of an entry with  either IsPassword=True or IsPassword=False on Android

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #11428

https://user-images.githubusercontent.com/21988533/213532916-4e1030e3-43d6-4191-aaca-acf087246b0c.mp4

