### PR TITLE
[Windows] Fix Shell FlyoutBackground property

### DIFF
--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Maui.DeviceTests
 		public async Task ShellFlyoutBackgroundInitializesCorrectly(string colorHex)
 		{
 			SetupBuilder();
-			
+
 			var expectedColor = Color.FromArgb(colorHex);
 
 			var shell = await CreateShellAsync((shell) =>
@@ -45,21 +45,34 @@ namespace Microsoft.Maui.DeviceTests
 				shell.Items.Add(shellItem);
 			});
 
-			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			await InvokeOnMainThreadAsync(async () =>
 			{
-				var rootNavView = handler.PlatformView;
-				var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
-				var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.Left;
-				var expectedShellItems = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+				await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler)  =>
+				{
+					var rootNavView = handler.PlatformView;
+					var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
+					var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.Left;
+					var expectedShellItems = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
 
-				Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
-				Assert.NotNull(shellItemView);
-				Assert.Equal(expectedShellItems, shellItemView.PaneDisplayMode);
+					Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
+					Assert.NotNull(shellItemView);
+					Assert.Equal(expectedShellItems, shellItemView.PaneDisplayMode);
 
-				return Task.CompletedTask;
+					return Task.CompletedTask;
+				});
+
+				await AssertionExtensions.Wait(() =>
+				{
+					var platformView = shell.Handler.PlatformView as FrameworkElement;
+
+					if (platformView != null)
+					{
+						return platformView.Height > 0 || platformView.Width > 0;
+					}
+
+					return false;
+				});
 			});
-
-			await Task.Delay(100);
 
 			await ValidateHasColor(shell, expectedColor, typeof(ShellHandler));
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -64,8 +64,7 @@ namespace Microsoft.Maui.DeviceTests
 				await AssertionExtensions.Wait(() =>
 				{
 					var platformView = shell.Handler.PlatformView as FrameworkElement;
-
-                   return platformView is not null && (platformView.Height > 0 || platformView.Width > 0)
+					return platformView is not null && (platformView.Height > 0 || platformView.Width > 0);
 				});
 			});
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -65,12 +65,7 @@ namespace Microsoft.Maui.DeviceTests
 				{
 					var platformView = shell.Handler.PlatformView as FrameworkElement;
 
-					if (platformView != null)
-					{
-						return platformView.Height > 0 || platformView.Width > 0;
-					}
-
-					return false;
+                   return platformView is not null && (platformView.Height > 0 || platformView.Width > 0)
 				});
 			});
 

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -47,12 +47,13 @@ namespace Microsoft.Maui.DeviceTests
 
 			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
 			{
-				var rootNavView = (handler.PlatformView);
+				var rootNavView = handler.PlatformView;
 				var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
 				var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.Left;
 				var expectedShellItems = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
 
 				Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
+				Assert.NotNull(shellItemView);
 				Assert.Equal(expectedShellItems, shellItemView.PaneDisplayMode);
 
 				return Task.CompletedTask;

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Platform;
+using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Xunit;
@@ -21,6 +22,45 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			Assert.Equal(desiredState, handler.PlatformView.IsPaneOpen);
 			return Task.CompletedTask;
+		}
+
+		[Theory(DisplayName = "Shell FlyoutBackground Initializes Correctly")]
+		[InlineData("#FF0000")]
+		[InlineData("#00FF00")]
+		[InlineData("#0000FF")]
+		[InlineData("#000000")]
+		public async Task ShellFlyoutBackgroundInitializesCorrectly(string colorHex)
+		{
+			SetupBuilder();
+			
+			var expectedColor = Color.FromArgb(colorHex);
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.FlyoutBehavior = FlyoutBehavior.Locked;
+				shell.FlyoutBackground = new SolidColorBrush(expectedColor);
+
+				var shellItem = new FlyoutItem();
+				shellItem.Items.Add(new ContentPage());
+				shell.Items.Add(shellItem);
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			{
+				var rootNavView = (handler.PlatformView);
+				var shellItemView = shell.CurrentItem.Handler.PlatformView as MauiNavigationView;
+				var expectedRoot = UI.Xaml.Controls.NavigationViewPaneDisplayMode.Left;
+				var expectedShellItems = UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
+
+				Assert.Equal(expectedRoot, rootNavView.PaneDisplayMode);
+				Assert.Equal(expectedShellItems, shellItemView.PaneDisplayMode);
+
+				return Task.CompletedTask;
+			});
+
+			await Task.Delay(100);
+
+			await ValidateHasColor(shell, expectedColor, typeof(ShellHandler));
 		}
 
 		[Fact(DisplayName = "Back Button Enabled/Disabled")]

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Maui.Platform
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundPressed"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemForegroundDisabled"] = brush;
 				}
