### PR TITLE
Add some capabilities!

### DIFF
--- a/src/Maui.InTree.targets
+++ b/src/Maui.InTree.targets
@@ -8,6 +8,10 @@
     <ProjectCapability Include="MauiEssentials" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectCapability Include="MauiRepository" />
+  </ItemGroup>
+
   <ImportGroup Condition="Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll') and Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.dll')">
 
     <!-- Microsoft.Maui.Core.targets -->

--- a/src/Maui.InTree.targets
+++ b/src/Maui.InTree.targets
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectCapability Include="MauiRepository" />
+    <ProjectCapability Include="MauiRepositorySampleProject" Contition="'$(SampleProject)' == 'true'" />
   </ItemGroup>
 
   <ImportGroup Condition="Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Controls.Build.Tasks.dll') and Exists('$(_MauiBuildTasksLocation)Microsoft.Maui.Resizetizer.dll')">


### PR DESCRIPTION
### Description of Change

Add some `<ProjectCapability>` items so we can trac the repo builds.

The metrics system will counts builds, but we don't want to could the every day work in the repo. So we can now count all maui things minus the maui repo sessions.

These changes do NOT make out of the repo and are just in the local tree.