### PR TITLE
[iOS] Better Find Next Textfield Algo

### DIFF
--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -735,42 +735,49 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
-		internal static UIView? FindNextView(this UIView view, UIView containerView, Func<UIView, bool> isValidType)
+		internal static UIView? FindNextView(this UIView? view, UIView containerView, Func<UIView, bool> isValidType)
 		{
 			UIView? nextView = null;
 
-			while (view != containerView && view is not null)
+			while (view is not null && view != containerView && nextView is null)
 			{
-				var siblings = view.Superview.Subviews;
-				nextView = view.FindNextView(siblings.IndexOf(view) + 1, isValidType);
+				var siblings = view.Superview?.Subviews;
 
-				if (nextView is not null)
+				if (siblings is null)
 					break;
+
+				nextView = view.FindNextView(siblings.IndexOf(view) + 1, isValidType);
 
 				view = view.Superview;
 			}
 
 			// if we did not find the next view, try to find the first one
-			nextView ??= containerView.Subviews[0].FindNextView(0, isValidType);
+			nextView ??= containerView.Subviews?[0]?.FindNextView(0, isValidType);
 
 			return nextView;
 		}
 
-		static UIView? FindNextView(this UIView view, int index, Func<UIView, bool> isValidType)
+		static UIView? FindNextView(this UIView? view, int index, Func<UIView, bool> isValidType)
 		{
 			// search through the view's siblings and traverse down their branches
-			var siblings = view.Superview.Subviews;
+			var siblings = view?.Superview?.Subviews;
+
+			if (siblings is null)
+				return null;
+
 			for (int i = index; i < siblings.Length; i++)
 			{
-				if (siblings[i].Subviews.Length > 0)
+				var sibling = siblings[i];
+
+				if (sibling.Subviews is not null && sibling.Subviews.Length > 0)
 				{
-					var childVal = siblings[i].Subviews[0].FindNextView(0, isValidType);
+					var childVal = sibling.Subviews[0].FindNextView(0, isValidType);
 					if (childVal is not null)
 						return childVal;
 				}
 
-				if (isValidType(siblings[i]))
-					return siblings[i];
+				if (isValidType(sibling))
+					return sibling;
 			}
 
 			return null;

--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -735,40 +735,42 @@ namespace Microsoft.Maui.Platform
 			return null;
 		}
 
-		internal static UIView? FindNextView(this UIView view, UIView superView, Func<UIView, bool> isValidType)
+		internal static UIView? FindNextView(this UIView view, UIView containerView, Func<UIView, bool> isValidType)
 		{
-			var passedOriginal = false;
+			UIView? nextView = null;
 
-			var nextView = superView.FindNextView(view, ref passedOriginal, isValidType);
+			while (view != containerView && view is not null)
+			{
+				var siblings = view.Superview.Subviews;
+				nextView = view.FindNextView(siblings.IndexOf(view) + 1, isValidType);
+
+				if (nextView is not null)
+					break;
+
+				view = view.Superview;
+			}
 
 			// if we did not find the next view, try to find the first one
-			nextView ??= superView.FindNextView(null, ref passedOriginal, isValidType);
+			nextView ??= containerView.Subviews[0].FindNextView(0, isValidType);
 
 			return nextView;
 		}
 
-		static UIView? FindNextView(this UIView view, UIView? origView, ref bool passedOriginal, Func<UIView, bool> isValidType)
+		static UIView? FindNextView(this UIView view, int index, Func<UIView, bool> isValidType)
 		{
-			foreach (var child in view.Subviews)
+			// search through the view's siblings and traverse down their branches
+			var siblings = view.Superview.Subviews;
+			for (int i = index; i < siblings.Length; i++)
 			{
-				if (isValidType(child))
+				if (siblings[i].Subviews.Length > 0)
 				{
-					if (origView is null)
-						return child;
-
-					if (passedOriginal)
-						return child;
-
-					if (child == origView)
-						passedOriginal = true;
+					var childVal = siblings[i].Subviews[0].FindNextView(0, isValidType);
+					if (childVal is not null)
+						return childVal;
 				}
 
-				else if (child.Subviews.Length > 0 && !child.Hidden && child.Alpha > 0f)
-				{
-					var nextLevel = child.FindNextView(origView, ref passedOriginal, isValidType);
-					if (nextLevel is not null)
-						return nextLevel;
-				}
+				if (isValidType(siblings[i]))
+					return siblings[i];
 			}
 
 			return null;


### PR DESCRIPTION
### Description of Change

This PR brings a more efficient algorithm for searching for the next valid textfield/textview than the search found here: https://github.com/dotnet/maui/pull/11914.

Instead of starting from the start of the ContainerView and searching through all the children until we find the first choice after the original view, we can now start at the original view and traverse up and down as needed until we find the next view!

### Issues Fixed

Fixes: https://github.com/dotnet/maui/issues/13147


### Discovered Issue

Issues with ListView and TableView: https://github.com/dotnet/maui/issues/13176