### PR TITLE
[CI] Allow to find the eng folder when multiple projects are checkedout.

### DIFF
--- a/eng/pipelines/common/controlgallery-android.yml
+++ b/eng/pipelines/common/controlgallery-android.yml
@@ -6,7 +6,7 @@ steps:
     displayName: 'Provisionator'
     condition: eq(variables['provisioning'], 'true')
     inputs:
-      provisioning_script: $(provisionator.path)
+      provisioning_script: $(System.DefaultWorkingDirectory)/$(provisionator.path)
       provisioning_extra_args: $(provisionator.extraArguments)
     env:
       AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)

--- a/eng/pipelines/common/controlgallery-ios.yml
+++ b/eng/pipelines/common/controlgallery-ios.yml
@@ -6,7 +6,7 @@ steps:
     displayName: 'Provision Xcode'
     condition: ne(variables['REQUIRED_XCODE'], '')
     inputs:
-      provisioning_script: $(provisionator.xcode)
+      provisioning_script: $(System.DefaultWorkingDirectory)/$(provisionator.xcode)
     env:
       AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
@@ -14,7 +14,7 @@ steps:
     displayName: 'Provisionator'
     condition: eq(variables['provisioning'], 'true')
     inputs:
-      provisioning_script: $(provisionator.path)
+      provisioning_script: $(System.DefaultWorkingDirectory)/$(provisionator.path)
       provisioning_extra_args: $(provisionator.extraArguments)
     env:
       AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)

--- a/eng/pipelines/common/controlgallery-windows.yml
+++ b/eng/pipelines/common/controlgallery-windows.yml
@@ -6,7 +6,7 @@ steps:
     displayName: 'Provisionator'
     condition: eq(variables['provisioning'], 'true')
     inputs:
-      provisioning_script: $(provisionator.path)
+      provisioning_script: $(System.DefaultWorkingDirectory)/$(provisionator.path)
       provisioning_extra_args: $(provisionator.extraArguments)
     env:
       AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -4,6 +4,7 @@ parameters:
   skipXcode: false
   skipVS: true
   skipProvisioning: $(skipProvisionator)
+  checkoutDirectory: $(System.DefaultWorkingDirectory)
   provisionatorPath: $(provisionator.path)
   provisionatorXCodePath: $(provisionator.xcode)
   provisionatorVSPath: $(provisionator.vs)
@@ -26,7 +27,7 @@ steps:
       - task: xamops.azdevex.provisionator-task.provisionator@2
         displayName: 'Provision Xcode'
         inputs:
-          provisioning_script: ${{ parameters.provisionatorXCodePath }}
+          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorXCodePath }}
           provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
           github_token: ${{ parameters.gitHubToken }}
         env:
@@ -37,7 +38,7 @@ steps:
         displayName: 'Provision Additional Software'
         continueOnError: true 
         inputs:
-          provisioning_script: ${{ parameters.provisionatorPath }}
+          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
           provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
           github_token: ${{ parameters.gitHubToken }}
         env:
@@ -99,7 +100,7 @@ steps:
       - task: xamops.azdevex.provisionator-task.provisionator@2
         displayName: 'Provision Visual Studio'
         inputs:
-          provisioning_script: ${{ parameters.provisionatorVSPath }}
+          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorVSPath }}
           provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
           github_token: ${{ parameters.gitHubToken }}
         env:
@@ -114,7 +115,7 @@ steps:
       - task: xamops.azdevex.provisionator-task.provisionator@2
         displayName: 'Provision Additional Software'
         inputs:
-          provisioning_script: ${{ parameters.provisionatorPath }}
+          provisioning_script: ${{ parameters.checkoutDirectory }}/${{ parameters.provisionatorPath }}
           provisioning_extra_args: ${{ parameters.provisionatorExtraArguments }}
           github_token: ${{ parameters.gitHubToken }}
         env:

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -40,11 +40,11 @@ variables:
 - name: skipProvisionator
   value: $[ne(variables['provisioning'], 'true')]
 - name: provisionator.xcode
-  value: '$(System.DefaultWorkingDirectory)/eng/provisioning/xcode.csx'
+  value: 'eng/provisioning/xcode.csx'
 - name: provisionator.path
-  value: '$(System.DefaultWorkingDirectory)/eng/provisioning/provisioning.csx'
+  value: 'eng/provisioning/provisioning.csx'
 - name: provisionator.vs
-  value: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
+  value: 'eng/provisioning/vs.csx'
 - name: provisionator.extraArguments
   value: '-vvvv'
 - name: DotNet.Dir


### PR DESCRIPTION
One of the curious decisions from the VSTS team was to use a different directory for the checkout depending if the project was checkoued alone or was checkedout along with other repos.

If we only check out maui, the directory will be the (DefaultWorkingDirectory), but if are checkingout other repos, the directory will be (DefaultWorkingDirectory)/maui".

In order to be able to use the provisioning scripts from other pipeline along other projects (megapipeline) we must adapt our templates to that diff directory structure.


