### PR TITLE
Fix back button tap for older iOS APIs

### DIFF
--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -574,11 +574,17 @@ namespace Microsoft.Maui.DeviceTests
 		public static void TapBackButton(this UINavigationBar uINavigationBar)
 		{
 			var item = uINavigationBar.GetBackButton();
-
-			var recognizer = item!.GestureRecognizers!.OfType<UITapGestureRecognizer>().FirstOrDefault();
-			_ = recognizer ?? throw new Exception("Unable to Back Button TapGestureRecognizer");
-
-			recognizer.State = UIGestureRecognizerState.Ended;
+						
+			if (item.GestureRecognizers is null && item is UIControl control)
+			{
+				control.SendActionForControlEvents(UIControlEvent.TouchUpInside);
+			}
+			else
+			{
+				var recognizer = item?.GestureRecognizers?.OfType<UITapGestureRecognizer>()?.FirstOrDefault();
+				_ = recognizer ?? throw new Exception("Unable to Back Button TapGestureRecognizer");
+				recognizer.State = UIGestureRecognizerState.Ended;
+			}
 		}
 
 		public static string? GetToolbarTitle(this UINavigationBar uINavigationBar)

--- a/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
+++ b/src/TestUtils/src/DeviceTests/AssertionExtensions.iOS.cs
@@ -574,15 +574,15 @@ namespace Microsoft.Maui.DeviceTests
 		public static void TapBackButton(this UINavigationBar uINavigationBar)
 		{
 			var item = uINavigationBar.GetBackButton();
-						
-			if (item.GestureRecognizers is null && item is UIControl control)
+
+			var recognizer = item?.GestureRecognizers?.OfType<UITapGestureRecognizer>()?.FirstOrDefault();
+			if (recognizer is null && item is UIControl control)
 			{
 				control.SendActionForControlEvents(UIControlEvent.TouchUpInside);
 			}
 			else
 			{
-				var recognizer = item?.GestureRecognizers?.OfType<UITapGestureRecognizer>()?.FirstOrDefault();
-				_ = recognizer ?? throw new Exception("Unable to Back Button TapGestureRecognizer");
+				_ = recognizer ?? throw new Exception("Unable to figure out how to tap back button");
 				recognizer.State = UIGestureRecognizerState.Ended;
 			}
 		}


### PR DESCRIPTION
### Description of Change
Use a different mechanism for tapping the back button if we can't find any Gesture Recognizers. 

This fixes an issue with simulating the back button tap on older iOS APIs
