### PR TITLE
Add shell pages via controller instead of handler

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Shell/iOS/ShellSectionRootRenderer.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Maui.Controls.Platform.Compatibility
 
 				if (item == currentItem)
 				{
-					_containerArea.AddSubview(renderer.PlatformView);
+					_containerArea.AddSubview(renderer.ViewController.View);
 					_currentContent = currentItem;
 					_currentIndex = i;
 				}

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -41,26 +41,8 @@ namespace Microsoft.Maui.DeviceTests
 			return mauiAppBuilder.ConfigureTestBuilder();
 		}
 
-		protected void SetupShellHandlers(IMauiHandlersCollection handlers)
-		{
-			handlers.TryAddHandler(typeof(Controls.Shell), typeof(ShellHandler));
-			handlers.TryAddHandler<Layout, LayoutHandler>();
-			handlers.TryAddHandler<Image, ImageHandler>();
-			handlers.TryAddHandler<Label, LabelHandler>();
-			handlers.TryAddHandler<Page, PageHandler>();
-			handlers.TryAddHandler(typeof(Toolbar), typeof(ToolbarHandler));
-			handlers.TryAddHandler(typeof(MenuBar), typeof(MenuBarHandler));
-			handlers.TryAddHandler(typeof(MenuBarItem), typeof(MenuBarItemHandler));
-			handlers.TryAddHandler(typeof(MenuFlyoutItem), typeof(MenuFlyoutItemHandler));
-			handlers.TryAddHandler(typeof(MenuFlyoutSubItem), typeof(MenuFlyoutSubItemHandler));
-			handlers.TryAddHandler<ScrollView, ScrollViewHandler>();
-
-#if WINDOWS
-			handlers.TryAddHandler(typeof(ShellItem), typeof(ShellItemHandler));
-			handlers.TryAddHandler(typeof(ShellSection), typeof(ShellSectionHandler));
-			handlers.TryAddHandler(typeof(ShellContent), typeof(ShellContentHandler));
-#endif
-		}
+		protected void SetupShellHandlers(IMauiHandlersCollection handlers) =>
+			handlers.SetupShellHandlers();
 
 		protected THandler CreateHandler<THandler>(IElement view)
 			where THandler : IElementHandler, new()
@@ -99,6 +81,35 @@ namespace Microsoft.Maui.DeviceTests
 			});
 		}
 
