### PR TITLE
[Android] Fix wrong conversions between Graphics RectF and Android RectF

### DIFF
--- a/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Graphics/GraphicsTests.Android.cs
@@ -1,0 +1,143 @@
+﻿using Xunit;
+
+namespace Microsoft.Maui.DeviceTests;
+
+[Category(TestCategory.Graphics)]
+public partial class GraphicsTests : TestBase
+{
+	[Theory]
+	[InlineData(0, 0, 0, 0)]
+	[InlineData(10, 10, 100, 100)]
+	[InlineData(0, 0, 10, 100)]
+	[InlineData(0, 0, 100, 10)]
+	[InlineData(50, 100, 100, 50)]
+	[InlineData(15, 15, 50, 50)]
+	public void RectFImplicitConversionTest(float x, float y, float width, float height)
+	{
+		var rectF = new Microsoft.Maui.Graphics.RectF(x, y, width, height);
+		Android.Graphics.RectF aRectF = rectF;
+
+		Assert.Equal(rectF.X, aRectF.Left);
+		Assert.Equal(rectF.Y, aRectF.Top);
+		Assert.Equal(rectF.Width, aRectF.Width());
+		Assert.Equal(rectF.Height, aRectF.Height());
+	}
+
+	[Theory]
+	[InlineData(0, 0, 0, 0)]
+	[InlineData(10, 10, 100, 100)]
+	[InlineData(0, 0, 10, 100)]
+	[InlineData(0, 0, 100, 10)]
+	[InlineData(50, 100, 100, 50)]
+	[InlineData(15, 15, 50, 50)]
+	public void RectFExplicitConversionTest(float x, float y, float width, float height)
+	{
+		var rectF = new Microsoft.Maui.Graphics.RectF(x, y, width, height);
+		var aRectF = (Android.Graphics.RectF)rectF;
+
+		Assert.Equal(rectF.X, aRectF.Left);
+		Assert.Equal(rectF.Y, aRectF.Top);
+		Assert.Equal(rectF.Width, aRectF.Width());
+		Assert.Equal(rectF.Height, aRectF.Height());
+	}
+
+	[Theory]
+	[InlineData(0, 0, 0, 0)]
+	[InlineData(10, 10, 100, 100)]
+	[InlineData(0, 0, 10, 100)]
+	[InlineData(0, 0, 100, 10)]
+	[InlineData(50, 100, 100, 50)]
+	[InlineData(15, 15, 50, 50)]
+	public void RectImplicitConversionTest(double x, double y, double width, double height)
+	{
+		var rect = new Microsoft.Maui.Graphics.Rect(x, y, width, height);
+		Android.Graphics.Rect aRect = rect;
+
+		Assert.Equal(rect.X, aRect.Left);
+		Assert.Equal(rect.Y, aRect.Top);
+		Assert.Equal(rect.Width, aRect.Width());
+		Assert.Equal(rect.Height, aRect.Height());
+	}
+
+	[Theory]
+	[InlineData(0, 0, 0, 0)]
+	[InlineData(10, 10, 100, 100)]
+	[InlineData(0, 0, 10, 100)]
+	[InlineData(0, 0, 100, 10)]
+	[InlineData(50, 100, 100, 50)]
+	[InlineData(15, 15, 50, 50)]
+	public void RectExplicitConversionTest(float x, float y, float width, float height)
+	{
+		var rect = new Microsoft.Maui.Graphics.Rect(x, y, width, height);
+		var aRect = (Android.Graphics.Rect)rect;
+
+		Assert.Equal(rect.X, aRect.Left);
+		Assert.Equal(rect.Y, aRect.Top);
+		Assert.Equal(rect.Width, aRect.Width());
+		Assert.Equal(rect.Height, aRect.Height());
+	}
+
+	[Theory]
+	[InlineData(0, 0)]
+	[InlineData(100, 100)]
+	[InlineData(10, 100)]
+	[InlineData(100, 10)]
+	[InlineData(50, 100)]
+	[InlineData(15, 15)]
+	public void PointFImplicitConversionTest(float x, float y)
+	{
+		var pointF = new Microsoft.Maui.Graphics.PointF(x, y);
+		Android.Graphics.PointF aPointF = pointF;
+
+		Assert.Equal(pointF.X, aPointF.X);
+		Assert.Equal(pointF.Y, aPointF.Y);
+	}
+
+	[Theory]
+	[InlineData(0, 0)]
+	[InlineData(100, 100)]
+	[InlineData(10, 100)]
+	[InlineData(100, 10)]
+	[InlineData(50, 100)]
+	[InlineData(15, 15)]
+	public void PointFExplicitConversionTest(float x, float y)
+	{
+		var pointF = new Microsoft.Maui.Graphics.PointF(x, y);
+		var aPointF = (Android.Graphics.PointF)pointF;
+
+		Assert.Equal(pointF.X, aPointF.X);
+		Assert.Equal(pointF.Y, aPointF.Y);
+	}
+
+	[Theory]
+	[InlineData(0, 0)]
+	[InlineData(100, 100)]
+	[InlineData(10, 100)]
+	[InlineData(100, 10)]
+	[InlineData(50, 100)]
+	[InlineData(15, 15)]
+	public void PointImplicitConversionTest(float x, float y)
+	{
+		var point = new Microsoft.Maui.Graphics.Point(x, y);
+		Android.Graphics.Point aPoint = point;
+
+		Assert.Equal(point.X, aPoint.X);
+		Assert.Equal(point.Y, aPoint.Y);
+	}
+
+	[Theory]
+	[InlineData(0, 0)]
+	[InlineData(100, 100)]
+	[InlineData(10, 100)]
+	[InlineData(100, 10)]
+	[InlineData(50, 100)]
+	[InlineData(15, 15)]
+	public void PointExplicitConversionTest(float x, float y)
+	{
+		var point = new Microsoft.Maui.Graphics.Point(x, y);
+		var aPoint = (Android.Graphics.Point)point;
+
+		Assert.Equal(point.X, aPoint.X);
+		Assert.Equal(point.Y, aPoint.Y);
+	}
+}

