### PR TITLE
Use and clear a local nuget cache

### DIFF
--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -490,6 +490,8 @@ Task("VS")
             Error("!!!!BUILD TASKS FAILED: !!!!!");
         }
 
+        UseLocalNuGetCacheFolder();
+
         StartVisualStudioForDotNet6();
     }); 
 
@@ -566,6 +568,18 @@ void SetDotNetEnvironmentVariables()
     // Get "full" .binlog in Project System Tools
     if (HasArgument("dbg"))
         SetEnvironmentVariable("MSBuildDebugEngine", "1");
+}
+
+void UseLocalNuGetCacheFolder()
+{
+    var temp = Context.Environment.GetSpecialPath(SpecialPath.LocalTemp);
+    var packages = temp.Combine("Microsoft.Maui.Cache/NuGet/packages");
+
+    CleanDirectories(packages.FullPath + "/microsoft.maui.*");
+    CleanDirectories(packages.FullPath + "/microsoft.aspnetcore.*");
+
+    SetEnvironmentVariable("RestorePackagesPath", packages.FullPath);
+    SetEnvironmentVariable("NUGET_PACKAGES", packages.FullPath);
 }
 
 void StartVisualStudioForDotNet6()

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -570,13 +570,18 @@ void SetDotNetEnvironmentVariables()
         SetEnvironmentVariable("MSBuildDebugEngine", "1");
 }
 
-void UseLocalNuGetCacheFolder()
+void UseLocalNuGetCacheFolder(bool reset = false)
 {
     var temp = Context.Environment.GetSpecialPath(SpecialPath.LocalTemp);
     var packages = temp.Combine("Microsoft.Maui.Cache/NuGet/packages");
 
+    EnsureDirectoryExists(packages);
+
     CleanDirectories(packages.FullPath + "/microsoft.maui.*");
     CleanDirectories(packages.FullPath + "/microsoft.aspnetcore.*");
+
+    if (reset)
+        CleanDirectories(packages.FullPath);
 
     SetEnvironmentVariable("RestorePackagesPath", packages.FullPath);
     SetEnvironmentVariable("NUGET_PACKAGES", packages.FullPath);


### PR DESCRIPTION
### Description of Change

When using the `--target=VS`, we want to not fill the global nuget cache with all the build artifacts as they all use the same version. We want to use a local nuget cache and make sure to delete all the artifacts before we start VS.