### PR TITLE
Add NotNullWhen to IsAlive()

### DIFF
--- a/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
+++ b/src/Controls/src/Core/Platform/ModalNavigationManager/ModalNavigationManager.Android.cs
@@ -257,13 +257,13 @@ namespace Microsoft.Maui.Controls.Platform
 
 			void UpdateRootView(AView? rootView)
 			{
-				if (_rootView.IsAlive() && _rootView != null)
+				if (_rootView.IsAlive())
 				{
 					_rootView.LayoutChange -= OnRootViewLayoutChanged;
 					_rootView = null;
 				}
 
-				if (rootView.IsAlive() && rootView != null)
+				if (rootView.IsAlive())
 				{
 					rootView.LayoutChange += OnRootViewLayoutChanged;
 					_rootView = rootView;

--- a/src/Core/src/Platform/Android/JavaObjectExtensions.cs
+++ b/src/Core/src/Platform/Android/JavaObjectExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Maui
 {
@@ -14,7 +15,7 @@ namespace Microsoft.Maui
 			return obj.Handle == IntPtr.Zero;
 		}
 
-		public static bool IsAlive(this Java.Lang.Object? obj)
+		public static bool IsAlive([NotNullWhen(true)] this Java.Lang.Object? obj)
 		{
 			if (obj == null)
 				return false;
@@ -22,7 +23,7 @@ namespace Microsoft.Maui
 			return !obj.IsDisposed();
 		}
 
-		public static bool IsAlive(this global::Android.Runtime.IJavaObject? obj)
+		public static bool IsAlive([NotNullWhen(true)] this global::Android.Runtime.IJavaObject? obj)
 		{
 			if (obj == null)
 				return false;

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Maui.Platform
 				// If you try to access `ChildFragmentManager` and the `NavHost`
 				// isn't attached to a context then android will throw an IllegalStateException
 				if (_navHost.IsAlive() &&
-					_navHost.Context != null &&
+					_navHost.Context is not null &&
 					_navHost.ChildFragmentManager.IsAlive())
 				{
 					return _navHost.ChildFragmentManager;

--- a/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
+++ b/src/Core/src/Platform/Android/Navigation/StackNavigationManager.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Maui.Platform
 				// If you try to access `ChildFragmentManager` and the `NavHost`
 				// isn't attached to a context then android will throw an IllegalStateException
 				if (_navHost.IsAlive() &&
-					_navHost?.Context != null &&
+					_navHost.Context != null &&
 					_navHost.ChildFragmentManager.IsAlive())
 				{
 					return _navHost.ChildFragmentManager;


### PR DESCRIPTION
### Description of Change

Add NotNullWhen  to `IsAlive` on Android. `IsAlive` already checks if the incoming view is null or not so we can take advantage of this to simplify our nullability checks. 

https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.notnullwhenattribute?view=net-7.0