### PR TITLE
When measuring FlexLayout unconstrained, allow child to be desired size

### DIFF
--- a/src/Controls/src/Core/Layout/FlexLayout.cs
+++ b/src/Controls/src/Core/Layout/FlexLayout.cs
@@ -483,6 +483,14 @@ namespace Microsoft.Maui.Controls
 		{
 			if (_root == null)
 				return;
+
+			if (child is not BindableObject)
+			{
+				// If this is a pure Core IView, we need to track all the flex properties
+				// locally because we don't have attached properties for them
+				_viewInfo.Add(child, new FlexInfo());
+			}
+
 			var item = (child as FlexLayout)?._root ?? new Flex.Item();
 			InitItemProperties(child, item);
 			if (child is not FlexLayout)

--- a/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/FlexLayoutTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Layouts;
 using Xunit;
+using NSubstitute;
 
 namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 {
@@ -79,6 +80,54 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			// The location of the second view should have changed
 			// now that the first view is not visible
 			Assert.True(whenInvisible != whenVisible);
+		}
+
+		/*
+		 * These next two tests deal with unconstrained measure of FlexLayout. Be default, FL
+		 * wants to stretch children across each axis. But you can't stretch things across infinity
+		 * without it getting weird. So for _measurement_ purposes, we treat infinity as zero and 
+		 * just give the children their desired size in the unconstrained direction. Otherwise, FL
+		 * would just set their flex frame sizes to zero, which can either cause blanks or layout cycles,
+		 * depending on the target platform.
+		 */
+
+		(IFlexLayout, IView) SetUpUnconstrainedTest() 
+		{
+			var root = new Grid(); // FlexLayout requires a parent, at least for now
+			var flexLayout = new FlexLayout() as IFlexLayout;
+
+			var view = Substitute.For<IView>();
+			var size = new Size(100, 100);
+			view.Measure(Arg.Any<double>(), Arg.Any<double>()).Returns(size);
+
+			root.Add(flexLayout);
+			flexLayout.Add(view);
+
+			return (flexLayout, view);
+		}
+
+		[Fact]
+		public void UnconstrainedHeightChildrenHaveHeight()
+		{
+			(var flexLayout, var view) = SetUpUnconstrainedTest();
+
+			_ = flexLayout.CrossPlatformMeasure(400, double.PositiveInfinity);
+
+			var flexFrame = flexLayout.GetFlexFrame(view);
+			
+			Assert.Equal(100, flexFrame.Height);
+		}
+
+		[Fact]
+		public void UnconstrainedWidthChildrenHaveWidth()
+		{
+			(var flexLayout, var view) = SetUpUnconstrainedTest();
+
+			_ = flexLayout.CrossPlatformMeasure(double.PositiveInfinity, 400);
+
+			var flexFrame = flexLayout.GetFlexFrame(view);
+
+			Assert.Equal(100, flexFrame.Width);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
@@ -150,6 +151,50 @@ namespace Microsoft.Maui.DeviceTests
 
 				layout.Add(label);
 			}
+		}
+
+		[Fact, Category(TestCategory.FlexLayout)]
+		public async Task FlexLayoutInVerticalStackLayoutDoesNotCycle()
+		{
+			var root = new VerticalStackLayout();
+			var flexLayout = new FlexLayout();
+			var label = new Label { Text = "Hello" };
+
+			flexLayout.Add(label);
+			root.Add(flexLayout);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var labelHandler = CreateHandler<LabelHandler>(label);
+				var flexLayoutHandler = CreateHandler<LayoutHandler>(flexLayout);
+				var layoutHandler = CreateHandler<LayoutHandler>(root);
+
+				// If this can be attached to the hierarchy and make it through a layout 
+				// without crashing, then we're good. 
+				root.ToPlatform(MauiContext).AttachAndRun(() => { });
+			});
+		}
+
+		[Fact, Category(TestCategory.FlexLayout)]
+		public async Task FlexLayoutInHorizontalStackLayoutDoesNotCycle()
+		{
+			var root = new HorizontalStackLayout();
+			var flexLayout = new FlexLayout();
+			var label = new Label { Text = "Hello" };
+
+			flexLayout.Add(label);
+			root.Add(flexLayout);
+
+			await InvokeOnMainThreadAsync(() =>
+			{
+				var labelHandler = CreateHandler<LabelHandler>(label);
+				var flexLayoutHandler = CreateHandler<LayoutHandler>(flexLayout);
+				var layoutHandler = CreateHandler<LayoutHandler>(root);
+
+				// If this can be attached to the hierarchy and make it through a layout 
+				// without crashing, then we're good. 
+				root.ToPlatform(MauiContext).AttachAndRun(() => { });
+			});
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Layout/LayoutTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -154,46 +155,35 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact, Category(TestCategory.FlexLayout)]
-		public async Task FlexLayoutInVerticalStackLayoutDoesNotCycle()
+		public async Task FlexLayoutInVerticalStackLayoutDoesNotCycle() 
 		{
-			var root = new VerticalStackLayout();
-			var flexLayout = new FlexLayout();
-			var label = new Label { Text = "Hello" };
-
-			flexLayout.Add(label);
-			root.Add(flexLayout);
-
-			await InvokeOnMainThreadAsync(() =>
-			{
-				var labelHandler = CreateHandler<LabelHandler>(label);
-				var flexLayoutHandler = CreateHandler<LayoutHandler>(flexLayout);
-				var layoutHandler = CreateHandler<LayoutHandler>(root);
-
-				// If this can be attached to the hierarchy and make it through a layout 
-				// without crashing, then we're good. 
-				root.ToPlatform(MauiContext).AttachAndRun(() => { });
-			});
+			await FlexLayoutInStackLayoutDoesNotCycle(new VerticalStackLayout());
 		}
 
 		[Fact, Category(TestCategory.FlexLayout)]
 		public async Task FlexLayoutInHorizontalStackLayoutDoesNotCycle()
 		{
-			var root = new HorizontalStackLayout();
+			await FlexLayoutInStackLayoutDoesNotCycle(new HorizontalStackLayout());
+		}
+
+		async Task FlexLayoutInStackLayoutDoesNotCycle(IStackLayout root)
+		{
 			var flexLayout = new FlexLayout();
 			var label = new Label { Text = "Hello" };
 
 			flexLayout.Add(label);
 			root.Add(flexLayout);
 
-			await InvokeOnMainThreadAsync(() =>
+			await InvokeOnMainThreadAsync(async () =>
 			{
 				var labelHandler = CreateHandler<LabelHandler>(label);
 				var flexLayoutHandler = CreateHandler<LayoutHandler>(flexLayout);
 				var layoutHandler = CreateHandler<LayoutHandler>(root);
 
 				// If this can be attached to the hierarchy and make it through a layout 
-				// without crashing, then we're good. 
-				root.ToPlatform(MauiContext).AttachAndRun(() => { });
+				// without crashing, then we're good.
+				
+				await root.ToPlatform(MauiContext).AttachAndRun(() => { });
 			});
 		}
 	}

