### PR TITLE
[Resizetizer] Do not update images if they have not been updated.

### DIFF
--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -64,8 +64,17 @@ namespace Microsoft.Maui.Resizetizer
 			{
 				var dir = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path);
 				var destination = Path.Combine(dir, backgroundDestFilename);
+				var destinationExists = File.Exists(destination);
 				Directory.CreateDirectory(dir);
 
+				var sourceModifiedDateTime = backgroundExists ? File.GetLastWriteTimeUtc(backgroundFile) : System.DateTime.MinValue;
+				var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(destination) : System.DateTime.MinValue;
+
+				if (destinationModifiedDateTime > sourceModifiedDateTime) {
+					Logger.Log($"Skipping `{backgroundFile}` => `{destination}` file it up to date.");
+					continue;
+				}
+	
 				Logger.Log($"App Icon Background Part: " + destination);
 
 				if (backgroundExists)
@@ -100,7 +109,16 @@ namespace Microsoft.Maui.Resizetizer
 			{
 				var dir = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path);
 				var destination = Path.Combine(dir, foregroundDestFilename);
+				var destinationExists = File.Exists(destination);
 				Directory.CreateDirectory(dir);
+
+				var sourceModifiedDateTime = foregroundExists ? File.GetLastWriteTimeUtc(foregroundFile) : System.DateTime.MinValue;
+				var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(destination) : System.DateTime.MinValue;
+
+				if (destinationModifiedDateTime > sourceModifiedDateTime) {
+					Logger.Log($"Skipping `{foregroundFile}` => `{destination}` file it up to date.");
+					continue;
+				}
 
 				Logger.Log($"App Icon Foreground Part: " + destination);
 
@@ -132,8 +150,10 @@ namespace Microsoft.Maui.Resizetizer
 			Directory.CreateDirectory(dir);
 
 			// Write out the adaptive icon xml drawables
