### PR TITLE
Pre-compute Grid star values when possible

### DIFF
--- a/src/Core/src/Layouts/GridLayoutManager.cs
+++ b/src/Core/src/Layouts/GridLayoutManager.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Primitives;
 
@@ -51,9 +52,6 @@ namespace Microsoft.Maui.Layouts
 
 		class GridStructure
 		{
-			public double HeightConstraint => _gridHeightConstraint;
-			public double WidthConstraint => _gridWidthConstraint;
-
 			readonly IGridLayout _grid;
 			readonly double _gridWidthConstraint;
 			readonly double _gridHeightConstraint;
@@ -65,6 +63,9 @@ namespace Microsoft.Maui.Layouts
 			readonly double _gridMaxWidth;
 			readonly double _gridMinWidth;
 
+			readonly bool _isStarWidthPrecomputable;
+			readonly bool _isStarHeightPrecomputable;
+
 			Definition[] _rows { get; }
 			Definition[] _columns { get; }
 
@@ -74,8 +75,6 @@ namespace Microsoft.Maui.Layouts
 			readonly Thickness _padding;
 			readonly double _rowSpacing;
 			readonly double _columnSpacing;
-			readonly IReadOnlyList<IGridRowDefinition> _rowDefinitions;
-			readonly IReadOnlyList<IGridColumnDefinition> _columnDefinitions;
 
 			readonly Dictionary<SpanKey, Span> _spans = new();
 
@@ -99,11 +98,15 @@ namespace Microsoft.Maui.Layouts
 				_padding = grid.Padding;
 				_columnSpacing = grid.ColumnSpacing;
 				_rowSpacing = grid.RowSpacing;
-				_rowDefinitions = grid.RowDefinitions;
-				_columnDefinitions = grid.ColumnDefinitions;
 
-				_rows = InitializeRows();
-				_columns = InitializeColumns();
+				_rows = InitializeRows(grid.RowDefinitions);
+				_columns = InitializeColumns(grid.ColumnDefinitions);
+
+				// Determine whether we can figure out the * values before doing any measurements
+				// i.e., are there any Auto values in the relevant dimensions, and are we working 
+				// with fixed constraints on the Grid itself
+				_isStarHeightPrecomputable = IsStarHeightPrecomputable();
+				_isStarWidthPrecomputable = IsStarWidthPrecomputable();
 
 				// We could work out the _childrenToLayOut array (with the Collapsed items filtered out) with a Linq 1-liner
 				// but doing it the hard way means we don't allocate extra enumerators, especially if we're in the 
@@ -142,9 +145,9 @@ namespace Microsoft.Maui.Layouts
 				};
 			}
 
-			Definition[] InitializeRows()
+			Definition[] InitializeRows(IReadOnlyList<IGridRowDefinition> rowDefinitions)
 			{
-				int count = _rowDefinitions.Count;
+				int count = rowDefinitions.Count;
 
 				if (count == 0)
 				{
@@ -156,16 +159,16 @@ namespace Microsoft.Maui.Layouts
 
 				for (int n = 0; n < count; n++)
 				{
-					var definition = _rowDefinitions[n];
+					var definition = rowDefinitions[n];
 					rows[n] = new Definition(definition.Height);
 				}
 
 				return rows;
 			}
 
-			Definition[] InitializeColumns()
+			Definition[] InitializeColumns(IReadOnlyList<IGridColumnDefinition> columnDefinitions)
 			{
-				int count = _columnDefinitions.Count;
+				int count = columnDefinitions.Count;
 
 				if (count == 0)
 				{
@@ -177,7 +180,7 @@ namespace Microsoft.Maui.Layouts
 
 				for (int n = 0; n < count; n++)
 				{
-					var definition = _columnDefinitions[n];
+					var definition = columnDefinitions[n];
 					definitions[n] = new Definition(definition.Width);
 				}
 
@@ -215,10 +218,28 @@ namespace Microsoft.Maui.Layouts
 						rowGridLengthType |= ToGridLengthType(_rows[rowIndex].GridLength.GridUnitType);
 					}
 
-					_cells[n] = new Cell(n, row, column, rowSpan, columnSpan, columnGridLengthType, rowGridLengthType);
+					var cell = new Cell(n, row, column, rowSpan, columnSpan, columnGridLengthType, rowGridLengthType);
+
+					// We may have enough info at this point to determine some of the measurement constraints for cells
+					DetermineCellMeasureWidth(cell);
+					DetermineCellMeasureHeight(cell);
+
+					_cells[n] = cell;
+				}
+
+				if (_isStarWidthPrecomputable)
+				{
+					// We have enough information to go ahead and work out the sizes of the * columns
+					ResolveStarColumns(_gridWidthConstraint);
+				}
+
+				if (_isStarHeightPrecomputable)
+				{
+					// We have enough information to go ahead and work out the sizes of the * rows
+					ResolveStarRows(_gridHeightConstraint);
 				}
 			}
