### PR TITLE
Fix Layout issues with the details page on Flyout

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 					if (!IsRTL)
 						flyoutFrame.X -= flyoutFrame.Width;
 					else
-						flyoutFrame.X = flyoutFrame.Width + frame.Width;
+						flyoutFrame.X = frame.Width;
 				}
 				else if (IsRTL)
 				{
@@ -609,8 +609,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			var center = new PointF();
 			_panGesture = new UIPanGestureRecognizer(g =>
 			{
-				var IsRTL = (Element as IVisualElementController)?.EffectiveFlowDirection.IsRightToLeft() == true;
-
 				int directionModifier = IsRTL ? -1 : 1;
 
 				switch (g.State)
@@ -658,7 +656,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 							else
 								targetFrame.X = (nfloat)Math.Min(0, Math.Max(0, motion) - flyoutWidth);
 
-							targetFrame.X = targetFrame.X * directionModifier;
+							if (IsRTL)
+							{
+								targetFrame.X = (float)Element.Bounds.Width - (flyoutWidth + targetFrame.X);
+							}
+
 							if (_applyShadow)
 							{
 								var openProgress = targetFrame.X / flyoutWidth;
@@ -693,18 +695,23 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 						else
 						{
 							var flyoutFrame = _flyoutController.View.Frame;
-							var progress = flyoutFrame.Width + flyoutFrame.X;
+							var flyoutOffsetX = flyoutFrame.X + flyoutFrame.Width;
+
+							if (IsRTL)
+							{
+								flyoutOffsetX = (float)Element.Bounds.Width - flyoutFrame.X;
+							}
 
 							if (Presented)
 							{
-								if (flyoutFrame.X * directionModifier < flyoutFrame.Width * .75)
+								if (flyoutOffsetX < flyoutFrame.Width * .75)
 									UpdatePresented(false);
 								else
 									LayoutChildren(true);
 							}
 							else
 							{
-								if ((flyoutFrame.X + flyoutFrame.Width) * directionModifier > flyoutFrame.Width * .25)
+								if (flyoutOffsetX > flyoutFrame.Width * .25)
 									UpdatePresented(true);
 								else
 									LayoutChildren(true);

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				_flyoutOverlapsDetailsInPopoverMode = value;
 			}
 		}
-		
+
 		bool IsRTL => (Element as IVisualElementController)?.EffectiveFlowDirection.IsRightToLeft() == true;
 
 		public static IPropertyMapper<FlyoutPage, PhoneFlyoutPageRenderer> Mapper = new PropertyMapper<FlyoutPage, PhoneFlyoutPageRenderer>(ViewHandler.ViewMapper);

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -247,7 +247,27 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return;
 
 			View.Add(_clickOffView);
-			_clickOffView.Frame = _detailController.View.Frame;
+			UpdateClickOffViewFrame();
+		}
+
+		void UpdateClickOffViewFrame()
+		{
+			if (IsPad)
+			{
+				var detailsFrame = _detailController.View.Frame;
+				var flyoutWidth = _flyoutController.View.Frame.Width;
+
+				_clickOffView.Frame =
+					new CoreGraphics.CGRect(
+							_flyoutController.View.Frame.Width,
+							detailsFrame.Y,
+							detailsFrame.Width - flyoutWidth,
+							detailsFrame.Height);
+			}
+			else
+			{
+				_clickOffView.Frame = _detailController.View.Frame;
+			}
 		}
 
 		void RemoveClickOffView()
@@ -373,7 +393,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				FlyoutPageController.DetailBounds = new Rect(0, 0, frame.Width, frame.Height);
 
 			if (Presented)
-				_clickOffView.Frame = _detailController.View.Frame;
+				UpdateClickOffViewFrame();
 		}
 
 		void PackContainers()

--- a/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/FlyoutPage/iOS/PhoneFlyoutPageRenderer.cs
@@ -349,7 +349,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 
 			FlyoutPageController.FlyoutBounds = new Rect(flyoutFrame.X, 0, flyoutFrame.Width, flyoutFrame.Height);
-			FlyoutPageController.DetailBounds = new Rect(target.X, 0, frame.Width, frame.Height);
+
+			if (IsPad)
+				FlyoutPageController.DetailBounds = new Rect(target.X, 0, frame.Width, frame.Height);
+			else
+				FlyoutPageController.DetailBounds = new Rect(0, 0, frame.Width, frame.Height);
 
 			if (Presented)
 				_clickOffView.Frame = _detailController.View.Frame;

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1324,6 +1324,16 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return empty;
 			}
 
+			[System.Runtime.Versioning.UnsupportedOSPlatform("ios8.0")]
+			[System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+#pragma warning disable RS0016 // Add public types and members to the declared API
+			public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)
+#pragma warning restore RS0016 // Add public types and members to the declared API
+			{
+				base.WillRotate(toInterfaceOrientation, duration);
+				UpdateLeftBarButtonItem();
+			}
+
 			internal void UpdateLeftBarButtonItem(Page pageBeingRemoved = null)
 			{
 				NavigationRenderer n;

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -1324,14 +1324,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				return empty;
 			}
 
-			[System.Runtime.Versioning.UnsupportedOSPlatform("ios8.0")]
-			[System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
-#pragma warning disable RS0016 // Add public types and members to the declared API
-			public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)
-#pragma warning restore RS0016 // Add public types and members to the declared API
+			public override void ViewWillTransitionToSize(SizeF toSize, IUIViewControllerTransitionCoordinator coordinator)
 			{
-				base.WillRotate(toInterfaceOrientation, duration);
-				UpdateLeftBarButtonItem();
+				base.ViewWillTransitionToSize(toSize, coordinator);
+
+				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+					UpdateLeftBarButtonItem();
 			}
 
 			internal void UpdateLeftBarButtonItem(Page pageBeingRemoved = null)

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> b
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void
 Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
+override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillLayoutSubviews() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewDidDisappear(bool animated) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void
+Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.get -> bool
+Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.set -> void
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Platform.ShapesExtensions
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -85,3 +85,4 @@ Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targ
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 ~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
+*REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.WillRotate(UIKit.UIInterfaceOrientation toInterfaceOrientation, double duration) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -27,6 +27,7 @@ static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
+~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> b
 Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
 Microsoft.Maui.Controls.Shapes.Shape.~Shape() -> void
 Microsoft.Maui.Controls.VisualElement.~VisualElement() -> void
+override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillLayoutSubviews() -> void
 override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRenderer.ViewDidDisappear(bool animated) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Border.~Border() -> void
+Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.get -> bool
+Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.FlyoutOverlapsDetailsInPopoverMode.set -> void
 Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
 Microsoft.Maui.Controls.Platform.ShapesExtensions
 Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -85,3 +85,4 @@ Microsoft.Maui.Controls.IValueConverter.Convert(object? value, System.Type! targ
 Microsoft.Maui.Controls.IValueConverter.ConvertBack(object? value, System.Type! targetType, object? parameter, System.Globalization.CultureInfo! culture) -> object?
 ~static Microsoft.Maui.Controls.GridExtensions.Add(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int left, int right, int top, int bottom) -> void
 ~static Microsoft.Maui.Controls.GridExtensions.AddWithSpan(this Microsoft.Maui.Controls.Grid grid, Microsoft.Maui.IView view, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) -> void
+*REMOVED*override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.WillRotate(UIKit.UIInterfaceOrientation toInterfaceOrientation, double duration) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -27,6 +27,7 @@ static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 Microsoft.Maui.Controls.Handlers.BoxViewHandler
 Microsoft.Maui.Controls.Handlers.BoxViewHandler.BoxViewHandler() -> void
+~override Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.TraitCollectionDidChange(UIKit.UITraitCollection previousTraitCollection) -> void
 ~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Platform.Compatibility.ShellSectionRootRenderer.ViewWillTransitionToSize(CoreGraphics.CGSize toSize, UIKit.IUIViewControllerTransitionCoordinator coordinator) -> void

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -222,6 +222,8 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					Assert.Equal(flyoutBounds.Width, detailBounds.X);
 				}
+
+				Assert.Equal(detailBounds.Width, windowBounds.Width - flyoutBounds.Width);
 			});
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -197,8 +197,8 @@ namespace Microsoft.Maui.DeviceTests
 				if (!CanDeviceDoSplitMode(flyoutPage))
 					return Task.CompletedTask;
 
