### PR TITLE
Fix DotNetCoreTestSettings.Logger build warning

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -707,7 +707,9 @@ void RunTestWithLocalDotNet(string csproj)
             Configuration = configuration,
             ToolPath = dotnetPath,
             NoBuild = true,
-            Logger = $"trx;LogFileName={results}",
+            Loggers = {
+                $"trx;LogFileName={results}"
+            },
             ResultsDirectory = GetTestResultsDirectory(),
             ArgumentCustomization = args => args.Append($"-bl:{binlog}")
         });


### PR DESCRIPTION
Fix `warning CS0618: 'DotNetCoreTestSettings.Logger' is obsolete: 'Please use Loggers instead.'` build warning.