--- a/src/Core/tests/DeviceTests/Graphics/GraphicsTests.cs
+++ b/src/Core/tests/DeviceTests/Graphics/GraphicsTests.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Maui.DeviceTests;
+
+[Category(TestCategory.Graphics)]
+public partial class GraphicsTests : TestBase
+{
+
+}

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -18,6 +18,7 @@
 		public const string FlowDirection = "FlowDirection";
 		public const string FlyoutView = "FlyoutView";
 		public const string Fonts = "Fonts";
+		public const string Graphics = "Graphics";
 		public const string GraphicsView = "GraphicsView";
 		public const string Image = "Image";
 		public const string ImageButton = "ImageButton";

--- a/src/Graphics/src/Graphics/Platforms/Android/AndroidDrawingImplicitConversions.cs
+++ b/src/Graphics/src/Graphics/Platforms/Android/AndroidDrawingImplicitConversions.cs
@@ -1,18 +1,15 @@
-using System;
-using Android.Graphics;
-
 namespace Microsoft.Maui.Graphics
 {
 	public partial struct RectF
 	{
-		public static implicit operator global::Android.Graphics.Rect(RectF rect) => new global::Android.Graphics.Rect((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height);
-		public static implicit operator global::Android.Graphics.RectF(RectF rect) => new global::Android.Graphics.RectF(rect.X, rect.Y, rect.Width, rect.Height);
+		public static implicit operator global::Android.Graphics.Rect(RectF rect) => new global::Android.Graphics.Rect((int)rect.X, (int)rect.Y, (int)(rect.X + rect.Width), (int)(rect.Y + rect.Height));
+		public static implicit operator global::Android.Graphics.RectF(RectF rect) => new global::Android.Graphics.RectF(rect.X, rect.Y, rect.X + rect.Width, rect.Y + rect.Height);
 	}
 
 	public partial struct Rect
 	{
-		public static implicit operator global::Android.Graphics.Rect(Rect rect) => new global::Android.Graphics.Rect((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height);
-		public static implicit operator global::Android.Graphics.RectF(Rect rect) => new global::Android.Graphics.RectF((float)rect.X, (float)rect.Y, (float)rect.Width, (float)rect.Height);
+		public static implicit operator global::Android.Graphics.Rect(Rect rect) => new global::Android.Graphics.Rect((int)rect.X, (int)rect.Y, (int)(rect.X + rect.Width), (int)(rect.Y + rect.Height));
+		public static implicit operator global::Android.Graphics.RectF(Rect rect) => new global::Android.Graphics.RectF((float)rect.X, (float)rect.Y, (float)(rect.X + rect.Width), (float)(rect.Y + rect.Height));
 	}
 
 	public partial struct PointF


### PR DESCRIPTION
### Description of Change

Fix wrong conversions between Graphics RectF and Android RectF.

To validate the changes, use the added tests doing implicit and explicit conversions between Graphics types and Android.
![image](https://user-images.githubusercontent.com/6755973/217858149-42282ccb-1241-4e27-8d1b-f9f032fe1f0c.png)

### Issues Fixed

Fixes #8165 