### PR TITLE
Fix a couple life cycle scenarios on shell modals

### DIFF
--- a/src/Controls/src/Core/Page.cs
+++ b/src/Controls/src/Core/Page.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Maui.Controls
 			// Visual Hierarchy
 			// The window/application will take care of re-firing this appearing 
 			// if it needs to
-			var window = this.FindParentOfType<Window>();
+			var window = this.FindParentOfType<IWindow>();
 			if (window?.Parent == null)
 			{
 				return;

--- a/src/Controls/src/Core/Shell/Shell.cs
+++ b/src/Controls/src/Core/Shell/Shell.cs
@@ -1693,7 +1693,14 @@ namespace Microsoft.Maui.Controls
 				modal.Parent = (Element)_shell.FindParentOfType<IWindow>();
 
 				if (!_shell.CurrentItem.CurrentItem.IsPushingModalStack)
+				{
+					if (ModalStack.Count > 0)
+					{
+						ModalStack[ModalStack.Count - 1].SendDisappearing();
+					}
+
 					modal.SendAppearing();
+				}
 
 				await base.OnPushModal(modal, animated);
 

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -321,6 +321,8 @@ namespace Microsoft.Maui.Controls
 			// Pop the stack down to where it no longer matches 
 			if (request.StackRequest == ShellNavigationRequest.WhatToDoWithTheStack.ReplaceIt)
 			{
+				var currentPage = Shell?.CurrentPage;
+
 				// If there's a visible Modal Stack then let's remove the pages under it that
 				// are going to be popped so they never become visible and never fire OnAppearing
 				if (Navigation.ModalStack.Count > 0)
@@ -407,6 +409,11 @@ namespace Microsoft.Maui.Controls
 							if (!isLast)
 								continue;
 						}
+
+						// This is the page that we will eventually get to once we've finished
+						// modifying the existing navigation stack
+						// So we want to fire appearing on it						
+						navPage.SendAppearing();
 
 						IsPoppingModalStack = true;
 

--- a/src/Controls/src/Core/Shell/ShellSection.cs
+++ b/src/Controls/src/Core/Shell/ShellSection.cs
@@ -321,8 +321,6 @@ namespace Microsoft.Maui.Controls
 			// Pop the stack down to where it no longer matches 
 			if (request.StackRequest == ShellNavigationRequest.WhatToDoWithTheStack.ReplaceIt)
 			{
-				var currentPage = Shell?.CurrentPage;
-
 				// If there's a visible Modal Stack then let's remove the pages under it that
 				// are going to be popped so they never become visible and never fire OnAppearing
 				if (Navigation.ModalStack.Count > 0)

--- a/src/Controls/tests/Core.UnitTests/ShellLifeCycleTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellLifeCycleTests.cs
@@ -318,7 +318,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			Assert.False(state.ContentAppearing);
 		}
 
-
 		[Fact]
 		public async Task ShellPartWithModalPush()
 		{
@@ -335,7 +334,6 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 			await shell.Navigation.PopModalAsync();
 			lifeCycleState.AllTrue();
 		}
-
 
 		[Fact]
 		public async Task ShellPartWithPagePush()

--- a/src/Controls/tests/Core.UnitTests/ShellModalTests.cs
+++ b/src/Controls/tests/Core.UnitTests/ShellModalTests.cs
@@ -13,6 +13,50 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 	public class ShellModalTests : ShellTestBase
 	{
 		[Fact]
+		public async Task AppearingAndDisappearingFireOnMultipleModals()
+		{
+			var windowPage = new ContentPage();
+			var modalPage1 = new ContentPage();
+			var modalPage2 = new ContentPage();
+
+			int modal1Appearing = 0;
+			int modal1Disappearing = 0;
+			int modal2Appearing = 0;
+			int modal2Disappearing = 0;
+			int windowAppearing = 0;
+			int windowDisappearing = 0;
+
+			modalPage1.Appearing += (_, _) => modal1Appearing++;
+			modalPage1.Disappearing += (_, _) => modal1Disappearing++;
+
+			modalPage2.Appearing += (_, _) => modal2Appearing++;
+			modalPage2.Disappearing += (_, _) => modal2Disappearing++;
+
+			windowPage.Appearing += (_, _) => windowAppearing++;
+			windowPage.Disappearing += (_, _) => windowDisappearing++;
+
+			var window = new TestWindow(new TestShell() { CurrentItem = windowPage });
+			await windowPage.Navigation.PushModalAsync(modalPage1);
+			Assert.Equal(1, modal1Appearing);
+
+			await windowPage.Navigation.PushModalAsync(modalPage2);
+			Assert.Equal(1, modal2Appearing);
+			Assert.Equal(1, modal1Disappearing);
+
+			await windowPage.Navigation.PopModalAsync();
+			await windowPage.Navigation.PopModalAsync();
+
+			Assert.Equal(2, modal1Appearing);
+			Assert.Equal(2, modal1Disappearing);
+
+			Assert.Equal(1, modal2Appearing);
+			Assert.Equal(1, modal2Disappearing);
+
+			Assert.Equal(2, windowAppearing);
+			Assert.Equal(1, windowDisappearing);
+		}
+
+		[Fact]
 		public async Task BasicModalBehaviorTest()
 		{
 			Shell shell = new TestShell();


### PR DESCRIPTION
### Description of Change

With `Shell` you can modify the entire stack with a single URI request so with modals we're smart with `Appearing` and `Disappearing` so it doesn't fire on all the intermediate pages while the navigation is happening. 

This PR covers a couple cases where we weren't firing the `Appearing` and `Disappearing` event when pushing modals through the `INavigation` APIs.

I'm working to centralize all the `Modal` code into `ModalNavigationManager` https://github.com/dotnet/maui/pull/13025

Eventually this logic won't be spread out everywhere and just isolated down to a single class. This PR for now fixes a couple pain points for users and adds some tests for future refactoring. 

### Issues Fixed

Fixes #11498
Fixes #8513


