### PR TITLE
[Windows] Fixed dupe items in ShellView

### DIFF
--- a/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
+++ b/src/Controls/src/Core/Handlers/Shell/Windows/ShellView.cs
@@ -155,17 +155,25 @@ namespace Microsoft.Maui.Controls.Platform
 
 				foreach (var item in group)
 				{
+					bool foundExistingVM = false;
+
 					// Check to see if this element already has a VM counter part
 					foreach (var navItem in FlyoutItems)
 					{
 						if (navItem is NavigationViewItemViewModel viewModel && viewModel.Data == item)
+						{
+							foundExistingVM = true;
 							yield return viewModel;
+						}
 					}
 
-					yield return new NavigationViewItemViewModel()
+					if (!foundExistingVM)
 					{
-						Data = item
-					};
+						yield return new NavigationViewItemViewModel()
+						{
+							Data = item
+						};
+					}
 				}
 			}
 		}

--- a/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Shell/ShellTests.Windows.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
@@ -237,6 +238,35 @@ namespace Microsoft.Maui.DeviceTests
 				var distance = rootManager.AppTitleBar.ActualHeight - position.Value.Y;
 				Assert.True(Math.Abs(distance) < 1);
 				return Task.CompletedTask;
+			});
+		}
+
+		[Fact(DisplayName = "Shell Has Correct Item Count")]
+		public async Task ShellContentHasCorrectItemCount()
+		{
+			SetupBuilder();
+
+			var content1 = new ShellContent();
+			content1.Title = "Hello";
+			content1.Route = $"...";
+
+			var content2 = new ShellContent();
+			content2.Title = "World";
+			content2.Route = $"...";
+
+			var shell = await CreateShellAsync((shell) =>
+			{
+				shell.Items.Add(content1);
+				shell.Items.Add(content2);
+			});
+
+			await CreateHandlerAndAddToWindow<ShellHandler>(shell, (handler) =>
+			{
+				shell.FlyoutBehavior = FlyoutBehavior.Flyout;
+				handler.PlatformView.UpdateMenuItemSource();
+
+				var items = handler.PlatformView.MenuItemsSource as ObservableCollection<object>;
+				Assert.True(items.Count == 2);
 			});
 		}
 


### PR DESCRIPTION
### Description of Change

This change fixes an issue in the Windows `ShellView` where items added to the `ShellView` would be added multiple times. This issue occurs when the internal `FlyoutItems` is updated with items that have the same ViewModel counterpart. Instead of only returning the existing item, both the existing item and a new item are returned.

Here's an example of what happens. Each `ShellContent` should only have one `FlyoutItemLayout`, but instead have a copy of all other items nested inside it.
![image](https://user-images.githubusercontent.com/890772/218822577-78b9bcd8-1e31-41fc-bd7d-4b3b274a8962.png)

### Issues Fixed
Fixes #12149