### PR TITLE
Add more BlazorWebView device tests

### DIFF
--- a/src/BlazorWebView/samples/WebViewAppShared/CustomStart.razor
+++ b/src/BlazorWebView/samples/WebViewAppShared/CustomStart.razor
@@ -1,0 +1,8 @@
+﻿@page "/CustomStart/{ExtraData}"
+
+<div id="controlDiv">Found the start path with: '@ExtraData'</div>
+
+@code
+{
+    [Parameter] public string ExtraData { get; set; }
+}

--- a/src/BlazorWebView/samples/WebViewAppShared/CustomStart.razor.css
+++ b/src/BlazorWebView/samples/WebViewAppShared/CustomStart.razor.css
@@ -1,0 +1,6 @@
+﻿.my-component {
+    border: 2px dashed red;
+    padding: 1em;
+    margin: 1em 0;
+    background-image: url('background.png');
+}

--- a/src/BlazorWebView/samples/WebViewAppShared/NoOpComponent.razor
+++ b/src/BlazorWebView/samples/WebViewAppShared/NoOpComponent.razor
@@ -1,0 +1,3 @@
+﻿This component does nothing.
+
+<div id="controlDiv">Static</div>

--- a/src/BlazorWebView/samples/WebViewAppShared/RouterComponent.razor
+++ b/src/BlazorWebView/samples/WebViewAppShared/RouterComponent.razor
@@ -1,0 +1,9 @@
+﻿<Router AppAssembly="@typeof(RouterComponent).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <p role="alert">Sorry, there's nothing at this address.</p>
+    </NotFound>
+</Router>

--- a/src/BlazorWebView/samples/WebViewAppShared/_Imports.razor
+++ b/src/BlazorWebView/samples/WebViewAppShared/_Imports.razor
@@ -1,1 +1,7 @@
-﻿@using Microsoft.AspNetCore.Components.Web
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop

--- a/src/BlazorWebView/tests/MauiDeviceTests/Elements/BlazorWebViewTests.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/Elements/BlazorWebViewTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using WebViewAppShared;
 using Xunit;
 
@@ -55,7 +57,81 @@ namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests.Elements
 				actualFinalCounterValue = actualFinalCounterValue.Trim('\"'); // some platforms return quoted values, so we trim them
 				Assert.Equal("3", actualFinalCounterValue);
 			});
+		}
 
+		[Fact]
+		public async Task BlazorWebViewLogsRequests()
+		{
+			var testLoggerProvider = new TestLoggerProvider();
+			EnsureHandlerCreated(additionalCreationActions: appBuilder =>
+			{
+				appBuilder.Services.AddMauiBlazorWebView();
+				appBuilder.Services.AddLogging(c =>
+				{
+					// Enable maximum logging for BlazorWebView
+					c.AddFilter("Microsoft.AspNetCore.Components.WebView", LogLevel.Trace);
+
+					c.AddProvider(testLoggerProvider);
+				});
+			});
+
+			var bwv = new BlazorWebViewWithCustomFiles
+			{
+				HostPage = "wwwroot/index.html",
+				CustomFiles = new Dictionary<string, string>
+				{
+					{ "index.html", TestStaticFilesContents.DefaultMauiIndexHtmlContent },
+				},
+			};
+			bwv.RootComponents.Add(new RootComponent { ComponentType = typeof(NoOpComponent), Selector = "#app", });
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
+				var platformWebView = bwvHandler.PlatformView;
+				await WebViewHelpers.WaitForWebViewReady(platformWebView);
+
+				// Wait for the no-op component to load
+				await WebViewHelpers.WaitForControlDiv(bwvHandler.PlatformView, controlValueToWaitFor: "Static");
+			});
+
+			var events = testLoggerProvider.GetEvents();
+
+			// Here we choose an arbitrary subset of logs to verify. We could check every single one, but
+			// it's different on each platform, and subject to change in the future. Less is more.
+			Assert.Equal(1, events.Count(c => c.EventId.Id == 0 && c.LogLevel == LogLevel.Debug && c.EventId.Name == "NavigatingToUri"));
+			Assert.Equal(1, events.Count(c => c.EventId.Id == 4 && c.LogLevel == LogLevel.Debug && c.EventId.Name == "HandlingWebRequest" && c.Message.Contains("/_framework/blazor.webview.js", System.StringComparison.Ordinal)));
+		}
+
+
+		[Fact]
+		public async Task BlazorWebViewUsesStartPath()
+		{
+			EnsureHandlerCreated(additionalCreationActions: appBuilder =>
+			{
+				appBuilder.Services.AddMauiBlazorWebView();
+			});
+
+			var bwv = new BlazorWebViewWithCustomFiles
+			{
+				StartPath = "CustomStart/SomeData",
+				HostPage = "wwwroot/index.html",
+				CustomFiles = new Dictionary<string, string>
+				{
+					{ "index.html", TestStaticFilesContents.DefaultMauiIndexHtmlContent },
+				},
+			};
+			bwv.RootComponents.Add(new RootComponent { ComponentType = typeof(RouterComponent), Selector = "#app", });
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var bwvHandler = CreateHandler<BlazorWebViewHandler>(bwv);
+				var platformWebView = bwvHandler.PlatformView;
+				await WebViewHelpers.WaitForWebViewReady(platformWebView);
+
+				// Wait for the no-op component to load
+				await WebViewHelpers.WaitForControlDiv(bwvHandler.PlatformView, controlValueToWaitFor: "Found the start path with: 'SomeData'");
+			});
 		}
 
 		public static class TestStaticFilesContents

--- a/src/BlazorWebView/tests/MauiDeviceTests/TestLogger.cs
+++ b/src/BlazorWebView/tests/MauiDeviceTests/TestLogger.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Maui.MauiBlazorWebView.DeviceTests
+{
+	internal class TestLoggerProvider : ILoggerProvider
+	{
+		private readonly TestLogger _logger = new();
+
+		/// <summary>
+		/// Provides a snapshot of the current events.
+		/// </summary>
+		public LogEvent[] GetEvents() => _logger.GetEvents();
+
+		public ILogger CreateLogger(string categoryName)
+		{
+			return _logger;
+		}
+
+		public void Dispose() { }
+
+		private class TestLogger : ILogger
+		{
+			private readonly ConcurrentQueue<LogEvent> _events = new();
+
+			internal LogEvent[] GetEvents() => _events.ToArray();
+
+			public IDisposable BeginScope<TState>(TState state) => new Scope();
+
+			public bool IsEnabled(LogLevel logLevel) => true;
+
+			public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+			{
+				_events.Enqueue(new LogEvent()
+				{
+					LogLevel = logLevel,
+					EventId = eventId,
+					Message = formatter(state, exception)
+				});
+			}
+
+			private class Scope : IDisposable
+			{
+				public void Dispose()
+				{
+				}
+			}
+		}
+	}
+
+	internal class LogEvent
+	{
+		public LogLevel LogLevel { get; set; }
+		public EventId EventId { get; set; }
+		public string Message { get; set; }
+	}
+}


### PR DESCRIPTION
- A test to verify that logging is performed
- A test to verify that StartPath is respected

Background: I remember ages ago hearing that there was some issue with having more than 1 test in the BlazorWebView device tests. So I gave it another try, and at least on _my_ machine it seems to work fine. And more tests would be a good thing.

Note: There's an issue running device tests locally on Windows (they don't run on CI on Windows anyway). It's not specific to BlazorWebView tests, but MAUI in general, so not relevant to this PR.