### PR TITLE
[CI] Enure the pwsh is in the right dir.

### DIFF
--- a/eng/pipelines/common/pack.yml
+++ b/eng/pipelines/common/pack.yml
@@ -48,18 +48,24 @@ steps:
   - pwsh: ./build.ps1 --target=dotnet --configuration="Release" --verbosity=diagnostic --nugetsource="${{ parameters.nugetFolder }}"
     displayName: 'Install .NET'
     retryCountOnTaskFailure: 3
+    workingDirectory: ${{ parameters.checkoutDirectory }}
     env:
       DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
       PRIVATE_BUILD: $(PrivateBuild)
+
   - pwsh: ./build.ps1 --target=dotnet-pack --configuration="Release" --verbosity=diagnostic --nugetsource="${{ parameters.nugetFolder }}"
     displayName: 'Pack .NET Maui'
     name: PackMaui
+    workingDirectory: ${{ parameters.checkoutDirectory }}
     env:
       DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)
       PRIVATE_BUILD: $(PrivateBuild)
+
   - ${{ if eq(parameters.platform, 'Windows') }}:
     - pwsh: ./build.ps1 --target=dotnet-diff --configuration="Release" --verbosity=diagnostic
       displayName: 'Diff .NET Maui artifacts with NuGet'
+      workingDirectory: ${{ parameters.checkoutDirectory }}
+
   # artifacts
   - task: CopyFiles@2
     condition: always()


### PR DESCRIPTION
Follow up of https://github.com/dotnet/maui/pull/13264

We need to be sure that the pwsh is executed from the right dir, the simplest way is to set the working dir for the step.


