### PR TITLE
[iOS] Use same font size for Editor/Entry placeholders

### DIFF
--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -97,6 +97,15 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		internal double PlaceholderFontSize
+		{
+			get => _placeholderLabel.Font.PointSize;
+			set
+			{
+				_placeholderLabel.Font = _placeholderLabel.Font.WithSize((nfloat)value);
+			}
+		}
+
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -178,7 +178,10 @@ namespace Microsoft.Maui.Platform
 		{
 			if (value != null)
 			{
-				_defaultPlaceholderSize = _placeholderLabel.Font.PointSize;
+				if (_defaultPlaceholderSize == -1)
+				{
+					_defaultPlaceholderSize = _placeholderLabel.Font.PointSize;
+				}
 				_placeholderLabel.Font = _placeholderLabel.Font.WithSize(value.PointSize);
 			}
 			else if (_defaultPlaceholderSize != -1)

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Maui.Platform
 	public class MauiTextView : UITextView
 	{
 		readonly UILabel _placeholderLabel;
+		nfloat _defaultPlaceholderSize = -1;
 
 		public MauiTextView()
 		{
@@ -80,6 +81,17 @@ namespace Microsoft.Maui.Platform
 			}
 		}
 
+		public override UIFont? Font
+		{
+			get => base.Font;
+			set
+			{
+				base.Font = value;
+				UpdatePlaceholderFontSize(value);
+
+			}
+		}
+
 		public override NSAttributedString AttributedText
 		{
 			get => base.AttributedText;
@@ -94,15 +106,6 @@ namespace Microsoft.Maui.Platform
 					HidePlaceholderIfTextIsPresent(value?.Value);
 					TextSetOrChanged?.Invoke(this, EventArgs.Empty);
 				}
-			}
-		}
-
-		internal double PlaceholderFontSize
-		{
-			get => _placeholderLabel.Font.PointSize;
-			set
-			{
-				_placeholderLabel.Font = _placeholderLabel.Font.WithSize((nfloat)value);
 			}
 		}
 
@@ -169,6 +172,19 @@ namespace Microsoft.Maui.Platform
 				Maui.TextAlignment.End => new CGPoint(0, -Math.Max(1, availableSpace)),
 				_ => new CGPoint(0, 0),
 			};
+		}
+
+		void UpdatePlaceholderFontSize(UIFont? value)
+		{
+			if (value != null)
+			{
+				_defaultPlaceholderSize = _placeholderLabel.Font.PointSize;
+				_placeholderLabel.Font = _placeholderLabel.Font.WithSize(value.PointSize);
+			}
+			else if (_defaultPlaceholderSize != -1)
+			{
+				_placeholderLabel.Font = _placeholderLabel.Font.WithSize(_defaultPlaceholderSize);
+			}
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/TextViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextViewExtensions.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Maui.Platform
 			var font = textStyle.Font;
 			var uiFont = fontManager.GetFont(font, UIFont.LabelFontSize);
 			textView.Font = uiFont;
+
+			UpdatePlaceHolderFont(textView, textStyle);
 		}
 
 		public static void UpdateIsReadOnly(this UITextView textView, IEditor editor)
@@ -115,6 +117,14 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdatePlaceholderColor(this MauiTextView textView, IEditor editor) =>
 			textView.PlaceholderTextColor = editor.PlaceholderColor?.ToPlatform() ?? ColorExtensions.PlaceholderColor;
+
+		internal static void UpdatePlaceHolderFont(UITextView textView, ITextStyle textStyle)
+		{
+			if (textView is MauiTextView mauiTextView)
+			{
+				mauiTextView.PlaceholderFontSize = textStyle.Font.Size;
+			}
+		}
 
 		static void UpdateCursorSelection(this UITextView textView, IEditor editor)
 		{

--- a/src/Core/src/Platform/iOS/TextViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/TextViewExtensions.cs
@@ -58,8 +58,6 @@ namespace Microsoft.Maui.Platform
 			var font = textStyle.Font;
 			var uiFont = fontManager.GetFont(font, UIFont.LabelFontSize);
 			textView.Font = uiFont;
-
-			UpdatePlaceHolderFont(textView, textStyle);
 		}
 
 		public static void UpdateIsReadOnly(this UITextView textView, IEditor editor)
@@ -117,14 +115,6 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdatePlaceholderColor(this MauiTextView textView, IEditor editor) =>
 			textView.PlaceholderTextColor = editor.PlaceholderColor?.ToPlatform() ?? ColorExtensions.PlaceholderColor;
-
-		internal static void UpdatePlaceHolderFont(UITextView textView, ITextStyle textStyle)
-		{
-			if (textView is MauiTextView mauiTextView)
-			{
-				mauiTextView.PlaceholderFontSize = textStyle.Font.Size;
-			}
-		}
 
 		static void UpdateCursorSelection(this UITextView textView, IEditor editor)
 		{

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 override Microsoft.Maui.Handlers.SwitchHandler.NeedsContainer.get -> bool
+override Microsoft.Maui.Platform.MauiTextView.Font.get -> UIKit.UIFont?
+override Microsoft.Maui.Platform.MauiTextView.Font.set -> void
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.MauiTextField.WillMoveToWindow(UIKit.UIWindow? window) -> void
 override Microsoft.Maui.Platform.MauiTextView.WillMoveToWindow(UIKit.UIWindow? window) -> void

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 override Microsoft.Maui.Handlers.SwitchHandler.NeedsContainer.get -> bool
+override Microsoft.Maui.Platform.MauiTextView.Font.get -> UIKit.UIFont?
+override Microsoft.Maui.Platform.MauiTextView.Font.set -> void
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.MauiTextField.WillMoveToWindow(UIKit.UIWindow? window) -> void
 override Microsoft.Maui.Platform.MauiTextView.WillMoveToWindow(UIKit.UIWindow? window) -> void

--- a/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Editor/EditorHandlerTests.iOS.cs
@@ -12,6 +12,26 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EditorHandlerTests
 	{
+#if IOS
+		[Fact(DisplayName = "Placeholder Size is the same as control")]
+		public async Task PlaceholderFontHasTheSameSize()
+		{
+			var sizeFont = 22;
+			var editor = new EditorStub()
+			{
+				Text = "Text",
+				Font = Font.SystemFontOfSize(sizeFont)
+			};
+			
+			var nativePlaceholderSize = await GetValueAsync(editor, handler =>
+			{
+				return GetNativePlaceholder(handler).Font.PointSize;
+			});
+
+			Assert.True(nativePlaceholderSize == sizeFont);
+		}
+#endif
+
 		[Fact(DisplayName = "Placeholder Toggles Correctly When Text Changes")]
 		public async Task PlaceholderTogglesCorrectlyWhenTextChanges()
 		{


### PR DESCRIPTION
### Description of Change

If we set a font size of the Editor to a value different from the default, the size of the placeholder would be different and seem misaligned  

### Issues Fixed

Fixes #585 
