### PR TITLE
[Android] Don't lose the padding when background is set

### DIFF
--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -190,10 +190,20 @@ namespace Microsoft.Maui.Platform
 				mauiDrawable.Dispose();
 			}
 
+			// Android will reset the padding when setting a Background drawable
+			// So we need to reapply the padding after
+			var padLeft = platformView.PaddingLeft;
+			var padTop = platformView.PaddingTop;
+			var padRight = platformView.PaddingRight;
+			var padBottom = platformView.PaddingBottom;
+
 			var previousDrawable = platformView.Background;
 			var backgroundDrawable = paint!.ToDrawable(platformView.Context);
 			LayerDrawable layer = new LayerDrawable(new Drawable[] { backgroundDrawable!, previousDrawable! });
 			platformView.Background = layer;
+
+			// Apply previous padding
+			platformView.SetPadding(padLeft, padTop, padRight, padBottom);		
 		}
 
 		public static void UpdateBackground(this AView platformView, Paint? background) =>

--- a/src/Core/src/Platform/Android/ViewExtensions.cs
+++ b/src/Core/src/Platform/Android/ViewExtensions.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Maui.Platform
 			platformView.Background = layer;
 
 			// Apply previous padding
-			platformView.SetPadding(padLeft, padTop, padRight, padBottom);		
+			platformView.SetPadding(padLeft, padTop, padRight, padBottom);
 		}
 
 		public static void UpdateBackground(this AView platformView, Paint? background) =>

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -15,6 +15,45 @@ namespace Microsoft.Maui.DeviceTests
 {
 	public partial class EntryHandlerTests
 	{
+
+		[Fact(DisplayName = "Padding is the same after background changes")]
+		public async Task PaddingDoesntChangeAfterBackground()
+		{
+			var paddingLeft = 0;
+			var paddingTop = 0;
+			var paddingRight = 0;
+			var paddingBottom = 0;
+
+			var entry = new EntryStub();
+
+			entry.PropertyMapperOverrides = new PropertyMapper<IEntry, IEntryHandler>(EntryHandler.Mapper)
+			{
+				["MyCustomization"] = (handler, view) =>
+				{
+					handler.PlatformView.SetPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
+				}
+			};
+
+			var paddingLeftNative = await GetValueAsync(entry, h => h.PlatformView.PaddingLeft);
+			var paddingRightNative = await GetValueAsync(entry, h => h.PlatformView.PaddingRight);
+			var paddingTopNative = await GetValueAsync(entry, h => h.PlatformView.PaddingTop);
+			var paddingBottomNative = await GetValueAsync(entry, h => h.PlatformView.PaddingBottom);
+			Assert.Equal(paddingLeft, paddingLeftNative);
+			Assert.Equal(paddingTop, paddingTopNative);
+			Assert.Equal(paddingRight, paddingRightNative);
+			Assert.Equal(paddingBottom, paddingBottomNative);
+			entry.Background = new SolidPaint(Colors.Red);
+			var paddingLeftNativeAfter = await GetValueAsync(entry, h => h.PlatformView.PaddingLeft);
+			var paddingRightNativeAfter = await GetValueAsync(entry, h => h.PlatformView.PaddingRight);
+			var paddingTopNativeAfter = await GetValueAsync(entry, h => h.PlatformView.PaddingTop);
+			var paddingBottomNativeAfter = await GetValueAsync(entry, h => h.PlatformView.PaddingBottom);
+			Assert.Equal(paddingLeft, paddingLeftNative);
+			Assert.Equal(paddingTop, paddingTopNativeAfter);
+			Assert.Equal(paddingRight, paddingRightNativeAfter);
+			Assert.Equal(paddingBottom, paddingBottomNativeAfter);
+		}
+
+
 		[Fact(DisplayName = "PlaceholderColor Initializes Correctly")]
 		public async Task PlaceholderColorInitializesCorrectly()
 		{


### PR DESCRIPTION
### Description of Change

Seems that when we apply a new background drawable to a View the padding get's lost. Seems this is a[ "bug" on Android ](https://stackoverflow.com/questions/10095196/whered-padding-go-when-setting-background-drawable).

So we save the padding and re apply after setting the background layer.

fixes #12224