-
+			
 			public Rect GetCellBoundsFor(IView view, double xOffset, double yOffset)
 			{
 				var firstColumn = _grid.GetColumn(view).Clamp(0, _columns.Length - 1);
@@ -315,14 +336,23 @@ namespace Microsoft.Maui.Layouts
 
 			void MeasureCells()
 			{
-				// Do the initial pass for all the auto/star stuff
-				MeasureCellsWithUnknowns();
+				AutoMeasurePass();
 
-				ResolveStarColumns(_gridWidthConstraint);
-				ResolveStarRows(_gridHeightConstraint);
+				if (!_isStarWidthPrecomputable)
+				{
+					// We didn't have enough info to work out the * column sizes earlier, but now that
+					// we've measured the Auto dimensions, we can finalize those values
+					ResolveStarColumns(_gridWidthConstraint);
+				}
 
-				// Measure the content for cells where we know the dimensions
-				MeasureKnownCells();
+				if (!_isStarHeightPrecomputable)
+				{
+					// We didn't have enough info to work out the * row sizes earlier, but now that
+					// we've measured the Auto dimensions, we can finalize those values
+					ResolveStarRows(_gridHeightConstraint);
+				}
+
+				SecondMeasurePass();
 
 				ResolveSpans();
 
@@ -332,34 +362,26 @@ namespace Microsoft.Maui.Layouts
 
 			Size MeasureCell(Cell cell, double width, double height)
 			{
-				if (cell.LastMeasureHeight == height && cell.LastMeasureWidth == width)
-				{
-					return cell.LastMeasureResult;
-				}
-
-				var result = _childrenToLayOut[cell.ViewIndex].Measure(width, height);
-				cell.CacheMeasure(width, height, result);
-
+				var child = _childrenToLayOut[cell.ViewIndex];
+				var result = child.Measure(width, height);
 				return result;
 			}
 
-			void MeasureCellsWithUnknowns()
+			void AutoMeasurePass()
 			{
 				for (int n = 0; n < _cells.Length; n++)
 				{
 					var cell = _cells[n];
 
-					if (cell.IsAbsolute)
+					if (double.IsNaN(cell.MeasureHeight) || double.IsNaN(cell.MeasureWidth))
 					{
-						// This cell is entirely within rows/columns with absolute sizes; we don't need to measure
-						// it to figure out those sizes
-						continue;
+						cell.NeedsSecondPass = true;
 					}
 
-					var availableWidth = cell.IsColumnSpanAuto ? double.PositiveInfinity : AvailableWidth(cell);
-					var availableHeight = cell.IsRowSpanAuto ? double.PositiveInfinity : AvailableHeight(cell);
+					var measureWidth = double.IsNaN(cell.MeasureWidth) ? double.PositiveInfinity : cell.MeasureWidth;
+					var measureHeight = double.IsNaN(cell.MeasureHeight) ? double.PositiveInfinity : cell.MeasureHeight;
 
-					var measure = MeasureCell(cell, availableWidth, availableHeight);
+					var measure = MeasureCell(cell, measureWidth, measureHeight);
 
 					if (cell.IsColumnSpanAuto)
 					{
@@ -369,8 +391,7 @@ namespace Microsoft.Maui.Layouts
 						}
 						else
 						{
-							var span = new Span(cell.Column, cell.ColumnSpan, true, measure.Width);
-							TrackSpan(span);
+							TrackSpan(new Span(cell.Column, cell.ColumnSpan, true, measure.Width));
 						}
 					}
 
@@ -382,9 +403,49 @@ namespace Microsoft.Maui.Layouts
 						}
 						else
 						{
-							var span = new Span(cell.Row, cell.RowSpan, false, measure.Height);
-							TrackSpan(span);
+							TrackSpan(new Span(cell.Row, cell.RowSpan, false, measure.Height));
 						}
+					}
+				}
+			}
+
+			void SecondMeasurePass()
+			{
+				foreach (var cell in _cells)
+				{
+					if (!cell.NeedsSecondPass)
+					{
+						continue;
+					}
+
+					double width = 0;
+					double height = 0;
+
+					for (int n = cell.Row; n < cell.Row + cell.RowSpan; n++)
+					{
+						height += _rows[n].Size;
+					}
+
+					for (int n = cell.Column; n < cell.Column + cell.ColumnSpan; n++)
+					{
+						width += _columns[n].Size;
+					}
+
+					if (width == 0 || height == 0)
+					{
+						continue;
+					}
+
+					var measure = MeasureCell(cell, width, height);
+
+					if (cell.IsColumnSpanStar && cell.ColumnSpan > 1)
+					{
+						TrackSpan(new Span(cell.Column, cell.ColumnSpan, true, measure.Width));
+					}
+
+					if (cell.IsRowSpanStar && cell.RowSpan > 1)
+					{
+						TrackSpan(new Span(cell.Row, cell.RowSpan, false, measure.Height));
 					}
 				}
 			}
