### PR TITLE
[Windows] Add convenience and nullable safe method.

### DIFF
--- a/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
+++ b/src/Core/src/Platform/Windows/FrameworkElementExtensions.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -131,6 +132,12 @@ namespace Microsoft.Maui.Platform
 					return target;
 			}
 			return null;
+		}
+
+		internal static bool TryGetFirstDescendant<T>(this DependencyObject element, [NotNullWhen(true)]out T? result) where T : FrameworkElement
+		{
+			result = element.GetFirstDescendant<T> ();
+			return result is not null;
 		}
 
 		internal static ResourceDictionary CloneResources(this FrameworkElement element)


### PR DESCRIPTION
During the code reviews I have noticed several occurrences of the of the following pattern:

```csharp
if (nativeSlider.GetFirstDescendant<Thumb>() is Thumb thumb)
{
  thumb.Height = defaultThumbSize.Value.Height;
  thumb.Width = defaultThumbSize.Value.Width;
}
```

The above works, but it is abussing the is operator and is making us type more than is really needed (several ocurrences of the type). The given method will be used as follows:

```csharp
if (nativeSlider.TryGetFirstDescendant<Thumb>(out var thumb))
{
  thumb.Height = defaultThumbSize.Value.Height;
  thumb.Width = defaultThumbSize.Value.Width;
}
```
or
```csharp
if (nativeSlider.TryGetFirstDescendant(out Thumb? thumb))
{
  thumb.Height = defaultThumbSize.Value.Height;
  thumb.Width = defaultThumbSize.Value.Width;
}
```
Nullability is not needed thansk to the NotNullWhenAttribute.
