### PR TITLE
[Android] Fix crash adding items to CollectionView on navigating

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Android.cs
+++ b/src/Controls/src/Core/Handlers/Items/ItemsViewHandler.Android.cs
@@ -21,6 +21,13 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			base.ConnectHandler(platformView);
 			(platformView as IMauiRecyclerView<TItemsView>)?.SetUpNewElement(VirtualView);
 		}
+
+		protected override void DisconnectHandler(RecyclerView platformView)
+		{
+			base.DisconnectHandler(platformView);
+			(platformView as IMauiRecyclerView<TItemsView>)?.TearDownOldElement(VirtualView);
+		}
+
 		protected override RecyclerView CreatePlatformView() =>
 			new MauiRecyclerView<TItemsView, ItemsViewAdapter<TItemsView, IItemsViewSource>, IItemsViewSource>(Context, GetItemsLayout, CreateAdapter);
 

--- a/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
+++ b/src/Controls/src/Core/PublicAPI/net-android/PublicAPI.Unshipped.txt
@@ -22,6 +22,7 @@ override Microsoft.Maui.Controls.ImageButton.IsEnabledCore.get -> bool
 override Microsoft.Maui.Controls.SearchBar.IsEnabledCore.get -> bool
 ~Microsoft.Maui.Controls.WebView.UserAgent.get -> string
 ~Microsoft.Maui.Controls.WebView.UserAgent.set -> void
+~override Microsoft.Maui.Controls.Handlers.Items.ItemsViewHandler<TItemsView>.DisconnectHandler(AndroidX.RecyclerView.Widget.RecyclerView platformView) -> void
 ~override Microsoft.Maui.Controls.LayoutOptions.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Region.Equals(object obj) -> bool
 ~override Microsoft.Maui.Controls.Shapes.Matrix.Equals(object obj) -> bool

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.Android.cs
@@ -1,7 +1,54 @@
-﻿namespace Microsoft.Maui.DeviceTests
-{
-	public partial class CollectionViewTests
-	{
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Handlers;
+using Xunit;
 
+namespace Microsoft.Maui.DeviceTests
+{
+	public partial class CollectionViewTests : ControlsHandlerTestBase
+	{
+		[Fact]
+		public async Task PushAndPopPageWithCollectionView()
+		{
+			NavigationPage rootPage = new NavigationPage(new ContentPage());
+			ContentPage modalPage = new ContentPage();
+
+			var collectionView = new CollectionView
+			{
+				ItemsSource = new string[]
+				{
+				  "Item 1",
+				  "Item 2",
+				  "Item 3",
+				}
+			};
+
+			modalPage.Content = collectionView;
+
+			SetupBuilder();
+
+			await CreateHandlerAndAddToWindow<IWindowHandler>(rootPage,
+				async (_) =>
+				{
+					var currentPage = (rootPage as IPageContainer<Page>).CurrentPage;
+
+					await currentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(modalPage);
+
+					await currentPage.Navigation.PopModalAsync();
+					await OnUnloadedAsync(modalPage);
+
+					// Navigate a second time
+					await currentPage.Navigation.PushModalAsync(modalPage);
+					await OnLoadedAsync(modalPage);
+
+					await currentPage.Navigation.PopModalAsync();
+					await OnUnloadedAsync(modalPage);
+				});
+
+
+			// Without Exceptions here, the test has passed.
+			Assert.Equal(0, (rootPage as IPageContainer<Page>).CurrentPage.Navigation.ModalStack.Count);
+		}
 	}
 }

--- a/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
+++ b/src/Controls/tests/DeviceTests/Elements/CollectionView/CollectionViewTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
+using Microsoft.Maui.DeviceTests.Stubs;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using Xunit;
@@ -16,6 +17,11 @@ namespace Microsoft.Maui.DeviceTests
 			{
 				builder.ConfigureMauiHandlers(handlers =>
 				{
+					handlers.AddHandler(typeof(Toolbar), typeof(ToolbarHandler));
+					handlers.AddHandler(typeof(NavigationPage), typeof(NavigationViewHandler));
+					handlers.AddHandler<Page, PageHandler>();
+					handlers.AddHandler<Window, WindowHandlerStub>();
+
 					handlers.AddHandler<CollectionView, CollectionViewHandler>();
 					handlers.AddHandler<VerticalStackLayout, LayoutHandler>();
 					handlers.AddHandler<Label, LabelHandler>();


### PR DESCRIPTION
### Description of Change

Fix crash adding items to CollectionView on Android navigating.

In the example, tapping the second page button we clear and add new items to the collection with a 1sg delay. When navigating back, the `VirtualView `is set to null but we are not invoking the logic of the `TearDown `method of the `MauiRecyclerView` where we dispose elements like the adapter etc. So, when adding the first element, the Adapter reports the inserted item that forces the EmptyView to be updated where the VirtualView is used, but it is null and we throw an exception because it is something not expected.

This PR include changes to invoke the Teardown method correctly and avoid the issue.

To validate the changes used the sample from 12219.
![fix-12219](https://user-images.githubusercontent.com/6755973/219347206-6ddd9ae2-ddfc-4d0d-9a6e-1a41c2fb712f.gif)

Also included a device test.
![image](https://user-images.githubusercontent.com/6755973/219347222-fa583292-c525-45b6-9f39-6df88488190d.png)

### Issues Fixed

Fixes #12219 