### PR TITLE
[iOS] Fix sizing of button when using CharacterSpacing

### DIFF
--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateStrokeColor(this UIButton platformButton, IButtonStroke buttonStroke)
 		{
-			if (buttonStroke.StrokeColor != null)
+			if (buttonStroke.StrokeColor is not null)
 				platformButton.Layer.BorderColor = buttonStroke.StrokeColor.ToCGColor();
 		}
 
@@ -30,16 +30,16 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateTextColor(this UIButton platformButton, ITextStyle button)
 		{
-			if (button.TextColor != null)
-			{
-				var color = button.TextColor.ToPlatform();
+			if (button.TextColor is null)
+				return;
 
-				platformButton.SetTitleColor(color, UIControlState.Normal);
-				platformButton.SetTitleColor(color, UIControlState.Highlighted);
-				platformButton.SetTitleColor(color, UIControlState.Disabled);
+			var color = button.TextColor.ToPlatform();
 
-				platformButton.TintColor = color;
-			}
+			platformButton.SetTitleColor(color, UIControlState.Normal);
+			platformButton.SetTitleColor(color, UIControlState.Highlighted);
+			platformButton.SetTitleColor(color, UIControlState.Disabled);
+
+			platformButton.TintColor = color;
 		}
 
 		public static void UpdateCharacterSpacing(this UIButton platformButton, ITextStyle textStyle)
@@ -80,7 +80,5 @@ namespace Microsoft.Maui.Platform
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CA1416
 		}
-
-
 	}
 }

--- a/src/Core/src/Platform/iOS/ButtonExtensions.cs
+++ b/src/Core/src/Platform/iOS/ButtonExtensions.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Maui.Platform
 
 		public static void UpdateCharacterSpacing(this UIButton platformButton, ITextStyle textStyle)
 		{
-			platformButton.TitleLabel.UpdateCharacterSpacing(textStyle);
+			var attributedText = platformButton?.TitleLabel.AttributedText?.WithCharacterSpacing(textStyle.CharacterSpacing);
+			platformButton?.SetAttributedTitle(attributedText, UIControlState.Normal);
 		}
 
 		public static void UpdateFont(this UIButton platformButton, ITextStyle textStyle, IFontManager fontManager)

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var button = GetNativeButton(buttonHandler);
 
-			//var attributedText = button.TitleLabel.AttributedText;
 			var attributedText = button.GetAttributedTitle(UIControlState.Normal);
 
 			return attributedText.GetCharacterSpacing();

--- a/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Button/ButtonHandlerTests.iOS.cs
@@ -86,7 +86,8 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			var button = GetNativeButton(buttonHandler);
 
-			var attributedText = button.TitleLabel.AttributedText;
+			//var attributedText = button.TitleLabel.AttributedText;
+			var attributedText = button.GetAttributedTitle(UIControlState.Normal);
 
 			return attributedText.GetCharacterSpacing();
 		}


### PR DESCRIPTION
### Description of Change

We were setting the CharacterSpacing on the internal label while we can use the AttributedTitle on UIButton itself so it sizes correctly .

### Issues Fixed

Fixes #10293 
