### PR TITLE
Fix the WorkloadManifest.json

### DIFF
--- a/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
+++ b/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json
@@ -36,6 +36,9 @@
           "Microsoft.Maui.Templates.net@MAUI_PREVIOUS_DOTNET_VERSION_MAJOR@",
           "Microsoft.Maui.Core",
           "Microsoft.Maui.Controls",
+          "Microsoft.Maui.Controls.Build.Tasks",
+          "Microsoft.Maui.Controls.Core",
+          "Microsoft.Maui.Controls.Xaml",
           "Microsoft.Maui.Essentials"
       ]
     },
@@ -104,6 +107,10 @@
       "version": "@VERSION@"
     },
     "Microsoft.Maui.Controls.Xaml": {
+      "kind": "library",
+      "version": "@VERSION@"
+    },
+    "Microsoft.Maui.Essentials": {
       "kind": "library",
       "version": "@VERSION@"
     },


### PR DESCRIPTION
### Description of Change

The WorkloadManifest.json file did not include all the packs, nor did it correctly list all the dependencies.