### PR TITLE
[Actions] Github actions do not support double quotes on expressions.

### DIFF
--- a/.github/workflows/sdk-insertion-bump.yml
+++ b/.github/workflows/sdk-insertion-bump.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: 'Update remote repository from manual trigger'
         uses: peter-evans/repository-dispatch@v2
-        if: ${{ github.event_name == "workflow_dispatch" }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           token: ${{ secrets.MEGAPIPELINE_PAT }}
           event-type: 'sdk_insertion'
@@ -48,7 +48,7 @@ jobs:
       - name: Parse commit
         shell: pwsh
         id: commit_title
-        if: ${{ github.event_name == "push" }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           Write-Host "Commit message is $Env:COMMIT_MESSAGE"
           $title = ($Env:COMMIT_MESSAGE -split '\n')[0]
@@ -58,7 +58,7 @@ jobs:
 
       - name: 'Update remote repository from push event'
         uses: peter-evans/repository-dispatch@v2
-        if: ${{ github.event_name == "push" }}
+        if: ${{ github.event_name == 'push' }}
         with:
           token: ${{ secrets.MEGAPIPELINE_PAT }}
           event-type: 'sdk_insertion'


### PR DESCRIPTION
VSTS on the other hand does work with ""