### PR TITLE
[iOS] Simplify the code used to set the same font size for Editor/Entry.

### DIFF
--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -176,11 +176,7 @@ namespace Microsoft.Maui.Platform
 
 		void UpdatePlaceholderFontSize(UIFont? value)
 		{
-			if (_defaultPlaceholderSize is null)
-			{
-				_defaultPlaceholderSize ??= _placeholderLabel.Font.PointSize;
-			}
-
+			_defaultPlaceholderSize ??= _placeholderLabel.Font.PointSize;
 			_placeholderLabel.Font = _placeholderLabel.Font.WithSize (
 				value?.PointSize ?? _defaultPlaceholderSize.Value);
 		}

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Maui.Platform
 			}
 
 			_placeholderLabel.Font = _placeholderLabel.Font.WithSize (
-					value is null? _defaultPlaceholderSize.Value : value.PointSize);
+				value?.PointSize ?? _defaultPlaceholderSize.Value);
 		}
 	}
 }

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Maui.Platform
 		{
 			if (_defaultPlaceholderSize is null)
 			{
-				_defaultPlaceholderSize = _placeholderLabel.Font.PointSize;
+				_defaultPlaceholderSize ??= _placeholderLabel.Font.PointSize;
 			}
 
 			_placeholderLabel.Font = _placeholderLabel.Font.WithSize (

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Maui.Platform
 	public class MauiTextView : UITextView
 	{
 		readonly UILabel _placeholderLabel;
-		nfloat _defaultPlaceholderSize = -1;
+		nfloat? _defaultPlaceholderSize;
 
 		public MauiTextView()
 		{
@@ -176,18 +176,13 @@ namespace Microsoft.Maui.Platform
 
 		void UpdatePlaceholderFontSize(UIFont? value)
 		{
-			if (value != null)
+			if (_defaultPlaceholderSize is null)
 			{
-				if (_defaultPlaceholderSize == -1)
-				{
-					_defaultPlaceholderSize = _placeholderLabel.Font.PointSize;
-				}
-				_placeholderLabel.Font = _placeholderLabel.Font.WithSize(value.PointSize);
+				_defaultPlaceholderSize = _placeholderLabel.Font.PointSize;
 			}
-			else if (_defaultPlaceholderSize != -1)
-			{
-				_placeholderLabel.Font = _placeholderLabel.Font.WithSize(_defaultPlaceholderSize);
-			}
+
+			_placeholderLabel.Font = _placeholderLabel.Font.WithSize (
+					value is null? _defaultPlaceholderSize.Value : value.PointSize);
 		}
 	}
 }


### PR DESCRIPTION
PR https://github.com/dotnet/maui/pull/13140 landed with a property implementation that is more complicatd than needed (also a little unsafe).

Changes in this PR:

1. Use a nullable nfloat to ensure that we do not use a magic number as the default value of the variable.
2. Simplify the if nests. There is no needed to have that many nested code to achiecve the same. This implementation does the same with a much simpler approach.

Please follow the logic of the changes in the comment review I gave to the original PR: https://github.com/dotnet/maui/pull/13140#pullrequestreview-1286209075


