### PR TITLE
Obsolete some of the AutomationProperties

### DIFF
--- a/src/Compatibility/Core/src/Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/src/Compatibility/Core/src/Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (e.PropertyName == AutomationProperties.HelpTextProperty.PropertyName)
 			{
 				SetContentDescription();
@@ -108,6 +109,7 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android.FastRenderers
 			{
 				SetLabeledBy();
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Compatibility/Core/src/Windows/AccessibilityExtensions.cs
+++ b/src/Compatibility/Core/src/Windows/AccessibilityExtensions.cs
@@ -22,9 +22,13 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.UWP
 		{
 			string separator;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var hint = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
 			if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(hint))

--- a/src/Controls/src/Core/AutomationProperties.cs
+++ b/src/Controls/src/Core/AutomationProperties.cs
@@ -1,10 +1,13 @@
 #nullable disable
+using System;
+
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="Type[@FullName='Microsoft.Maui.Controls.AutomationProperties']/Docs/*" />
 	public class AutomationProperties
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='HelpTextProperty']/Docs/*" />
+		[Obsolete("Use SemanticProperties.Hint instead. See the conceptual docs about accessibility for more information.")]
 		public static readonly BindableProperty HelpTextProperty = BindableProperty.Create("HelpText", typeof(string), typeof(AutomationProperties), default(string));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='IsInAccessibleTreeProperty']/Docs/*" />
@@ -13,15 +16,19 @@ namespace Microsoft.Maui.Controls
 		public static readonly BindableProperty ExcludedWithChildrenProperty = BindableProperty.Create("ExcludedWithChildren", typeof(bool?), typeof(AutomationProperties), null);
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='LabeledByProperty']/Docs/*" />
+		[Obsolete("Use a SemanticProperties.Description binding instead. See the conceptual docs about accessibility for more information.")]
 		public static readonly BindableProperty LabeledByProperty = BindableProperty.Create("LabeledBy", typeof(VisualElement), typeof(AutomationProperties), default(VisualElement));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='NameProperty']/Docs/*" />
+		[Obsolete("Use SemanticProperties.Description instead. See the conceptual docs about accessibility for more information.")]
 		public static readonly BindableProperty NameProperty = BindableProperty.Create("Name", typeof(string), typeof(AutomationProperties), default(string));
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='GetHelpText']/Docs/*" />
 		public static string GetHelpText(BindableObject bindable)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			return (string)bindable.GetValue(HelpTextProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='GetIsInAccessibleTree']/Docs/*" />
@@ -39,19 +46,25 @@ namespace Microsoft.Maui.Controls
 		[System.ComponentModel.TypeConverter(typeof(ReferenceTypeConverter))]
 		public static VisualElement GetLabeledBy(BindableObject bindable)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			return (VisualElement)bindable.GetValue(LabeledByProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='GetName']/Docs/*" />
 		public static string GetName(BindableObject bindable)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			return (string)bindable.GetValue(NameProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='SetHelpText']/Docs/*" />
 		public static void SetHelpText(BindableObject bindable, string value)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			bindable.SetValue(HelpTextProperty, value);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='SetIsInAccessibleTree']/Docs/*" />
@@ -68,13 +81,17 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='SetLabeledBy']/Docs/*" />
 		public static void SetLabeledBy(BindableObject bindable, VisualElement value)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			bindable.SetValue(LabeledByProperty, value);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='SetName']/Docs/*" />
 		public static void SetName(BindableObject bindable, string value)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			bindable.SetValue(NameProperty, value);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 	}
 }

--- a/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/ListView/iOS/CellRenderer.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			else
 				tableViewCell.AccessibilityElementsHidden = false;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			if (cell.IsSet(AutomationProperties.NameProperty))
 				tableViewCell.AccessibilityLabel = cell.GetValue(AutomationProperties.NameProperty).ToString();
 			else
@@ -85,6 +86,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 				tableViewCell.AccessibilityHint = cell.GetValue(AutomationProperties.HelpTextProperty).ToString();
 			else
 				tableViewCell.AccessibilityHint = null;
+#pragma warning restore CS0618 // Type or member is obsolete
+
 		}
 
 		public virtual void SetBackgroundColor(UITableViewCell tableViewCell, Cell cell, UIColor color)

--- a/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/NavigationPage/iOS/NavigationRenderer.cs
@@ -844,7 +844,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (_defaultAccessibilityHint == null)
 				_defaultAccessibilityHint = uIBarButtonItem.AccessibilityHint;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			uIBarButtonItem.AccessibilityHint = (string)element.GetValue(AutomationProperties.HelpTextProperty) ?? _defaultAccessibilityHint;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		static void SetAccessibilityLabel(UIBarButtonItem uIBarButtonItem, Element element)
@@ -855,7 +857,9 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			if (_defaultAccessibilityLabel == null)
 				_defaultAccessibilityLabel = uIBarButtonItem.AccessibilityLabel;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			uIBarButtonItem.AccessibilityLabel = (string)element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		static void SetIsAccessibilityElement(UIBarButtonItem uIBarButtonItem, Element element)

--- a/src/Controls/src/Core/Compatibility/Handlers/VisualElementRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/VisualElementRenderer.cs
@@ -35,9 +35,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			[nameof(VisualElement.BackgroundColor)] = MapBackgroundColor,
 			[AutomationProperties.IsInAccessibleTreeProperty.PropertyName] = MapAutomationPropertiesIsInAccessibleTree,
 #if WINDOWS
+#pragma warning disable CS0618 // Type or member is obsolete
 			[AutomationProperties.NameProperty.PropertyName] = MapAutomationPropertiesName,
 			[AutomationProperties.HelpTextProperty.PropertyName] = MapAutomationPropertiesHelpText,
 			[AutomationProperties.LabeledByProperty.PropertyName] = MapAutomationPropertiesLabeledBy,
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 		};
 

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/AccessibilityExtensions.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			if (_defaultAccessibilityHint == null)
 				_defaultAccessibilityHint = Control.AccessibilityHint;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Control.AccessibilityHint = (string)Element.GetValue(AutomationProperties.HelpTextProperty) ?? _defaultAccessibilityHint;
+#pragma warning restore CS0618 // Type or member is obsolete
 #else
 			if (_defaultAccessibilityHint == null)
 				_defaultAccessibilityHint = Control.AccessibilityTitle;
@@ -52,7 +54,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			if (_defaultAccessibilityLabel == null)
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return _defaultAccessibilityLabel;
 		}
@@ -66,7 +70,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			if (_defaultAccessibilityHint == null)
 				_defaultAccessibilityHint = Control.AccessibilityHint;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Control.AccessibilityHint = (string)Element.GetValue(AutomationProperties.HelpTextProperty) ?? _defaultAccessibilityHint;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return _defaultAccessibilityHint;
 
@@ -80,7 +86,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.MacOS
 			if (_defaultAccessibilityLabel == null)
 				_defaultAccessibilityLabel = Control.AccessibilityLabel;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			Control.AccessibilityLabel = (string)Element.GetValue(AutomationProperties.NameProperty) ?? _defaultAccessibilityLabel;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			return _defaultAccessibilityLabel;
 		}

--- a/src/Controls/src/Core/Compatibility/iOS/Extensions/ToolbarItemExtensions.cs
+++ b/src/Controls/src/Core/Compatibility/iOS/Extensions/ToolbarItemExtensions.cs
@@ -75,10 +75,12 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 							UpdateTextAndStyle();
 					}
 				}
+#pragma warning disable CS0618 // Type or member is obsolete
 				else if (e.PropertyName == AutomationProperties.HelpTextProperty.PropertyName)
 					this.SetAccessibilityHint(_item);
 				else if (e.PropertyName == AutomationProperties.NameProperty.PropertyName)
 					this.SetAccessibilityLabel(_item);
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			void UpdateIconAndStyle()
@@ -149,9 +151,11 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 					UpdateIcon();
 				else if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName)
 					UpdateIsEnabled();
+#pragma warning disable CS0618 // Type or member is obsolete
 				else if (e.PropertyName == AutomationProperties.HelpTextProperty.PropertyName)
 					this.SetAccessibilityHint(_item);
 				else if (e.PropertyName == AutomationProperties.NameProperty.PropertyName)
+#pragma warning restore CS0618 // Type or member is obsolete
 					this.SetAccessibilityLabel(_item);
 			}
 

--- a/src/Controls/src/Core/Platform/Android/AutomationPropertiesProvider.cs
+++ b/src/Controls/src/Core/Platform/Android/AutomationPropertiesProvider.cs
@@ -79,8 +79,10 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			string separator;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
 			var hint = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(hint))
 				separator = "";
@@ -166,7 +168,9 @@ namespace Microsoft.Maui.Controls.Platform
 			if (element == null || control == null)
 				return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var elemValue = (VisualElement)element.GetValue(AutomationProperties.LabeledByProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (elemValue != null)
 			{
@@ -232,8 +236,10 @@ namespace Microsoft.Maui.Controls.Platform
 
 		internal static string ConcatenateNameAndHelpText(BindableObject Element)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
 			var helpText = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (string.IsNullOrWhiteSpace(name))
 				return helpText;

--- a/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
+++ b/src/Controls/src/Core/Platform/Windows/Extensions/AccessibilityExtensions.cs
@@ -20,7 +20,9 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_defaultAutomationPropertiesName == null)
 				_defaultAutomationPropertiesName = (string)Control.GetValue(NativeAutomationProperties.NameProperty);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var elemValue = (string)Element.GetValue(AutomationProperties.NameProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				Control.SetValue(NativeAutomationProperties.NameProperty, elemValue);
@@ -60,7 +62,9 @@ namespace Microsoft.Maui.Controls.Platform
 			if (_defaultAutomationPropertiesHelpText == null)
 				_defaultAutomationPropertiesHelpText = (string)Control.GetValue(NativeAutomationProperties.HelpTextProperty);
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var elemValue = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				Control.SetValue(NativeAutomationProperties.HelpTextProperty, elemValue);
@@ -85,16 +89,18 @@ namespace Microsoft.Maui.Controls.Platform
 
 			if (_defaultAutomationPropertiesLabeledBy == null)
 				_defaultAutomationPropertiesLabeledBy = (UIElement)Control.GetValue(NativeAutomationProperties.LabeledByProperty);
-
+#pragma warning disable CS0618 // Type or member is obsolete
 			var elemValue = (VisualElement)Element.GetValue(AutomationProperties.LabeledByProperty);
-
+#pragma warning restore CS0618 // Type or member is obsolete
 			FrameworkElement nativeElement = null;
 
 			if (mauiContext != null)
 				nativeElement = (elemValue as IView)?.ToHandler(mauiContext)?.PlatformView as FrameworkElement;
 
 			if (nativeElement != null)
+#pragma warning disable CS0618 // Type or member is obsolete
 				Control.SetValue(AutomationProperties.LabeledByProperty, nativeElement);
+#pragma warning restore CS0618 // Type or member is obsolete
 			else
 				Control.SetValue(NativeAutomationProperties.LabeledByProperty, _defaultAutomationPropertiesLabeledBy);
 
@@ -117,10 +123,11 @@ namespace Microsoft.Maui.Controls.Platform
 		{
 			string separator;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
 
 			var hint = (string)Element.GetValue(AutomationProperties.HelpTextProperty);
-
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(hint))
 				separator = "";

--- a/src/Controls/src/Core/SemanticProperties.cs
+++ b/src/Controls/src/Core/SemanticProperties.cs
@@ -47,10 +47,12 @@ namespace Microsoft.Maui.Controls
 			SemanticProperties.DescriptionProperty,
 			SemanticProperties.HintProperty,
 			SemanticProperties.HeadingLevelProperty,
+#pragma warning disable CS0618 // Type or member is obsolete
 			AutomationProperties.NameProperty,
 			AutomationProperties.LabeledByProperty,
 			AutomationProperties.HelpTextProperty,
 			AutomationProperties.IsInAccessibleTreeProperty,
+#pragma warning restore CS0618 // Type or member is obsolete
 		};
 
 		// https://github.com/dotnet/maui/issues/9156

--- a/src/Controls/src/Core/SemanticProperties.cs
+++ b/src/Controls/src/Core/SemanticProperties.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Maui.Controls
 			AutomationProperties.NameProperty,
 			AutomationProperties.LabeledByProperty,
 			AutomationProperties.HelpTextProperty,
-			AutomationProperties.IsInAccessibleTreeProperty,
 #pragma warning restore CS0618 // Type or member is obsolete
+			AutomationProperties.IsInAccessibleTreeProperty,
 		};
 
 		// https://github.com/dotnet/maui/issues/9156


### PR DESCRIPTION
### Description of Change

Marks `AutomationProperties.Name`, `AutomationProperties.HelpText` and `AutomationProperties.LabeledBy` as obsolete for removal later.

### Issues Fixed

Fixes #2888