### PR TITLE
[Housekeeping] Revert changes from 11721

### DIFF
--- a/src/Core/src/Platform/iOS/ViewExtensions.cs
+++ b/src/Core/src/Platform/iOS/ViewExtensions.cs
@@ -268,23 +268,16 @@ namespace Microsoft.Maui.Platform
 
 			var layer = view.Layer;
 
-			UpdateBackgroundLayerFrame(layer, view.Bounds);
-		}
-
-		static void UpdateBackgroundLayerFrame(CALayer layer, CGRect bounds)
-		{
 			if (layer == null || layer.Sublayers == null || layer.Sublayers.Length == 0)
 				return;
 
 			foreach (var sublayer in layer.Sublayers)
 			{
-				if (sublayer.Name == BackgroundLayerName && sublayer.Frame != bounds)
+				if (sublayer.Name == BackgroundLayerName && sublayer.Frame != view.Bounds)
 				{
-					sublayer.Frame = bounds;
+					sublayer.Frame = view.Bounds;
 					break;
 				}
-
-				UpdateBackgroundLayerFrame(sublayer, bounds);
 			}
 		}
 

--- a/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/ContentView/ContentViewTests.iOS.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.Maui.DeviceTests.Stubs;
 using UIKit;
 using Xunit;
@@ -9,23 +8,6 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 	[Category(TestCategory.ContentView)]
 	public partial class ContentViewTests
 	{
-		[Theory(DisplayName = "Background Updates Correctly")]
-		[InlineData(0xFF0000)]
-		[InlineData(0x00FF00)]
-		[InlineData(0x0000FF)]
-		public async Task BackgroundUpdatesCorrectly(uint color)
-		{
-			var expected = Color.FromUint(color);
-
-			var contentView = new ContentViewStub()
-			{
-				Content = new LabelStub { Text = "Background", TextColor = Colors.White },
-				Background = new LinearGradientPaintStub(Colors.Red, Colors.Blue),
-			};
-
-			await ValidateHasColor(contentView, expected);
-		}
-
 		[Fact, Category(TestCategory.FlowDirection)]
 		public async Task FlowDirectionPropagatesToContent()
 		{
@@ -122,19 +104,6 @@ namespace Microsoft.Maui.DeviceTests.Handlers.ContentView
 			});
 
 			Assert.Equal(UIUserInterfaceLayoutDirection.LeftToRight, labelFlowDirection);
-		}
-
-		Platform.ContentView GetNativeContentView(ContentViewHandler contentViewHandler) =>
-			contentViewHandler.PlatformView;
-
-		Task ValidateHasColor(IContentView contentView, Color color, Action action = null)
-		{
-			return InvokeOnMainThreadAsync(() =>
-			{
-				var nativeContentView = GetNativeContentView(CreateHandler(contentView));
-				action?.Invoke();
-				nativeContentView.AssertContainsColor(color);
-			});
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

Revert changes from #11721. Doing tests we have noticed an error in the calculation of the background Layer in some Views.

![image](https://user-images.githubusercontent.com/6755973/218161125-f8503c73-2c9f-4cf3-8dd7-7d8dea2881ed.png)

After debugging the issue, when updating the Frame of a UIView, if it has a Background (Layer) assigned with the changes introduced in 11721, we iterate through all the sublayers of a visual element. In the case of a Layout containing a Button, we also access the Button background layer but... the size of the View is greater than that of the button, generating the previous unwanted effect.

This PR directly reverts the changes. We reopen the issue where we will look for the most optimal and correct solution.