@@ -530,7 +591,7 @@ namespace Microsoft.Maui.Layouts
 					{
 						if (cellCheck(cell)) // Check whether this cell should count toward the type of star value we're measuring
 						{
-							// Update the star width if the view in this cell is bigger
+							// Update the star size if the view in this cell is bigger
 							starSize = Math.Max(starSize, dimension(_childrenToLayOut[cell.ViewIndex].DesiredSize));
 						}
 					}
@@ -551,63 +612,48 @@ namespace Microsoft.Maui.Layouts
 				}
 			}
 
-			void ResolveStarColumns(double widthConstraint)
+			void ResolveStarColumns(double widthConstraint, bool decompressing = false)
 			{
 				var availableSpace = widthConstraint - GridWidth();
 				static bool cellCheck(Cell cell) => cell.IsColumnSpanStar;
 				static double getDimension(Size size) => size.Width;
 
 				ResolveStars(_columns, availableSpace, cellCheck, getDimension);
+
+				if (decompressing)
+				{
+					// This pass is for arrangement, we don't need to update the measure values
+					return;				
+				}
+
+				foreach (var cell in _cells)
+				{
+					if (double.IsNaN(cell.MeasureWidth))
+					{
+						UpdateKnownMeasureWidth(cell);
+					}
+				}
 			}
 
-			void ResolveStarRows(double heightConstraint)
+			void ResolveStarRows(double heightConstraint, bool decompressing = false)
 			{
 				var availableSpace = heightConstraint - GridHeight();
 				static bool cellCheck(Cell cell) => cell.IsRowSpanStar;
 				static double getDimension(Size size) => size.Height;
 
 				ResolveStars(_rows, availableSpace, cellCheck, getDimension);
-			}
 
-			void MeasureKnownCells()
-			{
+				if (decompressing)
+				{
+					// This pass is for arrangement, we don't need to update the measure values
+					return;
+				}
+
 				foreach (var cell in _cells)
 				{
-					if (!cell.NeedsKnownMeasurePass)
+					if (double.IsNaN(cell.MeasureHeight))
 					{
-						continue;
-					}
-
-					double width = 0;
-					double height = 0;
-
-					for (int n = cell.Row; n < cell.Row + cell.RowSpan; n++)
-					{
-						height += _rows[n].Size;
-					}
-
-					for (int n = cell.Column; n < cell.Column + cell.ColumnSpan; n++)
-					{
-						width += _columns[n].Size;
-					}
-
-					if (width == 0 || height == 0)
-					{
-						continue;
-					}
-
-					var measure = MeasureCell(cell, width, height);
-
-					if (cell.IsColumnSpanStar && cell.ColumnSpan > 1)
-					{
-						var span = new Span(cell.Column, cell.ColumnSpan, true, measure.Width);
-						TrackSpan(span);
-					}
-
-					if (cell.IsRowSpanStar && cell.RowSpan > 1)
-					{
-						var span = new Span(cell.Row, cell.RowSpan, false, measure.Height);
-						TrackSpan(span);
+						UpdateKnownMeasureHeight(cell);
 					}
 				}
 			}
