### PR TITLE
[core] WeakEventManager.RemoveEventHandler() should clear subscriptions

### DIFF
--- a/src/Core/src/WeakEventManager.cs
+++ b/src/Core/src/WeakEventManager.cs
@@ -125,9 +125,9 @@ namespace Microsoft.Maui
 			if (!_eventHandlers.TryGetValue(eventName, out List<Subscription>? subscriptions))
 				return;
 
-			for (int n = subscriptions.Count; n > 0; n--)
+			for (int n = subscriptions.Count - 1; n >= 0; n--)
 			{
-				Subscription current = subscriptions[n - 1];
+				Subscription current = subscriptions[n];
 
 				if (current.Subscriber != null && !current.Subscriber.IsAlive)
 				{

--- a/src/Core/src/WeakEventManager.cs
+++ b/src/Core/src/WeakEventManager.cs
@@ -129,11 +129,19 @@ namespace Microsoft.Maui
 			{
 				Subscription current = subscriptions[n - 1];
 
-				if (current.Subscriber?.Target != handlerTarget || current.Handler.Name != methodInfo.Name)
+				if (current.Subscriber != null && !current.Subscriber.IsAlive)
+				{
+					// If not alive, remove and continue
+					subscriptions.RemoveAt(n);
 					continue;
+				}
 
-				subscriptions.Remove(current);
-				break;
+				if (current.Subscriber?.Target == handlerTarget && current.Handler.Name == methodInfo.Name)
+				{
+					// Found the match, we can break
+					subscriptions.RemoveAt(n);
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/12039
Context: https://github.com/Vroomer/MAUI-master-detail-memory-leak
Context: https://github.com/symbiogenesis/Maui.DataGrid/tree/memory-leak

fixes #9162

Reviewing memory snapshots in the above apps, sometimes I would see new `WeakEventManager+Subscription` objects be created and never go away.

I noticed the `WeakEventManager.RemoveEventHandler()` method did not remove any `Subscription` entries that it encountered were no longer alive.

I could reproduce this problem in a test, and improved an existing test to check this collection is cleared appropriately:

    readonly Dictionary<string, List<Subscription>> _eventHandlers = new();