### PR TITLE
[controls] fix memory leak in `Window`

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Application/Application.Impl.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Devices;
@@ -9,10 +10,10 @@ namespace Microsoft.Maui.Controls
 {
 	public partial class Application : IApplication
 	{
-		const string MauiWindowIdKey = "__MAUI_WINDOW_ID__";
+		internal const string MauiWindowIdKey = "__MAUI_WINDOW_ID__";
 
 		readonly List<Window> _windows = new();
-		readonly Dictionary<string, Window> _requestedWindows = new();
+		readonly Dictionary<string, WeakReference<Window>> _requestedWindows = new();
 		ILogger<Application>? _logger;
 
 		ILogger<Application>? Logger =>
@@ -29,8 +30,14 @@ namespace Microsoft.Maui.Controls
 			// try get the window that is pending
 			if (activationState?.State?.TryGetValue(MauiWindowIdKey, out var requestedWindowId) ?? false)
 			{
-				if (requestedWindowId != null && _requestedWindows.TryGetValue(requestedWindowId, out var w))
-					window = w;
+				if (requestedWindowId != null && _requestedWindows.TryGetValue(requestedWindowId, out var r))
+				{
+					if (r.TryGetTarget(out var w))
+					{
+						window = w;
+					}
+					_requestedWindows.Remove(requestedWindowId);
+				}
 			}
 
 			// create a new one if there is no pending windows
@@ -86,9 +93,8 @@ namespace Microsoft.Maui.Controls
 
 		public virtual void OpenWindow(Window window)
 		{
-			var id = Guid.NewGuid().ToString();
-
-			_requestedWindows[id] = window;
+			var id = Guid.NewGuid().ToString("n");
+			_requestedWindows.Add(id, new WeakReference<Window>(window));
 
 			var state = new PersistedState
 			{

--- a/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/Window/Window.Impl.cs
@@ -504,6 +504,7 @@ namespace Microsoft.Maui.Controls
 			OnDestroying();
 
 			Application?.RemoveWindow(this);
+			Handler?.DisconnectHandler();
 		}
 
 		void IWindow.Resumed()


### PR DESCRIPTION
Fixes #10029

I could reproduce a memory leak by doing:

    App.Current.OpenWindow(new Window { Page = new ContentPage() });

I found that `App.Current._requestedWindows` just held onto every `Window` object forever.

Note that we *can't* use `ConditionalWeakTable` here:

https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.conditionalweaktable-2

After initially trying this, I added a test showing not to use it. The problem is if the `string` is GC'd the `Window` will be lost.

We can use `Dictionary<string, WeakReference<Window>>` instead.

The only other change I made was to use `Guid.ToString("n")` as it removes `{`, `}`, and `-` characters from the string.

After these changes, I still found `Window` objects hanging around that appeared to be held onto by many other objects.

Then I reviewed:

```csharp
void IWindow.Destroying()
{
    SendWindowDisppearing();
    Destroying?.Invoke(this, EventArgs.Empty);
    OnDestroying();

    Application?.RemoveWindow(this);
    // This wasn't here!
    Handler?.DisconnectHandler();
}
```

It appears that upon `Window`'s closing, we didn't have any code that "disconnected" the MAUI handler. After this change, I could see `Window` objects properly go away.

I added a unit test as well.