-				var detailBounds = flyoutPage.Flyout.GetPlatformViewBounds();
-				var flyoutBounds = flyoutPage.Detail.GetPlatformViewBounds();
+				var detailBounds = flyoutPage.Detail.GetPlatformViewBounds();
+				var flyoutBounds = flyoutPage.Flyout.GetPlatformViewBounds();
 				var windowBounds = Microsoft.Maui.Devices.DeviceDisplay.Current.MainDisplayInfo;
 
 				Assert.True(detailBounds.Height <= windowBounds.Height, $"Details is measuring too high. Details - {detailBounds} Window - {windowBounds}");

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			});
 
-			await CreateHandlerAndAddToWindow<PhoneFlyoutPageRenderer>(flyoutPage, (handler) =>
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, (handler) =>
 			{
 				if (!CanDeviceDoSplitMode(flyoutPage))
 					return Task.CompletedTask;

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.iOS.cs
@@ -15,12 +15,17 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using UIKit;
 using Xunit;
+#if IOS || MACCATALYST
+using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
+#endif
 
 namespace Microsoft.Maui.DeviceTests
 {
 	[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
 	public partial class FlyoutPageTests
 	{
+		bool IsPad => UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad;
+
 #if MACCATALYST
 		[Fact(DisplayName = "Flyout Page Takes Into Account Safe Area by Default")]
 		public async Task FlyoutPageTakesIntoAccountSafeAreaByDefault()
@@ -51,6 +56,66 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 #endif
+
+		[Fact]
+		public async Task DetailsViewLayoutIsCorrectForIdiom()
+		{
+			SetupBuilder();
+			var flyoutLabel = new Label() { Text = "Content" };
+			var flyoutPage = await InvokeOnMainThreadAsync(() => new FlyoutPage()
+			{
+				FlyoutLayoutBehavior = FlyoutLayoutBehavior.Popover,
+				IsPresented = true,
+				Detail = new ContentPage()
+				{
+					Title = "Detail",
+					Content = new Label()
+				},
+				Flyout = new ContentPage()
+				{
+					Title = "Flyout",
+					Content = flyoutLabel
+				}
+			});
+
+			await CreateHandlerAndAddToWindow<FlyoutViewHandler>(flyoutPage, async (handler) =>
+			{
+				var detailBounds = flyoutPage.Detail.GetPlatformViewBounds();
+				var flyoutBounds = flyoutPage.Flyout.GetPlatformViewBounds();
+
+				if (IsPad)
+				{
+					Assert.Equal(0, detailBounds.X);
+					Assert.Equal(0, flyoutBounds.X);
+				}
+				else
+				{
+					Assert.Equal(flyoutBounds.Width, detailBounds.X);
+					Assert.Equal(0, flyoutBounds.X);
+				}
+
+				flyoutPage.IsPresented = false;
+
+				await Task.Yield();
+				await AssertionExtensions.Wait(() =>
+				{
+					var flyoutBounds = flyoutPage.Flyout.GetPlatformViewBounds();
+					return -flyoutBounds.Width == flyoutBounds.X;
+				});
+
+				var detailBoundsNotPresented = flyoutPage.Detail.GetPlatformViewBounds();
+				var flyoutBoundsNotPresented = flyoutPage.Flyout.GetPlatformViewBounds();
+
+				if (IsPad)
+				{
+					Assert.Equal(detailBoundsNotPresented, detailBounds);
+				}
+
+				// ensure flyout is off screen
+				Assert.Equal(-flyoutBoundsNotPresented.Width, flyoutBoundsNotPresented.X);
+			});
+		}
+
 
 		UIView FindPlatformFlyoutView(UIView uiView) =>
 			uiView.FindResponder<PhoneFlyoutPageRenderer>()?.View;

--- a/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/FlyoutPage/FlyoutPageTests.iOS.cs
@@ -51,5 +51,8 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 #endif
+
+		UIView FindPlatformFlyoutView(UIView uiView) =>
+			uiView.FindResponder<PhoneFlyoutPageRenderer>()?.View;
 	}
 }


### PR DESCRIPTION
### Description of Change

When we moved over to MAUI we switched  to using `PhoneFlyoutPageRenderer` for both iPad and Phone in order to simplify and make the behavior symmetric.  The `PhoneFlyoutPageRenderer` unfortunately had more short comings then I'd anticipated so this PR fixes a number of them.

- `PhoneFlyoutPageRenderer` didn't really work with `Split` mode at all, so this takes into account different measuring/arranging based on if you're in SplitMode. 
- This changes iPad to to work how it did in `Forms` where the popover goes over the details instead of shifting the details view over.
- Fixes a number of RTL bugs as well found along the way.

If time allows for it we'll shift all this back into `core` and then shell and non-shell can just use the same code.

### Issues Fixed
Fixes #7520
Fixes #10291

### Docs Notes
- By default, the behavior has been made to match `XF`. If you're on an iPhone it'll push the content over when the popup opens and on an iPad the popver will overlap.
- API added to `PhoneFlyoutPageRenderer` FlyoutOverlapsDetailsInPopoverMode which allows users to toggle between the two behaviors if they want to influence how it works.  