+		IWindow CreateWindowForContent(IElement view)
+		{
+			IWindow window;
+
+			if (view is IWindow w)
+			{
+				window = w;
+			}
+			else if (view is Page page)
+			{
+				window = new Controls.Window(page);
+			}
+			else
+			{
+				window = new Controls.Window(new ContentPage() { Content = (View)view });
+			}
+
+			return window;
+		}
+
+		protected Task CreateHandlerAndAddToWindow(IElement view, Action action)
+		{
+			return CreateHandlerAndAddToWindow<IWindowHandler>(CreateWindowForContent(view), handler =>
+			{
+				action();
+				return Task.CompletedTask;
+			});
+		}
+
 		protected Task CreateHandlerAndAddToWindow<THandler>(IElement view, Action<THandler> action)
 			where THandler : class, IElementHandler
 		{
@@ -117,22 +128,9 @@ namespace Microsoft.Maui.DeviceTests
 
 			return InvokeOnMainThreadAsync(async () =>
 			{
-				IWindow window = null;
+				IWindow window = CreateWindowForContent(view);
 
 				var application = mauiContext.Services.GetService<IApplication>();
-
-				if (view is IWindow w)
-				{
-					window = w;
-				}
-				else if (view is Page page)
-				{
-					window = new Controls.Window(page);
-				}
-				else
-				{
-					window = new Controls.Window(new ContentPage() { Content = (View)view });
-				}
 
 				if (application is ApplicationStub appStub)
 				{
@@ -180,7 +178,9 @@ namespace Microsoft.Maui.DeviceTests
 							await action((THandler)window.Content.Handler);
 						else if (window.Content is ContentPage cp && typeof(THandler).IsAssignableFrom(cp.Content.Handler.GetType()))
 							await action((THandler)cp.Content.Handler);
-						else
+						else if (typeof(THandler).IsAssignableFrom(typeof(WindowHandler)))
+							throw new Exception($"Use IWindowHandler instead of WindowHandler for CreateHandlerAndAddToWindow");
+						else 
 							throw new Exception($"I can't work with {typeof(THandler)}");
 
 						window.Deactivated();

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Maui.DeviceTests
 							await action((THandler)cp.Content.Handler);
 						else if (typeof(THandler).IsAssignableFrom(typeof(WindowHandler)))
 							throw new Exception($"Use IWindowHandler instead of WindowHandler for CreateHandlerAndAddToWindow");
-						else 
+						else
 							throw new Exception($"I can't work with {typeof(THandler)}");
 
 						window.Deactivated();

--- a/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
+++ b/src/Controls/tests/DeviceTests/ControlsHandlerTestBase.cs
@@ -86,17 +86,11 @@ namespace Microsoft.Maui.DeviceTests
 			IWindow window;
 
 			if (view is IWindow w)
-			{
 				window = w;
-			}
 			else if (view is Page page)
-			{
 				window = new Controls.Window(page);
-			}
 			else
-			{
 				window = new Controls.Window(new ContentPage() { Content = (View)view });
-			}
 
 			return window;
 		}
@@ -147,6 +141,9 @@ namespace Microsoft.Maui.DeviceTests
 					await SetupWindowForTests<THandler>(window, async () =>
 					{
 						IView content = window.Content;
+
+						if (content is FlyoutPage fp)
+							content = fp.Detail;
 
 						if (content is IPageContainer<Page> pc)
 						{

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -82,9 +82,10 @@ namespace Microsoft.Maui.DeviceTests
 
 				Page rootPage = ControlsPageTypesTestCases.CreatePageType(page, contentPage);
 
-				await CreateHandlerAndAddToWindow(rootPage, () =>
+				await CreateHandlerAndAddToWindow(rootPage, async () =>
 				{
 					KeyboardAutoManager.GoToNextResponderOrResign(entry1.ToPlatform());
+					await AssertionExtensions.Wait(() => entry2.IsFocused);
 					Assert.True(entry2.IsFocused);
 				});
 			}

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -1,6 +1,11 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.DeviceTests.TestCases;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
 using UIKit;
+using Xunit;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -35,6 +40,54 @@ namespace Microsoft.Maui.DeviceTests
 				return (int)textField.GetOffsetFromPosition(textField.SelectedTextRange.Start, textField.SelectedTextRange.End);
 
 			return -1;
+		}
+
+		[Category(TestCategory.Entry)]
+		[Collection(ControlsHandlerTestBase.RunInNewWindowCollection)]
+		public partial class EntryTestsWithWindow : ControlsHandlerTestBase
+		{
+			[Theory]
+			[ClassData(typeof(ControlsPageTypesTestCases))]
+			public async Task NextMovesToNextEntry(string page)
+			{
+				EnsureHandlerCreated(builder =>
+				{
+					ControlsPageTypesTestCases.Setup(builder);
+					builder.ConfigureMauiHandlers(handlers =>
+					{
+						handlers.AddHandler(typeof(Entry), typeof(EntryHandler));
+					});
+				});
+
+				var entry1 = new Entry
+				{
+					Text = "Entry 1",
+					ReturnType = ReturnType.Next
+				};
+
+				var entry2 = new Entry
+				{
+					Text = "Entry 2",
+					ReturnType = ReturnType.Next
+				};
+
+				ContentPage contentPage = new ContentPage()
+				{
+					Content = new VerticalStackLayout()
+					{
+						entry1,
+						entry2
+					}
+				};
+
+				Page rootPage = ControlsPageTypesTestCases.CreatePageType(page, contentPage);
+
+				await CreateHandlerAndAddToWindow(rootPage, () =>
+				{
+					KeyboardAutoManager.GoToNextResponderOrResign(entry1.ToPlatform());
+					Assert.True(entry2.IsFocused);
+				});
+			}
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Entry/EntryTests.iOS.cs
@@ -81,9 +81,11 @@ namespace Microsoft.Maui.DeviceTests
 				};
 
 				Page rootPage = ControlsPageTypesTestCases.CreatePageType(page, contentPage);
+				Page hostPage = new ContentPage();
 
-				await CreateHandlerAndAddToWindow(rootPage, async () =>
+				await CreateHandlerAndAddToWindow(hostPage, async () =>
 				{
+					await hostPage.Navigation.PushModalAsync(rootPage);
 					KeyboardAutoManager.GoToNextResponderOrResign(entry1.ToPlatform());
 					await AssertionExtensions.Wait(() => entry2.IsFocused);
 					Assert.True(entry2.IsFocused);

--- a/src/Controls/tests/DeviceTests/Extensions.cs
+++ b/src/Controls/tests/DeviceTests/Extensions.cs
@@ -1,6 +1,18 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform;
+using Xunit;
+#if ANDROID || IOS || MACCATALYST
+using ShellHandler = Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer;
+#endif
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -8,6 +20,32 @@ namespace Microsoft.Maui.DeviceTests
 	{
 		public static Task Wait(this Image image, int timeout = 1000) =>
 			AssertionExtensions.Wait(() => !image.IsLoading, timeout);
+
+		public static void SetupShellHandlers(this MauiAppBuilder builder)
+		{
+			builder.ConfigureMauiHandlers(SetupShellHandlers);
+		}
+
+		public static void SetupShellHandlers(this IMauiHandlersCollection handlers)
+		{
+			handlers.TryAddHandler(typeof(Controls.Shell), typeof(ShellHandler));
+			handlers.TryAddHandler<Layout, LayoutHandler>();
+			handlers.TryAddHandler<Image, ImageHandler>();
+			handlers.TryAddHandler<Label, LabelHandler>();
+			handlers.TryAddHandler<Page, PageHandler>();
+			handlers.TryAddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+			handlers.TryAddHandler(typeof(MenuBar), typeof(MenuBarHandler));
+			handlers.TryAddHandler(typeof(MenuBarItem), typeof(MenuBarItemHandler));
+			handlers.TryAddHandler(typeof(MenuFlyoutItem), typeof(MenuFlyoutItemHandler));
+			handlers.TryAddHandler(typeof(MenuFlyoutSubItem), typeof(MenuFlyoutSubItemHandler));
+			handlers.TryAddHandler<ScrollView, ScrollViewHandler>();
+
+#if WINDOWS
+			handlers.TryAddHandler(typeof(ShellItem), typeof(ShellItemHandler));
+			handlers.TryAddHandler(typeof(ShellSection), typeof(ShellSectionHandler));
+			handlers.TryAddHandler(typeof(ShellContent), typeof(ShellContentHandler));
+#endif
+		}
 	}
 }
 

--- a/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
+++ b/src/Controls/tests/DeviceTests/TestCases/ControlsPageTypesTestCases.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.DeviceTests.Stubs;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+
+#if IOS || MACCATALYST
+using FlyoutViewHandler = Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer;
+#endif
+
+namespace Microsoft.Maui.DeviceTests.TestCases
+{
+	public class ControlsPageTypesTestCases : IEnumerable<object[]>
+	{
+		private readonly List<object[]> _data = new()
+		{
+			new object[] { nameof(FlyoutPage) },
+			new object[] { nameof(TabbedPage) },
+			new object[] { nameof(ContentPage) },
+			new object[] { nameof(Shell) },
+			new object[] { nameof(NavigationPage) },
+		};
+
+		public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+
+		public static Page CreatePageType(string name, Page content)
+		{
+			switch (name)
+			{
+				case nameof(FlyoutPage):
+					content.Title = content.Title ?? "Detail Title";
+					return new FlyoutPage() { Flyout = new ContentPage() { Title = "title" }, Detail = content };
+				case nameof(TabbedPage):
+					return new TabbedPage() { Children = { content } };
+				case nameof(ContentPage):
+					return content;
+				case nameof(Shell):
+					return new Shell() { CurrentItem = (ContentPage)content };
+				case nameof(NavigationPage):
+					return new NavigationPage(content);
+			}
+
+			throw new Exception($"{name} not found");
+		}
+
+		public static void Setup(MauiAppBuilder builder)
+		{
+			builder.ConfigureMauiHandlers(handlers =>
+			{
+				handlers.SetupShellHandlers();
+
+				handlers.AddHandler(typeof(Controls.Label), typeof(LabelHandler));
+				handlers.AddHandler(typeof(Controls.Toolbar), typeof(ToolbarHandler));
+				handlers.AddHandler(typeof(FlyoutPage), typeof(FlyoutViewHandler));
+#if IOS || MACCATALYST
+				handlers.AddHandler(typeof(TabbedPage), typeof(TabbedRenderer));
+				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationRenderer));
+#else
+				handlers.AddHandler(typeof(TabbedPage), typeof(TabbedViewHandler));
+				handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+#endif
+				handlers.AddHandler<Page, PageHandler>();
+				handlers.AddHandler<Controls.Window, WindowHandlerStub>();
+			});
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change

Go to next entry code wasn't working with shell because on iOS with shell we were never accessing `ViewController.View` on the `PageViewController`. This means that the `View` property on the `PageViewController` was never loading. We would just add the `PageView`. 

This PR adds the `View` via the VC instead of the `Handler` so that the `PageViewController` can be setup as a `NextResponder` and thus be located by the `FindNext` code