### PR TITLE
Handle renamed or deleted MauiImage files

### DIFF
--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -178,10 +178,13 @@ namespace Microsoft.Maui.Resizetizer
 				if (destinationModified > sourceModified)
 				{
 					Logger.Log($"Skipping `{img.Filename}` => `{destination}` file is up to date.");
+					resizedImages.Add(new ResizedImageInfo () { Dpi = dpi, Filename = destination});
 					continue;
 				}
 
 				appTool.Resize(dpi, destination);
+				var r = appTool.Resize(dpi, destination);
+				resizedImages.Add(r);
 			}
 		}
 

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Maui.Resizetizer
 				if (destinationModified > sourceModified)
 				{
 					Logger.Log($"Skipping `{img.Filename}` => `{destination}` file is up to date.");
-					resizedImages.Add(new ResizedImageInfo () { Dpi = dpi, Filename = destination});
+					resizedImages.Add(new ResizedImageInfo() { Dpi = dpi, Filename = destination });
 					continue;
 				}
 

--- a/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
+++ b/src/SingleProject/Resizetizer/src/ResizetizeImages.cs
@@ -90,7 +90,9 @@ namespace Microsoft.Maui.Resizetizer
 			if (PlatformType == "tizen")
 			{
 				var tizenResourceXmlGenerator = new TizenResourceXmlGenerator(IntermediateOutputPath, Logger);
-				tizenResourceXmlGenerator.Generate();
+				var r = tizenResourceXmlGenerator.Generate();
+				if (r is not null)
+					resizedImages.Add(r);
 			}
 
 			var copiedResources = new List<TaskItem>();

--- a/src/SingleProject/Resizetizer/src/TizenResourceXmlGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/TizenResourceXmlGenerator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Maui.Resizetizer
 
 		public ILogger Logger { get; private set; }
 
-		public void Generate()
+		public ResizedImageInfo Generate()
 		{
 			XmlDocument doc = new XmlDocument();
 			XmlNode docNode = doc.CreateXmlDeclaration("1.0", "UTF-8", "yes");
@@ -54,12 +54,13 @@ namespace Microsoft.Maui.Resizetizer
 
 			string outputResourceDir = Path.Combine(IntermediateOutputPath, "res");
 			string outputContentsDir = Path.Combine(outputResourceDir, "contents");
+			string destination = Path.Combine(outputResourceDir, "res.xml");
 
 			var contentsDirInfo = new DirectoryInfo(outputContentsDir);
 			if (!contentsDirInfo.Exists)
 			{
 				Logger.Log("No 'res/contents/' directory to generate res.xml.");
-				return;
+				return null;
 			}
 			foreach (DirectoryInfo subDir in contentsDirInfo.GetDirectories())
 			{
@@ -80,8 +81,9 @@ namespace Microsoft.Maui.Resizetizer
 					}
 				}
 			}
-			doc.Save(Path.Combine(outputResourceDir, "res.xml"));
+			doc.Save(destination);
 			Logger.Log($"res.xml file has been saved in {outputResourceDir}");
+			return new ResizedImageInfo () { Filename = destination };
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/src/TizenResourceXmlGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/TizenResourceXmlGenerator.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Resizetizer
 			}
 			doc.Save(destination);
 			Logger.Log($"res.xml file has been saved in {outputResourceDir}");
-			return new ResizedImageInfo () { Filename = destination };
+			return new ResizedImageInfo () { Dpi = DpiPath.Tizen.Original,  Filename = destination };
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/src/TizenResourceXmlGenerator.cs
+++ b/src/SingleProject/Resizetizer/src/TizenResourceXmlGenerator.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Maui.Resizetizer
 			}
 			doc.Save(destination);
 			Logger.Log($"res.xml file has been saved in {outputResourceDir}");
-			return new ResizedImageInfo () { Dpi = DpiPath.Tizen.Original,  Filename = destination };
+			return new ResizedImageInfo() { Dpi = DpiPath.Tizen.Original, Filename = destination };
 		}
 	}
 }

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -595,7 +595,7 @@
 
         <!-- Remove files which are no longer needed -->
         <Delete
-            Condition="'@(_ResizetizerImagesToDelete)' != ''"
+            Condition="'@(_ResizetizerImagesToDelete->Count())' != '0'"
             Files="@(_ResizetizerImagesToDelete)"
         />
 

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -586,7 +586,7 @@
         <ItemGroup>
             <!-- Get Images that were generated -->
             <!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
-            <_ResizetizerCollectedImages Condition="'@(_CopiedResources)' != ''" Include="@(_CopiedResources)" />
+            <_ResizetizerCollectedImages Condition="'@(_CopiedResources->Count())' != '0'" Include="@(_CopiedResources)" />
             <_ResizetizerExistingImages Include="$(_MauiIntermediateImages)\**\*" />
             <_ResizetizerImagesToDelete Include="@(_ResizetizerExistingImages->'%(FullPath)')" />
             <_ResizetizerCollectedImages Condition="'@(_CopiedResources)' == ''" Include="@(_ResizetizerExistingImages->'%(FullPath)')" />

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -386,10 +386,25 @@
             MauiSplashScreen="@(MauiSplashScreen)"
             InputsFile="$(_MauiSplashInputsFile)"
         />
