### PR TITLE
Windows apps do not need GUIDs (drop GUIDs)

### DIFF
--- a/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
+++ b/src/Controls/samples/Controls.Sample.Sandbox/Maui.Controls.Sample.Sandbox.csproj
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <ApplicationTitle>.NET MAUI Controls Sandbox</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.sandbox</ApplicationId>
-    <ApplicationIdGuid>5ee3361c-1cf9-443e-87f1-a7667fba9caa</ApplicationIdGuid>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
     <_FastDeploymentDiagnosticLogging>True</_FastDeploymentDiagnosticLogging>

--- a/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
+++ b/src/Controls/samples/Controls.Sample/Maui.Controls.Sample.csproj
@@ -13,7 +13,6 @@
   <PropertyGroup>
     <ApplicationTitle>.NET MAUI Controls</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.sample</ApplicationId>
-    <ApplicationIdGuid>f9e4fa3e-3505-4742-9b2b-d1acdaff4ec8</ApplicationIdGuid>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
     <_FastDeploymentDiagnosticLogging>True</_FastDeploymentDiagnosticLogging>

--- a/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
+++ b/src/Essentials/test/DeviceTests/Essentials.DeviceTests.csproj
@@ -11,7 +11,6 @@
   <PropertyGroup>
     <ApplicationTitle>Essentials Tests</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.essentials.devicetests</ApplicationId>
-    <ApplicationIdGuid>CD693923-B3C2-4043-B044-F070046D2DAF</ApplicationIdGuid>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
   </PropertyGroup>

--- a/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
+++ b/src/Graphics/tests/DeviceTests/Graphics.DeviceTests.csproj
@@ -11,7 +11,6 @@
   <PropertyGroup>
     <ApplicationTitle>Graphics Tests</ApplicationTitle>
     <ApplicationId>com.microsoft.maui.graphics.devicetests</ApplicationId>
-    <ApplicationIdGuid>CD693923-4043-B044-B3C2-F070046D2DAF</ApplicationIdGuid>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
   </PropertyGroup>

--- a/src/SingleProject/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/SingleProject/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Maui.Resizetizer
 		const string PackageNamePlaceholder = "maui-package-name-placeholder";
 		const string PackageVersionPlaceholder = "0.0.0.0";
 
-		const string ErrorInvalidApplicationId = "ApplicationId '{0}' was not a valid GUID. Windows apps use a GUID for an application ID instead of the reverse domain used by Android and/or iOS apps. Either set the <ApplicationIdGuid> property to a valid GUID or use a condition on <ApplicationId> for Windows apps.";
 		const string ErrorVersionNumberCombination = "ApplicationDisplayVersion '{0}' was not a valid 3 part semver version number and/or ApplicationVersion '{1}' was not a valid integer.";
 
 		static readonly XNamespace xmlnsUap = "http://schemas.microsoft.com/appx/manifest/uap/windows10";
@@ -93,12 +92,6 @@ namespace Microsoft.Maui.Resizetizer
 					var attr = identity.Attribute(xname);
 					if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PackageNamePlaceholder)
 					{
-						if (!Guid.TryParse(ApplicationId, out _))
-						{
-							Log.LogError(ErrorInvalidApplicationId, ApplicationId);
-							return;
-						}
-
 						identity.SetAttributeValue(xname, ApplicationId);
 					}
 				}

--- a/src/Templates/src/templates/maui-blazor/.template.config/template.json
+++ b/src/Templates/src/templates/maui-blazor/.template.config/template.json
@@ -49,8 +49,7 @@
     ],
     "preferNameDirectory": true,
     "guids": [
-      "07CD65EF-6238-4365-AF5D-F6D433967F48",
-      "8B51DC95-6D07-4C39-BC6C-3BFE96E8A7EA"
+      "07CD65EF-6238-4365-AF5D-F6D433967F48"
     ],
     "symbols": {
       "applicationId": {

--- a/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-blazor/MauiApp.1.csproj
@@ -17,7 +17,6 @@
 
         <!-- App Identifier -->
         <ApplicationId>com.companyname.mauiapp._1</ApplicationId>
-        <ApplicationIdGuid>8B51DC95-6D07-4C39-BC6C-3BFE96E8A7EA</ApplicationIdGuid>
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>

--- a/src/Templates/src/templates/maui-mobile/.template.config/template.json
+++ b/src/Templates/src/templates/maui-mobile/.template.config/template.json
@@ -53,8 +53,7 @@
     ],
     "preferNameDirectory": true,
     "guids": [
-      "07CD65EF-6238-4365-AF5D-F6D433967F48",
-      "919dc1f9-17a9-48b3-81f8-0b8016bdfbf7"
+      "07CD65EF-6238-4365-AF5D-F6D433967F48"
     ],
     "symbols": {
       "applicationId": {

--- a/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
+++ b/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj
@@ -16,7 +16,6 @@
 
 		<!-- App Identifier -->
 		<ApplicationId>com.companyname.mauiapp._1</ApplicationId>
-		<ApplicationIdGuid>919dc1f9-17a9-48b3-81f8-0b8016bdfbf7</ApplicationIdGuid>
 
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>


### PR DESCRIPTION
### Description of Change

It appears that Windows apps do not need GUIDs as app IDs. In fact, they work just fine with the same reverse domains that android and ios use.

They do have a restriction though: https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-identity#attributes

> A string with a value between 3 and 50 characters in length that consists of alpha-numeric, period, and dash characters. Additionally, it cannot be any of the following string values: CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, or LPT9.

But, these restrictions are not really limiting because these are not useful app IDs.

Another point is that the Windows Store will actually provide you the value without you having any way to control this, and it is neither a GUID nor a nice reverse domain:

> 12345.PublisherNameTruncated.1234568790

As you can see, publishing apps to the store basically means you are told what ID to use. It may be best to do general development with a reverse domain for everything, and then when it is time to go to the store you can either use the prescribed name or use an existing name for an app you are migrating or even rewriting. And this applies to any platform. You may have an existing Android of iOS app/package name that you need to use.

> NOTE: This PR will need to be synchronized with the IDE:
> ![image](https://user-images.githubusercontent.com/1096616/215907701-17834ace-df5a-4313-acb7-ecce362f19f6.png)