-			File.WriteAllText(adaptiveIconDestination, adaptiveIconXmlStr);
-			File.WriteAllText(adaptiveIconRoundDestination, adaptiveIconXmlStr);
+			if (!File.Exists(adaptiveIconDestination))
+				File.WriteAllText(adaptiveIconDestination, adaptiveIconXmlStr);
+			if (!File.Exists(adaptiveIconRoundDestination))
+				File.WriteAllText(adaptiveIconRoundDestination, adaptiveIconXmlStr);
 
 			results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1), Filename = adaptiveIconDestination });
 			results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1, "_round"), Filename = adaptiveIconRoundDestination });

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -53,10 +53,10 @@ namespace Microsoft.Maui.Resizetizer
 		void ProcessBackground(List<ResizedImageInfo> results, DirectoryInfo fullIntermediateOutputPath)
 		{
 			var backgroundFile = Info.Filename;
-			(bool Exists, DateTime Modified) backgroundExists = Utils.FileExists(backgroundFile);
+			var (backgroundExists, backgroundModified) = Utils.FileExists(backgroundFile);
 			var backgroundDestFilename = AppIconName + "_background.png";
 
-			if (backgroundExists.Exists)
+			if (backgroundExists)
 				Logger.Log("Converting Background SVG to PNG: " + backgroundFile);
 			else
 				Logger.Log("Background was not found (will manufacture): " + backgroundFile);
@@ -65,10 +65,10 @@ namespace Microsoft.Maui.Resizetizer
 			{
 				var dir = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path);
 				var destination = Path.Combine(dir, backgroundDestFilename);
-				(bool Exists, DateTime Modified) destinationExists = Utils.FileExists(destination);
+				var (destinationExists, destinationModified) = Utils.FileExists(destination);
 				Directory.CreateDirectory(dir);
 
-				if (destinationExists.Modified > backgroundExists.Modified) {
+				if (destinationModified > backgroundModified) {
 					Logger.Log($"Skipping `{backgroundFile}` => `{destination}` file is up to date.");
 					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
 					continue;
@@ -76,7 +76,7 @@ namespace Microsoft.Maui.Resizetizer
 	
 				Logger.Log($"App Icon Background Part: " + destination);
 
-				if (backgroundExists.Exists)
+				if (backgroundExists)
 				{
 					// resize the background
 					var tools = SkiaSharpTools.Create(Info.IsVector, Info.Filename, dpi.Size, Info.Color, null, Logger);
@@ -96,10 +96,10 @@ namespace Microsoft.Maui.Resizetizer
 		void ProcessForeground(List<ResizedImageInfo> results, DirectoryInfo fullIntermediateOutputPath)
 		{
 			var foregroundFile = Info.ForegroundFilename;
-			(bool Exists, DateTime Modified) foregroundExists = Utils.FileExists(foregroundFile);
+			var (foregroundExists, foregroundModified) = Utils.FileExists(foregroundFile);
 			var foregroundDestFilename = AppIconName + "_foreground.png";
 
-			if (foregroundExists.Exists)
+			if (foregroundExists)
 				Logger.Log("Converting Foreground SVG to PNG: " + foregroundFile);
 			else
 				Logger.Log("Foreground was not found (will manufacture): " + foregroundFile);
@@ -108,10 +108,10 @@ namespace Microsoft.Maui.Resizetizer
 			{
 				var dir = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path);
 				var destination = Path.Combine(dir, foregroundDestFilename);
-				(bool Exists, DateTime Modified) destinationExists = Utils.FileExists(destination);
+				var (destinationExists, destinationModified) = Utils.FileExists(destination);
 				Directory.CreateDirectory(dir);
 
-				if (destinationExists.Modified > foregroundExists.Modified) {
+				if (destinationModified > foregroundModified) {
 					Logger.Log($"Skipping `{foregroundFile}` => `{destination}` file is up to date.");
 					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
 					continue;
@@ -119,7 +119,7 @@ namespace Microsoft.Maui.Resizetizer
 
 				Logger.Log($"App Icon Foreground Part: " + destination);
 
-				if (foregroundExists.Exists)
+				if (foregroundExists)
 				{
 					// resize the forground
 					var tools = SkiaSharpTools.Create(Info.ForegroundIsVector, Info.ForegroundFilename, dpi.Size, null, Info.TintColor, Logger);

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -138,19 +138,23 @@ namespace Microsoft.Maui.Resizetizer
 
 		void ProcessAdaptiveIcon(List<ResizedImageInfo> results, DirectoryInfo fullIntermediateOutputPath)
 		{
-			var adaptiveIconXmlStr = AdaptiveIconDrawableXml
-				.Replace("{name}", AppIconName);
-
 			var dir = Path.Combine(fullIntermediateOutputPath.FullName, "mipmap-anydpi-v26");
 			var adaptiveIconDestination = Path.Combine(dir, AppIconName + ".xml");
 			var adaptiveIconRoundDestination = Path.Combine(dir, AppIconName + "_round.xml");
 			Directory.CreateDirectory(dir);
 
+			if (File.Exists(adaptiveIconDestination) && File.Exists(adaptiveIconRoundDestination)) {
+				results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1), Filename = adaptiveIconDestination });
+				results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1, "_round"), Filename = adaptiveIconRoundDestination });
+				return;
+			}
+
+			var adaptiveIconXmlStr = AdaptiveIconDrawableXml
+				.Replace("{name}", AppIconName);
+
 			// Write out the adaptive icon xml drawables
-			if (!File.Exists(adaptiveIconDestination))
-				File.WriteAllText(adaptiveIconDestination, adaptiveIconXmlStr);
-			if (!File.Exists(adaptiveIconRoundDestination))
-				File.WriteAllText(adaptiveIconRoundDestination, adaptiveIconXmlStr);
+			File.WriteAllText(adaptiveIconDestination, adaptiveIconXmlStr);
+			File.WriteAllText(adaptiveIconRoundDestination, adaptiveIconXmlStr);
 
 			results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1), Filename = adaptiveIconDestination });
 			results.Add(new ResizedImageInfo { Dpi = new DpiPath("mipmap-anydpi-v26", 1, "_round"), Filename = adaptiveIconRoundDestination });

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System;
 
 namespace Microsoft.Maui.Resizetizer
 {
@@ -68,12 +68,13 @@ namespace Microsoft.Maui.Resizetizer
 				var (destinationExists, destinationModified) = Utils.FileExists(destination);
 				Directory.CreateDirectory(dir);
 
-				if (destinationModified > backgroundModified) {
+				if (destinationModified > backgroundModified)
+				{
 					Logger.Log($"Skipping `{backgroundFile}` => `{destination}` file is up to date.");
 					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
 					continue;
 				}
-	
+
 				Logger.Log($"App Icon Background Part: " + destination);
 
 				if (backgroundExists)
@@ -111,7 +112,8 @@ namespace Microsoft.Maui.Resizetizer
 				var (destinationExists, destinationModified) = Utils.FileExists(destination);
 				Directory.CreateDirectory(dir);
 
-				if (destinationModified > foregroundModified) {
+				if (destinationModified > foregroundModified)
+				{
 					Logger.Log($"Skipping `{foregroundFile}` => `{destination}` file is up to date.");
 					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
 					continue;

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Maui.Resizetizer
 
 				if (destinationModifiedDateTime > sourceModifiedDateTime) {
 					Logger.Log($"Skipping `{backgroundFile}` => `{destination}` file it up to date.");
+					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
 					continue;
 				}
 	
@@ -117,6 +118,7 @@ namespace Microsoft.Maui.Resizetizer
 
 				if (destinationModifiedDateTime > sourceModifiedDateTime) {
 					Logger.Log($"Skipping `{foregroundFile}` => `{destination}` file it up to date.");
+					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
 					continue;
 				}
 

--- a/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System;
 
 namespace Microsoft.Maui.Resizetizer
 {
@@ -52,10 +53,10 @@ namespace Microsoft.Maui.Resizetizer
 		void ProcessBackground(List<ResizedImageInfo> results, DirectoryInfo fullIntermediateOutputPath)
 		{
 			var backgroundFile = Info.Filename;
-			var backgroundExists = File.Exists(backgroundFile);
+			(bool Exists, DateTime Modified) backgroundExists = Utils.FileExists(backgroundFile);
 			var backgroundDestFilename = AppIconName + "_background.png";
 
-			if (backgroundExists)
+			if (backgroundExists.Exists)
 				Logger.Log("Converting Background SVG to PNG: " + backgroundFile);
 			else
 				Logger.Log("Background was not found (will manufacture): " + backgroundFile);
@@ -64,21 +65,18 @@ namespace Microsoft.Maui.Resizetizer
 			{
 				var dir = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path);
 				var destination = Path.Combine(dir, backgroundDestFilename);
-				var destinationExists = File.Exists(destination);
+				(bool Exists, DateTime Modified) destinationExists = Utils.FileExists(destination);
 				Directory.CreateDirectory(dir);
 
-				var sourceModifiedDateTime = backgroundExists ? File.GetLastWriteTimeUtc(backgroundFile) : System.DateTime.MinValue;
-				var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(destination) : System.DateTime.MinValue;
-
-				if (destinationModifiedDateTime > sourceModifiedDateTime) {
-					Logger.Log($"Skipping `{backgroundFile}` => `{destination}` file it up to date.");
+				if (destinationExists.Modified > backgroundExists.Modified) {
+					Logger.Log($"Skipping `{backgroundFile}` => `{destination}` file is up to date.");
 					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
 					continue;
 				}
 	
 				Logger.Log($"App Icon Background Part: " + destination);
 
-				if (backgroundExists)
+				if (backgroundExists.Exists)
 				{
 					// resize the background
 					var tools = SkiaSharpTools.Create(Info.IsVector, Info.Filename, dpi.Size, Info.Color, null, Logger);
@@ -98,10 +96,10 @@ namespace Microsoft.Maui.Resizetizer
 		void ProcessForeground(List<ResizedImageInfo> results, DirectoryInfo fullIntermediateOutputPath)
 		{
 			var foregroundFile = Info.ForegroundFilename;
-			var foregroundExists = File.Exists(foregroundFile);
+			(bool Exists, DateTime Modified) foregroundExists = Utils.FileExists(foregroundFile);
 			var foregroundDestFilename = AppIconName + "_foreground.png";
 
-			if (foregroundExists)
+			if (foregroundExists.Exists)
 				Logger.Log("Converting Foreground SVG to PNG: " + foregroundFile);
 			else
 				Logger.Log("Foreground was not found (will manufacture): " + foregroundFile);
@@ -110,21 +108,18 @@ namespace Microsoft.Maui.Resizetizer
 			{
 				var dir = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path);
 				var destination = Path.Combine(dir, foregroundDestFilename);
-				var destinationExists = File.Exists(destination);
+				(bool Exists, DateTime Modified) destinationExists = Utils.FileExists(destination);
 				Directory.CreateDirectory(dir);
 
-				var sourceModifiedDateTime = foregroundExists ? File.GetLastWriteTimeUtc(foregroundFile) : System.DateTime.MinValue;
-				var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(destination) : System.DateTime.MinValue;
-
-				if (destinationModifiedDateTime > sourceModifiedDateTime) {
-					Logger.Log($"Skipping `{foregroundFile}` => `{destination}` file it up to date.");
+				if (destinationExists.Modified > foregroundExists.Modified) {
+					Logger.Log($"Skipping `{foregroundFile}` => `{destination}` file is up to date.");
 					results.Add(new ResizedImageInfo { Dpi = dpi, Filename = destination });
 					continue;
 				}
 
 				Logger.Log($"App Icon Foreground Part: " + destination);
 
-				if (foregroundExists)
+				if (foregroundExists.Exists)
 				{
 					// resize the forground
 					var tools = SkiaSharpTools.Create(Info.ForegroundIsVector, Info.ForegroundFilename, dpi.Size, null, Info.TintColor, Logger);

--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Maui.Resizetizer
 			var (sourceExists, sourceModified) = Utils.FileExists(Info.Filename);
 			var (destinationExists, destinationModified) = Utils.FileExists(appIconSetContentsFile);
 
-			if (destinationModified > sourceModified) {
+			if (destinationModified > sourceModified)
+			{
 				Logger.Log($"Skipping `{Info.Filename}` => `{appIconSetContentsFile}` file is up to date.");
 				return new List<ResizedImageInfo> {
 					new ResizedImageInfo { Dpi = new DpiPath("", 1), Filename = appIconSetContentsFile }

--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -41,6 +41,19 @@ namespace Microsoft.Maui.Resizetizer
 			var assetContentsFile = Path.Combine(outputAssetsDir, "Contents.json");
 			var appIconSetContentsFile = Path.Combine(outputAppIconSetDir, "Contents.json");
 
+			var sourceExists = File.Exists(Info.Filename);
+			var destinationExists = File.Exists(appIconSetContentsFile);
+
+			var sourceModifiedDateTime = sourceExists ? File.GetLastWriteTimeUtc(Info.Filename) : System.DateTime.MinValue;
+			var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(appIconSetContentsFile) : System.DateTime.MinValue;
+
+			if (destinationModifiedDateTime > sourceModifiedDateTime) {
+				Logger.Log($"Skipping `{Info.Filename}` => `{appIconSetContentsFile}` file it up to date.");
+				return new List<ResizedImageInfo> {
+					new ResizedImageInfo { Dpi = new DpiPath("", 1), Filename = appIconSetContentsFile }
+				};
+			}
+
 			var infoJsonProp = new JsonObject
 			{
 				["info"] = new JsonObject

--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -41,14 +41,11 @@ namespace Microsoft.Maui.Resizetizer
 			var assetContentsFile = Path.Combine(outputAssetsDir, "Contents.json");
 			var appIconSetContentsFile = Path.Combine(outputAppIconSetDir, "Contents.json");
 
-			var sourceExists = File.Exists(Info.Filename);
-			var destinationExists = File.Exists(appIconSetContentsFile);
+			(bool Exists, DateTime Modified) sourceExists = Utils.FileExists(Info.Filename);
+			(bool Exists, DateTime Modified) destinationExists = Utils.FileExists(appIconSetContentsFile);
 
-			var sourceModifiedDateTime = sourceExists ? File.GetLastWriteTimeUtc(Info.Filename) : System.DateTime.MinValue;
-			var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(appIconSetContentsFile) : System.DateTime.MinValue;
-
-			if (destinationModifiedDateTime > sourceModifiedDateTime) {
-				Logger.Log($"Skipping `{Info.Filename}` => `{appIconSetContentsFile}` file it up to date.");
+			if (destinationExists.Modified > sourceExists.Modified) {
+				Logger.Log($"Skipping `{Info.Filename}` => `{appIconSetContentsFile}` file is up to date.");
 				return new List<ResizedImageInfo> {
 					new ResizedImageInfo { Dpi = new DpiPath("", 1), Filename = appIconSetContentsFile }
 				};

--- a/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -41,10 +41,10 @@ namespace Microsoft.Maui.Resizetizer
 			var assetContentsFile = Path.Combine(outputAssetsDir, "Contents.json");
 			var appIconSetContentsFile = Path.Combine(outputAppIconSetDir, "Contents.json");
 
-			(bool Exists, DateTime Modified) sourceExists = Utils.FileExists(Info.Filename);
-			(bool Exists, DateTime Modified) destinationExists = Utils.FileExists(appIconSetContentsFile);
+			var (sourceExists, sourceModified) = Utils.FileExists(Info.Filename);
+			var (destinationExists, destinationModified) = Utils.FileExists(appIconSetContentsFile);
 
-			if (destinationExists.Modified > sourceExists.Modified) {
+			if (destinationModified > sourceModified) {
 				Logger.Log($"Skipping `{Info.Filename}` => `{appIconSetContentsFile}` file is up to date.");
 				return new List<ResizedImageInfo> {
 					new ResizedImageInfo { Dpi = new DpiPath("", 1), Filename = appIconSetContentsFile }

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -170,15 +170,13 @@ namespace Microsoft.Maui.Resizetizer
 
 				var destination = Resizer.GetRasterFileDestination(img, dpi, IntermediateOutputPath)
 					.Replace("{name}", appIconName);
-				var destinationExists = File.Exists (destination);
-				var sourceExists = File.Exists (img.Filename);
+				(bool Exists, DateTime Modified) destinationExists = Utils.FileExists (destination);
+				(bool Exists, DateTime Modified) sourceExists = Utils.FileExists (img.Filename);
 
 				LogDebugMessage($"App Icon Destination: " + destination);
-				var sourceModifiedDateTime = sourceExists ? File.GetLastWriteTimeUtc(img.Filename) : System.DateTime.MinValue;
-				var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(destination) : System.DateTime.MinValue;
-
-				if (destinationModifiedDateTime > sourceModifiedDateTime) {
-					Logger.Log ($"Skipping `{img.Filename}` => `{destination}` file it up to date.");
+				
+				if (destinationExists.Modified > sourceExists.Modified) {
+					Logger.Log ($"Skipping `{img.Filename}` => `{destination}` file is up to date.");
 					continue;
 				}
 

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -170,13 +170,14 @@ namespace Microsoft.Maui.Resizetizer
 
 				var destination = Resizer.GetRasterFileDestination(img, dpi, IntermediateOutputPath)
 					.Replace("{name}", appIconName);
-				var (sourceExists, sourceModified) = Utils.FileExists (img.Filename);
-				var (destinationExists, destinationModified)= Utils.FileExists (destination);
+				var (sourceExists, sourceModified) = Utils.FileExists(img.Filename);
+				var (destinationExists, destinationModified) = Utils.FileExists(destination);
 
 				LogDebugMessage($"App Icon Destination: " + destination);
-				
-				if (destinationModified > sourceModified) {
-					Logger.Log ($"Skipping `{img.Filename}` => `{destination}` file is up to date.");
+
+				if (destinationModified > sourceModified)
+				{
+					Logger.Log($"Skipping `{img.Filename}` => `{destination}` file is up to date.");
 					continue;
 				}
 

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -170,12 +170,12 @@ namespace Microsoft.Maui.Resizetizer
 
 				var destination = Resizer.GetRasterFileDestination(img, dpi, IntermediateOutputPath)
 					.Replace("{name}", appIconName);
-				(bool Exists, DateTime Modified) destinationExists = Utils.FileExists (destination);
-				(bool Exists, DateTime Modified) sourceExists = Utils.FileExists (img.Filename);
+				var (sourceExists, sourceModified) = Utils.FileExists (img.Filename);
+				var (destinationExists, destinationModified)= Utils.FileExists (destination);
 
 				LogDebugMessage($"App Icon Destination: " + destination);
 				
-				if (destinationExists.Modified > sourceExists.Modified) {
+				if (destinationModified > sourceModified) {
 					Logger.Log ($"Skipping `{img.Filename}` => `{destination}` file is up to date.");
 					continue;
 				}

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -170,8 +170,17 @@ namespace Microsoft.Maui.Resizetizer
 
 				var destination = Resizer.GetRasterFileDestination(img, dpi, IntermediateOutputPath)
 					.Replace("{name}", appIconName);
+				var destinationExists = File.Exists (destination);
+				var sourceExists = File.Exists (img.Filename);
 
 				LogDebugMessage($"App Icon Destination: " + destination);
+				var sourceModifiedDateTime = sourceExists ? File.GetLastWriteTimeUtc(img.Filename) : System.DateTime.MinValue;
+				var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(destination) : System.DateTime.MinValue;
+
+				if (destinationModifiedDateTime > sourceModifiedDateTime) {
+					Logger.Log ($"Skipping `{img.Filename}` => `{destination}` file it up to date.");
+					continue;
+				}
 
 				appTool.Resize(dpi, destination);
 			}

--- a/src/SingleProject/Resizetizer/src/Utils.cs
+++ b/src/SingleProject/Resizetizer/src/Utils.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text.RegularExpressions;
 using SkiaSharp;
 
@@ -48,6 +49,13 @@ namespace Microsoft.Maui.Resizetizer
 			}
 
 			return null;
+		}
+
+		public static (bool Exists, DateTime Modified) FileExists(string path)
+		{
+			var exists = File.Exists(path);
+			var modified = exists ? File.GetLastWriteTimeUtc(path) : System.DateTime.MinValue;
+			return (exists, modified);
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
@@ -28,15 +28,15 @@ namespace Microsoft.Maui.Resizetizer
 			string destination = Path.Combine(destinationFolder, $"{fileName}.ico");
 			Directory.CreateDirectory(destinationFolder);
 
-			(bool Exists, DateTime Modified) sourceExists = Utils.FileExists(Info.Filename);
-			(bool Exists, DateTime Modified) destinationExists = Utils.FileExists(destination);
+			var (sourceExists, sourceModified) = Utils.FileExists(Info.Filename);
+			var (destinationExists, destinationModified) = Utils.FileExists(destination);
 
 			Logger.Log($"Generating ICO: {destination}");
 			
 			var tools = new SkiaSharpAppIconTools(Info, Logger);
 			var dpi = new DpiPath(fileName, 1.0m, size: new SKSize(64, 64));
 
-			if (destinationExists.Modified > sourceExists.Modified) {
+			if (destinationModified > sourceModified) {
 				Logger.Log($"Skipping `{Info.Filename}` => `{destination}` file is up to date.");
 				return new ResizedImageInfo { Dpi = dpi, Filename = destination };
 			}

--- a/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using SkiaSharp;
 
 namespace Microsoft.Maui.Resizetizer
@@ -27,19 +28,16 @@ namespace Microsoft.Maui.Resizetizer
 			string destination = Path.Combine(destinationFolder, $"{fileName}.ico");
 			Directory.CreateDirectory(destinationFolder);
 
-			var sourceExists = File.Exists(Info.Filename);
-			var destinationExists = File.Exists(destination);
+			(bool Exists, DateTime Modified) sourceExists = Utils.FileExists(Info.Filename);
+			(bool Exists, DateTime Modified) destinationExists = Utils.FileExists(destination);
 
 			Logger.Log($"Generating ICO: {destination}");
 			
 			var tools = new SkiaSharpAppIconTools(Info, Logger);
 			var dpi = new DpiPath(fileName, 1.0m, size: new SKSize(64, 64));
 
-			var sourceModifiedDateTime = sourceExists ? File.GetLastWriteTimeUtc(Info.Filename) : System.DateTime.MinValue;
-			var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(destination) : System.DateTime.MinValue;
-
-			if (destinationModifiedDateTime > sourceModifiedDateTime) {
-				Logger.Log($"Skipping `{Info.Filename}` => `{destination}` file it up to date.");
+			if (destinationExists.Modified > sourceExists.Modified) {
+				Logger.Log($"Skipping `{Info.Filename}` => `{destination}` file is up to date.");
 				return new ResizedImageInfo { Dpi = dpi, Filename = destination };
 			}
 

--- a/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
@@ -32,11 +32,12 @@ namespace Microsoft.Maui.Resizetizer
 			var (destinationExists, destinationModified) = Utils.FileExists(destination);
 
 			Logger.Log($"Generating ICO: {destination}");
-			
+
 			var tools = new SkiaSharpAppIconTools(Info, Logger);
 			var dpi = new DpiPath(fileName, 1.0m, size: new SKSize(64, 64));
 
-			if (destinationModified > sourceModified) {
+			if (destinationModified > sourceModified)
+			{
 				Logger.Log($"Skipping `{Info.Filename}` => `{destination}` file is up to date.");
 				return new ResizedImageInfo { Dpi = dpi, Filename = destination };
 			}

--- a/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/WindowsIconGenerator.cs
@@ -27,10 +27,21 @@ namespace Microsoft.Maui.Resizetizer
 			string destination = Path.Combine(destinationFolder, $"{fileName}.ico");
 			Directory.CreateDirectory(destinationFolder);
 
-			Logger.Log($"Generating ICO: {destination}");
+			var sourceExists = File.Exists(Info.Filename);
+			var destinationExists = File.Exists(destination);
 
+			Logger.Log($"Generating ICO: {destination}");
+			
 			var tools = new SkiaSharpAppIconTools(Info, Logger);
 			var dpi = new DpiPath(fileName, 1.0m, size: new SKSize(64, 64));
+
+			var sourceModifiedDateTime = sourceExists ? File.GetLastWriteTimeUtc(Info.Filename) : System.DateTime.MinValue;
+			var destinationModifiedDateTime = destinationExists ? File.GetLastWriteTimeUtc(destination) : System.DateTime.MinValue;
+
+			if (destinationModifiedDateTime > sourceModifiedDateTime) {
+				Logger.Log($"Skipping `{Info.Filename}` => `{destination}` file it up to date.");
+				return new ResizedImageInfo { Dpi = dpi, Filename = destination };
+			}
 
 			MemoryStream memoryStream = new MemoryStream();
 			tools.Resize(dpi, destination, () => memoryStream);

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -1367,7 +1367,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 			[InlineData("android")]
 			[InlineData("uwp")]
 			[InlineData("ios")]
-			public void GenerationSkippedOnIncrementalBuild (string platform)
+			public void GenerationSkippedOnIncrementalBuild(string platform)
 			{
 				var items = new[]
 				{
@@ -1380,17 +1380,17 @@ namespace Microsoft.Maui.Resizetizer.Tests
 					}),
 				};
 
-				var task = GetNewTask (platform, items);
+				var task = GetNewTask(platform, items);
 				var success = task.Execute();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				LogErrorEvents.Clear ();
-				LogMessageEvents.Clear ();
-				task = GetNewTask (platform, items);
-				success = task.Execute ();
+				LogErrorEvents.Clear();
+				LogMessageEvents.Clear();
+				task = GetNewTask(platform, items);
+				success = task.Execute();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				Assert.True (LogMessageEvents.Any (x=> x.Message.Contains("Skipping ", StringComparison.OrdinalIgnoreCase)), $"Image generation should have been skipped.");
+				Assert.True(LogMessageEvents.Any(x => x.Message.Contains("Skipping ", StringComparison.OrdinalIgnoreCase)), $"Image generation should have been skipped.");
 			}
 		}
 	}

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -1390,7 +1390,7 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				success = task.Execute ();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				Assert.True (LogMessageEvents.Any (x=> x.Message.Contains("Skipping ", StringComparison.OrdinalIgnoreCase)), $"Image Generation should have been skipped.");
+				Assert.True (LogMessageEvents.Any (x=> x.Message.Contains("Skipping ", StringComparison.OrdinalIgnoreCase)), $"Image generation should have been skipped.");
 			}
 		}
 	}

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -1362,6 +1362,36 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var size = ResizeImageInfo.Parse(item);
 				Assert.Equal(resize, size.Resize);
 			}
+
+			[Theory]
+			[InlineData("android")]
+			[InlineData("uwp")]
+			[InlineData("ios")]
+			public void GenerationSkippedOnIncrementalBuild (string platform)
+			{
+				var items = new[]
+				{
+					new TaskItem("images/dotnet_logo.svg", new Dictionary<string, string>
+					{
+						["IsAppIcon"] = bool.TrueString,
+						["ForegroundFile"] = $"images/dotnet_foreground.svg",
+						["Link"] = "appicon",
+						["BackgroundFile"] = $"images/dotnet_background.svg",
+					}),
+				};
+
+				var task = GetNewTask (platform, items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				LogErrorEvents.Clear ();
+				LogMessageEvents.Clear ();
+				task = GetNewTask (platform, items);
+				success = task.Execute ();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				Assert.True (LogMessageEvents.Any (x=> x.Message.Contains("Skipping ", StringComparison.OrdinalIgnoreCase)), $"Image Generation should have been skipped.");
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Rather than generating the images on every build we should check to see if the source has changed before calling the expensive generation processes. This seems to take about 120-200ms off an incremental build when only one image file was changed.

Also don't generate the adaptive icons is they already exist.

old 

`450 ms  ResizetizeImages`

new

`330 ms  ResizetizeImages`
