### PR TITLE
[build] pass $(RestoreConfigFile) to Workloads.csproj

### DIFF
--- a/src/DotNet/DotNet.csproj
+++ b/src/DotNet/DotNet.csproj
@@ -143,7 +143,7 @@
     <RemoveDir Directories="$(_WorkloadManifestDir);@(_WorkloadDirectoriesToRemove)" />
     <MakeDir Directories="$(_WorkloadManifestDir)" />
     <Exec
-        Command="&quot;$(DotNetToolPath)&quot; restore &quot;$(MSBuildThisFileDirectory)Dependencies/Workloads.csproj&quot; -bl:$(PackageOutputPath)/DotNetWorkloads.binlog"
+        Command="&quot;$(DotNetToolPath)&quot; restore &quot;$(MSBuildThisFileDirectory)Dependencies/Workloads.csproj&quot; -p:RestoreConfigFile=$(MauiRootDirectory)/NuGet.config -bl:$(PackageOutputPath)/DotNetWorkloads.binlog"
         EnvironmentVariables="NUGET_PACKAGES=$(_WorkloadManifestDir);DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1"
     />
     <!--


### PR DESCRIPTION
On dotnet/maui/main, if I do:

    dotnet cake

It fails spectacularly:

    C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1102: Unable to find package Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest-7.0.100 with version (= 7.0.0-rtm.22511.4)
        - Found 5 version(s) in dotnet-public [ Nearest version: 7.0.0 ]
        - Found 0 version(s) in C:\Program Files\dotnet\library-packs
        - Found 0 version(s) in darc-pub-dotnet-emsdk-c3fc739
        - Found 0 version(s) in darc-pub-dotnet-runtime-1e1f688
        - Found 0 version(s) in dotnet-eng
        - Found 0 version(s) in skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]
            C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1102: Unable to find package Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-7.0.100 with version (= 7.0.0-rtm.22511.4)
        - Found 5 version(s) in dotnet-public [ Nearest version: 7.0.0 ]
        - Found 0 version(s) in C:\Program Files\dotnet\library-packs
        - Found 0 version(s) in darc-pub-dotnet-emsdk-c3fc739
        - Found 0 version(s) in darc-pub-dotnet-runtime-1e1f688
        - Found 0 version(s) in dotnet-eng
        - Found 0 version(s) in skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]
            C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1102: Unable to find package Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100 with version (= 7.0.0-rtm.22504.3)
        - Found 5 version(s) in dotnet-public [ Nearest version: 7.0.0 ]
        - Found 0 version(s) in C:\Program Files\dotnet\library-packs
        - Found 0 version(s) in darc-pub-dotnet-emsdk-c3fc739
        - Found 0 version(s) in darc-pub-dotnet-runtime-1e1f688
        - Found 0 version(s) in dotnet-eng
        - Found 0 version(s) in skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]
            C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1102: Unable to find package Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100 with version (= 7.0.0-rtm.22504.3)
        - Found 5 version(s) in dotnet-public [ Nearest version: 7.0.0 ]
        - Found 0 version(s) in C:\Program Files\dotnet\library-packs
        - Found 0 version(s) in darc-pub-dotnet-emsdk-c3fc739
        - Found 0 version(s) in darc-pub-dotnet-runtime-1e1f688
        - Found 0 version(s) in dotnet-eng
        - Found 0 version(s) in skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]
    C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1101: Unable to find package Microsoft.NET.Sdk.Android.Manifest-7.0.100. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, dotnet-eng, dotnet-public, skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]
    C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1101: Unable to find package Microsoft.NET.Sdk.MacCatalyst.Manifest-7.0.100. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, dotnet-eng, dotnet-public, skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]
    C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1101: Unable to find package Microsoft.NET.Sdk.iOS.Manifest-7.0.100. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, dotnet-eng, dotnet-public, skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]
    C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1101: Unable to find package Microsoft.NET.Sdk.tvOS.Manifest-7.0.100. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, dotnet-eng, dotnet-public, skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]
    C:\src\maui\src\DotNet\Dependencies\Workloads.csproj error NU1101: Unable to find package Microsoft.NET.Sdk.macOS.Manifest-7.0.100. No packages exist with this id in source(s): C:\Program Files\dotnet\library-packs, darc-pub-dotnet-emsdk-c3fc739, darc-pub-dotnet-runtime-1e1f688, dotnet-eng, dotnet-public, skiasharp [C:\src\maui\src\DotNet\Dependencies\Workloads.csproj]

I set `$(RestoreConfigFile)` to the `NuGet.config` file to solve this issue.

I'm unsure how things are generally working without this?

Or maybe this is a recent development from 2dcc1482?