--- a/src/Controls/tests/DeviceTests/TestCategory.cs
+++ b/src/Controls/tests/DeviceTests/TestCategory.cs
@@ -17,8 +17,9 @@
 		public const string Editor = "Editor";
 		public const string Element = "Element";
 		public const string Entry = "Entry";
-		public const string Frame = "Frame";
+		public const string FlexLayout = "FlexLayout";
 		public const string FlyoutPage = "FlyoutPage";
+		public const string Frame = "Frame";
 		public const string Gesture = "Gesture";
 		public const string Image = "Image";
 		public const string Label = "Label";

--- a/src/Core/src/Layouts/Flex.cs
+++ b/src/Core/src/Layouts/Flex.cs
@@ -579,7 +579,13 @@ namespace Microsoft.Maui.Layouts.Flex
 				layout.flex_grows += child.Grow;
 				layout.flex_shrinks += child.Shrink;
 
-				layout.flex_dim -= child_size + child.MarginThickness(layout.vertical);
+				if(layout.flex_dim > 0) 
+				{
+					// If flex_dim is zero, it's because we're measuring unconstrained in that direction
+					// So we don't need to keep a running tally of available space
+
+					layout.flex_dim -= child_size + child.MarginThickness(layout.vertical);
+				}
 
 				relative_children_count++;
 

--- a/src/Core/src/Layouts/Flex.cs
+++ b/src/Core/src/Layouts/Flex.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Maui.Layouts.Flex
 					for (int j = 0; j < 2; j++)
 					{
 						int size_off = j + 2;
-						if (size_off == layout.frame_size2_i && child_align(child, item) == AlignItems.Stretch)
+						if (size_off == layout.frame_size2_i && child_align(child, item) == AlignItems.Stretch && layout.align_dim > 0)
 							continue;
 						float val = size[j];
 						if (!float.IsNaN(val))


### PR DESCRIPTION
### Description of Change

FlexLayout is treating measurements in unconstrained directions as effectively zero, which is leading it to set the size of children in those directions to zero (as FlexLayout tries to distribute the child sizes across the available space). Which means blank children in some cases, but on Windows it spurs additional layout cycles and eventually a crash. 

This change allows children in the unconstrained direction to have their flex frame sizes set if the FlexLayout does not have an explicit size to distribute them over. 

### Issues Fixed

Fixes #11909
Fixes #9905
Fixes #5091
Fixes #11708