### PR TITLE
[iOS/MacCatalyst] Fix Editor scrolling

### DIFF
--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -165,7 +165,9 @@ namespace Microsoft.Maui.Platform
 		{
 			var fittingSize = new CGSize(Bounds.Width, NFloat.MaxValue);
 			var sizeThatFits = SizeThatFits(fittingSize);
-			var availableSpace = (Bounds.Height - sizeThatFits.Height * ZoomScale);
+			var availableSpace = Bounds.Height - sizeThatFits.Height * ZoomScale;
+			if (availableSpace <= 0)
+				return;
 			ContentOffset = VerticalTextAlignment switch
 			{
 				Maui.TextAlignment.Center => new CGPoint(0, -Math.Max(1, availableSpace / 2)),

--- a/src/Core/src/Platform/iOS/MauiTextView.cs
+++ b/src/Core/src/Platform/iOS/MauiTextView.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Maui.Platform
 
 		UILabel InitPlaceholderLabel()
 		{
-			var placeholderLabel = new UILabel
+			var placeholderLabel = new MauiLabel
 			{
 				BackgroundColor = UIColor.Clear,
 				TextColor = ColorExtensions.PlaceholderColor,
@@ -129,23 +129,8 @@ namespace Microsoft.Maui.Platform
 			var edgeInsets = TextContainerInset;
 			var lineFragmentPadding = TextContainer.LineFragmentPadding;
 
-			var vConstraints = NSLayoutConstraint.FromVisualFormat(
-				"V:|-" + edgeInsets.Top + "-[PlaceholderLabel]-" + edgeInsets.Bottom + "-|", 0, new NSDictionary(),
-				NSDictionary.FromObjectsAndKeys(
-					new NSObject[] { placeholderLabel }, new NSObject[] { new NSString("PlaceholderLabel") })
-			);
-
-			var hConstraints = NSLayoutConstraint.FromVisualFormat(
-				"H:|-" + lineFragmentPadding + "-[PlaceholderLabel]-" + lineFragmentPadding + "-|",
-				0, new NSDictionary(),
-				NSDictionary.FromObjectsAndKeys(
-					new NSObject[] { placeholderLabel }, new NSObject[] { new NSString("PlaceholderLabel") })
-			);
-
-			placeholderLabel.TranslatesAutoresizingMaskIntoConstraints = false;
-
-			AddConstraints(hConstraints);
-			AddConstraints(vConstraints);
+			placeholderLabel.TextInsets = new UIEdgeInsets(edgeInsets.Top, edgeInsets.Left + lineFragmentPadding,
+				edgeInsets.Bottom, edgeInsets.Right + lineFragmentPadding);
 
 			return placeholderLabel;
 		}


### PR DESCRIPTION
### Description of Change

There were two issues keeping the Editor from scrolling:
 - We were always updating the ContentOffset to center the text, even if there was no available space. If there's no space to center (the text is bigger than the container) we should not center the text and just it be able to scroll.
- The constrains added to the placeholder so it has the same insets as the UITextView were keeping the UITextView from scrolling and right now I can't explain why. To fix this we can just use the MauiLabel that we have that allows to center and set insets to a UILabel.

I m not sure I can write a device test for this issue. 
To test the code you can visit the Editor gallery see it looks the same with and without this change. 
This code can be used to check that we are able to scroll and placeholders work.

```
<VerticalStackLayout
        Spacing="10"
        Padding="30,0"
        VerticalOptions="Center">
         <Editor Placeholder="Placeholder" />
         <Editor BackgroundColor="red" HeightRequest="100" Placeholder="Placeholder" VerticalTextAlignment="Center" />
       
        <Editor BackgroundColor="red" HeightRequest="100" Text="Lorem ipsum dolor sit amet" VerticalTextAlignment="Center" />
        <Editor BackgroundColor="Yellow" HeightRequest="100" Text="Lorem ipsum dolor sit amet" VerticalTextAlignment="End" />
        <Editor BackgroundColor="Green" HeightRequest="100" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />

    </VerticalStackLayout>
```

### Issues Fixed

Fixes #12485 
