### PR TITLE
Have Frame use MinimumHeight/Width for minimums instead of constraints

### DIFF
--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -111,12 +111,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (!Primitives.Dimension.IsExplicitSet(minWidth))
 			{
-				minWidth = LegacyMinimumFrameSize; 
+				minWidth = LegacyMinimumFrameSize;
 			}
 
 			if (!Primitives.Dimension.IsExplicitSet(minHeight))
 			{
-				minHeight = LegacyMinimumFrameSize; 
+				minHeight = LegacyMinimumFrameSize;
 			}
 
 			return VisualElementRenderer<Frame>.GetDesiredSize(this, widthConstraint, heightConstraint,

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -53,7 +53,6 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		public static CommandMapper<Frame, FrameRenderer> CommandMapper
 			= new CommandMapper<Frame, FrameRenderer>(ViewRenderer.VisualElementRendererCommandMapper);
 
-
 		float _defaultElevation = -1f;
 		float _defaultCornerRadius = -1f;
 
@@ -68,6 +67,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		Frame? _element;
 		public event EventHandler<VisualElementChangedEventArgs>? ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs>? ElementPropertyChanged;
+
+		const double LegacyMinimumFrameSize = 20;
 
 		public FrameRenderer(Context context) : this(context, Mapper)
 		{
@@ -110,12 +111,12 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 			if (!Primitives.Dimension.IsExplicitSet(minWidth))
 			{
-				minWidth = 20; // Legacy minimum value
+				minWidth = LegacyMinimumFrameSize; 
 			}
 
 			if (!Primitives.Dimension.IsExplicitSet(minHeight))
 			{
-				minHeight = 20; // Legacy minimum value
+				minHeight = LegacyMinimumFrameSize; 
 			}
 
 			return VisualElementRenderer<Frame>.GetDesiredSize(this, widthConstraint, heightConstraint,

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -101,11 +101,11 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 		{
 			var virtualView = (this as IViewHandler).VirtualView;
 			if (virtualView == null)
-			{ 
+			{
 				return Size.Zero;
 			}
 
-		 	var minWidth = virtualView.MinimumWidth;
+			var minWidth = virtualView.MinimumWidth;
 			var minHeight = virtualView.MinimumHeight;
 
 			if (!Primitives.Dimension.IsExplicitSet(minWidth))

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -99,8 +99,8 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 
 		Size IViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var virtualView = (this as IViewHandler).VirtualView;
-			if (virtualView == null)
+			var virtualView = (this as IViewHandler)?.VirtualView;
+			if (virtualView is null)
 			{
 				return Size.Zero;
 			}

--- a/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
+++ b/src/Controls/src/Core/Compatibility/Handlers/Android/FrameRenderer.cs
@@ -4,6 +4,7 @@ using Android.Content;
 using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Views;
+using Android.Views.Animations;
 using AndroidX.CardView.Widget;
 using AndroidX.Core.View;
 using Microsoft.Maui.Controls.Platform;
@@ -96,17 +97,28 @@ namespace Microsoft.Maui.Controls.Handlers.Compatibility
 			}
 		}
 
-		Size IViewHandler.GetDesiredSize(double widthMeasureSpec, double heightMeasureSpec)
+		Size IViewHandler.GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			double minWidth = 20;
-			if (Primitives.Dimension.IsExplicitSet(widthMeasureSpec) && !double.IsInfinity(widthMeasureSpec))
-				minWidth = widthMeasureSpec;
+			var virtualView = (this as IViewHandler).VirtualView;
+			if (virtualView == null)
+			{ 
+				return Size.Zero;
+			}
 
-			double minHeight = 20;
-			if (Primitives.Dimension.IsExplicitSet(widthMeasureSpec) && !double.IsInfinity(heightMeasureSpec))
-				minHeight = heightMeasureSpec;
+		 	var minWidth = virtualView.MinimumWidth;
+			var minHeight = virtualView.MinimumHeight;
 
-			return VisualElementRenderer<Frame>.GetDesiredSize(this, widthMeasureSpec, heightMeasureSpec,
+			if (!Primitives.Dimension.IsExplicitSet(minWidth))
+			{
+				minWidth = 20; // Legacy minimum value
+			}
+
+			if (!Primitives.Dimension.IsExplicitSet(minHeight))
+			{
+				minHeight = 20; // Legacy minimum value
+			}
+
+			return VisualElementRenderer<Frame>.GetDesiredSize(this, widthConstraint, heightConstraint,
 				new Size(minWidth, minHeight));
 		}
 

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameHandlerTest.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameHandlerTest.Android.cs
@@ -1,4 +1,8 @@
 ﻿using System.Threading.Tasks;
+using Xunit.Sdk;
+using Microsoft.Maui.Controls;
+using Xunit;
+using Java.Lang;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -20,6 +24,24 @@ namespace Microsoft.Maui.DeviceTests
 		{
 			// https://github.com/dotnet/maui/pull/12218
 			return Task.CompletedTask;
+		}
+
+		public override async Task ReturnsNonEmptyNativeBoundingBox(int size)
+		{
+			// Frames have a legacy hard-coded minimum size of 20x20
+			var expectedSize = Math.Max(20, size); 
+			var expectedBounds = new Graphics.Rect(0, 0, expectedSize, expectedSize);
+
+			var view = new Frame()
+			{
+				HeightRequest = size,
+				WidthRequest = size
+			};
+
+			var nativeBoundingBox = await GetValueAsync(view, handler => GetBoundingBox(handler));
+			Assert.NotEqual(nativeBoundingBox, Graphics.Rect.Zero);
+
+			AssertWithinTolerance(expectedBounds.Size, nativeBoundingBox.Size);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameHandlerTest.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameHandlerTest.Android.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
-using Xunit.Sdk;
+using Java.Lang;
 using Microsoft.Maui.Controls;
 using Xunit;
-using Java.Lang;
+using Xunit.Sdk;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -29,7 +29,7 @@ namespace Microsoft.Maui.DeviceTests
 		public override async Task ReturnsNonEmptyNativeBoundingBox(int size)
 		{
 			// Frames have a legacy hard-coded minimum size of 20x20
-			var expectedSize = Math.Max(20, size); 
+			var expectedSize = Math.Max(20, size);
 			var expectedBounds = new Graphics.Rect(0, 0, expectedSize, expectedSize);
 
 			var view = new Frame()

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -91,30 +91,7 @@ namespace Microsoft.Maui.DeviceTests
 				}
 			};
 
-			var layoutFrame =
-				await InvokeOnMainThreadAsync(() =>
-					layout.ToPlatform(MauiContext).AttachAndRun(async () =>
-					{
-						var size = (layout as IView).Measure(double.PositiveInfinity, double.PositiveInfinity);
-						(layout as IView).Arrange(new Graphics.Rect(0, 0, size.Width, size.Height));
-
-						await OnFrameSetToNotEmpty(layout);
-						await OnFrameSetToNotEmpty(frame);
-
-						// verify that the PlatformView was measured
-						var frameControlSize = (frame.Handler as IPlatformViewHandler).PlatformView.GetBoundingBox();
-						Assert.True(frameControlSize.Width > 0);
-						Assert.True(frameControlSize.Width > 0);
-
-						// if the control sits inside a container make sure that also measured
-						var containerControlSize = frame.ToPlatform().GetBoundingBox();
-						Assert.True(frameControlSize.Width > 0);
-						Assert.True(frameControlSize.Width > 0);
-
-						return layout.Frame;
-
-					})
-				);
+			var layoutFrame = await LayoutFrame(layout, frame, double.PositiveInfinity, double.PositiveInfinity);
 
 			Assert.True(entry.Width > 0);
 			Assert.True(entry.Height > 0);
@@ -186,6 +163,93 @@ namespace Microsoft.Maui.DeviceTests
 				var platformView = frame.ToPlatform(MauiContext);
 				platformView.AssertContainsColor(expectedColor);
 			});
+		}
+
+		[Fact(DisplayName = "Frame Respects minimum height/width")]
+		public async Task FrameRespectsMinimums()
+		{
+			SetupBuilder();
+
+			var content = new Button { Text = "Hey", WidthRequest = 50, HeightRequest = 50 };
+
+			var frame = new Frame()
+			{
+				Content = content,
+				MinimumHeightRequest = 100,
+				MinimumWidthRequest = 100,
+				VerticalOptions = LayoutOptions.Start,
+				HorizontalOptions = LayoutOptions.Start
+			};
+
+			var layout = new StackLayout()
+			{
+				Children =
+				{
+					frame
+				}
+			};
+
+			var layoutFrame = await LayoutFrame(layout, frame, 500, 500);
+
+			Assert.True(100 <= layoutFrame.Height);
+			Assert.True(100 <= layoutFrame.Width);
+		}
+
+		[Fact]
+		public async Task FrameDoesNotInterpretConstraintsAsMinimums() 
+		{
+			SetupBuilder();
+
+			var content = new Button { Text = "Hey", WidthRequest = 50, HeightRequest = 50 };
+
+			var frame = new Frame()
+			{
+				Content = content,
+				MinimumHeightRequest = 100,
+				MinimumWidthRequest = 100,
+				VerticalOptions = LayoutOptions.Start,
+				HorizontalOptions = LayoutOptions.Start
+			};
+
+			var layout = new StackLayout()
+			{
+				Children =
+				{
+					frame
+				}
+			};
+
+			var layoutFrame = await LayoutFrame(layout, frame, 500, 500);
+
+			Assert.True(500 > layoutFrame.Width);
+			Assert.True(500 > layoutFrame.Height);
+		}
+
+		async Task<Rect> LayoutFrame(Layout layout, Frame frame, double measureWidth, double measureHeight)
+		{
+			return await InvokeOnMainThreadAsync(() =>
+					layout.ToPlatform(MauiContext).AttachAndRun(async () =>
+					{
+						var size = (layout as IView).Measure(measureWidth, measureHeight);
+						(layout as IView).Arrange(new Graphics.Rect(0, 0, size.Width, size.Height));
+
+						await OnFrameSetToNotEmpty(layout);
+						await OnFrameSetToNotEmpty(frame);
+
+						// verify that the PlatformView was measured
+						var frameControlSize = (frame.Handler as IPlatformViewHandler).PlatformView.GetBoundingBox();
+						Assert.True(frameControlSize.Width > 0);
+						Assert.True(frameControlSize.Width > 0);
+
+						// if the control sits inside a container make sure that also measured
+						var containerControlSize = frame.ToPlatform().GetBoundingBox();
+						Assert.True(frameControlSize.Width > 0);
+						Assert.True(frameControlSize.Width > 0);
+
+						return layout.Frame;
+
+					})
+				);
 		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/Frame/FrameTests.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Maui.DeviceTests
 		}
 
 		[Fact]