+
+        <!-- delete the res.zip cache file as things have changed. -->
+        <Delete
+            Condition="'$(_ResizetizerIsAndroidApp)' == 'True' and Exists ('$(_MauiIntermediateSplashScreen)..\sp.zip')"
+            Files="$(_MauiIntermediateSplashScreen)..\sp.zip"
+        />
+
+        <ZipDirectory
+            Condition="'$(_ResizetizerIsAndroidApp)' == 'True' and Exists ('$(_MauiIntermediateSplashScreen)')"
+            SourceDirectory="$(_MauiIntermediateSplashScreen)"
+            DestinationFile="$(_MauiIntermediateSplashScreen)..\sp.zip"
+        />
+
         <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True' and '$(_MauiHasSplashScreens)' == 'true'">
             <_MauiSplashAssets Include="$(_MauiIntermediateSplashScreen)**\*" />
             <LibraryResourceDirectories Condition="Exists('$(_MauiIntermediateSplashScreen)')" Include="$(_MauiIntermediateSplashScreen)">
                 <StampFile>$(_ResizetizerStampFile)</StampFile>
+                <AndroidSkipResourceProcessing>true</AndroidSkipResourceProcessing>
+                <ResourceDirectoryArchive>$(_MauiIntermediateSplashScreen)..\sp.zip</ResourceDirectoryArchive>
             </LibraryResourceDirectories>
         </ItemGroup>
 
@@ -579,14 +594,24 @@
             IntermediateOutputPath="$(_MauiIntermediateImages)"
             InputsFile="$(_ResizetizerInputsFile)"
             Images="@(MauiImage->Distinct())">
+              <Output TaskParameter="CopiedResources" ItemName="_CopiedResources" />
         </ResizetizeImages>
 
         <ItemGroup>
             <!-- Get Images that were generated -->
             <!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
-            <_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
-            <_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_MauiIntermediateImages)**\*" />
+            <_ResizetizerCollectedImages Condition="'@(_CopiedResources)' != ''" Include="@(_CopiedResources)" />
+            <_ResizetizerExistingImages Include="$(_MauiIntermediateImages)\**\*" />
+            <_ResizetizerImagesToDelete Include="@(_ResizetizerExistingImages->'%(FullPath)')" />
+            <_ResizetizerCollectedImages Condition="'@(_CopiedResources)' == ''" Include="@(_ResizetizerExistingImages->'%(FullPath)')" />
+            <_ResizetizerImagesToDelete Remove="@(_ResizetizerCollectedImages)" />
         </ItemGroup>
+
+        <!-- Remove files which are no longer needed -->
+        <Delete
+            Condition="'@(_ResizetizerImagesToDelete)' != ''"
+            Files="@(_ResizetizerImagesToDelete)"
+        />
 
         <!-- iOS -->
         <ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True'">

--- a/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
+++ b/src/SingleProject/Resizetizer/src/nuget/buildTransitive/Microsoft.Maui.Resizetizer.After.targets
@@ -387,24 +387,10 @@
             InputsFile="$(_MauiSplashInputsFile)"
         />
 
-        <!-- delete the res.zip cache file as things have changed. -->
-        <Delete
-            Condition="'$(_ResizetizerIsAndroidApp)' == 'True' and Exists ('$(_MauiIntermediateSplashScreen)..\sp.zip')"
-            Files="$(_MauiIntermediateSplashScreen)..\sp.zip"
-        />
-
-        <ZipDirectory
-            Condition="'$(_ResizetizerIsAndroidApp)' == 'True' and Exists ('$(_MauiIntermediateSplashScreen)')"
-            SourceDirectory="$(_MauiIntermediateSplashScreen)"
-            DestinationFile="$(_MauiIntermediateSplashScreen)..\sp.zip"
-        />
-
         <ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True' and '$(_MauiHasSplashScreens)' == 'true'">
             <_MauiSplashAssets Include="$(_MauiIntermediateSplashScreen)**\*" />
             <LibraryResourceDirectories Condition="Exists('$(_MauiIntermediateSplashScreen)')" Include="$(_MauiIntermediateSplashScreen)">
                 <StampFile>$(_ResizetizerStampFile)</StampFile>
-                <AndroidSkipResourceProcessing>true</AndroidSkipResourceProcessing>
-                <ResourceDirectoryArchive>$(_MauiIntermediateSplashScreen)..\sp.zip</ResourceDirectoryArchive>
             </LibraryResourceDirectories>
         </ItemGroup>
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -676,6 +676,43 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				AssertFileMatches($"mipmap-xhdpi/{Path.GetFileNameWithoutExtension(bg)}_foreground.png", new object[] { fgScale, bg, fg, "xh", "f" });
 			}
 