@@ -696,7 +742,7 @@ namespace Microsoft.Maui.Layouts
 					ZeroOutStarSizes(_rows);
 
 					// And compute them for the actual arrangement height
-					ResolveStarRows(targetSize.Height);
+					ResolveStarRows(targetSize.Height, true);
 				}
 
 				if (_grid.HorizontalLayoutAlignment == LayoutAlignment.Fill || Dimension.IsExplicitSet(_explicitGridWidth))
@@ -705,7 +751,7 @@ namespace Microsoft.Maui.Layouts
 					ZeroOutStarSizes(_columns);
 
 					// And compute them for the actual arrangement width
-					ResolveStarColumns(targetSize.Width);
+					ResolveStarColumns(targetSize.Width, true);
 				}
 			}
 
@@ -853,6 +899,99 @@ namespace Microsoft.Maui.Layouts
 					original[n].Size = updated[n].Size;
 				}
 			}
+
+			static bool AnyAuto(Definition[] definitions)
+			{
+				foreach (var definition in definitions)
+				{
+					if (definition.IsAuto)
+					{
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			bool IsStarWidthPrecomputable()
+			{
+				if (double.IsInfinity(_gridWidthConstraint))
+				{
+					return false;
+				}
+
+				return !AnyAuto(_columns);
+			}
+
+			bool IsStarHeightPrecomputable()
+			{
+				if (double.IsInfinity(_gridHeightConstraint))
+				{
+					return false;
+				}
+
+				return !AnyAuto(_rows);
+			}
+
+			void UpdateKnownMeasureWidth(Cell cell) 
+			{
+				double measureWidth = 0;
+				for (int column = cell.Column; column < cell.Column + cell.ColumnSpan; column++)
+				{
+					measureWidth += _columns[column].Size;
+				}
+
+				cell.MeasureWidth = measureWidth;
+			}
+
+			void UpdateKnownMeasureHeight(Cell cell)
+			{
+				double measureHeight = 0;
+				for (int row = cell.Row; row < cell.Row + cell.RowSpan; row++)
+				{
+					measureHeight += _rows[row].Size;
+				}
+
+				cell.MeasureHeight = measureHeight;
+			}
+
+			void DetermineCellMeasureWidth(Cell cell)
+			{
+				if (cell.ColumnGridLengthType == GridLengthType.Absolute)
+				{
+					UpdateKnownMeasureWidth(cell);
+				}
+				else if (cell.IsColumnSpanAuto)
+				{
+					cell.MeasureWidth = double.PositiveInfinity;
+				}
+				else if (cell.IsColumnSpanStar && double.IsInfinity(_gridWidthConstraint))
+				{
+					// Because the Grid isn't horizontally constrained, we treat * columns as Auto 
+					cell.MeasureWidth = double.PositiveInfinity;
+				}
+
+				// For all other situations, we'll have to wait until we've measured the Auto columns
+			}
+
+			void DetermineCellMeasureHeight(Cell cell)
+			{
+				if (cell.RowGridLengthType == GridLengthType.Absolute)
+				{
+					UpdateKnownMeasureHeight(cell);
+				}
+				else if (cell.IsRowSpanAuto)
+				{
+					cell.MeasureHeight = double.PositiveInfinity;
+				}
+				else if (cell.IsRowSpanStar && double.IsInfinity(_gridHeightConstraint))
+				{
+					// Because the Grid isn't vertically constrained, we treat * rows as Auto 
+					cell.MeasureHeight = double.PositiveInfinity;
+				}
+
+				// For all other situations, we'll have to wait until we've measured the Auto rows
+			}
 		}
 
 		// Dictionary key for tracking a Span
@@ -885,6 +1024,9 @@ namespace Microsoft.Maui.Layouts
 			public int Column { get; }
 			public int RowSpan { get; }
 			public int ColumnSpan { get; }
+			public double MeasureWidth { get; set; } = double.NaN;
+			public double MeasureHeight { get; set; } = double.NaN;
+			public bool NeedsSecondPass { get; set; }
 
 			/// <summary>
 			/// A combination of all the measurement types in the columns this cell spans
@@ -912,28 +1054,11 @@ namespace Microsoft.Maui.Layouts
 			public bool IsRowSpanAuto => HasFlag(RowGridLengthType, GridLengthType.Auto);
 			public bool IsColumnSpanStar => HasFlag(ColumnGridLengthType, GridLengthType.Star);
 			public bool IsRowSpanStar => HasFlag(RowGridLengthType, GridLengthType.Star);
-			public bool IsAbsolute => ColumnGridLengthType == GridLengthType.Absolute
-						&& RowGridLengthType == GridLengthType.Absolute;
-
-			// If any part of the Cell's spans are Absolute or Star, then the Cell will need a measure pass at the known
-			// size once that's been determined (i.e., when the Auto stuff has been worked out)
-			public bool NeedsKnownMeasurePass => ((ColumnGridLengthType | RowGridLengthType) ^ GridLengthType.Auto) > 0;
 
 			static bool HasFlag(GridLengthType a, GridLengthType b)
 			{
 				// Avoiding Enum.HasFlag here for performance reasons; we don't need the type check
 				return (a & b) == b;
-			}
-
-			public double LastMeasureWidth { get; private set; } = -1;
-			public double LastMeasureHeight { get; private set; } = -1;
-			public Size LastMeasureResult { get; private set; }
-
-			public void CacheMeasure(double width, double height, Size result)
-			{
-				LastMeasureHeight = height;
-				LastMeasureWidth = width;
-				LastMeasureResult = result;
 			}
 		}
 

--- a/src/Core/tests/Benchmarks/Benchmarks/GridLayoutManagerBenchMarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/GridLayoutManagerBenchMarker.cs
@@ -1,0 +1,209 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Layouts;
+using NSubstitute;
+
+namespace Microsoft.Maui.Handlers.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class GridLayoutManagerBenchMarker
+	{
+		IGridLayout _gridLayout;
+		GridLayoutManager _manager;
+				
+		void BasicSetup()
+		{
+			_gridLayout = Substitute.For<IGridLayout>();
+
+			_manager = new GridLayoutManager(_gridLayout);
+
+			var view0 = CreateTestView();
+			var view1 = CreateTestView();
+			var view2 = CreateTestView();
+			var view3 = CreateTestView();
+
+			SubstituteChildren(_gridLayout, view0, view1, view2, view3);
+
+			SetLocation(_gridLayout, view0, row: 0, col: 0, rowSpan: 1, colSpan: 1);
+			SetLocation(_gridLayout, view1, row: 0, col: 1, rowSpan: 1, colSpan: 1);
+			SetLocation(_gridLayout, view2, row: 1, col: 0, rowSpan: 1, colSpan: 1);
+			SetLocation(_gridLayout, view3, row: 1, col: 1, rowSpan: 1, colSpan: 1);
+		}
+
+		[GlobalSetup(Target = nameof(AllAbsolute))]
+		public void AbsoluteSetup() 
+		{
+			BasicSetup();
+
+			SubRowDefs(_gridLayout, CreateTestRows("200, 200"));
+			SubColDefs(_gridLayout, CreateTestColumns("200, 200"));
+		}
+
+		[GlobalSetup(Target = nameof(AllStars))]
+		public void AllStarsSetup()
+		{
+			BasicSetup();
+
+			SubRowDefs(_gridLayout, CreateTestRows("*, *"));
+			SubColDefs(_gridLayout, CreateTestColumns("*, *"));
+		}
+
+		[GlobalSetup(Target = nameof(AllAuto))]
+		public void AllAutoSetup()
+		{
+			BasicSetup();
+
+			SubRowDefs(_gridLayout, CreateTestRows("auto, auto"));
+			SubColDefs(_gridLayout, CreateTestColumns("auto, auto"));
+		}
+
+		static IView CreateTestView() 
+		{
+			var viewSize = new Size(100, 100);
+
+			var view = Substitute.For<IView>();
+			view.Height.Returns(-1);
+			view.Width.Returns(-1);
+			view.Measure(Arg.Any<double>(), Arg.Any<double>()).Returns(viewSize);
+			view.DesiredSize.Returns(viewSize);
+
+			return view;
+		}
+
+		public static void SubstituteChildren(ILayout layout, params IView[] views)
+		{
+			var children = new List<IView>(views);
+
+			SubstituteChildren(layout, children);
+		}
+
+		public static void SubstituteChildren(ILayout layout, IList<IView> children)
+		{
+			layout[Arg.Any<int>()].Returns(args => children[(int)args[0]]);
+			layout.GetEnumerator().Returns(children.GetEnumerator());
+			layout.Count.Returns(children.Count);
+		}
+
+		static void SetLocation(IGridLayout grid, IView view, int row = 0, int col = 0, int rowSpan = 1, int colSpan = 1)
+		{
+			grid.GetRow(view).Returns(row);
+			grid.GetRowSpan(view).Returns(rowSpan);
+			grid.GetColumn(view).Returns(col);
+			grid.GetColumnSpan(view).Returns(colSpan);
+		}
+
+		static void SubRowDefs(IGridLayout grid, IEnumerable<IGridRowDefinition> rows = null)
+		{
+			if (rows == null)
+			{
+				var rowDefs = new List<IGridRowDefinition>();
+				grid.RowDefinitions.Returns(rowDefs);
+			}
+			else
+			{
+				grid.RowDefinitions.Returns(rows);
+			}
+		}
+
+		static void SubColDefs(IGridLayout grid, IEnumerable<IGridColumnDefinition> cols = null)
+		{
+			if (cols == null)
+			{
+				var colDefs = new List<IGridColumnDefinition>();
+				grid.ColumnDefinitions.Returns(colDefs);
+			}
+			else
+			{
+				grid.ColumnDefinitions.Returns(cols);
+			}
+		}
+
+		static List<IGridColumnDefinition> CreateTestColumns(string cols)
+		{
+			return CreateTestColumnsFromStrings(cols.Split(","));
+		}
+
+		static List<IGridColumnDefinition> CreateTestColumnsFromStrings(params string[] columnWidths)
+		{
+			var colDefs = new List<IGridColumnDefinition>();
+
+			foreach (var width in columnWidths)
+			{
+				var gridLength = GridLengthFromString(width);
+				var colDef = Substitute.For<IGridColumnDefinition>();
+				colDef.Width.Returns(gridLength);
+				colDefs.Add(colDef);
+			}
+
+			return colDefs;
+		}
+
+		static List<IGridRowDefinition> CreateTestRows(string rows) 
+		{
+			return CreateTestRowsFromStrings(rows.Split(","));
+		}
+
+		static List<IGridRowDefinition> CreateTestRowsFromStrings(params string[] rowHeights)
+		{
+			var rowDefs = new List<IGridRowDefinition>();
+
+			foreach (var height in rowHeights)
+			{
+				var gridLength = GridLengthFromString(height);
+				var rowDef = Substitute.For<IGridRowDefinition>();
+				rowDef.Height.Returns(gridLength);
+				rowDefs.Add(rowDef);
+			}
+
+			return rowDefs;
+		}
+
+		static GridLength GridLengthFromString(string gridLength)
+		{
+			gridLength = gridLength.Trim();
+
+			if (gridLength.EndsWith("*"))
+			{
+				gridLength = gridLength.Substring(0, gridLength.Length - 1);
+
+				if (gridLength.Length == 0)
+				{
+					return GridLength.Star;
+				}
+
+				return new GridLength(double.Parse(gridLength), GridUnitType.Star);
+			}
+
+			if (gridLength.ToLower() == "auto")
+			{
+				return GridLength.Auto;
+			}
+
+			return new GridLength(double.Parse(gridLength));
+		}
+
+		[Benchmark]
+		public void AllAbsolute() 
+		{
+			var result = _manager.Measure(500, 500);
+			_manager.ArrangeChildren(new Rect(Point.Zero, result));
+		}
+
+		[Benchmark]
+		public void AllStars()
+		{
+			var result = _manager.Measure(500, 500);
+			_manager.ArrangeChildren(new Rect(Point.Zero, result));
+		}
+
+		[Benchmark]
+		public void AllAuto()
+		{
+			var result = _manager.Measure(500, 500);
+			_manager.ArrangeChildren(new Rect(Point.Zero, result));
+		}
+	}
+}