+
+				navigationView.TopNavArea.RefreshThemeResources();
 			}
 
 			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
@@ -70,6 +72,8 @@ namespace Microsoft.Maui.Platform
 					navigationView.TopNavArea.Resources["TopNavigationViewItemBackgroundPointerOver"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemBackgroundPressed"] = brush;
 				}
+
+				navigationView.TopNavArea.RefreshThemeResources();
 			}
 
 			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
@@ -98,6 +102,8 @@ namespace Microsoft.Maui.Platform
 					navigationView.TopNavArea.Resources["TopNavigationViewItemBackgroundSelectedPointerOver"] = brush;
 					navigationView.TopNavArea.Resources["TopNavigationViewItemBackgroundSelectedPressed"] = brush;
 				}
+
+				navigationView.TopNavArea.RefreshThemeResources();
 			}
 
 			if (navigationView.MenuItemsSource is IList<NavigationViewItemViewModel> items)
@@ -111,32 +117,28 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdatePaneBackground(this MauiNavigationView navigationView, Paint? paint)
 		{
-			var rootSplitView = navigationView.RootSplitView;
+			var paneContentGrid = navigationView.PaneContentGrid;
+
+			if (paneContentGrid == null)
+				return;
+
 			var brush = paint?.ToPlatform();
 
 			if (brush == null)
 			{
-				object? color = null;
+				object? color;
 				if (navigationView.IsPaneOpen)
 					color = navigationView.Resources["NavigationViewExpandedPaneBackground"];
 				else
 					color = navigationView.Resources["NavigationViewDefaultPaneBackground"];
 
-				if (rootSplitView != null)
-				{
-					if (color is WBrush colorBrush)
-						rootSplitView.PaneBackground = colorBrush;
-					else if (color is global::Windows.UI.Color uiColor)
-						rootSplitView.PaneBackground = new WSolidColorBrush(uiColor);
-				}
+				if (color is WBrush colorBrush)
+					paneContentGrid.Background = colorBrush;
+				else if (color is global::Windows.UI.Color uiColor)
+					paneContentGrid.Background = new WSolidColorBrush(uiColor);
 			}
 			else
-			{
-				if (rootSplitView != null)
-				{
-					rootSplitView.PaneBackground = brush;
-				}
-			}
+				paneContentGrid.Background = brush;
 		}
 
 		public static void UpdateFlyoutVerticalScrollMode(this MauiNavigationView navigationView, ScrollMode scrollMode)

--- a/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/NavigationViewExtensions.cs
@@ -119,12 +119,12 @@ namespace Microsoft.Maui.Platform
 		{
 			var paneContentGrid = navigationView.PaneContentGrid;
 
-			if (paneContentGrid == null)
+			if (paneContentGrid is null)
 				return;
 
 			var brush = paint?.ToPlatform();
 
-			if (brush == null)
+			if (brush is null)
 			{
 				object? color;
 				if (navigationView.IsPaneOpen)


### PR DESCRIPTION
### Description of Change

Fix issue using Shell **FlyoutBackground** on Windows. We apply changes to directly access the panel and update the background.

Tested with the 12325 issue sample using different FlyoutBehaviors and with solid and gradient backgrounds.
![flyout-back-fix](https://user-images.githubusercontent.com/6755973/216962170-6e842e7d-2c18-483e-8cda-0df17f451cb7.gif)
![image](https://user-images.githubusercontent.com/6755973/216962234-6d84feaa-0eb6-4177-92d8-0e428fc67fe3.png)

To test/validate the changes can use the Shell sample included in the .NET MAUI Gallery o use the added device tests.
![image](https://user-images.githubusercontent.com/6755973/216962063-199df110-52f8-4ef4-a224-4ec150c0098d.png)

### Issues Fixed

Fixes #12325 