### PR TITLE
[net7.0] Windows apps do not need GUIDs (remove check)

### DIFF
--- a/src/SingleProject/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/SingleProject/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Maui.Resizetizer
 		const string PackageNamePlaceholder = "maui-package-name-placeholder";
 		const string PackageVersionPlaceholder = "0.0.0.0";
 
-		const string ErrorInvalidApplicationId = "ApplicationId '{0}' was not a valid GUID. Windows apps use a GUID for an application ID instead of the reverse domain used by Android and/or iOS apps. Either set the <ApplicationIdGuid> property to a valid GUID or use a condition on <ApplicationId> for Windows apps.";
 		const string ErrorVersionNumberCombination = "ApplicationDisplayVersion '{0}' was not a valid 3 part semver version number and/or ApplicationVersion '{1}' was not a valid integer.";
 
 		static readonly XNamespace xmlnsUap = "http://schemas.microsoft.com/appx/manifest/uap/windows10";
@@ -94,12 +93,6 @@ namespace Microsoft.Maui.Resizetizer
 					var attr = identity.Attribute(xname);
 					if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == PackageNamePlaceholder)
 					{
-						if (!Guid.TryParse(ApplicationId, out _))
-						{
-							Log.LogError(ErrorInvalidApplicationId, ApplicationId);
-							return;
-						}
-
 						identity.SetAttributeValue(xname, ApplicationId);
 					}
 				}


### PR DESCRIPTION
Backport of #13032

### Description of Change

Smaller, backport version of https://github.com/dotnet/maui/pull/13032


It appears that Windows apps do not need GUIDs as app IDs. In fact, they work just fine with the same reverse domains that android and ios use.

They do have a restriction though: https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-identity#attributes

> A string with a value between 3 and 50 characters in length that consists of alpha-numeric, period, and dash characters. Additionally, it cannot be any of the following string values: CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, or LPT9.

But, these restrictions are not really limiting because these are not useful app IDs.

Another point is that the Windows Store will actually provide you the value without you having any way to control this, and it is neither a GUID nor a nice reverse domain:

> 12345.PublisherNameTruncated.1234568790


As you can see, publishing apps to the store basically means you are told what ID to use. It may be best to do general development with a reverse domain for everything, and then when it is time to go to the store you can either use the prescribed name or use an existing name for an app you are migrating or even rewriting. And this applies to any platform. You may have an existing Android of iOS app/package name that you need to use.

> NOTE: This PR will need to be synchronized with the IDE:
> ![image](https://user-images.githubusercontent.com/1096616/215907701-17834ace-df5a-4313-acb7-ecce362f19f6.png)