--- a/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
+++ b/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
+++ b/src/Core/tests/UnitTests/Layouts/GridLayoutManagerTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 using Microsoft.Maui.Primitives;
@@ -88,15 +87,37 @@ namespace Microsoft.Maui.UnitTests.Layouts
 			}
 		}
 
+		static GridLength GridLengthFromString(string gridLength)
+		{
+			gridLength = gridLength.Trim();
+
+			if (gridLength.EndsWith("*"))
+			{
+				gridLength = gridLength.Substring(0, gridLength.Length - 1);
+
+				if (gridLength.Length == 0)
+				{
+					return GridLength.Star;
+				}
+
+				return new GridLength(double.Parse(gridLength), GridUnitType.Star);
+			}
+
+			if (gridLength.ToLower() == "auto")
+			{
+				return GridLength.Auto;
+			}
+
+			return new GridLength(double.Parse(gridLength));
+		}
+
 		List<IGridColumnDefinition> CreateTestColumns(params string[] columnWidths)
 		{
-			var converter = new GridLengthTypeConverter();
-
 			var colDefs = new List<IGridColumnDefinition>();
 
 			foreach (var width in columnWidths)
 			{
-				var gridLength = converter.ConvertFromInvariantString(width);
+				var gridLength = GridLengthFromString(width);
 				var colDef = Substitute.For<IGridColumnDefinition>();
 				colDef.Width.Returns(gridLength);
 				colDefs.Add(colDef);
@@ -107,13 +128,11 @@ namespace Microsoft.Maui.UnitTests.Layouts
 
 		List<IGridRowDefinition> CreateTestRows(params string[] rowHeights)
 		{
-			var converter = new GridLengthTypeConverter();
-
 			var rowDefs = new List<IGridRowDefinition>();
 
 			foreach (var height in rowHeights)
 			{
-				var gridLength = converter.ConvertFromInvariantString(height);
+				var gridLength = GridLengthFromString(height);
 				var rowDef = Substitute.For<IGridRowDefinition>();
 				rowDef.Height.Returns(gridLength);
 				rowDefs.Add(rowDef);


### PR DESCRIPTION
### Description of Change

The current Grid measurement algorithm measures cells in Auto rows/columns more than is strictly necessary; a side-effect of the extra measure at the final Auto row/column size on Windows is that the underlying platform is confused about control size changes and does not report them correctly to the containing controls (thus, the non-update issue reported in #12103). 

One of the reasons for the extra measurements stems from updating the sizes of Star rows/columns after all of the Auto values have been determined. The algorithm assumes the need for this any time a cell intersects an Auto row or column in any direction. However, in many cases either the row or column is entirely pre-computable, because the Grid is constrained in that direction and there are no Auto values. In those situations, we can compute the value for Star in that direction up front, and avoid multiple measurements. Pre-computing also means that we have final values for width/height to use with controls where the measurements are interdependent (e.g., with Images where the aspect ratio affects the measurement results, like in #7388). 

Pre-computing also means that we can avoid the duplicate measure scenarios originally addressed by #12660, so we no longer need to cache the first measurement values. 

These changes pre-compute all cell sizes where possible and avoid secondary measures of Auto values. They also add a benchmark for the GridLayoutManager so we can verify that future fixes don't adversely impact performance. 

The benchmark is limited to the performance of the GridLayoutManager specifically; it does not speak to the performance of the Grid on any actual platform. 

Benchmarks _before_ these changes:

|      Method |     Mean |    Error |   StdDev |   Gen0 |   Gen1 | Allocated |
|------------ |---------:|---------:|---------:|-------:|-------:|----------:|
| AllAbsolute | 96.99 us | 1.930 us | 5.381 us | 3.1738 | 1.0986 |     22 KB |
|    AllStars | 96.17 us | 1.159 us | 1.027 us | 3.5400 | 1.2207 |  22.25 KB |
|     AllAuto | 88.05 us | 1.235 us | 1.095 us | 3.1738 | 1.0986 |     20 KB |

_After_ these changes:

|      Method |      Mean |    Error |   StdDev |   Gen0 |   Gen1 | Allocated |
|------------ |----------:|---------:|---------:|-------:|-------:|----------:|
| AllAbsolute |  90.58 us | 1.667 us | 1.478 us | 3.1738 | 1.0986 |  19.93 KB |
|    AllStars | 100.66 us | 1.491 us | 1.321 us | 3.5400 | 1.2207 |  22.18 KB |
|     AllAuto |  92.77 us | 1.788 us | 1.987 us | 3.1738 | 1.0986 |  19.93 KB |

### Issues Fixed

Fixes #12103
Fixes #7388
Fixes #7363
Fixes #11453
Fixes #10799
Fixes #9078
Fixes #5363