### PR TITLE
Geolocation: Add #nullable for Essentials Geolocation code

### DIFF
--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		public async Task<Location?> GetLastKnownLocationAsync()
 		{
-			if (LocationManager == null)
+			if (LocationManager is null)
 				throw new FeatureNotSupportedException("Android LocationManager is not available");
 
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
@@ -56,7 +56,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		{
 			ArgumentNullException.ThrowIfNull(request);
 
-			if (LocationManager == null)
+			if (LocationManager is null)
 				throw new FeatureNotSupportedException("Android LocationManager is not available");
 
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
@@ -122,7 +122,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			void RemoveUpdates()
 			{
-				if (LocationManager == null)
+				if (LocationManager is null)
 					return;
 
 				for (var i = 0; i < providers.Count; i++)
@@ -145,7 +145,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		{
 			ArgumentNullException.ThrowIfNull(request);
 
-			if (LocationManager == null)
+			if (LocationManager is null)
 				throw new FeatureNotSupportedException("Android LocationManager is not available");
 
 			if (IsListeningForeground)
@@ -218,8 +218,8 @@ namespace Microsoft.Maui.Devices.Sensors
 			continuousListener.LocationHandler = null;
 			continuousListener.ErrorHandler = null;
 
-			if (listeningProviders == null ||
-				LocationManager == null)
+			if (listeningProviders is null ||
+				LocationManager is null)
 				return;
 
 			for (var i = 0; i < listeningProviders.Count; i++)
@@ -382,7 +382,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		void ILocationListener.OnStatusChanged(string? provider, Availability status, Bundle? extras)
 		{
-			if (provider == null)
+			if (provider is null)
 				return;
 
 			switch (status)

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		/// <summary>
 		/// Indicates if currently listening to location updates while the app is in foreground.
 		/// </summary>
-		public bool IsListeningForeground { get => continuousListener != null; }
+		public bool IsListeningForeground { get => continuousListener is not null; }
 
 		public async Task<Location?> GetLastKnownLocationAsync()
 		{
@@ -45,7 +45,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			{
 				var location = LocationManager.GetLastKnownLocation(provider);
 
-				if (location != null && IsBetterLocation(location, bestLocation))
+				if (location is not null && IsBetterLocation(location, bestLocation))
 					bestLocation = location;
 			}
 
@@ -154,7 +154,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
 			var enabledProviders = LocationManager.GetProviders(true);
-			var hasProviders = enabledProviders != null &&
+			var hasProviders = enabledProviders is not null &&
 				enabledProviders.Any(p => !ignoredProviders.Contains(p));
 
 			if (!hasProviders)
@@ -343,7 +343,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			foreach (var provider in activeProviders)
 			{
 				var location = manager?.GetLastKnownLocation(provider);
-				if (location != null && GeolocationImplementation.IsBetterLocation(location, BestLocation))
+				if (location is not null && GeolocationImplementation.IsBetterLocation(location, BestLocation))
 					BestLocation = location;
 			}
 		}
@@ -414,7 +414,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			foreach (var provider in providers)
 			{
-				if (manager != null && manager.IsProviderEnabled(provider))
+				if (manager is not null && manager.IsProviderEnabled(provider))
 					activeProviders.Add(provider);
 			}
 		}

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,12 +19,12 @@ namespace Microsoft.Maui.Devices.Sensors
 		const long twoMinutes = 120000;
 		static readonly string[] ignoredProviders = new string[] { LocationManager.PassiveProvider, "local_database" };
 
-		static ContinuousLocationListener continuousListener;
-		static List<string> listeningProviders;
+		static ContinuousLocationListener? continuousListener;
+		static List<string>? listeningProviders;
 
-		static LocationManager locationManager;
+		static LocationManager? locationManager;
 
-		static LocationManager LocationManager =>
+		static LocationManager? LocationManager =>
 			locationManager ??= Application.Context.GetSystemService(Context.LocationService) as LocationManager;
 
 		/// <summary>
@@ -31,11 +32,14 @@ namespace Microsoft.Maui.Devices.Sensors
 		/// </summary>
 		public bool IsListeningForeground { get => continuousListener != null; }
 
-		public async Task<Location> GetLastKnownLocationAsync()
+		public async Task<Location?> GetLastKnownLocationAsync()
 		{
+			if (LocationManager == null)
+				throw new FeatureNotSupportedException("Android LocationManager is not available");
+
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
-			AndroidLocation bestLocation = null;
+			AndroidLocation? bestLocation = null;
 
 			foreach (var provider in LocationManager.GetProviders(true))
 			{
@@ -48,9 +52,12 @@ namespace Microsoft.Maui.Devices.Sensors
 			return bestLocation?.ToLocation();
 		}
 
-		public async Task<Location> GetLocationAsync(GeolocationRequest request, CancellationToken cancellationToken)
+		public async Task<Location?> GetLocationAsync(GeolocationRequest request, CancellationToken cancellationToken)
 		{
 			ArgumentNullException.ThrowIfNull(request);
+
+			if (LocationManager == null)
+				throw new FeatureNotSupportedException("Android LocationManager is not available");
 
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
@@ -68,7 +75,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			if (string.IsNullOrEmpty(providerInfo.Provider))
 				return await GetLastKnownLocationAsync();
 
-			var tcs = new TaskCompletionSource<AndroidLocation>();
+			var tcs = new TaskCompletionSource<AndroidLocation?>();
 
 			var allProviders = LocationManager.GetProviders(false);
 
@@ -110,11 +117,14 @@ namespace Microsoft.Maui.Devices.Sensors
 			void Cancel()
 			{
 				RemoveUpdates();
-				tcs.TrySetResult(listener.BestLocation);
+				tcs.TrySetResult(listener?.BestLocation);
 			}
 
 			void RemoveUpdates()
 			{
+				if (LocationManager == null)
+					return;
+
 				for (var i = 0; i < providers.Count; i++)
 					LocationManager.RemoveUpdates(listener);
 			}
@@ -135,13 +145,17 @@ namespace Microsoft.Maui.Devices.Sensors
 		{
 			ArgumentNullException.ThrowIfNull(request);
 
+			if (LocationManager == null)
+				throw new FeatureNotSupportedException("Android LocationManager is not available");
+
 			if (IsListeningForeground)
 				throw new InvalidOperationException("Already listening to location changes.");
 
 			await Permissions.EnsureGrantedOrRestrictedAsync<Permissions.LocationWhenInUse>();
 
 			var enabledProviders = LocationManager.GetProviders(true);
-			var hasProviders = enabledProviders.Any(p => !ignoredProviders.Contains(p));
+			var hasProviders = enabledProviders != null &&
+				enabledProviders.Any(p => !ignoredProviders.Contains(p));
 
 			if (!hasProviders)
 				throw new FeatureNotEnabledException("Location services are not enabled on device.");
@@ -204,7 +218,8 @@ namespace Microsoft.Maui.Devices.Sensors
 			continuousListener.LocationHandler = null;
 			continuousListener.ErrorHandler = null;
 
-			if (listeningProviders == null)
+			if (listeningProviders == null ||
+				LocationManager == null)
 				return;
 
 			for (var i = 0; i < listeningProviders.Count; i++)
@@ -215,7 +230,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			continuousListener = null;
 		}
 
-		static (string Provider, float Accuracy) GetBestProvider(LocationManager locationManager, GeolocationAccuracy accuracy)
+		static (string? Provider, float Accuracy) GetBestProvider(LocationManager locationManager, GeolocationAccuracy accuracy)
 		{
 			// Criteria: https://developer.android.com/reference/android/location/Criteria
 
@@ -268,7 +283,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			return (provider, accuracyDistance);
 		}
 
-		internal static bool IsBetterLocation(AndroidLocation location, AndroidLocation bestLocation)
+		internal static bool IsBetterLocation(AndroidLocation location, AndroidLocation? bestLocation)
 		{
 			if (bestLocation == null)
 				return true;
@@ -311,15 +326,15 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		float desiredAccuracy;
 
-		internal AndroidLocation BestLocation { get; set; }
+		internal AndroidLocation? BestLocation { get; set; }
 
 		HashSet<string> activeProviders = new HashSet<string>();
 
 		bool wasRaised = false;
 
-		internal Action<AndroidLocation> LocationHandler { get; set; }
+		internal Action<AndroidLocation>? LocationHandler { get; set; }
 
-		internal SingleLocationListener(LocationManager manager, float desiredAccuracy, IEnumerable<string> activeProviders)
+		internal SingleLocationListener(LocationManager? manager, float desiredAccuracy, IEnumerable<string> activeProviders)
 		{
 			this.desiredAccuracy = desiredAccuracy;
 
@@ -327,7 +342,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			foreach (var provider in activeProviders)
 			{
-				var location = manager.GetLastKnownLocation(provider);
+				var location = manager?.GetLastKnownLocation(provider);
 				if (location != null && GeolocationImplementation.IsBetterLocation(location, BestLocation))
 					BestLocation = location;
 			}
@@ -365,8 +380,11 @@ namespace Microsoft.Maui.Devices.Sensors
 				activeProviders.Add(provider);
 		}
 
-		void ILocationListener.OnStatusChanged(string provider, Availability status, Bundle extras)
+		void ILocationListener.OnStatusChanged(string? provider, Availability status, Bundle? extras)
 		{
+			if (provider == null)
+				return;
+
 			switch (status)
 			{
 				case Availability.Available:
@@ -382,24 +400,21 @@ namespace Microsoft.Maui.Devices.Sensors
 
 	class ContinuousLocationListener : Java.Lang.Object, ILocationListener
 	{
-		readonly LocationManager manager;
-
 		float desiredAccuracy;
 
 		HashSet<string> activeProviders = new HashSet<string>();
 
-		internal Action<AndroidLocation> LocationHandler { get; set; }
+		internal Action<AndroidLocation>? LocationHandler { get; set; }
 
-		internal Action<GeolocationError> ErrorHandler { get; set; }
+		internal Action<GeolocationError>? ErrorHandler { get; set; }
 
-		internal ContinuousLocationListener(LocationManager manager, float desiredAccuracy, IEnumerable<string> providers)
+		internal ContinuousLocationListener(LocationManager? manager, float desiredAccuracy, IEnumerable<string> providers)
 		{
-			this.manager = manager;
 			this.desiredAccuracy = desiredAccuracy;
 
 			foreach (var provider in providers)
 			{
-				if (manager.IsProviderEnabled(provider))
+				if (manager != null && manager.IsProviderEnabled(provider))
 					activeProviders.Add(provider);
 			}
 		}
@@ -429,8 +444,11 @@ namespace Microsoft.Maui.Devices.Sensors
 				activeProviders.Add(provider);
 		}
 
-		void ILocationListener.OnStatusChanged(string provider, Availability status, Bundle extras)
+		void ILocationListener.OnStatusChanged(string? provider, Availability status, Bundle? extras)
 		{
+			if (provider == null)
+				return;
+
 			switch (status)
 			{
 				case Availability.Available:

--- a/src/Essentials/src/Geolocation/Geolocation.android.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.android.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			var androidLocation = await tcs.Task;
 
-			if (androidLocation == null)
+			if (androidLocation is null)
 				return null;
 
 			return androidLocation.ToLocation();
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		/// </summary>
 		public void StopListeningForeground()
 		{
-			if (continuousListener == null)
+			if (continuousListener is null)
 				return;
 
 			continuousListener.LocationHandler = null;
@@ -285,7 +285,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		internal static bool IsBetterLocation(AndroidLocation location, AndroidLocation? bestLocation)
 		{
-			if (bestLocation == null)
+			if (bestLocation is null)
 				return true;
 
 			var timeDelta = location.Time - bestLocation.Time;
@@ -446,7 +446,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		void ILocationListener.OnStatusChanged(string? provider, Availability status, Bundle? extras)
 		{
-			if (provider == null)
+			if (provider is null)
 				return;
 
 			switch (status)

--- a/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Maui.Devices.Sensors
 		public void StopListeningForeground()
 		{
 			if (!IsListeningForeground ||
-				listeningManager == null)
+				listeningManager is null)
 				return;
 
 			listeningManager.StopUpdatingLocation();

--- a/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.ios.macos.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Threading;
@@ -10,14 +11,14 @@ namespace Microsoft.Maui.Devices.Sensors
 {
 	partial class GeolocationImplementation : IGeolocation
 	{
-		CLLocationManager listeningManager;
+		CLLocationManager? listeningManager;
 
 		/// <summary>
 		/// Indicates if currently listening to location updates while the app is in foreground.
 		/// </summary>
 		public bool IsListeningForeground { get => listeningManager != null; }
 
-		public async Task<Location> GetLastKnownLocationAsync()
+		public async Task<Location?> GetLastKnownLocationAsync()
 		{
 			if (!CLLocationManager.LocationServicesEnabled)
 				throw new FeatureNotEnabledException("Location services are not enabled on device.");
@@ -37,7 +38,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			return location?.ToLocation(reducedAccuracy);
 		}
 
-		public async Task<Location> GetLocationAsync(GeolocationRequest request, CancellationToken cancellationToken)
+		public async Task<Location?> GetLocationAsync(GeolocationRequest request, CancellationToken cancellationToken)
 		{
 			ArgumentNullException.ThrowIfNull(request);
 
@@ -50,7 +51,7 @@ namespace Microsoft.Maui.Devices.Sensors
 			// so just use the main loop
 			var manager = MainThread.InvokeOnMainThread(() => new CLLocationManager());
 
-			var tcs = new TaskCompletionSource<CLLocation>(manager);
+			var tcs = new TaskCompletionSource<CLLocation?>(manager);
 
 			var listener = new SingleLocationListener();
 			listener.LocationHandler += HandleLocation;
@@ -155,7 +156,7 @@ namespace Microsoft.Maui.Devices.Sensors
 
 			void HandleLocation(CLLocation clLocation)
 			{
-				OnLocationChanged(clLocation?.ToLocation(reducedAccuracy));
+				OnLocationChanged(clLocation.ToLocation(reducedAccuracy));
 			}
 
 			void HandleError(GeolocationError error)
@@ -172,7 +173,8 @@ namespace Microsoft.Maui.Devices.Sensors
 		/// </summary>
 		public void StopListeningForeground()
 		{
-			if (!IsListeningForeground)
+			if (!IsListeningForeground ||
+				listeningManager == null)
 				return;
 
 			listeningManager.StopUpdatingLocation();
@@ -183,7 +185,7 @@ namespace Microsoft.Maui.Devices.Sensors
 				listener.ErrorHandler = null;
 			}
 
-			listeningManager.Delegate = null;
+			listeningManager.WeakDelegate = null;
 
 			listeningManager = null;
 		}
@@ -193,7 +195,7 @@ namespace Microsoft.Maui.Devices.Sensors
 	{
 		bool wasRaised = false;
 
-		internal Action<CLLocation> LocationHandler { get; set; }
+		internal Action<CLLocation>? LocationHandler { get; set; }
 
 		/// <inheritdoc/>
 		public override void LocationsUpdated(CLLocationManager manager, CLLocation[] locations)
@@ -217,9 +219,9 @@ namespace Microsoft.Maui.Devices.Sensors
 
 	class ContinuousLocationListener : CLLocationManagerDelegate
 	{
-		internal Action<CLLocation> LocationHandler { get; set; }
+		internal Action<CLLocation>? LocationHandler { get; set; }
 
-		internal Action<GeolocationError> ErrorHandler { get; set; }
+		internal Action<GeolocationError>? ErrorHandler { get; set; }
 
 		/// <inheritdoc/>
 		public override void LocationsUpdated(CLLocationManager manager, CLLocation[] locations)

--- a/src/Essentials/src/Geolocation/Geolocation.netstandard.tvos.watchos.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.netstandard.tvos.watchos.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,10 +8,10 @@ namespace Microsoft.Maui.Devices.Sensors
 {
 	partial class GeolocationImplementation : IGeolocation
 	{
-		public Task<Location> GetLastKnownLocationAsync() =>
+		public Task<Location?> GetLastKnownLocationAsync() =>
 			throw ExceptionUtils.NotSupportedOrImplementedException;
 
-		public Task<Location> GetLocationAsync(GeolocationRequest request, CancellationToken cancellationToken) =>
+		public Task<Location?> GetLocationAsync(GeolocationRequest request, CancellationToken cancellationToken) =>
 			throw ExceptionUtils.NotSupportedOrImplementedException;
 
 		public bool IsListeningForeground { get => false; }

--- a/src/Essentials/src/Geolocation/Geolocation.tizen.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.tizen.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Essentials/src/Geolocation/Geolocation.tizen.cs
+++ b/src/Essentials/src/Geolocation/Geolocation.tizen.cs
@@ -13,15 +13,15 @@ namespace Microsoft.Maui.Devices.Sensors
 
 		public bool IsListeningForeground { get => false; }
 
-		public Task<Location> GetLastKnownLocationAsync() => Task.FromResult(lastKnownLocation);
+		public Task<Location?> GetLastKnownLocationAsync() => Task.FromResult<Location?>(lastKnownLocation);
 
-		public async Task<Location> GetLocationAsync(GeolocationRequest request, CancellationToken cancellationToken)
+		public async Task<Location?> GetLocationAsync(GeolocationRequest request, CancellationToken cancellationToken)
 		{
 			ArgumentNullException.ThrowIfNull(request);
 
 			await Permissions.EnsureGrantedAsync<Permissions.LocationWhenInUse>();
 
-			Locator service = null;
+			Locator? service = null;
 			var gps = PlatformUtils.GetFeatureInfo<bool>("location.gps");
 			var wps = PlatformUtils.GetFeatureInfo<bool>("location.wps");
 			if (gps)

--- a/src/Essentials/src/Geolocation/GeolocationAccuracyExtensionMethods.uwp.cs
+++ b/src/Essentials/src/Geolocation/GeolocationAccuracyExtensionMethods.uwp.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Maui.Devices.Sensors
+﻿#nullable enable
+
+namespace Microsoft.Maui.Devices.Sensors
 {
 	static class GeolocationAccuracyExtensionMethods
 	{

--- a/src/Essentials/src/Geolocation/GeolocationRequest.shared.cs
+++ b/src/Essentials/src/Geolocation/GeolocationRequest.shared.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Microsoft.Maui.Devices.Sensors

--- a/src/Essentials/src/Geolocation/GeolocationRequest.uwp.cs
+++ b/src/Essentials/src/Geolocation/GeolocationRequest.uwp.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Microsoft.Maui.Devices.Sensors
 {
 	public partial class GeolocationRequest

--- a/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs.GeolocationLi
 Microsoft.Maui.Devices.Sensors.IGeolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>?
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Devices.Sensors.Geolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>!
+override Microsoft.Maui.Devices.Sensors.GeolocationRequest.ToString() -> string!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsListeningForeground.get -> bool
 Microsoft.Maui.Devices.Sensors.IGeolocation.LocationChanged -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationLocationChangedEventArgs!>?

--- a/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-ios/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs.GeolocationLi
 Microsoft.Maui.Devices.Sensors.IGeolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>?
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Devices.Sensors.Geolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>!
+override Microsoft.Maui.Devices.Sensors.GeolocationRequest.ToString() -> string!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsListeningForeground.get -> bool
 Microsoft.Maui.Devices.Sensors.IGeolocation.LocationChanged -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationLocationChangedEventArgs!>?

--- a/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-maccatalyst/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs.GeolocationLi
 Microsoft.Maui.Devices.Sensors.IGeolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>?
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Devices.Sensors.Geolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>!
+override Microsoft.Maui.Devices.Sensors.GeolocationRequest.ToString() -> string!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsListeningForeground.get -> bool
 Microsoft.Maui.Devices.Sensors.IGeolocation.LocationChanged -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationLocationChangedEventArgs!>?

--- a/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-tizen/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs.GeolocationLi
 Microsoft.Maui.Devices.Sensors.IGeolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>?
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Devices.Sensors.Geolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>!
+override Microsoft.Maui.Devices.Sensors.GeolocationRequest.ToString() -> string!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsListeningForeground.get -> bool
 Microsoft.Maui.Devices.Sensors.IGeolocation.LocationChanged -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationLocationChangedEventArgs!>?

--- a/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net-windows/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs.GeolocationLi
 Microsoft.Maui.Devices.Sensors.IGeolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>?
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Devices.Sensors.Geolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>!
+override Microsoft.Maui.Devices.Sensors.GeolocationRequest.ToString() -> string!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsListeningForeground.get -> bool
 Microsoft.Maui.Devices.Sensors.IGeolocation.LocationChanged -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationLocationChangedEventArgs!>?

--- a/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs.GeolocationLi
 Microsoft.Maui.Devices.Sensors.IGeolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>?
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Devices.Sensors.Geolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>!
+override Microsoft.Maui.Devices.Sensors.GeolocationRequest.ToString() -> string!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsListeningForeground.get -> bool
 Microsoft.Maui.Devices.Sensors.IGeolocation.LocationChanged -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationLocationChangedEventArgs!>?

--- a/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
+++ b/src/Essentials/src/PublicAPI/netstandard/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs.GeolocationLi
 Microsoft.Maui.Devices.Sensors.IGeolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>?
 Microsoft.Maui.Storage.ISecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 static Microsoft.Maui.Devices.Sensors.Geolocation.ListeningFailed -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationListeningFailedEventArgs!>!
+override Microsoft.Maui.Devices.Sensors.GeolocationRequest.ToString() -> string!
 static Microsoft.Maui.Storage.SecureStorage.GetAsync(string! key) -> System.Threading.Tasks.Task<string?>!
 Microsoft.Maui.Devices.Sensors.IGeolocation.IsListeningForeground.get -> bool
 Microsoft.Maui.Devices.Sensors.IGeolocation.LocationChanged -> System.EventHandler<Microsoft.Maui.Devices.Sensors.GeolocationLocationChangedEventArgs!>?


### PR DESCRIPTION
### Description of Change

This PR is a follow-up to #9572 and adds `#nullable enable` to the remaining Essentials' Geolocation classes.

### Issues Fixed

No issue, but follow-up code changes left over from #9572.
