### PR TITLE
Don't refresh the filtered tests if the filter hasn't actually changed

### DIFF
--- a/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Utils/FilteredCollectionView.cs
+++ b/src/TestUtils/src/DeviceTests.Runners/VisualRunner/Utils/FilteredCollectionView.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Maui.TestUtils.DeviceTests.Runners.VisualRunner
 			get { return filterArgument; }
 			set
 			{
+				if (filterArgument.Equals(value))
+				{
+					return;
+				}
+
 				filterArgument = value;
 				RefreshFilter();
 			}


### PR DESCRIPTION
### Description of Change

The filtering mechanism on the tests clears out and re-loads the entire list when the filter is updated, even if it's updated to the exact same value.

This adds a check to avoid the refresh if the filter hasn't changed. Since this is being triggered on the initial load of the tests into the CollectionView, it knocks off about half of the loading time of the test listing page.

### Issues Fixed

Having to wait almost a minute to actually run tests after I tap on the assembly in the runner.