### PR TITLE
[core] fix memory leaks in bindings

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Maui.Controls
 
 		readonly Dictionary<BindableProperty, BindablePropertyContext> _properties = new Dictionary<BindableProperty, BindablePropertyContext>(4);
 		bool _applying;
-		object _inheritedContext;
+		WeakReference _inheritedContext;
 
 		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='BindingContextProperty']/Docs/*" />
 		public static readonly BindableProperty BindingContextProperty =
@@ -41,7 +41,7 @@ namespace Microsoft.Maui.Controls
 		/// <include file="../../docs/Microsoft.Maui.Controls/BindableObject.xml" path="//Member[@MemberName='BindingContext']/Docs/*" />
 		public object BindingContext
 		{
-			get => _inheritedContext ?? GetValue(BindingContextProperty);
+			get => _inheritedContext?.Target ?? GetValue(BindingContextProperty);
 			set => SetValue(BindingContextProperty, value);
 		}
 
@@ -238,7 +238,7 @@ namespace Microsoft.Maui.Controls
 			if (bpContext != null && ((bpContext.Attributes & BindableContextAttributes.IsManuallySet) != 0))
 				return;
 
-			object oldContext = bindable._inheritedContext;
+			object oldContext = bindable._inheritedContext?.Target;
 
 			if (ReferenceEquals(oldContext, value))
 				return;
@@ -253,7 +253,7 @@ namespace Microsoft.Maui.Controls
 			}
 			else
 			{
-				bindable._inheritedContext = value;
+				bindable._inheritedContext = new WeakReference(value);
 			}
 
 			bindable.ApplyBindings(skipBindingContext: false, fromBindingContextChanged: true);
@@ -557,7 +557,7 @@ namespace Microsoft.Maui.Controls
 
 		static void BindingContextPropertyBindingChanging(BindableObject bindable, BindingBase oldBindingBase, BindingBase newBindingBase)
 		{
-			object context = bindable._inheritedContext;
+			object context = bindable._inheritedContext?.Target;
 			var oldBinding = oldBindingBase as Binding;
 			var newBinding = newBindingBase as Binding;
 

--- a/src/Controls/src/Core/Brush.cs
+++ b/src/Controls/src/Core/Brush.cs
@@ -8,10 +8,7 @@ namespace Microsoft.Maui.Controls
 	public abstract partial class Brush : Element
 	{
 		/// <include file="../../docs/Microsoft.Maui.Controls/Brush.xml" path="//Member[@MemberName='Default']/Docs/*" />
-		public static Brush Default
-		{
-			get { return new SolidColorBrush(null); }
-		}
+		public static Brush Default => new ImmutableBrush(null);
 
 		public static implicit operator Brush(Color color) => new SolidColorBrush(color);
 

--- a/src/Controls/src/Core/Brush.cs
+++ b/src/Controls/src/Core/Brush.cs
@@ -7,8 +7,9 @@ namespace Microsoft.Maui.Controls
 	[System.ComponentModel.TypeConverter(typeof(BrushTypeConverter))]
 	public abstract partial class Brush : Element
 	{
+		static ImmutableBrush defaultBrush;
 		/// <include file="../../docs/Microsoft.Maui.Controls/Brush.xml" path="//Member[@MemberName='Default']/Docs/*" />
-		public static Brush Default => new ImmutableBrush(null);
+		public static Brush Default => defaultBrush ??= new(null);
 
 		public static implicit operator Brush(Color color) => new SolidColorBrush(color);
 

--- a/src/Controls/src/Core/TypedBinding.cs
+++ b/src/Controls/src/Core/TypedBinding.cs
@@ -251,6 +251,9 @@ namespace Microsoft.Maui.Controls.Internals
 			public BindingExpression.WeakPropertyChangedProxy Listener { get; }
 			readonly BindingBase _binding;
 			PropertyChangedEventHandler handler;
+
+			~PropertyChangedProxy() => Listener?.Unsubscribe(finalizer: true);
+
 			public INotifyPropertyChanged Part
 			{
 				get

--- a/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
+++ b/src/Controls/tests/Core.UnitTests/BindingUnitTests.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
@@ -1183,6 +1185,81 @@ namespace Microsoft.Maui.Controls.Core.UnitTests
 				"Target property changed from what it was set to");
 
 			AssertNoErrorsLogged();
+		}
+
+
+		[Theory, Category("[Binding] Complex paths")]
+		[InlineData(BindingMode.OneWay)]
+		[InlineData(BindingMode.OneWayToSource)]
+		[InlineData(BindingMode.TwoWay)]
+		public async Task WeakPropertyChangedProxyDoesNotLeak(BindingMode mode)
+		{
+			var proxies = new List<WeakReference>();
+			WeakReference weakViewModel = null, weakBindable = null;
+
+			int i = 0;
+			void create ()
+			{
+				if (i++ < 1024)
+				{
+					create();
+					return;
+				}
+
+				var binding = new Binding("Model.Model[1]");
+				var bindable = new MockBindable();
+				weakBindable = new WeakReference(bindable);
+
+				var viewmodel = new ComplexMockViewModel
+				{
+					Model = new ComplexMockViewModel
+					{
+						Model = new ComplexMockViewModel()
+					}
+				};
+
+				weakViewModel = new WeakReference(viewmodel);
+
+				bindable.BindingContext = viewmodel;
+				bindable.SetBinding(MockBindable.TextProperty, binding);
+
+				// Access private members:
+				// WeakPropertyChangedProxy proxy = binding._expression._parts[i]._listener;
+				var flags = BindingFlags.NonPublic | BindingFlags.Instance;
+				var expression = binding.GetType().GetField("_expression", flags).GetValue(binding);
+				Assert.NotNull(expression);
+				var parts = expression.GetType().GetField("_parts", flags).GetValue(expression) as IEnumerable;
+				Assert.NotNull(parts);
+				foreach (var part in parts)
+				{
+					var listener = part.GetType().GetField("_listener", flags).GetValue(part);
+					if (listener == null)
+						continue;
+					proxies.Add(new WeakReference(listener));
+				}
+				Assert.NotEmpty(proxies); // Should be at least 1
+			};
+			create();
+
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			if (mode == BindingMode.TwoWay || mode == BindingMode.OneWay)
+				Assert.False(weakViewModel.IsAlive, "ViewModel wasn't collected");
+
+			if (mode == BindingMode.TwoWay || mode == BindingMode.OneWayToSource)
+				Assert.False(weakBindable.IsAlive, "Bindable wasn't collected");
+
+			// WeakPropertyChangedProxy won't go away until the second GC, BindingExpressionPart unsubscribes in its finalizer
+			await Task.Yield();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			foreach (var proxy in proxies)
+			{
+				Assert.False(proxy.IsAlive, "WeakPropertyChangedProxy wasn't collected");
+			}
 		}
 
 		[Theory, Category("[Binding] Complex paths")]


### PR DESCRIPTION
Fixes #12039
Fixes #10560
Context: https://github.com/Vroomer/MAUI-master-detail-memory-leak
Context: https://github.com/symbiogenesis/Maui.DataGrid/tree/memory-leak

In investigating various MAUI samples, I found the following object leaking:

    WeakPropertyChangedProxy ->
        TypedBinding
        Binding

In ~2016, I contributed a fix to Xamarin.Forms:

https://github.com/xamarin/Xamarin.Forms/commit/f6febd4c81a80430331c7fcdcc63271aa4fa636c

Back then, this solved the follow case:

1. You have a long-lived `ViewModel` class. Could be a singleton, etc.

2. Data-bind a `View` to this `ViewModel`.

3. The `ViewModel` indefinitely held on to any object that subscribed to `PropertyChanged`.

At the time, this solved a huge memory leak, because a data-bound `View` would have a reference to its parent, then to its parent, etc. Effectively this was leaking entire `Page`'s at the time.

Unfortunately, there was still a flaw in this change... `WeakPropertyChangedProxy` hangs around forever instead! I could reproduce this problem in unit tests, by accessing various internal members through reflection -- asserting they were alive or not.

We do have another layer of indirection, where other objects are GC'd that can free the `WeakPropertyChangedProxy`, such as:

    // Regular Binding
    ~BindingExpressionPart() => _listener?.Unsubscribe();
    // TypedBinding
    ~PropertyChangedProxy() => Listener?.Unsubscribe();

This means it would take two GC's for these objects to go away, but it is better than the alternative -- they *can* actually go away now.

After testing apps with this change, sometimes I would get an `InvalidOperationException` in `WeakReference<T>`:

https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs,103

So I added a parameter to `Unsubscribe(finalizer: true)`, to skip `WeakReference<T>.SetTarget()` from finalizers.

After this change, I still found an issue! In my new unit test, the following would hold onto a `ViemModel` object forever:

    VisualElement.BackgroundProperty.DefaultValue

This held the value of `Brush.Default`, in which
`Brush.Default.BindingContext` was the `ViewModel`!

My first thought was for `Brush.Default` to return `ImmutableBrush`:

    public static Brush Default => new ImmutableBrush(null);

Because anyone could do `Brush.Default.Color = Colors.Red` if they liked.

When this didn't fix it, I found the underlying `_inheritedContext` is what held a reference to my `ViewModel` object. I changed this value to a `WeakReference`.

The types of leaks this fixes:

* Bindings to application-lifetime, singleton `ViewModel`s

* Scrolling `CollectionView`, `ListView`, etc. with data-bindings.

* Styles that were used on a `View` or `Page` that is now removed from the screen via navigation, de-parenting, etc.

Ok, I really think the leaks are gone now. Maybe?