### PR TITLE
Changes in project template to avoid BoxView mistake

### DIFF
--- a/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
+++ b/src/Templates/src/templates/maui-mobile/Resources/Styles/Styles.xaml
@@ -20,7 +20,7 @@
     </Style>
 
     <Style TargetType="BoxView">
-        <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
     </Style>
 
     <Style TargetType="Button">


### PR DESCRIPTION
### Description of Change

Changes in project template to avoid confusion with **BoxView**.

_What is the problem?_

Currently in the BoxView we have three properties to do the same, Color that is specific but also the inherited properties Background and BackgroundColor. What happens if we assign values to all these properties? We assign by priority in the following order:

**Color > Background > BackgroundColor**

Color wins over the rest as it is a specific property of the BoxView. Then, the Background property, as with the rest of the Views, has more priority than BackgroundColor.

That is, if Background=Red and Color=Green are assigned in a BoxView, the green color would be used. Currently, in the project template we have a style assigning the Color property. This means that, if we create a BoxView and set the BackgroundColor, that color is not applied because use the Color property value and it seems that there is a bug or something weird.

With the changes in this PR, if any of the properties are assigned directly to the BoxView, it will force to use it.

### Issues Fixed

Fixes #8972
Fixes #10850
Fixes #12209
Fixes #9292