### PR TITLE
[core] `WeakEventManager+Subscription` needs `IEquatable`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,7 @@ dotnet_diagnostic.IL2050.severity = none
 # Code analyzers
 dotnet_diagnostic.CA1307.severity = error
 dotnet_diagnostic.CA1309.severity = error
+dotnet_diagnostic.CA1815.severity = error
 
 # Modifier preferences
 dotnet_style_require_accessibility_modifiers = never:suggestion

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8958.xaml.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/Issue8958.xaml.cs
@@ -49,7 +49,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 	}
 
 	[Preserve(AllMembers = true)]
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 	public struct Issue8958Model
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 	{
 		public string Title { get; set; }
 	}

--- a/src/Compatibility/ControlGallery/src/Issues.Shared/TransparentOverlayTests.cs
+++ b/src/Compatibility/ControlGallery/src/Issues.Shared/TransparentOverlayTests.cs
@@ -65,7 +65,9 @@ namespace Microsoft.Maui.Controls.Compatibility.ControlGallery.Issues
 		}
 
 		[Preserve(AllMembers = true)]
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 		public struct TestPoint
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 		{
 			public TestPoint(int i) : this()
 			{

--- a/src/Compatibility/Core/src/Android/AppCompat/FormsAppCompatActivity.cs
+++ b/src/Compatibility/Core/src/Android/AppCompat/FormsAppCompatActivity.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.Android
 		DisableSetStatusBarColor = 1 << 0,
 	}
 
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 	public struct ActivationOptions
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 	{
 		public ActivationOptions(Bundle bundle)
 		{

--- a/src/Compatibility/Core/src/Android/Forms.cs
+++ b/src/Compatibility/Core/src/Android/Forms.cs
@@ -29,9 +29,11 @@ using Trace = System.Diagnostics.Trace;
 namespace Microsoft.Maui.Controls.Compatibility
 {
 	[Obsolete]
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 	public struct InitializationOptions
 	{
 		public struct EffectScope
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 		{
 			public string Name;
 			public ExportEffectAttribute[] Effects;

--- a/src/Compatibility/Core/src/Tizen/Forms.cs
+++ b/src/Compatibility/Core/src/Tizen/Forms.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 	}
 
 	[Obsolete]
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 	public class InitializationOptions
 	{
 		public CoreApplication Context { get; set; }
@@ -47,6 +48,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 		public DisplayResolutionUnit DisplayResolutionUnit { get; set; }
 
 		public struct EffectScope
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 		{
 			public string Name;
 			public ExportEffectAttribute[] Effects;

--- a/src/Compatibility/Core/src/Windows/Forms.cs
+++ b/src/Compatibility/Core/src/Windows/Forms.cs
@@ -13,7 +13,9 @@ using WSolidColorBrush = Microsoft.UI.Xaml.Media.SolidColorBrush;
 namespace Microsoft.Maui.Controls.Compatibility
 {
 	[Obsolete]
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 	public struct InitializationOptions
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 	{
 		public InitializationOptions(UI.Xaml.LaunchActivatedEventArgs args)
 		{

--- a/src/Compatibility/Core/src/iOS/Forms.cs
+++ b/src/Compatibility/Core/src/iOS/Forms.cs
@@ -33,7 +33,9 @@ using TNativeView = AppKit.NSView;
 namespace Microsoft.Maui.Controls.Compatibility
 {
 	[Obsolete]
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 	public struct InitializationOptions
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 	{
 		public InitializationFlags Flags;
 	}

--- a/src/Controls/src/Core/LayoutOptions.cs
+++ b/src/Controls/src/Core/LayoutOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/LayoutOptions.xml" path="Type[@FullName='Microsoft.Maui.Controls.LayoutOptions']/Docs/*" />
 	[System.ComponentModel.TypeConverter(typeof(LayoutOptionsConverter))]
-	public struct LayoutOptions
+	public struct LayoutOptions : IEquatable<LayoutOptions>
 	{
 		int _flags;
 
@@ -73,5 +73,15 @@ namespace Microsoft.Maui.Controls
 
 			return Primitives.LayoutAlignment.Start;
 		}
+
+		public bool Equals(LayoutOptions other) => _flags == other._flags;
+
+		public override bool Equals(object obj) => obj is LayoutOptions other && Equals(other);
+
+		public override int GetHashCode() => _flags.GetHashCode();
+
+		public static bool operator ==(LayoutOptions left, LayoutOptions right) => left.Equals(right);
+
+		public static bool operator !=(LayoutOptions left, LayoutOptions right) => !(left == right);
 	}
 }

--- a/src/Controls/src/Core/Profiler.cs
+++ b/src/Controls/src/Core/Profiler.cs
@@ -9,12 +9,14 @@ namespace Microsoft.Maui.Controls.Internals
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls.Internals/Profile.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.Profile']/Docs/*" />
 	[EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 	public struct Profile : IDisposable
 	{
 		const int Capacity = 1000;
 
 		[DebuggerDisplay("{Name,nq} {Id} {Ticks}")]
 		public struct Datum
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 		{
 			public string Name;
 			public string Id;

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -2,7 +2,19 @@
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Android.Content.Context! context, Microsoft.Maui.IPropertyMapper! mapper) -> void
 Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Android.Content.Context! context, Microsoft.Maui.IPropertyMapper! mapper, Microsoft.Maui.CommandMapper! commandMapper) -> void
+Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
+Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
+override Microsoft.Maui.Controls.Region.GetHashCode() -> int
+override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
+static Microsoft.Maui.Controls.LayoutOptions.operator !=(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.LayoutOptions.operator ==(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
 virtual Microsoft.Maui.Controls.VisualElement.IsEnabledCore.get -> bool
 Microsoft.Maui.Controls.VisualElement.RefreshIsEnabledProperty() -> void
 override Microsoft.Maui.Controls.Button.IsEnabledCore.get -> bool
@@ -10,6 +22,9 @@ override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
+~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender>(TSender sender, string message) -> void

--- a/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -1,9 +1,22 @@
 #nullable enable
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
+Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void
+override Microsoft.Maui.Controls.Region.GetHashCode() -> int
+override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int
+static Microsoft.Maui.Controls.LayoutOptions.operator !=(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.LayoutOptions.operator ==(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper) -> void
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper, Microsoft.Maui.CommandMapper commandMapper) -> void
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
+~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Platform.Compatibility.UIContainerView.AddSubview(UIKit.UIView view) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.UIContainerView.WillRemoveSubview(UIKit.UIView uiview) -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
@@ -21,6 +34,8 @@ override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
+~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Send<TSender>(TSender sender, string message) -> void

--- a/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -1,9 +1,22 @@
 #nullable enable
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
+Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
 override Microsoft.Maui.Controls.Platform.Compatibility.ShellPageRendererTracker.TitleViewContainer.LayoutSubviews() -> void
+override Microsoft.Maui.Controls.Region.GetHashCode() -> int
+override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int
+static Microsoft.Maui.Controls.LayoutOptions.operator !=(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.LayoutOptions.operator ==(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper) -> void
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper, Microsoft.Maui.CommandMapper commandMapper) -> void
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
+~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Platform.Compatibility.UIContainerView.AddSubview(UIKit.UIView view) -> void
 ~override Microsoft.Maui.Controls.Platform.Compatibility.UIContainerView.WillRemoveSubview(UIKit.UIView uiview) -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
@@ -21,6 +34,8 @@ override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
+~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Send<TSender>(TSender sender, string message) -> void

--- a/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,19 @@
 #nullable enable
+Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
+Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
+override Microsoft.Maui.Controls.Region.GetHashCode() -> int
+override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int
+static Microsoft.Maui.Controls.LayoutOptions.operator !=(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.LayoutOptions.operator ==(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static Microsoft.Maui.Controls.Platform.FormattedStringExtensions.ToFormattedString(this Microsoft.Maui.Controls.Label label) -> Tizen.UIExtensions.Common.FormattedString
 Microsoft.Maui.Controls.Platform.FormattedStringExtensions
 *REMOVED*Microsoft.Maui.Controls.Platform.ShellView.DefaultBackgroundCorlor -> Tizen.NUI.Color!

--- a/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,5 +1,17 @@
 #nullable enable
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
+Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
+override Microsoft.Maui.Controls.Region.GetHashCode() -> int
+override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int
+static Microsoft.Maui.Controls.LayoutOptions.operator !=(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.LayoutOptions.operator ==(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper) -> void
 ~Microsoft.Maui.Controls.Handlers.Compatibility.FrameRenderer.FrameRenderer(Microsoft.Maui.IPropertyMapper mapper, Microsoft.Maui.CommandMapper commandMapper) -> void
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
@@ -18,6 +30,9 @@ override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
+~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Send<TSender>(TSender sender, string message) -> void

--- a/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,6 +1,18 @@
 #nullable enable
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
+Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
+override Microsoft.Maui.Controls.Region.GetHashCode() -> int
+override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
+static Microsoft.Maui.Controls.LayoutOptions.operator !=(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.LayoutOptions.operator ==(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
 virtual Microsoft.Maui.Controls.VisualElement.IsEnabledCore.get -> bool
 Microsoft.Maui.Controls.VisualElement.RefreshIsEnabledProperty() -> void
 override Microsoft.Maui.Controls.Button.IsEnabledCore.get -> bool
@@ -8,6 +20,9 @@ override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
+~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender>(TSender sender, string message) -> void

--- a/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
 #nullable enable
 *REMOVED*override Microsoft.Maui.Controls.RefreshView.MeasureOverride(double widthConstraint, double heightConstraint) -> Microsoft.Maui.Graphics.Size
+Microsoft.Maui.Controls.LayoutOptions.Equals(Microsoft.Maui.Controls.LayoutOptions other) -> bool
+Microsoft.Maui.Controls.Region.Equals(Microsoft.Maui.Controls.Region other) -> bool
+Microsoft.Maui.Controls.Shapes.Matrix.Equals(Microsoft.Maui.Controls.Shapes.Matrix other) -> bool
+override Microsoft.Maui.Controls.LayoutOptions.GetHashCode() -> int
+override Microsoft.Maui.Controls.Region.GetHashCode() -> int
+override Microsoft.Maui.Controls.Shapes.Matrix.GetHashCode() -> int
 override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Send<TSender>(TSender sender, string message) -> void
@@ -9,6 +15,12 @@ override Microsoft.Maui.Controls.View.ChangeVisualState() -> void
 *REMOVED*~Microsoft.Maui.Controls.IMessagingCenter.Unsubscribe<TSender>(object subscriber, string message) -> void
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Instance.get -> Microsoft.Maui.Controls.IMessagingCenter
 *REMOVED*Microsoft.Maui.Controls.IMessagingCenter
+static Microsoft.Maui.Controls.LayoutOptions.operator !=(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.LayoutOptions.operator ==(Microsoft.Maui.Controls.LayoutOptions left, Microsoft.Maui.Controls.LayoutOptions right) -> bool
+static Microsoft.Maui.Controls.Region.operator !=(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Region.operator ==(Microsoft.Maui.Controls.Region left, Microsoft.Maui.Controls.Region right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator !=(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
+static Microsoft.Maui.Controls.Shapes.Matrix.operator ==(Microsoft.Maui.Controls.Shapes.Matrix left, Microsoft.Maui.Controls.Shapes.Matrix right) -> bool
 virtual Microsoft.Maui.Controls.VisualElement.IsEnabledCore.get -> bool
 Microsoft.Maui.Controls.VisualElement.RefreshIsEnabledProperty() -> void
 override Microsoft.Maui.Controls.Button.IsEnabledCore.get -> bool
@@ -16,6 +28,9 @@ override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
+~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
+~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool
 ~static readonly Microsoft.Maui.Controls.WebView.UserAgentProperty -> Microsoft.Maui.Controls.BindableProperty
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Send<TSender, TArgs>(TSender sender, string message, TArgs args) -> void
 *REMOVED*~static Microsoft.Maui.Controls.MessagingCenter.Send<TSender>(TSender sender, string message) -> void

--- a/src/Controls/src/Core/Region.cs
+++ b/src/Controls/src/Core/Region.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.Maui.Graphics;
@@ -6,7 +7,7 @@ using Microsoft.Maui.Graphics;
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../docs/Microsoft.Maui.Controls/Region.xml" path="Type[@FullName='Microsoft.Maui.Controls.Region']/Docs/*" />
-	public struct Region
+	public struct Region : IEquatable<Region>
 	{
 		// While Regions are currently rectangular, they could in the future be transformed into any shape.
 		// As such the internals of how it keeps shapes is hidden, so that future internal changes can occur to support shapes
@@ -116,5 +117,16 @@ namespace Microsoft.Maui.Controls
 
 			return new Region(rectangles, inflation);
 		}
+
+		public bool Equals(Region other) =>
+			Regions == other.Regions && _inflation == other._inflation;
+
+		public override bool Equals(object obj) => obj is Region other && Equals(other);
+
+		public override int GetHashCode() => Regions.GetHashCode() ^ _inflation?.GetHashCode() ?? 0;
+
+		public static bool operator ==(Region left, Region right) => left.Equals(right);
+
+		public static bool operator !=(Region left, Region right) => !(left == right);
 	}
 }

--- a/src/Controls/src/Core/Shapes/Matrix.cs
+++ b/src/Controls/src/Core/Shapes/Matrix.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Controls.Shapes
 
 	/// <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Matrix.xml" path="Type[@FullName='Microsoft.Maui.Controls.Shapes.Matrix']/Docs/*" />
 	[System.ComponentModel.TypeConverter(typeof(MatrixTypeConverter))]
-	public struct Matrix
+	public struct Matrix : IEquatable<Matrix>
 	{
 		internal double _m11;
 		internal double _m12;
@@ -671,6 +671,20 @@ namespace Microsoft.Maui.Controls.Shapes
 			}
 			return;
 		}
+
+		public bool Equals(Matrix other) =>
+			_m11 == other._m11 && _m12 == other._m12 && _m21 == other._m21 && _m22 == other._m22 &&
+			_offsetX == other._offsetX && _offsetY == other._offsetY && _type == other._type && _padding == other._padding;
+
+		public override bool Equals(object obj) => obj is Matrix other && Equals(other);
+
+		public override int GetHashCode() =>
+			_m11.GetHashCode() ^ _m12.GetHashCode() ^ _m21.GetHashCode() ^ _m22.GetHashCode() ^
+			_offsetX.GetHashCode() ^ _offsetY.GetHashCode() ^ _type.GetHashCode() ^ _padding.GetHashCode();
+
+		public static bool operator ==(Matrix left, Matrix right) => left.Equals(right);
+
+		public static bool operator !=(Matrix left, Matrix right) => !(left == right);
 	}
 
 	internal static class MatrixUtil

--- a/src/Controls/tests/Core.UnitTests/AcceleratorUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/AcceleratorUnitTests.cs
@@ -73,7 +73,9 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 
 
 		[Preserve(AllMembers = true)]
+#pragma warning disable CA1815 // Override equals and operator equals on value types
 		public struct TestShortcut
+#pragma warning restore CA1815 // Override equals and operator equals on value types
 		{
 			internal TestShortcut(string modifier)
 			{

--- a/src/Core/src/Fonts/FontSize.Android.cs
+++ b/src/Core/src/Fonts/FontSize.Android.cs
@@ -1,11 +1,12 @@
-﻿using Android.Util;
+﻿using System;
+using Android.Util;
 
 namespace Microsoft.Maui
 {
 	/// <summary>
 	/// Represents the size of a font on Android.
 	/// </summary>
-	public readonly struct FontSize
+	public readonly struct FontSize : IEquatable<FontSize>
 	{
 		/// <summary>
 		/// Creates a new <see cref="FontSize"/> instance.
@@ -27,5 +28,15 @@ namespace Microsoft.Maui
 		/// The unit in which the font size is expressed.
 		/// </summary>
 		public ComplexUnitType Unit { get; }
+
+		public bool Equals(FontSize other) => Value == other.Value && Unit == other.Unit;
+
+		public override bool Equals(object? obj) => obj is FontSize other && Equals(other);
+
+		public override int GetHashCode() => Value.GetHashCode() ^ Unit.GetHashCode();
+
+		public static bool operator ==(FontSize left, FontSize right) => left.Equals(right);
+
+		public static bool operator !=(FontSize left, FontSize right) => !(left == right);
 	}
 }

--- a/src/Core/src/Layouts/FlexEnums.cs
+++ b/src/Core/src/Layouts/FlexEnums.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Maui.Layouts
 	}
 
 	[TypeConverter(typeof(Converters.FlexBasisTypeConverter))]
-	public struct FlexBasis
+	public struct FlexBasis : IEquatable<FlexBasis>
 	{
 		bool _isLength;
 		bool _isRelative;
@@ -94,5 +94,15 @@ namespace Microsoft.Maui.Layouts
 
 		public static implicit operator FlexBasis(float length)
 			=> new FlexBasis(length);
+
+		public bool Equals(FlexBasis other) => _isLength == other._isLength && _isRelative == other._isRelative && Length == other.Length;
+
+		public override bool Equals(object? obj) => obj is FlexBasis other && Equals(other);
+
+		public override int GetHashCode() => _isRelative.GetHashCode() ^ Length.GetHashCode();
+
+		public static bool operator ==(FlexBasis left, FlexBasis right) => left.Equals(right);
+
+		public static bool operator !=(FlexBasis left, FlexBasis right) => !(left == right);
 	}
 }

--- a/src/Core/src/Primitives/GridLength.cs
+++ b/src/Core/src/Primitives/GridLength.cs
@@ -82,5 +82,9 @@ namespace Microsoft.Maui
 		{
 			return string.Format("{0}.{1}", Value, GridUnitType);
 		}
+
+		public static bool operator ==(GridLength left, GridLength right) => left.Equals(right);
+
+		public static bool operator !=(GridLength left, GridLength right) => !(left == right);
 	}
 }

--- a/src/Core/src/Primitives/SizeRequest.cs
+++ b/src/Core/src/Primitives/SizeRequest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Microsoft.Maui.Graphics;
 
@@ -5,7 +6,7 @@ namespace Microsoft.Maui
 {
 	/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="Type[@FullName='Microsoft.Maui.SizeRequest']/Docs/*" />
 	[DebuggerDisplay("Request={Request.Width}x{Request.Height}, Minimum={Minimum.Width}x{Minimum.Height}")]
-	public struct SizeRequest
+	public struct SizeRequest : IEquatable<SizeRequest>
 	{
 		/// <include file="../../docs/Microsoft.Maui/SizeRequest.xml" path="//Member[@MemberName='Request']/Docs/*" />
 		public Size Request { get; set; }
@@ -33,8 +34,18 @@ namespace Microsoft.Maui
 			return string.Format("{{Request={0} Minimum={1}}}", Request, Minimum);
 		}
 
+		public bool Equals(SizeRequest other) => Request.Equals(other.Request) && Minimum.Equals(other.Minimum);
+
 		public static implicit operator SizeRequest(Size size) => new SizeRequest(size);
 
 		public static implicit operator Size(SizeRequest size) => size.Request;
+
+		public override bool Equals(object? obj) => obj is SizeRequest other && Equals(other);
+
+		public override int GetHashCode() => Request.GetHashCode() ^ Minimum.GetHashCode();
+
+		public static bool operator ==(SizeRequest left, SizeRequest right) => left.Equals(right);
+
+		public static bool operator !=(SizeRequest left, SizeRequest right) => !(left == right);
 	}
 }

--- a/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,21 @@
 #nullable enable
+Microsoft.Maui.FontSize.Equals(Microsoft.Maui.FontSize other) -> bool
+Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
+override Microsoft.Maui.FontSize.Equals(object? obj) -> bool
+override Microsoft.Maui.FontSize.GetHashCode() -> int
 override Microsoft.Maui.Handlers.EditorHandler.PlatformArrange(Microsoft.Maui.Graphics.Rect frame) -> void
+override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
+override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool
+override Microsoft.Maui.SizeRequest.GetHashCode() -> int
+static Microsoft.Maui.FontSize.operator !=(Microsoft.Maui.FontSize left, Microsoft.Maui.FontSize right) -> bool
+static Microsoft.Maui.FontSize.operator ==(Microsoft.Maui.FontSize left, Microsoft.Maui.FontSize right) -> bool
+static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
 static Microsoft.Maui.Handlers.StepperHandler.MapIsEnabled(Microsoft.Maui.Handlers.IStepperHandler! handler, Microsoft.Maui.IStepper! stepper) -> void
+static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void
@@ -8,3 +23,5 @@ static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handle
 static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this Android.Webkit.WebView! platformWebView, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
+static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool

--- a/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -2,13 +2,23 @@
 Microsoft.Maui.Handlers.SwipeItemButton
 Microsoft.Maui.Handlers.SwipeItemButton.FrameChanged -> System.EventHandler?
 Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
+Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.set -> void
 override Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.ConnectHandler(UIKit.UIButton! platformView) -> void
 override Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.DisconnectHandler(UIKit.UIButton! platformView) -> void
 override Microsoft.Maui.Handlers.SwitchHandler.NeedsContainer.get -> bool
+override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.Platform.MauiTextView.Font.get -> UIKit.UIFont?
 override Microsoft.Maui.Platform.MauiTextView.Font.set -> void
+override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool
+override Microsoft.Maui.SizeRequest.GetHashCode() -> int
+static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.MauiTextField.WillMoveToWindow(UIKit.UIWindow? window) -> void
 override Microsoft.Maui.Platform.MauiTextView.WillMoveToWindow(UIKit.UIWindow? window) -> void
@@ -20,3 +30,5 @@ static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handle
 static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this WebKit.WKWebView! platformWebView, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
+static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool

--- a/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -2,13 +2,23 @@
 Microsoft.Maui.Handlers.SwipeItemButton
 Microsoft.Maui.Handlers.SwipeItemButton.FrameChanged -> System.EventHandler?
 Microsoft.Maui.Handlers.SwipeItemButton.SwipeItemButton() -> void
+Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.get -> CoreGraphics.CGRect
 override Microsoft.Maui.Handlers.SwipeItemButton.Frame.set -> void
 override Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.ConnectHandler(UIKit.UIButton! platformView) -> void
 override Microsoft.Maui.Handlers.SwipeItemMenuItemHandler.DisconnectHandler(UIKit.UIButton! platformView) -> void
 override Microsoft.Maui.Handlers.SwitchHandler.NeedsContainer.get -> bool
+override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
 override Microsoft.Maui.Platform.MauiTextView.Font.get -> UIKit.UIFont?
 override Microsoft.Maui.Platform.MauiTextView.Font.set -> void
+override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool
+override Microsoft.Maui.SizeRequest.GetHashCode() -> int
+static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 override Microsoft.Maui.Platform.MauiTextField.WillMoveToWindow(UIKit.UIWindow? window) -> void
 override Microsoft.Maui.Platform.MauiTextView.WillMoveToWindow(UIKit.UIWindow? window) -> void
@@ -20,3 +30,5 @@ static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handle
 static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this WebKit.WKWebView! platformWebView, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
+static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool

--- a/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -1,4 +1,14 @@
 #nullable enable
+Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
+override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool
+override Microsoft.Maui.SizeRequest.GetHashCode() -> int
+static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void
 static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
@@ -6,3 +16,5 @@ static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this Microsoft.
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
+static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool

--- a/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -1,4 +1,14 @@
 #nullable enable
+Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
+override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool
+override Microsoft.Maui.SizeRequest.GetHashCode() -> int
+static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void
@@ -6,3 +16,5 @@ static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handle
 static Microsoft.Maui.Platform.WebViewExtensions.UpdateUserAgent(this Microsoft.UI.Xaml.Controls.WebView2! platformWebView, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
+static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool

--- a/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,7 +1,19 @@
 #nullable enable
+Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
+override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool
+override Microsoft.Maui.SizeRequest.GetHashCode() -> int
+static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void
 static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
+static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool

--- a/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -1,7 +1,19 @@
 #nullable enable
+Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
+override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool
+override Microsoft.Maui.SizeRequest.GetHashCode() -> int
+static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void
 static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
+static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool

--- a/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Core/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,19 @@
 #nullable enable
+Microsoft.Maui.Layouts.FlexBasis.Equals(Microsoft.Maui.Layouts.FlexBasis other) -> bool
+Microsoft.Maui.SizeRequest.Equals(Microsoft.Maui.SizeRequest other) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.Equals(object? obj) -> bool
+override Microsoft.Maui.Layouts.FlexBasis.GetHashCode() -> int
+override Microsoft.Maui.SizeRequest.Equals(object? obj) -> bool
+override Microsoft.Maui.SizeRequest.GetHashCode() -> int
+static Microsoft.Maui.GridLength.operator !=(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.GridLength.operator ==(Microsoft.Maui.GridLength left, Microsoft.Maui.GridLength right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator !=(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
+static Microsoft.Maui.Layouts.FlexBasis.operator ==(Microsoft.Maui.Layouts.FlexBasis left, Microsoft.Maui.Layouts.FlexBasis right) -> bool
 static Microsoft.Maui.Layouts.LayoutExtensions.ArrangeContentUnbounded(this Microsoft.Maui.IContentView! contentView, Microsoft.Maui.Graphics.Rect bounds) -> Microsoft.Maui.Graphics.Size
 Microsoft.Maui.IWebView.UserAgent.get -> string?
 Microsoft.Maui.IWebView.UserAgent.set -> void
 static Microsoft.Maui.Handlers.WebViewHandler.MapUserAgent(Microsoft.Maui.Handlers.IWebViewHandler! handler, Microsoft.Maui.IWebView! webView) -> void
 *REMOVED*Microsoft.Maui.WeakEventManager.HandleEvent(object! sender, object! args, string! eventName) -> void
 Microsoft.Maui.WeakEventManager.HandleEvent(object? sender, object? args, string! eventName) -> void
+static Microsoft.Maui.SizeRequest.operator !=(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool
+static Microsoft.Maui.SizeRequest.operator ==(Microsoft.Maui.SizeRequest left, Microsoft.Maui.SizeRequest right) -> bool

--- a/src/Core/src/WeakEventManager.cs
+++ b/src/Core/src/WeakEventManager.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui
 			}
 		}
 
-		struct Subscription
+		readonly struct Subscription : IEquatable<Subscription>
 		{
 			/// <include file="../docs/Microsoft.Maui/WeakEventManager.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 			public Subscription(WeakReference? subscriber, MethodInfo handler)
@@ -148,6 +148,12 @@ namespace Microsoft.Maui
 
 			public readonly WeakReference? Subscriber;
 			public readonly MethodInfo Handler;
+
+			public bool Equals(Subscription other) => Subscriber == other.Subscriber && Handler == other.Handler;
+
+			public override bool Equals(object? obj) => obj is Subscription other && Equals(other);
+
+			public override int GetHashCode() => Subscriber?.GetHashCode() ?? 0 ^ Handler.GetHashCode();
 		}
 	}
 }

--- a/src/Graphics/src/Graphics/Font.cs
+++ b/src/Graphics/src/Graphics/Font.cs
@@ -55,5 +55,9 @@ namespace Microsoft.Maui.Graphics
 
 		public bool IsDefault
 			=> string.IsNullOrEmpty(Name);
+
+		public static bool operator ==(Font left, Font right) => left.Equals(right);
+
+		public static bool operator !=(Font left, Font right) => !(left == right);
 	}
 }

--- a/src/Graphics/src/Graphics/FontSource.cs
+++ b/src/Graphics/src/Graphics/FontSource.cs
@@ -23,5 +23,11 @@ namespace Microsoft.Maui.Graphics
 
 		public override int GetHashCode()
 			=> Name.GetHashCode() ^ Weight.GetHashCode() ^ FontStyleType.GetHashCode();
+
+		public override bool Equals(object? obj) => obj is FontSource other && Equals(other);
+
+		public static bool operator ==(FontSource left, FontSource right) => left.Equals(right);
+
+		public static bool operator !=(FontSource left, FontSource right) => !(left == right);
 	}
 }

--- a/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -763,6 +763,7 @@ Microsoft.Maui.Graphics.WindingMode.NonZero = 0 -> Microsoft.Maui.Graphics.Windi
 Microsoft.Maui.Graphics.XmlnsPrefixAttribute
 override Microsoft.Maui.Graphics.Color.GetHashCode() -> int
 override Microsoft.Maui.Graphics.Font.GetHashCode() -> int
+override Microsoft.Maui.Graphics.FontSource.Equals(object? obj) -> bool
 override Microsoft.Maui.Graphics.FontSource.GetHashCode() -> int
 override Microsoft.Maui.Graphics.GradientPaint.IsTransparent.get -> bool
 override Microsoft.Maui.Graphics.ImagePaint.IsTransparent.get -> bool
@@ -819,6 +820,10 @@ readonly Microsoft.Maui.Graphics.FontSource.Weight -> int
 static Microsoft.Maui.Graphics.CanvasState.GetLengthScale(System.Numerics.Matrix3x2 matrix) -> float
 static Microsoft.Maui.Graphics.Font.Default.get -> Microsoft.Maui.Graphics.Font
 static Microsoft.Maui.Graphics.Font.DefaultBold.get -> Microsoft.Maui.Graphics.Font
+static Microsoft.Maui.Graphics.Font.operator !=(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.Font.operator ==(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator !=(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator ==(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(double angle) -> double
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(float angle) -> float
 static Microsoft.Maui.Graphics.GeometryUtil.EllipseAngleToPoint(float x, float y, float width, float height, float angleInDegrees) -> Microsoft.Maui.Graphics.PointF

--- a/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -767,6 +767,7 @@ Microsoft.Maui.Graphics.WindingMode.NonZero = 0 -> Microsoft.Maui.Graphics.Windi
 Microsoft.Maui.Graphics.XmlnsPrefixAttribute
 override Microsoft.Maui.Graphics.Color.GetHashCode() -> int
 override Microsoft.Maui.Graphics.Font.GetHashCode() -> int
+override Microsoft.Maui.Graphics.FontSource.Equals(object? obj) -> bool
 override Microsoft.Maui.Graphics.FontSource.GetHashCode() -> int
 override Microsoft.Maui.Graphics.GradientPaint.IsTransparent.get -> bool
 override Microsoft.Maui.Graphics.ImagePaint.IsTransparent.get -> bool
@@ -823,6 +824,10 @@ readonly Microsoft.Maui.Graphics.FontSource.Weight -> int
 static Microsoft.Maui.Graphics.CanvasState.GetLengthScale(System.Numerics.Matrix3x2 matrix) -> float
 static Microsoft.Maui.Graphics.Font.Default.get -> Microsoft.Maui.Graphics.Font
 static Microsoft.Maui.Graphics.Font.DefaultBold.get -> Microsoft.Maui.Graphics.Font
+static Microsoft.Maui.Graphics.Font.operator !=(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.Font.operator ==(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator !=(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator ==(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(double angle) -> double
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(float angle) -> float
 static Microsoft.Maui.Graphics.GeometryUtil.EllipseAngleToPoint(float x, float y, float width, float height, float angleInDegrees) -> Microsoft.Maui.Graphics.PointF

--- a/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -767,6 +767,7 @@ Microsoft.Maui.Graphics.WindingMode.NonZero = 0 -> Microsoft.Maui.Graphics.Windi
 Microsoft.Maui.Graphics.XmlnsPrefixAttribute
 override Microsoft.Maui.Graphics.Color.GetHashCode() -> int
 override Microsoft.Maui.Graphics.Font.GetHashCode() -> int
+override Microsoft.Maui.Graphics.FontSource.Equals(object? obj) -> bool
 override Microsoft.Maui.Graphics.FontSource.GetHashCode() -> int
 override Microsoft.Maui.Graphics.GradientPaint.IsTransparent.get -> bool
 override Microsoft.Maui.Graphics.ImagePaint.IsTransparent.get -> bool
@@ -823,6 +824,10 @@ readonly Microsoft.Maui.Graphics.FontSource.Weight -> int
 static Microsoft.Maui.Graphics.CanvasState.GetLengthScale(System.Numerics.Matrix3x2 matrix) -> float
 static Microsoft.Maui.Graphics.Font.Default.get -> Microsoft.Maui.Graphics.Font
 static Microsoft.Maui.Graphics.Font.DefaultBold.get -> Microsoft.Maui.Graphics.Font
+static Microsoft.Maui.Graphics.Font.operator !=(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.Font.operator ==(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator !=(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator ==(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(double angle) -> double
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(float angle) -> float
 static Microsoft.Maui.Graphics.GeometryUtil.EllipseAngleToPoint(float x, float y, float width, float height, float angleInDegrees) -> Microsoft.Maui.Graphics.PointF

--- a/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-macos/PublicAPI.Unshipped.txt
@@ -767,6 +767,7 @@ Microsoft.Maui.Graphics.WindingMode.NonZero = 0 -> Microsoft.Maui.Graphics.Windi
 Microsoft.Maui.Graphics.XmlnsPrefixAttribute
 override Microsoft.Maui.Graphics.Color.GetHashCode() -> int
 override Microsoft.Maui.Graphics.Font.GetHashCode() -> int
+override Microsoft.Maui.Graphics.FontSource.Equals(object? obj) -> bool
 override Microsoft.Maui.Graphics.FontSource.GetHashCode() -> int
 override Microsoft.Maui.Graphics.GradientPaint.IsTransparent.get -> bool
 override Microsoft.Maui.Graphics.ImagePaint.IsTransparent.get -> bool
@@ -823,6 +824,10 @@ readonly Microsoft.Maui.Graphics.FontSource.Weight -> int
 static Microsoft.Maui.Graphics.CanvasState.GetLengthScale(System.Numerics.Matrix3x2 matrix) -> float
 static Microsoft.Maui.Graphics.Font.Default.get -> Microsoft.Maui.Graphics.Font
 static Microsoft.Maui.Graphics.Font.DefaultBold.get -> Microsoft.Maui.Graphics.Font
+static Microsoft.Maui.Graphics.Font.operator !=(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.Font.operator ==(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator !=(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator ==(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(double angle) -> double
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(float angle) -> float
 static Microsoft.Maui.Graphics.GeometryUtil.EllipseAngleToPoint(float x, float y, float width, float height, float angleInDegrees) -> Microsoft.Maui.Graphics.PointF

--- a/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -725,6 +725,7 @@ Microsoft.Maui.Graphics.WindingMode.NonZero = 0 -> Microsoft.Maui.Graphics.Windi
 Microsoft.Maui.Graphics.XmlnsPrefixAttribute
 override Microsoft.Maui.Graphics.Color.GetHashCode() -> int
 override Microsoft.Maui.Graphics.Font.GetHashCode() -> int
+override Microsoft.Maui.Graphics.FontSource.Equals(object? obj) -> bool
 override Microsoft.Maui.Graphics.FontSource.GetHashCode() -> int
 override Microsoft.Maui.Graphics.GradientPaint.IsTransparent.get -> bool
 override Microsoft.Maui.Graphics.ImagePaint.IsTransparent.get -> bool
@@ -750,6 +751,10 @@ readonly Microsoft.Maui.Graphics.FontSource.Weight -> int
 static Microsoft.Maui.Graphics.CanvasState.GetLengthScale(System.Numerics.Matrix3x2 matrix) -> float
 static Microsoft.Maui.Graphics.Font.Default.get -> Microsoft.Maui.Graphics.Font
 static Microsoft.Maui.Graphics.Font.DefaultBold.get -> Microsoft.Maui.Graphics.Font
+static Microsoft.Maui.Graphics.Font.operator !=(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.Font.operator ==(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator !=(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator ==(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(double angle) -> double
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(float angle) -> float
 static Microsoft.Maui.Graphics.GeometryUtil.EllipseAngleToPoint(float x, float y, float width, float height, float angleInDegrees) -> Microsoft.Maui.Graphics.PointF

--- a/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -721,6 +721,7 @@ Microsoft.Maui.Graphics.WindingMode.NonZero = 0 -> Microsoft.Maui.Graphics.Windi
 Microsoft.Maui.Graphics.XmlnsPrefixAttribute
 override Microsoft.Maui.Graphics.Color.GetHashCode() -> int
 override Microsoft.Maui.Graphics.Font.GetHashCode() -> int
+override Microsoft.Maui.Graphics.FontSource.Equals(object? obj) -> bool
 override Microsoft.Maui.Graphics.FontSource.GetHashCode() -> int
 override Microsoft.Maui.Graphics.GradientPaint.IsTransparent.get -> bool
 override Microsoft.Maui.Graphics.ImagePaint.IsTransparent.get -> bool
@@ -746,6 +747,10 @@ readonly Microsoft.Maui.Graphics.FontSource.Weight -> int
 static Microsoft.Maui.Graphics.CanvasState.GetLengthScale(System.Numerics.Matrix3x2 matrix) -> float
 static Microsoft.Maui.Graphics.Font.Default.get -> Microsoft.Maui.Graphics.Font
 static Microsoft.Maui.Graphics.Font.DefaultBold.get -> Microsoft.Maui.Graphics.Font
+static Microsoft.Maui.Graphics.Font.operator !=(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.Font.operator ==(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator !=(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator ==(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(double angle) -> double
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(float angle) -> float
 static Microsoft.Maui.Graphics.GeometryUtil.EllipseAngleToPoint(float x, float y, float width, float height, float angleInDegrees) -> Microsoft.Maui.Graphics.PointF

--- a/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -725,6 +725,7 @@ Microsoft.Maui.Graphics.WindingMode.NonZero = 0 -> Microsoft.Maui.Graphics.Windi
 Microsoft.Maui.Graphics.XmlnsPrefixAttribute
 override Microsoft.Maui.Graphics.Color.GetHashCode() -> int
 override Microsoft.Maui.Graphics.Font.GetHashCode() -> int
+override Microsoft.Maui.Graphics.FontSource.Equals(object? obj) -> bool
 override Microsoft.Maui.Graphics.FontSource.GetHashCode() -> int
 override Microsoft.Maui.Graphics.GradientPaint.IsTransparent.get -> bool
 override Microsoft.Maui.Graphics.ImagePaint.IsTransparent.get -> bool
@@ -750,6 +751,10 @@ readonly Microsoft.Maui.Graphics.FontSource.Weight -> int
 static Microsoft.Maui.Graphics.CanvasState.GetLengthScale(System.Numerics.Matrix3x2 matrix) -> float
 static Microsoft.Maui.Graphics.Font.Default.get -> Microsoft.Maui.Graphics.Font
 static Microsoft.Maui.Graphics.Font.DefaultBold.get -> Microsoft.Maui.Graphics.Font
+static Microsoft.Maui.Graphics.Font.operator !=(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.Font.operator ==(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator !=(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator ==(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(double angle) -> double
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(float angle) -> float
 static Microsoft.Maui.Graphics.GeometryUtil.EllipseAngleToPoint(float x, float y, float width, float height, float angleInDegrees) -> Microsoft.Maui.Graphics.PointF

--- a/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Graphics/src/Graphics/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -725,6 +725,7 @@ Microsoft.Maui.Graphics.WindingMode.NonZero = 0 -> Microsoft.Maui.Graphics.Windi
 Microsoft.Maui.Graphics.XmlnsPrefixAttribute
 override Microsoft.Maui.Graphics.Color.GetHashCode() -> int
 override Microsoft.Maui.Graphics.Font.GetHashCode() -> int
+override Microsoft.Maui.Graphics.FontSource.Equals(object? obj) -> bool
 override Microsoft.Maui.Graphics.FontSource.GetHashCode() -> int
 override Microsoft.Maui.Graphics.GradientPaint.IsTransparent.get -> bool
 override Microsoft.Maui.Graphics.ImagePaint.IsTransparent.get -> bool
@@ -750,6 +751,10 @@ readonly Microsoft.Maui.Graphics.FontSource.Weight -> int
 static Microsoft.Maui.Graphics.CanvasState.GetLengthScale(System.Numerics.Matrix3x2 matrix) -> float
 static Microsoft.Maui.Graphics.Font.Default.get -> Microsoft.Maui.Graphics.Font
 static Microsoft.Maui.Graphics.Font.DefaultBold.get -> Microsoft.Maui.Graphics.Font
+static Microsoft.Maui.Graphics.Font.operator !=(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.Font.operator ==(Microsoft.Maui.Graphics.Font left, Microsoft.Maui.Graphics.Font right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator !=(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
+static Microsoft.Maui.Graphics.FontSource.operator ==(Microsoft.Maui.Graphics.FontSource left, Microsoft.Maui.Graphics.FontSource right) -> bool
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(double angle) -> double
 static Microsoft.Maui.Graphics.GeometryUtil.DegreesToRadians(float angle) -> float
 static Microsoft.Maui.Graphics.GeometryUtil.EllipseAngleToPoint(float x, float y, float width, float height, float angleInDegrees) -> Microsoft.Maui.Graphics.PointF


### PR DESCRIPTION
Context: https://github.com/Vroomer/MAUI-master-detail-memory-leak
Context: https://github.com/dotnet/maui/issues/12039

Using the Visual Studio's `.NET Object Allocation Tracking` profiler on the sample above I noticed after app launch:

    Microsoft.Maui.WeakEventManager+Subscription
    Allocations: 686,114
    Bytes: 21,955,648

![image](https://user-images.githubusercontent.com/840039/217906691-26c42a97-2a28-44f1-915f-87b329ef452a.png)

After spitting out my coffee, I drilled in a bit to see where these are being created:

    System.Collections.Generic.ObjectEqualityComparer<Microsoft.Maui.WeakEventManager+Subscription>.IndexOf

It turns out this `struct` doesn't implement `IEquatable<T>`:

https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815

To solve this:

* `Subscription` is private, so we can make it a `readonly struct`.

* `dotnet_diagnostic.CA1815.severity = error` across the entire repo.

* Implement `IEquatable<T>` for all `struct` types.

After these changes, I can't find `Microsoft.Maui.WeakEventManager+Subscription` in the memory report at all. Which assuming means, I saved ~21 MB of allocations in this app.

Note that this doesn't actually solve #12039, as I'm still investigating the leak. Maybe this partially closes the floodgate?