### PR TITLE
Fix count comparison when switching tabs

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellSectionRenderer.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 			// This mainly happens if all of the items that are part of this shell section 
 			// vanish. Android calls `OnPageSelected` with position zero even though the view pager is
 			// empty
-			if (visibleItems.Count >= position)
+			if (position >= visibleItems.Count)
 				return;
 
 			var shellContent = visibleItems[position];

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Android.cs
@@ -8,6 +8,7 @@ using AndroidX.AppCompat.Widget;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Core.View;
 using AndroidX.DrawerLayout.Widget;
+using AndroidX.ViewPager2.Widget;
 using Google.Android.Material.AppBar;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Compatibility;
@@ -360,6 +361,27 @@ namespace Microsoft.Maui.DeviceTests
 			}
 
 			return flyoutContainer ?? throw new Exception("RecyclerView not found");
+		}
+
+		async Task TapToSelect(ContentPage page)
+		{
+			var shellContent = page.Parent as ShellContent;
+			var shellSection = shellContent.Parent as ShellSection;
+			var shellItem = shellSection.Parent as ShellItem;
+			var shell = shellItem.Parent as Shell;
+			await OnNavigatedToAsync(shell.CurrentPage);
+
+			if (shellItem != shell.CurrentItem)
+				throw new NotImplementedException();
+
+			if (shellSection != shell.CurrentItem.CurrentItem)
+				throw new NotImplementedException();
+
+			var pagerParent = (shell.CurrentPage.Handler as IPlatformViewHandler)
+				.PlatformView.GetParentOfType<ViewPager2>();
+
+			pagerParent.CurrentItem = shellSection.Items.IndexOf(shellContent);
+			await OnNavigatedToAsync(page);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -580,5 +580,55 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal((rootView.SelectedItem as NavigationViewItemViewModel).Data, flyoutItems[0][1]);
 			});
 		}
+
+		async Task TapToSelect(ContentPage page)
+		{
+			var shellContent = page.Parent as ShellContent;
+			var shellSection = shellContent.Parent as ShellSection;
+			var shellItem = shellSection.Parent as ShellItem;
+			var shell = shellItem.Parent as Shell;
+
+			await OnNavigatedToAsync(shell.CurrentPage);
+
+			if (shellItem != shell.CurrentItem)
+				throw new NotImplementedException();
+
+			if (shellSection != shell.CurrentItem.CurrentItem)
+				throw new NotImplementedException();
+
+			var mauiNavigationView = shellItem.Handler.PlatformView as MauiNavigationView;
+			var navSource = mauiNavigationView.MenuItemsSource as IEnumerable;
+
+			bool found = false;
+			foreach (NavigationViewItemViewModel item in navSource)
+			{
+				if (item.Data == shellContent)
+				{
+					mauiNavigationView.SelectedItem = item;
+					found = true;
+					break;
+				}
+				else if (item.MenuItemsSource is IEnumerable children)
+				{
+					foreach (NavigationViewItemViewModel childContent in children)
+					{
+						if (childContent.Data == shellContent)
+						{
+							mauiNavigationView.SelectedItem = childContent;
+							found = true;
+							break;
+						}
+					}
+				}
+
+				if (found)
+					break;
+			}
+
+			if (!found)
+				throw new InvalidOperationException("Unable to locate page inside platform shell components");
+
+			await OnNavigatedToAsync(page);
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.cs
@@ -635,6 +635,45 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		[Fact(DisplayName = "LifeCycleEvents Fire When Navigating Top Tabs")]
+		public async Task LifeCycleEventsFireWhenNavigatingTopTabs()
+		{
+			SetupBuilder();
+
+			var page1 = new LifeCycleTrackingPage() { Content = new Label() { Padding = 40, Text = "Page 1", Background = SolidColorBrush.Purple } };
+			var page2 = new LifeCycleTrackingPage() { Content = new Label() { Padding = 40, Text = "Page 2", Background = SolidColorBrush.Green } };
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(new Tab()
+				{
+					Items =
+					{
+						new ShellContent()
+						{
+							Title = "Tab 1",
+							Content = page1
+						},
+						new ShellContent()
+						{
+							Title = "Tab 2",
+							Content = page2
+						},
+					}
+				});
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, async (handler) =>
+			{
+				await OnNavigatedToAsync(page1);
+
+				Assert.Equal(0, page2.OnNavigatedToCount);
+				await TapToSelect(page2);
+				Assert.Equal(page2.Parent, shell.CurrentItem.CurrentItem.CurrentItem);
+				page2.AssertLifeCycleCounts();
+			});
+		}
+
 		protected Task<Shell> CreateShellAsync(Action<Shell> action) =>
 			InvokeOnMainThreadAsync(() =>
 			{

--- a/src/Controls/tests/DeviceTests/TestClasses/LifeCycleTrackingPage.cs
+++ b/src/Controls/tests/DeviceTests/TestClasses/LifeCycleTrackingPage.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Microsoft.Maui.DeviceTests
+{
+	public class LifeCycleTrackingPage : ContentPage
+	{
+		public NavigatedFromEventArgs NavigatedFromArgs { get; private set; }
+		public NavigatingFromEventArgs NavigatingFromArgs { get; private set; }
+		public NavigatedToEventArgs NavigatedToArgs { get; private set; }
+		public int AppearingCount { get; private set; }
+		public int DisappearingCount { get; private set; }
+		public int OnNavigatedToCount { get; private set; }
+		public int OnNavigatingFromCount { get; private set; }
+		public int OnNavigatedFromCount { get; private set; }
+
+		public void ClearNavigationArgs()
+		{
+			NavigatedFromArgs = null;
+			NavigatingFromArgs = null;
+			NavigatedToArgs = null;
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			AppearingCount++;
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+			DisappearingCount++;
+		}
+
+		protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+		{
+			base.OnNavigatedFrom(args);
+			NavigatedFromArgs = args;
+			OnNavigatedFromCount++;
+		}
+
+		protected override void OnNavigatingFrom(NavigatingFromEventArgs args)
+		{
+			base.OnNavigatingFrom(args);
+			NavigatingFromArgs = args;
+			OnNavigatingFromCount++;
+		}
+
+		protected override void OnNavigatedTo(NavigatedToEventArgs args)
+		{
+			base.OnNavigatedTo(args);
+			NavigatedToArgs = args;
+			OnNavigatedToCount++;
+		}
+
+		public void AssertLifeCycleCounts()
+		{
+			if (!this.HasAppeared)
+			{
+				Assert.Equal(AppearingCount, DisappearingCount);
+				Assert.Equal(DisappearingCount, OnNavigatedToCount);
+				Assert.Equal(OnNavigatingFromCount, OnNavigatedToCount);
+			}
+			else
+			{
+				Assert.Equal(AppearingCount, OnNavigatedToCount);
+				Assert.Equal(DisappearingCount, AppearingCount - 1);
+				Assert.Equal(OnNavigatingFromCount, AppearingCount - 1);
+			}
+
+			Assert.Equal(DisappearingCount, OnNavigatingFromCount);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

A bad count comparison when changing top tabs is currently causing none of the ShellContent activation code to run. 

### Issues Fixed
Fixes #8102

