### PR TITLE
[build] Disable codeQL test

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -56,10 +56,7 @@ variables:
 - name: POWERSHELL_VERSION
   value: 7.1.3
 - name: Codeql.Enabled
-  value: $[and(
-            eq(variables['Build.SourceBranch'], 'refs/heads/main'),
-            eq(variables['Build.DefinitionName'], 'MAUI')
-         )]
+  value: false
 - ${{ if ne(variables['Build.DefinitionName'], 'MAUI-private') }}:
   - name: PrivateBuild
     value: false


### PR DESCRIPTION
### Description of Change

Disable codeQL to try see if it's related with failures we saw on main on DevDiv

```
/Users/builder/azdo/_work/1/s/tools/NuGet.CommandLine.5.8.1/tools/NuGet.exe is a .NET Framework executable, you might need to install Mono for it to execute successfully.
Executing: /Users/builder/azdo/_work/1/s/tools/NuGet.CommandLine.5.8.1/tools/NuGet.exe install "_NativeAssets.windows" -OutputDirectory "/Users/builder/azdo/_work/1/s/artifacts/additional-assets" -Version "0.0.0-commit.193b587552cb0ed39372a049d7e6c692db98c267.483" -ExcludeVersion -Source "[https://aka.ms/skiasharp-eap/index.json"](https://aka.ms/skiasharp-eap/index.json%22) -NonInteractive
An error occurred when executing task 'dotnet-pack-additional'.
Error: System.AggregateException: One or more errors occurred. (An error occurred trying to start process '/Users/builder/azdo/_work/1/s/tools/NuGet.CommandLine.5.8.1/tools/NuGet.exe' with working directory '/Users/builder/azdo/_work/1/s'. Exec format error)
```