### PR TITLE
[controls] one less WeakReference in TypedBinding

### DIFF
--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -249,29 +249,28 @@ namespace Microsoft.Maui.Controls.Internals
 			public Func<TSource, object> PartGetter { get; }
 			public string PropertyName { get; }
 			public BindingExpression.WeakPropertyChangedProxy Listener { get; }
-			WeakReference<INotifyPropertyChanged> _weakPart = new WeakReference<INotifyPropertyChanged>(null);
 			readonly BindingBase _binding;
 			PropertyChangedEventHandler handler;
 			public INotifyPropertyChanged Part
 			{
 				get
 				{
-					INotifyPropertyChanged target;
-					if (_weakPart.TryGetTarget(out target))
+					if (Listener != null && Listener.Source.TryGetTarget(out var target))
 						return target;
 					return null;
 				}
 				set
 				{
-					if (Listener != null && Listener.Source.TryGetTarget(out var source) && ReferenceEquals(value, source))
+					if (Listener != null)
+					{
 						//Already subscribed
-						return;
+						if (Listener.Source.TryGetTarget(out var source) && ReferenceEquals(value, source))
+							return;
 
-					//clear out previous subscription
-					Listener?.Unsubscribe();
-
-					_weakPart.SetTarget(value);
-					Listener.SubscribeTo(value, handler);
+						//clear out previous subscription
+						Listener.Unsubscribe();
+						Listener.SubscribeTo(value, handler);
+					}
 				}
 			}
 


### PR DESCRIPTION
Context: https://github.com/Vroomer/MAUI-master-detail-memory-leak
Context: https://github.com/dotnet/maui/issues/12039

When reviewing the memory snapshots in #12039, I noticed a `WeakReference<T>` that could be completely removed in `TypedBinding`. `BindingExpression.WeakPropertyChangedProxy` already had this exposed as a `Source` property we can just use instead.

I also updated some `TypedBindingUnitTests` to assert more things are GC'd properly.

I don't think this fixes an issue, except saving ~8 bytes per `TypedBinding` and makes memory snapshots smaller/easier to read.