-		public async Task FrameDoesNotInterpretConstraintsAsMinimums() 
+		public async Task FrameDoesNotInterpretConstraintsAsMinimums()
 		{
 			SetupBuilder();
 

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui.Graphics;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Media;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Maui.DeviceTests
 {
@@ -244,7 +245,7 @@ namespace Microsoft.Maui.DeviceTests
 			Assert.NotEqual(platformViewBounds, new Graphics.Rect());
 		}
 
-		[Theory(DisplayName = "Native View Bounding Box are not empty"
+		[Theory(DisplayName = "Native View Bounding Box is not empty"
 #if WINDOWS
 			, Skip = "https://github.com/dotnet/maui/issues/9054"
 #endif
@@ -252,7 +253,7 @@ namespace Microsoft.Maui.DeviceTests
 		[InlineData(1)]
 		[InlineData(100)]
 		[InlineData(1000)]
-		public async Task ReturnsNonEmptyNativeBoundingBounds(int size)
+		public virtual async Task ReturnsNonEmptyNativeBoundingBox(int size)
 		{
 			var view = new TStub()
 			{
@@ -261,8 +262,7 @@ namespace Microsoft.Maui.DeviceTests
 			};
 
 			var nativeBoundingBox = await GetValueAsync(view, handler => GetBoundingBox(handler));
-			Assert.NotEqual(nativeBoundingBox, new Graphics.Rect());
-
+			Assert.NotEqual(nativeBoundingBox, Graphics.Rect.Zero);
 
 			// Currently there's an issue with label/progress where they don't set the frame size to
 			// the explicit Width and Height values set
@@ -287,32 +287,32 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				// https://github.com/dotnet/maui/issues/11020
 			}
-
-			// This type name check is gross, but this project doesn't know anything about Frame/FrameStub
-			else if(size == 1 && view.GetType().Name.EndsWith("FrameStub")) 
-			{
-				// Frames have a legacy hard-coded minimum size of 20x20
-				Assert.True(CloseEnough(20, nativeBoundingBox.Size.Width));
-				Assert.True(CloseEnough(20, nativeBoundingBox.Size.Height));
-			}
 #endif
 			else if (view is IProgress)
 			{
-				if (!CloseEnough(size, nativeBoundingBox.Size.Width))
-					Assert.Equal(new Size(size, size), nativeBoundingBox.Size);
+				AssertWithinTolerance(size, nativeBoundingBox.Size.Width);
 			}
 			else
 			{
-				if (!CloseEnough(size, nativeBoundingBox.Size.Height) || !CloseEnough(size, nativeBoundingBox.Size.Width))
-					Assert.Equal(new Size(size, size), nativeBoundingBox.Size);
-			}
-
-			bool CloseEnough(double value1, double value2)
-			{
-				return System.Math.Abs(value2 - value1) < 0.2;
+				var expectedSize = new Size(size, size);
+				AssertWithinTolerance(expectedSize, nativeBoundingBox.Size);
 			}
 		}
 
+		protected void AssertWithinTolerance(double expected, double actual, double tolerance = 0.2, string message = "Value was not within tolerance.") 
+		{
+			var diff = System.Math.Abs(expected - actual);
+			if (diff > tolerance)
+			{
+				throw new XunitException($"{message} Expected: {expected}; Actual: {actual}; Tolerance {tolerance}");
+			}
+		}
+
+		protected void AssertWithinTolerance(Graphics.Size expected, Graphics.Size actual, double tolerance = 0.2) 
+		{
+			AssertWithinTolerance(expected.Height, actual.Height, tolerance, "Height was not within tolerance.");
+			AssertWithinTolerance(expected.Width, actual.Width, tolerance, "Width was not within tolerance.");
+		}
 
 		[Theory(DisplayName = "Native View Transforms are not empty"
 #if IOS

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -292,7 +292,8 @@ namespace Microsoft.Maui.DeviceTests
 			else if(size == 1 && view.GetType().Name.EndsWith("FrameStub")) 
 			{
 				// Frames have a legacy hard-coded minimum size of 20x20
-				Assert.Equal(new Size(20, 20), nativeBoundingBox.Size);
+				Assert.True(CloseEnough(20, nativeBoundingBox.Size.Width));
+				Assert.True(CloseEnough(20, nativeBoundingBox.Size.Height));
 			}
 #endif
 			else if (view is IProgress)

--- a/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
+++ b/src/Core/tests/DeviceTests.Shared/HandlerTests/HandlerTestBaseOfT.Tests.cs
@@ -287,6 +287,13 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				// https://github.com/dotnet/maui/issues/11020
 			}
+
+			// This type name check is gross, but this project doesn't know anything about Frame/FrameStub
+			else if(size == 1 && view.GetType().Name.EndsWith("FrameStub")) 
+			{
+				// Frames have a legacy hard-coded minimum size of 20x20
+				Assert.Equal(new Size(20, 20), nativeBoundingBox.Size);
+			}
 #endif
 			else if (view is IProgress)
 			{


### PR DESCRIPTION
### Description of Change

The legacy FrameRenderer on Android is using the measurement constraints as minimum values, which means all Frames attempt to consume the size they're measured with.

These changes use the MinimumHeight and MinimumWidth as the minimums for the Frame, and add tests for this scenario.

### Issues Fixed

Fixes #13074
Fixes #13469