### PR TITLE
Remove Navigation workaround in tests

### DIFF
--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -342,14 +342,6 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			await OnLoadedAsync(page, timeOut);
 
-			// Navigation Events currently aren't wired up
-			// correctly on iOS
-			if (OperatingSystem.IsIOS() && page.Parent is NavigationPage)
-			{
-				await Task.Delay(100);
-				return;
-			}
-
 			if (page.HasNavigatedTo)
 			{
 				// TabbedPage fires OnNavigated earlier than it should

--- a/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/TabbedPage/TabbedPageTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
-#if !IOS
+#if !IOS && !MACCATALYST
 		// iOS currently can't handle recreating a handler if it's disconnecting
 		// This is left over behavior from Forms and will be fixed by a different PR
 		[Theory]


### PR DESCRIPTION
### Description of Change

We had a workaround in the tests to fake the navigated timing for the initial page load. This hack was added on a PR that was created before the fix for that workaround. https://github.com/dotnet/maui/pull/12348

This PR just removes that workaround in our tests and now everything flows naturally without the hack!