### PR TITLE
Ensure OnMeasure always calls SetMeasuredDimension in ShellPageContainer

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellPageContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellPageContainer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				SetMeasuredDimension(aView.MeasuredWidth, aView.MeasuredHeight);
 			}
 			else
-				SetMeasuredDimension(MeasureSpec.GetSize(widthMeasureSpec), MeasureSpec.GetSize(heightMeasureSpec));
+				SetMeasuredDimension(0, 0);
 		}
 	}
 }

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellPageContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellPageContainer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				SetMeasuredDimension(aView.MeasuredWidth, aView.MeasuredHeight);
 			}
 			else
-				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+				SetMeasuredDimension(MeasureSpec.GetSize(widthMeasureSpec), MeasureSpec.GetSize(heightMeasureSpec));
 		}
 	}
 }

--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellPageContainer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/Android/ShellPageContainer.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 				aView.Measure(widthMeasureSpec, heightMeasureSpec);
 				SetMeasuredDimension(aView.MeasuredWidth, aView.MeasuredHeight);
 			}
+			else
+				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Android documentation (https://developer.android.com/reference/android/view/View#setMeasuredDimension(int,%20int)) says `SetMeasuredDimension` must be called prior to exiting `OnMeasure`. Currently, `ShellPageContainer` allows a condition where this contract may be violated, leading to rare run-time exceptions (See #13152, #10776).

It seems that this pattern existed at one point for `PageContainer`, but has since changed to always call this method.

~Android docs say that calling the base `OnMeasure` method is sufficient. I'm not aware of other design considerations, so I just picked that one to submit.~ Corrected this to the pattern I observed in other MAUI code, to use `MeasureSpec.GetSize` to call `SetMeasuredDimension`.

### Issues Fixed

Fixes #13152, #10776
