### PR TITLE
Close open cursors correctly

### DIFF
--- a/src/Essentials/src/Contacts/Contacts.android.cs
+++ b/src/Essentials/src/Contacts/Contacts.android.cs
@@ -120,12 +120,16 @@ namespace Microsoft.Maui.ApplicationModel.Communication
 			if (cursor?.MoveToFirst() != true)
 				return (null, null, null, null, null);
 
-			return (
+			var result = (
 				GetString(cursor, StructuredName.Prefix),
 				GetString(cursor, StructuredName.GivenName),
 				GetString(cursor, StructuredName.MiddleName),
 				GetString(cursor, StructuredName.FamilyName),
 				GetString(cursor, StructuredName.Suffix));
+
+			cursor?.Close();
+
+			return result;
 		}
 
 		static string GetString(ICursor cursor, string column) =>


### PR DESCRIPTION
### Description of Change

I noticed that we leave this open and we get a stack of warnings:

```
[System] A resource failed to call AbstractCursor.close. 
[System] A resource failed to call CursorWrapperInner.close. 
```