+			[Fact]
+			public void NonExistantFilesAreDeleted()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/camera.svg", new Dictionary<string, string>
+					{
+						["Link"] = "dog",
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				AssertFileNotExists ("drawable-hdpi/cat.png");
+				AssertFileExists ("drawable-hdpi/dog.png");
+
+				LogErrorEvents.Clear();
+				LogMessageEvents.Clear();
+
+				items = new[]
+				{
+					new TaskItem("images/camera.svg", new Dictionary<string, string>
+					{
+						["Link"] = "cat",
+					}),
+				};
+
+				task = GetNewTask(items);
+				success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				AssertFileNotExists ("drawable-hdpi/dot.png");
+				AssertFileExists ("drawable-hdpi/cat.png");
+			}
+
 			//[Theory]
 			//[InlineData(1, 1, "dotnet_background.svg", "tall_image.png", 300, 300)]
 			//[InlineData(1, 1, "dotnet_background.svg", "wide_image.png", 300, 300)]
@@ -1015,6 +1052,43 @@ namespace Microsoft.Maui.Resizetizer.Tests
 					$"\"filename\": \"{outputName}20x20@2x.png\"",
 					$"\"size\": \"20x20\",");
 			}
+
+			[Fact]
+			public void NonExistantFilesAreDeleted()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/camera.svg", new Dictionary<string, string>
+					{
+						["Link"] = "dog",
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				AssertFileNotExists ("cat.png");
+				AssertFileExists ("dog.png");
+
+				LogErrorEvents.Clear();
+				LogMessageEvents.Clear();
+
+				items = new[]
+				{
+					new TaskItem("images/camera.svg", new Dictionary<string, string>
+					{
+						["Link"] = "cat",
+					}),
+				};
+
+				task = GetNewTask(items);
+				success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				AssertFileNotExists ("dot.png");
+				AssertFileExists ("cat.png");
+			}
 		}
 
 		public class ExecuteForWindows : ExecuteForApp
@@ -1334,6 +1408,43 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				AssertFileSize("not_working.scale-100.png", 24, 24);
 
 				AssertFileContains("not_working.scale-100.png", 0xFF71559B, 2, 6);
+			}
+
+			[Fact]
+			public void NonExistantFilesAreDeleted()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/camera.svg", new Dictionary<string, string>
+					{
+						["Link"] = "dog",
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				AssertFileNotExists ("cat.scale-150.png");
+				AssertFileExists ("dog.scale-150.png");
+
+				LogErrorEvents.Clear();
+				LogMessageEvents.Clear();
+
+				items = new[]
+				{
+					new TaskItem("images/camera.svg", new Dictionary<string, string>
+					{
+						["Link"] = "cat",
+					}),
+				};
+
+				task = GetNewTask(items);
+				success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				AssertFileNotExists ("dot.scale-150.png");
+				AssertFileExists ("cat.scale-150.png");
 			}
 		}
 

--- a/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/SingleProject/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -691,8 +691,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				AssertFileNotExists ("drawable-hdpi/cat.png");
-				AssertFileExists ("drawable-hdpi/dog.png");
+				AssertFileNotExists("drawable-hdpi/cat.png");
+				AssertFileExists("drawable-hdpi/dog.png");
 
 				LogErrorEvents.Clear();
 				LogMessageEvents.Clear();
@@ -709,8 +709,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				success = task.Execute();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				AssertFileNotExists ("drawable-hdpi/dot.png");
-				AssertFileExists ("drawable-hdpi/cat.png");
+				AssertFileNotExists("drawable-hdpi/dot.png");
+				AssertFileExists("drawable-hdpi/cat.png");
 			}
 
 			//[Theory]
@@ -1068,8 +1068,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				AssertFileNotExists ("cat.png");
-				AssertFileExists ("dog.png");
+				AssertFileNotExists("cat.png");
+				AssertFileExists("dog.png");
 
 				LogErrorEvents.Clear();
 				LogMessageEvents.Clear();
@@ -1086,8 +1086,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				success = task.Execute();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				AssertFileNotExists ("dot.png");
-				AssertFileExists ("cat.png");
+				AssertFileNotExists("dot.png");
+				AssertFileExists("cat.png");
 			}
 		}
 
@@ -1425,8 +1425,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				var success = task.Execute();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				AssertFileNotExists ("cat.scale-150.png");
-				AssertFileExists ("dog.scale-150.png");
+				AssertFileNotExists("cat.scale-150.png");
+				AssertFileExists("dog.scale-150.png");
 
 				LogErrorEvents.Clear();
 				LogMessageEvents.Clear();
@@ -1443,8 +1443,8 @@ namespace Microsoft.Maui.Resizetizer.Tests
 				success = task.Execute();
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
-				AssertFileNotExists ("dot.scale-150.png");
-				AssertFileExists ("cat.scale-150.png");
+				AssertFileNotExists("dot.scale-150.png");
+				AssertFileExists("cat.scale-150.png");
 			}
 		}
 


### PR DESCRIPTION
### Description of Change

If a users renames or deletes a MauiImage file the old file remains in the `$(IntermediateOutputPath)` until the next `IncrementalClean` is called. This is normall AFTER the build has been done. 
So we should clean up any files which are not expecting in the `_MauiIntermediateImages` directory. 