### PR TITLE
[net7.0] [core] `WeakEventManager+Subscription` needs `IEquatable`

### DIFF
--- a/src/Core/src/WeakEventManager.cs
+++ b/src/Core/src/WeakEventManager.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Maui
 			}
 		}
 
-		struct Subscription
+		readonly struct Subscription : IEquatable<Subscription>
 		{
 			/// <include file="../docs/Microsoft.Maui/WeakEventManager.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
 			public Subscription(WeakReference? subscriber, MethodInfo handler)
@@ -148,6 +148,12 @@ namespace Microsoft.Maui
 
 			public readonly WeakReference? Subscriber;
 			public readonly MethodInfo Handler;
+
+			public bool Equals(Subscription other) => Subscriber == other.Subscriber && Handler == other.Handler;
+
+			public override bool Equals(object? obj) => obj is Subscription other && Equals(other);
+
+			public override int GetHashCode() => Subscriber?.GetHashCode() ?? 0 ^ Handler.GetHashCode();
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/13232

This is a smaller backport of 505b93a for .NET 7 servicing.