### PR TITLE
[Actions] Update the action to use a new PAT and be able to trigger it manually

### DIFF
--- a/.github/workflows/sdk-insertion-bump.yml
+++ b/.github/workflows/sdk-insertion-bump.yml
@@ -5,6 +5,20 @@ on:
   push:
     branches:
       - '*'
+  workflow_dispatch:
+    inputs:
+      brach:
+        description: 'The dotnet maui branch the contains the commit.'
+        required: true
+        type: string
+      commit:
+        description: 'The hash to be used to bump the sdk insertion.'
+        required: true
+        type: string
+      commit_title:
+        description: 'The commit title to be used for the bump.'
+        required: true
+        type: string
 
 jobs:
   pingRemote:
@@ -13,9 +27,28 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # because we want to be able to execute the action manually, we need diff steps
+      # depending on the event that triggered the action. If we are executing the event
+      # manually we want to parse the given data and add it to the variables, els we just
+      # copy  what we got from the push
+
+      # if manual trigger
+
+      - name: 'Update remote repository from manual trigger'
+        uses: peter-evans/repository-dispatch@v2
+        if: ${{ github.event_name == "workflow_dispatch" }}
+        with:
+          token: ${{ secrets.MEGAPIPELINE_PAT }}
+          event-type: 'sdk_insertion'
+          repository: 'xamarin/sdk-insertions'
+          client-payload: '{"repository": "dotnet/maui", "branch": "${{ input.branch }}", "commit": "${{ input.commit }}", "commit_message": "${{ input.commit_title }}"}'
+
+      # if push event
+
       - name: Parse commit
         shell: pwsh
         id: commit_title
+        if: ${{ github.event_name == "push" }}
         run: |
           Write-Host "Commit message is $Env:COMMIT_MESSAGE"
           $title = ($Env:COMMIT_MESSAGE -split '\n')[0]
@@ -23,10 +56,11 @@ jobs:
         env:
           COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
 
-      - name: 'Update remote repository'
+      - name: 'Update remote repository from push event'
         uses: peter-evans/repository-dispatch@v2
+        if: ${{ github.event_name == "push" }}
         with:
-          token: ${{ secrets.SERVICEACCOUNT_PAT }}
+          token: ${{ secrets.MEGAPIPELINE_PAT }}
           event-type: 'sdk_insertion'
           repository: 'xamarin/sdk-insertions'
           client-payload: '{"repository": "dotnet/maui", "branch": "${{ github.ref_name }}", "commit": "${{ github.sha }}", "commit_message": "${{ steps.commit_title.outputs.COMMIT_TITLE }}"}'


### PR DESCRIPTION
There are two important changes:

1. Updated to use a new secret that should have a PAT that can ping the
   sdk-insertions repo.
2. Added support to manully trigger the action that will use the
   given inputs to perform a bump in the sdk-insertions repository.

Change 1 is needed because we have been havin gissues with the default
PAT. Change 2 is added in order to make testin of the action easier.
