### PR TITLE
Use the new permissions on Android 33+

### DIFF
--- a/src/Controls/samples/Controls.Sample/Platforms/Android/AndroidManifest.xml
+++ b/src/Controls/samples/Controls.Sample/Platforms/Android/AndroidManifest.xml
@@ -22,7 +22,11 @@
   <permission android:name="com.microsoft.maui.sample.permission.MAPS_RECEIVE" android:protectionLevel="signature" />
   
   <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+  <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
   <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
   
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/src/Controls/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Controls/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 </manifest>

--- a/src/Core/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Core/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 	<queries>
 		<!-- Email -->

--- a/src/Essentials/samples/Samples/Platforms/Android/AndroidManifest.xml
+++ b/src/Essentials/samples/Samples/Platforms/Android/AndroidManifest.xml
@@ -7,8 +7,11 @@
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-permission android:name="android.permission.FLASHLIGHT" />
 	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<queries>

--- a/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
+++ b/src/Essentials/samples/Samples/ViewModel/MediaPickerViewModel.cs
@@ -97,7 +97,7 @@ namespace Samples.ViewModel
 
 				await LoadVideoAsync(video);
 
-				Console.WriteLine($"PickVideoAsync COMPLETED: {PhotoPath}");
+				Console.WriteLine($"PickVideoAsync COMPLETED: {VideoPath}");
 			}
 			catch (Exception ex)
 			{
@@ -113,7 +113,7 @@ namespace Samples.ViewModel
 
 				await LoadVideoAsync(photo);
 
-				Console.WriteLine($"CaptureVideoAsync COMPLETED: {PhotoPath}");
+				Console.WriteLine($"CaptureVideoAsync COMPLETED: {VideoPath}");
 			}
 			catch (Exception ex)
 			{

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Media
 			if (OperatingSystem.IsAndroidVersionAtLeast(33)) // >= 33
 				await Permissions.EnsureGrantedAsync<Permissions.Media>();
 			else // <= 32
-				await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
+				await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
 
 			var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Media
 				throw new FeatureNotSupportedException();
 
 			await Permissions.EnsureGrantedAsync<Permissions.Camera>();
-			await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
+			await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
 
 			var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Maui.Media
 			if (OperatingSystem.IsAndroidVersionAtLeast(33)) // >= 33
 				await Permissions.EnsureGrantedAsync<Permissions.Media>();
 			else // <= 32
-				await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
+				await Permissions.EnsureGrantedAsync<Permissions.StorageWrite>();
 
 			var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
 

--- a/src/Essentials/src/MediaPicker/MediaPicker.android.cs
+++ b/src/Essentials/src/MediaPicker/MediaPicker.android.cs
@@ -62,7 +62,10 @@ namespace Microsoft.Maui.Media
 				throw new FeatureNotSupportedException();
 
 			await Permissions.EnsureGrantedAsync<Permissions.Camera>();
-			await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
+			if (OperatingSystem.IsAndroidVersionAtLeast(33)) // >= 33
+				await Permissions.EnsureGrantedAsync<Permissions.Media>();
+			else // <= 32
+				await Permissions.EnsureGrantedAsync<Permissions.StorageRead>();
 
 			var capturePhotoIntent = new Intent(photo ? MediaStore.ActionImageCapture : MediaStore.ActionVideoCapture);
 

--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -441,8 +441,28 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class StorageRead : BasePlatformPermission
 		{
-			public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
-				new (string, bool)[] { (Manifest.Permission.ReadExternalStorage, true) };
+			public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+			{
+				get
+				{
+					var permissions = new List<(string, bool)>();
+
+#if __ANDROID_33__
+					if (OperatingSystem.IsAndroidVersionAtLeast(33) && Application.Context.ApplicationInfo.TargetSdkVersion >= BuildVersionCodes.Tiramisu)
+					{
+						permissions.Add((Manifest.Permission.ReadMediaAudio, true));
+						permissions.Add((Manifest.Permission.ReadMediaImages, true));
+						permissions.Add((Manifest.Permission.ReadMediaVideo, true));
+					}
+					else
+#endif
+					{
+						permissions.Add((Manifest.Permission.ReadExternalStorage, true));
+					}
+
+					return permissions.ToArray();
+				}
+			}
 		}
 
 		public partial class StorageWrite : BasePlatformPermission

--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Maui.ApplicationModel
 				{
 					var permissions = new List<(string, bool)>();
 
-#if __ANDROID_33__
+#if ANDROID33
 					if (OperatingSystem.IsAndroidVersionAtLeast(33) && Application.Context.ApplicationInfo.TargetSdkVersion >= BuildVersionCodes.Tiramisu)
 					{
 						permissions.Add((Manifest.Permission.ReadMediaAudio, true));

--- a/src/Essentials/src/Permissions/Permissions.android.cs
+++ b/src/Essentials/src/Permissions/Permissions.android.cs
@@ -318,6 +318,25 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class Media : BasePlatformPermission
 		{
+			public override (string androidPermission, bool isRuntime)[] RequiredPermissions
+			{
+				get
+				{
+					var permissions = new List<(string, bool)>();
+
+					if (OperatingSystem.IsAndroidVersionAtLeast(33) && Application.Context.ApplicationInfo.TargetSdkVersion >= BuildVersionCodes.Tiramisu)
+					{
+						if (IsDeclaredInManifest(Manifest.Permission.ReadMediaAudio))
+							permissions.Add((Manifest.Permission.ReadMediaAudio, true));
+						if (IsDeclaredInManifest(Manifest.Permission.ReadMediaImages))
+							permissions.Add((Manifest.Permission.ReadMediaImages, true));
+						if (IsDeclaredInManifest(Manifest.Permission.ReadMediaVideo))
+							permissions.Add((Manifest.Permission.ReadMediaVideo, true));
+					}
+
+					return permissions.ToArray();
+				}
+			}
 		}
 
 		public partial class Microphone : BasePlatformPermission
@@ -441,28 +460,8 @@ namespace Microsoft.Maui.ApplicationModel
 
 		public partial class StorageRead : BasePlatformPermission
 		{
-			public override (string androidPermission, bool isRuntime)[] RequiredPermissions
-			{
-				get
-				{
-					var permissions = new List<(string, bool)>();
-
-#if __ANDROID_33__
-					if (OperatingSystem.IsAndroidVersionAtLeast(33) && Application.Context.ApplicationInfo.TargetSdkVersion >= BuildVersionCodes.Tiramisu)
-					{
-						permissions.Add((Manifest.Permission.ReadMediaAudio, true));
-						permissions.Add((Manifest.Permission.ReadMediaImages, true));
-						permissions.Add((Manifest.Permission.ReadMediaVideo, true));
-					}
-					else
-#endif
-					{
-						permissions.Add((Manifest.Permission.ReadExternalStorage, true));
-					}
-
-					return permissions.ToArray();
-				}
-			}
+			public override (string androidPermission, bool isRuntime)[] RequiredPermissions =>
+				new (string, bool)[] { (Manifest.Permission.ReadExternalStorage, true) };
 		}
 
 		public partial class StorageWrite : BasePlatformPermission

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+~override Microsoft.Maui.ApplicationModel.Permissions.Media.RequiredPermissions.get -> (string androidPermission, bool isRuntime)[]

--- a/src/Essentials/test/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Essentials/test/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/src/Graphics/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/src/Graphics/tests/DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/src/TestUtils/samples/DeviceTests.Sample/Platforms/Android/AndroidManifest.xml
+++ b/src/TestUtils/samples/DeviceTests.Sample/Platforms/Android/AndroidManifest.xml
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
### Description of Change

Use the new permissions on Android 33+.


On older Androids, we use the global "read" permission and ask for everything. On Android 33 and newer (for now) we use the new media permissions. The ones we pick are the ones defined in the manifest.

It is possible to call this permission and it to return granted if there are no permissions defined. Not sure if that is something we want. Maybe when we call this on 33+ we should also throw if none are declared?

The `Media` permission is only used on iOS and it is just for `MPMediaLibrary` which also only gives read-only access:

* **MPMediaLibraryAuthorizationStatusNotDetermined** The user hasn't determined whether to authorize the use of their media library.
* **MPMediaLibraryAuthorizationStatusDenied** The app may not access the items in the user's media library.
* **MPMediaLibraryAuthorizationStatusRestricted** The app may access some of the content in the user's media library.
* **MPMediaLibraryAuthorizationStatusAuthorized** Your app may access items in the user's media library.

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

* Fixes #11275
* Fixes #11211
<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
