### PR TITLE
SensorSpeed: unify sensor intervals across all platforms

### DIFF
--- a/src/Essentials/src/Types/SensorSpeed.android.cs
+++ b/src/Essentials/src/Types/SensorSpeed.android.cs
@@ -2,7 +2,7 @@ using Android.Hardware;
 
 namespace Microsoft.Maui.Devices.Sensors
 {
-	static class SensorSpeedExtensions
+	internal static partial class SensorSpeedExtensions
 	{
 		internal static SensorDelay ToPlatform(this SensorSpeed sensorSpeed)
 		{

--- a/src/Essentials/src/Types/SensorSpeed.ios.tvos.watchos.cs
+++ b/src/Essentials/src/Types/SensorSpeed.ios.tvos.watchos.cs
@@ -1,20 +1,20 @@
 namespace Microsoft.Maui.Devices.Sensors
 {
-	static class SensorSpeedExtensions
+	internal static partial class SensorSpeedExtensions
 	{
 		internal static double ToPlatform(this SensorSpeed sensorSpeed)
 		{
 			switch (sensorSpeed)
 			{
 				case SensorSpeed.Fastest:
-					return .02;
+					return sensorIntervalFastest / 1000.0;
 				case SensorSpeed.Game:
-					return .04;
+					return sensorIntervalGame / 1000.0;
 				case SensorSpeed.UI:
-					return .08;
+					return sensorIntervalUI / 1000.0;
 			}
 
-			return .225;
+			return sensorIntervalDefault / 1000.0;
 		}
 	}
 }

--- a/src/Essentials/src/Types/SensorSpeed.shared.cs
+++ b/src/Essentials/src/Types/SensorSpeed.shared.cs
@@ -17,4 +17,14 @@ namespace Microsoft.Maui.Devices.Sensors
 		/// <summary>Get the sensor data as fast as possible.</summary>
 		Fastest = 3,
 	}
+
+	internal static partial class SensorSpeedExtensions
+	{
+		// Timing intervals to match Android sensor speeds in milliseconds
+		// https://developer.android.com/guide/topics/sensors/sensors_overview
+		internal const uint sensorIntervalDefault = 200;
+		internal const uint sensorIntervalUI = 60;
+		internal const uint sensorIntervalGame = 20;
+		internal const uint sensorIntervalFastest = 5;
+	}
 }

--- a/src/Essentials/src/Types/SensorSpeed.tizen.cs
+++ b/src/Essentials/src/Types/SensorSpeed.tizen.cs
@@ -1,20 +1,20 @@
 namespace Microsoft.Maui.Devices.Sensors
 {
-	static class SensorSpeedExtensions
+	internal static partial class SensorSpeedExtensions
 	{
 		internal static uint ToPlatform(this SensorSpeed sensorSpeed)
 		{
 			switch (sensorSpeed)
 			{
 				case SensorSpeed.Fastest:
-					return 10;
+					return sensorIntervalFastest;
 				case SensorSpeed.Game:
-					return 20;
+					return sensorIntervalGame;
 				case SensorSpeed.UI:
-					return 60;
+					return sensorIntervalUI;
 			}
 
-			return 100;
+			return sensorIntervalDefault;
 		}
 	}
 }

--- a/src/Essentials/src/Types/SensorSpeed.uwp.cs
+++ b/src/Essentials/src/Types/SensorSpeed.uwp.cs
@@ -1,20 +1,20 @@
 namespace Microsoft.Maui.Devices.Sensors
 {
-	static class SensorSpeedExtensions
+	internal static partial class SensorSpeedExtensions
 	{
 		internal static uint ToPlatform(this SensorSpeed sensorSpeed)
 		{
 			switch (sensorSpeed)
 			{
 				case SensorSpeed.Fastest:
-					return 20;
+					return sensorIntervalFastest;
 				case SensorSpeed.Game:
-					return 40;
+					return sensorIntervalGame;
 				case SensorSpeed.UI:
-					return 80;
+					return sensorIntervalUI;
 			}
 
-			return 225;
+			return sensorIntervalDefault;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change

This is a carry-over from https://github.com/xamarin/Essentials/pull/1439 (as suggested by @jfversluis).

It unifies the sensor intervals across all platforms, matching Android's intervals, see https://developer.android.com/guide/topics/sensors/sensors_overview.

Note that we do not use a zero-interval for `SensorSpeed.Fastest` (since this might turn off the sensor, in particular on UWP). Instead we use 5ms (=200 Hz), which is roughly what I have measured on Android (v10) for `SensorSpeed.Fastest`.


<!-- Enter description of the fix in this section -->

### Issues Fixed

Fixes #12281

<!--
Are you targeting main? All PRs should target the main branch unless otherwise noted.
-->
