### PR TITLE
[Windows] Fix crash on Windows WebView updating the Html Source more than once

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml
@@ -12,6 +12,7 @@
                     Text="HtmlWebViewSource (String)"
                     Style="{StaticResource Headline}"/>
                 <WebView 
+                    x:Name="HtmlSourceWebView"
                     HeightRequest="150"
                     HorizontalOptions="FillAndExpand">
                     <WebView.Source>
@@ -31,6 +32,9 @@
                         </HtmlWebViewSource>
                     </WebView.Source>
                 </WebView>
+                <Button
+                    Text="Update Source"
+                    Clicked="OnUpdateHtmlSourceClicked"/>
                 <Label
                     Text="HtmlWebViewSource (File)"
                     Style="{StaticResource Headline}"/>

--- a/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/Controls/WebViewPage.xaml.cs
@@ -28,6 +28,14 @@ namespace Maui.Controls.Sample.Pages
 			MauiWebView.Navigated -= OnMauiWebViewNavigated;
 		}
 
+		void OnUpdateHtmlSourceClicked(object sender, EventArgs args)
+		{
+			Random rnd = new();
+			HtmlWebViewSource htmlWebViewSource = new();
+			HtmlSourceWebView.Source = htmlWebViewSource;
+			htmlWebViewSource.Html += $"<h1>Updated Content {rnd.Next()}!</h1><br>";
+		}
+
 		void OnGoBackClicked(object sender, EventArgs args)
 		{
 			Debug.WriteLine($"CanGoBack {MauiWebView.CanGoBack}");

--- a/src/Core/src/Platform/Windows/MauiWebView.cs
+++ b/src/Core/src/Platform/Windows/MauiWebView.cs
@@ -99,11 +99,16 @@ namespace Microsoft.Maui.Platform
 				NavigateToString(!string.IsNullOrEmpty(htmlWithBaseTag) ? htmlWithBaseTag : html);
 
 				// Free up memory after we're done with _internalWebView
-				_internalWebView = null;
+				if (_internalWebView.IsValid())
+				{
+					_internalWebView.Close();
+					_internalWebView = null;
+				}
 			};
 
 			// Kick off the initial navigation
-			_internalWebView.NavigateToString(html);
+			if (_internalWebView.IsValid())
+				_internalWebView.NavigateToString(html);
 		}
 
 		public async void LoadUrl(string? url)

--- a/src/Core/src/Platform/Windows/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/WebViewExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Maui.Platform
 		{
 			try
 			{
-				return webView != null && webView.CoreWebView2 != null;
+				return webView is not null && webView.CoreWebView2 is not null;
 			}
 			catch (Exception ex) when (ex is ObjectDisposedException || ex is InvalidOperationException)
 			{

--- a/src/Core/src/Platform/Windows/WebViewExtensions.cs
+++ b/src/Core/src/Platform/Windows/WebViewExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Platform
@@ -79,6 +78,18 @@ namespace Microsoft.Maui.Platform
 		public static void EvaluateJavaScript(this WebView2 webView, EvaluateJavaScriptAsyncRequest request)
 		{
 			request.RunAndReport(webView.ExecuteScriptAsync(request.Script));
+		}
+
+		internal static bool IsValid(this WebView2 webView)
+		{
+			try
+			{
+				return webView != null && webView.CoreWebView2 != null;
+			}
+			catch (Exception ex) when (ex is ObjectDisposedException || ex is InvalidOperationException)
+			{
+				return false;
+			}
 		}
 	}
 }

--- a/src/Core/tests/DeviceTests/Handlers/WebView/WebViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/WebView/WebViewHandlerTests.Windows.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Maui.DeviceTests
 					// If the new source is loaded without exceptions, the test has passed
 					Assert.True(await tcsLoaded.Task);
 				});
+			});
 		}
     
 		[Fact(DisplayName = "Closing Window With WebView Doesnt Crash")]

--- a/src/Core/tests/DeviceTests/Handlers/WebView/WebViewHandlerTests.Windows.cs
+++ b/src/Core/tests/DeviceTests/Handlers/WebView/WebViewHandlerTests.Windows.cs
@@ -1,9 +1,60 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.UI.Xaml.Controls;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
 	public partial class WebViewHandlerTests
 	{
+		[Theory(DisplayName = "UrlSource Updates Correctly")]
+		[InlineData("<h1>Old Source</h1><br>", "<p>New Source</p>\"")]
+		[InlineData("<p>Old Source</p><br>", "<h1>New Source</h1>\"")]
+		public async Task HtmlSourceUpdatesCorrectly(string oldSource, string newSource)
+		{
+			var pageLoadTimeout = TimeSpan.FromSeconds(2);
+
+			await InvokeOnMainThreadAsync(async () =>
+			{
+				var webView = new WebViewStub()
+				{
+					Width = 100,
+					Height = 100,
+					Source = new HtmlWebViewSourceStub { Html = oldSource }
+				};
+
+				var handler = CreateHandler(webView);
+
+				var platformView = handler.PlatformView;
+
+				// Setup the view to be displayed/parented and run our tests on it
+				await platformView.AttachAndRun(async () =>
+				{
+					// Wait for the page to load
+					var tcsLoaded = new TaskCompletionSource<bool>();
+					var ctsTimeout = new CancellationTokenSource(pageLoadTimeout);
+					ctsTimeout.Token.Register(() => tcsLoaded.TrySetException(new TimeoutException($"Failed to load HTML")));
+
+					webView.NavigatedDelegate = (evnt, url, result) =>
+					{
+						// Set success when we have a successful nav result
+						if (result == WebNavigationResult.Success)
+							tcsLoaded.TrySetResult(result == WebNavigationResult.Success);
+					};
+
+					// Load the new Source
+					webView.Source = new HtmlWebViewSourceStub { Html = newSource };
+
+					handler.UpdateValue(nameof(IWebView.Source));
+
+					// If the new source is loaded without exceptions, the test has passed
+					Assert.True(await tcsLoaded.Task);
+				});
+			});
+		}
+
 		WebView2 GetNativeWebView(WebViewHandler webViewHandler) =>
 			webViewHandler.PlatformView;
 

--- a/src/Core/tests/DeviceTests/Stubs/HtmlWebViewSourceStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/HtmlWebViewSourceStub.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.Maui.DeviceTests.Stubs
+{
+	class HtmlWebViewSourceStub : IWebViewSource
+	{
+		public string Html { get; set; }
+
+		public void Load(IWebViewDelegate webViewDelegate)
+		{
+			webViewDelegate.LoadHtml(Html, null);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Fix crash on Windows WebView updating the Html Source more than once.

![fix-webview-source2](https://user-images.githubusercontent.com/6755973/217800369-d1432774-909a-4e57-9a5a-8fd72234de14.gif)

To validate the changes, launch the .NET MAUI Gallery on Windows and navigate to the WebView sample. Tap the Update Html Source more than once. Without exceptions, the test has passed. Also, can use the new added Device tests to validate the changes.

![image](https://user-images.githubusercontent.com/6755973/217800386-c42eb813-1eb4-48f4-8707-b0b7adcbddaa.png)

### Issues Fixed

Fixes #10438 