### PR TITLE
Remove PhoneDialer.Current

### DIFF
--- a/src/Essentials/src/PhoneDialer/PhoneDialer.shared.cs
+++ b/src/Essentials/src/PhoneDialer/PhoneDialer.shared.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 		/// Gets a value indicating whether using the phone dialer is supported on this device.
 		/// </summary>
 		public static bool IsSupported =>
-			Current.IsSupported;
+			Default.IsSupported;
 
 		/// <summary>
 		/// Open the phone dialer to a specific phone number.
@@ -48,12 +48,15 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 		/// <exception cref="FeatureNotSupportedException">Thrown if making phone calls is not supported on the device.</exception>
 		/// <param name="number">Phone number to initialize the dialer with.</param>
 		public static void Open(string number)
-			=> Current.Open(number);
-
-		public static IPhoneDialer Current =>
-			defaultImplementation ??= new PhoneDialerImplementation();
+			=> Default.Open(number);
 
 		static IPhoneDialer? defaultImplementation;
+
+		/// <summary>
+		/// Provides the default implementation for static usage of this API.
+		/// </summary>
+		public static IPhoneDialer Default =>
+			defaultImplementation ??= new PhoneDialerImplementation();
 
 		internal static void SetDefault(IPhoneDialer? implementation) =>
 			defaultImplementation = implementation;

--- a/src/Essentials/src/PhoneDialer/PhoneDialer.shared.cs
+++ b/src/Essentials/src/PhoneDialer/PhoneDialer.shared.cs
@@ -50,15 +50,10 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 		public static void Open(string number)
 			=> Current.Open(number);
 
-		public static IPhoneDialer Current => ApplicationModel.Communication.PhoneDialer.Default;
+		public static IPhoneDialer Current =>
+			defaultImplementation ??= new PhoneDialerImplementation();
 
 		static IPhoneDialer? defaultImplementation;
-
-		/// <summary>
-		/// Provides the default implementation for static usage of this API.
-		/// </summary>
-		public static IPhoneDialer Default =>
-			defaultImplementation ??= new PhoneDialerImplementation();
 
 		internal static void SetDefault(IPhoneDialer? implementation) =>
 			defaultImplementation = implementation;

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -3,4 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
-*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Current.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -3,4 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
-*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Current.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -3,4 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
-*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Current.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -3,4 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
-*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Current.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -3,4 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
-*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Current.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -3,4 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
-*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Current.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -3,4 +3,4 @@
 *REMOVED*static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string!>!
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
-*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Default.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!
+*REMOVED*static Microsoft.Maui.ApplicationModel.Communication.PhoneDialer.Current.get -> Microsoft.Maui.ApplicationModel.Communication.IPhoneDialer!


### PR DESCRIPTION
### Description of Change

There is both a `PhoneDialer.Default` and `PhoneDialer.Current` which doesn't make sense and is due to a bad merge earlier. Let's remove `.Default`!